### PR TITLE
chore: release 0.20.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,14 +8,16 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.20.1</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.20.1 — Bug fixes for Anthropic MCP tool names, stale approval buttons, and sub-agent working directories
+    <VersionPrefix>0.20.2</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.20.2 — Outbound HTTP identity headers and MCP approval grant lookup fix
+
+**Features**
+
+* **Outbound HTTP identity headers** — every outbound HTTP request now carries a `User-Agent: Netclaw/{version}` header and an `X-Netclaw-Component` header identifying the subsystem making the call (`mcp`, `webhook`, `skill-sync`, `provider-oauth`, etc.), making Netclaw traffic identifiable to remote services and MCP server operators. `MCP clientInfo` now also reports the correct version instead of the stale `0.1.0` placeholder. ([#1145](https://github.com/netclaw-dev/netclaw/pull/1145))
 
 **Bug Fixes**
 
-* **MCP Anthropic tool-name alias** — MCP tools with `/` in their names now use an Anthropic-safe alias, fixing `BadRequest` errors on every LLM call when using Anthropic models with MCP tools. ([#1134](https://github.com/netclaw-dev/netclaw/pull/1134))
-* **Stale approval button forwarding** — Slack, Discord, and Mattermost approval buttons now correctly forward stale approval clicks back to the session instead of becoming dead/unresponsive after a turn completes. ([#1139](https://github.com/netclaw-dev/netclaw/pull/1139))
-* **Sub-agent working directory propagation** — parent's resolved `cwd` is now propagated to spawned sub-agents, fixing shell approvals showing "(no working directory)" and broken folder-scoped grant matching. ([#1130](https://github.com/netclaw-dev/netclaw/pull/1130))</PackageReleaseNotes>
+* **MCP approval grant lookup by canonical tool name** — approval grants recorded under the canonical tool name (e.g., `notion/notion-create-pages`) were not found when the lookup used the Anthropic-safe sanitized alias (e.g., `notion__notion-create-pages`), causing repeated approval prompts even after the user had approved the session. The lookup now uses the canonical name consistently, resolving the infinite re-approval loop. ([#1147](https://github.com/netclaw-dev/netclaw/pull/1147))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 0.20.2 2026-05-22 ####
+
+Netclaw v0.20.2 — Outbound HTTP identity headers and MCP approval grant lookup fix
+
+**Features**
+
+* **Outbound HTTP identity headers** — every outbound HTTP request now carries a `User-Agent: Netclaw/{version}` header and an `X-Netclaw-Component` header identifying the subsystem making the call (`mcp`, `webhook`, `skill-sync`, `provider-oauth`, etc.), making Netclaw traffic identifiable to remote services and MCP server operators. `MCP clientInfo` now also reports the correct version instead of the stale `0.1.0` placeholder. ([#1145](https://github.com/netclaw-dev/netclaw/pull/1145))
+
+**Bug Fixes**
+
+* **MCP approval grant lookup by canonical tool name** — approval grants recorded under the canonical tool name (e.g., `notion/notion-create-pages`) were not found when the lookup used the Anthropic-safe sanitized alias (e.g., `notion__notion-create-pages`), causing repeated approval prompts even after the user had approved the session. The lookup now uses the canonical name consistently, resolving the infinite re-approval loop. ([#1147](https://github.com/netclaw-dev/netclaw/pull/1147))
+
 #### 0.20.1 2026-05-21 ####
 
 Netclaw v0.20.1 — Bug fixes for Anthropic MCP tool names, stale approval buttons, and sub-agent working directories


### PR DESCRIPTION
## Release 0.20.2

This PR prepares the 0.20.2 release, which includes the following changes:

### New Features
- **HTTP User-Agent advertising**: Netclaw now advertises its `User-Agent` header and `X-Netclaw-Component` on all outbound HTTP requests (#1145)

### Bug Fixes
- **MCP approval grants**: Fixed approval grant lookups to use the canonical tool name, ensuring grants are correctly matched (#1147)
- **MCP tool name aliasing**: Exposed an Anthropic-safe alias for MCP tool names to ensure compatibility with Anthropic's tool naming requirements (#1134)
- **Channel stale approval clicks**: Stale approval clicks in channels are now correctly forwarded to the session instead of being dropped (#1139)

## Files Changed
- `RELEASE_NOTES.md` — added 0.20.2 release section
- `Directory.Build.props` — bumped version to 0.20.2