### PR TITLE
fix(sessions): persist volatile context into history for cross-turn cache stability

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
@@ -67,94 +67,87 @@ public sealed class SessionMessageAssemblerTests
     [Fact]
     public void Prefix_extends_through_history_when_startup_layers_settled()
     {
-        // Simulate the steady-state condition: both turns have
-        // StartupContextInjected=true, so the static block is structurally
-        // identical across them. This is the case during normal multi-turn
-        // operation (after the first turn fires).
-        const string turn1RecallMarker = "remembered-turn-1-secret-payload";
-        const string turn2RecallMarker = "completely-different-turn-2-content";
-
-        var turn1History = SeedHistory("first question");
-        var turn1 = MakeInput(turn1History, FakeRecall(turn1RecallMarker), startupDone: true);
+        // Steady-state: both turns have StartupContextInjected=true so the
+        // static block is structurally identical across them. The assembler
+        // no longer wraps the last User message — it just emits the static
+        // block + history verbatim. Cache prefix stability comes from the
+        // actor persisting the per-turn volatile block as a system-nudge
+        // entry in history (via SessionState.AddSystemNudge) BEFORE the
+        // assembler runs. We simulate that here by pre-populating history.
+        var turn1History = SeedHistory("first question")
+            .Add(new SerializableChatMessage
+            {
+                Role = ProtocolChatRole.User,
+                Content = $"{SessionState.SystemNudgePrefix} turn-1-volatile-snapshot]",
+            });
+        var turn1 = MakeInput(turn1History, activeRecall: null, startupDone: true);
         var turn1Messages = SessionMessageAssembler.Assemble(turn1);
 
         var turn2History = turn1History
             .Add(new SerializableChatMessage { Role = ProtocolChatRole.Assistant, Content = "First answer" })
-            .Add(new SerializableChatMessage { Role = ProtocolChatRole.User, Content = "second question" });
-        var turn2 = MakeInput(turn2History, FakeRecall(turn2RecallMarker), startupDone: true);
+            .Add(new SerializableChatMessage { Role = ProtocolChatRole.User, Content = "second question" })
+            .Add(new SerializableChatMessage
+            {
+                Role = ProtocolChatRole.User,
+                Content = $"{SessionState.SystemNudgePrefix} turn-2-volatile-snapshot]",
+            });
+        var turn2 = MakeInput(turn2History, activeRecall: null, startupDone: true);
         var turn2Messages = SessionMessageAssembler.Assemble(turn2);
 
         var prefix = LongestCommonPrefix(turn1Messages, turn2Messages);
 
-        // Expected stable prefix: [0] persisted prompt, [1] static dynamic
-        // context. The user turn 1 message diverges between assemblies
-        // because turn 1's last User-role message carries the turn-1
-        // volatile <context> while turn 2's last User-role message is the
-        // turn-2 user message ("second question") carrying turn-2's
-        // <context>. The intervening "first question" user message in
-        // turn 2 is NOT the last User-role message and therefore has no
-        // <context> wrapper — but in turn 1 the SAME message IS the
-        // last User and does have a wrapper, so it diverges too. The
-        // stable prefix is therefore [0]+[1] only when only the volatile
-        // tail differs (which is the cache property we care about: the
-        // cacheable prefix is byte-stable across turns).
-        Assert.True(prefix >= 2,
-            $"Expected cache prefix ≥ 2 messages (persisted prompt + static context), got {prefix}. " +
+        // Turn 1 wire: [persisted, static, user "first question", nudge-1]
+        // Turn 2 wire: [persisted, static, user "first question", nudge-1, assistant, user "second", nudge-2]
+        // Cache prefix should extend through turn 1's full content (4 messages)
+        // before turn 2 diverges with its own assistant+user2+nudge2.
+        Assert.True(prefix >= 4,
+            $"Expected cache prefix ≥ 4 (persisted+static+user1+nudge1), got {prefix}. " +
             $"Turn 1: [{FormatMessages(turn1Messages)}] Turn 2: [{FormatMessages(turn2Messages)}]");
-
-        // Guard against passing vacuously if recall was silently dropped:
-        // each turn's marker must appear in its own assembly's last User
-        // message, and must not leak into the other turn's assembly.
-        var turn1LastUser = LastUserMessage(turn1Messages);
-        var turn2LastUser = LastUserMessage(turn2Messages);
-        Assert.NotNull(turn1LastUser);
-        Assert.NotNull(turn2LastUser);
-        Assert.Contains("<context>", turn1LastUser!.Text ?? string.Empty);
-        Assert.Contains("<context>", turn2LastUser!.Text ?? string.Empty);
-        Assert.Contains(turn1RecallMarker, turn1LastUser.Text ?? string.Empty);
-        Assert.Contains(turn2RecallMarker, turn2LastUser.Text ?? string.Empty);
-        Assert.DoesNotContain(turn2RecallMarker,
-            string.Join("\n", turn1Messages.Select(m => m.Text ?? string.Empty)));
-        Assert.DoesNotContain(turn1RecallMarker,
-            string.Join("\n", turn2Messages.Select(m => m.Text ?? string.Empty)));
     }
 
     [Fact]
-    public void Volatile_block_is_wrapped_in_context_on_last_user_message()
+    public void Assemble_emits_history_verbatim_does_not_inject_volatile()
     {
-        // Volatile per-turn context (memory recall, slash command body,
-        // working context, etc.) is consolidated into a <context>...
-        // </context> block prepended to the text of the last User-role
-        // message. See SessionMessageAssembler XML doc for why this
-        // placement is correct across both strict OpenAI-compatible
-        // servers (vLLM rejects trailing System) and the mid-tool-loop
-        // chat-template "fake user turn" failure mode (would re-fire
-        // assistant restarts if the volatile tail were a User role).
+        // Post-#1176 follow-up: the assembler stopped wrapping the last
+        // User message with a <context> block. Volatile content (memory
+        // recall, slash command, working context, current time, etc.) is
+        // injected into history by LlmSessionActor via AddSystemNudge at
+        // turn-start, before the assembler runs. The assembler emits
+        // history verbatim — no <context> wrapper, no trailing System.
         var input = MakeInput(
             SeedHistory("hi"),
             FakeRecall("mem-1"),
             slashCommand: "[skill] do a thing");
         var messages = SessionMessageAssembler.Assemble(input);
 
-        Assert.NotEmpty(messages);
-        var lastUser = LastUserMessage(messages);
-        Assert.NotNull(lastUser);
+        var allText = string.Join("\n", messages.Select(m => m.Text ?? string.Empty));
+        Assert.DoesNotContain("<context>", allText);
+        Assert.DoesNotContain("</context>", allText);
+        Assert.DoesNotContain("[memory-recall]", allText);
+        Assert.DoesNotContain("[skill] do a thing", allText);
 
-        var text = lastUser!.Text ?? string.Empty;
-        Assert.Contains("<context>", text, StringComparison.Ordinal);
-        Assert.Contains("</context>", text, StringComparison.Ordinal);
-        Assert.Contains("[memory-recall]", text, StringComparison.Ordinal);
-        Assert.Contains("[skill] do a thing", text, StringComparison.Ordinal);
+        // Last message in the assembly is whatever was last in history —
+        // here, the user "hi" (no nudge pre-seeded for this test).
+        Assert.Equal(Microsoft.Extensions.AI.ChatRole.User, messages[^1].Role);
+        Assert.Equal("hi", messages[^1].Text);
+    }
 
-        // The original user content ("hi") must still be present AFTER
-        // the closing </context> tag.
-        var closingIndex = text.IndexOf("</context>", StringComparison.Ordinal);
-        Assert.True(closingIndex >= 0);
-        var afterClose = text[(closingIndex + "</context>".Length)..];
-        Assert.Contains("hi", afterClose);
+    [Fact]
+    public void BuildVolatileContextBlock_composes_recall_and_slash_command()
+    {
+        // Pure-function helper test — this is the composition logic that
+        // LlmSessionActor calls at turn-start to compute what to nudge
+        // into history. Verifies content presence; format is checked by
+        // existing FormatRecallForLlm / WorkingContext.ToContextBlock tests.
+        var input = MakeInput(
+            SeedHistory("hi"),
+            FakeRecall("mem-1"),
+            slashCommand: "[skill] do a thing");
+        var block = SessionMessageAssembler.BuildVolatileContextBlock(input);
 
-        // And no trailing System-role message must be appended.
-        Assert.NotEqual(Microsoft.Extensions.AI.ChatRole.System, messages[^1].Role);
+        Assert.Contains("[memory-recall]", block);
+        Assert.Contains("mem-1", block);
+        Assert.Contains("[skill] do a thing", block);
     }
 
     [Fact]
@@ -173,13 +166,13 @@ public sealed class SessionMessageAssemblerTests
     [Fact]
     public void Working_context_update_does_not_poison_system_prefix()
     {
-        // Turn 1: no file in working context.
+        // Turn 1: no file in working context. The static block (messages[1])
+        // must stay byte-stable when working_context changes on turn 2 —
+        // it lives in the leading System prefix and is part of the
+        // cacheable head.
         var turn1 = MakeInput(SeedHistory("read Rect.cs"), FakeRecall("m"));
         var turn1Messages = SessionMessageAssembler.Assemble(turn1);
 
-        // Turn 2: same history but working context now has a file. If
-        // working-context content poisoned the static prefix, messages[1]
-        // would differ between the turns. It must not.
         var stateWithFile = turn1.State with
         {
             WorkingContext = WorkingContext.Empty.AddRecentFile("src/Rect.cs")
@@ -193,42 +186,36 @@ public sealed class SessionMessageAssemblerTests
         var staticSystemBlock = turn2Messages[1].Text ?? string.Empty;
         Assert.DoesNotContain("[working-context]", staticSystemBlock);
 
-        // Volatile working-context content lands in the <context> wrapper
-        // on the last User-role message, not in any System block.
-        var lastUser = LastUserMessage(turn2Messages);
-        Assert.NotNull(lastUser);
-        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
-        Assert.Contains("[working-context]", lastUser.Text ?? string.Empty);
+        // Working-context content does NOT appear in the assembler output —
+        // it would be injected by LlmSessionActor via AddSystemNudge at
+        // turn-start (verified separately by actor-level tests). The
+        // assembler-level invariant is that the static head stays clean.
+        Assert.DoesNotContain("[working-context]",
+            string.Join("\n", turn2Messages.Select(m => m.Text ?? string.Empty)));
     }
 
     [Fact]
-    public void Recall_is_not_in_leading_system_prefix_even_when_resolved()
+    public void Recall_is_not_emitted_by_assembler_lives_in_history_nudge()
     {
-        // Cache stability requires that volatile content only appears in the
-        // <context> wrapper on the last User-role message, never in the
-        // leading contiguous System prefix that makes up the cacheable
-        // prompt.
+        // Post-cache-history-stable: the assembler stopped composing the
+        // volatile block (recall, time, working context, etc.) into the
+        // wire format. LlmSessionActor persists those into History via
+        // AddSystemNudge before calling Assemble. The assembler tests for
+        // those things now exercise BuildVolatileContextBlock directly
+        // (see BuildVolatileContextBlock_composes_recall_and_slash_command).
+        // This test pins the assembler-side invariant: passing ActiveRecall
+        // does NOT cause recall content to leak into the leading system or
+        // the user message text.
         var input = MakeInput(SeedHistory("hi"), FakeRecall("remembered thing"));
         var messages = SessionMessageAssembler.Assemble(input);
 
-        foreach (var msg in messages)
-        {
-            if (msg.Role != Microsoft.Extensions.AI.ChatRole.System)
-                break;
-            var text = msg.Text ?? string.Empty;
-            Assert.DoesNotContain("[memory-recall]", text);
-            Assert.DoesNotContain("remembered thing", text);
-        }
-
-        var lastUser = LastUserMessage(messages);
-        Assert.NotNull(lastUser);
-        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
-        Assert.Contains("[memory-recall]", lastUser.Text ?? string.Empty);
-        Assert.Contains("remembered thing", lastUser.Text ?? string.Empty);
+        var allText = string.Join("\n", messages.Select(m => m.Text ?? string.Empty));
+        Assert.DoesNotContain("[memory-recall]", allText);
+        Assert.DoesNotContain("remembered thing", allText);
     }
 
     [Fact]
-    public void Volatile_block_does_not_create_fake_user_turn_after_tool_result()
+    public void Assembler_does_not_add_trailing_message_after_tool_result()
     {
         // Regression test for the production loop observed in
         // D0AC6CKBK5K/1776051715.090089 turn 10 on 2026-04-13.
@@ -276,20 +263,21 @@ public sealed class SessionMessageAssemblerTests
 
         Assert.NotEmpty(messages);
 
-        // The volatile block must NOT add a trailing message. The tail
-        // role must be whatever was last in the conversation history —
-        // here, a Tool result.
+        // The assembler must NOT add a trailing message. The tail role
+        // must be whatever was last in the conversation history — here,
+        // a Tool result.
         var tail = messages[^1];
         Assert.Equal(Microsoft.Extensions.AI.ChatRole.Tool, tail.Role);
 
-        // The volatile block must have landed on the LAST User-role
-        // message in history (the correction). The Tool result content
-        // must remain unwrapped.
+        // Volatile content (recall etc.) is NOT injected by the assembler
+        // anywhere — it lives in history via AddSystemNudge (actor-side).
+        var allText = string.Join("\n", messages.Select(m => m.Text ?? string.Empty));
+        Assert.DoesNotContain("[memory-recall]", allText);
+
+        // The original user correction stays as-is in history.
         var lastUser = LastUserMessage(messages);
         Assert.NotNull(lastUser);
-        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
-        Assert.Contains("[memory-recall]", lastUser.Text ?? string.Empty);
-        Assert.Contains("Public is the most restrictive audience", lastUser.Text ?? string.Empty);
+        Assert.Equal("Public is the most restrictive audience", lastUser!.Text);
 
         // Stronger invariant (kept from the original regression test):
         // no User-role message may appear AFTER the last Tool/Assistant
@@ -311,49 +299,6 @@ public sealed class SessionMessageAssemblerTests
         {
             Assert.NotEqual(Microsoft.Extensions.AI.ChatRole.User, messages[i].Role);
         }
-    }
-
-    [Fact]
-    public void Volatile_block_drop_emits_warning_when_no_user_message_in_history()
-    {
-        // History contains only System + Assistant — no User-role message.
-        // The volatile block has nowhere to land. CLAUDE.md "No silent
-        // fallbacks" requires we surface this loudly rather than drop in
-        // silence.
-        var history = ImmutableList.Create(
-            new SerializableChatMessage { Role = ProtocolChatRole.System, Content = PersistedSystemPrompt },
-            new SerializableChatMessage { Role = ProtocolChatRole.Assistant, Content = "post-compaction summary" });
-
-        var input = MakeInput(history, FakeRecall("important-memory"));
-
-        var warnings = new List<string>();
-        var messages = SessionMessageAssembler.Assemble(input, warn: warnings.Add);
-
-        Assert.Single(warnings);
-        Assert.Contains("volatile_block_dropped", warnings[0]);
-        Assert.Contains("reason=no_user_message", warnings[0]);
-
-        // And the volatile content really did NOT leak into any message.
-        var allText = string.Join("\n", messages.Select(m => m.Text ?? string.Empty));
-        Assert.DoesNotContain("[memory-recall]", allText);
-        Assert.DoesNotContain("important-memory", allText);
-    }
-
-    [Fact]
-    public void Volatile_block_drop_does_not_warn_when_volatile_is_empty()
-    {
-        // No recall, no working context, no slash command → volatile block
-        // is empty → no warning fires even if no user message exists.
-        var history = ImmutableList.Create(
-            new SerializableChatMessage { Role = ProtocolChatRole.System, Content = PersistedSystemPrompt },
-            new SerializableChatMessage { Role = ProtocolChatRole.Assistant, Content = "post-compaction summary" });
-
-        var input = MakeInput(history, activeRecall: null);
-
-        var warnings = new List<string>();
-        SessionMessageAssembler.Assemble(input, warn: warnings.Add);
-
-        Assert.Empty(warnings);
     }
 
     [Fact]
@@ -432,24 +377,21 @@ public sealed class SessionMessageAssemblerTests
     [Fact]
     public void Personal_audience_includes_working_context_in_volatile_block()
     {
+        // Working-context inclusion is audience-gated inside
+        // BuildVolatileContextBlock. The assembler itself no longer
+        // composes the volatile block; the actor calls BVCB at turn-start.
+        // Verifying the helper directly here.
         var stateWithWorkingContext = SessionState.Empty with
         {
             History = SeedHistory("hi"),
             WorkingContext = WorkingContext.Empty.AddRecentFile("src/Rect.cs")
         };
         var input = MakeInput(SeedHistory("hi"), FakeRecall("mem-1"), audience: TrustAudience.Personal);
-        input = input with
-        {
-            State = stateWithWorkingContext
-        };
-        var messages = SessionMessageAssembler.Assemble(input);
+        input = input with { State = stateWithWorkingContext };
 
-        // Working-context content surfaces inside the <context> wrapper
-        // on the last User-role message.
-        var lastUser = LastUserMessage(messages);
-        Assert.NotNull(lastUser);
-        Assert.Contains("<context>", lastUser!.Text ?? string.Empty);
-        Assert.Contains("[working-context]", lastUser.Text ?? string.Empty);
+        var block = SessionMessageAssembler.BuildVolatileContextBlock(input);
+        Assert.Contains("[working-context]", block);
+        Assert.Contains("src/Rect.cs", block);
     }
 
     private static ContextAssemblyInput MakeInput(

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -254,13 +254,21 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
     }
 
     [Fact]
-    public async Task WorkingContext_populated_by_file_read_tool_execution()
+    public async Task WorkingContext_populated_by_file_read_tool_execution_visible_in_next_turn()
     {
-        // End-to-end: LLM emits a file_read tool call, the actor executes
-        // it and appends the result to history, the tool-execution hook
-        // pushes the path onto WorkingContext.RecentFiles, and the next
-        // LLM call receives a [working-context] block in its dynamic
-        // system message.
+        // End-to-end: LLM emits a file_read tool call on turn 1, the actor
+        // executes it and the tool-execution hook pushes the path onto
+        // WorkingContext.RecentFiles. The agent must see a [working-context]
+        // block mentioning that file on turn 2 (the next user turn).
+        //
+        // Under the cache-history-stable design (see SessionMessageAssembler
+        // class comment), volatile context is captured ONCE per turn at
+        // turn-start via SessionState.AddSystemNudge — not refreshed on
+        // each tool-loop iteration. Turn 1's nudge therefore reflects
+        // working_context as of turn-start (empty); the file opened during
+        // turn 1's tool loop surfaces in turn 2's nudge. This is the
+        // explicit trade-off for keeping the wire bytes byte-stable across
+        // turns (every byte-prefix-caching provider benefits).
         //
         // CRITICAL: the argument key here ("Path", PascalCase) must match
         // what NetclawToolGenerator emits for first-party file tools —
@@ -293,37 +301,39 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
             Content = "please read Rect.cs"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        // Wait for the full tool-call loop: ToolCallOutput, ToolResultOutput,
-        // second LLM call's TextOutput, TurnCompleted.
+        // Drain turn 1's events: tool call, tool result, follow-up text, complete.
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
-        // The second (follow-up) main-model call after the tool execution
-        // should see a `[working-context]` block. Since #608, volatile
-        // content (including working-context) lives in a User-role tail
-        // message rather than a System message, so the agent sees it as
-        // runtime context appended after the user's message.
-        var mainModelCalls = _fakeChatClient.ReceivedMessages
-            .Where(msgs => !(msgs.FirstOrDefault(m => m.Role == Microsoft.Extensions.AI.ChatRole.System)?.Text
-                ?? string.Empty).Contains("session summarizer", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        // Turn 2: a follow-up user message. The fresh nudge captured at
+        // turn-2-start must include working_context with src/Rect.cs from
+        // turn 1's tool execution.
+        var turn1CallCount = _fakeChatClient.ReceivedMessages.Count;
 
-        Assert.True(mainModelCalls.Count >= 2,
-            $"Expected at least 2 main-model calls (initial + tool-loop follow-up); got {mainModelCalls.Count}");
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "what file did you read?"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        var followUpCall = mainModelCalls[^1];
-        var allContent = followUpCall
-            .Select(m => m.Text ?? string.Empty)
-            .ToList();
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        // Inspect the first main-model LLM call of turn 2 (the one with
+        // the fresh nudge applied).
+        Assert.True(_fakeChatClient.ReceivedMessages.Count > turn1CallCount,
+            $"Expected at least one main-model call on turn 2; total before={turn1CallCount} after={_fakeChatClient.ReceivedMessages.Count}");
+        var turn2Call = _fakeChatClient.ReceivedMessages[turn1CallCount];
+        var allContent = turn2Call.Select(m => m.Text ?? string.Empty).ToList();
 
         var hasWorkingContextBlock = allContent.Any(s =>
             s.Contains("[working-context]", StringComparison.Ordinal)
             && s.Contains("src/Rect.cs", StringComparison.Ordinal));
 
         Assert.True(hasWorkingContextBlock,
-            $"Expected the follow-up LLM call to include a [working-context] block mentioning src/Rect.cs. All messages:\n{string.Join("\n---\n", allContent)}");
+            $"Expected turn 2's first LLM call to include a [working-context] block mentioning src/Rect.cs. All messages:\n{string.Join("\n---\n", allContent)}");
     }
 }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2532,14 +2532,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             resolved = _recallManager.ApplyProgressiveRecall(resolved, _log);
 
-            // Persist recalled memories into session history so they survive
-            // across turns. Without this, recalled memories are transient system
-            // messages that vanish after one turn, and the exclusion set prevents
-            // re-injection — making the memory invisible for the rest of the session.
+            // Observer audit: track which memories were recalled this turn
+            // independently of how they end up on the wire. Downstream
+            // distillation prompts grep for "[recalled-memory]" entries.
             if (resolved.Items.Count > 0)
             {
                 var recallContent = SessionRecallManager.FormatForHistory(resolved);
-                _state = _state.AddSystemNudge(recallContent);
                 _observerActor?.Tell(new ObserverSystemContext("recalled-memory", recallContent));
             }
 
@@ -2556,6 +2554,36 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             if (resolved.Items.Count > 0)
                 _sessionMetrics?.RecordMemoriesRecalled(resolved.Items.Count);
+
+            // Persist the FULL volatile context block (recall + current
+            // time + working context + skill hint + slash command body +
+            // session prompt overlay + turn restart notice + active
+            // background jobs) into History via AddSystemNudge. Gated on
+            // the same first-call-of-turn sentinel as recall resolution,
+            // so tool-loop iterations don't re-nudge. By persisting at
+            // turn-start (rather than wrapping at assemble-time), the
+            // volatile bytes become part of History — every byte-prefix
+            // caching provider (llama.cpp, vLLM, OpenAI, Ollama, ...)
+            // can extend the cache prefix through this content on every
+            // subsequent turn instead of re-tokenizing it from scratch.
+            _activeRecall = _recallManager.TurnRecallCache;
+            var volatileBlock = SessionMessageAssembler.BuildVolatileContextBlock(new ContextAssemblyInput(
+                State: _state,
+                ContextLayers: _contextLayers,
+                StartupContextInjected: _startupContextInjected,
+                SlashCommandSkillContent: _slashCommandSkillContent,
+                SessionPromptOverlay: _sessionPromptOverlay,
+                TurnRestartNotice: _turnRestartNotice,
+                SessionId: _sessionId,
+                SessionsBasePath: _sessionsBasePath,
+                FileReadGranted: HasFileReadGranted(),
+                ActiveRecall: _activeRecall,
+                Audience: CurrentTurnAudience(),
+                SkillHint: BuildSkillHint()));
+            if (!string.IsNullOrEmpty(volatileBlock))
+            {
+                _state = _state.AddSystemNudge(volatileBlock);
+            }
         }
 
         _activeRecall = _recallManager.TurnRecallCache;
@@ -2564,18 +2592,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Static content (persisted prompt, OnceAtStart layers, [session],
         // [attachments]) sits at the head so the prompt prefix stays
         // byte-stable across turns. Volatile per-turn content (memory
-        // recall, current time, working context, slash command overlay,
-        // turn restart notice) is wrapped in a <context>...</context>
-        // block and prepended to the text of the last User-role message
-        // in the list. That placement keeps cache misses confined to the
-        // user turn while remaining wire-compatible with strict providers
-        // (vLLM rejects trailing System messages with HTTP 400) and
-        // avoiding the mid-tool-loop "fake user turn" failure mode where
-        // a trailing User message makes Qwen-family chat templates
-        // restart the assistant response. See SessionMessageAssembler
-        // for the full assembly contract. Mark startup injection complete
-        // after the first call to preserve the existing OnceAtStart
-        // semantics.
+        // recall, current time, working context, etc.) was already
+        // persisted into History above via AddSystemNudge — the assembler
+        // just emits the static head + history verbatim. See
+        // SessionMessageAssembler for the full assembly contract. Mark
+        // startup injection complete after the first call to preserve the
+        // existing OnceAtStart semantics.
         var skillHint = BuildSkillHint();
         var messages = SessionMessageAssembler.Assemble(new ContextAssemblyInput(
             State: _state,
@@ -2592,8 +2614,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             SkillHint: skillHint,
             // Canonical names live in history (post-PR follow-up); the
             // LLM provider wants the sanitized alias back on the wire.
-            ToolNameToLlmFacing: _toolRegistry is null ? null : _toolRegistry.ToLlmFacingName),
-            warn: msg => TurnLog().Warning(msg));
+            ToolNameToLlmFacing: _toolRegistry is null ? null : _toolRegistry.ToLlmFacingName));
         _startupContextInjected = true;
 
         var self = Self;

--- a/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
@@ -48,39 +48,37 @@ public sealed record ContextAssemblyInput(
 /// [1]      System  static dynamic context (OnceAtStart layers + [session] + [attachments])
 /// [2..N]   User/Assistant/Tool  conversation history (from SessionState.History,
 ///                               minus the persisted prompt which was already at index 0).
-///                               The last User-role message in this range carries the
-///                               volatile turn-context block as a &lt;context&gt; prefix on
-///                               its text content (see below).
+///                               The actor injects the turn's volatile context as a
+///                               User-role <c>[system: ...]</c> nudge entry in
+///                               History at turn-start (see remarks).
 /// </code>
 ///
 /// The critical cache property: when the same session fires two turns in
 /// sequence, the longest common prefix of both assemblies extends through
-/// the leading System prefix and all conversation history up to (but not
-/// including) the user message whose <c>&lt;context&gt;</c> prefix carries
-/// volatile content. Adding a turn to history extends the cache prefix
-/// for the next turn by exactly one more user/assistant pair.
+/// the leading System prefix and the ENTIRE conversation history. Adding
+/// a turn extends the cache prefix for the next turn by every user, nudge,
+/// assistant, and tool message of the completed turn.
 ///
 /// All volatile content (memory recall, current time, working context,
-/// slash command, overlay, turn restart) is consolidated into a single
-/// <c>&lt;context&gt;...&lt;/context&gt;</c> block prepended to the text of
-/// the last User-role message in the list. This placement satisfies three
-/// constraints simultaneously:
+/// skill hint, slash command, overlay, turn restart, background jobs) is
+/// composed by <see cref="BuildVolatileContextBlock"/> and persisted into
+/// History via <c>SessionState.AddSystemNudge</c> at turn-start by the
+/// actor — NOT here. That placement satisfies the constraints that the
+/// previous design discovered the hard way:
 ///
 /// <list type="bullet">
-///   <item>Keeps volatile content out of the leading System prefix so
-///   the cacheable head stays byte-stable across turns.</item>
-///   <item>Avoids emitting any message after the last conversation
-///   message — so a mid-tool-loop assembly (where the conversation
-///   tail is a Tool-role result, not a User-role message) does NOT
-///   inject a fake User turn that would make chat templates restart
-///   the assistant response and cause repeating-acknowledgement loops
-///   (e.g. "You're absolutely right — I had that backwards" restated
-///   on every tool call).</item>
-///   <item>Avoids emitting a trailing System-role message, which
-///   strict OpenAI-compatible servers (vLLM with the Qwen/Llama chat
-///   templates among them) reject with HTTP 400 "System message must
-///   be at the beginning." A trailing System tail used to be the
-///   previous design here and broke vLLM after PR #1171.</item>
+///   <item>Volatile bytes live inside History, so on every subsequent
+///   turn's assembly they are reproduced verbatim — the cache prefix
+///   extends through every prior turn's volatile region as well.</item>
+///   <item>No trailing System-role message is emitted, so strict
+///   OpenAI-compatible servers (vLLM with Qwen/Llama chat templates)
+///   don't reject the request with "System message must be at the
+///   beginning." (PR #1171's regression.)</item>
+///   <item>No message is appended after the last conversation message,
+///   so mid-tool-loop assemblies (where the tail is a Tool result)
+///   don't accidentally inject a fake User turn that would make chat
+///   templates restart the assistant response and produce
+///   repeating-acknowledgement loops.</item>
 /// </list>
 /// </summary>
 public static class SessionMessageAssembler
@@ -108,7 +106,7 @@ public static class SessionMessageAssembler
         "Never silently ignore an attachment the user sent — always acknowledge what you received by name, " +
         "even if you cannot fully process it.";
 
-    public static List<AiChatMessage> Assemble(ContextAssemblyInput input, Action<string>? warn = null)
+    public static List<AiChatMessage> Assemble(ContextAssemblyInput input)
     {
         var sessionDir = SessionDirectoryHelper.GetSessionDirectory(input.SessionId, input.SessionsBasePath);
         var messages = ChatMessageConverter.ToAiMessages(
@@ -131,61 +129,15 @@ public static class SessionMessageAssembler
             messages.Insert(insertIndex, staticMessage);
         }
 
-        var volatileBlock = BuildVolatileContextBlock(input);
-        if (!string.IsNullOrEmpty(volatileBlock))
-        {
-            PrependContextToLastUserMessage(messages, volatileBlock, warn);
-        }
-
+        // The volatile per-turn context (memory recall, current time,
+        // working context, slash command body, etc.) is NOT injected
+        // here. It is composed by LlmSessionActor at turn-start and
+        // persisted into History via SessionState.AddSystemNudge so the
+        // wire bytes for that content are byte-stable across consecutive
+        // turns (the cache prefix can extend through history naturally
+        // on every byte-prefix-caching provider). The assembler now
+        // just emits the static head + history verbatim.
         return messages;
-    }
-
-    /// <summary>
-    /// Prepends the volatile context block to the text of the last
-    /// User-role message in <paramref name="messages"/>, wrapped in
-    /// <c>&lt;context&gt;...&lt;/context&gt;</c> tags. Preserves any
-    /// non-text contents (images, attachments) on that message intact.
-    /// If no User message is present (edge case: fresh session before
-    /// the first user turn lands in history, or post-compaction state
-    /// where only System/Assistant/Tool messages remain), the volatile
-    /// block has no valid wire position; the assembler invokes
-    /// <paramref name="warn"/> so the caller can surface this as a loud
-    /// failure instead of silently degrading.
-    /// </summary>
-    private static void PrependContextToLastUserMessage(List<AiChatMessage> messages, string volatileBlock, Action<string>? warn)
-    {
-        var prefix = "<context>\n" + volatileBlock + "\n</context>\n\n";
-
-        for (var i = messages.Count - 1; i >= 0; i--)
-        {
-            var msg = messages[i];
-            if (msg.Role != Microsoft.Extensions.AI.ChatRole.User)
-                continue;
-
-            var newContents = new List<AIContent>(msg.Contents.Count + 1);
-            var prepended = false;
-            foreach (var content in msg.Contents)
-            {
-                if (!prepended && content is TextContent text)
-                {
-                    newContents.Add(new TextContent(prefix + (text.Text ?? string.Empty)));
-                    prepended = true;
-                }
-                else
-                {
-                    newContents.Add(content);
-                }
-            }
-            if (!prepended)
-            {
-                newContents.Insert(0, new TextContent(prefix));
-            }
-
-            messages[i] = new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, newContents);
-            return;
-        }
-
-        warn?.Invoke($"volatile_block_dropped reason=no_user_message chars={volatileBlock.Length}");
     }
 
     private static string BuildStaticContextBlock(ContextAssemblyInput input, string sessionDir)
@@ -228,7 +180,18 @@ public static class SessionMessageAssembler
         return string.Join("\n\n", parts);
     }
 
-    private static string BuildVolatileContextBlock(ContextAssemblyInput input)
+    /// <summary>
+    /// Composes the per-turn volatile context block — memory recall, current
+    /// time, working context, skill hint, slash command body, session prompt
+    /// overlay, turn restart notice, active background jobs. Exposed
+    /// <c>internal</c> so <c>LlmSessionActor</c> can call this at turn-start
+    /// and persist the result into history via <c>AddSystemNudge</c>; that
+    /// makes the wire bytes for the volatile content byte-stable across turns
+    /// (the cache prefix can extend through history naturally). The assembler
+    /// itself no longer injects this block — it just emits the assembled
+    /// history verbatim, with the nudge already in place.
+    /// </summary>
+    internal static string BuildVolatileContextBlock(ContextAssemblyInput input)
     {
         var parts = new List<string>();
 


### PR DESCRIPTION
PR #1176 wrapped volatile context on the last User message, which fixed vLLM but the wrapper got stripped when that user message became inner-history on the next turn — cache prefix invalidated at that position for every byte-prefix-caching provider.

Move volatile composition to `LlmSessionActor.FireLlmCall` (turn-start gate) and persist it via the existing `AddSystemNudge` inline pattern. Assembler stops wrapping; volatile lives in History.

**llama.cpp cache profile** (testlab, `Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf`):

| Scenario | Before | After |
|---|---|---|
| simple_chitchat | 75.0% | **94.4%** |
| memory_recall | 61.8% | **93.4%** |
| tool_every_turn | 93.8% | 98.3% |
| tool_then_text | 92.9% | 96.4% |
| long_session | 91.4% | 93.9% |
| context_heavy | 88.4% | 86.5% |
| memory_recall_mid_session | 92.9% | 94.6% |
| tool_loaded_mid_session | 45.6% | 46.2% (MCP-specific, separate) |

Trade-off: mid-tool-loop `working_context` updates surface in the NEXT user turn rather than within-turn. Tool results themselves still announce the file op. `ToolExecutionIntegrationTests` updated to reflect the new contract.

Signed-off-by: Aaron Stannard <aaron@petabridge.com>