### PR TITLE
fix(channels): truncate oversized approval prompt text per channel cap

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/ApprovalDisplayTextFormatterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/ApprovalDisplayTextFormatterTests.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalDisplayTextFormatterTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Channels;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class ApprovalDisplayTextFormatterTests
+{
+    [Fact]
+    public void Text_under_budget_passes_through_unchanged()
+    {
+        Assert.Equal("git status", ApprovalDisplayTextFormatter.Truncate("git status", 100));
+    }
+
+    [Fact]
+    public void Null_or_empty_returns_empty()
+    {
+        Assert.Equal(string.Empty, ApprovalDisplayTextFormatter.Truncate(null, 100));
+        Assert.Equal(string.Empty, ApprovalDisplayTextFormatter.Truncate(string.Empty, 100));
+    }
+
+    [Fact]
+    public void Zero_or_negative_budget_returns_empty()
+    {
+        Assert.Equal(string.Empty, ApprovalDisplayTextFormatter.Truncate("anything", 0));
+        Assert.Equal(string.Empty, ApprovalDisplayTextFormatter.Truncate("anything", -1));
+    }
+
+    [Fact]
+    public void Oversized_text_stays_within_budget()
+    {
+        var input = new string('x', 10_000);
+
+        var result = ApprovalDisplayTextFormatter.Truncate(input, 200);
+
+        Assert.True(result.Length <= 200, $"Result length {result.Length} exceeded budget 200");
+        Assert.Contains("truncated, original 10000 chars", result);
+    }
+
+    [Fact]
+    public void Truncated_output_preserves_head_and_tail()
+    {
+        var input = "AAAAAAAAAA" + new string('m', 1000) + "ZZZZZZZZZZ";
+
+        var result = ApprovalDisplayTextFormatter.Truncate(input, 200);
+
+        Assert.StartsWith("AAAAAAAAAA", result);
+        Assert.EndsWith("ZZZZZZZZZZ", result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
@@ -366,4 +366,21 @@ public sealed class DiscordApprovalPromptBuilderTests
 
         Assert.Contains("Saved for this chat: jsonlint config.json in /home/user/repos/foo", text);
     }
+
+    [Fact]
+    public void Oversized_command_keeps_prompt_under_Discord_cap()
+    {
+        // Discord rejects messages over 2000 chars; without truncation
+        // the binding's auto-deny fallback misreports as a user decline.
+        // Same failure shape as the Slack regression — see session
+        // D0AC6CKBK5K/1779811366.695739.
+        var oversized = new string('y', 10_000);
+        var request = V2Request(oversized, ["gh issue create"], "/home/user/repos/foo", FullButtonRow());
+
+        var textPrompt = DiscordApprovalPromptBuilder.BuildTextPrompt(request);
+        var (buttonPromptText, _) = DiscordApprovalPromptBuilder.BuildButtonPrompt(request);
+
+        Assert.True(textPrompt.Length < 2001, $"Text prompt length {textPrompt.Length} exceeded Discord's 2000-char cap");
+        Assert.True(buttonPromptText.Length < 2001, $"Button prompt length {buttonPromptText.Length} exceeded Discord's 2000-char cap");
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
@@ -300,4 +300,34 @@ public sealed class MattermostApprovalPromptBuilderTests
                 new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
+
+    [Fact]
+    public void Oversized_command_keeps_prompt_under_Mattermost_cap()
+    {
+        // Mattermost's hard message cap is 16K, but approval prompts
+        // bypass ChunkMessage. Without truncation the post fails outright
+        // and the binding auto-denies, misreported to the model.
+        var oversized = new string('z', 30_000);
+        var request = new ToolInteractionRequest
+        {
+            SessionId = new SessionId("test/session"),
+            Kind = "approval",
+            CallId = new Netclaw.Tools.ToolCallId("call-big-1"),
+            ToolName = new Netclaw.Tools.ToolName("shell_execute"),
+            DisplayText = oversized,
+            RequesterSenderId = new SenderId("requester-1"),
+            Patterns = ["gh issue create"],
+            Options = [
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+            ]
+        };
+
+        var textPrompt = MattermostApprovalPromptBuilder.BuildTextPrompt(request);
+        var (buttonText, _) = MattermostApprovalPromptBuilder.BuildButtonPrompt(
+            request, "https://callback.example/url", channelId: "ch-1", rootPostId: "root-1");
+
+        Assert.True(textPrompt.Length < 16_001, $"Text prompt length {textPrompt.Length} exceeded Mattermost's 16000-char cap");
+        Assert.True(buttonText.Length < 16_001, $"Button prompt length {buttonText.Length} exceeded Mattermost's 16000-char cap");
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
@@ -177,4 +177,23 @@ public sealed class SlackApprovalBlockBuilderTests
 
         Assert.Contains("Denied", text);
     }
+
+    [Fact]
+    public void Oversized_command_keeps_every_block_under_Slack_cap()
+    {
+        // Regression for the auto-deny-on-Slack-failure bug: a multi-KB
+        // `gh issue create --body '...'` blew past Slack's 3000-char per
+        // SectionBlock text cap and the API returned invalid_blocks. See
+        // session D0AC6CKBK5K/1779811366.695739.
+        var oversized = new string('x', 10_000);
+        var request = Request(oversized, ["gh issue create"], "/home/user/repos/foo", FullButtonRow());
+
+        var blocks = SlackApprovalBlockBuilder.BuildApprovalBlocks(request);
+
+        foreach (var block in blocks)
+        {
+            if (block is SectionBlock { Text: Markdown md })
+                Assert.True(md.Text.Length < 3001, $"SectionBlock text length {md.Text.Length} exceeded Slack's 3000-char cap");
+        }
+    }
 }

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.Text;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels;
 
 namespace Netclaw.Channels.Discord;
 
@@ -12,12 +13,20 @@ internal static class DiscordApprovalPromptBuilder
 {
     private const string ComplexCommandHint = "_complex command — only one-shot approval available_";
 
+    /// <summary>
+    /// Display-text budget chosen to keep the assembled prompt under
+    /// Discord's hard 2000-char per-message cap once scaffolding is added.
+    /// Exceeding the cap causes the post to fail and the binding to
+    /// auto-deny, which the model misreads as a user decline.
+    /// </summary>
+    internal const int MaxDisplayTextChars = 1700;
+
     public static string BuildTextPrompt(ToolInteractionRequest request)
     {
         var sb = new StringBuilder();
         sb.AppendLine("Netclaw approval required:");
         sb.Append("Tool: ").AppendLine(request.ToolName.Value);
-        sb.Append("Action: ").AppendLine(request.DisplayText);
+        sb.Append("Action: ").AppendLine(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars));
         sb.AppendLine(BuildApproveHeader(request));
 
         var verbs = ResolveDisplayVerbs(request);
@@ -79,7 +88,7 @@ internal static class DiscordApprovalPromptBuilder
         var sb = new StringBuilder();
         sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(request.DisplayText).AppendLine("`");
+        sb.Append("**Action:** `").Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
         sb.Append("**").Append(BuildResolutionLine(request, selectedKey)).Append("**");
         sb.Append(" (by <@").Append(senderId).Append(">)");
 
@@ -96,7 +105,7 @@ internal static class DiscordApprovalPromptBuilder
     private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
     {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(request.DisplayText).AppendLine("`");
+        sb.Append("**Action:** `").Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
         sb.Append("**").Append(BuildApproveHeader(request)).AppendLine("**");
 
         var verbs = ResolveDisplayVerbs(request);

--- a/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
@@ -5,11 +5,19 @@
 // -----------------------------------------------------------------------
 using System.Text;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels;
 
 namespace Netclaw.Channels.Mattermost;
 
 internal static class MattermostApprovalPromptBuilder
 {
+    /// <summary>
+    /// Display-text budget. Mattermost's hard message cap is 16000 chars,
+    /// but approval prompts bypass the regular chunking path in
+    /// <c>MattermostSessionBindingActor</c> — so an oversized command
+    /// would be rejected outright and trigger an auto-deny.
+    /// </summary>
+    internal const int MaxDisplayTextChars = 12000;
     public static (string Text, IReadOnlyList<MattermostAttachment> Attachments) BuildButtonPrompt(
         ToolInteractionRequest request,
         string callbackUrl,
@@ -112,7 +120,7 @@ internal static class MattermostApprovalPromptBuilder
     private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
     {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(request.DisplayText).AppendLine("`");
+        sb.Append("**Action:** `").Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
 
         if (request.Patterns.Count > 0)
         {

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -14,12 +14,21 @@ internal static class SlackApprovalBlockBuilder
 
     private const string ComplexCommandHint = "_complex command — only one-shot approval available_";
 
+    /// <summary>
+    /// Display-text budget sized to stay under Slack's hard 3000-char
+    /// SectionBlock text cap after accounting for the surrounding markdown
+    /// scaffolding. Exceeding the cap causes Slack to reject the post with
+    /// <c>invalid_blocks</c>, which today triggers an auto-deny the model
+    /// misreads as the user declining.
+    /// </summary>
+    internal const int MaxDisplayTextChars = 2500;
+
     public static string BuildApprovalText(ToolInteractionRequest request)
     {
         var lines = new List<string>
         {
             ":lock: *Tool approval required*",
-            $"> `{request.ToolName}`: `{request.DisplayText}`",
+            $"> `{request.ToolName}`: `{ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)}`",
             BuildApproveHeader(request)
         };
 
@@ -53,7 +62,7 @@ internal static class SlackApprovalBlockBuilder
             },
             new SectionBlock
             {
-                Text = new Markdown($"*Tool:* `{EscapeMarkdown(request.ToolName.Value)}`\n*Request:* `{EscapeMarkdown(request.DisplayText)}`"),
+                Text = new Markdown($"*Tool:* `{EscapeMarkdown(request.ToolName.Value)}`\n*Request:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars))}`"),
                 Expand = true
             },
             new SectionBlock
@@ -125,7 +134,7 @@ internal static class SlackApprovalBlockBuilder
         return string.Join("\n", new[]
         {
             $"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>",
-            $"> `{request.ToolName}`: `{request.DisplayText}`",
+            $"> `{request.ToolName}`: `{ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)}`",
             BuildResolutionLine(request, selectedKey)
         });
     }
@@ -150,7 +159,7 @@ internal static class SlackApprovalBlockBuilder
             {
                 Text = new Markdown(
                     $"*Tool:* `{EscapeMarkdown(request.ToolName.Value)}`\n"
-                    + $"*Request:* `{EscapeMarkdown(request.DisplayText)}`\n"
+                    + $"*Request:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars))}`\n"
                     + $"*{EscapeMarkdown(resolutionLine)}*"),
                 Expand = true
             }

--- a/src/Netclaw.Channels/ApprovalDisplayTextFormatter.cs
+++ b/src/Netclaw.Channels/ApprovalDisplayTextFormatter.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalDisplayTextFormatter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Shrinks the raw command shown in an approval prompt so it fits inside
+/// per-channel transport size caps. When a chat platform rejects an
+/// oversized post the channel binding actor falls back to auto-denying
+/// (see each adapter's <c>SendApprovalDenyOnFailureAsync</c>) — keeping
+/// the prompt within bounds is what prevents that fallback from firing.
+/// </summary>
+public static class ApprovalDisplayTextFormatter
+{
+    /// <summary>
+    /// Marker inserted in place of the elided middle. Includes a length hint
+    /// so reviewers know the visible text is a summary, not the full
+    /// command.
+    /// </summary>
+    public const string TruncationMarker = " … [truncated, original {0} chars] … ";
+
+    /// <summary>
+    /// Returns <paramref name="text"/> unchanged when it already fits inside
+    /// <paramref name="maxChars"/>. Otherwise returns a middle-elided form
+    /// no longer than <paramref name="maxChars"/>, with the original
+    /// character count rendered into the marker.
+    /// </summary>
+    public static string Truncate(string? text, int maxChars)
+    {
+        if (string.IsNullOrEmpty(text) || maxChars <= 0)
+            return string.Empty;
+
+        if (text.Length <= maxChars)
+            return text;
+
+        var marker = string.Format(TruncationMarker, text.Length);
+
+        // Budget smaller than the marker itself: drop the marker and use a
+        // plain "…" so the prompt still posts.
+        if (maxChars <= marker.Length)
+            return string.Concat(text.AsSpan(0, maxChars - 1), "…");
+
+        var keep = maxChars - marker.Length;
+        var head = keep / 2;
+        var tail = keep - head;
+
+        return string.Concat(
+            text.AsSpan(0, head),
+            marker,
+            text.AsSpan(text.Length - tail, tail));
+    }
+}

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -20,6 +20,13 @@ namespace Netclaw.Cli.Tui;
 /// </summary>
 public partial class ChatViewModel : ReactiveViewModel
 {
+    /// <summary>
+    /// Cap on the approval body shown in the expanded (Ctrl+V) view.
+    /// Without it, a multi-KB command handed verbatim to a TextNode can
+    /// break the terminal renderer.
+    /// </summary>
+    internal const int MaxExpandedApprovalBodyChars = 8000;
+
     private readonly DaemonClient _daemonClient;
     private readonly TimeProvider _timeProvider;
     private readonly ModelCapabilities _modelCapabilities;
@@ -304,7 +311,7 @@ public partial class ChatViewModel : ReactiveViewModel
         var fullBody = $"{interaction.DisplayText}{patterns}";
 
         if (IsApprovalDetailVisible.Value)
-            return fullBody;
+            return Netclaw.Channels.ApprovalDisplayTextFormatter.Truncate(fullBody, MaxExpandedApprovalBodyChars);
 
         // Collapse to one line: any embedded newlines would also push the
         // selection list past the panel cap, not just length.


### PR DESCRIPTION
## Summary

- Multi-KB shell commands (`gh issue create --body '...'` with embedded reports) blew past Slack's 3000-char per-block cap, Discord's 2000-char message cap, and Mattermost's effective post cap. Each channel binding caught the resulting transport error, synthesized a Deny, and the pipeline reported `approval_denied_by_user` to the model — so the LLM invented reasons that had nothing to do with the real failure.
- Shared `ApprovalDisplayTextFormatter.Truncate` middle-elides the command with a marker carrying the original length, wired into the four prompt-assembly sites: Slack (request + resolved, text + block forms), Discord (text/button/resolved/shared summary), Mattermost (shared `AppendToolSummary`), and the CLI/TUI expanded view (`ChatViewModel.GetApprovalBody`).
- Per-platform budgets: Slack 2500, Discord 1700, Mattermost 12000, CLI 8000. The user now sees the approval prompt, clicks Approve, and the command runs — the auto-deny fallback no longer fires for size-driven failures.

Reproducer: session `D0AC6CKBK5K/1779811366.695739` (Akka DData LWWDictionary investigation) — model tried `gh issue create` with a ~5KB body, Slack returned `invalid_blocks` (`must be less than 3001 characters`), the binding auto-denied at 16:23:29 in `~/.netclaw/logs/daemon-2026-05-26.log:21999-22026`.

## What's intentionally NOT in this PR

A first attempt threaded a `FailureReason` field + `ApprovalDecision.PostFailed` enum value through the response protocol, the session actor, the approval channel, and the pipeline so the model would see the real transport error instead of `approval_denied_by_user`. A high-effort code review caught three blocking bugs in that approach — the upgrade rule was missing from the idle re-drive handler, `BuildApprovalRedrivePlan` didn't add `PostFailed` to the override dict, and the pipeline's `decisionOverride` early-return didn't match `PostFailed` either. Together these would have caused infinite reprompts on session restart during the exact failure scenario the change was meant to fix.

That work was reset. The truncation alone fixes the user-visible bug for the common case. If we want honest model-facing error reporting for residual post failures later, it should be a separate change with a cleaner shape (probably a dedicated `ToolApprovalChannelFailed` message rather than overloading `ToolInteractionResponse`).

## Test plan

- [x] `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj` — 2001 / 2001 passing
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [x] `dotnet build Netclaw.slnx` — clean
- [x] New `ApprovalDisplayTextFormatterTests` (5 cases: under-budget passthrough, null/empty, zero/negative budget, oversize within cap + marker, head/tail preserved)
- [x] One oversize regression per channel builder (Slack `< 3001` per SectionBlock, Discord `< 2001` for text + button prompts, Mattermost `< 16001` for text + button prompts)
- [ ] Draft — held for human review before merge

Branch: `Aaronontheweb:claude-wt-auto-declined-shell-why` → `netclaw-dev/netclaw:dev`