### PR TITLE
fix(providers): decrypt ENC: secrets when binding ProviderEntry

### DIFF
--- a/src/Netclaw.Configuration.Tests/ProviderConfigurationLoaderTests.cs
+++ b/src/Netclaw.Configuration.Tests/ProviderConfigurationLoaderTests.cs
@@ -5,12 +5,37 @@
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Secrets;
+using Netclaw.Tests.Utilities;
 using Xunit;
 
 namespace Netclaw.Configuration.Tests;
 
-public sealed class ProviderConfigurationLoaderTests
+/// <summary>
+/// Checks that <see cref="ProviderConfigurationLoader"/> loads provider API keys
+/// and OAuth tokens correctly. Secrets in <c>secrets.json</c> are saved in a
+/// scrambled form that starts with <c>ENC:</c>. The loader must turn them back
+/// into the real values before the daemon uses them. These tests make sure
+/// scrambled values come out unscrambled, and plain values are left alone.
+/// </summary>
+[Collection(SensitiveStringStaticStateCollection.Name)]
+public sealed class ProviderConfigurationLoaderTests : IDisposable
 {
+    private readonly DisposableTempDir _dir = new();
+    private readonly ISecretsProtector? _previousProtector;
+
+    public ProviderConfigurationLoaderTests()
+    {
+        _previousProtector = SensitiveStringTypeConverter.Protector;
+    }
+
+    public void Dispose()
+    {
+        SensitiveStringTypeConverter.Protector = _previousProtector;
+        _dir.Dispose();
+    }
+
+
     [Fact]
     public void Load_PreservesVendorOptionsBag()
     {
@@ -54,6 +79,99 @@ public sealed class ProviderConfigurationLoaderTests
         Assert.NotNull(options);
         Assert.True(options!.DisableThinking);
         Assert.Equal("fast", options.Mode);
+    }
+
+    [Fact]
+    public void Load_DecryptsEncApiKey()
+    {
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+        SensitiveStringTypeConverter.Protector = protector;
+
+        var encrypted = protector.Protect("sk-or-real-key");
+        Assert.StartsWith("ENC:", encrypted, StringComparison.Ordinal);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Providers:openrouter:Type"] = "openrouter",
+                ["Providers:openrouter:ApiKey"] = encrypted,
+            })
+            .Build();
+
+        var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+
+        Assert.Equal("sk-or-real-key", providers["openrouter"].ApiKey?.Value);
+    }
+
+    [Fact]
+    public void Load_DecryptsEncOAuthTokens()
+    {
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+        SensitiveStringTypeConverter.Protector = protector;
+
+        var encryptedAccess = protector.Protect("oauth-access-abc");
+        var encryptedRefresh = protector.Protect("oauth-refresh-xyz");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Providers:anthropic:Type"] = "anthropic",
+                ["Providers:anthropic:AuthMethod"] = "OAuthDevice",
+                ["Providers:anthropic:OAuthAccessToken"] = encryptedAccess,
+                ["Providers:anthropic:OAuthRefreshToken"] = encryptedRefresh,
+            })
+            .Build();
+
+        var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+
+        Assert.Equal("oauth-access-abc", providers["anthropic"].OAuthAccessToken?.Value);
+        Assert.Equal("oauth-refresh-xyz", providers["anthropic"].OAuthRefreshToken?.Value);
+    }
+
+    [Fact]
+    public void Load_ParsesOAuthTokenExpiry()
+    {
+        // The CLI writes expiry via DateTimeOffset.ToString("o") (ISO 8601 round-trip).
+        // The loader must round-trip that back to the same DateTimeOffset.
+        var expiry = new DateTimeOffset(2026, 7, 4, 12, 30, 0, TimeSpan.FromHours(-4));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Providers:anthropic:Type"] = "anthropic",
+                ["Providers:anthropic:OAuthTokenExpiry"] = expiry.ToString("o"),
+            })
+            .Build();
+
+        var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+
+        Assert.Equal(expiry, providers["anthropic"].OAuthTokenExpiry);
+    }
+
+    [Fact]
+    public void Load_PassesPlaintextSecretsThrough()
+    {
+        // Migration paths and tests sometimes write plaintext directly. Anything
+        // without the ENC: prefix must be treated as already-plaintext.
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+        SensitiveStringTypeConverter.Protector = SecretsProtection.CreateProtector(paths);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Providers:openai:Type"] = "openai",
+                ["Providers:openai:ApiKey"] = "sk-plaintext",
+            })
+            .Build();
+
+        var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+
+        Assert.Equal("sk-plaintext", providers["openai"].ApiKey?.Value);
     }
 
     private sealed class TestVendorOptions : IVendorOptions

--- a/src/Netclaw.Configuration/ProviderConfigurationLoader.cs
+++ b/src/Netclaw.Configuration/ProviderConfigurationLoader.cs
@@ -21,40 +21,15 @@ public static class ProviderConfigurationLoader
 
         foreach (var providerSection in section.GetChildren())
         {
-            var entry = BindProviderEntry(providerSection);
+            // Typed binding invokes SensitiveStringTypeConverter on ApiKey / OAuth tokens,
+            // which decrypts ENC: ciphertext from secrets.json. VendorOptions is excluded
+            // from binding via its internal setter (see ProviderEntry) and populated here.
+            var entry = providerSection.Get<ProviderEntry>() ?? new ProviderEntry();
             entry.VendorOptions = BindVendorOptions(providerSection.GetSection(nameof(ProviderEntry.VendorOptions)));
             providers[providerSection.Key] = entry;
         }
 
         return providers;
-    }
-
-    private static ProviderEntry BindProviderEntry(IConfigurationSection section)
-    {
-        var entry = new ProviderEntry
-        {
-            Type = section[nameof(ProviderEntry.Type)] ?? "ollama",
-            Endpoint = section[nameof(ProviderEntry.Endpoint)] ?? string.Empty,
-            AuthMethod = ParseEnum(section[nameof(ProviderEntry.AuthMethod)], AuthMethod.None)
-        };
-
-        var apiKey = section[nameof(ProviderEntry.ApiKey)];
-        if (!string.IsNullOrWhiteSpace(apiKey))
-            entry.ApiKey = new SensitiveString(apiKey);
-
-        var oauthAccessToken = section[nameof(ProviderEntry.OAuthAccessToken)];
-        if (!string.IsNullOrWhiteSpace(oauthAccessToken))
-            entry.OAuthAccessToken = new SensitiveString(oauthAccessToken);
-
-        var oauthRefreshToken = section[nameof(ProviderEntry.OAuthRefreshToken)];
-        if (!string.IsNullOrWhiteSpace(oauthRefreshToken))
-            entry.OAuthRefreshToken = new SensitiveString(oauthRefreshToken);
-
-        var oauthTokenExpiry = section[nameof(ProviderEntry.OAuthTokenExpiry)];
-        if (!string.IsNullOrWhiteSpace(oauthTokenExpiry))
-            entry.OAuthTokenExpiry = DateTimeOffset.Parse(oauthTokenExpiry, CultureInfo.InvariantCulture);
-
-        return entry;
     }
 
     private static JsonObject? BindVendorOptions(IConfigurationSection section)
@@ -102,14 +77,5 @@ public static class ProviderConfigurationLoader
             return JsonValue.Create(decimalValue);
 
         return JsonValue.Create(value);
-    }
-
-    private static TEnum ParseEnum<TEnum>(string? value, TEnum fallback)
-        where TEnum : struct, Enum
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return fallback;
-
-        return Enum.Parse<TEnum>(value, ignoreCase: true);
     }
 }

--- a/src/Netclaw.Configuration/ProviderEntry.cs
+++ b/src/Netclaw.Configuration/ProviderEntry.cs
@@ -30,5 +30,11 @@ public sealed class ProviderEntry
     /// <c>Providers:&lt;name&gt;:VendorOptions</c>. Plugins deserialize their own
     /// typed view instead of adding provider-specific properties here.
     /// </summary>
-    public JsonObject? VendorOptions { get; set; }
+    /// <remarks>
+    /// Setter is <c>internal</c> so Microsoft.Extensions.Configuration's binder skips this property —
+    /// <see cref="JsonObject"/> has multiple parameterized constructors the binder
+    /// can't pick from, and we populate it ourselves in
+    /// <see cref="ProviderConfigurationLoader"/>.
+    /// </remarks>
+    public JsonObject? VendorOptions { get; internal set; }
 }


### PR DESCRIPTION
Provider API keys saved to secrets.json are scrambled, but the loader was sending them out scrambled — so OpenRouter, Anthropic, and OpenAI all said 401. This fix unscrambles them first.