### PR TITLE
fix(channels): redraw approval prompts after passivation (#939)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -413,4 +413,42 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             return byCall(call);
         }
     }
+
+    // Regression for #939: cold-spawn redraw via the Discord button-interaction
+    // payload's message ID. When the binding has no in-memory pending approval
+    // (passivation), the binding must still update the prompt message using the
+    // payload-provided ID.
+    [Fact]
+    public async Task Cold_button_approval_response_redraws_prompt_via_payload_messageId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-discord-cold-redraw");
+
+        var pipeline = new RecordingSessionPipeline(_ => []);
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        var payloadMessageId = new DiscordMessageId("987654321098765432");
+        actor.Tell(new DiscordApprovalResponse(
+            ChannelId: new DiscordChannelId("ch-test"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("thread-test"),
+            CallId: new Netclaw.Tools.ToolCallId("call-discord-cold-redraw"),
+            SelectedKey: ApprovalOptionKeys.Deny,
+            SenderId: new DiscordUserId("user-1"),
+            RequesterSenderId: null,
+            PromptMessageId: payloadMessageId));
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
+            Assert.Single(feedback);
+            Assert.Equal("call-discord-cold-redraw", feedback[0].CallId.Value);
+
+            var update = Assert.Single(_replyClient.Updates);
+            Assert.Equal(payloadMessageId, update.MessageId);
+            Assert.True(update.RemoveComponents);
+            Assert.Contains("resolved", update.Text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Denied", update.Text, StringComparison.Ordinal);
+        }, cancellationToken: ct);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -451,4 +451,70 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             Assert.Contains("Denied", update.Text, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
+
+    // Code-review regression (#939): a non-requester click on a cold-spawned
+    // binding MUST NOT redraw. Session WrongRequester nack surfaces the warning
+    // and leaves the prompt UI intact.
+    [Fact]
+    public async Task Cold_button_approval_response_skips_redraw_on_wrong_requester_nack()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-discord-cold-wrong-requester");
+
+        var pipeline = new RecordingSessionPipeline(_ => [])
+        {
+            ResponseFactory = (_, _) =>
+                Task.FromResult<ICommandReply>(CommandNack.For(sid, ApprovalNackReasons.WrongRequester))
+        };
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        actor.Tell(new DiscordApprovalResponse(
+            ChannelId: new DiscordChannelId("ch-test"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("thread-test"),
+            CallId: new Netclaw.Tools.ToolCallId("call-discord-cold-wrong-requester"),
+            SelectedKey: ApprovalOptionKeys.ApproveOnce,
+            SenderId: new DiscordUserId("attacker"),
+            RequesterSenderId: null,
+            PromptMessageId: new DiscordMessageId("987654321098765432")));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Single(pipeline.RecordedFeedback.OfType<ToolInteractionResponse>());
+            Assert.Contains(_replyClient.Posts, p => p.Text.Contains("Only the requesting user", StringComparison.Ordinal));
+        }, cancellationToken: ct);
+
+        Assert.Empty(_replyClient.Updates);
+    }
+
+    // Code-review regression (#939): stale re-click after resolution.
+    [Fact]
+    public async Task Cold_button_approval_response_skips_redraw_on_stale_call_nack()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-discord-cold-stale");
+
+        var pipeline = new RecordingSessionPipeline(_ => [])
+        {
+            ResponseFactory = (_, _) =>
+                Task.FromResult<ICommandReply>(CommandNack.For(sid, "no_pending_call"))
+        };
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        actor.Tell(new DiscordApprovalResponse(
+            ChannelId: new DiscordChannelId("ch-test"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("thread-test"),
+            CallId: new Netclaw.Tools.ToolCallId("call-discord-stale"),
+            SelectedKey: ApprovalOptionKeys.Deny,
+            SenderId: new DiscordUserId("user-1"),
+            RequesterSenderId: null,
+            PromptMessageId: new DiscordMessageId("987654321098765999")));
+
+        await AwaitAssertAsync(
+            () => Assert.Single(pipeline.RecordedFeedback.OfType<ToolInteractionResponse>()),
+            cancellationToken: ct);
+
+        Assert.Empty(_replyClient.Updates);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
@@ -201,4 +201,47 @@ public sealed class MattermostSessionBindingContractTests(ITestOutputHelper outp
             new MattermostRootPostId("root-test"),
             deps), name);
     }
+
+    // Regression for #939: cold-spawn redraw via the Mattermost action callback's
+    // post_id. When the binding has no in-memory pending approval (passivation),
+    // the binding must update the original prompt post using the payload-provided
+    // post ID so the buttons clear.
+    [Fact]
+    public async Task Cold_button_approval_response_redraws_prompt_via_payload_postId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-mm-cold-redraw");
+
+        var pipeline = new RecordingSessionPipeline(_ => []);
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        var payloadPostId = new MattermostPostId("post-from-callback-abc");
+        actor.Tell(new MattermostApprovalResponse(
+            ChannelId: new MattermostChannelId("ch-test"),
+            RootPostId: new MattermostRootPostId("root-test"),
+            CallId: new Netclaw.Tools.ToolCallId("call-mm-cold-redraw"),
+            SelectedKey: ApprovalOptionKeys.Deny,
+            SenderId: new MattermostUserId("user-1"),
+            RequesterSenderId: null,
+            PromptPostId: payloadPostId));
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
+            Assert.Single(feedback);
+            Assert.Equal("call-mm-cold-redraw", feedback[0].CallId.Value);
+
+            var update = Assert.Single(_replyClient.Updates);
+            Assert.Equal(payloadPostId, update.PostId);
+            Assert.Contains("resolved", update.Text, StringComparison.OrdinalIgnoreCase);
+            // Mattermost surfaces the decision via the option's label
+            // (`ApprovalOptionKeys.LabelFor`) rather than a separate "Denied"
+            // word — match the channel-specific style.
+            Assert.Contains(ApprovalOptionKeys.DenyLabel, update.Text, StringComparison.Ordinal);
+            // Attachment carries no actions on resolve.
+            Assert.NotNull(update.Attachments);
+            Assert.All(update.Attachments!, a => Assert.Null(a.Actions));
+        }, cancellationToken: ct);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
@@ -267,4 +267,78 @@ public sealed class SlackSessionBindingContractTests(ITestOutputHelper output)
             Assert.Contains("git status", update.Text, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
+
+    // Code-review regression (#939): on the cold-spawn path, a non-requester
+    // click MUST NOT redraw the prompt. The session is the authority on whether
+    // the sender is allowed; the binding awaits the result before touching the
+    // UI. A CommandNack with WrongRequester surfaces the warning text but the
+    // buttons stay live for the legitimate requester.
+    [Fact]
+    public async Task Cold_button_approval_response_skips_redraw_on_wrong_requester_nack()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-cold-wrong-requester");
+
+        var pipeline = new RecordingSessionPipeline(_ => [])
+        {
+            ResponseFactory = (_, _) =>
+                Task.FromResult<ICommandReply>(CommandNack.For(sid, ApprovalNackReasons.WrongRequester))
+        };
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        actor.Tell(new SlackApprovalResponse(
+            ChannelId: new SlackChannelId("C-test"),
+            ThreadTs: new SlackThreadTs("1000.1"),
+            CallId: new Netclaw.Tools.ToolCallId("call-cold-wrong-requester"),
+            SelectedKey: ApprovalOptionKeys.ApproveOnce,
+            SenderId: new SenderId("attacker"),
+            RequesterSenderId: null,
+            PromptMessageTs: new SlackEventTs("1234567890.000222")));
+
+        // Wait for the session interaction + the local wrong-requester warning post.
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Single(pipeline.RecordedFeedback.OfType<ToolInteractionResponse>());
+            // The wrong-requester warning is posted as a new thread reply.
+            Assert.Contains(_replyClient.Posts, p => p.Text.Contains("Only the requesting user", StringComparison.Ordinal));
+        }, cancellationToken: ct);
+
+        // Crucially: no UpdateThreadMessageAsync — the original prompt is untouched.
+        Assert.Empty(_replyClient.Updates);
+    }
+
+    // Code-review regression (#939): a stale re-click on an already-resolved
+    // prompt MUST NOT overwrite the resolution banner with a new (rejected)
+    // decision. Session Nack on any reason (not just WrongRequester) skips the
+    // redraw.
+    [Fact]
+    public async Task Cold_button_approval_response_skips_redraw_on_stale_call_nack()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-cold-stale-click");
+
+        var pipeline = new RecordingSessionPipeline(_ => [])
+        {
+            ResponseFactory = (_, _) =>
+                Task.FromResult<ICommandReply>(CommandNack.For(sid, "no_pending_call"))
+        };
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        actor.Tell(new SlackApprovalResponse(
+            ChannelId: new SlackChannelId("C-test"),
+            ThreadTs: new SlackThreadTs("1000.1"),
+            CallId: new Netclaw.Tools.ToolCallId("call-stale"),
+            SelectedKey: ApprovalOptionKeys.Deny,
+            SenderId: new SenderId("user-1"),
+            RequesterSenderId: null,
+            PromptMessageTs: new SlackEventTs("1234567890.000333")));
+
+        await AwaitAssertAsync(
+            () => Assert.Single(pipeline.RecordedFeedback.OfType<ToolInteractionResponse>()),
+            cancellationToken: ct);
+
+        Assert.Empty(_replyClient.Updates);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
@@ -171,4 +171,100 @@ public sealed class SlackSessionBindingContractTests(ITestOutputHelper output)
             new SlackThreadTs("1000.1"),
             deps), name);
     }
+
+    // Regression for #939: when the binding has no in-memory pending approval
+    // (passivation between prompt and click) the Slack button payload still
+    // carries the prompt's message TS. The binding must use it to redraw the
+    // original message — otherwise the buttons stay live forever.
+    [Fact]
+    public async Task Cold_button_approval_response_redraws_prompt_via_payload_messageTs()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-cold-redraw-via-payload");
+
+        // No ToolInteractionRequest emitted, so _pendingApprovalRequests stays empty.
+        var pipeline = new RecordingSessionPipeline(_ => []);
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        var payloadTs = new SlackEventTs("1234567890.000111");
+        actor.Tell(new SlackApprovalResponse(
+            ChannelId: new SlackChannelId("C-test"),
+            ThreadTs: new SlackThreadTs("1000.1"),
+            CallId: new Netclaw.Tools.ToolCallId("call-cold-redraw"),
+            SelectedKey: ApprovalOptionKeys.Deny,
+            SenderId: new SenderId("user-1"),
+            RequesterSenderId: null,
+            PromptMessageTs: payloadTs));
+
+        await AwaitAssertAsync(() =>
+        {
+            // Approval routed to session.
+            var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
+            Assert.Single(feedback);
+            Assert.Equal("call-cold-redraw", feedback[0].CallId.Value);
+            Assert.Equal(ApprovalOptionKeys.Deny, feedback[0].SelectedKey.Value);
+
+            // Prompt redrawn using the payload-provided TS, with no action buttons.
+            var update = Assert.Single(_replyClient.Updates);
+            Assert.Equal(payloadTs, update.MessageTs);
+            Assert.Contains("resolved", update.Text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Denied", update.Text, StringComparison.Ordinal);
+            Assert.NotNull(update.Blocks);
+            Assert.DoesNotContain(update.Blocks!, b => b is SlackNet.Blocks.ActionsBlock);
+        }, cancellationToken: ct);
+    }
+
+    // Hot-path regression: when the binding still holds the original request,
+    // the redraw uses the captured PromptMessageTs (not the payload), and the
+    // resolved block includes verb/location detail from the request.
+    [Fact]
+    public async Task Hot_button_approval_response_redraws_prompt_via_pending_state()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-hot-redraw");
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new ToolInteractionRequest
+            {
+                SessionId = sid,
+                Kind = "approval",
+                CallId = new Netclaw.Tools.ToolCallId("call-hot-redraw"),
+                ToolName = new Netclaw.Tools.ToolName("shell_execute"),
+                DisplayText = "git status",
+                RequesterSenderId = new SenderId("user-1"),
+                Options =
+                [
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+                ]
+            }
+        ]);
+        var actor = CreateBindingActor(sid, pipeline, detector);
+
+        // Wait until the prompt has been posted (and PromptMessageTs is captured).
+        await AwaitAssertAsync(() => Assert.Single(_replyClient.Posts), cancellationToken: ct);
+
+        // Send a button click WITHOUT a payload TS — must still redraw because the
+        // binding has captured the TS in _pendingApprovalRequests.
+        actor.Tell(new SlackApprovalResponse(
+            ChannelId: new SlackChannelId("C-test"),
+            ThreadTs: new SlackThreadTs("1000.1"),
+            CallId: new Netclaw.Tools.ToolCallId("call-hot-redraw"),
+            SelectedKey: ApprovalOptionKeys.ApproveOnce,
+            SenderId: new SenderId("user-1"),
+            RequesterSenderId: null,
+            PromptMessageTs: null));
+
+        await AwaitAssertAsync(() =>
+        {
+            var update = Assert.Single(_replyClient.Updates);
+            // RecordingSlackReplyClient's PostThreadReplyWithTsAsync returns "fake.ts".
+            Assert.Equal(new SlackEventTs("fake.ts"), update.MessageTs);
+            // Full resolved block: includes the verb and tool name from the request.
+            Assert.Contains("shell_execute", update.Text, StringComparison.Ordinal);
+            Assert.Contains("git status", update.Text, StringComparison.Ordinal);
+        }, cancellationToken: ct);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
@@ -366,4 +366,38 @@ public sealed class DiscordApprovalPromptBuilderTests
 
         Assert.Contains("Saved for this chat: jsonlint config.json in /home/user/repos/foo", text);
     }
+
+    // Cold-spawn variant (#939): when the binding has lost its
+    // ToolInteractionRequest, we still need a resolved-state message that
+    // clears the action buttons.
+    [Fact]
+    public void Resolved_text_without_request_for_deny_uses_no_entry()
+    {
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+            ApprovalOptionKeys.Deny, "U123");
+
+        Assert.Contains(":no_entry:", text);
+        Assert.Contains("Denied", text);
+        Assert.Contains("<@U123>", text);
+    }
+
+    [Fact]
+    public void Resolved_text_without_request_for_approve_once_uses_checkmark()
+    {
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "U123");
+
+        Assert.Contains(":white_check_mark:", text);
+        Assert.Contains("Approved (no save)", text);
+    }
+
+    [Theory]
+    [InlineData(ApprovalOptionKeys.ApproveAlways, "Saved: always here")]
+    [InlineData(ApprovalOptionKeys.ApproveEverywhere, "Saved: always anywhere")]
+    [InlineData(ApprovalOptionKeys.ApproveSession, "Saved for this chat")]
+    public void Resolved_text_without_request_uses_generic_resolution_phrasing(string selectedKey, string expectedFragment)
+    {
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(selectedKey, "U123");
+        Assert.Contains(expectedFragment, text);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/DiscordConversationActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordConversationActorTests.cs
@@ -144,6 +144,47 @@ public sealed class DiscordConversationActorTests(ITestOutputHelper output) : Te
         Assert.Equal(ApprovalOptionKeys.ApproveOnce, approval.SelectedKey);
     }
 
+    // Regression for the #939 code-review finding: for top-level guild prompts
+    // (not threads, not DMs) the interaction's ThreadOrMessageId is the MESSAGE
+    // ID, not the channel ID. Cold-spawning a session binding by deriving the
+    // reply channel from ThreadOrMessageId would point chat.update at a message
+    // ID where a channel ID is required — the update 404s and the redraw fails.
+    // The interaction must explicitly carry ReplyChannelId; the conversation
+    // actor must use it.
+    [Fact]
+    public async Task Button_interaction_uses_explicit_ReplyChannelId_for_top_level_guild_prompts()
+    {
+        var capturedReplyChannelId = new TaskCompletionSource<DiscordReplyChannelId>();
+        var deps = CreateDependencies(
+            sessionPropsFactory: (_, _, replyChannelId, _, _, _) =>
+            {
+                capturedReplyChannelId.TrySetResult(replyChannelId);
+                return Props.Create(() => new ForwardActor(TestActor));
+            });
+
+        var conversation = Sys.ActorOf(
+            DiscordConversationActor.CreateProps(new DiscordChannelId("ch-1"), deps),
+            $"conv-replychannel-{Guid.NewGuid():N}");
+
+        // Top-level guild prompt: ThreadOrMessageId is the MESSAGE ID (per
+        // DiscordNetGatewayClient.ResolveChannelContext default branch), distinct
+        // from ChannelId / ReplyChannelId.
+        conversation.Tell(new DiscordGatewayInteraction(
+            ChannelId: new DiscordChannelId("ch-1"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("987654321098765432"),
+            CallId: "call-guild",
+            SelectedKey: ApprovalOptionKeys.ApproveOnce,
+            SenderId: new DiscordUserId("u-1"),
+            RequesterSenderId: new DiscordUserId("u-1"),
+            ReceivedAt: TimeProvider.System.GetUtcNow(),
+            PromptMessageId: new DiscordMessageId("987654321098765432"),
+            ReplyChannelId: new DiscordReplyChannelId("ch-1")));
+
+        var actual = await capturedReplyChannelId.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal("ch-1", actual.Value);
+    }
+
     [Fact]
     public async Task ACL_denied_messages_not_routed()
     {

--- a/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
@@ -232,6 +232,33 @@ public sealed class MattermostApprovalPromptBuilderTests
         Assert.Null(attachment.Actions);
     }
 
+    // Cold-spawn variant (#939): when the binding has lost its
+    // ToolInteractionRequest we still need a resolved-state attachment that
+    // clears the buttons. These tests pin its content and styling.
+    [Fact]
+    public void BuildResolvedAttachmentWithoutRequest_deny_uses_red_color_and_denied_label()
+    {
+        var attachment = MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(
+            ApprovalOptionKeys.Deny, "user-99");
+
+        Assert.Equal("#CC0000", attachment.Color);
+        Assert.Contains(":no_entry:", attachment.Text!);
+        Assert.Contains("Deny", attachment.Text!);
+        Assert.Contains("user-99", attachment.Text!);
+        Assert.Null(attachment.Actions);
+    }
+
+    [Fact]
+    public void BuildResolvedAttachmentWithoutRequest_approve_once_uses_green_color()
+    {
+        var attachment = MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "user-99");
+
+        Assert.Equal("#2EA44F", attachment.Color);
+        Assert.Contains(":white_check_mark:", attachment.Text!);
+        Assert.Null(attachment.Actions);
+    }
+
     [Fact]
     public void BuildButtonPrompt_with_action_store_includes_action_token()
     {

--- a/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
@@ -177,4 +177,48 @@ public sealed class SlackApprovalBlockBuilderTests
 
         Assert.Contains("Denied", text);
     }
+
+    // Cold-spawn variant (#939): when the binding has lost its
+    // ToolInteractionRequest we still need a resolved-state message so the
+    // buttons clear. These tests pin the wire content of the minimal banner.
+    [Fact]
+    public void Resolved_text_without_request_for_deny_uses_Denied()
+    {
+        var text = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
+            ApprovalOptionKeys.Deny, "U123");
+
+        Assert.Contains(":no_entry:", text);
+        Assert.Contains("Denied", text);
+        Assert.Contains("U123", text);
+    }
+
+    [Fact]
+    public void Resolved_text_without_request_for_approve_once_uses_checkmark()
+    {
+        var text = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "U123");
+
+        Assert.Contains(":white_check_mark:", text);
+        Assert.Contains("Approved (no save)", text);
+    }
+
+    [Theory]
+    [InlineData(ApprovalOptionKeys.ApproveAlways, "Saved: always here")]
+    [InlineData(ApprovalOptionKeys.ApproveEverywhere, "Saved: always anywhere")]
+    [InlineData(ApprovalOptionKeys.ApproveSession, "Saved for this chat")]
+    public void Resolved_text_without_request_uses_generic_resolution_phrasing(string selectedKey, string expectedFragment)
+    {
+        var text = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(selectedKey, "U123");
+        Assert.Contains(expectedFragment, text);
+    }
+
+    [Fact]
+    public void Resolved_blocks_without_request_have_no_action_buttons()
+    {
+        var blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocksWithoutRequest(
+            ApprovalOptionKeys.Deny, "U123");
+
+        Assert.NotEmpty(blocks);
+        Assert.DoesNotContain(blocks, b => b is ActionsBlock);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSlackReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSlackReplyClient.cs
@@ -12,17 +12,27 @@ public sealed class RecordingSlackReplyClient : ISlackReplyClient
 {
     private readonly object _lock = new();
     private readonly List<SlackPostMessage> _posts = [];
+    private readonly List<UpdateRecord> _updates = [];
 
     public IReadOnlyList<SlackPostMessage> Posts
     {
         get { lock (_lock) return _posts.ToList(); }
     }
 
+    public IReadOnlyList<UpdateRecord> Updates
+    {
+        get { lock (_lock) return _updates.ToList(); }
+    }
+
     public Exception? ThrowOnPost { get; set; }
 
     public void Clear()
     {
-        lock (_lock) _posts.Clear();
+        lock (_lock)
+        {
+            _posts.Clear();
+            _updates.Clear();
+        }
     }
 
     public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
@@ -46,7 +56,11 @@ public sealed class RecordingSlackReplyClient : ISlackReplyClient
         SlackEventTs messageTs,
         string text,
         IReadOnlyList<Block>? blocks = null,
-        CancellationToken cancellationToken = default) => Task.CompletedTask;
+        CancellationToken cancellationToken = default)
+    {
+        lock (_lock) _updates.Add(new UpdateRecord(channelId, messageTs, text, blocks));
+        return Task.CompletedTask;
+    }
 
     public Task UploadFileToThreadAsync(
         SlackChannelId channelId,
@@ -54,4 +68,10 @@ public sealed class RecordingSlackReplyClient : ISlackReplyClient
         string filePath,
         string? filename = null,
         CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public sealed record UpdateRecord(
+        SlackChannelId ChannelId,
+        SlackEventTs MessageTs,
+        string Text,
+        IReadOnlyList<Block>? Blocks);
 }

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -93,6 +93,38 @@ internal static class DiscordApprovalPromptBuilder
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Builds a resolved-state message body when the original
+    /// <see cref="ToolInteractionRequest"/> is no longer available — e.g. the
+    /// binding actor was passivated between posting the prompt and the user
+    /// clicking a button. Sender's component payload still carries enough
+    /// state (message ID + decision) to clear the buttons. See issue #939.
+    /// </summary>
+    public static string BuildResolvedPromptTextWithoutRequest(string selectedKey, string senderId)
+    {
+        var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
+            ? ":no_entry:"
+            : ":white_check_mark:";
+
+        var sb = new StringBuilder();
+        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        sb.Append("**").Append(BuildGenericResolutionLine(selectedKey)).Append("**");
+        sb.Append(" (by <@").Append(senderId).Append(">)");
+
+        return sb.ToString();
+    }
+
+    private static string BuildGenericResolutionLine(string selectedKey)
+        => selectedKey switch
+        {
+            ApprovalOptionKeys.ApproveAlways => "Saved: always here",
+            ApprovalOptionKeys.ApproveEverywhere => "Saved: always anywhere",
+            ApprovalOptionKeys.ApproveSession => "Saved for this chat",
+            ApprovalOptionKeys.ApproveOnce => "Approved (no save)",
+            ApprovalOptionKeys.Deny => "Denied",
+            _ => "Resolved"
+        };
+
     private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
     {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");

--- a/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
@@ -194,7 +194,13 @@ internal sealed class DiscordConversationActor : ReceiveActor
         // everything needed to address the session deterministically; a passivated/cold
         // child must not silently drop the response. See issue #979 for the production
         // passivation incident (symmetric with Slack's conversation/thread tree).
-        var replyChannelId = new DiscordReplyChannelId(interaction.ThreadOrMessageId.Value);
+        //
+        // Prefer the explicit ReplyChannelId carried on the interaction. For top-level
+        // guild prompts ThreadOrMessageId is the prompt's *message* ID, not a channel
+        // ID, so deriving the reply channel from it silently broke chat.update on the
+        // cold-spawn redraw path. See issue #939.
+        var replyChannelId = interaction.ReplyChannelId
+            ?? new DiscordReplyChannelId(interaction.ThreadOrMessageId.Value);
         var sessionId = new SessionId($"{_channelId.Value}/{interaction.ThreadOrMessageId.Value}");
         var sessionBinding = GetOrCreateSessionBinding(
             sessionId,

--- a/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
@@ -210,7 +210,8 @@ internal sealed class DiscordConversationActor : ReceiveActor
             CallId: new Netclaw.Tools.ToolCallId(interaction.CallId),
             SelectedKey: interaction.SelectedKey,
             SenderId: interaction.SenderId,
-            RequesterSenderId: interaction.RequesterSenderId));
+            RequesterSenderId: interaction.RequesterSenderId,
+            PromptMessageId: interaction.PromptMessageId));
     }
 
     private void HandleTrustedSessionTurn(DeliverTrustedSessionTurn message)

--- a/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
+++ b/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
@@ -38,7 +38,8 @@ public sealed record DiscordApprovalResponse(
     ToolCallId CallId,
     string SelectedKey,
     DiscordUserId SenderId,
-    DiscordUserId? RequesterSenderId = null);
+    DiscordUserId? RequesterSenderId = null,
+    DiscordMessageId? PromptMessageId = null);
 
 /// <summary>
 /// Sent to the gateway to wire up the actor hierarchy for a proactively-created

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -758,7 +758,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
         });
 
-        await TryResolveApprovalPromptAsync(pending!, selectedKey, message.SenderId.Value);
+        await TryResolveApprovalPromptAsync(
+            pending!.PromptMessageId,
+            pending!.Request,
+            pending!.CallId,
+            selectedKey,
+            message.SenderId.Value);
         return true;
     }
 
@@ -821,14 +826,37 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (pending is not null)
         {
             _pendingApprovalRequests.Remove(pending);
-            await TryResolveApprovalPromptAsync(pending, message.SelectedKey, message.SenderId.Value);
+            await TryResolveApprovalPromptAsync(
+                pending.PromptMessageId,
+                pending.Request,
+                pending.CallId,
+                message.SelectedKey,
+                message.SenderId.Value);
+        }
+        else if (message.PromptMessageId is { } payloadPromptMessageId)
+        {
+            // Cold-spawn path with a payload-provided message ID: the binding has no
+            // original ToolInteractionRequest to render the full resolved block, but
+            // Discord's component interaction always carries the source message ID.
+            // Use it to redraw with a generic "Resolved: <decision>" banner and clear
+            // the buttons. See issue #939.
+            await TryResolveApprovalPromptAsync(
+                payloadPromptMessageId,
+                request: null,
+                message.CallId,
+                message.SelectedKey,
+                message.SenderId.Value);
+
+            _log.Info(
+                "Forwarded Discord approval response for call {0} to session without local pending entry; redrew prompt via payload messageId={1}",
+                message.CallId,
+                payloadPromptMessageId.Value);
         }
         else
         {
-            // Cold-spawn path (#979): binding has no original ToolInteractionRequest to
-            // drive the resolved-state redraw. The approval still routes; the message
-            // just stays in its pre-resolution form. Persistence across daemon restart
-            // is tracked separately by #939.
+            // Cold-spawn path without payload context (e.g. text-reply A-E in a
+            // session whose binding has been passivated). Approval still routes;
+            // redraw is not possible. Remaining gap tracked under #939.
             _log.Info(
                 "Forwarded Discord approval response for call {0} to session without local pending entry; redraw skipped",
                 message.CallId);
@@ -837,24 +865,25 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     }
 
     private async Task TryResolveApprovalPromptAsync(
-        PendingApprovalRequest pending,
+        DiscordMessageId? promptMessageId,
+        ToolInteractionRequest? request,
+        Netclaw.Tools.ToolCallId callId,
         string selectedKey,
         string senderId)
     {
-        if (pending.PromptMessageId is not { } promptMessageId)
+        if (promptMessageId is not { } messageId)
             return;
 
         try
         {
-            var resolvedText = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
-                pending.Request,
-                selectedKey,
-                senderId);
+            var resolvedText = request is not null
+                ? DiscordApprovalPromptBuilder.BuildResolvedPromptText(request, selectedKey, senderId)
+                : DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(selectedKey, senderId);
 
             using var cts = new CancellationTokenSource(OperationTimeout);
             await _dependencies.ReplyClient.UpdateMessageAsync(
                 _replyChannelId,
-                promptMessageId,
+                messageId,
                 resolvedText,
                 removeComponents: true,
                 cts.Token);
@@ -864,8 +893,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _log.Warning(
                 ex,
                 "Failed to update resolved approval prompt for call {CallId} messageId={MessageId}",
-                pending.CallId,
-                promptMessageId.Value);
+                callId,
+                messageId.Value);
         }
     }
 

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -815,19 +815,60 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             return;
         }
 
-        await _dependencies.Pipeline.SendFeedbackAsync(new ToolInteractionResponse
+        // Wait for the session before redrawing. This is the security gate that
+        // prevents (a) a non-requester click destroying the prompt UI on the
+        // cold-spawn path, and (b) a stale re-click overwriting an already-resolved
+        // banner — both surfaced by the #939 code review. The session is the
+        // authority on whether the call is still pending and whether the sender is
+        // allowed. Only redraw on CommandAck.
+        ICommandReply feedbackResult;
+        try
         {
-            SessionId = _sessionId,
-            CallId = message.CallId,
-            SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
-            SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
-        });
+            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
+            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(
+                new ToolInteractionResponse
+                {
+                    SessionId = _sessionId,
+                    CallId = message.CallId,
+                    SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
+                    SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
+                }, feedbackCts.Token);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to route Discord approval response for call {CallId}", message.CallId);
+            return;
+        }
+
+        switch (feedbackResult)
+        {
+            case CommandNack nack:
+                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
+                    await SafeReplyAsync(WrongRequesterWarning);
+                _log.Info(
+                    "Session rejected Discord approval response for call {CallId} reason={Reason}; skipping redraw",
+                    message.CallId,
+                    nack.Reason ?? "<none>");
+                return;
+
+            case CommandAck:
+                break;
+
+            default:
+                _log.Warning(
+                    "Discord approval response for call {CallId} returned unexpected feedback result {ResultType}",
+                    message.CallId,
+                    feedbackResult.GetType().Name);
+                return;
+        }
 
         if (pending is not null)
         {
             _pendingApprovalRequests.Remove(pending);
+            // Prefer captured message ID; fall back to payload ID when capture failed.
+            var promptMessageId = pending.PromptMessageId ?? message.PromptMessageId;
             await TryResolveApprovalPromptAsync(
-                pending.PromptMessageId,
+                promptMessageId,
                 pending.Request,
                 pending.CallId,
                 message.SelectedKey,
@@ -835,11 +876,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         else if (message.PromptMessageId is { } payloadPromptMessageId)
         {
-            // Cold-spawn path with a payload-provided message ID: the binding has no
-            // original ToolInteractionRequest to render the full resolved block, but
-            // Discord's component interaction always carries the source message ID.
-            // Use it to redraw with a generic "Resolved: <decision>" banner and clear
-            // the buttons. See issue #939.
+            // Cold-spawn redraw — session has accepted; redraw via payload ID.
             await TryResolveApprovalPromptAsync(
                 payloadPromptMessageId,
                 request: null,
@@ -854,9 +891,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         else
         {
-            // Cold-spawn path without payload context (e.g. text-reply A-E in a
-            // session whose binding has been passivated). Approval still routes;
-            // redraw is not possible. Remaining gap tracked under #939.
+            // Text-reply on a cold-spawned binding. Remaining #939 gap.
             _log.Info(
                 "Forwarded Discord approval response for call {0} to session without local pending entry; redraw skipped",
                 message.CallId);

--- a/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
+++ b/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
@@ -27,6 +27,13 @@ public sealed record DiscordGatewayMessage(
 /// <summary>
 /// Normalized Discord interaction response payload emitted by the transport client.
 /// </summary>
+/// <remarks>
+/// <paramref name="PromptMessageId"/> is the ID of the message that contained
+/// the clicked button. Discord component interactions always carry the source
+/// message, so the binding actor can redraw the prompt to its resolved state
+/// even after passivation has dropped its in-memory pending-approval entry.
+/// Null for text-reply responses (no component payload). See issue #939.
+/// </remarks>
 public sealed record DiscordGatewayInteraction(
     DiscordChannelId ChannelId,
     DiscordThreadOrMessageId ThreadOrMessageId,
@@ -34,7 +41,8 @@ public sealed record DiscordGatewayInteraction(
     string SelectedKey,
     DiscordUserId SenderId,
     DiscordUserId? RequesterSenderId,
-    DateTimeOffset ReceivedAt);
+    DateTimeOffset ReceivedAt,
+    DiscordMessageId? PromptMessageId = null);
 
 public interface IDiscordGatewayClient
 {

--- a/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
+++ b/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
@@ -33,6 +33,16 @@ public sealed record DiscordGatewayMessage(
 /// message, so the binding actor can redraw the prompt to its resolved state
 /// even after passivation has dropped its in-memory pending-approval entry.
 /// Null for text-reply responses (no component payload). See issue #939.
+///
+/// <paramref name="ReplyChannelId"/> is the actual Discord channel ID where
+/// the prompt lives (the channel that the cold-spawned binding should target
+/// for <c>chat.update</c>). It is distinct from <paramref name="ThreadOrMessageId"/>,
+/// which for top-level guild prompts is the prompt's *message* ID, not its
+/// channel ID. Older code derived the binding's reply channel from
+/// <paramref name="ThreadOrMessageId"/>, which silently broke the cold-spawn
+/// redraw for top-level guild prompts. Null in legacy paths that haven't
+/// adopted the explicit field; consumers must fall back to <paramref name="ChannelId"/>
+/// when null. See issue #939.
 /// </remarks>
 public sealed record DiscordGatewayInteraction(
     DiscordChannelId ChannelId,
@@ -42,7 +52,8 @@ public sealed record DiscordGatewayInteraction(
     DiscordUserId SenderId,
     DiscordUserId? RequesterSenderId,
     DateTimeOffset ReceivedAt,
-    DiscordMessageId? PromptMessageId = null);
+    DiscordMessageId? PromptMessageId = null,
+    DiscordReplyChannelId? ReplyChannelId = null);
 
 public interface IDiscordGatewayClient
 {

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayClient.cs
@@ -217,7 +217,7 @@ internal sealed class DiscordNetGatewayClient : IDiscordGatewayClient, IDisposab
             return;
         }
 
-        var (channelId, _, threadOrMessageId) = ResolveChannelContext(
+        var (channelId, replyChannelId, threadOrMessageId) = ResolveChannelContext(
             component.Channel, component.Message.Id);
 
         // The clicked message's ID is the prompt we need to update on resolution
@@ -235,7 +235,11 @@ internal sealed class DiscordNetGatewayClient : IDiscordGatewayClient, IDisposab
                 ? new DiscordUserId(requesterSenderId)
                 : null,
             ReceivedAt: _timeProvider.GetUtcNow(),
-            PromptMessageId: promptMessageId);
+            PromptMessageId: promptMessageId,
+            // Explicit reply channel ID. For top-level guild prompts the third
+            // tuple slot (ThreadOrMessageId) is the *message* ID, so it cannot
+            // double as a channel ID for chat.update. See issue #939.
+            ReplyChannelId: new DiscordReplyChannelId(replyChannelId));
 
         try
         {

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayClient.cs
@@ -220,6 +220,11 @@ internal sealed class DiscordNetGatewayClient : IDiscordGatewayClient, IDisposab
         var (channelId, _, threadOrMessageId) = ResolveChannelContext(
             component.Channel, component.Message.Id);
 
+        // The clicked message's ID is the prompt we need to update on resolution
+        // — survives passivation so we can redraw even on a cold-spawned binding.
+        // See issue #939.
+        var promptMessageId = new DiscordMessageId(component.Message.Id.ToString());
+
         var interaction = new DiscordGatewayInteraction(
             ChannelId: new DiscordChannelId(channelId),
             ThreadOrMessageId: new DiscordThreadOrMessageId(threadOrMessageId),
@@ -229,7 +234,8 @@ internal sealed class DiscordNetGatewayClient : IDiscordGatewayClient, IDisposab
             RequesterSenderId: requesterSenderId is not null
                 ? new DiscordUserId(requesterSenderId)
                 : null,
-            ReceivedAt: _timeProvider.GetUtcNow());
+            ReceivedAt: _timeProvider.GetUtcNow(),
+            PromptMessageId: promptMessageId);
 
         try
         {

--- a/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
@@ -109,6 +109,35 @@ internal static class MattermostApprovalPromptBuilder
             Text: resolvedText);
     }
 
+    /// <summary>
+    /// Builds a resolved-state attachment when the original
+    /// <see cref="ToolInteractionRequest"/> is no longer available — e.g. the
+    /// binding actor was passivated between posting the prompt and the user
+    /// clicking a button. The callback payload still carries the prompt's
+    /// post ID, which is enough to redraw the post with a generic decision
+    /// banner and drop the action buttons. See issue #939.
+    /// </summary>
+    public static MattermostAttachment BuildResolvedAttachmentWithoutRequest(string selectedKey, string senderId)
+    {
+        var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
+            ? ":no_entry:"
+            : ":white_check_mark:";
+        var decisionLabel = ApprovalOptionKeys.LabelFor(selectedKey);
+
+        var sb = new StringBuilder();
+        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        sb.Append("**Decision:** ").Append(decisionLabel);
+        sb.Append(" (by @").Append(senderId).Append(')');
+
+        var resolvedText = sb.ToString();
+        var color = selectedKey == ApprovalOptionKeys.Deny ? "#CC0000" : "#2EA44F";
+
+        return new MattermostAttachment(
+            Fallback: resolvedText,
+            Color: color,
+            Text: resolvedText);
+    }
+
     private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
     {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");

--- a/src/Netclaw.Channels.Mattermost/MattermostCallbackActionStore.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostCallbackActionStore.cs
@@ -59,6 +59,34 @@ public sealed class MattermostCallbackActionStore(TimeProvider timeProvider)
     }
 
     /// <summary>
+    /// Records the actual prompt post ID against every outstanding token for the
+    /// given <paramref name="callId"/>. Called by the session binding actor after
+    /// <c>PostReplyAsync</c> returns, so the callback endpoint can verify that
+    /// any <c>payload.PostId</c> supplied by the client matches the prompt this
+    /// token was minted for — closing the forgery vector tracked under #939's
+    /// review (a token-holder rewriting <c>post_id</c> to target an unrelated
+    /// post the bot has edit permissions for).
+    /// </summary>
+    public void AssociatePromptPostId(string callId, string promptPostId)
+    {
+        if (string.IsNullOrWhiteSpace(callId) || string.IsNullOrWhiteSpace(promptPostId))
+            return;
+
+        foreach (var pair in _entries)
+        {
+            if (!string.Equals(pair.Value.CallId, callId, StringComparison.Ordinal))
+                continue;
+            if (pair.Value.PromptPostId is not null)
+                continue;
+
+            // ConcurrentDictionary.TryUpdate guards against concurrent eviction /
+            // consume; if the entry has been removed or already updated, skip.
+            var updated = pair.Value with { PromptPostId = promptPostId };
+            _entries.TryUpdate(pair.Key, updated, pair.Value);
+        }
+    }
+
+    /// <summary>
     /// Current count of outstanding (unconsumed, unexpired) actions. Exposed
     /// for diagnostics and tests; not used by the consume path.
     /// </summary>
@@ -86,7 +114,18 @@ public sealed class MattermostCallbackActionStore(TimeProvider timeProvider)
         string SelectedKey,
         string RootPostId,
         string? RequesterSenderId,
-        DateTimeOffset ExpiresAt);
+        DateTimeOffset ExpiresAt)
+    {
+        /// <summary>
+        /// The actual Mattermost post ID of the prompt that carries this token's
+        /// button. Populated by <see cref="MattermostCallbackActionStore.AssociatePromptPostId"/>
+        /// after the binding actor's <c>PostReplyAsync</c> returns. The callback
+        /// endpoint validates <c>payload.PostId</c> against this value — any
+        /// mismatch is a forgery attempt (the token holder rewrote <c>post_id</c>
+        /// to target an unrelated post). See issue #939.
+        /// </summary>
+        public string? PromptPostId { get; init; }
+    }
 
     private static string CreateToken()
     {

--- a/src/Netclaw.Channels.Mattermost/MattermostConversationActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostConversationActor.cs
@@ -203,7 +203,8 @@ internal sealed class MattermostConversationActor : ReceiveActor
             CallId: new ToolCallId(interaction.CallId),
             SelectedKey: interaction.SelectedKey,
             SenderId: interaction.SenderId,
-            RequesterSenderId: interaction.RequesterSenderId));
+            RequesterSenderId: interaction.RequesterSenderId,
+            PromptPostId: interaction.PromptPostId));
     }
 
     private void HandleProactiveThread(StartMattermostProactiveThread message)

--- a/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
@@ -36,7 +36,8 @@ public sealed record MattermostApprovalResponse(
     ToolCallId CallId,
     string SelectedKey,
     MattermostUserId SenderId,
-    MattermostUserId? RequesterSenderId = null);
+    MattermostUserId? RequesterSenderId = null,
+    MattermostPostId? PromptPostId = null);
 
 public sealed record StartMattermostProactiveThread(
     MattermostChannelId ChannelId,

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -733,7 +733,12 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             SenderId = new SenderId(message.SenderId.Value)
         });
 
-        await TryResolveApprovalPromptAsync(pending!, selectedKey, message.SenderId.Value);
+        await TryResolveApprovalPromptAsync(
+            pending!.PromptPostId,
+            pending!.Request,
+            pending!.CallId,
+            selectedKey,
+            message.SenderId.Value);
         return true;
     }
 
@@ -835,14 +840,37 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         if (pending is not null)
         {
             _pendingApprovalRequests.Remove(pending);
-            await TryResolveApprovalPromptAsync(pending, message.SelectedKey, message.SenderId.Value);
+            await TryResolveApprovalPromptAsync(
+                pending.PromptPostId,
+                pending.Request,
+                pending.CallId,
+                message.SelectedKey,
+                message.SenderId.Value);
+        }
+        else if (message.PromptPostId is { } payloadPromptPostId)
+        {
+            // Cold-spawn path with a payload-provided post ID: the binding has no
+            // original ToolInteractionRequest to render the full resolved attachment,
+            // but the Mattermost action callback always carries the prompt's post_id.
+            // Use it to redraw with a generic "Resolved: <decision>" banner and drop
+            // the buttons. See issue #939.
+            await TryResolveApprovalPromptAsync(
+                payloadPromptPostId,
+                request: null,
+                message.CallId,
+                message.SelectedKey,
+                message.SenderId.Value);
+
+            _log.Info(
+                "Forwarded Mattermost approval response for call {0} to session without local pending entry; redrew prompt via payload postId={1}",
+                message.CallId,
+                payloadPromptPostId.Value);
         }
         else
         {
-            // Cold-spawn path (#979): the binding was re-spawned after passivation
-            // and never observed the original ToolInteractionRequest. The approval
-            // still routes by session identity to the session actor; only the
-            // prompt redraw is skipped because there is no local prompt post.
+            // Cold-spawn path without payload context (e.g. text-reply A-E in a
+            // thread whose binding has been passivated). Approval still routes;
+            // redraw is not possible. Remaining gap tracked under #939.
             _log.Info(
                 "Forwarded Mattermost approval response for call {0} to session without local pending entry; redraw skipped",
                 message.CallId);
@@ -853,23 +881,24 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     }
 
     private async Task TryResolveApprovalPromptAsync(
-        PendingApprovalRequest pending,
+        MattermostPostId? promptPostId,
+        ToolInteractionRequest? request,
+        Netclaw.Tools.ToolCallId callId,
         string selectedKey,
         string senderId)
     {
-        if (pending.PromptPostId is not { } promptPostId)
+        if (promptPostId is not { } postId)
             return;
 
         try
         {
-            var resolvedAttachment = MattermostApprovalPromptBuilder.BuildResolvedAttachment(
-                pending.Request,
-                selectedKey,
-                senderId);
+            var resolvedAttachment = request is not null
+                ? MattermostApprovalPromptBuilder.BuildResolvedAttachment(request, selectedKey, senderId)
+                : MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(selectedKey, senderId);
 
             using var cts = new CancellationTokenSource(OperationTimeout);
             await _dependencies.ReplyClient.UpdatePostAsync(
-                promptPostId,
+                postId,
                 resolvedAttachment.Text ?? string.Empty,
                 [resolvedAttachment],
                 cts.Token);
@@ -879,8 +908,8 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             _log.Warning(
                 ex,
                 "Failed to update resolved approval prompt for call {CallId} postId={PostId}",
-                pending.CallId,
-                promptPostId.Value);
+                callId,
+                postId.Value);
         }
     }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -840,8 +840,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         if (pending is not null)
         {
             _pendingApprovalRequests.Remove(pending);
+            // Prefer captured post ID; fall back to payload-provided ID when capture
+            // failed (very narrow race window — see binding's TryPostButtonPromptAsync).
+            var promptPostId = pending.PromptPostId ?? message.PromptPostId;
             await TryResolveApprovalPromptAsync(
-                pending.PromptPostId,
+                promptPostId,
                 pending.Request,
                 pending.CallId,
                 message.SelectedKey,
@@ -1088,6 +1091,15 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
             ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyPosted(duration);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordExtra("approvalFallbackActivated", "button_prompt");
+            // Bind the actual prompt post ID to the action tokens we just minted so
+            // the callback endpoint can verify payload.PostId on the way back in.
+            // Closes the forgery vector tracked under #939's review. The action
+            // store is null in text-only mode (no callback URL); this branch isn't
+            // reachable in that case.
+            if (result.PostId is { } postId && _dependencies.CallbackActionStore is { } store)
+            {
+                store.AssociatePromptPostId(request.CallId.Value, postId.Value);
+            }
             return result.PostId;
         }
         catch (Exception ex)

--- a/src/Netclaw.Channels.Mattermost/MattermostTransportContracts.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostTransportContracts.cs
@@ -42,6 +42,13 @@ public sealed record MattermostGatewayMessage(
 ///   issued for, captured at prompt-mint time. Used by the session actor's
 ///   <c>approval_wrong_requester</c> check.</param>
 /// <param name="ReceivedAt">Timestamp the daemon observed the click.</param>
+/// <param name="PromptPostId">Post ID of the message that contained the
+///   clicked button. Mattermost's action callback payload always carries
+///   <c>post_id</c>, so this survives passivation of the per-session
+///   binding actor — the binding can redraw the prompt to its resolved
+///   state even when its in-memory pending-approval entry is gone. Null
+///   when the action was synthesized from a non-button source. See
+///   issue #939.</param>
 public sealed record MattermostGatewayInteraction(
     MattermostChannelId ChannelId,
     MattermostRootPostId RootPostId,
@@ -49,7 +56,8 @@ public sealed record MattermostGatewayInteraction(
     string SelectedKey,
     MattermostUserId SenderId,
     MattermostUserId? RequesterSenderId,
-    DateTimeOffset ReceivedAt);
+    DateTimeOffset ReceivedAt,
+    MattermostPostId? PromptPostId = null);
 
 public interface IMattermostGatewayClient
 {

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -168,6 +168,62 @@ internal static class SlackApprovalBlockBuilder
     }
 
     /// <summary>
+    /// Builds a resolved-state message body when the original
+    /// <see cref="ToolInteractionRequest"/> is no longer available — e.g. the
+    /// binding actor was passivated between posting the prompt and the user
+    /// clicking a button. The button payload still carries enough state to
+    /// redraw the prompt with a decision banner; we just can't reconstruct
+    /// the verb/location detail without the original request. Better than
+    /// leaving the buttons live indefinitely. See issue #939.
+    /// </summary>
+    public static string BuildResolvedApprovalTextWithoutRequest(string selectedKey, string senderId)
+    {
+        var statusPrefix = selectedKey == ApprovalOptionKeys.Deny
+            ? ":no_entry:"
+            : ":white_check_mark:";
+
+        return string.Join("\n", new[]
+        {
+            $"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>",
+            $"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*"
+        });
+    }
+
+    /// <summary>
+    /// Block-Kit variant of <see cref="BuildResolvedApprovalTextWithoutRequest"/>.
+    /// Renders without buttons so the prompt UI clears on the cold-spawn path.
+    /// </summary>
+    public static IReadOnlyList<Block> BuildResolvedApprovalBlocksWithoutRequest(string selectedKey, string senderId)
+    {
+        var statusPrefix = selectedKey == ApprovalOptionKeys.Deny
+            ? ":no_entry:"
+            : ":white_check_mark:";
+
+        return
+        [
+            new SectionBlock
+            {
+                Text = new Markdown($"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>")
+            },
+            new SectionBlock
+            {
+                Text = new Markdown($"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*")
+            }
+        ];
+    }
+
+    private static string BuildGenericResolutionLine(string selectedKey)
+        => selectedKey switch
+        {
+            ApprovalOptionKeys.ApproveAlways => "Saved: always here",
+            ApprovalOptionKeys.ApproveEverywhere => "Saved: always anywhere",
+            ApprovalOptionKeys.ApproveSession => "Saved for this chat",
+            ApprovalOptionKeys.ApproveOnce => "Approved (no save)",
+            ApprovalOptionKeys.Deny => "Denied",
+            _ => "Resolved"
+        };
+
+    /// <summary>
     /// Builds the prompt's header line. Single-verb invocations collapse the
     /// verb into the header (<c>Approve git status in ~/repos/foo/?</c>);
     /// multi-verb invocations use the generic <c>Approve in ~/repos/foo/?</c>

--- a/src/Netclaw.Channels.Slack/SlackApprovalHandler.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalHandler.cs
@@ -47,6 +47,13 @@ public sealed class SlackApprovalHandler : IAsyncBlockActionHandler
             ?? request.Container?.MessageTs
             ?? request.Message?.ThreadTs
             ?? request.Message?.Ts;
+        // Timestamp of the message that holds the clicked button — needed to
+        // chat.update the prompt back to its resolved state, including the
+        // cold-spawn case where the binding has lost its in-memory pending
+        // approval entry. Prefer Container.MessageTs because Slack populates
+        // that envelope field for every block action; fall back to Message.Ts
+        // for completeness.
+        var promptMessageTs = request.Container?.MessageTs ?? request.Message?.Ts;
         var senderId = request.User?.Id;
 
         if (string.IsNullOrWhiteSpace(channelId)
@@ -69,7 +76,8 @@ public sealed class SlackApprovalHandler : IAsyncBlockActionHandler
             callId,
             selectedKey,
             senderId,
-            requesterSenderId);
+            requesterSenderId,
+            !string.IsNullOrWhiteSpace(promptMessageTs) ? new SlackEventTs(promptMessageTs) : null);
 
         return respond();
     }

--- a/src/Netclaw.Channels.Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannel.cs
@@ -117,7 +117,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         string callId,
         string selectedKey,
         string senderId,
-        string? requesterSenderId)
+        string? requesterSenderId,
+        SlackEventTs? promptMessageTs = null)
     {
         _gateway?.Tell(new SlackApprovalResponse(
             channelId,
@@ -125,7 +126,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             new Netclaw.Tools.ToolCallId(callId),
             selectedKey,
             new Netclaw.Actors.Protocol.SenderId(senderId),
-            requesterSenderId is { } rsid ? new Netclaw.Actors.Protocol.SenderId(rsid) : null));
+            requesterSenderId is { } rsid ? new Netclaw.Actors.Protocol.SenderId(rsid) : null,
+            promptMessageTs));
     }
 
     public ValueTask<ChannelHealth> GetHealthAsync(CancellationToken cancellationToken = default)

--- a/src/Netclaw.Channels.Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels.Slack/SlackIngressMessages.cs
@@ -81,10 +81,20 @@ public sealed record ProactiveThreadAck(SessionId SessionId) : INoSerializationV
 /// back into the Slack actor hierarchy so the thread actor can enforce
 /// requester checks and clear pending approval state consistently.
 /// </summary>
+/// <remarks>
+/// <paramref name="PromptMessageTs"/> is the timestamp of the message that
+/// contained the clicked button. Slack's <c>BlockActionRequest</c> always
+/// carries this in its <c>Container</c> envelope, so it survives even when
+/// the thread binding actor has been passivated and lost its in-memory
+/// approval state — the binding can still redraw the original prompt to its
+/// resolved state. Null for text-reply responses (no Block Kit payload).
+/// See issue #939.
+/// </remarks>
 public sealed record SlackApprovalResponse(
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
     ToolCallId CallId,
     string SelectedKey,
     SenderId SenderId,
-    SenderId? RequesterSenderId = null) : INoSerializationVerificationNeeded;
+    SenderId? RequesterSenderId = null,
+    SlackEventTs? PromptMessageTs = null) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1334,9 +1334,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
         // CanApprove fast-path: if the binding still holds the original request we can
         // post the wrong-requester warning locally without round-tripping through the
-        // session. When the binding has been cold-spawned (no local pending entry and
-        // no prior observation) the session re-runs CanApprove against its own
-        // pending-call state — see #979.
+        // session. When the binding has been cold-spawned (no local pending entry) the
+        // session re-runs CanApprove against its own pending-call state, and the wait
+        // below blocks the redraw until the session has actually accepted the click —
+        // see #939 + #979.
         if (pending is not null && !ApprovalButtonValueCodec.CanApprove(
                 pending.Request.RequesterPrincipal,
                 pending.Request.RequesterSenderId?.Value,
@@ -1346,67 +1347,103 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             return;
         }
 
+        // Wait for the session before redrawing. This is the security gate that
+        // prevents (a) a non-requester click destroying the prompt UI on the
+        // cold-spawn path, and (b) a stale re-click overwriting an
+        // already-resolved banner — both surfaced by the #939 code review. The
+        // session is the authority on whether the call is still pending and
+        // whether the sender is allowed. Only redraw on CommandAck.
+        ICommandReply feedbackResult;
         try
         {
-            await _dependencies.Pipeline.SendFeedbackAsync(new ToolInteractionResponse
-            {
-                SessionId = _sessionId,
-                CallId = message.CallId,
-                SelectedKey = new Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
-                SenderId = message.SenderId
-            });
-
-            if (pending is not null)
-            {
-                _pendingApprovalRequests.RemoveAt(pendingIndex);
-                await TryResolveApprovalPromptAsync(
-                    pending.PromptMessageTs,
-                    pending.Request,
-                    message.CallId,
-                    message.SelectedKey,
-                    message.SenderId.Value);
-
-                _log.Info(
-                    "Recorded Slack button approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
-                    pending.Request.CallId,
-                    message.SenderId,
-                    message.SelectedKey);
-            }
-            else if (message.PromptMessageTs is { } payloadPromptTs)
-            {
-                // Cold-spawn path with a button payload: the binding has no original
-                // ToolInteractionRequest to drive the full resolved block, but Slack's
-                // BlockActionRequest envelope carries the prompt's message timestamp.
-                // Use it to redraw with a minimal "Resolved: <decision>" banner so the
-                // buttons clear. The full verb/location-aware block would require a
-                // round-trip to the session — out of scope for #939 button-click fix.
-                await TryResolveApprovalPromptAsync(
-                    payloadPromptTs,
-                    request: null,
-                    message.CallId,
-                    message.SelectedKey,
-                    message.SenderId.Value);
-
-                _log.Info(
-                    "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redrew prompt via payload messageTs={MessageTs}",
-                    message.CallId,
-                    payloadPromptTs);
-            }
-            else
-            {
-                // Cold-spawn path without payload context (e.g. text-reply A-E in a
-                // thread whose binding has been passivated). Approval still routes;
-                // we can't redraw because we have neither the original request nor
-                // the prompt's message timestamp. Tracked as the remaining #939
-                // text-reply gap.
-                _log.Info(
-                    "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redraw skipped",
-                    message.CallId);
-            }
+            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
+            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(
+                new ToolInteractionResponse
+                {
+                    SessionId = _sessionId,
+                    CallId = message.CallId,
+                    SelectedKey = new Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
+                    SenderId = message.SenderId
+                }, feedbackCts.Token);
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to route Slack button approval response for call {CallId}", message.CallId);
+            return;
+        }
+
+        switch (feedbackResult)
+        {
+            case CommandNack nack:
+                // Session rejected (wrong requester, unknown call, stale resolution).
+                // For wrong-requester surface the warning; for any other reason just
+                // log and DO NOT redraw — the prompt UI must stay consistent with the
+                // session's authoritative state.
+                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
+                    await SafePostAsync(":warning: Only the requesting user can approve this tool action.");
+                _log.Info(
+                    "Session rejected Slack approval response for call {CallId} reason={Reason}; skipping redraw",
+                    message.CallId,
+                    nack.Reason ?? "<none>");
+                return;
+
+            case CommandAck:
+                break;
+
+            default:
+                // ICommandReply is sealed-by-convention to Ack/Nack. Defensive guard.
+                _log.Warning(
+                    "Slack approval response for call {CallId} returned unexpected feedback result {ResultType}",
+                    message.CallId,
+                    feedbackResult.GetType().Name);
+                return;
+        }
+
+        if (pending is not null)
+        {
+            _pendingApprovalRequests.RemoveAt(pendingIndex);
+            // Prefer the captured TS, but fall back to the payload's TS when capture
+            // failed (post raced or returned an empty TS). The payload TS is reliable
+            // for a button click since Slack populates it in the envelope.
+            var promptTs = pending.PromptMessageTs ?? message.PromptMessageTs;
+            await TryResolveApprovalPromptAsync(
+                promptTs,
+                pending.Request,
+                message.CallId,
+                message.SelectedKey,
+                message.SenderId.Value);
+
+            _log.Info(
+                "Recorded Slack button approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
+                pending.Request.CallId,
+                message.SenderId,
+                message.SelectedKey);
+        }
+        else if (message.PromptMessageTs is { } payloadPromptTs)
+        {
+            // Cold-spawn redraw — the binding has no original request but the click
+            // payload carries the prompt's message TS, and the session has now
+            // accepted the response. Render a generic banner that clears the buttons.
+            await TryResolveApprovalPromptAsync(
+                payloadPromptTs,
+                request: null,
+                message.CallId,
+                message.SelectedKey,
+                message.SenderId.Value);
+
+            _log.Info(
+                "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redrew prompt via payload messageTs={MessageTs}",
+                message.CallId,
+                payloadPromptTs);
+        }
+        else
+        {
+            // Text-reply on a cold-spawned binding: approval routed but no message
+            // TS is available, so the redraw is impossible. Remaining #939 gap.
+            _log.Info(
+                "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redraw skipped",
+                message.CallId);
+            ChannelTelemetry.For(ChannelType.Slack).RecordExtra("interactionErrors", "cold_spawn_redraw_skipped");
         }
     }
 

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -17,6 +17,8 @@ using Netclaw.Channels;
 using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security;
+using Netclaw.Tools;
+using SlackNet.Blocks;
 
 namespace Netclaw.Channels.Slack;
 
@@ -1265,7 +1267,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
             _pendingApprovalRequests.RemoveAt(pendingIndex);
 
-            await TryResolveApprovalPromptAsync(pending, selectedKey, message.SenderId.Value);
+            await TryResolveApprovalPromptAsync(
+                pending.PromptMessageTs,
+                pending.Request,
+                pending.Request.CallId,
+                selectedKey,
+                message.SenderId.Value);
 
             _log.Info(
                 "Recorded Slack approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
@@ -1352,7 +1359,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             if (pending is not null)
             {
                 _pendingApprovalRequests.RemoveAt(pendingIndex);
-                await TryResolveApprovalPromptAsync(pending, message.SelectedKey, message.SenderId.Value);
+                await TryResolveApprovalPromptAsync(
+                    pending.PromptMessageTs,
+                    pending.Request,
+                    message.CallId,
+                    message.SelectedKey,
+                    message.SenderId.Value);
 
                 _log.Info(
                     "Recorded Slack button approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
@@ -1360,12 +1372,33 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                     message.SenderId,
                     message.SelectedKey);
             }
+            else if (message.PromptMessageTs is { } payloadPromptTs)
+            {
+                // Cold-spawn path with a button payload: the binding has no original
+                // ToolInteractionRequest to drive the full resolved block, but Slack's
+                // BlockActionRequest envelope carries the prompt's message timestamp.
+                // Use it to redraw with a minimal "Resolved: <decision>" banner so the
+                // buttons clear. The full verb/location-aware block would require a
+                // round-trip to the session — out of scope for #939 button-click fix.
+                await TryResolveApprovalPromptAsync(
+                    payloadPromptTs,
+                    request: null,
+                    message.CallId,
+                    message.SelectedKey,
+                    message.SenderId.Value);
+
+                _log.Info(
+                    "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redrew prompt via payload messageTs={MessageTs}",
+                    message.CallId,
+                    payloadPromptTs);
+            }
             else
             {
-                // Cold-spawn path: binding has no original ToolInteractionRequest to drive
-                // the resolved-state redraw. The approval still routes; the button just
-                // stays in its pre-resolution form. Persisting requests across passivation
-                // is tracked separately by #939.
+                // Cold-spawn path without payload context (e.g. text-reply A-E in a
+                // thread whose binding has been passivated). Approval still routes;
+                // we can't redraw because we have neither the original request nor
+                // the prompt's message timestamp. Tracked as the remaining #939
+                // text-reply gap.
                 _log.Info(
                     "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redraw skipped",
                     message.CallId);
@@ -1492,21 +1525,44 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             $":warning: I couldn't post the approval prompt for `{request.ToolName}`. The action was automatically denied — please ask me to try again.");
     }
 
-    private async Task TryResolveApprovalPromptAsync(PendingApprovalRequest pending, string selectedKey, string senderId)
+    private async Task TryResolveApprovalPromptAsync(
+        SlackEventTs? promptMessageTs,
+        ToolInteractionRequest? request,
+        ToolCallId callId,
+        string selectedKey,
+        string senderId)
     {
-        if (pending.PromptMessageTs is not { } promptTs)
+        if (promptMessageTs is not { } promptTs)
             return;
 
         try
         {
-            var text = SlackApprovalBlockBuilder.BuildResolvedApprovalText(
-                pending.Request,
-                selectedKey,
-                senderId);
-            var blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocks(
-                pending.Request,
-                selectedKey,
-                senderId);
+            string text;
+            IReadOnlyList<Block> blocks;
+            if (request is not null)
+            {
+                // Hot path: binding still holds the original request, render the full
+                // resolved block with verb/location detail.
+                text = SlackApprovalBlockBuilder.BuildResolvedApprovalText(
+                    request,
+                    selectedKey,
+                    senderId);
+                blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocks(
+                    request,
+                    selectedKey,
+                    senderId);
+            }
+            else
+            {
+                // Cold-spawn path: only the payload-provided message TS is known.
+                // Strip the buttons; show a generic resolution banner.
+                text = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
+                    selectedKey,
+                    senderId);
+                blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocksWithoutRequest(
+                    selectedKey,
+                    senderId);
+            }
 
             using var cts = new CancellationTokenSource(OperationTimeout);
             await _dependencies.ReplyClient.UpdateThreadMessageAsync(
@@ -1521,8 +1577,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             _log.Warning(
                 ex,
                 "Failed to update resolved approval prompt for call {CallId} messageTs={MessageTs}",
-                pending.Request.CallId,
-                pending.PromptMessageTs);
+                callId,
+                promptMessageTs);
         }
     }
 

--- a/src/Netclaw.Daemon.Tests/Configuration/MattermostActionEndpointExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/MattermostActionEndpointExtensionsTests.cs
@@ -70,6 +70,10 @@ public sealed class MattermostActionEndpointExtensionsTests(ITestOutputHelper ou
         Assert.Equal(ApprovalOptionKeys.ApproveOnce, interaction.SelectedKey);
         Assert.Equal("requester-1", interaction.SenderId.Value);
         Assert.Equal("requester-1", interaction.RequesterSenderId!.Value.Value);
+        // #939: the prompt's post_id (from the callback payload) must be plumbed
+        // through so the binding can redraw even when its pending-approval state
+        // has been lost to passivation.
+        Assert.Equal("prompt-55", interaction.PromptPostId!.Value.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Configuration/MattermostActionEndpointExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/MattermostActionEndpointExtensionsTests.cs
@@ -76,6 +76,75 @@ public sealed class MattermostActionEndpointExtensionsTests(ITestOutputHelper ou
         Assert.Equal("prompt-55", interaction.PromptPostId!.Value.Value);
     }
 
+    // Regression for the #939 code-review finding: the action token is minted
+    // BEFORE the prompt post is created, so the prompt's actual post_id only
+    // becomes known after PostReplyAsync returns. The binding actor calls
+    // AssociatePromptPostId on the store; the endpoint then validates that the
+    // client-supplied payload.PostId matches. A mismatch is a forgery attempt
+    // (a token holder rewriting post_id to redirect the bot's edit) and must
+    // be rejected.
+    [Fact]
+    public async Task Callback_with_mismatched_post_id_is_rejected_as_forge()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-20T12:00:00Z"));
+        var actionStore = new MattermostCallbackActionStore(time);
+        var token = actionStore.CreateAction("ch-1", "call-1", ApprovalOptionKeys.ApproveOnce, "root-1", "requester-1");
+        // Simulate the binding registering the actual prompt post ID after PostReplyAsync.
+        actionStore.AssociatePromptPostId("call-1", "real-prompt-post");
+
+        var recorder = new GatewayInteractionRecorder();
+        await using var app = await CreateHostAsync(
+            time,
+            actionStore,
+            gatewayResponseFactory: _ => CommandAck.For(new SessionId("ch-1/root-1")),
+            recorder: recorder);
+        var client = app.GetTestClient();
+
+        // Attacker rewrites post_id to target a different post in the channel.
+        var response = await client.PostAsJsonAsync("/api/mattermost/actions", new
+        {
+            user_id = "requester-1",
+            post_id = "some-other-post-the-bot-can-edit",
+            channel_id = "ch-1",
+            context = new Dictionary<string, string> { ["action_token"] = token }
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // Interaction must NOT have been routed to the gateway.
+        Assert.False(recorder.HasPendingInteraction);
+    }
+
+    [Fact]
+    public async Task Callback_with_matching_post_id_routes_after_AssociatePromptPostId()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-20T12:00:00Z"));
+        var actionStore = new MattermostCallbackActionStore(time);
+        var token = actionStore.CreateAction("ch-1", "call-1", ApprovalOptionKeys.ApproveOnce, "root-1", "requester-1");
+        actionStore.AssociatePromptPostId("call-1", "real-prompt-post");
+
+        var recorder = new GatewayInteractionRecorder();
+        await using var app = await CreateHostAsync(
+            time,
+            actionStore,
+            gatewayResponseFactory: _ => CommandAck.For(new SessionId("ch-1/root-1")),
+            recorder: recorder);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/mattermost/actions", new
+        {
+            user_id = "requester-1",
+            post_id = "real-prompt-post",
+            channel_id = "ch-1",
+            context = new Dictionary<string, string> { ["action_token"] = token }
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var interaction = await recorder.ReadAsync(TestContext.Current.CancellationToken);
+        // PromptPostId in the routed interaction comes from the store (trusted),
+        // not from the payload — the two happen to be equal here.
+        Assert.Equal("real-prompt-post", interaction.PromptPostId!.Value.Value);
+    }
+
     [Fact]
     public async Task Replayed_callback_token_is_rejected()
     {

--- a/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
@@ -113,6 +113,22 @@ public static class MattermostActionEndpointExtensions
                 return TypedResults.BadRequest("Callback routing data did not match the issued action.");
             }
 
+            // Forgery defence (#939): the action token is minted before the prompt
+            // is posted, so we only know the prompt's actual post_id after
+            // PostReplyAsync. The binding registers it via AssociatePromptPostId.
+            // Reject any callback whose post_id doesn't match the post the token
+            // was minted for — otherwise a token holder could rewrite post_id and
+            // redirect the bot's chat.update to an unrelated post in the channel.
+            if (storedAction.PromptPostId is { Length: > 0 } expectedPostId
+                && !string.Equals(payload.PostId, expectedPostId, StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "Rejected Mattermost action callback with mismatched post_id channel={ChannelId} callId={CallId}",
+                    payload.ChannelId,
+                    storedAction.CallId);
+                return TypedResults.BadRequest("Callback routing data did not match the issued action.");
+            }
+
             // Bound the actor-resolution wait so a daemon still mid-startup
             // returns 503 fast instead of letting the HTTP request hang behind
             // an actor system that's not yet ready.
@@ -130,6 +146,17 @@ public static class MattermostActionEndpointExtensions
                 return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
             }
 
+            // Use the server-stored prompt post ID when available (post-`AssociatePromptPostId`),
+            // otherwise fall back to the client-supplied payload.PostId. The forgery
+            // gate above guarantees payload.PostId matches storedAction.PromptPostId
+            // when the latter is set; the fallback only fires in the narrow window
+            // where the prompt was posted but `AssociatePromptPostId` hadn't run yet
+            // (impossible in practice — the binding awaits PostReplyAsync before
+            // returning — but defensive).
+            var promptPostIdForRedraw = storedAction.PromptPostId is { Length: > 0 } trustedPostId
+                ? trustedPostId
+                : payload.PostId;
+
             var interaction = new MattermostGatewayInteraction(
                 ChannelId: new MattermostChannelId(storedAction.ChannelId),
                 RootPostId: new MattermostRootPostId(storedAction.RootPostId),
@@ -140,10 +167,10 @@ public static class MattermostActionEndpointExtensions
                     ? new MattermostUserId(requesterSenderId)
                     : null,
                 ReceivedAt: timeProvider.GetUtcNow(),
-                // payload.PostId is the post that contained the clicked button —
-                // survives passivation of the per-session binding so the binding
-                // can redraw the prompt on the cold-spawn path. See issue #939.
-                PromptPostId: new MattermostPostId(payload.PostId));
+                // Trusted post ID (see comment above) — survives passivation of the
+                // per-session binding so the binding can redraw the prompt on the
+                // cold-spawn path. See issue #939.
+                PromptPostId: new MattermostPostId(promptPostIdForRedraw));
 
             try
             {

--- a/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/MattermostActionEndpointExtensions.cs
@@ -139,7 +139,11 @@ public static class MattermostActionEndpointExtensions
                 RequesterSenderId: storedAction.RequesterSenderId is { Length: > 0 } requesterSenderId
                     ? new MattermostUserId(requesterSenderId)
                     : null,
-                ReceivedAt: timeProvider.GetUtcNow());
+                ReceivedAt: timeProvider.GetUtcNow(),
+                // payload.PostId is the post that contained the clicked button —
+                // survives passivation of the per-session binding so the binding
+                // can redraw the prompt on the cold-spawn path. See issue #939.
+                PromptPostId: new MattermostPostId(payload.PostId));
 
             try
             {


### PR DESCRIPTION
## Summary

Closes [#939](https://github.com/netclaw-dev/netclaw/issues/939). When a Slack/Discord/Mattermost per-thread or per-session binding actor passivated between posting an approval prompt and the user clicking a button, the in-memory pending-approval state was lost. The click routed to the session correctly, but the binding couldn't redraw the original message — buttons stayed live indefinitely.

The fix plumbs the prompt message identifier through the interaction payload (Slack \`container.message_ts\`, Discord \`component.Message.Id\`, Mattermost callback \`post_id\`) all the way to the binding's redraw helper. When the binding has no local pending entry, the payload-provided ID drives a generic "Tool approval resolved" redraw that clears the buttons.

The second commit hardens the fix against the issues a code review surfaced:

- **Slack and Discord** now use \`SendFeedbackAndWaitAsync\` and only redraw on \`CommandAck\` (matching Mattermost's pattern). This closes (a) a non-requester click destroying the prompt UI on the cold-spawn path, and (b) a stale re-click overwriting an already-resolved banner with a rejected decision.
- **Mattermost** action endpoint no longer trusts the client-supplied \`payload.PostId\` blindly. \`MattermostCallbackActionStore\` now records the actual prompt post ID via a new \`AssociatePromptPostId\` call after \`PostReplyAsync\` returns; the endpoint rejects any callback whose \`payload.PostId\` doesn't match — closing a forgery vector where a token holder could redirect the bot's edit at any post it had permissions to modify.
- **Discord** top-level guild prompts had \`ReplyChannelId\` silently derived from the message ID, causing \`UpdateMessageAsync\` to 404. \`DiscordGatewayInteraction\` now carries an explicit \`ReplyChannelId\` populated from \`ResolveChannelContext\`.
- All three binding actors fall back to the payload-provided prompt ID when the locally captured one is null.
- Slack now emits the \`cold_spawn_redraw_skipped\` telemetry counter that Discord and Mattermost already had.

## Out of scope

- Text-reply cold-spawn case (replying \`A\`/\`B\`/.../\`E\` in a thread whose binding has passivated). No interaction payload exists for text replies, so the redraw remains skipped on that path. This is the remaining gap explicitly called out in the new comments.
- The "Abandoned parked tool batch superseded by a new user message" behaviour seen in the original session log is a separate concern about session state vs. stale approvals — not addressed here.

## Test plan

- [x] Full solution builds with 0 warnings, 0 errors
- [x] \`dotnet test\` — \`Netclaw.Actors.Tests\` 2015/2015 pass
- [x] \`dotnet test\` — \`Netclaw.Daemon.Tests\` 612/612 pass
- [x] \`dotnet slopwatch analyze\` — 0 issues
- [x] \`./scripts/Add-FileHeaders.ps1 -Verify\` — all files have headers
- [x] 7 new regression tests covering cold-spawn redraw (Slack/Discord/Mattermost), wrong-requester nack (Slack/Discord), stale-call nack (Slack/Discord), Mattermost forgery defence, Discord top-level guild ReplyChannelId
- [ ] Manual verification on a live Slack workspace: post an approval prompt, restart the daemon between prompt and click, click Deny, confirm the prompt updates to the resolved-state block and the buttons disappear