### PR TITLE
chore: bump Testcontainers from 4.7.0 to 4.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Verify.XunitV3" Version="31.17.0" />
-    <PackageVersion Include="Testcontainers" Version="4.7.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
   </ItemGroup>
   <!-- .NET Aspire (samples/Netclaw.Demo.AppHost only) -->
   <ItemGroup>

--- a/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostFixture.cs
+++ b/src/Netclaw.Channels.Mattermost.IntegrationTests/MattermostFixture.cs
@@ -59,8 +59,7 @@ public sealed class MattermostFixture : IAsyncLifetime
         {
             // Both the builder chain and StartAsync can surface a
             // Docker-unavailable error, so both run inside the try.
-            var builder = new ContainerBuilder()
-                .WithImage("mattermost/mattermost-preview")
+            var builder = new ContainerBuilder("mattermost/mattermost-preview")
                 .WithPortBinding(8065, true);
 
             foreach (var (name, value) in MattermostBootstrapper.DefaultEnvironmentVariables)

--- a/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
@@ -32,8 +32,7 @@ public class SearXngBackendIntegrationTests : IAsyncLifetime
 
         try
         {
-            container = new ContainerBuilder()
-                .WithImage(SearXngImage)
+            container = new ContainerBuilder(SearXngImage)
                 .WithPortBinding(8080, assignRandomHostPort: true)
                 .WithResourceMapping(
                     Encoding.UTF8.GetBytes(settingsYml),


### PR DESCRIPTION
Bumps Testcontainers from 4.7.0 → 4.11.0.

## Breaking Change

4.11.0 deprecated (and effectively requires) the  constructor instead of the parameterless  +  pattern. Two files updated:

-  — switched to 
-  — switched to 

## Why 4.11.0

-  class and  constructor support (needed for ARM host compatibility in Mattermost)
- Docker Engine v29 support
- Various module improvements (Seq, Temporal, ServiceBus, Postgres SSL, etc.)