### PR TITLE
fix(mcp): accept either tool-name form in config, CLI, and doctor

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/LlmFacingToolNameTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/LlmFacingToolNameTests.cs
@@ -48,4 +48,32 @@ public class LlmFacingToolNameTests
         Assert.Throws<ArgumentException>(() => LlmFacingToolName.FromCanonical(tooLong));
     }
 
+    [Theory]
+    [InlineData("notion__create-pages", "notion/create-pages")]
+    [InlineData("memorizer__store", "memorizer/store")]
+    [InlineData("browser_chrome_devtools__navigate_page", "browser_chrome_devtools/navigate_page")]
+    public void TryReverseSanitizedToCanonical_reverses_first_double_underscore(string llm, string canonical)
+    {
+        Assert.Equal(canonical, LlmFacingToolName.TryReverseSanitizedToCanonical(llm));
+    }
+
+    [Theory]
+    [InlineData("shell_execute")]         // first-party — no separator
+    [InlineData("file_read")]             // first-party — single underscores
+    [InlineData("notion/create-pages")]   // already canonical
+    [InlineData("")]                       // empty
+    public void TryReverseSanitizedToCanonical_returns_null_for_non_aliases(string name)
+    {
+        Assert.Null(LlmFacingToolName.TryReverseSanitizedToCanonical(name));
+    }
+
+    [Fact]
+    public void TryReverseSanitizedToCanonical_returns_null_for_leading_or_trailing_separator()
+    {
+        // `__foo` (no server prefix) and `foo__` (no tool suffix) are
+        // malformed; reverse-resolution returns null so callers don't
+        // build invalid canonical names.
+        Assert.Null(LlmFacingToolName.TryReverseSanitizedToCanonical("__foo"));
+        Assert.Null(LlmFacingToolName.TryReverseSanitizedToCanonical("foo__"));
+    }
 }

--- a/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
@@ -423,6 +423,59 @@ public sealed class ApprovalsCommandTests : IDisposable
         Assert.Contains("Unknown audience 'bogus'", _output.ToString());
     }
 
+    // ── MCP name-form acceptance ──
+
+    [Fact]
+    public async Task Revoke_all_resolves_LlmFacing_alias_to_canonical_stored_key()
+    {
+        // Operator pastes the LLM-facing alias they saw in a transcript
+        // — the grant is stored under canonical `notion/create-pages`,
+        // and the revoke must still find and remove it.
+        _store.AddApproval(TrustAudience.Personal, "notion/create-pages",
+            new ApprovalEntry("notion/create-pages") { Directory = null });
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "--tool", "notion__create-pages", "--all", "--audience", "personal"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(_store.GetApprovedEntries(TrustAudience.Personal, "notion/create-pages"));
+        Assert.Contains("Removed 1 approval(s)", _output.ToString());
+    }
+
+    [Fact]
+    public async Task List_filter_by_LlmFacing_alias_matches_canonical_stored_key()
+    {
+        _store.AddApproval(TrustAudience.Personal, "notion/create-pages",
+            new ApprovalEntry("notion/create-pages") { Directory = null });
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", Verb("git push"));
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "list", "--tool", "notion__create-pages"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        var text = _output.ToString();
+        Assert.Contains("notion/create-pages", text);
+        Assert.DoesNotContain("git push", text);
+    }
+
+    [Fact]
+    public async Task TrustVerb_persists_under_canonical_name_when_passed_LlmFacing_alias()
+    {
+        // If the operator passes the LLM-facing alias to trust-verb, the
+        // grant should land under the canonical key so the runtime
+        // approval gate — which queries canonical — finds it.
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "trust-verb", "freshdesk", "--tool", "notion__create-pages"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(_store.GetApprovedEntries(TrustAudience.Personal, "notion__create-pages"));
+        Assert.Single(_store.GetApprovedEntries(TrustAudience.Personal, "notion/create-pages"));
+        Assert.Contains("notion/create-pages", _output.ToString());
+    }
+
     // ── help mentions trust-verb ──
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
@@ -419,6 +419,45 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
     }
 
     [Fact]
+    public async Task McpServerWithPerToolOverrideUnderLlmFacingKey_DoesNotTriggerWarning()
+    {
+        // An operator who wrote the LLM-facing alias (`notion__create-pages`)
+        // into ToolOverrides — the form they saw in audit logs / transcripts
+        // — still credits the server with having per-tool approval coverage.
+        // Runtime now resolves both forms (see ToolApprovalConfig.TryGetExplicitMode),
+        // and the doctor matches the same shape.
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "McpServerToolGrants": { "notion": ["create-pages"] },
+                    "ApprovalPolicy": {
+                      "ToolOverrides": { "notion__create-pages": "Approval" }
+                    },
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              },
+              "McpServers": {
+                "notion": { "Transport": "http", "Url": "https://mcp.notion.com/mcp", "Enabled": true }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("approval default on Personal", result.Message);
+    }
+
+    [Fact]
     public async Task MissingApprovalWarning_DoesNotFireForServerNotInMcpServers()
     {
         // Server is in AllowedMcpServers but not in McpServers (stale allowlist).

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 using Netclaw.Cli.Json;
 using Netclaw.Configuration;
+using Netclaw.Tools;
 
 namespace Netclaw.Cli.Approvals;
 
@@ -135,7 +136,7 @@ internal static class ApprovalsCommand
 
             foreach (var (toolName, _) in tools)
             {
-                if (opts.Tool is not null && !string.Equals(toolName, opts.Tool, StringComparison.Ordinal))
+                if (opts.Tool is not null && !ToolFlagMatches(opts.Tool, toolName))
                     continue;
 
                 if (store.RemoveApproval(audience, toolName, lookup))
@@ -180,11 +181,15 @@ internal static class ApprovalsCommand
 
         var entry = new ApprovalEntry(opts.Verb) { Directory = null };
         var audienceWire = opts.Audience.ToWireValue();
+        // Persist under the canonical name so runtime lookups (which
+        // query canonical) find the grant. If the operator passed the
+        // LLM-facing alias, reverse-resolve it here.
+        var canonicalTool = LlmFacingToolName.TryReverseSanitizedToCanonical(opts.Tool) ?? opts.Tool;
 
-        if (store.AddApproval(opts.Audience, opts.Tool, entry))
-            writer.WriteLine($"Trusted '{entry.FormatScope()}' for {audienceWire} / {opts.Tool}.");
+        if (store.AddApproval(opts.Audience, canonicalTool, entry))
+            writer.WriteLine($"Trusted '{entry.FormatScope()}' for {audienceWire} / {canonicalTool}.");
         else
-            writer.WriteLine($"No changes: '{entry.FormatScope()}' is already trusted for {audienceWire} / {opts.Tool}.");
+            writer.WriteLine($"No changes: '{entry.FormatScope()}' is already trusted for {audienceWire} / {canonicalTool}.");
 
         return 0;
     }
@@ -233,12 +238,35 @@ internal static class ApprovalsCommand
             Tool: string.IsNullOrWhiteSpace(tool) ? DefaultTrustVerbTool : tool);
     }
 
+    /// <summary>
+    /// Whether the operator-supplied <c>--tool</c> flag value matches a
+    /// stored tool name. Stored names are canonical (server/tool for
+    /// MCP); the operator may pass either form (audit logs surface the
+    /// canonical name; LLM transcripts surface the LLM-facing alias).
+    /// First-party tools have identical canonical and LLM-facing names,
+    /// so the additional comparison is a no-op for them.
+    /// </summary>
+    private static bool ToolFlagMatches(string toolFlag, string storedToolName)
+    {
+        if (string.Equals(storedToolName, toolFlag, StringComparison.Ordinal))
+            return true;
+        var reversed = LlmFacingToolName.TryReverseSanitizedToCanonical(toolFlag);
+        return reversed is not null && string.Equals(storedToolName, reversed, StringComparison.Ordinal);
+    }
+
     private static int RunRevokeAll(RevokeOptions opts, ToolApprovalStore store, TextWriter writer)
     {
         IEnumerable<TrustAudience> audiences = opts.Audience is { } only ? [only] : TrustAudiences.All;
         var totalRemoved = 0;
+        // Approval grants are persisted under the canonical tool name
+        // (server/tool for MCP). If the operator passed the LLM-facing
+        // alias (server__tool) — the form audit logs and LLM transcripts
+        // surface — reverse-resolve it so `revoke --all` actually finds
+        // the entries. Names without a '__' separator (first-party
+        // tools) pass through unchanged.
+        var canonicalTool = LlmFacingToolName.TryReverseSanitizedToCanonical(opts.Tool!) ?? opts.Tool!;
         foreach (var audience in audiences)
-            totalRemoved += store.RemoveAllForTool(audience, opts.Tool!);
+            totalRemoved += store.RemoveAllForTool(audience, canonicalTool);
 
         if (totalRemoved == 0)
         {
@@ -408,7 +436,7 @@ internal static class ApprovalsCommand
             var filteredTools = new SortedDictionary<string, List<ApprovalEntry>>(StringComparer.Ordinal);
             foreach (var (toolName, entries) in tools)
             {
-                if (toolFilter is not null && !string.Equals(toolName, toolFilter, StringComparison.Ordinal))
+                if (toolFilter is not null && !ToolFlagMatches(toolFilter, toolName))
                     continue;
                 if (entries.Count == 0) continue;
                 filteredTools[toolName] =

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -245,9 +245,11 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
             if (approvalPolicy.McpServerDefaults.ContainsKey(serverName))
                 continue;
 
-            var serverPrefix = $"{serverName}/";
+            var canonicalPrefix = $"{serverName}/";
+            var aliasPrefix = $"{serverName}__";
             var hasPerToolOverride = approvalPolicy.ToolOverrides.Keys.Any(
-                k => k.StartsWith(serverPrefix, StringComparison.Ordinal));
+                k => k.StartsWith(canonicalPrefix, StringComparison.Ordinal)
+                  || k.StartsWith(aliasPrefix, StringComparison.Ordinal));
             if (hasPerToolOverride)
                 continue;
 

--- a/src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs
@@ -125,4 +125,44 @@ public sealed class ToolApprovalConfigTests
         Assert.True(config.TryGetExplicitMode("notion/create-pages", out var mode));
         Assert.Equal(ToolApprovalMode.Approval, mode);
     }
+
+    [Fact]
+    public void TryGetExplicitMode_finds_override_written_with_LlmFacing_key()
+    {
+        // Operator who wrote `notion__create-pages` (the form they saw in
+        // audit logs / LLM transcripts before the PR-3 audience split) gets
+        // their override honored when the runtime queries with the canonical
+        // form. Avoids a silent security misconfiguration.
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion__create-pages"] = ToolApprovalMode.Approval
+            }
+        };
+
+        Assert.True(config.TryGetExplicitMode("notion/create-pages", out var mode));
+        Assert.Equal(ToolApprovalMode.Approval, mode);
+    }
+
+    [Fact]
+    public void TryGetExplicitMode_canonical_override_still_wins_when_both_forms_present()
+    {
+        // Canonical is the documented form — when both shapes exist the
+        // exact match must take precedence, so an operator can use the
+        // alias as a 'shadow' entry without it shadowing a canonical one.
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion/create-pages"] = ToolApprovalMode.Deny,
+                ["notion__create-pages"] = ToolApprovalMode.Approval
+            }
+        };
+
+        Assert.True(config.TryGetExplicitMode("notion/create-pages", out var mode));
+        Assert.Equal(ToolApprovalMode.Deny, mode);
+    }
 }

--- a/src/Netclaw.Configuration/ToolApprovalConfig.cs
+++ b/src/Netclaw.Configuration/ToolApprovalConfig.cs
@@ -75,9 +75,23 @@ public sealed class ToolApprovalConfig
             return true;
         }
 
+        // PR follow-up: accept either canonical (server/tool) or
+        // LLM-facing (server__tool) keys in ToolOverrides. The runtime
+        // queries with canonical, but operators may have written the
+        // LLM-facing form they saw in audit logs / transcripts before
+        // the operator/LLM-audience split was tightened. Convention:
+        // first-party tool names never contain '__', so a '__' in the
+        // queried canonical name unambiguously maps to an MCP alias
+        // and vice versa.
         var slashIndex = toolName.IndexOf('/', StringComparison.Ordinal);
         if (slashIndex > 0)
         {
+            var aliasKey = toolName.Replace("/", "__", StringComparison.Ordinal);
+            if (ToolOverrides.TryGetValue(aliasKey, out mode))
+            {
+                return true;
+            }
+
             var serverName = toolName[..slashIndex];
             if (McpServerDefaults.TryGetValue(serverName, out mode))
             {

--- a/src/Netclaw.Tools.Abstractions/LlmFacingToolName.cs
+++ b/src/Netclaw.Tools.Abstractions/LlmFacingToolName.cs
@@ -61,4 +61,36 @@ public readonly record struct LlmFacingToolName
     }
 
     public override string ToString() => Value;
+
+    /// <summary>
+    /// Pure-string reversal of the LLM-facing alias to a canonical
+    /// candidate, used by surfaces that don't have a
+    /// <c>ToolRegistry</c> handy (config loader, doctor checks, CLI
+    /// against the on-disk approval store). Returns the canonical
+    /// candidate if <paramref name="name"/> matches the
+    /// <c>{server}__{tool}</c> shape; returns <c>null</c> if the input
+    /// already looks canonical (contains <c>/</c>) or doesn't contain a
+    /// <c>__</c> separator. First-party tool names use single
+    /// underscores by convention, so a name with <c>__</c> in it is
+    /// reliably an MCP alias.
+    /// </summary>
+    /// <remarks>
+    /// Heuristic, not authoritative: a tool literally named
+    /// <c>foo__bar</c> (no MCP server prefix) would be misread as
+    /// <c>foo/bar</c>. The convention is enforced by code review on
+    /// new first-party tools; if a future tool legitimately needs
+    /// <c>__</c> in its name, this method needs to grow a registry-
+    /// aware overload.
+    /// </remarks>
+    public static string? TryReverseSanitizedToCanonical(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return null;
+        if (name.Contains('/', StringComparison.Ordinal))
+            return null;
+        var idx = name.IndexOf("__", StringComparison.Ordinal);
+        if (idx <= 0 || idx + 2 >= name.Length)
+            return null;
+        return string.Concat(name.AsSpan(0, idx), "/", name.AsSpan(idx + 2));
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1153. That PR fixed the LLM-vs-operator audience split for the runtime hot path, but three operator-facing surfaces still did exact-string matching on tool names and would silently ignore the LLM-facing alias if an operator pasted it:

1. **`ToolApprovalConfig.TryGetExplicitMode`** — runtime override lookup. An operator who wrote `notion__create-pages` (the form they saw in audit logs or transcripts before #1153 tightened the surfaces) got no override applied; the tool silently fell through to `DefaultMode`. Security misconfiguration risk.
2. **`netclaw approvals` CLI** (`list --tool`, `revoke --tool`, `revoke --all --tool`, `trust-verb --tool`) — the on-disk store is canonical-keyed; the LLM-facing alias passed as `--tool` matched nothing. `trust-verb --tool notion__create-pages ...` would also *persist* under the alias key, creating a dead grant the runtime gate would never find.
3. **`ToolAudienceProfilesDoctorCheck`** — the "MCP server reachable on Personal without approval default" scan only recognized `{server}/` prefixes in `ToolOverrides`. Operators with sanitized-form override keys were warned to add coverage they had already (futilely) configured.

## Fix

Pure-string helper on `LlmFacingToolName`:

```csharp
public static string? TryReverseSanitizedToCanonical(string name)
```

Returns the canonical form (`{server}/{tool}`) when the input looks like the sanitized alias (`{server}__{tool}`); returns `null` for first-party names, already-canonical inputs, and malformed shapes (`__foo`, `foo__`). The convention "first-party tool names never contain `__`" makes this unambiguous in practice; a future first-party tool that legitimately needs `__` would need the helper to grow a registry-aware overload (documented in remarks).

Then:

- `ToolApprovalConfig.TryGetExplicitMode` inlines the same reverse-resolution (no `Tools.Abstractions` dep from `Configuration` — wrong layer direction) so the runtime hot-path lookup tries both forms with the canonical-exact-match keeping precedence when both shapes exist.
- `ApprovalsCommand` normalizes the `--tool` flag at all four call sites: list filter, revoke single-pattern filter, revoke-all store call, and trust-verb persistence (canonical only — so the grant the operator just made is something the runtime can actually consume).
- `ToolAudienceProfilesDoctorCheck` accepts both `{server}/` and `{server}__` prefixes when scanning `ToolOverrides`.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 1968 Actors / 743 Cli / 333 Configuration tests pass
- [x] New unit coverage:
  - `LlmFacingToolName.TryReverseSanitizedToCanonical_*` — round-trip for MCP aliases, identity for first-party / canonical / empty, null for malformed shapes
  - `ToolApprovalConfig.TryGetExplicitMode` — alias key resolved, canonical-exact-match precedence
  - `ApprovalsCommand` — list filter, revoke-all, trust-verb persistence under canonical
  - `ToolAudienceProfilesDoctorCheck` — alias-prefix coverage
- [x] `dotnet slopwatch analyze` — no new violations
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers

## Out of scope

JSON schema (`netclaw-config.v1.schema.json`) still validates `ToolOverrides` keys only by value-shape — neither form is rejected. With this PR both forms work at runtime, so schema-level enforcement is no longer urgent. Doctor remains the surface where misuse would be flagged; a future `--fix` resolver could rewrite alias keys to canonical for operator hygiene.