### PR TITLE
refactor(daemon): unify provider config load through ProviderConfigurationLoader

### DIFF
--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -386,9 +386,9 @@ static void ConfigureDaemonServices(
     // / LoggerFactory needed, and per-resolver Debug output is visible. The
     // factory is invoked eagerly after Build() (see RunDaemonAsync) so timing
     // matches a startup-bound resolution rather than first-session lazy hit.
-    var providers = configuration.GetSection("Providers")
-        .Get<Dictionary<string, ProviderEntry>>()
-        ?? new() { ["local-ollama"] = new ProviderEntry() };
+    var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+    if (providers.Count == 0)
+        providers = new() { ["local-ollama"] = new ProviderEntry() };
     var mainProviderType = providers.TryGetValue(models.Main.Provider, out var mainProvider)
         ? mainProvider.Type
         : null;


### PR DESCRIPTION
## Summary

- Routes `ConfigureDaemonServices`'s capability-resolver startup probe through `ProviderConfigurationLoader.Load` instead of `IConfiguration.Get<Dictionary<string, ProviderEntry>>()` directly.
- Removes the asymmetry between this site and `ConfigureSharedServices` (line 329), which was already going through the loader after #1195.

## Why

After #1195, both binders are correct — the loader's `.Get<ProviderEntry>()` path and the dictionary `.Get<>()` path both decrypt `ENC:` ciphertext via `SensitiveStringTypeConverter`. So this isn't a bug fix.

It's a defense-in-depth cleanup: the *asymmetry* is exactly what hid the original OpenRouter 401 regression. One site went through the type converter, the other didn't, and the divergence wasn't visible from either call site in isolation. Unifying on a single entry point means the next time someone changes how providers are loaded, both startup paths move together by construction.

Three-line diff:

```diff
-    var providers = configuration.GetSection("Providers")
-        .Get<Dictionary<string, ProviderEntry>>()
-        ?? new() { ["local-ollama"] = new ProviderEntry() };
+    var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+    if (providers.Count == 0)
+        providers = new() { ["local-ollama"] = new ProviderEntry() };
```

## Test plan

- [x] `dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj` — clean.
- [x] `dotnet slopwatch analyze` — 0 issues.
- [x] `pwsh scripts/Add-FileHeaders.ps1 -Verify` — clean.
- [ ] CI smoke harness on the daemon startup path.