### PR TITLE
refactor(mattermost): bump Mattermost.NET to 5.0 and delete HTTP-bypass shim

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <SlackNetVersion>0.17.10</SlackNetVersion>
     <DiscordNetVersion>3.19.1</DiscordNetVersion>
-    <MattermostNetVersion>4.0.4</MattermostNetVersion>
+    <MattermostNetVersion>5.0.0</MattermostNetVersion>
     <MicrosoftExtensionsAIVersion>10.6.0</MicrosoftExtensionsAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.8</MicrosoftAspNetCoreVersion>
     <!-- Aspire pins are exercised only by samples/Netclaw.Demo.AppHost and its

--- a/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostReplyClientIntegrationTests.cs
+++ b/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostReplyClientIntegrationTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Mattermost;
+using Mattermost.Models.Posts;
 using Netclaw.Channels.Mattermost.Transport;
 using Xunit;
 
@@ -29,8 +30,7 @@ public sealed class MattermostReplyClientIntegrationTests
         _fixture.SkipIfUnavailable();
         var ct = TestContext.Current.CancellationToken;
         using var botClient = new MattermostClient(_fixture.ServerUrl, _fixture.BotToken);
-        using var apiClient = _fixture.CreateBotApiClient();
-        var replyClient = new MattermostNetReplyClient(botClient, apiClient);
+        var replyClient = new MattermostNetReplyClient(botClient);
 
         var result = await replyClient.PostReplyAsync(new MattermostPostMessage(
             ChannelId: new MattermostChannelId(_fixture.ChannelId),
@@ -49,8 +49,7 @@ public sealed class MattermostReplyClientIntegrationTests
         _fixture.SkipIfUnavailable();
         var ct = TestContext.Current.CancellationToken;
         using var botClient = new MattermostClient(_fixture.ServerUrl, _fixture.BotToken);
-        using var apiClient = _fixture.CreateBotApiClient();
-        var replyClient = new MattermostNetReplyClient(botClient, apiClient);
+        var replyClient = new MattermostNetReplyClient(botClient);
 
         var root = await replyClient.PostReplyAsync(new MattermostPostMessage(
             ChannelId: new MattermostChannelId(_fixture.ChannelId),
@@ -73,8 +72,7 @@ public sealed class MattermostReplyClientIntegrationTests
         _fixture.SkipIfUnavailable();
         var ct = TestContext.Current.CancellationToken;
         using var botClient = new MattermostClient(_fixture.ServerUrl, _fixture.BotToken);
-        using var apiClient = _fixture.CreateBotApiClient();
-        var replyClient = new MattermostNetReplyClient(botClient, apiClient);
+        var replyClient = new MattermostNetReplyClient(botClient);
 
         var result = await replyClient.PostReplyAsync(new MattermostPostMessage(
             ChannelId: new MattermostChannelId(_fixture.ChannelId),
@@ -85,6 +83,62 @@ public sealed class MattermostReplyClientIntegrationTests
 
         var updated = await botClient.GetPostAsync(result.PostId.Value.Value);
         Assert.Contains("Updated message text", updated.Text);
+    }
+
+    [Fact]
+    public async Task PostReplyAsync_round_trips_attachment_with_button_action()
+    {
+        _fixture.SkipIfUnavailable();
+        var ct = TestContext.Current.CancellationToken;
+        using var botClient = new MattermostClient(_fixture.ServerUrl, _fixture.BotToken);
+        var replyClient = new MattermostNetReplyClient(botClient);
+
+        var attachment = new MattermostAttachment(
+            Fallback: "Approve or deny — reply with A or B",
+            Color: "#3AA3E3",
+            Text: "Tool approval required",
+            Actions:
+            [
+                new MattermostAttachmentAction(
+                    Id: "tool_approval_approve_once",
+                    Name: "Approve once",
+                    IntegrationUrl: "https://example.invalid/callback",
+                    Context: new Dictionary<string, string> { ["action_token"] = "abc123" },
+                    Style: "primary"),
+                new MattermostAttachmentAction(
+                    Id: "tool_approval_deny",
+                    Name: "Deny",
+                    IntegrationUrl: "https://example.invalid/callback",
+                    Context: new Dictionary<string, string> { ["action_token"] = "def456" },
+                    Style: "danger")
+            ]);
+
+        var result = await replyClient.PostReplyAsync(new MattermostPostMessage(
+            ChannelId: new MattermostChannelId(_fixture.ChannelId),
+            Text: "Post with attachment + buttons",
+            Attachments: [attachment]), ct);
+        Assert.NotNull(result.PostId);
+
+        // Re-fetch via the SDK and assert the server echoes the attachment
+        // shape we sent, including the typed Type = Button payload that 5.0's
+        // PostPropsButtonAction produces. This is the round-trip that the
+        // 4.x-era HTTP-bypass shim used to validate by hand.
+        //
+        // Note: Mattermost server intentionally strips integration.url from
+        // posts on read-back — that URL is the bot's private callback endpoint
+        // and is server-side only. We assert on Id/Name/Type/Style which are
+        // what 5.0's typed model actually changed.
+        var post = await botClient.GetPostAsync(result.PostId!.Value.Value);
+        var serverAttachment = Assert.Single(post.Props.Attachments);
+        Assert.Equal(2, serverAttachment.Actions.Count);
+        Assert.All(serverAttachment.Actions, action =>
+            Assert.Equal(PostActionType.Button, action.Type));
+        Assert.Equal("tool_approval_approve_once", serverAttachment.Actions[0].Id);
+        Assert.Equal("Approve once", serverAttachment.Actions[0].Name);
+        Assert.Equal(ActionStyle.Primary, serverAttachment.Actions[0].Style);
+        Assert.Equal("tool_approval_deny", serverAttachment.Actions[1].Id);
+        Assert.Equal("Deny", serverAttachment.Actions[1].Name);
+        Assert.Equal(ActionStyle.Danger, serverAttachment.Actions[1].Style);
     }
 
     [Fact]

--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostNetReplyClient.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostNetReplyClient.cs
@@ -3,51 +3,32 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Net.Http.Json;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Mattermost;
+using Mattermost.Models.Posts;
 
 namespace Netclaw.Channels.Mattermost.Transport;
 
 internal sealed class MattermostNetReplyClient : IMattermostReplyClient
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
-
     private readonly MattermostClient _client;
-    private readonly HttpClient _httpClient;
 
-    public MattermostNetReplyClient(MattermostClient client, HttpClient httpClient)
+    public MattermostNetReplyClient(MattermostClient client)
     {
         _client = client;
-        _httpClient = httpClient;
     }
 
     public async Task<MattermostPostResult> PostReplyAsync(MattermostPostMessage message, CancellationToken cancellationToken = default)
     {
-        if (message.Attachments is { Count: > 0 })
-            return await PostWithAttachmentsAsync(message, cancellationToken);
+        var props = BuildProps(message.Attachments);
 
         var post = await _client.CreatePostAsync(
             channelId: message.ChannelId.Value,
             message: message.Text,
             replyToPostId: message.RootPostId?.Value ?? string.Empty,
-            files: message.FileIds);
+            files: message.FileIds,
+            props: props);
 
-        return new MattermostPostResult(
-            PostId: new MattermostPostId(post.Id));
-    }
-
-    public async Task UpdatePostAsync(
-        MattermostPostId postId,
-        string text,
-        CancellationToken cancellationToken = default)
-    {
-        await _client.UpdatePostAsync(postId.Value, text);
+        return new MattermostPostResult(PostId: new MattermostPostId(post.Id));
     }
 
     public async Task UpdatePostAsync(
@@ -56,123 +37,56 @@ internal sealed class MattermostNetReplyClient : IMattermostReplyClient
         IReadOnlyList<MattermostAttachment>? attachments,
         CancellationToken cancellationToken = default)
     {
-        if (attachments is null or { Count: 0 })
-        {
-            await _client.UpdatePostAsync(postId.Value, text);
-            return;
-        }
-
-        var attachmentPayloads = MapAttachments(attachments);
-
-        var payload = new UpdatePostPayload
-        {
-            Id = postId.Value,
-            Message = text,
-            Props = new PropsPayload { Attachments = attachmentPayloads }
-        };
-
-        var response = await _httpClient.PutAsJsonAsync(
-            $"/api/v4/posts/{postId.Value}",
-            payload,
-            JsonOptions,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await _client.UpdatePostAsync(postId.Value, text, BuildProps(attachments));
     }
 
-    private async Task<MattermostPostResult> PostWithAttachmentsAsync(
-        MattermostPostMessage message,
-        CancellationToken cancellationToken)
+    private static PostProps? BuildProps(IReadOnlyList<MattermostAttachment>? attachments)
     {
-        var attachments = MapAttachments(message.Attachments!);
+        if (attachments is null or { Count: 0 })
+            return null;
 
-        var payload = new CreatePostPayload
+        var props = new PostProps();
+        foreach (var attachment in attachments)
+            props.Attachments.Add(MapAttachment(attachment));
+        return props;
+    }
+
+    private static PostPropsAttachment MapAttachment(MattermostAttachment attachment)
+    {
+        var sdkAttachment = new PostPropsAttachment
         {
-            ChannelId = message.ChannelId.Value,
-            Message = message.Text,
-            RootId = message.RootPostId?.Value,
-            Props = new PropsPayload
+            Fallback = attachment.Fallback ?? string.Empty,
+            Color = attachment.Color,
+            Text = attachment.Text ?? string.Empty
+        };
+
+        if (attachment.Actions is { Count: > 0 })
+        {
+            foreach (var action in attachment.Actions)
+                sdkAttachment.Actions.Add(MapAction(action));
+        }
+
+        return sdkAttachment;
+    }
+
+    private static PostPropsAction MapAction(MattermostAttachmentAction action)
+    {
+        var sdkAction = new PostPropsButtonAction
+        {
+            Id = action.Id,
+            Name = action.Name,
+            Integration = new Integration
             {
-                Attachments = attachments
+                Url = action.IntegrationUrl,
+                Context = action.Context.ToDictionary(
+                    static kv => kv.Key,
+                    static kv => (object)kv.Value)
             }
         };
 
-        var response = await _httpClient.PostAsJsonAsync(
-            "/api/v4/posts",
-            payload,
-            JsonOptions,
-            cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (Enum.TryParse<ActionStyle>(action.Style, ignoreCase: true, out var style))
+            sdkAction.Style = style;
 
-        var doc = await JsonDocument.ParseAsync(
-            await response.Content.ReadAsStreamAsync(cancellationToken),
-            cancellationToken: cancellationToken);
-        var postId = doc.RootElement.GetProperty("id").GetString()!;
-
-        return new MattermostPostResult(PostId: new MattermostPostId(postId));
-    }
-
-    private static List<AttachmentPayload> MapAttachments(IReadOnlyList<MattermostAttachment> source)
-        => source
-            .Select(a => new AttachmentPayload
-            {
-                Fallback = a.Fallback,
-                Color = a.Color,
-                Text = a.Text,
-                Actions = a.Actions?.Select(act => new ActionPayload
-                {
-                    Id = act.Id,
-                    Name = act.Name,
-                    Type = "button",
-                    Style = act.Style,
-                    Integration = new IntegrationPayload
-                    {
-                        Url = act.IntegrationUrl,
-                        Context = act.Context
-                    }
-                }).ToList()
-            })
-            .ToList();
-
-    private sealed class UpdatePostPayload
-    {
-        public string Id { get; init; } = string.Empty;
-        public string Message { get; init; } = string.Empty;
-        public PropsPayload? Props { get; init; }
-    }
-
-    private sealed class CreatePostPayload
-    {
-        public string ChannelId { get; init; } = string.Empty;
-        public string Message { get; init; } = string.Empty;
-        public string? RootId { get; init; }
-        public PropsPayload? Props { get; init; }
-    }
-
-    private sealed class PropsPayload
-    {
-        public List<AttachmentPayload>? Attachments { get; init; }
-    }
-
-    private sealed class AttachmentPayload
-    {
-        public string? Fallback { get; init; }
-        public string? Color { get; init; }
-        public string? Text { get; init; }
-        public List<ActionPayload>? Actions { get; init; }
-    }
-
-    private sealed class ActionPayload
-    {
-        public string Id { get; init; } = string.Empty;
-        public string Name { get; init; } = string.Empty;
-        public string Type { get; init; } = "button";
-        public string? Style { get; init; }
-        public IntegrationPayload? Integration { get; init; }
-    }
-
-    private sealed class IntegrationPayload
-    {
-        public string Url { get; init; } = string.Empty;
-        public Dictionary<string, string>? Context { get; init; }
+        return sdkAction;
     }
 }

--- a/src/Netclaw.Daemon.Tests/Configuration/MattermostChannelRegistrationExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/MattermostChannelRegistrationExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Netclaw.Daemon.Tests.Configuration;
 public sealed class MattermostChannelRegistrationExtensionsTests
 {
     [Fact]
-    public void Invalid_server_url_does_not_throw_and_does_not_set_api_base_address()
+    public void Invalid_server_url_does_not_throw_during_registration()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -37,10 +37,6 @@ public sealed class MattermostChannelRegistrationExtensionsTests
         Assert.Null(ex);
 
         using var provider = services.BuildServiceProvider();
-        var factory = provider.GetRequiredService<IHttpClientFactory>();
-        using var client = factory.CreateClient("mattermost-api");
-        Assert.Null(client.BaseAddress);
-
         var options = provider.GetRequiredService<MattermostChannelOptions>();
         Assert.Equal("://not-a-uri", options.ServerUrl);
         Assert.Equal("fake-token", options.BotToken!.Value);

--- a/src/Netclaw.Daemon/Configuration/MattermostChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/MattermostChannelRegistrationExtensions.cs
@@ -41,10 +41,6 @@ public static class MattermostChannelRegistrationExtensions
             : mattermostOptions.ServerUrl;
         var botToken = mattermostOptions.BotToken?.Value ?? string.Empty;
 
-        Uri? parsedServerUri = null;
-        if (Uri.TryCreate(serverUrl.TrimEnd('/'), UriKind.Absolute, out var candidate))
-            parsedServerUri = candidate;
-
         services.AddSingleton(_ => new MattermostClient(serverUrl, botToken));
 
         services.AddHttpClient("mattermost-files", client =>
@@ -53,25 +49,12 @@ public static class MattermostChannelRegistrationExtensions
                 client.DefaultRequestHeaders.Authorization =
                     new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", botToken);
         }).AddNetclawHeaders("mattermost-files");
-        services.AddHttpClient("mattermost-api", client =>
-        {
-            if (parsedServerUri is not null)
-                client.BaseAddress = parsedServerUri;
-            if (!string.IsNullOrEmpty(botToken))
-                client.DefaultRequestHeaders.Authorization =
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", botToken);
-        }).AddNetclawHeaders("mattermost-api");
         if (!string.IsNullOrEmpty(mattermostOptions.CallbackUrl))
             services.AddSingleton(new MattermostCallbackActionStore(TimeProvider.System));
 
         services.AddSingleton<IMattermostGatewayClient, MattermostNetGatewayClient>();
         services.AddSingleton<IMattermostReplyClient>(sp =>
-        {
-            var client = sp.GetRequiredService<MattermostClient>();
-            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
-            var httpClient = httpClientFactory.CreateClient("mattermost-api");
-            return new MattermostNetReplyClient(client, httpClient);
-        });
+            new MattermostNetReplyClient(sp.GetRequiredService<MattermostClient>()));
         services.AddSingleton<IThreadHistoryFetcher>(sp =>
         {
             var client = sp.GetRequiredService<MattermostClient>();


### PR DESCRIPTION
## Summary

- Bump `Mattermost.NET` 4.0.4 → 5.0.0 (the version on Dependabot PR #1144).
- Delete the HTTP-bypass path in `MattermostNetReplyClient` and its six hand-rolled DTOs (`CreatePostPayload`, `UpdatePostPayload`, `PropsPayload`, `AttachmentPayload`, `ActionPayload`, `IntegrationPayload`). Replace with `MattermostClient.CreatePostAsync(..., PostProps?)` / `UpdatePostAsync(..., PostProps?)`, using 5.0's new `PostPropsButtonAction` so the literal `"button"` string disappears.
- Drop the unused `mattermost-api` named `HttpClient` registration and the `parsedServerUri` parsing it depended on.

## Why

The shim was built on the assumption that the SDK didn't support attachment props. It always has — `PostProps.Attachments` with action buttons shipped in 4.0.4. The 5.0 bump is a tiny additive release (typed `PostActionType` enum + `PostPropsButtonAction`/`PostPropsSelectAction` convenience subclasses), but it's the natural moment to delete the shim: bundle the cleanup with a version event reviewers will scrutinize, and adopt `PostPropsButtonAction` to type away the `"button"` magic string. `PostPropsSelectAction` for multi-option dropdown approvals is explicitly deferred.

## Test plan

- [x] `dotnet build` clean, 0 warnings
- [x] Full unit/integration suite: 4,271 tests pass
- [x] `Netclaw.Channels.Mattermost.IntegrationTests` against a real Mattermost Testcontainer: **12/12 pass**, including a new test asserting that `PostPropsButtonAction` round-trips through the server with `PostActionType.Button` + `ActionStyle.Primary`/`Danger` preserved
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers

Closes #1144 by superseding the bare dependency bump with the corresponding code cleanup.

Net delta: `+103 / -156` LOC across 5 files.