### PR TITLE
refactor(mcp): make canonical/LLM-facing tool name boundary type-enforced

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/FakeNetclawTool.cs
+++ b/src/Netclaw.Actors.Tests/Memory/FakeNetclawTool.cs
@@ -16,11 +16,13 @@ internal sealed class FakeNetclawTool : INetclawTool
     public FakeNetclawTool(string name, string result, string grantCategory = "builtin")
     {
         Name = name;
+        LlmFacingName = LlmFacingToolName.FromCanonical(name);
         _result = result;
         GrantCategory = grantCategory;
     }
 
     public string Name { get; }
+    public LlmFacingToolName LlmFacingName { get; }
     public string Description => "Fake tool";
     public string GrantCategory { get; }
     public System.Text.Json.JsonElement ParameterSchema => default;

--- a/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
@@ -171,6 +171,63 @@ public class ChatMessageConverterTests
     }
 
     [Fact]
+    public void ToAiMessage_applies_tool_name_resolver_to_FunctionCallContent_for_LLM_wire()
+    {
+        // History persists canonical names; when we rebuild the
+        // FunctionCallContent for an LLM request, the resolver maps
+        // canonical -> LLM-facing so the model sees the alias it
+        // originally emitted. Without this hop Anthropic rejects the
+        // request body for `/` in the tool name.
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.Assistant,
+            ToolCalls =
+            [
+                new SerializableToolCall
+                {
+                    CallId = new Netclaw.Tools.ToolCallId("call-mcp"),
+                    Name = new Netclaw.Tools.ToolName("notion/notion-search"),
+                    ArgumentsJson = """{"query":"plan"}"""
+                }
+            ]
+        };
+
+        var ai = ChatMessageConverter.ToAiMessage(
+            msg,
+            toolNameResolver: n => n.Replace("/", "__", StringComparison.Ordinal));
+
+        var toolCall = Assert.Single(ai.Contents.OfType<FunctionCallContent>());
+        Assert.Equal("notion__notion-search", toolCall.Name);
+    }
+
+    [Fact]
+    public void ToAiMessage_leaves_name_unchanged_when_resolver_is_null()
+    {
+        // Internal re-drive paths (RedriveToolBatchForApproval) pass no
+        // resolver because they re-dispatch by name through the
+        // registry's two-form lookup; the canonical form persisted in
+        // history is the right key for that.
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.Assistant,
+            ToolCalls =
+            [
+                new SerializableToolCall
+                {
+                    CallId = new Netclaw.Tools.ToolCallId("call-mcp"),
+                    Name = new Netclaw.Tools.ToolName("notion/notion-search"),
+                    ArgumentsJson = "{}"
+                }
+            ]
+        };
+
+        var ai = ChatMessageConverter.ToAiMessage(msg);
+
+        var toolCall = Assert.Single(ai.Contents.OfType<FunctionCallContent>());
+        Assert.Equal("notion/notion-search", toolCall.Name);
+    }
+
+    [Fact]
     public void Tool_result_message_round_trips()
     {
         var original = new SerializableChatMessage

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -568,6 +568,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
     private sealed class RecordingContextTool(string name, string result, string grantCategory = "builtin") : INetclawTool
     {
         public string Name { get; } = name;
+        public LlmFacingToolName LlmFacingName { get; } = LlmFacingToolName.FromCanonical(name);
         public string Description => "Recording fake tool";
         public string GrantCategory { get; } = grantCategory;
         public System.Text.Json.JsonElement ParameterSchema => default;

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -881,7 +881,7 @@ public class DispatchingToolExecutorTests
         // ever changes, the rest of the test loses its meaning.
         var adapter = (McpToolAdapter)registry.GetByName(canonicalName)!;
         Assert.Equal(canonicalName, adapter.Name);
-        Assert.Equal(sanitizedAlias, adapter.SanitizedName);
+        Assert.Equal(sanitizedAlias, adapter.LlmFacingName.Value);
 
         var system = ActorSystem.Create($"tool-approval-mcp-{Guid.NewGuid():N}");
         try

--- a/src/Netclaw.Actors.Tests/Tools/LlmFacingToolNameTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/LlmFacingToolNameTests.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmFacingToolNameTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class LlmFacingToolNameTests
+{
+    [Theory]
+    [InlineData("shell_execute", "shell_execute")]
+    [InlineData("file_read", "file_read")]
+    [InlineData("notion/notion-create-pages", "notion__notion-create-pages")]
+    [InlineData("memorizer/store", "memorizer__store")]
+    public void FromCanonical_replaces_slash_with_double_underscore(string canonical, string expectedLlmFacing)
+    {
+        var llm = LlmFacingToolName.FromCanonical(canonical);
+        Assert.Equal(expectedLlmFacing, llm.Value);
+    }
+
+    [Fact]
+    public void FromCanonical_is_idempotent_for_already_safe_names()
+    {
+        var once = LlmFacingToolName.FromCanonical("shell_execute");
+        var twice = LlmFacingToolName.FromCanonical(once.Value);
+        Assert.Equal(once, twice);
+    }
+
+    [Theory]
+    [InlineData("has space")]
+    [InlineData("has.dot")]
+    [InlineData("has:colon")]
+    [InlineData("has\\backslash")]
+    [InlineData("emoji_💥")]
+    public void FromCanonical_throws_for_names_with_other_disallowed_chars(string canonical)
+    {
+        Assert.Throws<ArgumentException>(() => LlmFacingToolName.FromCanonical(canonical));
+    }
+
+    [Fact]
+    public void FromCanonical_throws_for_names_exceeding_128_chars_after_sanitization()
+    {
+        // 65 chars + '/' + 64 chars = 130 sanitized chars.
+        var tooLong = new string('a', 65) + "/" + new string('b', 64);
+        Assert.Throws<ArgumentException>(() => LlmFacingToolName.FromCanonical(tooLong));
+    }
+
+}

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -32,7 +32,7 @@ public class McpToolAdapterTests
     }
 
     [Fact]
-    public void SanitizedName_uses_double_underscore_separator()
+    public void LlmFacingName_uses_double_underscore_separator()
     {
         // MCP tool names commonly include single underscores
         // (e.g. find_completed_tasks); double underscore between server and
@@ -41,7 +41,7 @@ public class McpToolAdapterTests
         var adapter = new McpToolAdapter(fakeTool, "todoist", "find_completed_tasks");
 
         Assert.Equal("todoist/find_completed_tasks", adapter.Name);
-        Assert.Equal("todoist__find_completed_tasks", adapter.SanitizedName);
+        Assert.Equal("todoist__find_completed_tasks", adapter.LlmFacingName.Value);
     }
 
     [Theory]
@@ -49,7 +49,7 @@ public class McpToolAdapterTests
     [InlineData("todoist", "find-tasks")]
     [InlineData("browser_chrome_devtools", "navigate_page")]
     [InlineData("bamboohr", "get_employee_details")]
-    public void SanitizedName_matches_Anthropic_tool_name_regex(string server, string tool)
+    public void LlmFacingName_matches_Anthropic_tool_name_regex(string server, string tool)
     {
         // Anthropic's documented tool-name constraint is
         // ^[a-zA-Z0-9_-]{1,64}$ (see Define tools docs). The whole point of
@@ -58,7 +58,7 @@ public class McpToolAdapterTests
         var fakeTool = AIFunctionFactory.Create(() => "result", tool);
         var adapter = new McpToolAdapter(fakeTool, server, tool);
 
-        Assert.Matches("^[a-zA-Z0-9_-]{1,64}$", adapter.SanitizedName);
+        Assert.Matches("^[a-zA-Z0-9_-]{1,64}$", adapter.LlmFacingName.Value);
         Assert.Matches("^[a-zA-Z0-9_-]{1,64}$", ((AIFunction)adapter.ToAITool()).Name);
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
@@ -203,8 +203,8 @@ public sealed class McpToolAudienceGrantsTests
             CancellationToken.None);
 
         Assert.Contains("search_memories", result);
-        Assert.DoesNotContain("memorizer/store", result);
-        Assert.DoesNotContain("memorizer/delete", result);
+        Assert.DoesNotContain("memorizer__store", result);
+        Assert.DoesNotContain("memorizer__delete", result);
     }
 
     // ── FilterExposedTools (session hot path) ──
@@ -289,7 +289,10 @@ public sealed class McpToolAudienceGrantsTests
             CreateExecutionContext(TrustAudience.Team),
             CancellationToken.None);
 
-        Assert.Equal("memorizer/search_memories", result);
+        // load_tool now returns the LLM-facing alias so the model can
+        // call the tool back using the same form Anthropic surfaces in
+        // its tool definitions.
+        Assert.Equal("memorizer__search_memories", result);
     }
 
     // ── Public audience ──

--- a/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
@@ -23,7 +23,7 @@ public class SearchToolsToolTests
             ToolInput.Create("Query", "store"),
             CancellationToken.None);
 
-        Assert.Contains("memorizer/store", result);
+        Assert.Contains("memorizer__store", result);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class SearchToolsToolTests
             ToolInput.Create("Query", "memories"),
             CancellationToken.None);
 
-        Assert.Contains("memorizer/search_memories", result);
+        Assert.Contains("memorizer__search_memories", result);
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class SearchToolsToolTests
             ToolInput.Create("Query", "store", "Server", "default"),
             CancellationToken.None);
 
-        Assert.Contains("memorizer/store", result);
+        Assert.Contains("memorizer__store", result);
     }
 
     [Fact]
@@ -143,9 +143,9 @@ public class SearchToolsToolTests
 
         Assert.Contains("No exact tools found", result);
         Assert.Contains("Did you mean", result);
-        Assert.Contains("browser_chrome_devtools/navigate_page", result);
+        Assert.Contains("browser_chrome_devtools__navigate_page", result);
         Assert.Contains("Suggestions are not loaded yet", result);
-        Assert.DoesNotContain("browser_chrome_devtools/navigate_page —", result);
+        Assert.DoesNotContain("browser_chrome_devtools__navigate_page —", result);
     }
 
     [Fact]
@@ -174,8 +174,8 @@ public class SearchToolsToolTests
             CancellationToken.None);
 
         Assert.Contains("Found 2 tool(s) in server 'memorizer'", result);
-        Assert.Contains("memorizer/store", result);
-        Assert.Contains("memorizer/search", result);
+        Assert.Contains("memorizer__store", result);
+        Assert.Contains("memorizer__search", result);
     }
 
     [Fact]
@@ -223,7 +223,7 @@ public class SearchToolsToolTests
             context,
             CancellationToken.None);
 
-        Assert.Contains("memorizer/search_memories", result);
+        Assert.Contains("memorizer__search_memories", result);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
@@ -258,6 +258,49 @@ public class ToolRegistryTests
         Assert.Same(byCanonical, bySanitized);
     }
 
+    [Fact]
+    public void ToCanonicalName_maps_sanitized_alias_to_canonical_for_McpTool()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("create-pages"), "notion", "create-pages"));
+
+        Assert.Equal("notion/create-pages", registry.ToCanonicalName("notion__create-pages"));
+        // Already canonical → idempotent
+        Assert.Equal("notion/create-pages", registry.ToCanonicalName("notion/create-pages"));
+        // Unknown tool — pass-through, no throw
+        Assert.Equal("unregistered__tool", registry.ToCanonicalName("unregistered__tool"));
+    }
+
+    [Fact]
+    public void ToLlmFacingName_maps_canonical_to_sanitized_alias_for_McpTool()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("create-pages"), "notion", "create-pages"));
+
+        Assert.Equal("notion__create-pages", registry.ToLlmFacingName("notion/create-pages"));
+        // Already LLM-facing — pass-through (no registered tool by that
+        // exact name; falls through to identity)
+        Assert.Equal("notion__create-pages", registry.ToLlmFacingName("notion__create-pages"));
+    }
+
+    [Fact]
+    public void Canonical_and_LlmFacing_round_trip_for_first_party_tools_is_identity()
+    {
+        // First-party tool names already satisfy the Anthropic regex —
+        // canonical and LLM-facing are the same string. Round-tripping
+        // must not mangle them in either direction.
+        var config = new ToolConfig();
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(config);
+
+        Assert.Equal("shell_execute", registry.ToCanonicalName("shell_execute"));
+        Assert.Equal("shell_execute", registry.ToLlmFacingName("shell_execute"));
+        Assert.Equal("file_read", registry.ToCanonicalName("file_read"));
+        Assert.Equal("file_read", registry.ToLlmFacingName("file_read"));
+    }
+
     private static AIFunction CreateFakeTool(string name)
     {
         return AIFunctionFactory.Create(() => "result", name);

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -19,7 +19,25 @@ namespace Netclaw.Actors.Protocol;
 /// </summary>
 public static class ChatMessageConverter
 {
-    public static AiChatMessage ToAiMessage(SerializableChatMessage msg, string? sessionDir = null, ILogger? logger = null)
+    /// <summary>
+    /// Convert a persisted message to a MEAI <see cref="AiChatMessage"/>.
+    /// </summary>
+    /// <param name="toolNameResolver">
+    /// Optional canonical→LLM-facing tool-name resolver. Persisted tool
+    /// call names are stored in canonical form (post-PR follow-up);
+    /// when building a request that goes to an LLM provider (Anthropic,
+    /// OpenAI) the names on <see cref="FunctionCallContent"/> must be
+    /// the LLM-facing alias the model originally emitted. Pass
+    /// <c>toolRegistry.ToLlmFacingName</c>. Null (default) leaves names
+    /// untouched — appropriate for internal re-drive paths where we
+    /// re-dispatch by canonical name through the registry's two-form
+    /// lookup.
+    /// </param>
+    public static AiChatMessage ToAiMessage(
+        SerializableChatMessage msg,
+        string? sessionDir = null,
+        ILogger? logger = null,
+        Func<string, string>? toolNameResolver = null)
     {
         var role = msg.Role switch
         {
@@ -54,7 +72,8 @@ public static class ChatMessageConverter
                     args = JsonSerializer.Deserialize<Dictionary<string, object?>>(tc.ArgumentsJson);
                 }
 
-                contents.Add(new FunctionCallContent(tc.CallId.Value, tc.Name.Value, args));
+                var wireName = toolNameResolver?.Invoke(tc.Name.Value) ?? tc.Name.Value;
+                contents.Add(new FunctionCallContent(tc.CallId.Value, wireName, args));
             }
 
             return new AiChatMessage(role, contents);
@@ -90,9 +109,10 @@ public static class ChatMessageConverter
     public static List<AiChatMessage> ToAiMessages(
         IEnumerable<SerializableChatMessage> messages,
         string? sessionDir = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        Func<string, string>? toolNameResolver = null)
     {
-        return [.. messages.Select(m => ToAiMessage(m, sessionDir, logger))];
+        return [.. messages.Select(m => ToAiMessage(m, sessionDir, logger, toolNameResolver))];
     }
 
     public static SerializableChatMessage FromAiMessage(AiChatMessage msg, string? sessionDir = null)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3011,10 +3011,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return false;
 
         var tool = registration.Tool;
-        _discoveredToolCache.Remember(toolName, tool,
+        // Cache and log under the canonical name regardless of which form
+        // the LLM sent (load_tool / search_tools now emit the LLM-facing
+        // alias for MCP, but legacy strings may still arrive). Cache key
+        // consistency makes per-tool lease accounting unambiguous.
+        var canonicalName = tool.Name;
+        _discoveredToolCache.Remember(canonicalName, tool,
             _config.Tuning.DiscoveredToolRetentionTurns,
             _config.Tuning.DiscoveredToolMaxCount);
-        AddAvailableToolIfMissing(toolName, tool.ToAITool());
+        AddAvailableToolIfMissing(canonicalName, tool.ToAITool());
         return true;
     }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -51,6 +51,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly ISystemPromptProvider _promptProvider;
     private readonly IReadOnlyList<IContextLayerProvider> _contextLayers;
     private readonly IToolExecutor? _toolExecutor;
+    private readonly Tools.ToolRegistry? _toolRegistry;
     private readonly IToolAuditLogger? _auditLogger;
     private readonly IToolApprovalService? _approvalService;
     private readonly ApprovalChannel _approvalChannel = new();
@@ -210,6 +211,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _subAgentSpawner = tools?.SubAgentSpawner;
         _subAgentLoader = tools?.SubAgentLoader;
         _toolExecutor = tools?.ToolExecutor;
+        _toolRegistry = tools?.ToolRegistry;
         _auditLogger = tools?.AuditLogger;
         _toolAccessPolicy = tools?.AccessPolicy;
         _approvalService = tools?.ApprovalService;
@@ -1664,6 +1666,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // fire again if the model stalls later in the chain.
         _turnState.ResetEmptyResponseGuards();
 
+        // Normalize the LLM-facing alias back to the canonical name BEFORE
+        // anything reads tc.Name. The LLM sees and emits sanitized names
+        // for MCP tools (e.g. `notion__notion-search`); every internal
+        // consumer downstream — audit log, ToolCallOutput rendered to the
+        // user, duplicate-call fingerprint, persisted assistant message,
+        // approval gate — keys on canonical (e.g. `notion/notion-search`).
+        // Doing the conversion here keeps each consumer free of name-form
+        // awareness; the outbound boundary (SessionMessageAssembler) does
+        // the reverse mapping when re-serializing history to the wire.
+        if (_toolRegistry is not null)
+        {
+            CanonicalizeToolCallNames(lastMessage, toolCalls, _toolRegistry);
+        }
+
         var assistantMsg = ChatMessageConverter.FromAiMessage(lastMessage);
         var userMsg = _state.FindLastUserMessage() ?? new SerializableChatMessage
         {
@@ -1682,6 +1698,43 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ApplyToolBatchStarted(evt);
             EmitAndDispatchToolBatch(lastMessage, toolCalls, usage);
         });
+    }
+
+    /// <summary>
+    /// Rewrite every <see cref="FunctionCallContent"/> in
+    /// <paramref name="lastMessage"/> and <paramref name="toolCalls"/> to use
+    /// the canonical tool name. The original list is mutated in-place
+    /// because every other consumer in this turn reads from these
+    /// references — including the persisted assistant message that gets
+    /// reconstructed by <see cref="ChatMessageConverter.FromAiMessage"/>.
+    /// Tool calls whose names don't resolve to a registered tool pass
+    /// through unchanged (the executor will reject them downstream).
+    /// </summary>
+    private static void CanonicalizeToolCallNames(
+        AiChatMessage lastMessage,
+        List<FunctionCallContent> toolCalls,
+        Tools.ToolRegistry registry)
+    {
+        for (var i = 0; i < toolCalls.Count; i++)
+        {
+            var tc = toolCalls[i];
+            var canonical = registry.ToCanonicalName(tc.Name);
+            if (string.Equals(canonical, tc.Name, StringComparison.Ordinal))
+                continue;
+
+            toolCalls[i] = new FunctionCallContent(tc.CallId, canonical, tc.Arguments);
+        }
+
+        for (var i = 0; i < lastMessage.Contents.Count; i++)
+        {
+            if (lastMessage.Contents[i] is not FunctionCallContent fc)
+                continue;
+            var canonical = registry.ToCanonicalName(fc.Name);
+            if (string.Equals(canonical, fc.Name, StringComparison.Ordinal))
+                continue;
+
+            lastMessage.Contents[i] = new FunctionCallContent(fc.CallId, canonical, fc.Arguments);
+        }
     }
 
     private void EmitAndDispatchToolBatch(
@@ -2503,7 +2556,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             FileReadGranted: HasFileReadGranted(),
             ActiveRecall: _activeRecall,
             Audience: CurrentTurnAudience(),
-            SkillHint: skillHint));
+            SkillHint: skillHint,
+            // Canonical names live in history (post-PR follow-up); the
+            // LLM provider wants the sanitized alias back on the wire.
+            ToolNameToLlmFacing: _toolRegistry is null ? null : _toolRegistry.ToLlmFacingName));
         _startupContextInjected = true;
 
         var self = Self;

--- a/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
@@ -27,7 +27,14 @@ public sealed record ContextAssemblyInput(
     bool FileReadGranted,
     AutomaticRecallResult? ActiveRecall,
     TrustAudience Audience = TrustAudience.Personal,
-    string? SkillHint = null);
+    string? SkillHint = null,
+    // Maps canonical tool names (the form persisted in history) back
+    // to the LLM-facing alias the model expects on the wire. Anthropic
+    // rejects `/` in tool names; if this is null and history contains
+    // MCP tool calls, the LLM provider will return 400. Production
+    // callers should pass `toolRegistry.ToLlmFacingName`; unit tests
+    // that don't exercise MCP can leave it null.
+    Func<string, string>? ToolNameToLlmFacing = null);
 
 /// <summary>
 /// Pure-function assembly of the <see cref="AiChatMessage"/> list sent to
@@ -94,7 +101,10 @@ public static class SessionMessageAssembler
     public static List<AiChatMessage> Assemble(ContextAssemblyInput input)
     {
         var sessionDir = SessionDirectoryHelper.GetSessionDirectory(input.SessionId, input.SessionsBasePath);
-        var messages = ChatMessageConverter.ToAiMessages(input.State.History, sessionDir);
+        var messages = ChatMessageConverter.ToAiMessages(
+            input.State.History,
+            sessionDir,
+            toolNameResolver: input.ToolNameToLlmFacing);
 
         var staticBlock = BuildStaticContextBlock(input, sessionDir);
         if (!string.IsNullOrEmpty(staticBlock))

--- a/src/Netclaw.Actors/Tools/LoadToolTool.cs
+++ b/src/Netclaw.Actors/Tools/LoadToolTool.cs
@@ -55,11 +55,13 @@ public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
         if (_policy is not null && !_policy.IsToolExposed(registration.Tool, context))
             return Task.FromResult($"Tool '{name}' is not available in the current trust context.");
 
-        // Return the canonical tool name. The session actor intercepts load_tool
-        // results and attempts a registry lookup on the content to activate the tool.
-        // Error messages above will not match any registry entry, so only successful
-        // loads trigger activation — no string parsing required.
-        return Task.FromResult(registration.Tool.Name);
+        // Return the LLM-facing alias so the model sees the same form
+        // it must emit in a subsequent tool_use call. The session actor
+        // intercepts load_tool results and runs the content back through
+        // the registry's two-form lookup to activate the tool. Error
+        // messages above will not match any registry entry, so only
+        // successful loads trigger activation — no string parsing required.
+        return Task.FromResult(registration.Tool.LlmFacingName.Value);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -44,13 +44,12 @@ public sealed class McpToolAdapter : INetclawTool
         _invoker = invoker;
         ServerName = serverName;
         Name = $"{serverName}/{toolName}";
-        // LLM-facing alias with Anthropic-safe separator. Anthropic API rejects
-        // tool names with `/` (regex ^[a-zA-Z0-9_-]{1,128}$). The internal Name
-        // keeps the slash for backward compat (skill text, registry keys);
-        // SanitizedName is what's surfaced to the LLM in tool definitions and
-        // what comes back in tool_use responses. ToolRegistry.GetByName
-        // accepts either form.
-        SanitizedName = $"{serverName}__{toolName}";
+        // LLM-facing alias: replaces `/` with `__` to satisfy the
+        // Anthropic tool-name regex (^[a-zA-Z0-9_-]{1,128}$). Surfaced
+        // to the model in tool definitions and echoed back on tool
+        // result messages; everything else (audit log, approvals,
+        // registry keys, CLI) stays canonical via Name.
+        LlmFacingName = LlmFacingToolName.FromCanonical(Name);
         GrantCategory = grantCategory ?? $"mcp:{serverName}";
 
         if (mcpTool is AIFunction func)
@@ -62,7 +61,7 @@ public sealed class McpToolAdapter : INetclawTool
             _rawSchema = func.JsonSchema;
             var sanitized = McpSchemaSanitizer.SanitizeSchema(func.JsonSchema);
             ParameterSchema = McpSchemaSanitizer.InjectMetaProperties(sanitized, Name, logger);
-            _sanitizedTool = new SanitizedAIFunction(func, SanitizedName, Description, ParameterSchema);
+            _sanitizedTool = new SanitizedAIFunction(func, LlmFacingName.Value, Description, ParameterSchema);
         }
         else
         {
@@ -94,12 +93,7 @@ public sealed class McpToolAdapter : INetclawTool
     }
 
     public string Name { get; }
-    /// <summary>
-    /// Anthropic-safe alias for <see cref="Name"/>. Format
-    /// <c>{server}__{tool}</c>. Surfaced to the LLM in tool definitions so the
-    /// Anthropic API does not reject the request for invalid tool-name chars.
-    /// </summary>
-    public string SanitizedName { get; }
+    public LlmFacingToolName LlmFacingName { get; }
     public string Description { get; }
     public string GrantCategory { get; }
     public string ServerName { get; }

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -93,7 +93,9 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
 
                 // NOTE: Keep suggestions in a distinct format so LlmSessionActor doesn't
                 // auto-load them as discovered tools. Auto-loading is only for exact matches.
-                suggestionBuilder.AppendLine($"  ? {tool.Name} :: {desc}{parameterHint}");
+                // Emit the LLM-facing alias so what the model reads here
+                // matches what it must emit in a tool_use call.
+                suggestionBuilder.AppendLine($"  ? {tool.LlmFacingName} :: {desc}{parameterHint}");
             }
 
             suggestionBuilder.AppendLine();
@@ -154,7 +156,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
                 ? tool.Description[..77] + "..."
                 : tool.Description;
             var parameterHint = GetParameterHint(tool);
-            sb.AppendLine($"  {tool.Name} — {desc}{parameterHint}");
+            sb.AppendLine($"  {tool.LlmFacingName} — {desc}{parameterHint}");
         }
 
         sb.AppendLine();

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -75,7 +75,7 @@ public sealed class ToolRegistry
             return direct;
         return _tools.FirstOrDefault(t =>
             t.Tool is McpToolAdapter mcp
-            && string.Equals(mcp.SanitizedName, name, StringComparison.Ordinal));
+            && string.Equals(mcp.LlmFacingName.Value, name, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -420,11 +420,17 @@ public sealed class ToolRegistry
             _tool = tool;
             GrantCategory = grantCategory;
             Name = tool is AIFunction f ? f.Name : tool.GetType().Name;
+            // Bare AITool adapters are only used for first-party / test
+            // fakes whose names already satisfy the Anthropic regex —
+            // FromCanonical round-trips them unchanged and asserts that
+            // assumption at construction.
+            LlmFacingName = LlmFacingToolName.FromCanonical(Name);
             Description = tool is AIFunction fn ? (fn.Description ?? "") : "";
             ParameterSchema = default;
         }
 
         public string Name { get; }
+        public LlmFacingToolName LlmFacingName { get; }
         public string Description { get; }
         public string GrantCategory { get; }
         public System.Text.Json.JsonElement ParameterSchema { get; }

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -68,6 +68,29 @@ public sealed class ToolRegistry
     public ToolRegistration? GetRegistrationByToolName(string name) =>
         FindRegistration(name);
 
+    /// <summary>
+    /// Map a canonical tool name to the LLM-facing alias the registered
+    /// tool exposes. Returns the input unchanged for first-party tools
+    /// (where the canonical form is already LLM-safe) and for names
+    /// that don't resolve to a registered tool. Called at the outbound
+    /// LLM-request boundary to translate canonical names stored in
+    /// conversation history back to what the model expects on the
+    /// wire.
+    /// </summary>
+    public string ToLlmFacingName(string canonicalName) =>
+        FindRegistration(canonicalName)?.Tool.LlmFacingName.Value ?? canonicalName;
+
+    /// <summary>
+    /// Map either a canonical or LLM-facing tool name to the canonical
+    /// form. Returns the input unchanged for names that don't resolve
+    /// to a registered tool. Used at the inbound LLM-response boundary
+    /// to normalize <see cref="Microsoft.Extensions.AI.FunctionCallContent.Name"/>
+    /// so internal consumers (audit, approvals, events) always see the
+    /// operator-facing identifier.
+    /// </summary>
+    public string ToCanonicalName(string name) =>
+        FindRegistration(name)?.Tool.Name ?? name;
+
     private ToolRegistration? FindRegistration(string name)
     {
         var direct = _tools.FirstOrDefault(t => t.Tool.Name == name);

--- a/src/Netclaw.Tools.Abstractions/INetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/INetclawTool.cs
@@ -20,8 +20,23 @@ public interface IChannelTool : INetclawTool;
 /// </summary>
 public interface INetclawTool
 {
-    /// <summary>Tool name as seen by the LLM.</summary>
+    /// <summary>
+    /// Canonical, operator-facing tool identity. Used by the registry,
+    /// approval store, audit log, configuration, and CLI. For MCP tools
+    /// this is <c>{server}/{tool}</c>. For first-party tools it equals
+    /// the <see cref="LlmFacingName"/> value because their names already
+    /// satisfy the Anthropic tool-name regex.
+    /// </summary>
     string Name { get; }
+
+    /// <summary>
+    /// LLM-facing alias for <see cref="Name"/>. Surfaced in tool
+    /// definitions sent to the model and echoed back on tool result
+    /// messages. Equal to <see cref="Name"/> for first-party tools;
+    /// for MCP tools the canonical <c>/</c> separator is replaced with
+    /// <c>__</c> so the name satisfies the Anthropic regex.
+    /// </summary>
+    LlmFacingToolName LlmFacingName { get; }
 
     /// <summary>Human-readable description included in the tool schema.</summary>
     string Description { get; }

--- a/src/Netclaw.Tools.Abstractions/LlmFacingToolName.cs
+++ b/src/Netclaw.Tools.Abstractions/LlmFacingToolName.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmFacingToolName.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Tools;
+
+/// <summary>
+/// The form of a tool name that is safe to surface to an LLM provider's
+/// tool-use API. Anthropic enforces <c>^[a-zA-Z0-9_-]{1,128}$</c> on tool
+/// names; OpenAI and others are at least as permissive. This type exists
+/// to keep that constraint at a type boundary instead of relying on
+/// every emit site to remember which form is required.
+/// </summary>
+/// <remarks>
+/// Inside Netclaw, tool identity is always the canonical
+/// <see cref="ToolName"/> (e.g. <c>notion/notion-create-pages</c> for
+/// MCP, <c>shell_execute</c> for first-party). The LLM-facing alias
+/// replaces characters disallowed by the regex above — currently only
+/// <c>/</c> → <c>__</c> — and is surfaced only at the two LLM boundaries:
+/// when emitting tool definitions, and when echoing tool result messages
+/// back. Internal code (audit logs, approvals, prompts, CLI) should
+/// keep working in canonical <see cref="ToolName"/> values.
+/// </remarks>
+public readonly record struct LlmFacingToolName
+{
+    private static readonly Regex AnthropicSafeName =
+        new("^[a-zA-Z0-9_-]{1,128}$", RegexOptions.Compiled);
+
+    private LlmFacingToolName(string value) => Value = value;
+
+    /// <summary>The LLM-facing string. Guaranteed to satisfy the
+    /// Anthropic tool-name regex.</summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Produce an LLM-facing alias from a canonical tool name. The only
+    /// transformation today is <c>/</c> → <c>__</c> (MCP namespacing);
+    /// names without disallowed characters round-trip unchanged. Throws
+    /// <see cref="ArgumentException"/> if the result still fails the
+    /// regex — that means a name with other disallowed characters (space,
+    /// dot, colon, etc.) made it this far, which is a bug at the source.
+    /// </summary>
+    public static LlmFacingToolName FromCanonical(string canonical)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(canonical);
+
+        var sanitized = canonical.Replace("/", "__", StringComparison.Ordinal);
+        if (!AnthropicSafeName.IsMatch(sanitized))
+        {
+            throw new ArgumentException(
+                $"Tool name '{canonical}' cannot be made LLM-safe by replacing '/' with '__'. " +
+                $"Result '{sanitized}' contains characters outside [a-zA-Z0-9_-] or exceeds 128 chars. " +
+                "Pick a name that satisfies the Anthropic tool-name regex.",
+                nameof(canonical));
+        }
+
+        return new LlmFacingToolName(sanitized);
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -118,6 +118,7 @@ public abstract partial class NetclawTool<TParams> : INetclawTool where TParams 
 
     // Partial method — implemented by the source generator
     public abstract string Name { get; }
+    public abstract LlmFacingToolName LlmFacingName { get; }
     public abstract string Description { get; }
     public abstract string GrantCategory { get; }
     public abstract JsonElement ParameterSchema { get; }

--- a/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
+++ b/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
@@ -217,6 +217,14 @@ public sealed class NetclawToolGenerator : IIncrementalGenerator
 
         // -- INetclawTool properties --
         sb.AppendLine($"    public override string Name => \"{EscapeJson(model.ToolName)}\";");
+        // LlmFacingName goes through LlmFacingToolName.FromCanonical at type
+        // init so any future attribute name containing '/' (or other
+        // disallowed chars) fails loudly the first time the tool is
+        // referenced, rather than at the Anthropic API boundary on the
+        // user's first call. First-party tool names today have no '/'
+        // so this round-trips unchanged.
+        sb.AppendLine($"    private static readonly Netclaw.Tools.LlmFacingToolName _generatedLlmFacingName = Netclaw.Tools.LlmFacingToolName.FromCanonical(\"{EscapeJson(model.ToolName)}\");");
+        sb.AppendLine("    public override Netclaw.Tools.LlmFacingToolName LlmFacingName => _generatedLlmFacingName;");
         sb.AppendLine($"    public override string Description => \"{EscapeJson(model.ToolDescription)}\";");
         sb.AppendLine($"    public override string GrantCategory => \"{EscapeJson(model.Grant)}\";");
         sb.AppendLine("    public override JsonElement ParameterSchema => _generatedSchema;");


### PR DESCRIPTION
## Summary

PR #1134 introduced an Anthropic-safe sanitized alias (`server__tool`) for MCP tool names but stored both forms as bare strings. PR #1147 fixed one acute symptom (approval grant lookup mismatch) but the broader drift remained — audit log emitted sanitized while approval grants stored canonical, the LLM saw canonical in `search_tools` output but emitted sanitized in `tool_use`, and several touched-but-correct sites were one refactor away from re-introducing the same class of bug.

This PR moves the canonical-vs-LLM-facing distinction to a type boundary so future drift becomes a compile error.

Three commits, each independently reviewable:

1. **Foundation** — `LlmFacingToolName` value object with `FromCanonical` factory that sanitizes `/` → `__` and asserts the result satisfies Anthropic's `^[a-zA-Z0-9_-]{1,128}$`. `INetclawTool.LlmFacingName` is now a required member; the source generator emits it for first-party tools (failing at type-init for any future tool whose name can't be made LLM-safe); `McpToolAdapter` replaces its `SanitizedName` string with the value-typed form. No behavior change — every call site that previously read `SanitizedName` now reads `LlmFacingName.Value` and gets the same string.

2. **LLM-actor boundary seam** — `LlmSessionActor.HandleToolCallResponse` rewrites incoming `FunctionCallContent.Name` from the sanitized alias to canonical before any internal consumer reads it. Persisted history carries canonical. `ChatMessageConverter.ToAiMessages` gains an optional `toolNameResolver` Func threaded from `ContextAssemblyInput`, which the session actor wires to `_toolRegistry.ToLlmFacingName` so the outbound LLM request gets the sanitized form back on the wire. Internal re-drive paths (`RedriveToolBatchForApproval`) leave the resolver null and round-trip canonical, exactly what their two-form registry lookup wants. Result: audit log, `ToolCallOutput` event stream, duplicate-tool nudge, and memory ledger all now record `notion/notion-create-pages` instead of `notion__notion-create-pages` — matching the Slack approval prompt and the persisted approval grant.

3. **LLM-facing surface alignment** — `search_tools`, `load_tool`, and discovered-tool activation logging all surfaced canonical names while the LLM emits sanitized in `tool_use`. The model saw the same tool under two distinct strings within a single turn. Now those surfaces emit `LlmFacingName` consistently; `TryActivateDiscoveredTool` still uses the registry's two-form lookup (no behavior change for older LLM strings) but caches and logs under the canonical name. Operator-facing surfaces from commit (2) and LLM-facing surfaces from this commit are now consistent within their respective audiences.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test src/Netclaw.Actors.Tests` — 1956 tests pass
- [x] New unit tests:
  - `LlmFacingToolNameTests` — sanitization, idempotence, regex enforcement, length cap
  - `ToolRegistryTests` — `ToCanonicalName` / `ToLlmFacingName` round-trip for MCP and first-party tools
  - `ChatMessageConverterTests` — resolver applied / not applied paths
  - `McpToolAdapterTests` — `LlmFacingName` replaces the prior `SanitizedName` getter
- [x] `dotnet slopwatch analyze` — no new violations
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers

## Out of scope (potential further follow-up)

- Configuration / CLI surfaces (`ToolApprovalConfig.TryGetExplicitMode`, `netclaw approvals revoke --tool`, `ToolAudienceProfilesDoctorCheck`) still match on exact strings. An operator who writes the sanitized alias into a config key would silently get no effect. Worth either teaching those surfaces to normalize via the registry, or adding a doctor check / schema-fix resolver to catch the misuse. Independent of this PR.