### PR TITLE
chore(release): prepare v0.21.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,46 +8,40 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.20.3</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.20.3 — KV cache stability overhaul, vLLM compatibility, OpenAPI support, and MCP tool-name robustness
+    <VersionPrefix>0.21.0</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.21.0 — Venice.ai provider, security hardening, approval prompt reliability, and ARM support
 
 **Features**
 
-* **OpenAPI support for the HTTP API** — the Netclaw daemon now publishes an OpenAPI document for its minimal API endpoints, enabling discovery and integration via standard OpenAPI tooling. The spec is auth-gated so it is not exposed unauthenticated. ([#1146](https://github.com/netclaw-dev/netclaw/pull/1146))
+* **Venice.ai provider support** — full end-to-end integration for the Venice.ai chat client. Venice is now discoverable in the provider picker and callable through the daemon. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
 
-* **Aspire end-to-end demo** — a new `samples/Netclaw.Demo.AppHost` project provides a self-contained .NET Aspire demo that boots the daemon alongside a Mattermost container and an Ollama container, wires the bot automatically, and includes integration tests that validate the full message-routing path. A good starting point for local exploration and contributor onboarding. ([#1135](https://github.com/netclaw-dev/netclaw/pull/1135))
+* **Venice.ai system-prompt override** — by default, Venice silently prepends their own system prompt which breaks Netclaw identity grounding. This release forces `include_venice_system_prompt = false` to keep SOUL.md / AGENTS.md as the first system message. Operators can opt in to Venice's default prefix via `VendorOptions:IncludeVeniceSystemPrompt = true`. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
 
-**KV Cache Improvements**
-
-* **Major KV cache hit-rate improvements** — a series of fixes dramatically improves prompt-prefix cache utilization across llama.cpp, vLLM, and other OpenAI-compatible backends. Simple conversations now achieve ~94% cache hit rates (up from ~75%), memory-recall sessions ~93% (up from ~62%), and tool-heavy sessions ~98% (up from ~94%). The root cause was `NormalizeMessages` merging volatile per-turn content (memory recall, current time, working context) into the static leading system prompt, busting the cache prefix from token 0 on every turn. ([#1171](https://github.com/netclaw-dev/netclaw/pull/1171), [#1174](https://github.com/netclaw-dev/netclaw/pull/1174), [#1178](https://github.com/netclaw-dev/netclaw/pull/1178))
-
-* **vLLM system-message placement compatibility** — vLLM (and other strict OpenAI-compatible servers using Qwen/Llama chat templates) rejected requests with a non-leading System message, causing HTTP 400 errors on every turn after the KV cache fix in 0.20.2. The volatile context block is now embedded in the last User-role message instead, satisfying the `System message must be at the beginning` constraint while preserving cache-prefix stability and avoiding spurious compaction loops. ([#1176](https://github.com/netclaw-dev/netclaw/pull/1176))
-
-* **SetSystemPrompt is now idempotent** — the system prompt is only replaced when its content actually changes, preventing unnecessary mid-session cache prefix rebuilds that caused partial cache drops between turns when identity files were unchanged. ([#1174](https://github.com/netclaw-dev/netclaw/pull/1174))
-
-* **Per-turn KV prefix diagnostics** — the daemon now emits per-turn SHA-256 prefix hashes for the system message, conversation history, and tools array to make future cache regressions immediately identifiable in logs. ([#1174](https://github.com/netclaw-dev/netclaw/pull/1174))
-
-**Bug Fixes**
-
-* **vLLM modality auto-detection at startup** — vision-capable models served via vLLM (e.g., `Qwen/Qwen3.6-35B-A3B-FP8`) were incorrectly detected as text-only at daemon startup because the startup capability detection returned early on vLLM's partial response, never querying HuggingFace for modality data. Modality is now resolved through the same composite resolver used at runtime, and HuggingFace is consulted unconditionally as an oracle to fill null modality fields. ([#1158](https://github.com/netclaw-dev/netclaw/pull/1158))
-
-* **Copilot OAuth restored** — the GitHub Copilot provider's OAuth exchange was rejected with HTTP 403 after PR #1075 switched to a Netclaw-owned GitHub App; the `/copilot_internal/v2/token` endpoint is gated to a specific allowlist of OAuth Apps. The exchange now uses the Neovim Copilot OAuth App client ID (the same approach taken by avante.nvim, copilot.lua, and CodeAlta), adds the required `Copilot-Integration-Id` header, and switches the `Authorization` scheme to `Bearer` to match VS Code and other reference implementations. ([#1159](https://github.com/netclaw-dev/netclaw/pull/1159))
-
-* **LLM failure detail now surfaced to users** — transport failures (connection refused, DNS failure, TLS errors) and HTTP errors (401/403, 429, 5xx) that were previously collapsed into the generic "I encountered an error" message are now reported with the relevant context (rate-limited, re-auth required, server error, or transport message). Raw response bodies and tokens are never forwarded. ([#1159](https://github.com/netclaw-dev/netclaw/pull/1159))
-
-* **Approval controls remain visible for long shell prompts** — long `shell_execute` approval bodies in `netclaw chat` previously pushed the confirmation controls off-screen inside the Input panel, leaving the user unable to respond. The body is now rendered as a one-line summary with a `[Ctrl+V to view full]` affordance; Ctrl+V expands the body while keeping all selection options on-screen. The layout scales dynamically with terminal size and reacts to resize events. ([#1156](https://github.com/netclaw-dev/netclaw/pull/1156))
-
-* **Normal chat no longer consumed by stale approval path** — short replies like `yes`, `a`, or `1` were matched as potential approval responses by the cold-text-approval path even when no pending approval existed, consuming the message and emitting a spurious "approval prompt expired" notice. The path now checks for actual approval history before claiming the message. ([#1165](https://github.com/netclaw-dev/netclaw/pull/1165))
-
-* **MCP tool-name forms accepted in config, CLI, and doctor** — operators who wrote the LLM-facing alias (`notion__notion-create-pages`) in `ToolOverrides`, `netclaw approvals revoke --tool`, or `netclaw doctor` instead of the canonical form (`notion/notion-create-pages`) saw their entries silently ignored. All three surfaces now accept either form and resolve to the canonical name. ([#1154](https://github.com/netclaw-dev/netclaw/pull/1154))
+* **Mattermost container ARM support** — the Mattermost Docker container now correctly pulls and runs on ARM hosts (e.g., Apple Silicon Macs) with explicit `--platform linux/amd64` specification. ([#1182](https://github.com/netclaw-dev/netclaw/pull/1182))
 
 **Security**
 
-* **CodeQL code-scanning alerts resolved** — four open alerts addressed: CI workflows now request only the minimum required `contents: read` permission; webhook route IDs are sanitized before logging to prevent log-injection; daemon lifecycle shutdown/crash reason strings are sanitized and length-capped; and the reminder store's file-path resolver now enforces explicit base-directory containment to prevent path traversal. ([#1152](https://github.com/netclaw-dev/netclaw/pull/1152))
+* **Closed tunnel loopback auth bypass (SEC-005)** — the loopback authentication handler previously auto-issued Operator tickets to anyone on loopback in tunnel modes (tailscale-serve, tailscale-funnel, cloudflare-tunnel), allowing remote attackers to bypass authentication. The handler now requires remote authentication in all tunnel modes. Additionally, session pairing codes are now rejected from loopback connections in tunnel modes to prevent the local tunnel forwarder from minting new pairing codes. ([#1185](https://github.com/netclaw-dev/netclaw/pull/1185))
 
-**Dependency Updates**
+**Bug Fixes**
 
-* Bumped Mattermost.NET from 4.x to 5.0, removing a hand-rolled HTTP bypass shim with six duplicate DTOs that the SDK has natively supported since 4.0.4. ([#1163](https://github.com/netclaw-dev/netclaw/pull/1163))</PackageReleaseNotes>
+* **Provider secrets decryption restored** — provider API keys saved to secrets.json were previously sent scrambled to LLM providers, causing 401 errors across OpenRouter, Anthropic, and OpenAI. Keys are now properly decrypted before use. ([#1195](https://github.com/netclaw-dev/netclaw/pull/1195))
+
+* **Approval prompts redraw after passivation** — when channel binding actors passivated between posting an approval prompt and the user clicking a button, the in-memory pending-approval state was lost and buttons stayed live indefinitely. Prompts now correctly redraw (clearing to "resolved") using the prompt message identifier from the interaction payload. ([#939](https://github.com/netclaw-dev/netclaw/pull/1187))
+
+* **Approval callbacks hardened against forgery** — Mattermost callbacks now verify the post ID against the actual prompt post, preventing token holders from redirecting the bot's edit to any post they had permissions to modify. ([#1193](https://github.com/netclaw-dev/netclaw/pull/1193))
+
+* **Oversized approval prompts truncated** — multi-KB shell commands (like `gh issue create` with embedded reports) previously blew past Slack's 3000-char, Discord's 2000-char, and Mattermost's caps, causing auto-deny fallbacks. Prompts are now truncated per-platform budget (Slack 2500, Discord 1700, Mattermost 12000) so the user can see and approve them. ([#1186](https://github.com/netclaw-dev/netclaw/pull/1186))
+
+**Improvements**
+
+* **Ollama sample pinned to 0.24.0** — the Aspire demo now pins Ollama to 0.24.0 (was 0.13.0) to support qwen3.5 models, which require a newer manifest format. ([#1194](https://github.com/netclaw-dev/netclaw/pull/1194))
+
+* **Unified provider config loading** — the daemon's capability-resolver startup probe now uses the same `ProviderConfigurationLoader` as the main config path, removing an asymmetry that hid the #1195 regression. ([#1196](https://github.com/netclaw-dev/netclaw/pull/1196))
+
+**Documentation**
+
+* **Local binary swap skill updated** — the local-binary-swap skill now explicitly requires a daemon re-launch after the binary swap to prevent leaving the install in a broken state. ([#1192](https://github.com/netclaw-dev/netclaw/pull/1192))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,39 @@
+#### 0.21.0 2026-05-27 ####
+
+Netclaw v0.21.0 — Venice.ai provider, security hardening, approval prompt reliability, and ARM support
+
+**Features**
+
+* **Venice.ai provider support** — full end-to-end integration for the Venice.ai chat client. Venice is now discoverable in the provider picker and callable through the daemon. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
+
+* **Venice.ai system-prompt override** — by default, Venice silently prepends their own system prompt which breaks Netclaw identity grounding. This release forces `include_venice_system_prompt = false` to keep SOUL.md / AGENTS.md as the first system message. Operators can opt in to Venice's default prefix via `VendorOptions:IncludeVeniceSystemPrompt = true`. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
+
+* **Mattermost container ARM support** — the Mattermost Docker container now correctly pulls and runs on ARM hosts (e.g., Apple Silicon Macs) with explicit `--platform linux/amd64` specification. ([#1182](https://github.com/netclaw-dev/netclaw/pull/1182))
+
+**Security**
+
+* **Closed tunnel loopback auth bypass (SEC-005)** — the loopback authentication handler previously auto-issued Operator tickets to anyone on loopback in tunnel modes (tailscale-serve, tailscale-funnel, cloudflare-tunnel), allowing remote attackers to bypass authentication. The handler now requires remote authentication in all tunnel modes. Additionally, session pairing codes are now rejected from loopback connections in tunnel modes to prevent the local tunnel forwarder from minting new pairing codes. ([#1185](https://github.com/netclaw-dev/netclaw/pull/1185))
+
+**Bug Fixes**
+
+* **Provider secrets decryption restored** — provider API keys saved to secrets.json were previously sent scrambled to LLM providers, causing 401 errors across OpenRouter, Anthropic, and OpenAI. Keys are now properly decrypted before use. ([#1195](https://github.com/netclaw-dev/netclaw/pull/1195))
+
+* **Approval prompts redraw after passivation** — when channel binding actors passivated between posting an approval prompt and the user clicking a button, the in-memory pending-approval state was lost and buttons stayed live indefinitely. Prompts now correctly redraw (clearing to "resolved") using the prompt message identifier from the interaction payload. ([#939](https://github.com/netclaw-dev/netclaw/pull/1187))
+
+* **Approval callbacks hardened against forgery** — Mattermost callbacks now verify the post ID against the actual prompt post, preventing token holders from redirecting the bot's edit to any post they had permissions to modify. ([#1193](https://github.com/netclaw-dev/netclaw/pull/1193))
+
+* **Oversized approval prompts truncated** — multi-KB shell commands (like `gh issue create` with embedded reports) previously blew past Slack's 3000-char, Discord's 2000-char, and Mattermost's caps, causing auto-deny fallbacks. Prompts are now truncated per-platform budget (Slack 2500, Discord 1700, Mattermost 12000) so the user can see and approve them. ([#1186](https://github.com/netclaw-dev/netclaw/pull/1186))
+
+**Improvements**
+
+* **Ollama sample pinned to 0.24.0** — the Aspire demo now pins Ollama to 0.24.0 (was 0.13.0) to support qwen3.5 models, which require a newer manifest format. ([#1194](https://github.com/netclaw-dev/netclaw/pull/1194))
+
+* **Unified provider config loading** — the daemon's capability-resolver startup probe now uses the same `ProviderConfigurationLoader` as the main config path, removing an asymmetry that hid the #1195 regression. ([#1196](https://github.com/netclaw-dev/netclaw/pull/1196))
+
+**Documentation**
+
+* **Local binary swap skill updated** — the local-binary-swap skill now explicitly requires a daemon re-launch after the binary swap to prevent leaving the install in a broken state. ([#1192](https://github.com/netclaw-dev/netclaw/pull/1192))
+
 #### 0.20.3 2026-05-26 ####
 
 Netclaw v0.20.3 — KV cache stability overhaul, vLLM compatibility, OpenAPI support, and MCP tool-name robustness


### PR DESCRIPTION
## Summary

Netclaw v0.21.0 — Venice.ai provider, security hardening, approval prompt reliability, and ARM support

## Changes since 0.20.3

**Features**

* **Venice.ai provider support** — full end-to-end integration for the Venice.ai chat client. Venice is now discoverable in the provider picker and callable through the daemon. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
* **Venice.ai system-prompt override** — by default, Venice silently prepends their own system prompt which breaks Netclaw identity grounding. This release forces `include_venice_system_prompt = false`. Operators can opt in via `VendorOptions:IncludeVeniceSystemPrompt = true`. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
* **Mattermost container ARM support** — the Mattermost Docker container now correctly pulls and runs on ARM hosts (e.g., Apple Silicon Macs). ([#1182](https://github.com/netclaw-dev/netclaw/pull/1182))

**Security**

* **Closed tunnel loopback auth bypass (SEC-005)** — the loopback authentication handler previously auto-issued Operator tickets to anyone on loopback in tunnel modes. The handler now requires remote authentication in all tunnel modes. ([#1185](https://github.com/netclaw-dev/netclaw/pull/1185))

**Bug Fixes**

* **Provider secrets decryption restored** — provider API keys saved to secrets.json were previously sent scrambled to LLM providers, causing 401 errors. Keys are now properly decrypted. ([#1195](https://github.com/netclaw-dev/netclaw/pull/1195))
* **Approval prompts redraw after passivation** — when channel binding actors passivated between posting an approval prompt and the user clicking a button, buttons stayed live indefinitely. Prompts now correctly redraw. ([#939](https://github.com/netclaw-dev/netclaw/pull/1187))
* **Approval callbacks hardened against forgery** — Mattermost callbacks now verify the post ID against the actual prompt post. ([#1193](https://github.com/netclaw-dev/netclaw/pull/1193))
* **Oversized approval prompts truncated** — multi-KB shell commands previously blew past Slack/Discord/Mattermost caps causing auto-deny. Prompts are now truncated per-platform budget. ([#1186](https://github.com/netclaw-dev/netclaw/pull/1186))

**Improvements**

* **Ollama sample pinned to 0.24.0** — supports qwen3.5 models which require a newer manifest format. ([#1194](https://github.com/netclaw-dev/netclaw/pull/1194))
* **Unified provider config loading** — removes asymmetry that hid the #1195 regression. ([#1196](https://github.com/netclaw-dev/netclaw/pull/1196))

**Documentation**

* **Local binary swap skill updated** — now explicitly requires a daemon re-launch after the binary swap. ([#1192](https://github.com/netclaw-dev/netclaw/pull/1192))

## Test-only deps excluded

Test-only dependency bumps NOT mentioned in release notes:
- Testcontainers 4.11.0 → 4.12.0 (#1199)
- Verify.XunitV3 31.17.0 → 31.18.0 (#1179)
- Microsoft.NET.Test.Sdk 18.5.1 → 18.6.0 (#1198)
- Testcontainers 4.7.0 → 4.11.0 (#1184)