### PR TITLE
fix(providers): vLLM modality auto-detection at daemon startup (#987)

### DIFF
--- a/scripts/swap-daemon.sh
+++ b/scripts/swap-daemon.sh
@@ -37,7 +37,10 @@ start_daemon() {
         echo "Starting netclaw.service via systemd..."
         systemctl --user start netclaw.service
     else
-        netclaw daemon start
+        # Detach stdio. The CLI's Process.Start inherits the parent's stdio
+        # handles into the daemon child, so without this redirect the script
+        # hangs forever waiting for the daemon to close the inherited pipes.
+        netclaw daemon start </dev/null >/dev/null 2>&1
     fi
 }
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -203,6 +203,12 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     // Eagerly resolve so StartedAt reflects daemon startup, not first request.
     app.Services.GetRequiredService<DaemonStartClock>();
 
+    // Eagerly resolve so capability auto-detection (HF / OpenRouter / provider
+    // probes) runs at startup, not on first session creation — preserving the
+    // timing of the previous eager-resolution path while letting detection use
+    // the host's IModelCapabilityResolver chain and ILoggerFactory.
+    app.Services.GetRequiredService<ModelCapabilities>();
+
     app.UseAuthentication();
     app.UseAuthorization();
     app.UseRateLimiter();
@@ -374,9 +380,12 @@ static void ConfigureDaemonServices(
         .Get<ModelSelection>() ?? new ModelSelection();
     services.AddSingleton(models);
 
-    // Auto-detect model capabilities when not manually specified in config.
-    // Provider-first resolution: query the hosting provider (e.g. Ollama /api/show)
-    // before falling back to external oracles (OpenRouter, HuggingFace).
+    // Auto-detect model capabilities via the runtime IModelCapabilityResolver
+    // chain (registered further down). Lazy factory so detection runs against
+    // the real DI-wired resolvers with the host's logger — no temp HttpClient
+    // / LoggerFactory needed, and per-resolver Debug output is visible. The
+    // factory is invoked eagerly after Build() (see RunDaemonAsync) so timing
+    // matches a startup-bound resolution rather than first-session lazy hit.
     var providers = configuration.GetSection("Providers")
         .Get<Dictionary<string, ProviderEntry>>()
         ?? new() { ["local-ollama"] = new ProviderEntry() };
@@ -397,11 +406,32 @@ static void ConfigureDaemonServices(
         ? mainProvider?.ApiKey?.Value
         : null;
 
-    var detected = ResolveStartupCapabilities(
-        models.Main.ModelId, daemonLogLevel, mainProviderType, ollamaEndpoint, openAiCompatibleEndpoint, openAiCompatibleApiKey);
+    services.AddSingleton<ModelCapabilities>(sp =>
+    {
+        var resolver = sp.GetRequiredService<IModelCapabilityResolver>();
+        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("Netclaw.Startup");
 
-    var modelCapabilities = ModelCapabilityResolution.ResolveModelCapabilities(models, detected);
-    services.AddSingleton(modelCapabilities);
+        var detected = resolver.ResolveAsync(models.Main.ModelId, CancellationToken.None)
+            .GetAwaiter().GetResult();
+
+        if (detected is not null)
+        {
+            logger.LogInformation(
+                "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
+                models.Main.ModelId,
+                detected.InputModalities?.ToString() ?? "unknown",
+                detected.OutputModalities?.ToString() ?? "unknown",
+                detected.ContextWindowTokens?.ToString() ?? "unknown");
+        }
+        else
+        {
+            logger.LogInformation(
+                "Model {ModelId} not found in capability oracles; defaulting to text-only",
+                models.Main.ModelId);
+        }
+
+        return ModelCapabilityResolution.ResolveModelCapabilities(models, detected);
+    });
 
     // Session config: bind operator-facing settings from config section
     var sessionConfig = SessionConfig.BindFromConfiguration(configuration.GetSection("Session"));
@@ -1047,93 +1077,6 @@ static ISearchBackend? CreateSearchBackend(SearchConfig config)
         default:
             throw new ArgumentOutOfRangeException(nameof(config.Backend), config.Backend,
                 $"Unknown search backend: {config.Backend}");
-    }
-}
-
-/// <summary>
-/// One-time capability detection at startup. Builds a resolver chain
-/// (provider-specific resolver + oracles) and merges partial results
-/// across them via <see cref="CompositeCapabilityResolver"/> — first
-/// non-null per field wins. This is what lets a vLLM probe supply the
-/// context window while HuggingFace fills in the modality flags it
-/// intentionally left null. Runs before the DI container is built, so
-/// resolvers are instantiated by hand with a shared transient
-/// <see cref="HttpClient"/>. Returns null if every resolver in the chain
-/// produced nothing (caller falls back to text-only).
-/// </summary>
-static ResolvedModelCapabilities? ResolveStartupCapabilities(
-    string modelId, LogLevel logLevel, string? providerType, string? ollamaEndpoint, string? openAiCompatibleEndpoint, string? openAiCompatibleApiKey)
-{
-    try
-    {
-        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-        using var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(logLevel));
-        var logger = loggerFactory.CreateLogger("Netclaw.Startup");
-
-        var resolvers = new List<IModelCapabilityResolver>();
-
-        // Provider-specific resolver — narrow but authoritative for the
-        // active backend's local quirks (Ollama's /api/show, vLLM's
-        // max_model_len, llama.cpp's /props). Each typically supplies only
-        // a subset of fields — modalities or context window, rarely both.
-        if (providerType?.Equals("ollama", StringComparison.OrdinalIgnoreCase) == true
-            && ollamaEndpoint is not null)
-        {
-            resolvers.Add(new OllamaCapabilityResolver(
-                httpClient, loggerFactory.CreateLogger<OllamaCapabilityResolver>(), ollamaEndpoint));
-        }
-        else if (providerType?.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) == true
-            && openAiCompatibleEndpoint is not null)
-        {
-            resolvers.Add(new OpenAiCompatibleCapabilityResolver(
-                httpClient,
-                loggerFactory.CreateLogger<OpenAiCompatibleCapabilityResolver>(),
-                openAiCompatibleEndpoint,
-                openAiCompatibleApiKey));
-        }
-
-        // Oracles — always queried regardless of provider type. The
-        // composite's merge picks up modality / context-window fields the
-        // provider-specific resolver left null. OpenRouter covers
-        // commercial models; HuggingFace covers open-source weights that
-        // self-hosted backends (vLLM, llama.cpp) serve under HF-shaped ids.
-        var openRouterDescriptor = new OpenRouterDescriptor(httpClient);
-        var registry = new ProviderDescriptorRegistry([openRouterDescriptor]);
-        resolvers.Add(new OpenRouterOracleResolver(
-            httpClient, loggerFactory.CreateLogger<OpenRouterOracleResolver>(), registry));
-        resolvers.Add(new HuggingFaceCapabilityResolver(
-            httpClient, loggerFactory.CreateLogger<HuggingFaceCapabilityResolver>()));
-
-        var composite = new CompositeCapabilityResolver(
-            resolvers,
-            loggerFactory.CreateLogger<CompositeCapabilityResolver>(),
-            activeProviderForModel: _ => providerType);
-
-        var result = composite.ResolveAsync(modelId, CancellationToken.None)
-            .GetAwaiter().GetResult();
-
-        if (result is not null)
-        {
-            logger.LogInformation(
-                "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                modelId,
-                result.InputModalities?.ToString() ?? "unknown",
-                result.OutputModalities?.ToString() ?? "unknown",
-                result.ContextWindowTokens?.ToString() ?? "unknown");
-        }
-        else
-        {
-            logger.LogInformation(
-                "Model {ModelId} not found in capability oracles; defaulting to text-only",
-                modelId);
-        }
-
-        return result;
-    }
-    catch
-    {
-        // Startup capability detection is best-effort — don't crash the daemon
-        return null;
     }
 }
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1051,10 +1051,15 @@ static ISearchBackend? CreateSearchBackend(SearchConfig config)
 }
 
 /// <summary>
-/// One-time capability detection at startup. Creates temporary HTTP resources
-/// to query the hosting provider (Ollama) or OpenRouter public catalog before
-/// the DI container is built.
-/// Returns null if detection fails (caller falls back to text-only).
+/// One-time capability detection at startup. Builds a resolver chain
+/// (provider-specific resolver + oracles) and merges partial results
+/// across them via <see cref="CompositeCapabilityResolver"/> — first
+/// non-null per field wins. This is what lets a vLLM probe supply the
+/// context window while HuggingFace fills in the modality flags it
+/// intentionally left null. Runs before the DI container is built, so
+/// resolvers are instantiated by hand with a shared transient
+/// <see cref="HttpClient"/>. Returns null if every resolver in the chain
+/// produced nothing (caller falls back to text-only).
 /// </summary>
 static ResolvedModelCapabilities? ResolveStartupCapabilities(
     string modelId, LogLevel logLevel, string? providerType, string? ollamaEndpoint, string? openAiCompatibleEndpoint, string? openAiCompatibleApiKey)
@@ -1065,57 +1070,46 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(
         using var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(logLevel));
         var logger = loggerFactory.CreateLogger("Netclaw.Startup");
 
-        // Provider-first: try Ollama /api/show when running against an Ollama backend
+        var resolvers = new List<IModelCapabilityResolver>();
+
+        // Provider-specific resolver — narrow but authoritative for the
+        // active backend's local quirks (Ollama's /api/show, vLLM's
+        // max_model_len, llama.cpp's /props). Each typically supplies only
+        // a subset of fields — modalities or context window, rarely both.
         if (providerType?.Equals("ollama", StringComparison.OrdinalIgnoreCase) == true
             && ollamaEndpoint is not null)
         {
-            var ollamaResolver = new OllamaCapabilityResolver(
-                httpClient, loggerFactory.CreateLogger<OllamaCapabilityResolver>(), ollamaEndpoint);
-            var ollamaResult = ollamaResolver.ResolveAsync(modelId, CancellationToken.None)
-                .GetAwaiter().GetResult();
-
-            if (ollamaResult is not null)
-            {
-                logger.LogInformation(
-                    "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                    modelId,
-                    ollamaResult.InputModalities?.ToString() ?? "unknown",
-                    ollamaResult.OutputModalities?.ToString() ?? "unknown",
-                    ollamaResult.ContextWindowTokens?.ToString() ?? "unknown");
-                return ollamaResult;
-            }
+            resolvers.Add(new OllamaCapabilityResolver(
+                httpClient, loggerFactory.CreateLogger<OllamaCapabilityResolver>(), ollamaEndpoint));
         }
-
-        if (providerType?.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) == true
+        else if (providerType?.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) == true
             && openAiCompatibleEndpoint is not null)
         {
-            var openAiCompatibleResolver = new OpenAiCompatibleCapabilityResolver(
+            resolvers.Add(new OpenAiCompatibleCapabilityResolver(
                 httpClient,
                 loggerFactory.CreateLogger<OpenAiCompatibleCapabilityResolver>(),
                 openAiCompatibleEndpoint,
-                openAiCompatibleApiKey);
-            var openAiCompatibleResult = openAiCompatibleResolver.ResolveAsync(modelId, CancellationToken.None)
-                .GetAwaiter().GetResult();
-
-            if (openAiCompatibleResult is not null)
-            {
-                logger.LogInformation(
-                    "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                    modelId,
-                    openAiCompatibleResult.InputModalities?.ToString() ?? "unknown",
-                    openAiCompatibleResult.OutputModalities?.ToString() ?? "unknown",
-                    openAiCompatibleResult.ContextWindowTokens?.ToString() ?? "unknown");
-                return openAiCompatibleResult;
-            }
+                openAiCompatibleApiKey));
         }
 
-        // Fallback: OpenRouter public catalog (works for models from any provider)
+        // Oracles — always queried regardless of provider type. The
+        // composite's merge picks up modality / context-window fields the
+        // provider-specific resolver left null. OpenRouter covers
+        // commercial models; HuggingFace covers open-source weights that
+        // self-hosted backends (vLLM, llama.cpp) serve under HF-shaped ids.
         var openRouterDescriptor = new OpenRouterDescriptor(httpClient);
         var registry = new ProviderDescriptorRegistry([openRouterDescriptor]);
-        var resolver = new OpenRouterOracleResolver(
-            httpClient, loggerFactory.CreateLogger<OpenRouterOracleResolver>(), registry);
+        resolvers.Add(new OpenRouterOracleResolver(
+            httpClient, loggerFactory.CreateLogger<OpenRouterOracleResolver>(), registry));
+        resolvers.Add(new HuggingFaceCapabilityResolver(
+            httpClient, loggerFactory.CreateLogger<HuggingFaceCapabilityResolver>()));
 
-        var result = resolver.ResolveAsync(modelId, CancellationToken.None)
+        var composite = new CompositeCapabilityResolver(
+            resolvers,
+            loggerFactory.CreateLogger<CompositeCapabilityResolver>(),
+            activeProviderForModel: _ => providerType);
+
+        var result = composite.ResolveAsync(modelId, CancellationToken.None)
             .GetAwaiter().GetResult();
 
         if (result is not null)


### PR DESCRIPTION
## Summary

- **Fixes #987** — vLLM-served models with HF-shaped ids (e.g. `Qwen/Qwen3.6-35B-A3B-FP8`) were reported as text-only at startup even when vision-capable. `VllmBackendStrategy.Parse` correctly returns `(modalities: null, context: N)` expecting downstream resolvers to fill modality fields, but `Program.ResolveStartupCapabilities` short-circuited on the first non-null result and never invoked HuggingFace / OpenRouter. First commit routes startup through `CompositeCapabilityResolver` (the merge-aware chain that the rest of the daemon already uses at runtime).
- **Removes duplication** — the resolver chain was wired twice (pre-build snapshot in `ResolveStartupCapabilities` and DI-registered runtime composite). Second commit deletes the pre-build path entirely and turns `ModelCapabilities` into a lazy singleton factory that uses the DI-wired `IModelCapabilityResolver`. Eager resolve after `Build()` preserves startup-time timing (same pattern already used at line 204 for `DaemonStartClock`). Net: ~85 lines deleted, single source of truth, per-resolver Debug logs visible because the factory now uses the host's `ILoggerFactory` instead of a provider-less `LoggerFactory.Create`.
- **Likely makes #1127 moot** — that issue exists because hand-edited modality overrides got wiped by the model picker. With auto-detection working, the override workaround is no longer needed for the common case.
- **Operator-side fix** — `scripts/swap-daemon.sh` hung after the binary swap because `netclaw daemon start`'s child daemon inherited the script's stdio pipes; bash waited forever for the long-running daemon to close them. One-line fix: redirect to `/dev/null`.

## Verified end-to-end

Tested against the live vLLM endpoint `http://spark-362c:8000` serving `Qwen/Qwen3.6-35B-A3B-FP8`:

\`\`\`
[INF] OpenAI-compatible backend detected as vllm for model Qwen/Qwen3.6-35B-A3B-FP8
[DBG] CompositeCapabilityResolver: Resolved partial capabilities ... via OpenAiCompatibleCapabilityResolver: input=null, output=null, ctx=262144
[DBG] CompositeCapabilityResolver: Resolved partial capabilities ... via OpenRouterOracleResolver: input=Text, Image, Video, output=Text, ctx=262144
[INF] Netclaw.Startup: Auto-detected model capabilities for Qwen/Qwen3.6-35B-A3B-FP8: input=Text, Image, Video, output=Text, context_window=262144
\`\`\`

vLLM correctly returns partial info; OpenRouter fills the modalities; composite early-out fires before HF is needed.

## Test plan

- [x] `dotnet build src/Netclaw.Daemon` — clean
- [x] `dotnet test src/Netclaw.Daemon.Tests` — 606/606 pass (existing `CompositeCapabilityResolverTests.PartialResults_MergeAcrossResolvers` already locks in the vLLM+HF merge — no new test added per CLAUDE.md "no duplicate tests")
- [x] `dotnet slopwatch analyze` — no new violations
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [x] Binary swap + live daemon startup against real vLLM endpoint — auto-detection produced correct `Text, Image, Video` input modalities

## Out of scope (deferred)

- HF `/api/models?search=...` fuzzy fallback for friendly aliases like `qwen36-ultimate` (other half of #987)
- Config schema refactor (#1127) — likely unnecessary now that auto-detection is reliable