### PR TITLE
fix(channels): prevent cold approval path from swallowing normal chat (#1164)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -499,7 +499,7 @@ public abstract class SessionBindingContractTests : TestKit
             ResponseFactory = (feedback, _) =>
             {
                 return feedback is ToolInteractionTextResponse
-                    ? Task.FromResult<ICommandReply>(CommandNack.For(sid, "approval_no_history"))
+                    ? Task.FromResult<ICommandReply>(CommandNack.For(sid, ApprovalNackReasons.NoHistory))
                     : Task.FromResult<ICommandReply>(CommandAck.For(feedback.SessionId));
             }
         };
@@ -868,7 +868,7 @@ public abstract class SessionBindingContractTests : TestKit
 
         var nack = await probe.ExpectMsgAsync<CommandNack>(cancellationToken: ct);
         Assert.Equal(sid, nack.SessionId);
-        Assert.Equal("approval_wrong_requester", nack.Reason);
+        Assert.Equal(ApprovalNackReasons.WrongRequester, nack.Reason);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -480,6 +480,51 @@ public abstract class SessionBindingContractTests : TestKit
         }, cancellationToken: ct);
     }
 
+    // Regression for #1164: when no approval has ever been requested in the session,
+    // a short message like "yes", "a", or "1" should NOT be consumed by the cold
+    // approval path. The message must fall through to normal LLM ingress.
+    [Fact]
+    public async Task Normal_chat_text_that_looks_like_approval_is_not_consumed_when_no_approval_history()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-cold-text-false-positive");
+
+        // Empty output stream: the binding never observed an approval prompt,
+        // so _hasObservedApprovalRequest stays false and the cold path is active.
+        // The ResponseFactory simulates the session rejecting the cold-path
+        // response with approval_no_history (meaning: no approval ever existed).
+        var pipeline = new RecordingSessionPipeline(_ => [])
+        {
+            ResponseFactory = (feedback, _) =>
+            {
+                return feedback is ToolInteractionTextResponse
+                    ? Task.FromResult<ICommandReply>(CommandNack.For(sid, "approval_no_history"))
+                    : Task.FromResult<ICommandReply>(CommandAck.For(feedback.SessionId));
+            }
+        };
+
+        var actor = CreateBindingActorWithPipeline(sid, pipeline, detector);
+
+        // Send a message that LooksLikeApprovalResponse matches ("yes" -> ApproveOnce)
+        // but is ordinary conversation. With the fix, the message falls through
+        // to normal ChannelInput ingestion.
+        actor.Tell(CreateInboundMessage("yes", "user-1"), TestActor);
+
+        await AwaitAssertAsync(() =>
+        {
+            // The cold path should have forwarded the message to the session
+            Assert.Single(pipeline.RecordedFeedback.OfType<ToolInteractionTextResponse>());
+
+            // The message should NOT be consumed — it must fall through to normal input
+            Assert.NotEmpty(pipeline.CapturedInputs);
+            Assert.True(
+                pipeline.CapturedInputs.Any(ci =>
+                    ci.Contents.Any(c => c is TextContent tc && tc.Text == "yes")),
+                "The original message text should appear in ChannelInput");
+        }, cancellationToken: ct);
+    }
+
     // Regression for the silent-drop class of bugs: the binding observes a
     // ToolInteractionRequest then a TurnCompleted (which clears its local
     // _pendingApprovalRequests). A button click arriving afterwards must still

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
@@ -46,6 +46,7 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
     public SessionPipelineOptions? CapturedOptions { get; private set; }
     public List<IWithSessionId> RecordedFeedback { get; } = [];
     public ConcurrentQueue<ChannelInput> CapturedInputs { get; } = new();
+    public Func<IWithSessionId, CancellationToken, Task<ICommandReply>>? ResponseFactory { get; set; }
 
     public Task<MaterializedSession> CreateAsync(
         SessionId sessionId,
@@ -125,6 +126,8 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
     public Task<ICommandReply> SendFeedbackAndWaitAsync(IWithSessionId feedback, CancellationToken ct = default)
     {
         RecordedFeedback.Add(feedback);
-        return Task.FromResult<ICommandReply>(CommandAck.For(feedback.SessionId));
+        var response = ResponseFactory?.Invoke(feedback, ct)
+            ?? Task.FromResult<ICommandReply>(CommandAck.For(feedback.SessionId));
+        return response;
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -195,7 +195,7 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var nack = Assert.IsType<CommandNack>(invalidReply);
-        Assert.Equal("approval_option_unavailable", nack.Reason);
+        Assert.Equal(ApprovalNackReasons.OptionUnavailable, nack.Reason);
 
         var warning = await subscriber.ExpectMsgAsync<TextOutput>(
             TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors/Protocol/ApprovalNackReasons.cs
+++ b/src/Netclaw.Actors/Protocol/ApprovalNackReasons.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalNackReasons.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Canonical nack reasons for tool approval responses. Centralizes the magic
+/// strings used by <see cref="CommandNack"/> when a
+/// <see cref="ToolInteractionResponse"/> or <see cref="ToolInteractionTextResponse"/>
+/// cannot be honored. Every consumer — session actor, channel bindings,
+/// HTTP callback endpoints — should reference these constants.
+/// </summary>
+public static class ApprovalNackReasons
+{
+    /// <summary>
+    /// No pending approval exists and the session has no history of ever having
+    /// requested approval. The channel cold-path matched the text as approval-like,
+    /// but this is a false positive — the message should fall through to normal ingress.
+    /// </summary>
+    public const string NoHistory = "approval_no_history";
+
+    /// <summary>
+    /// No pending approval exists, but the session has a history of approval activity.
+    /// The prompt has expired.
+    /// </summary>
+    public const string PromptExpired = "approval_prompt_expired";
+
+    /// <summary>
+    /// The responding sender is not authorized to approve this tool action.
+    /// </summary>
+    public const string WrongRequester = "approval_wrong_requester";
+
+    /// <summary>
+    /// The selected option key was not among the options offered in the original prompt.
+    /// </summary>
+    public const string OptionUnavailable = "approval_option_unavailable";
+
+    /// <summary>
+    /// The approval decision could not be persisted.
+    /// </summary>
+    public const string PersistFailed = "approval_persist_failed";
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3262,6 +3262,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _ => ApprovalDecision.Denied
     };
 
+    private bool HasApprovalHistory
+        => _resolvedToolApprovals.Count > 0
+        || ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, null) is not null;
+
     /// <summary>
     /// Emits the channel-visible "approval prompt expired" notice. Used when a
     /// tool interaction response cannot be honored — fail loud instead of
@@ -3378,9 +3382,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             if (_pendingToolInteractions.Count == 0)
             {
-                _log.Warning("Ignoring text tool interaction response with no pending approvals for sender {SenderId}", msg.SenderId);
-                EmitExpiredPromptNotice();
-                nackReason = "approval_prompt_expired";
+                if (HasApprovalHistory)
+                {
+                    _log.Warning("Ignoring text tool interaction response with no pending approvals for sender {SenderId}", msg.SenderId);
+                    EmitExpiredPromptNotice();
+                    nackReason = "approval_prompt_expired";
+                }
+                else
+                {
+                    // Session has never had an approval request. The channel cold path
+                    // matched the text as approval-like, but this is almost certainly
+                    // ordinary conversation (e.g., "yes", "a", "1"). Don't emit a
+                    // user-visible notice and don't consume — the channel should
+                    // fall through to normal LLM ingress. See #1164.
+                    nackReason = "approval_no_history";
+                }
             }
             else
             {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -576,7 +576,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (!TryResolveTextApprovalResponse(msg, out var structured, out var nackReason)
                 || structured is null)
             {
-                TryReplyNack(nackReason ?? "approval_prompt_expired");
+                TryReplyNack(nackReason ?? ApprovalNackReasons.PromptExpired);
                 return;
             }
 
@@ -3321,7 +3321,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 "Ignoring tool interaction response for call {CallId} from sender {SenderId}; expected {ExpectedSenderId}",
                 msg.CallId, msg.SenderId, pending.RequesterSenderId);
             EmitWrongRequesterApprovalNotice();
-            return (null, "approval_wrong_requester");
+            return (null, ApprovalNackReasons.WrongRequester);
         }
 
         // Legacy journal entries created before option persistence landed have
@@ -3336,7 +3336,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 msg.CallId,
                 string.Join(", ", pending.OptionKeys));
             EmitUnavailableApprovalOptionNotice();
-            return (null, "approval_option_unavailable");
+            return (null, ApprovalNackReasons.OptionUnavailable);
         }
 
         var decision = MapApprovalDecision(msg.SelectedKey.Value);
@@ -3386,7 +3386,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 {
                     _log.Warning("Ignoring text tool interaction response with no pending approvals for sender {SenderId}", msg.SenderId);
                     EmitExpiredPromptNotice();
-                    nackReason = "approval_prompt_expired";
+                    nackReason = ApprovalNackReasons.PromptExpired;
                 }
                 else
                 {
@@ -3395,14 +3395,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     // ordinary conversation (e.g., "yes", "a", "1"). Don't emit a
                     // user-visible notice and don't consume — the channel should
                     // fall through to normal LLM ingress. See #1164.
-                    nackReason = "approval_no_history";
+                    nackReason = ApprovalNackReasons.NoHistory;
                 }
             }
             else
             {
                 _log.Warning("Ignoring text tool interaction response from unauthorized sender {SenderId}", msg.SenderId);
                 EmitWrongRequesterApprovalNotice();
-                nackReason = "approval_wrong_requester";
+                nackReason = ApprovalNackReasons.WrongRequester;
             }
 
             return false;
@@ -3431,7 +3431,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 pending.CallId,
                 string.Join(", ", pending.OptionKeys));
             EmitUnavailableApprovalOptionNotice();
-            nackReason = "approval_option_unavailable";
+            nackReason = ApprovalNackReasons.OptionUnavailable;
             return false;
         }
 
@@ -3459,7 +3459,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (!_pendingToolInteractions.TryGetValue(msg.CallId.Value, out var pending))
         {
             _log.Warning("Ignoring tool interaction response for unknown call {CallId}", msg.CallId);
-            TryReplyNack("approval_prompt_expired");
+            TryReplyNack(ApprovalNackReasons.PromptExpired);
             return;
         }
 
@@ -3468,7 +3468,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var authorization = await AuthorizeApprovalResponseAsync(pending, msg);
             if (authorization.Decision is not { } decision)
             {
-                TryReplyNack(authorization.NackReason ?? "approval_wrong_requester");
+                TryReplyNack(authorization.NackReason ?? ApprovalNackReasons.WrongRequester);
                 return;
             }
 
@@ -3481,7 +3481,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         catch (Exception ex)
         {
             FailCurrentTurn("I couldn't persist that approval decision. Please try again.", ex, ErrorCategory.ToolFailure);
-            TryReplyNack("approval_persist_failed");
+            TryReplyNack(ApprovalNackReasons.PersistFailed);
         }
     }
 
@@ -3536,7 +3536,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 "Tool interaction response for unknown/expired call {CallId} ({Classification}); pending={PendingCount} resolved={ResolvedCount}",
                 msg.CallId, classification, _pendingToolInteractions.Count, _resolvedToolApprovals.Count);
             EmitExpiredPromptNotice();
-            TryReplyNack("approval_prompt_expired");
+            TryReplyNack(ApprovalNackReasons.PromptExpired);
             return;
         }
 
@@ -3546,7 +3546,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var authorization = await AuthorizeApprovalResponseAsync(pending, msg);
             if (authorization.Decision is not { } authorizedDecision)
             {
-                TryReplyNack(authorization.NackReason ?? "approval_wrong_requester");
+                TryReplyNack(authorization.NackReason ?? ApprovalNackReasons.WrongRequester);
                 return;
             }
             decision = authorizedDecision;
@@ -3561,7 +3561,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 CorrelationId = Guid.NewGuid(),
                 Cause = ex
             });
-            TryReplyNack("approval_persist_failed");
+            TryReplyNack(ApprovalNackReasons.PersistFailed);
             return;
         }
 
@@ -3577,7 +3577,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (!TryResolveTextApprovalResponse(msg, out var structured, out var nackReason)
             || structured is null)
         {
-            TryReplyNack(nackReason ?? "approval_prompt_expired");
+            TryReplyNack(nackReason ?? ApprovalNackReasons.PromptExpired);
             return;
         }
 

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -788,7 +788,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             // approval_no_history means the session has never had an approval request.
             // The message was a false-positive from LooksLikeApprovalResponse.
             // Don't consume — let it fall through to normal LLM ingress. See #1164.
-            if (reply is CommandNack { Reason: "approval_no_history" })
+            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
                 return false;
 
             return reply is CommandNack;

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -785,6 +785,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 return true;
             }
 
+            // approval_no_history means the session has never had an approval request.
+            // The message was a false-positive from LooksLikeApprovalResponse.
+            // Don't consume — let it fall through to normal LLM ingress. See #1164.
+            if (reply is CommandNack { Reason: "approval_no_history" })
+                return false;
+
             return reply is CommandNack;
         }
         catch (Exception ex)

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -760,6 +760,12 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 return true;
             }
 
+            // approval_no_history means the session has never had an approval request.
+            // The message was a false-positive from LooksLikeApprovalResponse.
+            // Don't consume — let it fall through to normal LLM ingress. See #1164.
+            if (reply is CommandNack { Reason: "approval_no_history" })
+                return false;
+
             return reply is CommandNack;
         }
         catch (Exception ex)

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -763,7 +763,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             // approval_no_history means the session has never had an approval request.
             // The message was a false-positive from LooksLikeApprovalResponse.
             // Don't consume — let it fall through to normal LLM ingress. See #1164.
-            if (reply is CommandNack { Reason: "approval_no_history" })
+            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
                 return false;
 
             return reply is CommandNack;
@@ -783,7 +783,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         if (result is ApprovalLookupResult.WrongRequester)
         {
             await SafeReplyAsync(WrongRequesterWarning);
-            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, "approval_wrong_requester"));
+            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, ApprovalNackReasons.WrongRequester));
             return;
         }
 
@@ -802,7 +802,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to route Mattermost approval response for call {CallId}", message.CallId);
-            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, "approval_persist_failed"));
+            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, ApprovalNackReasons.PersistFailed));
             return;
         }
 
@@ -810,7 +810,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         switch (feedbackResult)
         {
             case CommandNack nack:
-                if (string.Equals(nack.Reason, "approval_wrong_requester", StringComparison.Ordinal))
+                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
                     await SafeReplyAsync(WrongRequesterWarning);
                 ReplyIfExpected(replyTo, nack);
                 return;
@@ -828,7 +828,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                     "Mattermost approval response for call {CallId} returned unexpected feedback result {ResultType}",
                     message.CallId,
                     feedbackResult.GetType().Name);
-                ReplyIfExpected(replyTo, CommandNack.For(_sessionId, "approval_persist_failed"));
+                ReplyIfExpected(replyTo, CommandNack.For(_sessionId, ApprovalNackReasons.PersistFailed));
                 return;
         }
 

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1307,7 +1307,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             // approval_no_history means the session has never had an approval request.
             // The message was a false-positive from LooksLikeApprovalResponse.
             // Don't consume — let it fall through to normal LLM ingress. See #1164.
-            if (reply is CommandNack { Reason: "approval_no_history" })
+            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
                 return false;
 
             return reply is CommandNack;

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1304,6 +1304,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 return true;
             }
 
+            // approval_no_history means the session has never had an approval request.
+            // The message was a false-positive from LooksLikeApprovalResponse.
+            // Don't consume — let it fall through to normal LLM ingress. See #1164.
+            if (reply is CommandNack { Reason: "approval_no_history" })
+                return false;
+
             return reply is CommandNack;
         }
         catch (Exception ex)

--- a/src/Netclaw.Daemon.Tests/Configuration/MattermostActionEndpointExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/MattermostActionEndpointExtensionsTests.cs
@@ -117,7 +117,7 @@ public sealed class MattermostActionEndpointExtensionsTests(ITestOutputHelper ou
         await using var app = await CreateHostAsync(
             time,
             actionStore,
-            gatewayResponseFactory: _ => CommandNack.For(new SessionId("ch-1/root-1"), "approval_wrong_requester"),
+            gatewayResponseFactory: _ => CommandNack.For(new SessionId("ch-1/root-1"), ApprovalNackReasons.WrongRequester),
             recorder: new GatewayInteractionRecorder());
         var client = app.GetTestClient();
 
@@ -144,7 +144,7 @@ public sealed class MattermostActionEndpointExtensionsTests(ITestOutputHelper ou
         await using var app = await CreateHostAsync(
             time,
             actionStore,
-            gatewayResponseFactory: _ => CommandNack.For(new SessionId("ch-1/root-1"), "approval_prompt_expired"),
+            gatewayResponseFactory: _ => CommandNack.For(new SessionId("ch-1/root-1"), ApprovalNackReasons.PromptExpired),
             recorder: new GatewayInteractionRecorder());
         var client = app.GetTestClient();
 
@@ -171,7 +171,7 @@ public sealed class MattermostActionEndpointExtensionsTests(ITestOutputHelper ou
         await using var app = await CreateHostAsync(
             time,
             actionStore,
-            gatewayResponseFactory: _ => CommandNack.For(new SessionId("ch-1/root-1"), "approval_option_unavailable"),
+            gatewayResponseFactory: _ => CommandNack.For(new SessionId("ch-1/root-1"), ApprovalNackReasons.OptionUnavailable),
             recorder: new GatewayInteractionRecorder());
         var client = app.GetTestClient();
 

--- a/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
@@ -238,9 +238,9 @@ public static class MattermostActionEndpointExtensions
     private static string MapRejectMessage(string reason)
         => reason switch
         {
-            "approval_wrong_requester" => "Only the requesting user can approve this tool action.",
-            "approval_prompt_expired" => "That approval prompt has expired. Please re-issue the request and try again.",
-            "approval_option_unavailable" => "That approval option is not available for this tool action. Please use one of the options shown on the prompt.",
+            ApprovalNackReasons.WrongRequester => "Only the requesting user can approve this tool action.",
+            ApprovalNackReasons.PromptExpired => "That approval prompt has expired. Please re-issue the request and try again.",
+            ApprovalNackReasons.OptionUnavailable => "That approval option is not available for this tool action. Please use one of the options shown on the prompt.",
             SessionIngressGate.RestartInProgressMessage => SessionIngressGate.RestartInProgressMessage,
             _ => "That approval could not be recorded. Please try again."
         };


### PR DESCRIPTION
## Summary

- Add `HasApprovalHistory` check in `LlmSessionActor.TryResolveTextApprovalResponse` — when no approval has ever been requested, return `approval_no_history` nack instead of emitting an expired notice
- All three channel bindings (Slack, Discord, Mattermost) treat `approval_no_history` as "not consumed" so the message falls through to normal LLM ingress
- New cross-channel contract test validates the fix on all three bindings at once

## Problem

`LooksLikeApprovalResponse` matches single letters `a-e` and numbers `1-5` by design. When the session has never had an approval request, this produced a false positive: normal chat like "yes" or "a" was consumed by the cold approval path and a phantom "approval prompt expired" notice appeared to the user.

## Changes

| File | Change |
|------|--------|
| `LlmSessionActor.cs` | `HasApprovalHistory` property + `approval_no_history` nack path |
| `SlackThreadBindingActor.cs` | Channel-side: treat `approval_no_history` as not consumed |
| `DiscordSessionBindingActor.cs` | Same fix |
| `MattermostSessionBindingActor.cs` | Same fix |
| `SessionBindingContractTests.cs` | New test `Normal_chat_text_that_looks_like_approval_is_not_consumed_when_no_approval_history` |
| `RecordingSessionPipeline.cs` | `ResponseFactory` for scripted nack responses in tests |

## Testing

- 1983 tests pass (all existing approval tests green + 3 new contract test instances)
- Slopwatch: 0 issues
- Copyright headers: all present

Fixes #1164