### PR TITLE
fix: Add --platform linux/amd64 for ARM host compatibility

### DIFF
--- a/samples/Netclaw.Demo.AppHost/Program.cs
+++ b/samples/Netclaw.Demo.AppHost/Program.cs
@@ -72,9 +72,12 @@ else
 
 // mattermost-preview ships DB + everything in a single image (no
 // separate Postgres needed). Deprecated upstream — documented in the
-// README as a future migration. Testing-mode env vars come from the
-// bootstrap library so the fixture and the demo share one source.
+// README as a future migration. The image is amd64-only; force that
+// platform so ARM hosts pull/run it under container-runtime emulation.
+// Testing-mode env vars come from the bootstrap library so the fixture
+// and the demo share one source.
 var mattermost = builder.AddContainer("mattermost", "mattermost/mattermost-preview")
+    .WithContainerRuntimeArgs("--platform", "linux/amd64")
     .WithHttpEndpoint(targetPort: 8065, name: "web");
 foreach (var (envName, envValue) in MattermostBootstrapper.DefaultEnvironmentVariables)
     mattermost = mattermost.WithEnvironment(envName, envValue);

--- a/samples/Netclaw.Demo.AppHost/README.md
+++ b/samples/Netclaw.Demo.AppHost/README.md
@@ -306,7 +306,9 @@ production deployments. That's deferred — see
   full state tree. Wipe with
   `rm -rf samples/Netclaw.Demo.AppHost/.demo-home/` for a clean run.
 - **Mattermost image pull is slow** — `mattermost/mattermost-preview` is
-  ~1GB. One time only; subsequent runs reuse the image.
+  ~1GB and currently runs as `linux/amd64` on ARM hosts because upstream
+  does not publish an ARM64 manifest. One time only; subsequent runs reuse
+  the image.
 - **Model pull is slow or interrupted** — Aspire retries automatically.
   Once `qwen3.5:2b-q4_K_M` is in the named volume, subsequent runs skip the pull.
 - **You want the old richer demo even if it's slower** — run with

--- a/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostFixture.cs
+++ b/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostFixture.cs
@@ -59,8 +59,12 @@ public sealed class MattermostFixture : IAsyncLifetime
         {
             // Both the builder chain and StartAsync can surface a
             // Docker-unavailable error, so both run inside the try.
+            // mattermost-preview is amd64-only; ARM hosts need an explicit
+            // platform so Docker pulls the emulated image instead of failing
+            // manifest resolution.
             var builder = new ContainerBuilder()
                 .WithImage("mattermost/mattermost-preview")
+                .WithCreateParameterModifier(x => x.Platform = "linux/amd64")
                 .WithPortBinding(8065, true);
 
             foreach (var (name, value) in MattermostBootstrapper.DefaultEnvironmentVariables)


### PR DESCRIPTION
The mattermost-preview image ships as amd64-only. On ARM hosts (Apple Silicon Macs, Linux ARM), Docker fails to pull it without an explicit platform override.

## Changes

- **MattermostFixture.cs** — Added `WithCreateParameterModifier(x => x.Platform = "linux/amd64")` to the Testcontainers builder chain so the container starts reliably on ARM machines.
- **Program.cs (AppHost)** — Added `WithContainerRuntimeArgs("--platform", "linux/amd64")` to the Aspire container definition.
- **README.md** — Updated the Mattermost troubleshooting section to document the amd64-only constraint and emulation behavior.

## Context

The `mattermost-preview` image is deprecated upstream and not maintained, so there's no expectation of an ARM64 manifest being released. This is a known limitation of the image, not a bug in our code.

Both the integration test fixture and the demo AppHost need the platform override to work on Apple Silicon development machines.