### PR TITLE
chore: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -447,3 +447,6 @@ samples/Netclaw.Demo.AppHost/.demo-home/
 # Playwright MCP working cache + ad-hoc session screenshots
 .playwright-mcp/
 phase*-mattermost-*.png
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- Add a bare `.DS_Store` pattern to `.gitignore` so macOS Finder metadata is ignored at any depth (root and subdirectories).

## Test plan
- [x] `git status` no longer reports `.DS_Store` or `.prose/.DS_Store` as untracked.