### PR TITLE
Add openapi support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Anthropic" Version="12.22.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsAIVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Anthropic" Version="12.22.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsAIVersion)" />

--- a/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
@@ -166,7 +166,11 @@ public static class MattermostActionEndpointExtensions
                 return TypedResults.StatusCode(500);
             }
 
-        }).RequireRateLimiting(CallbackRateLimitPolicy).AllowAnonymous();
+        })
+        .WithName("MattermostActionCallback")
+        .WithSummary("Handle a Mattermost interactive approval button callback.")
+        .WithTags("Mattermost")
+        .RequireRateLimiting(CallbackRateLimitPolicy).AllowAnonymous();
     }
 
     private sealed class ActionCallbackPayload

--- a/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading.RateLimiting;
 using Akka.Actor;
 using Akka.Hosting;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.RateLimiting;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Channels;
@@ -46,7 +47,7 @@ public static class MattermostActionEndpointExtensions
             return;
         }
 
-        app.MapPost("/api/mattermost/actions", async (
+        app.MapPost("/api/mattermost/actions", async ValueTask<Results<BadRequest<string>, StatusCodeHttpResult, JsonHttpResult<ActionCallbackResponse>>> (
             HttpContext httpContext,
             IRequiredActor<MattermostGatewayActorKey> gatewayActor,
             TimeProvider timeProvider,
@@ -62,34 +63,34 @@ public static class MattermostActionEndpointExtensions
             }
             catch (JsonException)
             {
-                return Results.BadRequest("Invalid JSON payload.");
+                return TypedResults.BadRequest("Invalid JSON payload.");
             }
 
             if (payload is null)
-                return Results.BadRequest("Invalid JSON payload.");
+                return TypedResults.BadRequest("Invalid JSON payload.");
 
             if (payload.RawBodyLength > MaxCallbackBodyBytes)
-                return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+                return TypedResults.StatusCode(StatusCodes.Status413PayloadTooLarge);
 
             if (string.IsNullOrEmpty(payload.UserId)
                 || string.IsNullOrEmpty(payload.PostId)
                 || string.IsNullOrEmpty(payload.ChannelId))
             {
-                return Results.BadRequest("Missing required fields: user_id, post_id, channel_id.");
+                return TypedResults.BadRequest("Missing required fields: user_id, post_id, channel_id.");
             }
 
             if (payload.Context is null
                 || !payload.Context.TryGetValue("action_token", out var actionToken)
                 || string.IsNullOrWhiteSpace(actionToken))
             {
-                return Results.BadRequest("Missing required context field: action_token.");
+                return TypedResults.BadRequest("Missing required context field: action_token.");
             }
 
             if (!actionStore.TryConsume(actionToken, out var storedAction)
                 || storedAction is null)
             {
                 logger.LogWarning("Rejected Mattermost action callback with invalid, expired, or replayed action token");
-                return Results.Json(new ActionCallbackResponse
+                return TypedResults.Json(new ActionCallbackResponse
                 {
                     EphemeralText = "That approval button is no longer valid. Please re-issue the request and try again."
                 }, JsonOptions);
@@ -98,7 +99,7 @@ public static class MattermostActionEndpointExtensions
             if (!MattermostAclPolicy.IsAllowedUser(new MattermostUserId(payload.UserId), options))
             {
                 logger.LogWarning("Rejected Mattermost action callback from non-allowed user {UserId}", payload.UserId);
-                return Results.Json(new ActionCallbackResponse
+                return TypedResults.Json(new ActionCallbackResponse
                 {
                     EphemeralText = "You are not authorized to respond to tool approval prompts."
                 }, JsonOptions);
@@ -109,7 +110,7 @@ public static class MattermostActionEndpointExtensions
                 logger.LogWarning(
                     "Rejected Mattermost action callback with mismatched routing data channel={ChannelId}",
                     payload.ChannelId);
-                return Results.BadRequest("Callback routing data did not match the issued action.");
+                return TypedResults.BadRequest("Callback routing data did not match the issued action.");
             }
 
             // Bound the actor-resolution wait so a daemon still mid-startup
@@ -126,7 +127,7 @@ public static class MattermostActionEndpointExtensions
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
                 logger.LogError("Mattermost callback received before the Mattermost gateway actor was registered.");
-                return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+                return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
             }
 
             var interaction = new MattermostGatewayInteraction(
@@ -148,21 +149,21 @@ public static class MattermostActionEndpointExtensions
 
                 return reply switch
                 {
-                    CommandAck => Results.Json(new ActionCallbackResponse
+                    CommandAck => TypedResults.Json(new ActionCallbackResponse
                     {
                         EphemeralText = $"You selected: **{ApprovalOptionKeys.LabelFor(storedAction.SelectedKey)}**"
                     }, JsonOptions),
-                    CommandNack nack => Results.Json(new ActionCallbackResponse
+                    CommandNack nack => TypedResults.Json(new ActionCallbackResponse
                     {
                         EphemeralText = MapRejectMessage(nack.Reason)
                     }, JsonOptions),
-                    _ => Results.StatusCode(StatusCodes.Status500InternalServerError)
+                    _ => TypedResults.StatusCode(StatusCodes.Status500InternalServerError)
                 };
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed routing Mattermost action callback for call {CallId}", storedAction.CallId);
-                return Results.StatusCode(500);
+                return TypedResults.StatusCode(500);
             }
 
         }).RequireRateLimiting(CallbackRateLimitPolicy).AllowAnonymous();
@@ -179,9 +180,9 @@ public static class MattermostActionEndpointExtensions
         public int RawBodyLength { get; set; }
     }
 
-    private sealed class ActionCallbackResponse
+    private sealed record ActionCallbackResponse
     {
-        public string? EphemeralText { get; set; }
+        public string? EphemeralText { get; init; }
     }
 
     internal static void AddMattermostActionEndpointRateLimiting(this IServiceCollection services)

--- a/src/Netclaw.Daemon/Lifecycle/LifecycleEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Lifecycle/LifecycleEndpointRouteBuilderExtensions.cs
@@ -33,7 +33,11 @@ public static class LifecycleEndpointRouteBuilderExtensions
 
             notifier.NotifyShutdown(request.Reason);
             return TypedResults.Ok(new ShutdownDaemonResponse(request.Reason, Environment.ProcessId));
-        }).RequireAuthorization();
+        })
+        .WithName("ShutdownDaemon")
+        .WithSummary("Request a graceful daemon shutdown ahead of SIGTERM.")
+        .WithTags("Lifecycle")
+        .RequireAuthorization();
 
         return app;
     }

--- a/src/Netclaw.Daemon/Lifecycle/LifecycleEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Lifecycle/LifecycleEndpointRouteBuilderExtensions.cs
@@ -3,11 +3,20 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Netclaw.Daemon.Services;
 
 namespace Netclaw.Daemon.Lifecycle;
+
+/// <summary>Request to shut down the daemon, sourced from query string.</summary>
+public sealed record ShutdownDaemonRequest([FromQuery(Name = "reason")] string? Reason);
+
+/// <summary>Successful shutdown acknowledgement: echoes the reason and reports the daemon PID.</summary>
+public sealed record ShutdownDaemonResponse(string Reason, int Pid);
+
+/// <summary>Error payload returned when a lifecycle request is malformed.</summary>
+public sealed record LifecycleErrorResponse(string Error);
 
 public static class LifecycleEndpointRouteBuilderExtensions
 {
@@ -15,16 +24,15 @@ public static class LifecycleEndpointRouteBuilderExtensions
     {
         // Daemon lifecycle endpoint — CLI calls this before sending SIGTERM.
         // Config-triggered restart coordination happens inside DaemonRestartCoordinator.
-        app.MapPost("/api/lifecycle/shutdown", (
-            DaemonLifecycleNotifier notifier,
-            HttpRequest request) =>
+        app.MapPost("/api/lifecycle/shutdown", Results<Ok<ShutdownDaemonResponse>, BadRequest<LifecycleErrorResponse>> (
+            [AsParameters] ShutdownDaemonRequest request,
+            DaemonLifecycleNotifier notifier) =>
         {
-            var reason = request.Query["reason"].ToString();
-            if (string.IsNullOrEmpty(reason))
-                return Results.BadRequest(new { error = "reason query parameter is required" });
+            if (string.IsNullOrEmpty(request.Reason))
+                return TypedResults.BadRequest(new LifecycleErrorResponse("reason query parameter is required"));
 
-            notifier.NotifyShutdown(reason);
-            return Results.Ok(new { reason, pid = Environment.ProcessId });
+            notifier.NotifyShutdown(request.Reason);
+            return TypedResults.Ok(new ShutdownDaemonResponse(request.Reason, Environment.ProcessId));
         }).RequireAuthorization();
 
         return app;

--- a/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
@@ -49,7 +49,11 @@ public static class McpEndpointRouteBuilderExtensions
 
             var (authUrl, state) = await oauthService.StartAuthorizationFlowAsync(new McpServerName(name), entry, ct);
             return TypedResults.Ok(new McpOAuthStartResponse(authUrl, state));
-        }).RequireAuthorization();
+        })
+        .WithName("StartMcpOAuth")
+        .WithSummary("Start an OAuth 2.1 authorization flow for an MCP server.")
+        .WithTags("MCP")
+        .RequireAuthorization();
 
         app.MapGet("/api/mcp/oauth/callback", async ValueTask<ContentHttpResult> (
             [AsParameters] McpOAuthCallbackQuery query,
@@ -94,7 +98,11 @@ public static class McpEndpointRouteBuilderExtensions
                     contentEncoding: null,
                     statusCode: StatusCodes.Status500InternalServerError);
             }
-        }).AllowAnonymous();
+        })
+        .WithName("McpOAuthCallback")
+        .WithSummary("Browser redirect callback that completes an MCP OAuth flow.")
+        .WithTags("MCP")
+        .AllowAnonymous();
 
         app.MapGet("/api/mcp/statuses", (McpClientManager mcpManager) =>
         {
@@ -106,26 +114,42 @@ public static class McpEndpointRouteBuilderExtensions
                     kvp.Value.ToolCount,
                     kvp.Value.ErrorMessage));
             return TypedResults.Ok(result);
-        }).RequireAuthorization();
+        })
+        .WithName("GetMcpServerStatuses")
+        .WithSummary("Get the connection status of all configured MCP servers.")
+        .WithTags("MCP")
+        .RequireAuthorization();
 
         app.MapGet("/api/mcp/tools/{name}", (string name, McpClientManager mcpManager) =>
         {
             var tools = mcpManager.GetToolNames(new McpServerName(name));
             return TypedResults.Ok(tools);
-        }).RequireAuthorization();
+        })
+        .WithName("GetMcpServerTools")
+        .WithSummary("List the tool names exposed by a single MCP server.")
+        .WithTags("MCP")
+        .RequireAuthorization();
 
         app.MapGet("/api/mcp/oauth/status/{name}", (string name, McpOAuthService oauthService) =>
         {
             var status = oauthService.GetFlowStatus(new McpServerName(name));
             return TypedResults.Ok(new McpOAuthStatusResponse(status.ToString()));
-        }).RequireAuthorization();
+        })
+        .WithName("GetMcpOAuthStatus")
+        .WithSummary("Get the OAuth flow status for an MCP server by name.")
+        .WithTags("MCP")
+        .RequireAuthorization();
 
         app.MapGet("/api/mcp/oauth/status-by-state/{state}", (string state, McpOAuthService oauthService) =>
         {
             var status = oauthService.GetFlowStatusByState(state);
             // Tokens are persisted daemon-side — never expose them over HTTP.
             return TypedResults.Ok(new McpOAuthStatusResponse(status.ToString()));
-        }).RequireAuthorization();
+        })
+        .WithName("GetMcpOAuthStatusByState")
+        .WithSummary("Get the OAuth flow status for an MCP server by state token.")
+        .WithTags("MCP")
+        .RequireAuthorization();
 
         return app;
     }

--- a/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
@@ -4,63 +4,77 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Mcp;
 
+/// <summary>Query string for the MCP OAuth browser callback.</summary>
+public sealed record McpOAuthCallbackQuery(
+    [FromQuery(Name = "code")] string? Code,
+    [FromQuery(Name = "state")] string? State);
+
+/// <summary>Authorization URL and opaque state returned when an MCP OAuth flow starts.</summary>
+public sealed record McpOAuthStartResponse(string AuthorizationUrl, string State);
+
+/// <summary>Connection status for a single MCP server.</summary>
+public sealed record McpServerStatusDto(string State, int ToolCount, string? Error);
+
+/// <summary>OAuth flow status for an MCP server or pending state token.</summary>
+public sealed record McpOAuthStatusResponse(string Status);
+
+/// <summary>Error payload returned when an MCP request is malformed or unknown.</summary>
+public sealed record McpErrorResponse(string Error);
+
 public static class McpEndpointRouteBuilderExtensions
 {
     public static IEndpointRouteBuilder MapMcpEndpoints(this IEndpointRouteBuilder app)
     {
         // MCP OAuth 2.1 endpoints
-        app.MapPost("/api/mcp/oauth/start/{name}", async (
+        app.MapPost("/api/mcp/oauth/start/{name}", async ValueTask<Results<Ok<McpOAuthStartResponse>, NotFound<McpErrorResponse>, BadRequest<McpErrorResponse>>> (
             string name,
             McpOAuthService oauthService,
             Dictionary<string, McpServerEntry> mcpServers,
             CancellationToken ct) =>
         {
             if (!mcpServers.TryGetValue(name, out var entry))
-                return Results.NotFound(new { error = $"MCP server '{name}' not found" });
+                return TypedResults.NotFound(new McpErrorResponse($"MCP server '{name}' not found"));
 
             if (string.IsNullOrWhiteSpace(entry.Url))
-                return Results.BadRequest(new { error = $"MCP server '{name}' has no URL (OAuth requires HTTP transport)" });
+                return TypedResults.BadRequest(new McpErrorResponse($"MCP server '{name}' has no URL (OAuth requires HTTP transport)"));
 
             var (authUrl, state) = await oauthService.StartAuthorizationFlowAsync(new McpServerName(name), entry, ct);
-            return Results.Ok(new { authorizationUrl = authUrl, state });
+            return TypedResults.Ok(new McpOAuthStartResponse(authUrl, state));
         }).RequireAuthorization();
 
-        app.MapGet("/api/mcp/oauth/callback", async (
-            HttpContext context,
+        app.MapGet("/api/mcp/oauth/callback", async ValueTask<ContentHttpResult> (
+            [AsParameters] McpOAuthCallbackQuery query,
             McpOAuthService oauthService,
+            IMcpReconnectable mcpManager,
+            ILogger<McpClientManager> reconnectLogger,
             CancellationToken ct) =>
         {
-            var code = context.Request.Query["code"].ToString();
-            var state = context.Request.Query["state"].ToString();
-
-            if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+            if (string.IsNullOrEmpty(query.Code) || string.IsNullOrEmpty(query.State))
             {
-                context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(
-                    "<html><body><h2>Authorization failed</h2><p>Missing code or state parameter.</p></body></html>", ct);
-                return;
+                return TypedResults.Content(
+                    "<html><body><h2>Authorization failed</h2><p>Missing code or state parameter.</p></body></html>",
+                    "text/html");
             }
 
             try
             {
-                await oauthService.CompleteAuthorizationAsync(code, state, ct);
+                await oauthService.CompleteAuthorizationAsync(query.Code, query.State, ct);
 
                 // Auto-reconnect the MCP server now that we have a valid token.
                 // Resolved as IMcpReconnectable so the callback is not coupled to the
                 // concrete McpClientManager type, which is heavyweight and hard to stub in tests.
-                var serverName = oauthService.GetServerNameForState(state);
+                var serverName = oauthService.GetServerNameForState(query.State);
                 if (serverName is not null)
                 {
-                    var mcpManager = context.RequestServices.GetRequiredService<IMcpReconnectable>();
-                    var reconnectLogger = context.RequestServices.GetRequiredService<ILogger<McpClientManager>>();
                     _ = Task.Run(async () =>
                     {
                         try { await mcpManager.TryReconnectAsync(serverName.Value, CancellationToken.None); }
@@ -68,16 +82,17 @@ public static class McpEndpointRouteBuilderExtensions
                     }, CancellationToken.None);
                 }
 
-                context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(
-                    "<html><body><h2>Authorization complete</h2><p>You may close this tab.</p></body></html>", ct);
+                return TypedResults.Content(
+                    "<html><body><h2>Authorization complete</h2><p>You may close this tab.</p></body></html>",
+                    "text/html");
             }
             catch (Exception ex)
             {
-                context.Response.StatusCode = 500;
-                context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(
-                    $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>", ct);
+                return TypedResults.Content(
+                    $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>",
+                    "text/html",
+                    contentEncoding: null,
+                    statusCode: StatusCodes.Status500InternalServerError);
             }
         }).AllowAnonymous();
 
@@ -86,32 +101,30 @@ public static class McpEndpointRouteBuilderExtensions
             var statuses = mcpManager.GetServerStatuses();
             var result = statuses.ToDictionary(
                 kvp => kvp.Key.Value,
-                kvp => new
-                {
-                    state = kvp.Value.State.ToString(),
-                    toolCount = kvp.Value.ToolCount,
-                    error = kvp.Value.ErrorMessage,
-                });
-            return Results.Ok(result);
+                kvp => new McpServerStatusDto(
+                    kvp.Value.State.ToString(),
+                    kvp.Value.ToolCount,
+                    kvp.Value.ErrorMessage));
+            return TypedResults.Ok(result);
         }).RequireAuthorization();
 
         app.MapGet("/api/mcp/tools/{name}", (string name, McpClientManager mcpManager) =>
         {
             var tools = mcpManager.GetToolNames(new McpServerName(name));
-            return Results.Ok(tools);
+            return TypedResults.Ok(tools);
         }).RequireAuthorization();
 
         app.MapGet("/api/mcp/oauth/status/{name}", (string name, McpOAuthService oauthService) =>
         {
             var status = oauthService.GetFlowStatus(new McpServerName(name));
-            return Results.Ok(new { status = status.ToString() });
+            return TypedResults.Ok(new McpOAuthStatusResponse(status.ToString()));
         }).RequireAuthorization();
 
         app.MapGet("/api/mcp/oauth/status-by-state/{state}", (string state, McpOAuthService oauthService) =>
         {
             var status = oauthService.GetFlowStatusByState(state);
             // Tokens are persisted daemon-side — never expose them over HTTP.
-            return Results.Ok(new { status = status.ToString() });
+            return TypedResults.Ok(new McpOAuthStatusResponse(status.ToString()));
         }).RequireAuthorization();
 
         return app;

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Akka.Hosting" />
     <PackageReference Include="Akka.Persistence.Hosting" />
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="Netclaw.SkillClient" />

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -1,56 +1,65 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <AssemblyName>netclawd</AssemblyName>
-    <OutputType>Exe</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-    <InvariantGlobalization>false</InvariantGlobalization>
-    <!-- OpenAI Responses API (ResponsesClient) is still marked experimental -->
-    <NoWarn>$(NoWarn);OPENAI001</NoWarn>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <AssemblyName>netclawd</AssemblyName>
+        <OutputType>Exe</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+        <InvariantGlobalization>false</InvariantGlobalization>
+        <!-- OpenAI Responses API (ResponsesClient) is still marked experimental -->
+        <NoWarn>$(NoWarn);OPENAI001</NoWarn>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Netclaw.Daemon.Tests" />
-    <InternalsVisibleTo Include="Netclaw.Cli.Tests" />
-  </ItemGroup>
+        <!-- Generate XML documentation file for public API (feeds OpenAPI metadata).
+             Doc-comment completeness/cref warnings are not enforced here: CS1591 (missing
+             doc on public member), CS1573 (missing param tag), CS1574/CS0419 (unresolved/
+             ambiguous cref), CS1587 (comment on a non-documentable element, e.g. top-level
+             local functions). -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <!-- slopwatch-ignore: SW005 GenerateDocumentationFile is on to feed OpenAPI metadata, not to enforce doc-comment completeness. These are non-functional doc-comment diagnostics (unresolved/ambiguous crefs, missing param tags, comments on top-level local functions); we intentionally do not gate the build on them. -->
+        <NoWarn>$(NoWarn);CS1573;CS1574;CS1587;CS0419</NoWarn>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Akka.Hosting" />
-    <PackageReference Include="Akka.Persistence.Hosting" />
-    <PackageReference Include="Akka.Persistence.Sql.Hosting" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="Microsoft.Data.Sqlite" />
-    <PackageReference Include="ModelContextProtocol.Core" />
-    <PackageReference Include="Netclaw.SkillClient" />
-    <PackageReference Include="OpenTelemetry" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
-    <PackageReference Include="SlackNet.Extensions.DependencyInjection" />
-  </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="Netclaw.Daemon.Tests"/>
+        <InternalsVisibleTo Include="Netclaw.Cli.Tests"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="migrations\sqlite\**\*.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <EmbeddedResource Include="migrations\sqlite\**\*.sql" />
-    <Content Include="..\..\feeds\skills\.system\files\**\*" Exclude="..\..\feeds\skills\.system\files\**\*.*.*\**" Link="BuiltInSkills\%(RecursiveDir)%(Filename)%(Extension)">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Akka.Hosting"/>
+        <PackageReference Include="Akka.Persistence.Hosting"/>
+        <PackageReference Include="Akka.Persistence.Sql.Hosting"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Microsoft.Data.Sqlite"/>
+        <PackageReference Include="ModelContextProtocol.Core"/>
+        <PackageReference Include="Netclaw.SkillClient"/>
+        <PackageReference Include="OpenTelemetry"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting"/>
+        <PackageReference Include="SlackNet.Extensions.DependencyInjection"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj" />
-    <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
-    <ProjectReference Include="..\Netclaw.Channels\Netclaw.Channels.csproj" />
-    <ProjectReference Include="..\Netclaw.Channels.Discord\Netclaw.Channels.Discord.csproj" />
-    <ProjectReference Include="..\Netclaw.Channels.Mattermost\Netclaw.Channels.Mattermost.csproj" />
-    <ProjectReference Include="..\Netclaw.Channels.Slack\Netclaw.Channels.Slack.csproj" />
-    <ProjectReference Include="..\Netclaw.Providers\Netclaw.Providers.csproj" />
-    <ProjectReference Include="..\Netclaw.Search\Netclaw.Search.csproj" />
-    <ProjectReference Include="..\Netclaw.Tools.Abstractions\Netclaw.Tools.Abstractions.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="migrations\sqlite\**\*.sql">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <EmbeddedResource Include="migrations\sqlite\**\*.sql"/>
+        <Content Include="..\..\feeds\skills\.system\files\**\*" Exclude="..\..\feeds\skills\.system\files\**\*.*.*\**" Link="BuiltInSkills\%(RecursiveDir)%(Filename)%(Extension)">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj"/>
+        <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj"/>
+        <ProjectReference Include="..\Netclaw.Channels\Netclaw.Channels.csproj"/>
+        <ProjectReference Include="..\Netclaw.Channels.Discord\Netclaw.Channels.Discord.csproj"/>
+        <ProjectReference Include="..\Netclaw.Channels.Mattermost\Netclaw.Channels.Mattermost.csproj"/>
+        <ProjectReference Include="..\Netclaw.Channels.Slack\Netclaw.Channels.Slack.csproj"/>
+        <ProjectReference Include="..\Netclaw.Providers\Netclaw.Providers.csproj"/>
+        <ProjectReference Include="..\Netclaw.Search\Netclaw.Search.csproj"/>
+        <ProjectReference Include="..\Netclaw.Tools.Abstractions\Netclaw.Tools.Abstractions.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -210,15 +210,34 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");
-    app.MapGet("/api/health/ready", () => TypedResults.Ok("healthy"));
+    app.MapGet("/api/health/ready", () => TypedResults.Ok("healthy"))
+        .WithName("HealthReady")
+        .WithSummary("Liveness probe reporting the daemon is accepting requests.")
+        .WithTags("Health");
     app.MapGet("/api/health/status", async ValueTask<Ok<DaemonRuntimeStatus.Response>> (DaemonRuntimeStatusService statusService, CancellationToken cancellationToken) =>
-        TypedResults.Ok(await statusService.GetStatusAsync(cancellationToken))).RequireAuthorization();
+        TypedResults.Ok(await statusService.GetStatusAsync(cancellationToken)))
+        .WithName("GetHealthStatus")
+        .WithSummary("Get the daemon's runtime status, including connector health.")
+        .WithTags("Health")
+        .RequireAuthorization();
     app.MapGet("/api/sessions", (SessionCatalogService catalog) =>
-        TypedResults.Ok(catalog.ListRecent(limit: 50))).RequireAuthorization();
+        TypedResults.Ok(catalog.ListRecent(limit: 50)))
+        .WithName("ListSessions")
+        .WithSummary("List the most recent sessions.")
+        .WithTags("Sessions")
+        .RequireAuthorization();
     app.MapGet("/api/stats", async ValueTask<Ok<DaemonStats.Response>> (DaemonStatsService statsService, int? days, CancellationToken ct) =>
-        TypedResults.Ok(await statsService.GetStatsAsync(days, ct))).RequireAuthorization();
+        TypedResults.Ok(await statsService.GetStatsAsync(days, ct)))
+        .WithName("GetStats")
+        .WithSummary("Get daemon usage statistics over the requested window.")
+        .WithTags("Stats")
+        .RequireAuthorization();
     app.MapGet("/api/stats/skills", async ValueTask<Ok<SkillUsageStats.Response>> (DaemonStatsService statsService, int? days, CancellationToken ct) =>
-        TypedResults.Ok(await statsService.GetSkillUsageStatsAsync(days, ct))).RequireAuthorization();
+        TypedResults.Ok(await statsService.GetSkillUsageStatsAsync(days, ct)))
+        .WithName("GetSkillUsageStats")
+        .WithSummary("Get per-skill usage statistics over the requested window.")
+        .WithTags("Stats")
+        .RequireAuthorization();
     app.MapWebhookEndpoints();
     app.MapMattermostActionEndpoint();
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -206,7 +206,12 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     app.UseAuthorization();
     app.UseRateLimiter();
 
-    app.MapOpenApi();
+    // Require authorization for the OpenAPI document so the full API surface is not
+    // exposed to unauthenticated callers when the daemon binds to a non-loopback
+    // address (e.g. ExposureMode.ReverseProxy). Loopback callers are still served:
+    // the AuthSelector routes them to LoopbackAuthenticationHandler, which issues an
+    // authenticated Operator ticket that satisfies the default policy.
+    app.MapOpenApi().RequireAuthorization();
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -135,6 +135,9 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     builder.Services.AddNetclawAuthSchemes(daemonConfig);
     builder.Services.AddAuthorization();
 
+    // Add OpenAPI
+    builder.Services.AddOpenApi();
+
     // Rate limiting for the unauthenticated pairing exchange endpoint.
     // 5 attempts per minute per IP — brute-force defense for the 8-char code space.
     builder.Services.AddRateLimiter(options =>
@@ -202,6 +205,8 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     app.UseAuthentication();
     app.UseAuthorization();
     app.UseRateLimiter();
+
+    app.MapOpenApi();
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -8,6 +8,7 @@ using Akka.Actor;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Sql.Hosting;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
@@ -204,15 +205,15 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");
-    app.MapGet("/api/health/ready", () => Results.Ok("healthy"));
-    app.MapGet("/api/health/status", async (DaemonRuntimeStatusService statusService, CancellationToken cancellationToken) =>
-        Results.Ok(await statusService.GetStatusAsync(cancellationToken))).RequireAuthorization();
+    app.MapGet("/api/health/ready", () => TypedResults.Ok("healthy"));
+    app.MapGet("/api/health/status", async ValueTask<Ok<DaemonRuntimeStatus.Response>> (DaemonRuntimeStatusService statusService, CancellationToken cancellationToken) =>
+        TypedResults.Ok(await statusService.GetStatusAsync(cancellationToken))).RequireAuthorization();
     app.MapGet("/api/sessions", (SessionCatalogService catalog) =>
-        Results.Ok(catalog.ListRecent(limit: 50))).RequireAuthorization();
-    app.MapGet("/api/stats", async (DaemonStatsService statsService, int? days, CancellationToken ct) =>
-        Results.Ok(await statsService.GetStatsAsync(days, ct))).RequireAuthorization();
-    app.MapGet("/api/stats/skills", async (DaemonStatsService statsService, int? days, CancellationToken ct) =>
-        Results.Ok(await statsService.GetSkillUsageStatsAsync(days, ct))).RequireAuthorization();
+        TypedResults.Ok(catalog.ListRecent(limit: 50))).RequireAuthorization();
+    app.MapGet("/api/stats", async ValueTask<Ok<DaemonStats.Response>> (DaemonStatsService statsService, int? days, CancellationToken ct) =>
+        TypedResults.Ok(await statsService.GetStatsAsync(days, ct))).RequireAuthorization();
+    app.MapGet("/api/stats/skills", async ValueTask<Ok<SkillUsageStats.Response>> (DaemonStatsService statsService, int? days, CancellationToken ct) =>
+        TypedResults.Ok(await statsService.GetSkillUsageStatsAsync(days, ct))).RequireAuthorization();
     app.MapWebhookEndpoints();
     app.MapMattermostActionEndpoint();
 

--- a/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
@@ -1,33 +1,59 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ProviderOAuthEndpointRouteBuilderExtensions.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Netclaw.Providers;
 using Netclaw.Providers.OAuth;
 
 namespace Netclaw.Daemon.Providers;
 
+/// <summary>Query string identifying which provider's OAuth flow to start.</summary>
+internal sealed record ProviderOAuthStartQuery([FromQuery(Name = "provider")] string? Provider);
+
+/// <summary>Query string for the provider OAuth browser callback.</summary>
+internal sealed record ProviderOAuthCallbackQuery(
+    [FromQuery(Name = "code")] string? Code,
+    [FromQuery(Name = "state")] string? State);
+
+/// <summary>Authorization URL and opaque state returned when a provider OAuth flow starts.</summary>
+internal sealed record ProviderOAuthStartResponse(string AuthorizationUrl, string State);
+
+/// <summary>
+/// Status of a provider OAuth flow. Tokens are only populated for loopback callers;
+/// remote paired devices see boolean flags only to prevent credential exfiltration.
+/// </summary>
+internal sealed record ProviderOAuthStatusResponse(
+    string Status,
+    bool HasToken,
+    string? AccessToken,
+    string? RefreshToken,
+    string? ExpiresAt);
+
+/// <summary>Error payload returned when a provider OAuth request is malformed or unknown.</summary>
+internal sealed record ProviderOAuthErrorResponse(string Error);
+
 internal static class ProviderOAuthEndpointRouteBuilderExtensions
 {
     public static IEndpointRouteBuilder MapProviderOAuthEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/provider/oauth/start", (
-            HttpContext context,
+        app.MapPost("/api/provider/oauth/start", Results<Ok<ProviderOAuthStartResponse>, BadRequest<ProviderOAuthErrorResponse>, NotFound<ProviderOAuthErrorResponse>> (
+            [AsParameters] ProviderOAuthStartQuery query,
             OAuthPkceService pkceService,
             ProviderDescriptorRegistry registry,
             IProviderOAuthCallbackListener callbackListener) =>
         {
-            var providerType = context.Request.Query["provider"].ToString();
-            if (string.IsNullOrEmpty(providerType))
-                return Results.BadRequest(new { error = "Missing 'provider' query parameter" });
+            if (string.IsNullOrEmpty(query.Provider))
+                return TypedResults.BadRequest(new ProviderOAuthErrorResponse("Missing 'provider' query parameter"));
 
-            if (!registry.TryGet(providerType, out var descriptor))
-                return Results.NotFound(new { error = $"Unknown provider type: {providerType}" });
+            if (!registry.TryGet(query.Provider, out var descriptor))
+                return TypedResults.NotFound(new ProviderOAuthErrorResponse($"Unknown provider type: {query.Provider}"));
 
             var oauth = descriptor.Auth.GetOAuthConfig();
             if (oauth is null || oauth.AuthorizationEndpoint is null || oauth.RedirectUri is null)
-                return Results.BadRequest(new { error = $"Provider '{providerType}' does not support browser OAuth" });
+                return TypedResults.BadRequest(new ProviderOAuthErrorResponse($"Provider '{query.Provider}' does not support browser OAuth"));
 
             var (authUrl, state) = pkceService.StartAuthorizationFlow(
                 oauth.AuthorizationEndpoint.AbsoluteUri,
@@ -39,38 +65,35 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
 
             callbackListener.StartListening(oauth.RedirectUri.AbsoluteUri, state);
 
-            return Results.Ok(new { authorizationUrl = authUrl, state });
+            return TypedResults.Ok(new ProviderOAuthStartResponse(authUrl, state));
         }).RequireAuthorization();
 
-        app.MapGet("/api/provider/oauth/callback", async (
-            HttpContext context,
+        app.MapGet("/api/provider/oauth/callback", async ValueTask<ContentHttpResult> (
+            [AsParameters] ProviderOAuthCallbackQuery query,
             OAuthPkceService pkceService,
             CancellationToken ct) =>
         {
-            var code = context.Request.Query["code"].ToString();
-            var state = context.Request.Query["state"].ToString();
-
-            if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+            if (string.IsNullOrEmpty(query.Code) || string.IsNullOrEmpty(query.State))
             {
-                context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(
-                    "<html><body><h2>Authorization failed</h2><p>Missing code or state parameter.</p></body></html>", ct);
-                return;
+                return TypedResults.Content(
+                    "<html><body><h2>Authorization failed</h2><p>Missing code or state parameter.</p></body></html>",
+                    "text/html");
             }
 
             try
             {
-                await pkceService.CompleteAuthorizationAsync(code, state, ct);
-                context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(
-                    "<html><body><h2>Authorization complete</h2><p>You may close this tab and return to the terminal.</p></body></html>", ct);
+                await pkceService.CompleteAuthorizationAsync(query.Code, query.State, ct);
+                return TypedResults.Content(
+                    "<html><body><h2>Authorization complete</h2><p>You may close this tab and return to the terminal.</p></body></html>",
+                    "text/html");
             }
             catch (Exception ex)
             {
-                context.Response.StatusCode = 500;
-                context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(
-                    $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>", ct);
+                return TypedResults.Content(
+                    $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>",
+                    "text/html",
+                    contentEncoding: null,
+                    statusCode: StatusCodes.Status500InternalServerError);
             }
         }).AllowAnonymous();
 
@@ -87,14 +110,12 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
             var remoteIp = httpContext.Connection.RemoteIpAddress;
             var isLoopback = remoteIp is not null && System.Net.IPAddress.IsLoopback(remoteIp);
 
-            return Results.Ok(new
-            {
-                status = status.ToString(),
-                hasToken = result is not null,
-                accessToken = isLoopback ? result?.AccessToken.Value : null,
-                refreshToken = isLoopback ? result?.RefreshToken?.Value : null,
-                expiresAt = result?.ExpiresAt?.ToString("o"),
-            });
+            return TypedResults.Ok(new ProviderOAuthStatusResponse(
+                Status: status.ToString(),
+                HasToken: result is not null,
+                AccessToken: isLoopback ? result?.AccessToken.Value : null,
+                RefreshToken: isLoopback ? result?.RefreshToken?.Value : null,
+                ExpiresAt: result?.ExpiresAt?.ToString("o")));
         }).RequireAuthorization();
 
         return app;

--- a/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
@@ -66,7 +66,11 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
             callbackListener.StartListening(oauth.RedirectUri.AbsoluteUri, state);
 
             return TypedResults.Ok(new ProviderOAuthStartResponse(authUrl, state));
-        }).RequireAuthorization();
+        })
+        .WithName("StartProviderOAuth")
+        .WithSummary("Start a browser OAuth authorization flow for a model provider.")
+        .WithTags("Provider OAuth")
+        .RequireAuthorization();
 
         app.MapGet("/api/provider/oauth/callback", async ValueTask<ContentHttpResult> (
             [AsParameters] ProviderOAuthCallbackQuery query,
@@ -95,7 +99,11 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
                     contentEncoding: null,
                     statusCode: StatusCodes.Status500InternalServerError);
             }
-        }).AllowAnonymous();
+        })
+        .WithName("ProviderOAuthCallback")
+        .WithSummary("Browser redirect callback that completes a provider OAuth flow.")
+        .WithTags("Provider OAuth")
+        .AllowAnonymous();
 
         app.MapGet("/api/provider/oauth/status/{state}", (
             string state,
@@ -116,7 +124,11 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
                 AccessToken: isLoopback ? result?.AccessToken.Value : null,
                 RefreshToken: isLoopback ? result?.RefreshToken?.Value : null,
                 ExpiresAt: result?.ExpiresAt?.ToString("o")));
-        }).RequireAuthorization();
+        })
+        .WithName("GetProviderOAuthStatus")
+        .WithSummary("Get the status (and, over loopback, tokens) of a provider OAuth flow.")
+        .WithTags("Provider OAuth")
+        .RequireAuthorization();
 
         return app;
     }

--- a/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Actors.Channels;
@@ -24,29 +25,27 @@ public static class ReminderEndpointRouteBuilderExtensions
         var reminders = app.MapGroup("/api/reminders")
             .RequireAuthorization();
 
-        reminders.MapGet("", async (
+        reminders.MapGet("", async ValueTask<Ok<IEnumerable<ReminderSummaryDto>>> (
             IRequiredActor<ReminderManagerActorKey> actor,
             CancellationToken ct) =>
         {
             var manager = await actor.GetAsync(ct);
             var response = await manager.Ask<ReminderListResponse>(
                 new ListRemindersCommand(IncludeDisabled: false), TimeSpan.FromSeconds(10), ct);
-            var projected = response.Reminders.Select(r => new
-            {
-                id = r.Id.Value,
-                title = r.Title,
-                enabled = r.Enabled,
-                schedule = ListRemindersTool.DescribeSchedule(r.Schedule),
-                nextFire = SetReminderTool.FormatTimestamp(r.NextFire),
-                expiresAt = r.ExpiresAt is null
+            var projected = response.Reminders.Select(r => new ReminderSummaryDto(
+                Id: r.Id.Value,
+                Title: r.Title,
+                Enabled: r.Enabled,
+                Schedule: ListRemindersTool.DescribeSchedule(r.Schedule),
+                NextFire: SetReminderTool.FormatTimestamp(r.NextFire),
+                ExpiresAt: r.ExpiresAt is null
                     ? null
                     : SetReminderTool.FormatTimestamp(r.ExpiresAt),
-                audience = r.Audience?.ToWireValue(),
-            });
-            return Results.Ok(projected);
+                Audience: r.Audience?.ToWireValue()));
+            return TypedResults.Ok(projected);
         });
 
-        reminders.MapPost("", async (
+        reminders.MapPost("", async ValueTask<Results<Ok<ReminderMessageResponse>, BadRequest<ReminderErrorResponse>, ProblemHttpResult>> (
             CreateReminderRequest request,
             IRequiredActor<ReminderManagerActorKey> actor,
             IServiceProvider serviceProvider,
@@ -63,7 +62,7 @@ public static class ReminderEndpointRouteBuilderExtensions
             // audience is now required and non-nullable, so a null authorization would otherwise
             // be silently defaulted, smuggling the request past the actor's authority check.
             if (authorization?.SourceAudience is not { } reminderSourceAudience)
-                return Results.Problem(
+                return TypedResults.Problem(
                     detail: "Creating a reminder requires Operator authority.",
                     statusCode: StatusCodes.Status403Forbidden);
 
@@ -102,11 +101,11 @@ public static class ReminderEndpointRouteBuilderExtensions
                 }, toolContext, ct);
 
             return result.StartsWith("Error", StringComparison.Ordinal)
-                ? Results.BadRequest(new { error = result })
-                : Results.Ok(new { message = result });
+                ? TypedResults.BadRequest(new ReminderErrorResponse(result))
+                : TypedResults.Ok(new ReminderMessageResponse(result));
         });
 
-        reminders.MapPost("/validate", (
+        reminders.MapPost("/validate", Results<Ok<ReminderValidationSuccessResponse>, BadRequest<ReminderValidationErrorResponse>> (
             CreateReminderRequest request,
             TimeProvider timeProvider) =>
         {
@@ -116,12 +115,15 @@ public static class ReminderEndpointRouteBuilderExtensions
                 timeProvider);
 
             if (schedule is null)
-                return Results.BadRequest(new { valid = false, error });
+                return TypedResults.BadRequest(new ReminderValidationErrorResponse(Valid: false, Error: error));
 
-            return Results.Ok(new { valid = true, scheduleType = schedule.Type.ToString(), nextFire = schedule.FireAt });
+            return TypedResults.Ok(new ReminderValidationSuccessResponse(
+                Valid: true,
+                ScheduleType: schedule.Type.ToString(),
+                NextFire: schedule.FireAt));
         });
 
-        reminders.MapPost("/import", async (
+        reminders.MapPost("/import", async ValueTask<Results<Ok<ReminderImportResponse>, BadRequest<ReminderErrorResponse>, JsonHttpResult<ReminderImportErrorResponse>>> (
             ImportReminderRequest request,
             IRequiredActor<ReminderManagerActorKey> actor,
             ClaimsPrincipalMapper mapper,
@@ -129,7 +131,7 @@ public static class ReminderEndpointRouteBuilderExtensions
             CancellationToken ct) =>
         {
             if (request.Definition is null)
-                return Results.BadRequest(new { error = "Reminder definition is required." });
+                return TypedResults.BadRequest(new ReminderErrorResponse("Reminder definition is required."));
 
             var authorization = ResolveReminderAuthorizationContext(mapper, httpContext);
 
@@ -142,7 +144,7 @@ public static class ReminderEndpointRouteBuilderExtensions
             };
 
             if (mode is null)
-                return Results.BadRequest(new { error = "Invalid writeMode. Use create, replace, or upsert." });
+                return TypedResults.BadRequest(new ReminderErrorResponse("Invalid writeMode. Use create, replace, or upsert."));
 
             var manager = await actor.GetAsync(ct);
             var response = await manager.Ask<ReminderSavedResponse>(
@@ -158,24 +160,22 @@ public static class ReminderEndpointRouteBuilderExtensions
                         ? StatusCodes.Status404NotFound
                         : StatusCodes.Status400BadRequest;
 
-                return Results.Json(new
-                {
-                    error = response.ErrorMessage ?? "Import failed.",
-                    code = response.Error.ToString(),
-                    id = response.Id.Value
-                }, statusCode: status);
+                return TypedResults.Json(
+                    new ReminderImportErrorResponse(
+                        Error: response.ErrorMessage ?? "Import failed.",
+                        Code: response.Error.ToString(),
+                        Id: response.Id.Value),
+                    statusCode: status);
             }
 
-            return Results.Ok(new
-            {
-                id = response.Id.Value,
-                title = response.Title,
-                nextFire = response.NextFire,
-                message = $"Imported reminder '{response.Id.Value}'."
-            });
+            return TypedResults.Ok(new ReminderImportResponse(
+                Id: response.Id.Value,
+                Title: response.Title,
+                NextFire: response.NextFire,
+                Message: $"Imported reminder '{response.Id.Value}'."));
         });
 
-        reminders.MapDelete("/{id}", async (
+        reminders.MapDelete("/{id}", async ValueTask<Results<Ok<ReminderMessageResponse>, NotFound<ReminderErrorResponse>>> (
             string id,
             bool? permanent,
             IRequiredActor<ReminderManagerActorKey> actor,
@@ -191,8 +191,8 @@ public static class ReminderEndpointRouteBuilderExtensions
                     TimeSpan.FromSeconds(10), ct);
 
                 return deleted.Found
-                    ? Results.Ok(new { message = $"Reminder '{id}' permanently deleted." })
-                    : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+                    ? TypedResults.Ok(new ReminderMessageResponse($"Reminder '{id}' permanently deleted."))
+                    : TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
             }
 
             var response = await manager.Ask<ReminderCancelledResponse>(
@@ -200,11 +200,11 @@ public static class ReminderEndpointRouteBuilderExtensions
                 TimeSpan.FromSeconds(10), ct);
 
             return response.Found
-                ? Results.Ok(new { message = $"Reminder '{id}' cancelled (disabled)." })
-                : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+                ? TypedResults.Ok(new ReminderMessageResponse($"Reminder '{id}' cancelled (disabled)."))
+                : TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
         });
 
-        reminders.MapPost("/{id}/disable", async (
+        reminders.MapPost("/{id}/disable", async ValueTask<Results<Ok<ReminderDisableResponse>, NotFound<ReminderErrorResponse>>> (
             string id,
             IRequiredActor<ReminderManagerActorKey> actor,
             CancellationToken ct) =>
@@ -216,11 +216,11 @@ public static class ReminderEndpointRouteBuilderExtensions
                 ct);
 
             return !response.Found
-                ? Results.NotFound(new { error = response.ErrorMessage ?? $"Reminder '{id}' not found." })
-                : Results.Ok(new { id = id, enabled = response.Enabled, message = $"Reminder '{id}' disabled." });
+                ? TypedResults.NotFound(new ReminderErrorResponse(response.ErrorMessage ?? $"Reminder '{id}' not found."))
+                : TypedResults.Ok(new ReminderDisableResponse(id, response.Enabled, $"Reminder '{id}' disabled."));
         });
 
-        reminders.MapPost("/{id}/enable", async (
+        reminders.MapPost("/{id}/enable", async ValueTask<Results<Ok<ReminderEnableResponse>, NotFound<ReminderErrorResponse>, BadRequest<ReminderEnableErrorResponse>>> (
             string id,
             IRequiredActor<ReminderManagerActorKey> actor,
             CancellationToken ct) =>
@@ -232,14 +232,14 @@ public static class ReminderEndpointRouteBuilderExtensions
                 ct);
 
             if (!response.Found)
-                return Results.NotFound(new { error = response.ErrorMessage ?? $"Reminder '{id}' not found." });
+                return TypedResults.NotFound(new ReminderErrorResponse(response.ErrorMessage ?? $"Reminder '{id}' not found."));
             if (!response.Enabled && !string.IsNullOrWhiteSpace(response.ErrorMessage))
-                return Results.BadRequest(new { error = response.ErrorMessage, id, enabled = false });
+                return TypedResults.BadRequest(new ReminderEnableErrorResponse(response.ErrorMessage, id, Enabled: false));
 
-            return Results.Ok(new { id, enabled = response.Enabled, nextFire = response.NextFire, message = $"Reminder '{id}' enabled." });
+            return TypedResults.Ok(new ReminderEnableResponse(id, response.Enabled, response.NextFire, $"Reminder '{id}' enabled."));
         });
 
-        reminders.MapGet("/{id}", async (
+        reminders.MapGet("/{id}", async ValueTask<Results<Ok<ReminderDetailDto>, NotFound<ReminderErrorResponse>>> (
             string id,
             IRequiredActor<ReminderManagerActorKey> actor,
             CancellationToken ct) =>
@@ -250,30 +250,28 @@ public static class ReminderEndpointRouteBuilderExtensions
                 TimeSpan.FromSeconds(10), ct);
 
             if (response.Reminder is null)
-                return Results.NotFound(new { error = $"Reminder '{id}' not found." });
+                return TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
 
             var r = response.Reminder;
-            return Results.Ok(new
-            {
-                id = r.Id.Value,
-                title = r.Title,
-                enabled = r.Enabled,
-                schedule = ListRemindersTool.DescribeSchedule(r.Schedule),
-                nextFire = SetReminderTool.FormatTimestamp(r.NextFire),
-                expiresAt = r.ExpiresAt is null
+            return TypedResults.Ok(new ReminderDetailDto(
+                Id: r.Id.Value,
+                Title: r.Title,
+                Enabled: r.Enabled,
+                Schedule: ListRemindersTool.DescribeSchedule(r.Schedule),
+                NextFire: SetReminderTool.FormatTimestamp(r.NextFire),
+                ExpiresAt: r.ExpiresAt is null
                     ? null
                     : SetReminderTool.FormatTimestamp(r.ExpiresAt),
-                instructions = r.Instructions,
-                deliveryKind = r.Delivery.Kind.ToString().ToLowerInvariant(),
-                deliveryTransport = r.Delivery.Transport,
-                deliveryAddress = r.Delivery.Address,
-                deliveryRequired = r.DeliveryRequired,
-                deliveryInstructions = r.DeliveryInstructions,
-                audience = r.Audience?.ToWireValue(),
-            });
+                Instructions: r.Instructions,
+                DeliveryKind: r.Delivery.Kind.ToString().ToLowerInvariant(),
+                DeliveryTransport: r.Delivery.Transport,
+                DeliveryAddress: r.Delivery.Address,
+                DeliveryRequired: r.DeliveryRequired,
+                DeliveryInstructions: r.DeliveryInstructions,
+                Audience: r.Audience?.ToWireValue()));
         });
 
-        reminders.MapGet("/{id}/history", async (
+        reminders.MapGet("/{id}/history", async ValueTask<Results<Ok<IReadOnlyList<HistoryRecord>>, NotFound<ReminderErrorResponse>>> (
             string id,
             int? last,
             ReminderDefinitionStore definitionStore,
@@ -282,11 +280,11 @@ public static class ReminderEndpointRouteBuilderExtensions
         {
             var rid = new ReminderId(id);
             if (!definitionStore.Exists(rid))
-                return Results.NotFound(new { error = $"Reminder '{id}' not found." });
+                return TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
 
             var maxRecords = Math.Clamp(last ?? 20, 1, 500);
             var records = await historyStore.ReadAsync(rid, maxRecords);
-            return Results.Ok(records);
+            return TypedResults.Ok(records);
         });
 
         return app;
@@ -336,3 +334,56 @@ internal sealed record ImportReminderRequest
     public required ReminderDefinition Definition { get; init; }
     public string? WriteMode { get; init; }
 }
+
+/// <summary>Summary projection of a reminder returned by the list endpoint.</summary>
+internal sealed record ReminderSummaryDto(
+    string Id,
+    string Title,
+    bool Enabled,
+    string Schedule,
+    string NextFire,
+    string? ExpiresAt,
+    string? Audience);
+
+/// <summary>Full reminder projection returned by <c>GET /api/reminders/{id}</c>.</summary>
+internal sealed record ReminderDetailDto(
+    string Id,
+    string Title,
+    bool Enabled,
+    string Schedule,
+    string NextFire,
+    string? ExpiresAt,
+    string Instructions,
+    string DeliveryKind,
+    string? DeliveryTransport,
+    string? DeliveryAddress,
+    bool DeliveryRequired,
+    string? DeliveryInstructions,
+    string? Audience);
+
+/// <summary>Acknowledgement carrying a human-readable message.</summary>
+internal sealed record ReminderMessageResponse(string Message);
+
+/// <summary>Error payload returned when a reminder request fails.</summary>
+internal sealed record ReminderErrorResponse(string Error);
+
+/// <summary>Successful schedule validation result.</summary>
+internal sealed record ReminderValidationSuccessResponse(bool Valid, string ScheduleType, DateTimeOffset? NextFire);
+
+/// <summary>Failed schedule validation result.</summary>
+internal sealed record ReminderValidationErrorResponse(bool Valid, string? Error);
+
+/// <summary>Successful reminder import acknowledgement.</summary>
+internal sealed record ReminderImportResponse(string Id, string Title, DateTimeOffset? NextFire, string Message);
+
+/// <summary>Failure detail for a rejected reminder import.</summary>
+internal sealed record ReminderImportErrorResponse(string Error, string Code, string Id);
+
+/// <summary>State of a reminder after a disable request.</summary>
+internal sealed record ReminderDisableResponse(string Id, bool Enabled, string Message);
+
+/// <summary>State of a reminder after an enable request.</summary>
+internal sealed record ReminderEnableResponse(string Id, bool Enabled, DateTimeOffset? NextFire, string Message);
+
+/// <summary>Failure detail for a rejected enable request.</summary>
+internal sealed record ReminderEnableErrorResponse(string? Error, string Id, bool Enabled);

--- a/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
@@ -23,6 +23,7 @@ public static class ReminderEndpointRouteBuilderExtensions
     public static IEndpointRouteBuilder MapReminderEndpoints(this IEndpointRouteBuilder app)
     {
         var reminders = app.MapGroup("/api/reminders")
+            .WithTags("Reminders")
             .RequireAuthorization();
 
         reminders.MapGet("", async ValueTask<Ok<IEnumerable<ReminderSummaryDto>>> (
@@ -43,7 +44,9 @@ public static class ReminderEndpointRouteBuilderExtensions
                     : SetReminderTool.FormatTimestamp(r.ExpiresAt),
                 Audience: r.Audience?.ToWireValue()));
             return TypedResults.Ok(projected);
-        });
+        })
+        .WithName("ListReminders")
+        .WithSummary("List all active reminders.");
 
         reminders.MapPost("", async ValueTask<Results<Ok<ReminderMessageResponse>, BadRequest<ReminderErrorResponse>, ProblemHttpResult>> (
             CreateReminderRequest request,
@@ -103,7 +106,9 @@ public static class ReminderEndpointRouteBuilderExtensions
             return result.StartsWith("Error", StringComparison.Ordinal)
                 ? TypedResults.BadRequest(new ReminderErrorResponse(result))
                 : TypedResults.Ok(new ReminderMessageResponse(result));
-        });
+        })
+        .WithName("CreateReminder")
+        .WithSummary("Create a reminder (requires Operator authority).");
 
         reminders.MapPost("/validate", Results<Ok<ReminderValidationSuccessResponse>, BadRequest<ReminderValidationErrorResponse>> (
             CreateReminderRequest request,
@@ -121,7 +126,9 @@ public static class ReminderEndpointRouteBuilderExtensions
                 Valid: true,
                 ScheduleType: schedule.Type.ToString(),
                 NextFire: schedule.FireAt));
-        });
+        })
+        .WithName("ValidateReminderSchedule")
+        .WithSummary("Validate a reminder schedule without persisting it.");
 
         reminders.MapPost("/import", async ValueTask<Results<Ok<ReminderImportResponse>, BadRequest<ReminderErrorResponse>, JsonHttpResult<ReminderImportErrorResponse>>> (
             ImportReminderRequest request,
@@ -173,7 +180,9 @@ public static class ReminderEndpointRouteBuilderExtensions
                 Title: response.Title,
                 NextFire: response.NextFire,
                 Message: $"Imported reminder '{response.Id.Value}'."));
-        });
+        })
+        .WithName("ImportReminder")
+        .WithSummary("Import a reminder definition with the requested write mode.");
 
         reminders.MapDelete("/{id}", async ValueTask<Results<Ok<ReminderMessageResponse>, NotFound<ReminderErrorResponse>>> (
             string id,
@@ -202,7 +211,9 @@ public static class ReminderEndpointRouteBuilderExtensions
             return response.Found
                 ? TypedResults.Ok(new ReminderMessageResponse($"Reminder '{id}' cancelled (disabled)."))
                 : TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
-        });
+        })
+        .WithName("DeleteReminder")
+        .WithSummary("Cancel a reminder, or permanently delete it with ?permanent=true.");
 
         reminders.MapPost("/{id}/disable", async ValueTask<Results<Ok<ReminderDisableResponse>, NotFound<ReminderErrorResponse>>> (
             string id,
@@ -218,7 +229,9 @@ public static class ReminderEndpointRouteBuilderExtensions
             return !response.Found
                 ? TypedResults.NotFound(new ReminderErrorResponse(response.ErrorMessage ?? $"Reminder '{id}' not found."))
                 : TypedResults.Ok(new ReminderDisableResponse(id, response.Enabled, $"Reminder '{id}' disabled."));
-        });
+        })
+        .WithName("DisableReminder")
+        .WithSummary("Disable a reminder without deleting it.");
 
         reminders.MapPost("/{id}/enable", async ValueTask<Results<Ok<ReminderEnableResponse>, NotFound<ReminderErrorResponse>, BadRequest<ReminderEnableErrorResponse>>> (
             string id,
@@ -237,7 +250,9 @@ public static class ReminderEndpointRouteBuilderExtensions
                 return TypedResults.BadRequest(new ReminderEnableErrorResponse(response.ErrorMessage, id, Enabled: false));
 
             return TypedResults.Ok(new ReminderEnableResponse(id, response.Enabled, response.NextFire, $"Reminder '{id}' enabled."));
-        });
+        })
+        .WithName("EnableReminder")
+        .WithSummary("Re-enable a previously disabled reminder.");
 
         reminders.MapGet("/{id}", async ValueTask<Results<Ok<ReminderDetailDto>, NotFound<ReminderErrorResponse>>> (
             string id,
@@ -269,7 +284,9 @@ public static class ReminderEndpointRouteBuilderExtensions
                 DeliveryRequired: r.DeliveryRequired,
                 DeliveryInstructions: r.DeliveryInstructions,
                 Audience: r.Audience?.ToWireValue()));
-        });
+        })
+        .WithName("GetReminder")
+        .WithSummary("Get a single reminder's full definition.");
 
         reminders.MapGet("/{id}/history", async ValueTask<Results<Ok<IReadOnlyList<HistoryRecord>>, NotFound<ReminderErrorResponse>>> (
             string id,
@@ -285,7 +302,9 @@ public static class ReminderEndpointRouteBuilderExtensions
             var maxRecords = Math.Clamp(last ?? 20, 1, 500);
             var records = await historyStore.ReadAsync(rid, maxRecords);
             return TypedResults.Ok(records);
-        });
+        })
+        .WithName("GetReminderHistory")
+        .WithSummary("Get recent fire history for a reminder.");
 
         return app;
     }

--- a/src/Netclaw.Daemon/Security/PairingEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Security/PairingEndpointRouteBuilderExtensions.cs
@@ -81,7 +81,11 @@ public static class PairingEndpointRouteBuilderExtensions
             }
 
             return TypedResults.Ok(new PairingTokenResponse(rawToken));
-        }).RequireRateLimiting("pairing-exchange").AllowAnonymous();
+        })
+        .WithName("ExchangePairingCode")
+        .WithSummary("Exchange a pairing code for a device bearer token.")
+        .WithTags("Pairing")
+        .RequireRateLimiting("pairing-exchange").AllowAnonymous();
 
         // Device registry management — authenticated (loopback or valid bearer token required).
         // Returns a sanitized view of paired devices (no TokenHash/Salt).
@@ -90,7 +94,11 @@ public static class PairingEndpointRouteBuilderExtensions
             var devices = await deviceRegistry.ListAsync(ct);
             var sanitized = devices.Select(d => new PairedDeviceInfoDto(d.Name, d.CreatedAt, d.LastUsedAt));
             return TypedResults.Ok(sanitized);
-        }).RequireAuthorization();
+        })
+        .WithName("ListPairedDevices")
+        .WithSummary("List paired devices (token material excluded).")
+        .WithTags("Pairing")
+        .RequireAuthorization();
 
         app.MapDelete("/api/pair/devices/{name}", async ValueTask<Results<NoContent, NotFound<PairingErrorResponse>>> (string name, DeviceRegistry deviceRegistry, CancellationToken ct) =>
         {
@@ -98,7 +106,11 @@ public static class PairingEndpointRouteBuilderExtensions
             return removed
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound(new PairingErrorResponse($"Device '{name}' not found."));
-        }).RequireAuthorization();
+        })
+        .WithName("RemovePairedDevice")
+        .WithSummary("Remove a paired device by name.")
+        .WithTags("Pairing")
+        .RequireAuthorization();
 
         return app;
     }

--- a/src/Netclaw.Daemon/Security/PairingEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Security/PairingEndpointRouteBuilderExtensions.cs
@@ -6,6 +6,7 @@
 using System.Buffers.Text;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
 using Netclaw.Configuration;
 
@@ -17,7 +18,7 @@ public static class PairingEndpointRouteBuilderExtensions
     {
         // Device pairing exchange — unauthenticated, rate-limited, with per-IP lockout guard.
         // Accepts a time-limited pairing code and a device name; returns a bearer token on success.
-        app.MapPost("/api/pair/exchange", async (
+        app.MapPost("/api/pair/exchange", async ValueTask<Results<Ok<PairingTokenResponse>, BadRequest<PairingErrorResponse>, NotFound, Conflict<PairingErrorResponse>, JsonHttpResult<PairingErrorResponse>>> (
             HttpContext httpContext,
             PairingCodeExchangeRequest request,
             PairingCodeService pairingCodeService,
@@ -33,23 +34,23 @@ public static class PairingEndpointRouteBuilderExtensions
             {
                 var retryAfter = exchangeGuard.GetRetryAfterSeconds(remoteIp);
                 httpContext.Response.Headers.RetryAfter = retryAfter?.ToString() ?? "900";
-                return Results.Json(
-                    new { error = "Too many failed attempts. Try again later." },
+                return TypedResults.Json(
+                    new PairingErrorResponse("Too many failed attempts. Try again later."),
                     statusCode: StatusCodes.Status429TooManyRequests);
             }
 
             // Layer 2: No-code-pending gate — if no code exists, hide the endpoint entirely.
             if (pairingCodeService.GetPendingExpiry() is null)
-                return Results.NotFound();
+                return TypedResults.NotFound();
 
             if (string.IsNullOrWhiteSpace(request.Code) || string.IsNullOrWhiteSpace(request.DeviceName))
-                return Results.BadRequest(new { error = "code and deviceName are required." });
+                return TypedResults.BadRequest(new PairingErrorResponse("code and deviceName are required."));
 
             if (!pairingCodeService.TryConsume(request.Code))
             {
                 exchangeGuard.RecordFailure(remoteIp);
-                return Results.Json(
-                    new { error = "Invalid, expired, or already-used pairing code." },
+                return TypedResults.Json(
+                    new PairingErrorResponse("Invalid, expired, or already-used pairing code."),
                     statusCode: StatusCodes.Status401Unauthorized);
             }
 
@@ -76,27 +77,27 @@ public static class PairingEndpointRouteBuilderExtensions
             }
             catch (InvalidOperationException ex)
             {
-                return Results.Conflict(new { error = ex.Message });
+                return TypedResults.Conflict(new PairingErrorResponse(ex.Message));
             }
 
-            return Results.Ok(new { token = rawToken });
+            return TypedResults.Ok(new PairingTokenResponse(rawToken));
         }).RequireRateLimiting("pairing-exchange").AllowAnonymous();
 
         // Device registry management — authenticated (loopback or valid bearer token required).
         // Returns a sanitized view of paired devices (no TokenHash/Salt).
-        app.MapGet("/api/pair/devices", async (DeviceRegistry deviceRegistry, CancellationToken ct) =>
+        app.MapGet("/api/pair/devices", async ValueTask<Ok<IEnumerable<PairedDeviceInfoDto>>> (DeviceRegistry deviceRegistry, CancellationToken ct) =>
         {
             var devices = await deviceRegistry.ListAsync(ct);
             var sanitized = devices.Select(d => new PairedDeviceInfoDto(d.Name, d.CreatedAt, d.LastUsedAt));
-            return Results.Ok(sanitized);
+            return TypedResults.Ok(sanitized);
         }).RequireAuthorization();
 
-        app.MapDelete("/api/pair/devices/{name}", async (string name, DeviceRegistry deviceRegistry, CancellationToken ct) =>
+        app.MapDelete("/api/pair/devices/{name}", async ValueTask<Results<NoContent, NotFound<PairingErrorResponse>>> (string name, DeviceRegistry deviceRegistry, CancellationToken ct) =>
         {
             var removed = await deviceRegistry.RemoveAsync(name, ct);
             return removed
-                ? Results.NoContent()
-                : Results.NotFound(new { error = $"Device '{name}' not found." });
+                ? TypedResults.NoContent()
+                : TypedResults.NotFound(new PairingErrorResponse($"Device '{name}' not found."));
         }).RequireAuthorization();
 
         return app;
@@ -107,3 +108,9 @@ public static class PairingEndpointRouteBuilderExtensions
 /// Request body for <c>POST /api/pair/exchange</c>.
 /// </summary>
 internal sealed record PairingCodeExchangeRequest(string Code, string DeviceName);
+
+/// <summary>Bearer token issued on a successful pairing exchange.</summary>
+internal sealed record PairingTokenResponse(string Token);
+
+/// <summary>Error payload returned when a pairing request fails.</summary>
+internal sealed record PairingErrorResponse(string Error);

--- a/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
@@ -161,7 +161,11 @@ public static class WebhookEndpointRouteBuilderExtensions
                     DeliveryId: verification.DeliveryId,
                     SessionId: sessionId.Value),
                 statusCode: StatusCodes.Status202Accepted);
-        }).AllowAnonymous();
+        })
+        .WithName("ReceiveWebhook")
+        .WithSummary("Receive, verify, and dispatch an inbound webhook delivery.")
+        .WithTags("Webhooks")
+        .AllowAnonymous();
 
         return app;
     }

--- a/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,7 +24,7 @@ public static class WebhookEndpointRouteBuilderExtensions
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("Netclaw.Daemon.Webhooks.Endpoint");
 
-        app.MapPost("/api/webhooks/{route}", async (
+        app.MapPost("/api/webhooks/{route}", async ValueTask<Results<NotFound, StatusCodeHttpResult, BadRequest<WebhookErrorResponse>, UnauthorizedHttpResult, JsonHttpResult<WebhookIgnoredResponse>, JsonHttpResult<WebhookAcceptedResponse>>> (
             string route,
             HttpContext httpContext,
             WebhookRouteCatalog routeCatalog,
@@ -36,7 +37,7 @@ public static class WebhookEndpointRouteBuilderExtensions
             CancellationToken ct) =>
         {
             if (!webhooksConfig.Enabled)
-                return Results.NotFound();
+                return TypedResults.NotFound();
 
             var remoteIp = httpContext.Connection.RemoteIpAddress?.ToString();
 
@@ -46,7 +47,7 @@ public static class WebhookEndpointRouteBuilderExtensions
                 logger.LogWarning(
                     "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                     route, "route_not_found", remoteIp, (string?)null, (string?)null);
-                return Results.NotFound();
+                return TypedResults.NotFound();
             }
 
             var bodyRead = await ReadRequestBodyAsync(httpContext.Request, registeredRoute.Config.MaxBodyBytes, ct);
@@ -57,14 +58,14 @@ public static class WebhookEndpointRouteBuilderExtensions
                     logger.LogWarning(
                         "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                         registeredRoute.Name, "body_too_large", remoteIp, (string?)null, (string?)null);
-                    return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+                    return TypedResults.StatusCode(StatusCodes.Status413PayloadTooLarge);
 
                 case WebhookBodyReadStatus.InvalidJson:
                     WebhookTelemetry.RecordInvalidJson(registeredRoute.Name);
                     logger.LogWarning(
                         "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                         registeredRoute.Name, "invalid_json", remoteIp, (string?)null, (string?)null);
-                    return Results.BadRequest(new { error = "Invalid JSON request body." });
+                    return TypedResults.BadRequest(new WebhookErrorResponse("Invalid JSON request body."));
             }
 
             var verification = verifier.Verify(registeredRoute, httpContext.Request.Headers, bodyRead.BodyBytes!);
@@ -74,7 +75,7 @@ public static class WebhookEndpointRouteBuilderExtensions
                 logger.LogWarning(
                     "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                     registeredRoute.Name, "verification_failed", remoteIp, verification.DeliveryId, verification.EventType);
-                return Results.Unauthorized();
+                return TypedResults.Unauthorized();
             }
 
             if (!registeredRoute.IsEventAllowed(verification.EventType))
@@ -83,8 +84,8 @@ public static class WebhookEndpointRouteBuilderExtensions
                 logger.LogDebug(
                     "Webhook filtered route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                     registeredRoute.Name, "event_filtered", remoteIp, verification.DeliveryId, verification.EventType);
-                return Results.Json(
-                    new { status = "ignored", reason = "event_filtered" },
+                return TypedResults.Json(
+                    new WebhookIgnoredResponse("ignored", "event_filtered"),
                     statusCode: StatusCodes.Status202Accepted);
             }
 
@@ -99,8 +100,8 @@ public static class WebhookEndpointRouteBuilderExtensions
                 logger.LogDebug(
                     "Webhook filtered route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                     registeredRoute.Name, "duplicate_delivery", remoteIp, verification.DeliveryId, verification.EventType);
-                return Results.Json(
-                    new { status = "ignored", reason = "duplicate_delivery" },
+                return TypedResults.Json(
+                    new WebhookIgnoredResponse("ignored", "duplicate_delivery"),
                     statusCode: StatusCodes.Status202Accepted);
             }
 
@@ -114,7 +115,7 @@ public static class WebhookEndpointRouteBuilderExtensions
                 if (guardDecision.RetryAfterSeconds is { } retryAfter)
                     httpContext.Response.Headers.RetryAfter = retryAfter.ToString();
 
-                return Results.StatusCode(StatusCodes.Status429TooManyRequests);
+                return TypedResults.StatusCode(StatusCodes.Status429TooManyRequests);
             }
 
             var now = timeProvider.GetUtcNow();
@@ -152,15 +153,13 @@ public static class WebhookEndpointRouteBuilderExtensions
                 }));
 
             executionService.StartInvocation(invocation);
-            return Results.Json(
-                new
-                {
-                    status = "accepted",
-                    route = registeredRoute.Name,
-                    eventType = verification.EventType,
-                    deliveryId = verification.DeliveryId,
-                    sessionId = sessionId.Value,
-                },
+            return TypedResults.Json(
+                new WebhookAcceptedResponse(
+                    Status: "accepted",
+                    Route: registeredRoute.Name,
+                    EventType: verification.EventType,
+                    DeliveryId: verification.DeliveryId,
+                    SessionId: sessionId.Value),
                 statusCode: StatusCodes.Status202Accepted);
         }).AllowAnonymous();
 
@@ -209,6 +208,20 @@ public static class WebhookEndpointRouteBuilderExtensions
             : sanitized;
     }
 }
+
+/// <summary>Error payload returned when a webhook request is malformed.</summary>
+internal sealed record WebhookErrorResponse(string Error);
+
+/// <summary>Acknowledgement that a webhook delivery was accepted but not acted on.</summary>
+internal sealed record WebhookIgnoredResponse(string Status, string Reason);
+
+/// <summary>Acknowledgement that a webhook delivery was accepted and dispatched.</summary>
+internal sealed record WebhookAcceptedResponse(
+    string Status,
+    string Route,
+    string? EventType,
+    string? DeliveryId,
+    string SessionId);
 
 internal enum WebhookBodyReadStatus
 {


### PR DESCRIPTION
Adds OpenAPI support, including updating Minimal API Endpoints to use TypedResults. This will facilitate letting agents interact with the API directly, including autogenerating an API client using Refitter for the Management UI.

OpenAPI document will be available at `http://localhost:5199/openapi/v1.json`

NOTE: I added warnings to the ignore list for the Daemon - these pop up because the default warning for public types when generating docs is very strict. I personally don't like this to be a warning or a failure, but happy to defer to you here.

Sample of what this looks like:
<img width="859" height="1264" alt="image" src="https://github.com/user-attachments/assets/e2e35939-b453-492d-bdc2-5b9a392d9ee5" />
