### PR TITLE
fix(providers): wrap volatile context in last user message for vLLM compat

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/ContextOverflowDetectionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ContextOverflowDetectionTests.cs
@@ -101,4 +101,25 @@ public sealed class ContextOverflowDetectionTests
         var ex = new ProviderException(msg, msg, statusCode: 400);
         Assert.False(LlmSessionActor.IsContextOverflowError(ex));
     }
+
+    [Fact]
+    public void Non_400_with_structural_keyword_does_not_suppress_overflow_classification()
+    {
+        // A 5xx (or non-400) exception whose message incidentally contains
+        // a structural keyword must NOT suppress overflow detection. The
+        // structural short-circuit is gated on ProviderException{StatusCode:400}.
+        const string msg = "upstream proxy returned invalid role configuration; context length exceeded retrying";
+        var ex = new ProviderException(msg, msg, statusCode: 500);
+        Assert.True(LlmSessionActor.IsContextOverflowError(ex));
+    }
+
+    [Fact]
+    public void Non_400_with_only_structural_keyword_is_not_overflow()
+    {
+        // 5xx without any overflow keyword should not classify as overflow
+        // regardless of structural-keyword presence (control case).
+        const string msg = "upstream proxy returned invalid role configuration";
+        var ex = new ProviderException(msg, msg, statusCode: 500);
+        Assert.False(LlmSessionActor.IsContextOverflowError(ex));
+    }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/ContextOverflowDetectionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ContextOverflowDetectionTests.cs
@@ -70,4 +70,35 @@ public sealed class ContextOverflowDetectionTests
         var ex = new ProviderException("context length exceeded", "context length exceeded", statusCode: 500);
         Assert.True(LlmSessionActor.IsContextOverflowError(ex));
     }
+
+    [Theory]
+    [InlineData("System message must be at the beginning.")]                  // vLLM verbatim (post-#1171 regression)
+    [InlineData("system message must be at the beginning")]                   // case-insensitive
+    [InlineData("messages must alternate between user and assistant")]        // generic shape rule
+    [InlineData("invalid role 'developer' for this model")]                   // unsupported role
+    public void Structural_badrequest_does_not_classify_as_overflow(string message)
+    {
+        // These are wire-format violations, not "too many tokens". Routing
+        // them through the overflow path triggers a doomed compact-and-retry
+        // loop that ends in the misleading "Context window exceeded even
+        // after compaction" user-visible message. Compaction cannot fix
+        // wire-format bugs; the classifier must short-circuit.
+        var providerEx = new ProviderException(message, message, statusCode: 400);
+        Assert.False(LlmSessionActor.IsContextOverflowError(providerEx));
+
+        // Also covered when the structural message hides in an inner exception.
+        var wrapped = new Exception("LLM streaming failed", providerEx);
+        Assert.False(LlmSessionActor.IsContextOverflowError(wrapped));
+    }
+
+    [Fact]
+    public void Structural_badrequest_wins_even_if_message_also_mentions_context()
+    {
+        // Defensive: if a provider emitted both keywords (unlikely but
+        // not impossible), the structural classification still wins so
+        // we don't compaction-loop.
+        const string msg = "System message must be at the beginning. Note: also exceeded context length.";
+        var ex = new ProviderException(msg, msg, statusCode: 400);
+        Assert.False(LlmSessionActor.IsContextOverflowError(ex));
+    }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
@@ -314,6 +314,49 @@ public sealed class SessionMessageAssemblerTests
     }
 
     [Fact]
+    public void Volatile_block_drop_emits_warning_when_no_user_message_in_history()
+    {
+        // History contains only System + Assistant — no User-role message.
+        // The volatile block has nowhere to land. CLAUDE.md "No silent
+        // fallbacks" requires we surface this loudly rather than drop in
+        // silence.
+        var history = ImmutableList.Create(
+            new SerializableChatMessage { Role = ProtocolChatRole.System, Content = PersistedSystemPrompt },
+            new SerializableChatMessage { Role = ProtocolChatRole.Assistant, Content = "post-compaction summary" });
+
+        var input = MakeInput(history, FakeRecall("important-memory"));
+
+        var warnings = new List<string>();
+        var messages = SessionMessageAssembler.Assemble(input, warn: warnings.Add);
+
+        Assert.Single(warnings);
+        Assert.Contains("volatile_block_dropped", warnings[0]);
+        Assert.Contains("reason=no_user_message", warnings[0]);
+
+        // And the volatile content really did NOT leak into any message.
+        var allText = string.Join("\n", messages.Select(m => m.Text ?? string.Empty));
+        Assert.DoesNotContain("[memory-recall]", allText);
+        Assert.DoesNotContain("important-memory", allText);
+    }
+
+    [Fact]
+    public void Volatile_block_drop_does_not_warn_when_volatile_is_empty()
+    {
+        // No recall, no working context, no slash command → volatile block
+        // is empty → no warning fires even if no user message exists.
+        var history = ImmutableList.Create(
+            new SerializableChatMessage { Role = ProtocolChatRole.System, Content = PersistedSystemPrompt },
+            new SerializableChatMessage { Role = ProtocolChatRole.Assistant, Content = "post-compaction summary" });
+
+        var input = MakeInput(history, activeRecall: null);
+
+        var warnings = new List<string>();
+        SessionMessageAssembler.Assemble(input, warn: warnings.Add);
+
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
     public void Volatile_tail_is_suppressed_when_empty()
     {
         // No recall, no working context, no slash command, no overlay, no

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
@@ -87,23 +87,32 @@ public sealed class SessionMessageAssemblerTests
         var prefix = LongestCommonPrefix(turn1Messages, turn2Messages);
 
         // Expected stable prefix: [0] persisted prompt, [1] static dynamic
-        // context, [2] user turn1 message, [3] assistant turn1 reply. The
-        // turn 1 assistant reply is only in turn 2's history, but turn 1's
-        // messages ended at the user turn1 + volatile tail. So the match
-        // should extend at least through turn 1's user message.
-        Assert.True(prefix >= 3,
-            $"Expected cache prefix ≥ 3 messages (persisted prompt, static context, user turn1), got {prefix}. " +
+        // context. The user turn 1 message diverges between assemblies
+        // because turn 1's last User-role message carries the turn-1
+        // volatile <context> while turn 2's last User-role message is the
+        // turn-2 user message ("second question") carrying turn-2's
+        // <context>. The intervening "first question" user message in
+        // turn 2 is NOT the last User-role message and therefore has no
+        // <context> wrapper — but in turn 1 the SAME message IS the
+        // last User and does have a wrapper, so it diverges too. The
+        // stable prefix is therefore [0]+[1] only when only the volatile
+        // tail differs (which is the cache property we care about: the
+        // cacheable prefix is byte-stable across turns).
+        Assert.True(prefix >= 2,
+            $"Expected cache prefix ≥ 2 messages (persisted prompt + static context), got {prefix}. " +
             $"Turn 1: [{FormatMessages(turn1Messages)}] Turn 2: [{FormatMessages(turn2Messages)}]");
 
         // Guard against passing vacuously if recall was silently dropped:
-        // each turn's marker must appear in its own tail, and must not
-        // leak into the other turn's assembly.
-        var turn1Tail = turn1Messages[^1];
-        var turn2Tail = turn2Messages[^1];
-        Assert.Equal(Microsoft.Extensions.AI.ChatRole.System, turn1Tail.Role);
-        Assert.Equal(Microsoft.Extensions.AI.ChatRole.System, turn2Tail.Role);
-        Assert.Contains(turn1RecallMarker, turn1Tail.Text ?? string.Empty);
-        Assert.Contains(turn2RecallMarker, turn2Tail.Text ?? string.Empty);
+        // each turn's marker must appear in its own assembly's last User
+        // message, and must not leak into the other turn's assembly.
+        var turn1LastUser = LastUserMessage(turn1Messages);
+        var turn2LastUser = LastUserMessage(turn2Messages);
+        Assert.NotNull(turn1LastUser);
+        Assert.NotNull(turn2LastUser);
+        Assert.Contains("<context>", turn1LastUser!.Text ?? string.Empty);
+        Assert.Contains("<context>", turn2LastUser!.Text ?? string.Empty);
+        Assert.Contains(turn1RecallMarker, turn1LastUser.Text ?? string.Empty);
+        Assert.Contains(turn2RecallMarker, turn2LastUser.Text ?? string.Empty);
         Assert.DoesNotContain(turn2RecallMarker,
             string.Join("\n", turn1Messages.Select(m => m.Text ?? string.Empty)));
         Assert.DoesNotContain(turn1RecallMarker,
@@ -111,10 +120,16 @@ public sealed class SessionMessageAssemblerTests
     }
 
     [Fact]
-    public void Volatile_tail_message_is_System_role_at_end_of_list()
+    public void Volatile_block_is_wrapped_in_context_on_last_user_message()
     {
-        // See Volatile_tail_does_not_create_fake_user_turn_after_tool_result
-        // for the full reasoning on why the role must be System, not User.
+        // Volatile per-turn context (memory recall, slash command body,
+        // working context, etc.) is consolidated into a <context>...
+        // </context> block prepended to the text of the last User-role
+        // message. See SessionMessageAssembler XML doc for why this
+        // placement is correct across both strict OpenAI-compatible
+        // servers (vLLM rejects trailing System) and the mid-tool-loop
+        // chat-template "fake user turn" failure mode (would re-fire
+        // assistant restarts if the volatile tail were a User role).
         var input = MakeInput(
             SeedHistory("hi"),
             FakeRecall("mem-1"),
@@ -122,10 +137,24 @@ public sealed class SessionMessageAssemblerTests
         var messages = SessionMessageAssembler.Assemble(input);
 
         Assert.NotEmpty(messages);
-        var tail = messages[^1];
-        Assert.Equal(Microsoft.Extensions.AI.ChatRole.System, tail.Role);
-        Assert.Contains("[memory-recall]", tail.Text ?? string.Empty, StringComparison.Ordinal);
-        Assert.Contains("[skill] do a thing", tail.Text ?? string.Empty, StringComparison.Ordinal);
+        var lastUser = LastUserMessage(messages);
+        Assert.NotNull(lastUser);
+
+        var text = lastUser!.Text ?? string.Empty;
+        Assert.Contains("<context>", text, StringComparison.Ordinal);
+        Assert.Contains("</context>", text, StringComparison.Ordinal);
+        Assert.Contains("[memory-recall]", text, StringComparison.Ordinal);
+        Assert.Contains("[skill] do a thing", text, StringComparison.Ordinal);
+
+        // The original user content ("hi") must still be present AFTER
+        // the closing </context> tag.
+        var closingIndex = text.IndexOf("</context>", StringComparison.Ordinal);
+        Assert.True(closingIndex >= 0);
+        var afterClose = text[(closingIndex + "</context>".Length)..];
+        Assert.Contains("hi", afterClose);
+
+        // And no trailing System-role message must be appended.
+        Assert.NotEqual(Microsoft.Extensions.AI.ChatRole.System, messages[^1].Role);
     }
 
     [Fact]
@@ -164,17 +193,21 @@ public sealed class SessionMessageAssemblerTests
         var staticSystemBlock = turn2Messages[1].Text ?? string.Empty;
         Assert.DoesNotContain("[working-context]", staticSystemBlock);
 
-        var tail = turn2Messages[^1];
-        Assert.Equal(Microsoft.Extensions.AI.ChatRole.System, tail.Role);
-        Assert.Contains("[working-context]", tail.Text ?? string.Empty);
+        // Volatile working-context content lands in the <context> wrapper
+        // on the last User-role message, not in any System block.
+        var lastUser = LastUserMessage(turn2Messages);
+        Assert.NotNull(lastUser);
+        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
+        Assert.Contains("[working-context]", lastUser.Text ?? string.Empty);
     }
 
     [Fact]
     public void Recall_is_not_in_leading_system_prefix_even_when_resolved()
     {
         // Cache stability requires that volatile content only appears in the
-        // trailing System-role tail, never in the leading contiguous System
-        // prefix that makes up the cacheable prompt.
+        // <context> wrapper on the last User-role message, never in the
+        // leading contiguous System prefix that makes up the cacheable
+        // prompt.
         var input = MakeInput(SeedHistory("hi"), FakeRecall("remembered thing"));
         var messages = SessionMessageAssembler.Assemble(input);
 
@@ -187,40 +220,37 @@ public sealed class SessionMessageAssemblerTests
             Assert.DoesNotContain("remembered thing", text);
         }
 
-        var tail = messages[^1];
-        Assert.Equal(Microsoft.Extensions.AI.ChatRole.System, tail.Role);
-        Assert.Contains("[memory-recall]", tail.Text ?? string.Empty);
-        Assert.Contains("remembered thing", tail.Text ?? string.Empty);
+        var lastUser = LastUserMessage(messages);
+        Assert.NotNull(lastUser);
+        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
+        Assert.Contains("[memory-recall]", lastUser.Text ?? string.Empty);
+        Assert.Contains("remembered thing", lastUser.Text ?? string.Empty);
     }
 
     [Fact]
-    public void Volatile_tail_does_not_create_fake_user_turn_after_tool_result()
+    public void Volatile_block_does_not_create_fake_user_turn_after_tool_result()
     {
         // Regression test for the production loop observed in
         // D0AC6CKBK5K/1776051715.090089 turn 10 on 2026-04-13.
         //
         // When a user correction triggers multi-step tool work, the
         // session actor calls Assemble on every LLM round-trip during
-        // the tool loop. The assembled list mid-loop looks like:
+        // the tool loop. Mid-loop, the conversation tail in history is
+        // a Tool-role result. If the assembler appended ANYTHING at
+        // the tail (especially a User-role message), Qwen3's ChatML
+        // template would read it as a fresh user turn → the model
+        // restarts its assistant response → scans back for the
+        // user-correction → re-emits "You're right — I had that
+        // backwards" → fires another tool call → loops indefinitely
+        // until context exhaustion (262144/262144 tokens in the
+        // production repro).
         //
-        //   [system]    persisted prompt
-        //   [system]    static dynamic context
-        //   [user]      "Public is the most restrictive audience"
-        //   [assistant] "You're right. Let me check." + tool_use(...)
-        //   [tool]      <tool result>
-        //   [???]       volatile tail (memory recall, time, ...)
-        //
-        // If the volatile tail is User-role, Qwen3's ChatML template
-        // reads it as a fresh user turn → the model restarts its
-        // assistant response → it scans back for recent user content to
-        // acknowledge → finds the correction → re-emits "You're right
-        // — I had that backwards" → fires another tool call → loops
-        // indefinitely until context exhaustion (262144/262144 tokens
-        // in the production repro).
-        //
-        // The fix is to emit the volatile tail as a System-role
-        // message. System-role messages at the end read as scaffolding
-        // and the model continues its tool work normally.
+        // Current design: the volatile block is wrapped in <context>
+        // and PREPENDED to the last User-role message already in
+        // history. No new message is appended. The assembled tail
+        // remains whatever the conversation tail was (Tool result
+        // here), so chat templates see a coherent post-tool turn and
+        // do not restart.
         var history = ImmutableList.Create(
             new SerializableChatMessage { Role = ProtocolChatRole.System, Content = PersistedSystemPrompt },
             new SerializableChatMessage
@@ -246,17 +276,25 @@ public sealed class SessionMessageAssemblerTests
 
         Assert.NotEmpty(messages);
 
-        // The volatile tail must be the last message AND it must be
-        // System-role (not User), otherwise the chat template sees it
-        // as a new user turn.
+        // The volatile block must NOT add a trailing message. The tail
+        // role must be whatever was last in the conversation history —
+        // here, a Tool result.
         var tail = messages[^1];
-        Assert.Equal(Microsoft.Extensions.AI.ChatRole.System, tail.Role);
-        Assert.Contains("[memory-recall]", tail.Text ?? string.Empty);
+        Assert.Equal(Microsoft.Extensions.AI.ChatRole.Tool, tail.Role);
 
-        // Stronger invariant: no User-role message may appear AFTER
-        // the last Tool/Assistant message in the list. If this fires,
-        // the assembler is injecting a fake user turn mid-tool-loop
-        // and we are about to regress the production loop.
+        // The volatile block must have landed on the LAST User-role
+        // message in history (the correction). The Tool result content
+        // must remain unwrapped.
+        var lastUser = LastUserMessage(messages);
+        Assert.NotNull(lastUser);
+        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
+        Assert.Contains("[memory-recall]", lastUser.Text ?? string.Empty);
+        Assert.Contains("Public is the most restrictive audience", lastUser.Text ?? string.Empty);
+
+        // Stronger invariant (kept from the original regression test):
+        // no User-role message may appear AFTER the last Tool/Assistant
+        // message in the list. If this fires, the assembler is again
+        // injecting a fake user turn mid-tool-loop.
         var lastToolOrAssistantIndex = -1;
         for (var i = 0; i < messages.Count; i++)
         {
@@ -363,8 +401,12 @@ public sealed class SessionMessageAssemblerTests
         };
         var messages = SessionMessageAssembler.Assemble(input);
 
-        var tail = messages[^1];
-        Assert.Contains("[working-context]", tail.Text ?? string.Empty);
+        // Working-context content surfaces inside the <context> wrapper
+        // on the last User-role message.
+        var lastUser = LastUserMessage(messages);
+        Assert.NotNull(lastUser);
+        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
+        Assert.Contains("[working-context]", lastUser.Text ?? string.Empty);
     }
 
     private static ContextAssemblyInput MakeInput(
@@ -435,6 +477,16 @@ public sealed class SessionMessageAssemblerTests
         }
     }
 
+    private static AiChatMessage? LastUserMessage(IReadOnlyList<AiChatMessage> messages)
+    {
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            if (messages[i].Role == Microsoft.Extensions.AI.ChatRole.User)
+                return messages[i];
+        }
+        return null;
+    }
+
     private static string FormatMessages(IReadOnlyList<AiChatMessage> messages)
     {
         return string.Join(" | ", messages.Select(m => $"{m.Role}:{Truncate(m.Text ?? string.Empty)}"));
@@ -447,19 +499,23 @@ public sealed class SessionMessageAssemblerTests
 
     /// <summary>
     /// Verifies that the OpenAI-compatible provider's <c>NormalizeMessages</c>
-    /// preserves the trailing volatile system message instead of merging it
-    /// into the leading system prefix. This is the wire-format test that
-    /// catches the KV cache prefix invalidation regression.
+    /// defensively merges ANY System-role message — leading or non-leading —
+    /// into a single leading System prefix on the wire. Strict
+    /// OpenAI-compatible servers (vLLM with Qwen/Llama chat templates)
+    /// reject non-leading System messages with HTTP 400 "System message
+    /// must be at the beginning." The session assembler is the source of
+    /// truth for keeping volatile per-turn context inside the last User
+    /// message wrapped in &lt;context&gt;; this test pins the provider
+    /// client's defensive fallback when an upstream bug emits a
+    /// non-leading System anyway.
     /// </summary>
     [Fact]
-    public void NormalizeMessages_preserves_trailing_volatile_system_for_cache_stability()
+    public void NormalizeMessages_merges_non_leading_system_into_leading_for_provider_compatibility()
     {
-        // Simulate the message structure produced by SessionMessageAssembler:
-        // [0] System - static prompt (cache prefix)
-        // [1] System - static dynamic context
-        // [2] User - turn 1
-        // [3] Assistant - reply
-        // [4] System - volatile tail (memory recall, current time, ...)
+        // Regression scenario from PR #1171: a non-leading System slipped
+        // through to the wire and vLLM rejected it. NormalizeMessages must
+        // recover by merging into the leading prefix (and log a Warning,
+        // which is not asserted here — caller wires _logger).
         var messages = new List<AiChatMessage>
         {
             new(Microsoft.Extensions.AI.ChatRole.System, "You are Netclaw"),
@@ -471,66 +527,59 @@ public sealed class SessionMessageAssemblerTests
 
         var normalized = OpenAiCompatibleChatClient.NormalizeMessages(messages);
 
-        // The leading system messages should be merged into one at position 0
-        Assert.True(normalized.Count >= 3, "Expected at least 3 messages after normalization");
+        // Exactly 3 messages out: merged-system, user, assistant.
+        Assert.Equal(3, normalized.Count);
 
-        // Position 0: merged leading system messages
         var leadingSystem = (System.Text.Json.Nodes.JsonObject)normalized[0]!;
         Assert.Equal("system", leadingSystem["role"]!.GetValue<string>());
         var leadingContent = leadingSystem["content"]!.GetValue<string>();
         Assert.Contains("You are Netclaw", leadingContent);
         Assert.Contains("[session]", leadingContent);
+        // The straggling non-leading System content must be merged in here.
+        Assert.Contains("[memory-recall]", leadingContent);
+        Assert.Contains("current_utc", leadingContent);
 
-        // CRITICAL: the volatile tail must NOT be merged into the leading system
-        Assert.DoesNotContain("[memory-recall]", leadingContent);
-        Assert.DoesNotContain("current_utc", leadingContent);
-
-        // The volatile tail must appear as a separate message at the end
-        var last = (System.Text.Json.Nodes.JsonObject)normalized[^1]!;
-        var lastRole = last["role"]!.GetValue<string>();
-        Assert.Equal("system", lastRole);
-
-        var lastContent = last["content"]!.GetValue<string>();
-        Assert.Contains("[memory-recall]", lastContent);
-        Assert.Contains("current_utc", lastContent);
-
-        // Conversation history in between should be intact
+        // Conversation history stays in order; no trailing System.
         Assert.Equal("user", normalized[1]!["role"]!.GetValue<string>());
         Assert.Equal("assistant", normalized[2]!["role"]!.GetValue<string>());
     }
 
     /// <summary>
-    /// Regression test: when volatile content differs between turns, the
-    /// normalized wire format must still produce a growing cache prefix
-    /// through the conversation history, not just the static system prompt.
+    /// Regression test: assembler output (volatile context wrapped in
+    /// <c>&lt;context&gt;</c> on the last User-role message, no trailing
+    /// System) must pass through <c>NormalizeMessages</c> unchanged
+    /// across the conversation history, so the cacheable wire prefix
+    /// extends through every static message and every history pair up
+    /// to (but not including) the user message that carries the
+    /// volatile wrapper.
     /// </summary>
     [Fact]
     public void NormalizeMessages_cache_prefix_grows_through_history_across_turns()
     {
-        // Turn 1: short history, volatile tail with recall-A
+        // Turn 1: short history. Last User message has <context> with recall-A.
         var turn1 = new List<AiChatMessage>
         {
             new(Microsoft.Extensions.AI.ChatRole.System, "You are Netclaw"),
             new(Microsoft.Extensions.AI.ChatRole.System, "[session]\nid: test/123"),
-            new(Microsoft.Extensions.AI.ChatRole.User, "first question"),
-            new(Microsoft.Extensions.AI.ChatRole.System, "[memory-recall]\nstatus: healthy\nrecall-A"),
+            new(Microsoft.Extensions.AI.ChatRole.User, "<context>\n[memory-recall]\nrecall-A\n</context>\n\nfirst question"),
         };
 
-        // Turn 2: history extended, volatile tail with recall-B (different!)
+        // Turn 2: history extended. The earlier "first question" is now
+        // an inner history user (no wrapper); the freshly added "second
+        // question" carries the <context> with recall-B.
         var turn2 = new List<AiChatMessage>
         {
             new(Microsoft.Extensions.AI.ChatRole.System, "You are Netclaw"),
             new(Microsoft.Extensions.AI.ChatRole.System, "[session]\nid: test/123"),
             new(Microsoft.Extensions.AI.ChatRole.User, "first question"),
             new(Microsoft.Extensions.AI.ChatRole.Assistant, "first answer"),
-            new(Microsoft.Extensions.AI.ChatRole.User, "second question"),
-            new(Microsoft.Extensions.AI.ChatRole.System, "[memory-recall]\nstatus: healthy\nrecall-B"),
+            new(Microsoft.Extensions.AI.ChatRole.User, "<context>\n[memory-recall]\nrecall-B\n</context>\n\nsecond question"),
         };
 
         var norm1 = OpenAiCompatibleChatClient.NormalizeMessages(turn1);
         var norm2 = OpenAiCompatibleChatClient.NormalizeMessages(turn2);
 
-        // Compute longest common prefix (by role + content string match)
+        // Longest common prefix by serialized-JSON equality.
         var prefix = 0;
         var minCount = Math.Min(norm1.Count, norm2.Count);
         for (var i = 0; i < minCount; i++)
@@ -543,10 +592,23 @@ public sealed class SessionMessageAssemblerTests
                 break;
         }
 
-        // The prefix should extend through: [0] merged system, [1] user turn1
-        // After normalization, the leading system is identical in both, and the
-        // user turn 1 is at position [1] in both. The prefix should be at least 2.
-        Assert.True(prefix >= 2,
-            $"Expected cache prefix >= 2 (merged system + user turn1), got {prefix}");
+        // Expected: [0] merged-leading-system matches (no volatile in
+        // either turn's leading system → byte-identical). [1] in turn 1
+        // is the wrapped user; [1] in turn 2 is "first question" plain.
+        // They diverge at [1] in turn 1 vs [1] in turn 2 because in turn 1
+        // the only user IS the wrapped one. The minimum guarantee here is
+        // prefix ≥ 1 (the merged-system). The growth-through-history
+        // property is exercised in the assembler-level prefix tests above
+        // (Prefix_extends_through_history_when_startup_layers_settled).
+        Assert.True(prefix >= 1,
+            $"Expected cache prefix >= 1 (merged system), got {prefix}");
+
+        // Stronger guarantee: turn 2's leading system contains no
+        // volatile content — i.e., NormalizeMessages did NOT accidentally
+        // pull <context> content out of the user message into system.
+        var leadingTurn2 = (System.Text.Json.Nodes.JsonObject)norm2[0]!;
+        var leadingTurn2Content = leadingTurn2["content"]!.GetValue<string>();
+        Assert.DoesNotContain("recall-B", leadingTurn2Content);
+        Assert.DoesNotContain("<context>", leadingTurn2Content);
     }
 }

--- a/src/Netclaw.Actors/Sessions/LlmFailureClassifier.cs
+++ b/src/Netclaw.Actors/Sessions/LlmFailureClassifier.cs
@@ -76,11 +76,26 @@ internal static class LlmFailureClassifier
         if (ex is null)
             return false;
 
+        // Structural BadRequest errors must NEVER classify as context overflow.
+        // vLLM and other strict OpenAI-compatible servers return 400 for
+        // wire-format violations like a non-leading System message ("System
+        // message must be at the beginning."). Routing those through the
+        // overflow path triggers a doomed compaction → retry → second 400,
+        // ending in the misleading user message "Context window exceeded
+        // even after compaction." Compaction cannot fix a wire-format bug.
+        var current = ex;
+        while (current is not null)
+        {
+            if (ContainsStructuralBadRequestKeyword(current.Message))
+                return false;
+            current = current.InnerException;
+        }
+
         var providerEx = FindException<ProviderException>(ex);
         if (providerEx is { StatusCode: 400 } && ContainsOverflowKeyword(providerEx.Message))
             return true;
 
-        var current = ex;
+        current = ex;
         while (current is not null)
         {
             if (ContainsOverflowKeyword(current.Message))
@@ -130,4 +145,14 @@ internal static class LlmFailureClassifier
         || message.Contains("prompt is too long", StringComparison.OrdinalIgnoreCase)
         || message.Contains("token", StringComparison.OrdinalIgnoreCase)
             && message.Contains("exceed", StringComparison.OrdinalIgnoreCase);
+
+    // Wire-format / request-structure errors. These are 400s that mean
+    // "your request is malformed", not "your request is too big". They
+    // must short-circuit overflow detection so we don't trigger a
+    // doomed compaction loop on a structural bug.
+    private static bool ContainsStructuralBadRequestKeyword(string message) =>
+        message.Contains("System message must be at the beginning", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("must alternate", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("invalid role", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("tools` must not be an empty array", StringComparison.Ordinal);
 }

--- a/src/Netclaw.Actors/Sessions/LlmFailureClassifier.cs
+++ b/src/Netclaw.Actors/Sessions/LlmFailureClassifier.cs
@@ -83,19 +83,19 @@ internal static class LlmFailureClassifier
         // overflow path triggers a doomed compaction → retry → second 400,
         // ending in the misleading user message "Context window exceeded
         // even after compaction." Compaction cannot fix a wire-format bug.
-        var current = ex;
-        while (current is not null)
-        {
-            if (ContainsStructuralBadRequestKeyword(current.Message))
-                return false;
-            current = current.InnerException;
-        }
-
+        //
+        // Gate strictly on ProviderException{StatusCode:400}: a 5xx whose
+        // chain incidentally contains a structural keyword (e.g.,
+        // "invalid role configuration in proxy") must NOT suppress overflow
+        // classification on the outer exception.
         var providerEx = FindException<ProviderException>(ex);
+        if (providerEx is { StatusCode: 400 } && ContainsStructuralBadRequestKeyword(providerEx.Message))
+            return false;
+
         if (providerEx is { StatusCode: 400 } && ContainsOverflowKeyword(providerEx.Message))
             return true;
 
-        current = ex;
+        var current = ex;
         while (current is not null)
         {
             if (ContainsOverflowKeyword(current.Message))

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2565,7 +2565,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             SkillHint: skillHint,
             // Canonical names live in history (post-PR follow-up); the
             // LLM provider wants the sanitized alias back on the wire.
-            ToolNameToLlmFacing: _toolRegistry is null ? null : _toolRegistry.ToLlmFacingName));
+            ToolNameToLlmFacing: _toolRegistry is null ? null : _toolRegistry.ToLlmFacingName),
+            warn: msg => TurnLog().Warning(msg));
         _startupContextInjected = true;
 
         var self = Self;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2538,11 +2538,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // [attachments]) sits at the head so the prompt prefix stays
         // byte-stable across turns. Volatile per-turn content (memory
         // recall, current time, working context, slash command overlay,
-        // turn restart notice) is consolidated into a single User-role
-        // message appended at the tail so cache misses are confined to
-        // the end of the list. See SessionMessageAssembler for the full
-        // assembly contract. Mark startup injection complete after the
-        // first call to preserve the existing OnceAtStart semantics.
+        // turn restart notice) is wrapped in a <context>...</context>
+        // block and prepended to the text of the last User-role message
+        // in the list. That placement keeps cache misses confined to the
+        // user turn while remaining wire-compatible with strict providers
+        // (vLLM rejects trailing System messages with HTTP 400) and
+        // avoiding the mid-tool-loop "fake user turn" failure mode where
+        // a trailing User message makes Qwen-family chat templates
+        // restart the assistant response. See SessionMessageAssembler
+        // for the full assembly contract. Mark startup injection complete
+        // after the first call to preserve the existing OnceAtStart
+        // semantics.
         var skillHint = BuildSkillHint();
         var messages = SessionMessageAssembler.Assemble(new ContextAssemblyInput(
             State: _state,

--- a/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
@@ -46,32 +46,42 @@ public sealed record ContextAssemblyInput(
 /// <code>
 /// [0]      System  persisted prompt (SOUL/AGENTS/TOOLING)
 /// [1]      System  static dynamic context (OnceAtStart layers + [session] + [attachments])
-/// [2..N]   User/Assistant  conversation history (from SessionState.History, minus the
-///                          persisted prompt which was already at index 0)
-/// [last]   User    turn-context tail: [memory-recall] + current time +
-///                  [working-context] + slash command content + overlay +
-///                  turn restart notice. Only emitted when non-empty.
+/// [2..N]   User/Assistant/Tool  conversation history (from SessionState.History,
+///                               minus the persisted prompt which was already at index 0).
+///                               The last User-role message in this range carries the
+///                               volatile turn-context block as a &lt;context&gt; prefix on
+///                               its text content (see below).
 /// </code>
 ///
 /// The critical cache property: when the same session fires two turns in
 /// sequence, the longest common prefix of both assemblies extends through
-/// all static content and all conversation history up to (but not
-/// including) the volatile turn-context tail. Adding a turn to history
-/// extends the cache prefix for the next turn by exactly one more
-/// user/assistant pair.
+/// the leading System prefix and all conversation history up to (but not
+/// including) the user message whose <c>&lt;context&gt;</c> prefix carries
+/// volatile content. Adding a turn to history extends the cache prefix
+/// for the next turn by exactly one more user/assistant pair.
 ///
 /// All volatile content (memory recall, current time, working context,
 /// slash command, overlay, turn restart) is consolidated into a single
-/// System-role message at the end of the list. Keeping this content out
-/// of the leading System prefix means cache misses happen only for the
-/// new user turn, not for the entire conversation history. The role is
-/// intentionally System (not User): a trailing User-role message looks
-/// to chat templates like a fresh user turn and causes the model to
-/// restart an assistant response on every tool-loop iteration, which
-/// produces repeating-acknowledgement loops (e.g. "You're absolutely
-/// right — I had that backwards" restated on every tool call). A
-/// trailing System-role message reads as scaffolding and the model
-/// continues its tool work normally.
+/// <c>&lt;context&gt;...&lt;/context&gt;</c> block prepended to the text of
+/// the last User-role message in the list. This placement satisfies three
+/// constraints simultaneously:
+///
+/// <list type="bullet">
+///   <item>Keeps volatile content out of the leading System prefix so
+///   the cacheable head stays byte-stable across turns.</item>
+///   <item>Avoids emitting any message after the last conversation
+///   message — so a mid-tool-loop assembly (where the conversation
+///   tail is a Tool-role result, not a User-role message) does NOT
+///   inject a fake User turn that would make chat templates restart
+///   the assistant response and cause repeating-acknowledgement loops
+///   (e.g. "You're absolutely right — I had that backwards" restated
+///   on every tool call).</item>
+///   <item>Avoids emitting a trailing System-role message, which
+///   strict OpenAI-compatible servers (vLLM with the Qwen/Llama chat
+///   templates among them) reject with HTTP 400 "System message must
+///   be at the beginning." A trailing System tail used to be the
+///   previous design here and broke vLLM after PR #1171.</item>
+/// </list>
 /// </summary>
 public static class SessionMessageAssembler
 {
@@ -124,10 +134,53 @@ public static class SessionMessageAssembler
         var volatileBlock = BuildVolatileContextBlock(input);
         if (!string.IsNullOrEmpty(volatileBlock))
         {
-            messages.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.System, volatileBlock));
+            PrependContextToLastUserMessage(messages, volatileBlock);
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Prepends the volatile context block to the text of the last
+    /// User-role message in <paramref name="messages"/>, wrapped in
+    /// <c>&lt;context&gt;...&lt;/context&gt;</c> tags. Preserves any
+    /// non-text contents (images, attachments) on that message intact.
+    /// If no User message is present (edge case: fresh session before
+    /// the first user turn lands in history), the volatile block is
+    /// silently dropped — there is no valid wire position for it.
+    /// </summary>
+    private static void PrependContextToLastUserMessage(List<AiChatMessage> messages, string volatileBlock)
+    {
+        var prefix = "<context>\n" + volatileBlock + "\n</context>\n\n";
+
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            var msg = messages[i];
+            if (msg.Role != Microsoft.Extensions.AI.ChatRole.User)
+                continue;
+
+            var newContents = new List<AIContent>(msg.Contents.Count + 1);
+            var prepended = false;
+            foreach (var content in msg.Contents)
+            {
+                if (!prepended && content is TextContent text)
+                {
+                    newContents.Add(new TextContent(prefix + (text.Text ?? string.Empty)));
+                    prepended = true;
+                }
+                else
+                {
+                    newContents.Add(content);
+                }
+            }
+            if (!prepended)
+            {
+                newContents.Insert(0, new TextContent(prefix));
+            }
+
+            messages[i] = new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, newContents);
+            return;
+        }
     }
 
     private static string BuildStaticContextBlock(ContextAssemblyInput input, string sessionDir)

--- a/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
@@ -108,7 +108,7 @@ public static class SessionMessageAssembler
         "Never silently ignore an attachment the user sent — always acknowledge what you received by name, " +
         "even if you cannot fully process it.";
 
-    public static List<AiChatMessage> Assemble(ContextAssemblyInput input)
+    public static List<AiChatMessage> Assemble(ContextAssemblyInput input, Action<string>? warn = null)
     {
         var sessionDir = SessionDirectoryHelper.GetSessionDirectory(input.SessionId, input.SessionsBasePath);
         var messages = ChatMessageConverter.ToAiMessages(
@@ -134,7 +134,7 @@ public static class SessionMessageAssembler
         var volatileBlock = BuildVolatileContextBlock(input);
         if (!string.IsNullOrEmpty(volatileBlock))
         {
-            PrependContextToLastUserMessage(messages, volatileBlock);
+            PrependContextToLastUserMessage(messages, volatileBlock, warn);
         }
 
         return messages;
@@ -146,10 +146,13 @@ public static class SessionMessageAssembler
     /// <c>&lt;context&gt;...&lt;/context&gt;</c> tags. Preserves any
     /// non-text contents (images, attachments) on that message intact.
     /// If no User message is present (edge case: fresh session before
-    /// the first user turn lands in history), the volatile block is
-    /// silently dropped — there is no valid wire position for it.
+    /// the first user turn lands in history, or post-compaction state
+    /// where only System/Assistant/Tool messages remain), the volatile
+    /// block has no valid wire position; the assembler invokes
+    /// <paramref name="warn"/> so the caller can surface this as a loud
+    /// failure instead of silently degrading.
     /// </summary>
-    private static void PrependContextToLastUserMessage(List<AiChatMessage> messages, string volatileBlock)
+    private static void PrependContextToLastUserMessage(List<AiChatMessage> messages, string volatileBlock, Action<string>? warn)
     {
         var prefix = "<context>\n" + volatileBlock + "\n</context>\n\n";
 
@@ -181,6 +184,8 @@ public static class SessionMessageAssembler
             messages[i] = new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, newContents);
             return;
         }
+
+        warn?.Invoke($"volatile_block_dropped reason=no_user_message chars={volatileBlock.Length}");
     }
 
     private static string BuildStaticContextBlock(ContextAssemblyInput input, string sessionDir)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -207,7 +207,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         var body = new JsonObject
         {
             ["model"] = options?.ModelId ?? _modelId,
-            ["messages"] = NormalizeMessages(messages),
+            ["messages"] = NormalizeMessages(messages, _logger),
             ["stream"] = stream
         };
 
@@ -247,47 +247,69 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         return body;
     }
 
-    internal static JsonArray NormalizeMessages(IEnumerable<ChatMessage> messages)
+    internal static JsonArray NormalizeMessages(IEnumerable<ChatMessage> messages, ILogger? logger = null)
     {
         var normalized = new JsonArray();
         var all = messages.ToList();
 
-        // Merge only the LEADING contiguous system messages into a single
-        // prefix. The assembler deliberately places volatile context
-        // (memory recall, current time, working context) in a trailing
-        // System-role message so it doesn't invalidate the cache prefix.
-        // If we merge that trailing system into the lead (as the old code
-        // did), the volatile content changes every turn and the prefix
-        // cache is busted from token 0.
-        int leadingSystemCount = 0;
-        while (leadingSystemCount < all.Count && all[leadingSystemCount].Role == ChatRole.System)
-            leadingSystemCount++;
+        // All System-role messages are merged into a single leading
+        // system message. Strict OpenAI-compatible servers (vLLM with
+        // Qwen/Llama chat templates among them) reject non-leading
+        // System messages with HTTP 400 "System message must be at the
+        // beginning." The session assembler is the source of truth and
+        // is expected to keep volatile per-turn context inside the last
+        // User-role message (wrapped in <context> tags), never as a
+        // trailing System. If a non-leading System slips through here
+        // it's a programming error upstream — we merge it into the
+        // leading prefix defensively so the request still reaches the
+        // provider, but we log Warning so the upstream bug surfaces.
+        var leadingSegments = new List<string>();
+        var passThrough = new List<ChatMessage>(all.Count);
+        var sawNonLeadingSystem = false;
+        var stillLeading = true;
 
-        // Merge the leading contiguous system messages
-        if (leadingSystemCount > 0)
+        foreach (var message in all)
         {
-            var segments = new List<string>(leadingSystemCount);
-            for (int i = 0; i < leadingSystemCount; i++)
+            if (message.Role == ChatRole.System)
             {
-                if (!string.IsNullOrWhiteSpace(all[i].Text))
-                    segments.Add(all[i].Text);
-            }
-
-            if (segments.Count > 0)
-            {
-                normalized.Add(new JsonObject
+                if (stillLeading)
                 {
-                    ["role"] = "system",
-                    ["content"] = string.Join("\n\n", segments)
-                });
+                    if (!string.IsNullOrWhiteSpace(message.Text))
+                        leadingSegments.Add(message.Text);
+                }
+                else
+                {
+                    sawNonLeadingSystem = true;
+                    if (!string.IsNullOrWhiteSpace(message.Text))
+                        leadingSegments.Add(message.Text);
+                }
+            }
+            else
+            {
+                stillLeading = false;
+                passThrough.Add(message);
             }
         }
 
-        // Process remaining messages, preserving the trailing volatile
-        // system message at its original position
-        for (int i = leadingSystemCount; i < all.Count; i++)
+        if (sawNonLeadingSystem)
         {
-            normalized.Add(ToMessage(all[i]));
+            logger?.LogWarning(
+                "NormalizeMessages received a non-leading System-role message — merging into the leading system prefix defensively. "
+                + "This indicates an upstream assembler bug: volatile per-turn context should be wrapped inside the last User-role message (<context>...</context>), not emitted as a separate System message.");
+        }
+
+        if (leadingSegments.Count > 0)
+        {
+            normalized.Add(new JsonObject
+            {
+                ["role"] = "system",
+                ["content"] = string.Join("\n\n", leadingSegments)
+            });
+        }
+
+        foreach (var message in passThrough)
+        {
+            normalized.Add(ToMessage(message));
         }
 
         return normalized;


### PR DESCRIPTION
Fixes the HTTP 400 "System message must be at the beginning" we hit on vLLM after PR #1171. Volatile per-turn context now wraps in `<context>...</context>` on the last User message instead of a trailing System.

Includes a follow-up commit closing two review findings: warn-on-drop in the assembler, and gating the structural-BadRequest classifier short-circuit on StatusCode==400.

Notes for #1174 author: rebases cleanly except for one wire-format test rewrite. Cache impact for long conversations covered in a separate follow-up.

Signed-off-by: Aaron Stannard <aaron@petabridge.com>