### PR TITLE
fix(security): close tunnel loopback auth bypass (SEC-005)

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/TestStreamingHelpers.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/TestStreamingHelpers.cs
@@ -34,6 +34,13 @@ internal static class TestStreamingHelpers
         string text,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        // Compiler needs at least one await for async IAsyncEnumerable. Using
+        // Task.CompletedTask here rather than Task.Yield() between updates —
+        // Task.Yield() bounces every iteration through ThreadPool.QueueUserWorkItem,
+        // which under Windows CI thread-pool contention can take >1s per round-trip
+        // and starve callers with tight FirstTokenTimeout watchdogs.
+        await Task.CompletedTask;
+
         var response = new ChatResponse(new ChatMessage(
             ChatRole.Assistant,
             [new TextContent(text)]));
@@ -42,7 +49,6 @@ internal static class TestStreamingHelpers
         {
             cancellationToken.ThrowIfCancellationRequested();
             yield return update;
-            await Task.Yield();
         }
     }
 }

--- a/src/Netclaw.Configuration/ExposureMode.cs
+++ b/src/Netclaw.Configuration/ExposureMode.cs
@@ -70,6 +70,20 @@ public static class ExposureModeExtensions
         ExposureMode.ReverseProxy or ExposureMode.TailscaleServe or ExposureMode.TailscaleFunnel or ExposureMode.CloudflareTunnel => true,
         _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, $"Unknown ExposureMode value: {mode}")
     };
+
+    /// <summary>
+    /// Returns <c>true</c> for the three tunnel modes (TailscaleServe / TailscaleFunnel /
+    /// CloudflareTunnel), where the local tunnel agent forwards remote traffic over loopback
+    /// and the daemon cannot distinguish a same-host caller from a remote one at the socket
+    /// level. ReverseProxy is excluded — it has its own auth topology (forwarded headers +
+    /// non-loopback bind + TrustedProxies). Local is excluded — no tunnel involved.
+    /// </summary>
+    public static bool IsTunnelMode(this ExposureMode mode) => mode switch
+    {
+        ExposureMode.Local or ExposureMode.ReverseProxy => false,
+        ExposureMode.TailscaleServe or ExposureMode.TailscaleFunnel or ExposureMode.CloudflareTunnel => true,
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, $"Unknown ExposureMode value: {mode}")
+    };
 }
 
 /// <summary>

--- a/src/Netclaw.Daemon.Tests/Security/LoopbackAuthenticationHandlerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/LoopbackAuthenticationHandlerTests.cs
@@ -108,4 +108,49 @@ public sealed class LoopbackAuthenticationHandlerTests
         Assert.Null(result.Failure);
         Assert.Null(result.Principal);
     }
+
+    // Tunnel agents (tailscaled, cloudflared) forward public traffic over the
+    // loopback socket, so every external request arrives with RemoteIpAddress
+    // == 127.0.0.1 / ::1. A handler that auto-promotes loopback to Operator
+    // under those modes hands an unauthenticated internet caller full local
+    // operator trust (audit finding #24). Loopback auto-auth must be reserved
+    // for ExposureMode.Local; under tunnel modes remote callers must go
+    // through the device bearer scheme. Both address families are exercised
+    // because the bug is symmetric across IPv4 and IPv6.
+    public static TheoryData<ExposureMode, string> TunnelModesWithLoopbackIps()
+    {
+        var data = new TheoryData<ExposureMode, string>();
+        foreach (var mode in new[]
+                 {
+                     ExposureMode.CloudflareTunnel,
+                     ExposureMode.TailscaleFunnel,
+                     ExposureMode.TailscaleServe,
+                 })
+        {
+            data.Add(mode, "127.0.0.1");
+            data.Add(mode, "::1");
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(TunnelModesWithLoopbackIps))]
+    public async Task Tunnel_modes_return_no_result_for_loopback_ip(
+        ExposureMode tunnelMode,
+        string loopbackIp)
+    {
+        var (sp, authService) = BuildAuthService(new DaemonConfig { ExposureMode = tunnelMode });
+        var ctx = BuildContext(IPAddress.Parse(loopbackIp), sp);
+
+        var result = await authService.AuthenticateAsync(ctx, LoopbackAuthenticationHandler.SchemeName);
+
+        Assert.False(
+            result.Succeeded,
+            $"ExposureMode={tunnelMode} with RemoteIpAddress={loopbackIp} must not auto-authenticate the caller as Operator. " +
+            "Loopback auto-auth is reserved for ExposureMode.Local; under tunnel modes the " +
+            "loopback peer is the tunnel agent forwarding remote traffic.");
+        Assert.Null(result.Failure);
+        Assert.Null(result.Principal);
+    }
 }

--- a/src/Netclaw.Daemon.Tests/Security/SessionHubAuthorizationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/SessionHubAuthorizationTests.cs
@@ -359,9 +359,13 @@ public sealed class SessionHubAuthorizationTests : IDisposable
     [Fact]
     public void IsDirectLocalControlPlaneConnection_ReturnsTrue_WhenRemoteMatchesLocal()
     {
+        // Non-loopback equality between remote and local IPs indicates an on-host
+        // connection; exposure mode does not affect this branch (governed by
+        // UseForwardedHeaders wiring elsewhere).
         Assert.True(SessionHub.IsDirectLocalControlPlaneConnection(
             IPAddress.Parse("10.0.0.10"),
-            IPAddress.Parse("10.0.0.10")));
+            IPAddress.Parse("10.0.0.10"),
+            ExposureMode.ReverseProxy));
     }
 
     [Fact]
@@ -369,10 +373,80 @@ public sealed class SessionHubAuthorizationTests : IDisposable
     {
         Assert.False(SessionHub.IsDirectLocalControlPlaneConnection(
             IPAddress.Parse("198.51.100.26"),
-            IPAddress.Parse("10.0.0.10")));
+            IPAddress.Parse("10.0.0.10"),
+            ExposureMode.ReverseProxy));
     }
 
-    private SessionHub CreateSessionHub(IPAddress remoteIp, string transport, bool isBootstrapDevice, IPAddress? localIp = null)
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    public void IsDirectLocalControlPlaneConnection_Loopback_LocalMode_ReturnsTrue(string loopbackIp)
+    {
+        // ExposureMode.Local is the only mode that treats loopback as proof of a
+        // same-host caller; tunnel / reverse-proxy modes forward remote traffic
+        // over loopback.
+        Assert.True(SessionHub.IsDirectLocalControlPlaneConnection(
+            IPAddress.Parse(loopbackIp),
+            IPAddress.None,
+            ExposureMode.Local));
+    }
+
+    [Theory]
+    [InlineData(ExposureMode.ReverseProxy, "127.0.0.1")]
+    [InlineData(ExposureMode.ReverseProxy, "::1")]
+    [InlineData(ExposureMode.TailscaleServe, "127.0.0.1")]
+    [InlineData(ExposureMode.TailscaleServe, "::1")]
+    [InlineData(ExposureMode.TailscaleFunnel, "127.0.0.1")]
+    [InlineData(ExposureMode.TailscaleFunnel, "::1")]
+    [InlineData(ExposureMode.CloudflareTunnel, "127.0.0.1")]
+    [InlineData(ExposureMode.CloudflareTunnel, "::1")]
+    public void IsDirectLocalControlPlaneConnection_Loopback_NonLocalMode_ReturnsFalse(
+        ExposureMode mode, string loopbackIp)
+    {
+        // Under any exposure mode that accepts remote traffic, a loopback remote IP
+        // is the local tunnel agent or reverse-proxy peer, NOT a direct on-host
+        // operator. Verifies the audit #24 follow-up: a paired (Verified) remote
+        // device whose connection arrives over loopback must not satisfy the
+        // "direct local control plane" predicate that gates GeneratePairingCode.
+        Assert.False(SessionHub.IsDirectLocalControlPlaneConnection(
+            IPAddress.Parse(loopbackIp),
+            IPAddress.None,
+            mode));
+    }
+
+    [Theory]
+    [InlineData(ExposureMode.TailscaleServe)]
+    [InlineData(ExposureMode.TailscaleFunnel)]
+    [InlineData(ExposureMode.CloudflareTunnel)]
+    public async Task Tunnel_mode_verified_bearer_token_over_loopback_cannot_invoke_daemon_pair(
+        ExposureMode mode)
+    {
+        // Post-#24 the loopback handler no longer auto-issues LocalProcess for
+        // tunnel modes, but a paired (Verified) device's connection still arrives
+        // at the daemon over loopback (via tailscaled/cloudflared). The pairing
+        // gate must not treat that loopback peer as "direct local control plane"
+        // or paired remote devices could mint additional pairing codes through
+        // the tunnel — defeating the documented "remote paired devices cannot
+        // mint new codes" rule.
+        var hub = CreateSessionHub(
+            remoteIp: IPAddress.Loopback,
+            transport: nameof(TransportAuthenticity.Verified),
+            isBootstrapDevice: false,
+            exposureMode: mode);
+
+        var ex = await Assert.ThrowsAsync<HubException>(() => hub.GeneratePairingCode());
+
+        Assert.Equal(
+            "GeneratePairingCode requires a daemon-host local operator connection or direct authenticated local control-plane access.",
+            ex.Message);
+    }
+
+    private SessionHub CreateSessionHub(
+        IPAddress remoteIp,
+        string transport,
+        bool isBootstrapDevice,
+        IPAddress? localIp = null,
+        ExposureMode exposureMode = ExposureMode.Local)
     {
         var pairingCodeService = new PairingCodeService(_time);
         var claims = new List<Claim>
@@ -384,6 +458,7 @@ public sealed class SessionHubAuthorizationTests : IDisposable
         var hub = new SessionHub(
             registry: null!,
             pairingCodeService,
+            new DaemonConfig { ExposureMode = exposureMode },
             NullLogger<SessionHub>.Instance)
         {
             Context = new TestHubCallerContext(new ClaimsPrincipal(new ClaimsIdentity(claims, "test")), remoteIp, localIp)

--- a/src/Netclaw.Daemon.Tests/Services/ExposureModeValidationServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ExposureModeValidationServiceTests.cs
@@ -160,10 +160,12 @@ public sealed class ExposureModeValidationServiceTests
             ExposureMode = mode,
             SkipTunnelProcessCheck = true
         };
+        // DeviceToken scheme IS wired (production reality), but no devices and no
+        // alternative scheme → "no usable remote auth path", not a wiring error.
         var sut = BuildService(
             config,
             _ => false,
-            remoteAuthSchemes: [],
+            remoteAuthSchemes: [new FakeRemoteAuthScheme(DeviceTokenAuthenticationHandler.SchemeName)],
             deviceCount: 0);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -187,14 +189,14 @@ public sealed class ExposureModeValidationServiceTests
     // ── Remote auth guard: non-local + no devices + no scheme ────────────────
 
     [Fact]
-    public async Task NonLocal_NoRemoteAuthScheme_NoPairedDevices_Throws()
+    public async Task NonLocal_NoAltScheme_NoPairedDevices_Throws()
     {
         var config = new DaemonConfig { ExposureMode = ExposureMode.TailscaleServe };
-        // Process is running, but no auth scheme and no devices → must fail.
+        // DeviceToken wired (production reality), no devices, no alt scheme → must fail.
         var sut = BuildService(
             config,
             name => name == "tailscaled",
-            remoteAuthSchemes: [],
+            remoteAuthSchemes: [new FakeRemoteAuthScheme(DeviceTokenAuthenticationHandler.SchemeName)],
             deviceCount: 0);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -204,14 +206,14 @@ public sealed class ExposureModeValidationServiceTests
     }
 
     [Fact]
-    public async Task NonLocal_NoRemoteAuthScheme_NoPairedDevices_WithBootstrapSeeder_StartSucceeds()
+    public async Task NonLocal_NoAltScheme_NoPairedDevices_WithBootstrapSeeder_StartSucceeds()
     {
         var config = new DaemonConfig { ExposureMode = ExposureMode.TailscaleServe };
         var (bootstrapSeeder, deviceCounter) = BuildBootstrapSeeder();
         var sut = BuildService(
             config,
             name => name == "tailscaled",
-            remoteAuthSchemes: [],
+            remoteAuthSchemes: [new FakeRemoteAuthScheme(DeviceTokenAuthenticationHandler.SchemeName)],
             deviceCounter: deviceCounter,
             bootstrapDeviceSeeder: bootstrapSeeder);
 
@@ -219,17 +221,95 @@ public sealed class ExposureModeValidationServiceTests
     }
 
     [Fact]
-    public async Task NonLocal_NoRemoteAuthScheme_WithPairedDevices_StartSucceeds()
+    public async Task NonLocal_NoAltScheme_WithPairedDevices_StartSucceeds()
     {
-        // Devices exist → remote clients CAN authenticate, even without a registered scheme.
+        // DeviceToken scheme registered (production reality) + paired device → remote
+        // clients CAN authenticate.
         var config = new DaemonConfig { ExposureMode = ExposureMode.TailscaleServe };
         var sut = BuildService(
             config,
             name => name == "tailscaled",
-            remoteAuthSchemes: [],
+            remoteAuthSchemes: [new FakeRemoteAuthScheme(DeviceTokenAuthenticationHandler.SchemeName)],
             deviceCount: 1);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Wiring-integrity check (audit finding #25 companion) ─────────────────
+
+    [Theory]
+    [InlineData(ExposureMode.TailscaleServe)]
+    [InlineData(ExposureMode.TailscaleFunnel)]
+    [InlineData(ExposureMode.CloudflareTunnel)]
+    public async Task TunnelModes_WithDeviceTokenSchemeUnregistered_ThrowsWiringError(ExposureMode mode)
+    {
+        // Simulates a broken DI wiring where the DeviceToken authentication scheme
+        // is missing despite the daemon running in a tunnel exposure mode. Post-#24
+        // (loopback bypass removed) this is the only legitimate remote-auth path for
+        // tunnel modes, so a missing scheme must abort startup loudly rather than
+        // serve an unauthenticatable surface.
+        var config = new DaemonConfig
+        {
+            ExposureMode = mode,
+            SkipTunnelProcessCheck = true,
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [],
+            deviceCount: 0);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("device-bearer authentication scheme", ex.Message);
+        Assert.Contains("DeviceToken", ex.Message);
+    }
+
+    [Fact]
+    public async Task TunnelMode_WithAlternativeSchemeOnly_BypassesWiringCheck()
+    {
+        // An alternative remote-auth scheme is registered, so the DeviceToken scheme
+        // is no longer the ONLY path; the wiring check tolerates a missing DeviceToken
+        // in that case (the alternative scheme handles remote auth).
+        var config = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.TailscaleServe,
+            SkipTunnelProcessCheck = true,
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("OtherScheme")],
+            deviceCount: 0);
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithDeviceTokenSchemeUnregistered_DoesNotTriggerTunnelWiringCheck()
+    {
+        // ReverseProxy mode has its own auth topology (forwarded headers + TrustedProxies)
+        // and is intentionally excluded from the tunnel wiring assertion. It should not
+        // throw the device-bearer wiring error — it will throw the existing
+        // "no remote authentication available" message instead.
+        var config = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"],
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [],
+            deviceCount: 0);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.DoesNotContain("device-bearer authentication scheme", ex.Message);
+        Assert.Contains("No remote authentication available", ex.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon/Gateway/SessionHub.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionHub.cs
@@ -40,15 +40,18 @@ public sealed class SessionHub : Hub<ISessionHubClient>
 {
     private readonly SessionRegistry _registry;
     private readonly PairingCodeService _pairingCodeService;
+    private readonly DaemonConfig _daemonConfig;
     private readonly ILogger<SessionHub> _logger;
 
     public SessionHub(
         SessionRegistry registry,
         PairingCodeService pairingCodeService,
+        DaemonConfig daemonConfig,
         ILogger<SessionHub> logger)
     {
         _registry = registry;
         _pairingCodeService = pairingCodeService;
+        _daemonConfig = daemonConfig;
         _logger = logger;
     }
 
@@ -95,7 +98,8 @@ public sealed class SessionHub : Hub<ISessionHubClient>
         var remoteIp = NormalizeIp(Context.GetHttpContext()?.Connection.RemoteIpAddress);
         var localIp = NormalizeIp(Context.GetHttpContext()?.Connection.LocalIpAddress);
         var transport = Context.User?.FindFirst(NetclawClaimTypes.TransportAuthenticity)?.Value;
-        var isDirectLocalControlPlaneConnection = IsDirectLocalControlPlaneConnection(remoteIp, localIp);
+        var isDirectLocalControlPlaneConnection = IsDirectLocalControlPlaneConnection(
+            remoteIp, localIp, _daemonConfig.ExposureMode);
 
         if (transport != nameof(TransportAuthenticity.LocalProcess)
             && (transport != nameof(TransportAuthenticity.Verified) || !isDirectLocalControlPlaneConnection))
@@ -114,11 +118,26 @@ public sealed class SessionHub : Hub<ISessionHubClient>
         return Task.FromResult(new PairingCodeResultDto(formattedCode, expiresAt));
     }
 
-    internal static bool IsDirectLocalControlPlaneConnection(IPAddress remoteIp, IPAddress localIp)
+    internal static bool IsDirectLocalControlPlaneConnection(
+        IPAddress remoteIp,
+        IPAddress localIp,
+        ExposureMode exposureMode)
     {
+        // Under any exposure mode that accepts remote traffic (reverse proxy or
+        // any tunnel agent), a loopback RemoteIpAddress is the local forwarder,
+        // NOT a same-host operator process. Only ExposureMode.Local can treat
+        // loopback as proof of a direct local control-plane caller — mirrors
+        // the LoopbackAuthenticationHandler trust rule and prevents an
+        // authenticated remote device from minting additional pairing codes via
+        // a tunnel (audit finding #24 follow-up).
         if (IPAddress.IsLoopback(remoteIp))
-            return true;
+            return exposureMode == ExposureMode.Local;
 
+        // Non-loopback equality with the local interface address still indicates
+        // a direct on-host connection (e.g., a process binding to the daemon's
+        // public address from the same machine). This path is unchanged and
+        // governed separately by UseForwardedHeaders being wired only for
+        // ReverseProxy mode.
         return localIp != IPAddress.None && remoteIp.Equals(localIp);
     }
 

--- a/src/Netclaw.Daemon/Security/LoopbackAuthenticationHandler.cs
+++ b/src/Netclaw.Daemon/Security/LoopbackAuthenticationHandler.cs
@@ -39,10 +39,14 @@ public sealed class LoopbackAuthenticationHandler : AuthenticationHandler<Authen
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        // Reverse-proxy mode must never inherit loopback operator trust from the
-        // final hop. Even a same-host proxy forwarding over 127.0.0.1/::1 has to
-        // flow through a remote-authenticated scheme instead.
-        if (_daemonConfig.ExposureMode == ExposureMode.ReverseProxy)
+        // Any exposure mode that accepts remote traffic must never inherit
+        // loopback operator trust. Tunnel agents (tailscaled, cloudflared) and
+        // reverse proxies all forward remote connections over the loopback
+        // socket, so a loopback source address is NOT proof of a same-host
+        // caller in those modes. Remote traffic must flow through a
+        // remote-authenticated scheme (the device bearer token) instead — fail
+        // closed here. Only ExposureMode.Local treats loopback as truly local.
+        if (_daemonConfig.ExposureMode.RequiresRemoteAuthentication())
             return Task.FromResult(AuthenticateResult.NoResult());
 
         var remoteIp = Context.Connection.RemoteIpAddress;

--- a/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
+++ b/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
@@ -128,25 +128,23 @@ internal sealed class ExposureModeValidationService : IHostedService
 
             hasRemoteAuthenticationPath = hasAlternativeRemoteAuthScheme || deviceCount > 0;
 
+            var hasDeviceTokenScheme = _remoteAuthSchemes.Any(s => string.Equals(
+                s.SchemeName,
+                DeviceTokenAuthenticationHandler.SchemeName,
+                StringComparison.Ordinal));
+
             // Wiring-integrity check for tunnel modes.
             //
             // Once LoopbackAuthenticationHandler is gated on RequiresRemoteAuthentication()
-            // (audit finding #24), the device-bearer scheme is the ONLY path a remote
-            // tunnel client can use to authenticate. ReverseProxy has its own auth
-            // topology (forwarded headers + non-loopback bind + TrustedProxies) so it
-            // is excluded from this assertion. For the three tunnel modes
-            // (TailscaleServe, TailscaleFunnel, CloudflareTunnel), if neither an
-            // alternative scheme nor the device-bearer scheme is registered, the daemon
-            // would start cleanly but be unreachable to any legitimate remote caller —
-            // fail loudly at startup with an actionable wiring error rather than
-            // silently serving an unauthenticatable surface.
-            if (_config.ExposureMode.RequiresRemoteAuthentication()
-                && _config.ExposureMode != ExposureMode.ReverseProxy
+            // (audit finding 24), the device-bearer scheme is the ONLY path a remote
+            // tunnel client can use to authenticate. If neither an alternative scheme nor
+            // the device-bearer scheme is registered, the daemon would start cleanly but
+            // be unreachable to any legitimate remote caller — fail loudly at startup
+            // with an actionable wiring error rather than silently serving an
+            // unauthenticatable surface.
+            if (_config.ExposureMode.IsTunnelMode()
                 && !hasAlternativeRemoteAuthScheme
-                && !_remoteAuthSchemes.Any(s => string.Equals(
-                    s.SchemeName,
-                    DeviceTokenAuthenticationHandler.SchemeName,
-                    StringComparison.Ordinal)))
+                && !hasDeviceTokenScheme)
             {
                 const string msg = "Tunnel exposure mode requires the device-bearer authentication scheme to be registered.";
                 const string remediation = "This is an internal wiring error — the DeviceToken authentication scheme must be registered in DI for tunnel exposure modes (tailscale-serve, tailscale-funnel, cloudflare-tunnel).";

--- a/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
+++ b/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
@@ -127,6 +127,36 @@ internal sealed class ExposureModeValidationService : IHostedService
                 : 0;
 
             hasRemoteAuthenticationPath = hasAlternativeRemoteAuthScheme || deviceCount > 0;
+
+            // Wiring-integrity check for tunnel modes.
+            //
+            // Once LoopbackAuthenticationHandler is gated on RequiresRemoteAuthentication()
+            // (audit finding #24), the device-bearer scheme is the ONLY path a remote
+            // tunnel client can use to authenticate. ReverseProxy has its own auth
+            // topology (forwarded headers + non-loopback bind + TrustedProxies) so it
+            // is excluded from this assertion. For the three tunnel modes
+            // (TailscaleServe, TailscaleFunnel, CloudflareTunnel), if neither an
+            // alternative scheme nor the device-bearer scheme is registered, the daemon
+            // would start cleanly but be unreachable to any legitimate remote caller —
+            // fail loudly at startup with an actionable wiring error rather than
+            // silently serving an unauthenticatable surface.
+            if (_config.ExposureMode.RequiresRemoteAuthentication()
+                && _config.ExposureMode != ExposureMode.ReverseProxy
+                && !hasAlternativeRemoteAuthScheme
+                && !_remoteAuthSchemes.Any(s => string.Equals(
+                    s.SchemeName,
+                    DeviceTokenAuthenticationHandler.SchemeName,
+                    StringComparison.Ordinal)))
+            {
+                const string msg = "Tunnel exposure mode requires the device-bearer authentication scheme to be registered.";
+                const string remediation = "This is an internal wiring error — the DeviceToken authentication scheme must be registered in DI for tunnel exposure modes (tailscale-serve, tailscale-funnel, cloudflare-tunnel).";
+                _logger.LogCritical(
+                    "Daemon startup aborted: {Message} Remediation: {Remediation}",
+                    msg,
+                    remediation);
+
+                throw new InvalidOperationException($"{msg} {remediation}");
+            }
         }
 
         foreach (var issue in DaemonExposureValidator.Validate(_config, hasRemoteAuthenticationPath)


### PR DESCRIPTION
## Summary

- **Audit finding 24 (Critical)** — `LoopbackAuthenticationHandler` now gates on `ExposureMode.RequiresRemoteAuthentication()` instead of `== ReverseProxy`. Closes the pre-auth remote-takeover bypass on tailscale-serve / tailscale-funnel / cloudflare-tunnel modes where the local tunnel agent forwards remote traffic over loopback and the handler was auto-issuing Operator tickets to anyone with no token.
- **Audit finding 25 (High)** — `ExposureModeValidationService` now fails loudly at startup if a tunnel exposure mode is configured but the `DeviceToken` authentication scheme is not registered. Post-fix that scheme is the only remote-auth path, so a missing registration would silently serve an unauthenticatable surface.
- **SessionHub follow-up** — `IsDirectLocalControlPlaneConnection` is now exposure-aware: loopback only counts as "direct local" under `ExposureMode.Local`. Prevents an authenticated `Verified` paired device from minting additional pairing codes through a tunnel (the loopback peer in tunnel modes is the local forwarder, not a same-host operator).

Findings sourced from the OpenProse security audit (`prose-run-archive.zip`, 2026-05-22) and independently verified by an external gist that also supplied the failing-test inspiration. Audit-finding numbers above refer to the audit report's own enumeration, **not** to issues in this repository.

## Behavior change for real callers

| Caller | Before | After |
|---|---|---|
| Local CLI in `Local` mode, loopback, no token | Operator (auto) | Operator (auto) — unchanged |
| Local CLI in tunnel mode, loopback, **with bootstrap token from secrets.json** | Operator (via Bearer) | Operator (via Bearer) — unchanged, this is what the CLI already does |
| Internet attacker via tunnel, no token | Operator (bypass) | 401 — **fixed** |
| Custom script in tunnel mode hitting loopback without a Bearer header | Operator (bypass) | 401 — **affected** |

The auto-pair-during-setup wizard flow is unaffected: `ExposureModeStepViewModel.WriteBootstrapDevice` pre-seeds the `PairedDevice` + `DeviceToken` into `devices.json` / `secrets.json` before restarting into tunnel mode, and `DaemonClientFactory.cs:58` already attaches that token for tunnel-mode loopback calls (it already uses the same `RequiresRemoteAuthentication()` helper this PR adopts in the handler).

## Test plan

- [x] `dotnet test src/Netclaw.Daemon.Tests` — 634 passed, 0 failed
- [x] New parameterized theory in `LoopbackAuthenticationHandlerTests`: 3 tunnel modes × 2 IP families (`127.0.0.1` / `::1`) → all `NoResult`
- [x] Updated `ExposureModeValidationServiceTests` to register `DeviceToken` scheme where the original intent was "no usable auth path"; added 3 new tests for the wiring-integrity check + a ReverseProxy exclusion regression
- [x] New `SessionHubAuthorizationTests` theories for the helper (`ExposureMode.Local` loopback → true, all other modes loopback → false) plus an integration test that `GeneratePairingCode` rejects loopback-Verified callers under tunnel modes
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [ ] Manual smoke (recommended for reviewer): start daemon with `ExposureMode = TailscaleFunnel` and `Host = 127.0.0.1`, hit `POST /api/lifecycle/shutdown` without a Bearer header → expect 401; with the bootstrap `DeviceToken` from `secrets.json` as `Authorization: Bearer` → expect 200

## Out of scope

P1 / P2 audit findings (webhook injection scan, web_fetch SSRF, Personal auto-approve, webhook audience clamp, startup ACL/schema validation, MCP scanning, anti-replay durability, shell tokenizer hardening, etc.) are deferred to follow-up PRs per the audit's prioritization. This PR ships only the P0 hotfix.
