### PR TITLE
fix(tui): keep approval controls visible for long prompts (#1132)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -169,6 +169,130 @@ public sealed class ChatPageTests
     }
 
     [Fact]
+    public async Task NarrowTerminal_PreservesCtrlVHint()
+    {
+        // 60-col terminal — narrower than the previous hard-coded 76-col
+        // body budget. The pre-scaling code would wrap the body+hint to a
+        // second line and body.Height(1) would clip the Ctrl+V suffix.
+        // With width-aware sizing the hint must still be visible.
+        var (terminal, app, _) = CreateHeadlessApp(
+            BuildApproval(LongShellBody), out var input, width: 60, height: 30);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var screen = terminal.ToString();
+        var bottom = BottomRows(screen, terminalWidth: 60, rowCount: 14);
+
+        Assert.True(bottom.Contains("Ctrl+V", StringComparison.Ordinal)
+                || bottom.Contains("^V", StringComparison.Ordinal),
+            $"Expected Ctrl+V affordance to be visible on a 60-col terminal. " +
+            $"Bottom rows:\n{bottom}\nFull screen:\n{terminal}");
+
+        // Confirm options are still visible — the original #1132 invariant
+        // must hold at narrow widths too.
+        Assert.True(bottom.Contains("Once", StringComparison.Ordinal),
+            $"Expected 'Once' option visible on narrow terminal. Screen:\n{terminal}");
+        Assert.True(bottom.Contains("Deny", StringComparison.Ordinal),
+            $"Expected 'Deny' option visible on narrow terminal. Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task FiveOptionApproval_AllOptionsVisibleWhenExpanded()
+    {
+        // Production ToolAccessPolicy emits up to 5 options for shell_execute
+        // (ApproveOnce, ApproveSession, ApproveAlways, ApproveEverywhere, Deny).
+        // The previous 14-row hardcoded panel cap could clip the 5th option
+        // when expanded body + chrome consumed the whole cap.
+        var fiveOptions = new[]
+        {
+            new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+            new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+            new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+            new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveEverywhereLabel),
+            new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+        };
+
+        var (terminal, app, _) = CreateHeadlessApp(
+            BuildApproval(LongShellBody), out var input,
+            width: 120, height: 40, options: fiveOptions);
+
+        // Expand first, then quit, so the assertion sees the harder layout.
+        input.EnqueueKey(ConsoleKey.V, false, false, true);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var bottom = BottomRows(terminal.ToString(), terminalWidth: 120, rowCount: 20);
+
+        AssertOptionVisible(bottom, ApprovalOptionKeys.ApproveOnceLabel, terminal);
+        AssertOptionVisible(bottom, ApprovalOptionKeys.ApproveSessionLabel, terminal);
+        AssertOptionVisible(bottom, ApprovalOptionKeys.ApproveAlwaysLabel, terminal);
+        AssertOptionVisible(bottom, ApprovalOptionKeys.ApproveEverywhereLabel, terminal);
+        AssertOptionVisible(bottom, ApprovalOptionKeys.DenyLabel, terminal);
+    }
+
+    [Fact]
+    public async Task SmallTerminal_PanelDoesNotEatChatHistory()
+    {
+        // 16-row terminal: the panel max must scale down so chat history
+        // (which uses .Fill()) still has at least a few visible rows.
+        var (terminal, app, _) = CreateHeadlessApp(
+            BuildApproval(LongShellBody), out var input, width: 100, height: 16);
+        input.EnqueueKey(ConsoleKey.V, false, false, true); // expand to stress
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var screen = terminal.ToString();
+        var lines = screen.Split('\n');
+
+        // The chat history panel border must appear (it's the first line of
+        // the rendered frame). If the input panel ate everything, we'd see
+        // the Input panel border on row 0 and no chat panel at all.
+        Assert.True(lines.Length > 4 && lines[0].Contains("Netclaw Chat", StringComparison.Ordinal),
+            $"Expected chat history panel header on row 0 on a 16-row terminal. Screen:\n{terminal}");
+
+        // Also confirm the selection list still renders inside the panel.
+        var bottom = BottomRows(screen, terminalWidth: 100, rowCount: 12);
+        Assert.True(bottom.Contains("Once", StringComparison.Ordinal),
+            $"Expected 'Once' option visible on small terminal. Screen:\n{terminal}");
+        Assert.True(bottom.Contains("Deny", StringComparison.Ordinal),
+            $"Expected 'Deny' option visible on small terminal. Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task Resize_RerendersStatusBarAndBody()
+    {
+        // Initial 120-col terminal renders the full-width key hints. After
+        // resizing to 50 cols and triggering re-render, the shortened keys
+        // string must replace the wide one.
+        var (terminal, app, _) = CreateHeadlessApp(
+            BuildApproval(LongShellBody), out var input, width: 120, height: 30);
+
+        // Resize the underlying VirtualTerminal first so subsequent renders
+        // read the new width; then push a ResizeEvent so the page bumps
+        // UiVersion and the layout re-evaluates.
+        terminal.Resize(50, 30);
+        input.EnqueueResize(50, 30);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var bottom = BottomRows(terminal.ToString(), terminalWidth: 50, rowCount: 12);
+
+        // The narrow status bar should use the short Ctrl-prefix form
+        // (^V) or omit the longer scroll/quit hints.
+        Assert.True(bottom.Contains("^V", StringComparison.Ordinal)
+                || bottom.Contains("[Ctrl+V]", StringComparison.Ordinal),
+            $"Expected resize to re-render with the narrow status bar. Bottom rows:\n{bottom}");
+    }
+
+    [Fact]
     public async Task LongApprovalBody_RenderedFrameSnapshot()
     {
         // Captures both the collapsed and expanded rendered frames for the
@@ -243,11 +367,11 @@ public sealed class ChatPageTests
     }
 
     private static (VirtualTerminal Terminal, TerminaApplication App, TestChatViewModel Vm)
-        CreateHeadlessApp(ToolInteractionRequest? seed, out VirtualInputSource input)
+        CreateHeadlessApp(ToolInteractionRequest? seed, out VirtualInputSource input,
+            int width = 120, int height = 40,
+            IReadOnlyList<ToolInteractionOption>? options = null)
     {
-        // 120x40 matches the existing ApprovalsManagerPageTests harness and
-        // gives the Input panel its full 10-row cap with room to spare.
-        var terminal = new VirtualTerminal(120, 40);
+        var terminal = new VirtualTerminal(width, height);
         var virtualInput = new VirtualInputSource();
         input = virtualInput;
 
@@ -260,10 +384,15 @@ public sealed class ChatPageTests
         {
             builder.RegisterRoute<ChatPage, ChatViewModel>(
                 "/chat",
-                _ => new ChatPage(),
+                sp => new ChatPage(sp.GetRequiredService<IAnsiTerminal>()),
                 _ =>
                 {
-                    capturedVm = new TestChatViewModel(seed);
+                    var effectiveSeed = seed is null
+                        ? null
+                        : options is null
+                            ? seed
+                            : seed with { Options = options };
+                    capturedVm = new TestChatViewModel(effectiveSeed);
                     return capturedVm;
                 });
         });

--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -1,0 +1,311 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChatPageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Actors.Protocol;
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Headless TUI tests for <see cref="ChatPage"/> using Termina's
+/// <see cref="VirtualTerminal"/> and <see cref="VirtualInputSource"/>.
+/// These exercise the Input-panel layout for pending approval interactions
+/// (issue #1132): the bug was that a long <c>shell_execute</c> body wrapped
+/// over many lines and pushed the selection list and key hints past the
+/// 10-row Input panel cap, leaving the user unable to see <c>[Enter] Confirm</c>.
+/// </summary>
+public sealed class ChatPageTests
+{
+    // A representative long body that reproduces the original report: a `cd`
+    // with many path arguments from kevin/code/compiler plus several macOS
+    // temp paths. Well over 400 chars, so the pre-fix code wrapped it onto
+    // 5+ rows and pushed the selection list off-screen.
+    private const string LongShellBody =
+        "cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder " +
+        "/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.aa " +
+        "/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.bb " +
+        "/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.cc " +
+        "/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.dd " +
+        "/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.ee " +
+        "SENTINEL_TAIL_MARKER";
+
+    [Fact]
+    public async Task LongApprovalBody_KeepsControlsVisible()
+    {
+        var (terminal, app, _) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var screen = terminal.ToString();
+
+        // The selection-list options must be on-screen INSIDE the Input panel
+        // (the bottom slice), not just somewhere in the chat history pane
+        // above. Pre-fix bug: the wrapped body filled the panel and the list
+        // rendered past the bottom border, leaving the user unable to pick.
+        var inputAndStatus = BottomRows(screen, terminalWidth: 120, rowCount: 14);
+        AssertOptionVisible(inputAndStatus, "Once", terminal);
+        AssertOptionVisible(inputAndStatus, "This chat", terminal);
+        AssertOptionVisible(inputAndStatus, "Deny", terminal);
+
+        // The status-bar Enter hint MUST stay visible — that's the key the
+        // user needs to confirm their choice, and was the specific control
+        // hidden in the original #1132 screenshot.
+        Assert.True(inputAndStatus.Contains("[Enter] Confirm", StringComparison.Ordinal),
+            $"Expected '[Enter] Confirm' hint in status bar. Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task CollapsedView_ShowsEllipsisAndCtrlVHint()
+    {
+        var (terminal, app, _) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var screen = terminal.ToString();
+
+        // Collapsed body must be truncated with an ellipsis marker. The body
+        // contains "SENTINEL_TAIL_MARKER" at the very end; in collapsed mode
+        // it MUST NOT be visible in the Input panel because it falls past the
+        // truncation point. (It IS expected to be visible up in the chat
+        // history pane, which always logs the full DisplayText on arrival —
+        // that's the security audit trail, not the user-action surface.)
+        Assert.True(screen.Contains('…'),
+            $"Expected ellipsis '…' in collapsed body. Screen:\n{terminal}");
+
+        var inputAndStatus = BottomRows(screen, terminalWidth: 120, rowCount: 14);
+        Assert.True(!inputAndStatus.Contains("SENTINEL_TAIL_MARKER", StringComparison.Ordinal),
+            $"Expected SENTINEL_TAIL_MARKER to be truncated out of the Input panel. " +
+            $"Bottom rows:\n{inputAndStatus}\nFull screen:\n{terminal}");
+
+        // The user needs to know how to see the full body. Both the inline
+        // hint in the Input panel AND the status-bar hint advertise Ctrl+V.
+        Assert.True(screen.Contains("Ctrl+V", StringComparison.Ordinal),
+            $"Expected 'Ctrl+V' affordance to be visible. Screen:\n{terminal}");
+    }
+
+    /// <summary>
+    /// Returns the last <paramref name="rowCount"/> rows of a
+    /// <see cref="VirtualTerminal.ToString"/> dump. Used to scope assertions
+    /// to the Input panel + status bar (the bottom slice), distinct from the
+    /// always-full chat history (the top slice).
+    /// </summary>
+    private static string BottomRows(string screen, int terminalWidth, int rowCount)
+    {
+        var lines = screen.Split('\n');
+        if (lines.Length <= rowCount)
+            return screen;
+        return string.Join('\n', lines.AsEnumerable().TakeLast(rowCount));
+    }
+
+    private static void AssertOptionVisible(string inputAndStatus, string optionLabel, VirtualTerminal terminal)
+    {
+        Assert.True(inputAndStatus.Contains(optionLabel, StringComparison.Ordinal),
+            $"Expected approval option '{optionLabel}' to render inside the Input panel " +
+            $"(bottom slice of the terminal). Bottom rows:\n{inputAndStatus}\nFull screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task CtrlV_TogglesFullBodyAndKeepsControlsVisible()
+    {
+        var (terminal, app, vm) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+
+        // Ctrl+V to expand, then quit. The toggle happens before the next
+        // render, so by the time the app shuts down the terminal holds the
+        // expanded frame.
+        input.EnqueueKey(ConsoleKey.V, false, false, true);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var screen = terminal.ToString();
+
+        // Controls remain visible even in expanded mode — that's the whole
+        // point: Ctrl+V must not regress the original bug. Scope assertions
+        // to the bottom of the screen so we're checking the Input panel,
+        // not the chat history pane that always echoes the full body.
+        var inputAndStatus = BottomRows(screen, terminalWidth: 120, rowCount: 14);
+        AssertOptionVisible(inputAndStatus, "Once", terminal);
+        AssertOptionVisible(inputAndStatus, "This chat", terminal);
+        AssertOptionVisible(inputAndStatus, "Deny", terminal);
+        Assert.True(inputAndStatus.Contains("[Enter] Confirm", StringComparison.Ordinal),
+            $"Expected '[Enter] Confirm' still visible after expand. Screen:\n{terminal}");
+
+        // The status-bar hint should now read "Collapse" instead of "View full".
+        Assert.True(screen.Contains("Collapse", StringComparison.Ordinal),
+            $"Expected status hint to flip to 'Collapse' after expand. Screen:\n{terminal}");
+
+        Assert.True(vm.IsApprovalDetailVisible.Value);
+    }
+
+    [Fact]
+    public void NewInteraction_ResetsCollapsedState()
+    {
+        // This case operates directly on the ViewModel — the goal is to
+        // verify that consecutive ToolInteractionRequest arrivals do not
+        // preserve a previous expanded state, so each new approval starts
+        // collapsed with controls visible by default.
+        var vm = new TestChatViewModel(seed: null);
+        vm.SeedPendingInteractionForTesting(BuildApproval("first body"));
+        vm.ToggleApprovalDetail();
+        Assert.True(vm.IsApprovalDetailVisible.Value);
+
+        vm.SeedPendingInteractionForTesting(BuildApproval("second body"));
+        Assert.False(vm.IsApprovalDetailVisible.Value);
+    }
+
+    [Fact]
+    public async Task LongApprovalBody_RenderedFrameSnapshot()
+    {
+        // Captures both the collapsed and expanded rendered frames for the
+        // long-body case and writes them as ASCII snapshots under the test
+        // project's __snapshots__ directory. Doubles as the visual artifact
+        // for issue #1132: paste the .txt into a GH comment as a fenced
+        // code block to show what the fixed UI looks like.
+        var collapsed = await CaptureFrameAsync(expand: false);
+        var expanded = await CaptureFrameAsync(expand: true);
+
+        WriteSnapshot("chat-approval-collapsed.txt", collapsed);
+        WriteSnapshot("chat-approval-expanded.txt", expanded);
+    }
+
+    private async Task<string> CaptureFrameAsync(bool expand)
+    {
+        var (terminal, app, _) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+        if (expand)
+            input.EnqueueKey(ConsoleKey.V, false, false, true);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        return terminal.ToString();
+    }
+
+    private static void WriteSnapshot(string filename, string content)
+    {
+        // Walk up from the test bin/ to the project's Tui directory.
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        DirectoryInfo? projectDir = null;
+        while (current is not null)
+        {
+            if (current.GetFiles("Netclaw.Cli.Tests.csproj").Length > 0)
+            {
+                projectDir = current;
+                break;
+            }
+            current = current.Parent;
+        }
+
+        // Fall back to bin/ if the source tree isn't reachable (e.g. when
+        // running off a published test bundle).
+        var targetDir = projectDir is not null
+            ? Path.Combine(projectDir.FullName, "Tui", "__snapshots__")
+            : Path.Combine(AppContext.BaseDirectory, "__snapshots__");
+        Directory.CreateDirectory(targetDir);
+
+        File.WriteAllText(Path.Combine(targetDir, filename), content);
+    }
+
+    private static ToolInteractionRequest BuildApproval(string displayText)
+    {
+        return new ToolInteractionRequest
+        {
+            SessionId = new SessionId("test-session"),
+            TimestampMs = 0,
+            Kind = "approval",
+            CallId = new Netclaw.Tools.ToolCallId("test-call"),
+            ToolName = new Netclaw.Tools.ToolName("shell_execute"),
+            DisplayText = displayText,
+            Patterns = ["cd"],
+            CandidateVerbs = ["cd"],
+            Options =
+            [
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+            ]
+        };
+    }
+
+    private static (VirtualTerminal Terminal, TerminaApplication App, TestChatViewModel Vm)
+        CreateHeadlessApp(ToolInteractionRequest? seed, out VirtualInputSource input)
+    {
+        // 120x40 matches the existing ApprovalsManagerPageTests harness and
+        // gives the Input panel its full 10-row cap with room to spare.
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        TestChatViewModel? capturedVm = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina("/chat", builder =>
+        {
+            builder.RegisterRoute<ChatPage, ChatViewModel>(
+                "/chat",
+                _ => new ChatPage(),
+                _ =>
+                {
+                    capturedVm = new TestChatViewModel(seed);
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!);
+    }
+
+    /// <summary>
+    /// ChatViewModel subclass that bypasses daemon initialization for headless
+    /// tests. The real <see cref="ChatViewModel.InitializeSessionAsync"/> opens
+    /// a SignalR connection and subscribes to live daemon output; we override
+    /// it to a no-op and stage a pre-baked <see cref="ToolInteractionRequest"/>
+    /// via <c>SeedPendingInteractionForTesting</c> instead.
+    /// </summary>
+    private sealed class TestChatViewModel : ChatViewModel
+    {
+        private readonly ToolInteractionRequest? _seed;
+
+        public TestChatViewModel(ToolInteractionRequest? seed)
+            : base(
+                // 127.0.0.1:1 is never dialed: InitializeSessionAsync is
+                // overridden to no-op, so the underlying HubConnection stays
+                // dormant. The DaemonClient constructor only validates that
+                // the endpoint string is non-empty.
+                new DaemonClient("http://127.0.0.1:1"),
+                TimeProvider.System,
+                new ModelCapabilities { ModelId = "test-model" },
+                new ChatNavigationState())
+        {
+            _seed = seed;
+        }
+
+        protected override Task InitializeSessionAsync() => Task.CompletedTask;
+
+        public override void OnActivated()
+        {
+            base.OnActivated();
+            if (_seed is not null)
+                SeedPendingInteractionForTesting(_seed);
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-collapsed.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-collapsed.txt
@@ -1,0 +1,40 @@
+╭─Netclaw Chat─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│System: Approval required for shell_execute                                                                           │
+│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.aa                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.bb                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.cc                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.dd                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.ee SENTINEL_TAIL_MARKER                                  │
+│  Patterns: cd                                                                                                        │
+│  Options: Once, This chat, Deny                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│Approval required for shell_execute.                                                                                  │
+│cd /Users/kevin/code/compiler/Diagnostics.pn compiler… [Ctrl+V to view full]                                          │
+│Select an option and press Enter.                                                                                     │
+│1. Once                                                                                                               │
+│2. This chat                                                                                                          │
+│3. Deny                                                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ [Up/Down] Select  [Enter] Confirm  [Ctrl+V] View full  [Ctrl+Q] Quit  |  Approval required  |  test-model

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-collapsed.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-collapsed.txt
@@ -31,10 +31,10 @@
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │Approval required for shell_execute.                                                                                  │
-│cd /Users/kevin/code/compiler/Diagnostics.pn compiler… [Ctrl+V to view full]                                          │
+│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder /private/var/… [Ctrl+V to view full]  │
 │Select an option and press Enter.                                                                                     │
 │1. Once                                                                                                               │
 │2. This chat                                                                                                          │
 │3. Deny                                                                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
- [Up/Down] Select  [Enter] Confirm  [Ctrl+V] View full  [Ctrl+Q] Quit  |  Approval required  |  test-model
+[Up/Down] Select [Enter] Confirm [Ctrl+V] View full [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-expanded.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-expanded.txt
@@ -1,0 +1,40 @@
+╭─Netclaw Chat─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│System: Approval required for shell_execute                                                                           │
+│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.aa                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.bb                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.cc                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.dd                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.ee SENTINEL_TAIL_MARKER                                  │
+│  Patterns: cd                                                                                                        │
+│  Options: Once, This chat, Deny                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│Approval required for shell_execute.                                                                                  │
+│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.aa                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.bb                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.cc                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.dd                                                       │
+│Select an option and press Enter.                                                                                     │
+│1. Once                                                                                                               │
+│2. This chat                                                                                                          │
+│3. Deny                                                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ [Up/Down] Select  [Enter] Confirm  [Ctrl+V] Collapse  [Ctrl+Q] Quit  |  Approval required  |  test-model

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-expanded.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-expanded.txt
@@ -23,7 +23,6 @@
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
-│                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │Approval required for shell_execute.                                                                                  │
@@ -32,9 +31,10 @@
 │/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.bb                                                       │
 │/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.cc                                                       │
 │/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.dd                                                       │
+│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.ee SENTINEL_TAIL_MARKER Patterns: cd                     │
 │Select an option and press Enter.                                                                                     │
 │1. Once                                                                                                               │
 │2. This chat                                                                                                          │
 │3. Deny                                                                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
- [Up/Down] Select  [Enter] Confirm  [Ctrl+V] Collapse  [Ctrl+Q] Quit  |  Approval required  |  test-model
+[Up/Down] Select [Enter] Confirm [Ctrl+V] Collapse [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -103,14 +103,19 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                     .WithBorderColor(Color.Gray)
                     .WithContent(_chatHistory.Fill())
                     .Fill())
-            // Input panel (grows with content, 3–10 rows)
+            // Input panel (grows with content). Cap is generous (14 rows) so
+            // an expanded approval prompt — summary + body (≤5 rows) + hint
+            // + 3-option selection list + borders = 12 rows — can render
+            // without clipping the selection list. The TextAreaNode in
+            // non-approval mode is independently capped via WithMaxHeight(8),
+            // so this cap only affects the approval-pending layout.
             .WithChild(
                 new PanelNode()
                     .WithTitle("Input")
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Cyan)
                     .WithContent(BuildInputContent())
-                    .HeightAuto(min: 3, max: 10))
+                    .HeightAuto(min: 3, max: 14))
             // Status bar
             .WithChild(
                 BuildStatusBar());
@@ -143,9 +148,34 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
 
             _approvalList.OnFocused();
 
+            // Body width budget for the collapsed view. The Input panel
+            // borders + a bit of padding cost ~4 columns; assume an 80-col
+            // minimum terminal so the body fits on one line. Termina has no
+            // measure callback we can hook here.
+            const int collapsedBodyWidth = 76;
+
+            var summary = new TextNode(ViewModel.GetApprovalSummary())
+                .WithForeground(Color.Yellow);
+            var hint = new TextNode(ViewModel.GetApprovalHint() ?? string.Empty)
+                .WithForeground(Color.Gray);
+
+            LayoutNode body = new TextNode(ViewModel.GetApprovalBody(collapsedBodyWidth))
+                .WithForeground(Color.White);
+
+            // Expanded body is allowed to wrap up to 5 rows. With the Input
+            // panel cap at 14, that leaves 1 summary + 1 hint + 3-option list
+            // + 2 borders = 7 rows for chrome, fitting cleanly. Users who
+            // need more than ~5 wrapped lines of body context still see the
+            // full body up in the chat history pane, which always logs the
+            // complete DisplayText on ToolInteractionRequest arrival.
+            body = ViewModel.IsApprovalDetailVisible.Value
+                ? body.HeightAuto(min: 1, max: 5)
+                : body.Height(1);
+
             return Layouts.Vertical()
-                .WithChild(new TextNode(ViewModel.GetApprovalPrompt()).WithForeground(Color.Yellow))
-                .WithChild(new TextNode(ViewModel.GetApprovalHint() ?? string.Empty).WithForeground(Color.Gray))
+                .WithChild(summary)
+                .WithChild(body)
+                .WithChild(hint)
                 .WithChild(_approvalList);
         });
 
@@ -163,10 +193,15 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 ViewModel.IsInputEnabled,
                 ViewModel.StatusMessage,
                 ViewModel.UsageDisplay,
-                (isGenerating, isInputEnabled, status, usage) =>
+                ViewModel.IsApprovalDetailVisible,
+                (isGenerating, isInputEnabled, status, usage, isApprovalDetailVisible) =>
                 {
+                    var approvalToggleHint = isApprovalDetailVisible
+                        ? "[Ctrl+V] Collapse"
+                        : "[Ctrl+V] View full";
+
                     var keys = ViewModel.HasPendingInteraction
-                        ? "[Up/Down] Select  [Enter] Confirm  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
+                        ? $"[Up/Down] Select  [Enter] Confirm  {approvalToggleHint}  [Ctrl+Q] Quit"
                         : isGenerating
                         ? "[Ctrl+Q] Quit"
                         : "[Enter] Send  [Ctrl+Enter] Newline  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit";
@@ -216,6 +251,18 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 ViewModel.RequestAppShutdown();
             }
 
+            return;
+        }
+
+        // Ctrl+V toggles full-body view of a pending approval prompt.
+        // Routed BEFORE the selection list so the list's own Ctrl+V (paste-ish)
+        // never overrides it while an approval is pending. When no approval
+        // is pending, Ctrl+V falls through to the text area for normal paste.
+        if (ViewModel.HasPendingInteraction
+            && keyInfo.Key == ConsoleKey.V
+            && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            ViewModel.ToggleApprovalDetail();
             return;
         }
 

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -98,14 +98,20 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
             .Subscribe(HandleMouseScroll)
             .DisposeWith(Subscriptions);
 
-        // Re-render on terminal resize. The input panel reads _terminal.Width
-        // and Height live inside its DynamicLayoutNode callback to recompute
-        // body width, expanded-body cap, and the panel max — so a UiVersion
-        // bump is enough to make the layout re-read those values. The status
-        // bar CombineLatest also observes UiVersion, so the keys hint
-        // re-shortens for narrow widths.
+        // Re-render on terminal resize. The outer Input panel's HeightAuto(max)
+        // constraint is baked into LayoutNode fields at BuildLayout-time and
+        // doesn't update on resize. InvalidateLayout() discards the cached tree
+        // and rebuilds via BuildLayout() with the updated _terminal.Height, so
+        // the panel cap follows the resize. The DynamicLayoutNode inside still
+        // re-evaluates body width and the internal expanded-body cap. The
+        // UiVersion bump is needed so the status bar CombineLatest triggers the
+        // key-hints re-pick for narrow widths.
         ViewModel.Input.OfType<IInputEvent, ResizeEvent>()
-            .Subscribe(_ => ViewModel.UiVersion.Value++)
+            .Subscribe(_ =>
+            {
+                InvalidateLayout();
+                ViewModel.UiVersion.Value++;
+            })
             .DisposeWith(Subscriptions);
     }
 

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -22,11 +22,18 @@ namespace Netclaw.Cli.Tui;
 /// </summary>
 public sealed class ChatPage : ReactivePage<ChatViewModel>
 {
+    private readonly IAnsiTerminal _terminal;
+
     private StreamingTextNode _chatHistory = null!;
     private TextAreaNode _promptInput = null!;
     private SelectionListNode<string>? _approvalList;
     private DynamicLayoutNode? _inputContentNode;
     private readonly CompositeDisposable _inputSubs = [];
+
+    public ChatPage(IAnsiTerminal terminal)
+    {
+        _terminal = terminal;
+    }
 
     private int _nextSegmentId = 1;
 
@@ -90,6 +97,16 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         ViewModel.Input.OfType<IInputEvent, MouseScrollEvent>()
             .Subscribe(HandleMouseScroll)
             .DisposeWith(Subscriptions);
+
+        // Re-render on terminal resize. The input panel reads _terminal.Width
+        // and Height live inside its DynamicLayoutNode callback to recompute
+        // body width, expanded-body cap, and the panel max — so a UiVersion
+        // bump is enough to make the layout re-read those values. The status
+        // bar CombineLatest also observes UiVersion, so the keys hint
+        // re-shortens for narrow widths.
+        ViewModel.Input.OfType<IInputEvent, ResizeEvent>()
+            .Subscribe(_ => ViewModel.UiVersion.Value++)
+            .DisposeWith(Subscriptions);
     }
 
     public override ILayoutNode BuildLayout()
@@ -103,19 +120,21 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                     .WithBorderColor(Color.Gray)
                     .WithContent(_chatHistory.Fill())
                     .Fill())
-            // Input panel (grows with content). Cap is generous (14 rows) so
-            // an expanded approval prompt — summary + body (≤5 rows) + hint
-            // + 3-option selection list + borders = 12 rows — can render
-            // without clipping the selection list. The TextAreaNode in
-            // non-approval mode is independently capped via WithMaxHeight(8),
-            // so this cap only affects the approval-pending layout.
+            // Input panel (grows with content). The cap is generous — the
+            // actual cap that prevents the chat-history pane from being
+            // squeezed comes from the body-cap math inside BuildInputContent,
+            // which derives an upper bound from _terminal.Height. We give the
+            // panel itself a wide ceiling here so HeightAuto sizes to the
+            // content we deliberately build, not the other way around.
+            // The TextAreaNode in non-approval mode is independently capped
+            // via WithMaxHeight(8).
             .WithChild(
                 new PanelNode()
                     .WithTitle("Input")
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Cyan)
                     .WithContent(BuildInputContent())
-                    .HeightAuto(min: 3, max: 14))
+                    .HeightAuto(min: 3, max: Math.Max(8, _terminal.Height - 4)))
             // Status bar
             .WithChild(
                 BuildStatusBar());
@@ -148,28 +167,34 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
 
             _approvalList.OnFocused();
 
-            // Body width budget for the collapsed view. The Input panel
-            // borders + a bit of padding cost ~4 columns; assume an 80-col
-            // minimum terminal so the body fits on one line. Termina has no
-            // measure callback we can hook here.
-            const int collapsedBodyWidth = 76;
+            // Read live terminal dimensions every render so the layout adapts
+            // to resize. Panel content width = terminal width minus the panel
+            // borders (2 cols) and a couple of safety cells.
+            var panelContentWidth = Math.Max(20, _terminal.Width - 4);
+
+            // How many rows can we afford for the body in expanded mode?
+            // Chrome cost per render: summary(1) + hint(1) + N options + borders(2).
+            // Cap the panel at half the terminal height so the chat history
+            // pane stays visible. Floor of 8 keeps the math sane on tiny
+            // terminals (the panel will still render best-effort).
+            var optionCount = Math.Max(1, ViewModel.ApprovalOptions.Count);
+            var panelMaxRows = Math.Max(8, _terminal.Height / 2);
+            var chromeRows = 4 + optionCount;
+            var expandedBodyMaxRows = Math.Max(1, panelMaxRows - chromeRows);
 
             var summary = new TextNode(ViewModel.GetApprovalSummary())
                 .WithForeground(Color.Yellow);
             var hint = new TextNode(ViewModel.GetApprovalHint() ?? string.Empty)
                 .WithForeground(Color.Gray);
 
-            LayoutNode body = new TextNode(ViewModel.GetApprovalBody(collapsedBodyWidth))
+            LayoutNode body = new TextNode(ViewModel.GetApprovalBody(panelContentWidth))
                 .WithForeground(Color.White);
 
-            // Expanded body is allowed to wrap up to 5 rows. With the Input
-            // panel cap at 14, that leaves 1 summary + 1 hint + 3-option list
-            // + 2 borders = 7 rows for chrome, fitting cleanly. Users who
-            // need more than ~5 wrapped lines of body context still see the
-            // full body up in the chat history pane, which always logs the
-            // complete DisplayText on ToolInteractionRequest arrival.
+            // Collapsed body is forced single-line; expanded body wraps up to
+            // the dynamic cap above. The full DisplayText is always available
+            // in the chat history pane regardless.
             body = ViewModel.IsApprovalDetailVisible.Value
-                ? body.HeightAuto(min: 1, max: 5)
+                ? body.HeightAuto(min: 1, max: expandedBodyMaxRows)
                 : body.Height(1);
 
             return Layouts.Vertical()
@@ -194,20 +219,20 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 ViewModel.StatusMessage,
                 ViewModel.UsageDisplay,
                 ViewModel.IsApprovalDetailVisible,
-                (isGenerating, isInputEnabled, status, usage, isApprovalDetailVisible) =>
+                ViewModel.UiVersion,
+                (isGenerating, isInputEnabled, status, usage, isApprovalDetailVisible, _) =>
                 {
-                    var approvalToggleHint = isApprovalDetailVisible
-                        ? "[Ctrl+V] Collapse"
-                        : "[Ctrl+V] View full";
+                    // Read terminal width live so a resize re-shortens the
+                    // keys string. UiVersion is included above to make the
+                    // CombineLatest re-emit on resize (ChatPage.OnBound bumps
+                    // UiVersion when ResizeEvent fires).
+                    var width = Math.Max(40, _terminal.Width);
 
-                    var keys = ViewModel.HasPendingInteraction
-                        ? $"[Up/Down] Select  [Enter] Confirm  {approvalToggleHint}  [Ctrl+Q] Quit"
-                        : isGenerating
-                        ? "[Ctrl+Q] Quit"
-                        : "[Enter] Send  [Ctrl+Enter] Newline  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit";
+                    var keys = BuildKeyHints(width, isGenerating, isApprovalDetailVisible);
 
                     var usagePart = usage is not null ? $"  |  {usage}" : "";
-                    var text = $" {keys}  |  {status}  |  {ViewModel.ModelId}{usagePart}";
+                    var modelPart = width >= 80 ? $"  |  {ViewModel.ModelId}" : "";
+                    var text = $" {keys}  |  {status}{modelPart}{usagePart}";
 
                     var barColor = status switch
                     {
@@ -226,6 +251,33 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 })
             .AsLayout()
             .Height(1);
+    }
+
+    /// <summary>
+    /// Builds the status-bar key hints, shortening on narrow terminals so
+    /// the bar stays on one line. The most critical action stays visible at
+    /// every width: Confirm/Cancel-equivalent for approval, Send for idle.
+    /// </summary>
+    private string BuildKeyHints(int width, bool isGenerating, bool isApprovalDetailVisible)
+    {
+        if (ViewModel.HasPendingInteraction)
+        {
+            var toggle = isApprovalDetailVisible ? "Collapse" : "View full";
+            return width >= 100
+                ? $"[Up/Down] Select  [Enter] Confirm  [Ctrl+V] {toggle}  [PgUp/PgDn] Scroll  [Ctrl+Q] Quit"
+                : width >= 70
+                    ? $"[↑↓] Select  [Enter] Confirm  [Ctrl+V] {toggle}  [Ctrl+Q] Quit"
+                    : $"[↑↓] [Enter] OK  [^V] {toggle}  [^Q] Quit";
+        }
+
+        if (isGenerating)
+            return "[Ctrl+Q] Quit";
+
+        return width >= 100
+            ? "[Enter] Send  [Ctrl+Enter] Newline  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
+            : width >= 70
+                ? "[Enter] Send  [Ctrl+Enter] Newline  [PgUp/PgDn] Scroll  [Ctrl+Q] Quit"
+                : "[Enter] Send  [^Enter] NL  [^Q] Quit";
     }
 
     private void HandleKeyPress(KeyPressed key)

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -43,6 +43,14 @@ public partial class ChatViewModel : ReactiveViewModel
     public ReactiveProperty<int> UiVersion { get; } = new(0);
 
     /// <summary>
+    /// When true, the approval prompt body renders in full inside the Input
+    /// panel. When false (default), the body is truncated to a single line so
+    /// the selection list and status controls remain visible (issue #1132).
+    /// Toggled by the page via <see cref="ToggleApprovalDetail"/>.
+    /// </summary>
+    public ReactiveProperty<bool> IsApprovalDetailVisible { get; } = new(false);
+
+    /// <summary>
     /// Observable stream of session output events. The page subscribes to this
     /// to render chat messages, tool activity, usage, etc.
     /// </summary>
@@ -80,7 +88,7 @@ public partial class ChatViewModel : ReactiveViewModel
         _ = InitializeSessionAsync();
     }
 
-    private Task InitializeSessionAsync()
+    protected virtual Task InitializeSessionAsync()
     {
         _daemonOutputSubscription = _daemonClient.SessionOutput
             .Subscribe(output =>
@@ -248,15 +256,52 @@ public partial class ChatViewModel : ReactiveViewModel
         return SubmitInteractionSelectionAsync(option.Key.Value);
     }
 
-    public string GetApprovalPrompt()
+    /// <summary>
+    /// Single-line headline of the current approval interaction, e.g.
+    /// <c>"Approval required for shell_execute."</c>. Always fits in the
+    /// Input panel regardless of how long the underlying command is.
+    /// </summary>
+    public string GetApprovalSummary()
     {
         if (CurrentInteraction is not { } interaction)
             return "Approval required";
 
+        return $"Approval required for {interaction.ToolName}.";
+    }
+
+    /// <summary>
+    /// Body of the current approval interaction (the command/path being
+    /// approved, plus any explicit patterns). When
+    /// <see cref="IsApprovalDetailVisible"/> is <c>false</c>, the body is
+    /// returned as a single line truncated to <paramref name="maxLineWidth"/>
+    /// with an ellipsis and a Ctrl+V hint. When <c>true</c>, the full
+    /// untruncated body is returned and the caller is expected to wrap it
+    /// inside a height-bounded layout node.
+    /// </summary>
+    public string GetApprovalBody(int maxLineWidth)
+    {
+        if (CurrentInteraction is not { } interaction)
+            return string.Empty;
+
         var patterns = interaction.Patterns.Count > 0
             ? $" Patterns: {string.Join(", ", interaction.Patterns)}"
             : string.Empty;
-        return $"Approval required for {interaction.ToolName}. {interaction.DisplayText}{patterns}";
+
+        var fullBody = $"{interaction.DisplayText}{patterns}";
+
+        if (IsApprovalDetailVisible.Value)
+            return fullBody;
+
+        // Collapse to one line: any embedded newlines would also push the
+        // selection list past the panel cap, not just length.
+        var singleLine = fullBody.ReplaceLineEndings(" ");
+
+        const string hint = " [Ctrl+V to view full]";
+        var budget = Math.Max(8, maxLineWidth - hint.Length);
+        if (singleLine.Length <= budget)
+            return singleLine + (singleLine.Length == fullBody.Length ? string.Empty : hint);
+
+        return string.Concat(singleLine.AsSpan(0, budget - 1), "…", hint);
     }
 
     public string? GetApprovalHint()
@@ -265,6 +310,35 @@ public partial class ChatViewModel : ReactiveViewModel
             return null;
 
         return "Select an option and press Enter.";
+    }
+
+    /// <summary>
+    /// Flips <see cref="IsApprovalDetailVisible"/> and forces a re-render.
+    /// Invoked by <c>ChatPage</c> on Ctrl+V when an approval is pending.
+    /// </summary>
+    public void ToggleApprovalDetail()
+    {
+        if (!HasPendingInteraction)
+            return;
+
+        IsApprovalDetailVisible.Value = !IsApprovalDetailVisible.Value;
+        UiVersion.Value++;
+    }
+
+    /// <summary>
+    /// Test seam: stage a pending approval interaction as if the daemon had
+    /// emitted it. Mirrors the production handler in
+    /// <see cref="InitializeSessionAsync"/>. Used by <c>ChatPageTests</c> to
+    /// exercise the Input-panel rendering without spinning up a daemon.
+    /// </summary>
+    internal void SeedPendingInteractionForTesting(ToolInteractionRequest interaction)
+    {
+        _outputSubject.OnNext(interaction);
+        _pendingInteractions.Enqueue(interaction);
+        RefreshApprovalOptions();
+        IsGenerating.Value = false;
+        StatusMessage.Value = "Approval required";
+        RequestRedraw();
     }
 
     public override void Dispose()
@@ -279,6 +353,7 @@ public partial class ChatViewModel : ReactiveViewModel
         SessionIdDisplay.Dispose();
         UsageDisplay.Dispose();
         UiVersion.Dispose();
+        IsApprovalDetailVisible.Dispose();
         base.Dispose();
     }
 
@@ -397,6 +472,10 @@ public partial class ChatViewModel : ReactiveViewModel
             foreach (var option in interaction.Options)
                 _approvalOptions.Add(option.Label);
         }
+
+        // Each new interaction opens collapsed so the user makes an explicit
+        // choice to expand a long body — keeps controls visible by default.
+        IsApprovalDetailVisible.Value = false;
 
         UiVersion.Value++;
     }


### PR DESCRIPTION
## Summary

Fixes #1132. Long `shell_execute` approval prompts (`cd ` with many path arguments, etc.) wrapped over many lines inside the Input panel and pushed both the selection list and the `[Enter] Confirm` status hint off-screen, leaving users unable to respond.

The fix renders a summary + a bounded body + hint + selection list. `Ctrl+V` toggles between collapsed (one-line truncated) and expanded (multi-line) body. **All sizing scales with the terminal**: body width, expanded body cap, Input panel cap, and status bar text are all derived from live `IAnsiTerminal.Width/Height` at each render, and the page subscribes to `ResizeEvent` to re-render on terminal resize.

- `IAnsiTerminal` is injected into `ChatPage`. The `DynamicLayoutNode` callback reads width/height every render.
- Expanded body cap = `panelMax - (4 + optionCount)` where `panelMax = max(8, terminalHeight / 2)`. Adapts to the actual `ApprovalOptions.Count` so the 5-option production set (Once, This chat, Always here, Always anywhere, Deny) doesn't clip.
- Body width budget = `terminalWidth - 4`; narrow terminals get a proportionally shorter truncation.
- Status bar picks short/medium/full key-hint variants by width (full ≥100 cols, medium ≥70, terse below). Model ID is dropped below 80 cols.
- `[PgUp/PgDn] Scroll` hint is restored to the pending-interaction state — the design's stated escape hatch for >cap bodies.
- Wire-level `DisplayText` (`ShellApprovalMatcher.FormatForDisplay`, `ToolAccessPolicy`, `SessionToolExecutionPipeline`) is **unchanged** — non-TUI surfaces (headless `-p`, JSON-RPC, future channels) still see the full prompt.

## What the new screen looks like

**Collapsed (default) on a 120-col terminal:**

```
╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│Approval required for shell_execute.                                                                                  │
│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder /private/var/… [Ctrl+V to view full]  │
│Select an option and press Enter.                                                                                     │
│1. Once                                                                                                               │
│2. This chat                                                                                                          │
│3. Deny                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[Up/Down] Select [Enter] Confirm [Ctrl+V] View full [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model
```

**Expanded (after pressing `Ctrl+V`) — body now scales to the available panel height:**

```
╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│Approval required for shell_execute.                                                                                  │
│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder                                       │
│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.aa                                                       │
│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.bb                                                       │
│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.cc                                                       │
│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.dd                                                       │
│/private/var/folders/pj/ncqg4f1s58l87j6n_9xvnz9m0000gn/T/tmp.ee SENTINEL_TAIL_MARKER Patterns: cd                     │
│Select an option and press Enter.                                                                                     │
│1. Once                                                                                                               │
│2. This chat                                                                                                          │
│3. Deny                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[Up/Down] Select [Enter] Confirm [Ctrl+V] Collapse [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model
```

The tail of the body (`SENTINEL_TAIL_MARKER Patterns: cd`) now renders inside the Input panel — earlier versions of this branch clipped it at a hardcoded 5-row cap.

Full ASCII captures committed under `src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-{collapsed,expanded}.txt`.

## Tests

`ChatPageTests` exercises the fix headlessly via Termina's `VirtualTerminal` (same pattern as `ApprovalsManagerPageTests`):

- `LongApprovalBody_KeepsControlsVisible` — direct regression for #1132 at 120×40.
- `CollapsedView_ShowsEllipsisAndCtrlVHint`, `CtrlV_TogglesFullBodyAndKeepsControlsVisible`, `NewInteraction_ResetsCollapsedState` — toggle and state semantics.
- `NarrowTerminal_PreservesCtrlVHint` — 60-col terminal: Ctrl+V affordance must remain visible.
- `FiveOptionApproval_AllOptionsVisibleWhenExpanded` — the canonical production option set fits in expanded mode without clipping.
- `SmallTerminal_PanelDoesNotEatChatHistory` — 16-row terminal: the Input panel cap scales down so the chat history pane still renders.
- `Resize_RerendersStatusBarAndBody` — 120 → 50 col resize re-renders with the shortened status text.
- `LongApprovalBody_RenderedFrameSnapshot` — writes the ASCII frames above to `__snapshots__/`.

## Test plan

- [x] `dotnet test src/Netclaw.Cli.Tests` — 752/752 pass (9 ChatPage tests + 743 existing)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — clean
- [ ] Manual verification: launch `netclaw chat` against a real provider; trigger a long approval; resize the terminal; confirm layout adapts and `Ctrl+V` works as shown above.

## Marked draft

Per request, opening in draft so the rendering and scaling behavior can be reviewed before merging.