### PR TITLE
samples: pin Ollama container to 0.24.0 for qwen3.5 support

### DIFF
--- a/samples/Netclaw.Demo.AppHost/Program.cs
+++ b/samples/Netclaw.Demo.AppHost/Program.cs
@@ -51,7 +51,12 @@ if (useHostOllama)
 }
 else
 {
-    var ollama = builder.AddOllama("ollama").WithDataVolume();
+    // 0.13.0 (default in CommunityToolkit.Aspire.Hosting.Ollama) doesn't
+    // understand the qwen3.5 model manifest — bump to 0.24.0 (the first
+    // stable release that supports it).
+    var ollama = builder.AddOllama("ollama")
+        .WithImageTag("0.24.0")
+        .WithDataVolume();
     if (demoProfile == DemoProfile.Fast)
     {
         ollama = ollama


### PR DESCRIPTION
## Problem

The `CommunityToolkit.Aspire.Hosting.Ollama` NuGet package hardcodes the Ollama Docker image tag to **0.13.0** — a version that doesn't understand the `qwen3.5` model manifest format, causing a 412 error when the Aspire demo sample tries to pull the model.



## Fix

Explicitly override the image tag to **0.24.0** (the first stable release that supports qwen3.5) via `WithImageTag(0.24.0)`.

### Files Changed

- `samples/Netclaw.Demo.AppHost/Program.cs` — added `WithImageTag(0.24.0)` to the embedded Ollama container resource with a comment explaining the rationale.

## Why not `latest`?

Pinning to a specific stable tag avoids regressions when the upstream package updates its default (e.g. if they bump to a pre-release or a version with breaking changes). We can revisit and bump the tag when the CommunityToolkit package itself updates.