### PR TITLE
feat: Ensure Mattermost container runs on ARM hosts

### DIFF
--- a/samples/Netclaw.Demo.AppHost/Program.cs
+++ b/samples/Netclaw.Demo.AppHost/Program.cs
@@ -72,9 +72,12 @@ else
 
 // mattermost-preview ships DB + everything in a single image (no
 // separate Postgres needed). Deprecated upstream — documented in the
-// README as a future migration. Testing-mode env vars come from the
-// bootstrap library so the fixture and the demo share one source.
+// README as a future migration. The image is amd64-only; force that
+// platform so ARM hosts pull/run it under container-runtime emulation.
+// Testing-mode env vars come from the bootstrap library so the fixture
+// and the demo share one source.
 var mattermost = builder.AddContainer("mattermost", "mattermost/mattermost-preview")
+    .WithContainerRuntimeArgs("--platform", "linux/amd64")
     .WithHttpEndpoint(targetPort: 8065, name: "web");
 foreach (var (envName, envValue) in MattermostBootstrapper.DefaultEnvironmentVariables)
     mattermost = mattermost.WithEnvironment(envName, envValue);

--- a/samples/Netclaw.Demo.AppHost/README.md
+++ b/samples/Netclaw.Demo.AppHost/README.md
@@ -306,7 +306,9 @@ production deployments. That's deferred — see
   full state tree. Wipe with
   `rm -rf samples/Netclaw.Demo.AppHost/.demo-home/` for a clean run.
 - **Mattermost image pull is slow** — `mattermost/mattermost-preview` is
-  ~1GB. One time only; subsequent runs reuse the image.
+  ~1GB and currently runs as `linux/amd64` on ARM hosts because upstream
+  does not publish an ARM64 manifest. One time only; subsequent runs reuse
+  the image.
 - **Model pull is slow or interrupted** — Aspire retries automatically.
   Once `qwen3.5:2b-q4_K_M` is in the named volume, subsequent runs skip the pull.
 - **You want the old richer demo even if it's slower** — run with

--- a/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostFixture.cs
+++ b/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostFixture.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Images;
 using Netclaw.Channels.Mattermost.Bootstrap;
 using Xunit;
 
@@ -60,7 +61,12 @@ public sealed class MattermostFixture : IAsyncLifetime
             // Both the builder chain and StartAsync can surface a
             // Docker-unavailable error, so both run inside the try.
             var builder = new ContainerBuilder()
-                .WithImage("mattermost/mattermost-preview")
+                // mattermost-preview is amd64-only; ARM hosts need an explicit
+                // platform so Docker pulls the emulated image instead of failing
+                // manifest resolution.
+                .WithImage(new DockerImage(
+                    "mattermost/mattermost-preview:latest",
+                    new Platform("linux/amd64")))
                 .WithPortBinding(8065, true);
 
             foreach (var (name, value) in MattermostBootstrapper.DefaultEnvironmentVariables)


### PR DESCRIPTION
The `mattermost/mattermost-preview` image is currently published only for `linux/amd64`. On ARM-based hosts (e.g., Apple Silicon Macs), container runtimes require explicit platform specification to correctly pull and run `amd64` images via emulation.

This change adds `--platform linux/amd64` to the Aspire AppHost configuration and explicitly defines the `linux/amd64` platform for Testcontainers in the integration tests. This ensures the Mattermost container starts reliably on ARM development machines.

The `README.md` is also updated to reflect this platform constraint and the emulation behavior.