### PR TITLE
chore: bump Termina to 0.10.0 (#223)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="Cronos" Version="0.12.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.0" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.9.0" />
+    <PackageVersion Include="Termina" Version="0.10.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>


### PR DESCRIPTION
## Summary
  
Bumps **Termina** from `0.9.0` to `0.10.0`.

## Changes included

- [ReactivePage.InvalidateLayout()](https://aaronontheweb.github.io/termina/components/reactive-page.html#invalidatelayout) — runtime layout rebuilds (#220)
- [ResizeEvent forwarded to ViewModel](https://aaronontheweb.github.io/termina/components/input.html#resizeevent) (#219)
- [Alternate-scroll mode rollout](https://aaronontheweb.github.io/termina/concepts/runtime-modes.html) (#215)
- Terminal conformance harness (#218)

## Testing

- ✅ All 743 tests in `Netclaw.Cli.Tests` pass
- ✅ Clean build with 0 warnings, 0 errors