### PR TITLE
fix: cold-recovery audience block and approval redraw detail loss (post-0.21.0)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -500,6 +500,13 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             Assert.Equal(new DiscordMessageId("msg-1"), update.MessageId);
             Assert.True(update.RemoveComponents);
             Assert.Contains("resolved", update.Text, StringComparison.OrdinalIgnoreCase);
+
+            // PendingApprovalPromptTracked now carries the tool name + display
+            // text through cold recovery, so the resolved message regains the
+            // Tool/Action detail the hot path renders. End-to-end guarantee
+            // that the binding journals and rehydrates the fields.
+            Assert.Contains("shell_execute", update.Text, StringComparison.Ordinal);
+            Assert.Contains("git status", update.Text, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
@@ -294,6 +294,13 @@ public sealed class MattermostSessionBindingContractTests(ITestOutputHelper outp
             Assert.Contains("resolved", update.Text, StringComparison.OrdinalIgnoreCase);
             Assert.NotNull(update.Attachments);
             Assert.All(update.Attachments!, attachment => Assert.Null(attachment.Actions));
+
+            // PendingApprovalPromptTracked now carries the tool name + display
+            // text through cold recovery, so the resolved attachment regains
+            // the Tool/Action detail the hot path renders. End-to-end guarantee
+            // that the binding journals and rehydrates the fields.
+            Assert.Contains("shell_execute", update.Text, StringComparison.Ordinal);
+            Assert.Contains("git status", update.Text, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
@@ -317,6 +317,14 @@ public sealed class SlackSessionBindingContractTests(ITestOutputHelper output)
             Assert.Contains("resolved", update.Text, StringComparison.OrdinalIgnoreCase);
             Assert.NotNull(update.Blocks);
             Assert.DoesNotContain(update.Blocks!, block => block is SlackNet.Blocks.ActionsBlock);
+
+            // The cold-spawn redraw now pulls the tool name + display text out of
+            // the persisted PendingApprovalPromptTracked record, so the resolved
+            // banner regains the Tool/Request detail the hot path renders. This
+            // pins the wire-level guarantee end-to-end: the binding cold-recovers
+            // those fields from its journal and threads them into the builder.
+            Assert.Contains("shell_execute", update.Text, StringComparison.Ordinal);
+            Assert.Contains("git status", update.Text, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
@@ -402,6 +402,49 @@ public sealed class DiscordApprovalPromptBuilderTests
     }
 
     [Fact]
+    public void Resolved_text_without_request_includes_persisted_tool_name_and_display_text()
+    {
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+            ApprovalOptionKeys.ApproveSession,
+            "U123",
+            toolName: "shell_execute",
+            displayText: "gh pr create --base master --head feature/foo");
+
+        Assert.Contains("**Tool:** `shell_execute`", text);
+        Assert.Contains("gh pr create --base master --head feature/foo", text);
+        Assert.Contains("Saved for this chat", text);
+    }
+
+    [Fact]
+    public void Resolved_text_without_request_falls_back_to_generic_when_only_one_field_supplied()
+    {
+        var toolOnly = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "U123", toolName: "shell_execute", displayText: null);
+        Assert.DoesNotContain("**Tool:**", toolOnly);
+        Assert.Contains("Approved (no save)", toolOnly);
+
+        var displayOnly = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "U123", toolName: null, displayText: "gh pr create");
+        Assert.DoesNotContain("gh pr create", displayOnly);
+        Assert.Contains("Approved (no save)", displayOnly);
+    }
+
+    [Fact]
+    public void Resolved_text_without_request_truncates_oversized_persisted_display_text()
+    {
+        // Cold-spawn redraw must respect Discord's 2000-char cap even when the
+        // persisted display text is at the 16 KB journal ceiling.
+        var oversized = new string('y', 5_000);
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+            ApprovalOptionKeys.ApproveSession,
+            "U123",
+            toolName: "shell_execute",
+            displayText: oversized);
+
+        Assert.True(text.Length < 2001, $"Resolved text length {text.Length} exceeded Discord's 2000-char cap");
+    }
+
+    [Fact]
     public void Oversized_command_keeps_prompt_under_Discord_cap()
     {
         // Discord rejects messages over 2000 chars; without truncation

--- a/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
@@ -260,6 +260,32 @@ public sealed class MattermostApprovalPromptBuilderTests
     }
 
     [Fact]
+    public void BuildResolvedAttachmentWithoutRequest_includes_persisted_tool_name_and_display_text()
+    {
+        var attachment = MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(
+            ApprovalOptionKeys.ApproveSession,
+            "user-99",
+            toolName: "shell_execute",
+            displayText: "gh pr create --base master --head feature/foo");
+
+        Assert.Contains("**Tool:** `shell_execute`", attachment.Text!);
+        Assert.Contains("gh pr create --base master --head feature/foo", attachment.Text!);
+        Assert.Null(attachment.Actions);
+    }
+
+    [Fact]
+    public void BuildResolvedAttachmentWithoutRequest_falls_back_to_generic_when_only_one_field_supplied()
+    {
+        var toolOnly = MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "user-99", toolName: "shell_execute", displayText: null);
+        Assert.DoesNotContain("**Tool:**", toolOnly.Text!);
+
+        var displayOnly = MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "user-99", toolName: null, displayText: "gh pr create");
+        Assert.DoesNotContain("gh pr create", displayOnly.Text!);
+    }
+
+    [Fact]
     public void BuildButtonPrompt_with_action_store_includes_action_token()
     {
         var request = CreateStandardRequest();

--- a/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
@@ -223,6 +223,79 @@ public sealed class SlackApprovalBlockBuilderTests
     }
 
     [Fact]
+    public void Resolved_text_without_request_includes_persisted_tool_name_and_display_text()
+    {
+        var text = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
+            ApprovalOptionKeys.ApproveSession,
+            "U123",
+            toolName: "shell_execute",
+            displayText: "gh pr create --base master --head feature/foo");
+
+        Assert.Contains("`shell_execute`", text);
+        Assert.Contains("gh pr create --base master --head feature/foo", text);
+        Assert.Contains("Saved for this chat", text);
+    }
+
+    [Fact]
+    public void Resolved_blocks_without_request_render_tool_request_section_when_persisted_summary_supplied()
+    {
+        var blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocksWithoutRequest(
+            ApprovalOptionKeys.ApproveSession,
+            "U123",
+            toolName: "shell_execute",
+            displayText: "gh pr create");
+
+        Assert.NotEmpty(blocks);
+        // No action buttons in cold-spawn redraw — the prompt is being cleared.
+        Assert.DoesNotContain(blocks, b => b is ActionsBlock);
+
+        var rendered = string.Join("\n", blocks.OfType<SectionBlock>()
+            .Select(b => b.Text is Markdown md ? md.Text : string.Empty));
+        Assert.Contains("`shell_execute`", rendered);
+        Assert.Contains("gh pr create", rendered);
+        Assert.Contains("Saved for this chat", rendered);
+    }
+
+    [Fact]
+    public void Resolved_without_request_falls_back_to_generic_when_only_one_field_supplied()
+    {
+        // Backward-compat guard: legacy journals that supplied only the tool name
+        // (or only the display text) should not produce a half-rendered Tool/Request
+        // section. Both must be present, otherwise fall through to the generic
+        // banner.
+        var toolOnly = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "U123", toolName: "shell_execute", displayText: null);
+        Assert.DoesNotContain("`shell_execute`", toolOnly);
+        Assert.Contains("Approved (no save)", toolOnly);
+
+        var displayOnly = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
+            ApprovalOptionKeys.ApproveOnce, "U123", toolName: null, displayText: "gh pr create");
+        Assert.DoesNotContain("gh pr create", displayOnly);
+        Assert.Contains("Approved (no save)", displayOnly);
+    }
+
+    [Fact]
+    public void Resolved_blocks_without_request_truncate_oversized_display_text()
+    {
+        // The persisted ceiling (16 KB) is much larger than Slack's per-section
+        // 2500-char cap. The builder must still truncate at render time so a
+        // recovered journal with a giant body doesn't blow the section cap.
+        var oversized = new string('x', 5_000);
+        var blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocksWithoutRequest(
+            ApprovalOptionKeys.ApproveSession,
+            "U123",
+            toolName: "shell_execute",
+            displayText: oversized);
+
+        foreach (var block in blocks.OfType<SectionBlock>())
+        {
+            if (block.Text is Markdown md)
+                Assert.True(md.Text.Length < 3001,
+                    $"SectionBlock text length {md.Text.Length} exceeded Slack's 3000-char cap");
+        }
+    }
+
+    [Fact]
     public void Oversized_command_keeps_every_block_under_Slack_cap()
     {
         // Regression for the auto-deny-on-Slack-failure bug: a multi-KB

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -463,6 +463,55 @@ public sealed class SerializationRoundTripTests : TestKit
     }
 
     [Fact]
+    public void PendingApprovalPromptTracked_round_trips_with_tool_name_and_display_text()
+    {
+        var original = new PendingApprovalPromptTracked
+        {
+            CallId = "call-shell-1",
+            RequesterSenderId = "U-requester",
+            RequesterPrincipal = Netclaw.Configuration.PrincipalClassification.TrustedInternal,
+            OptionKeys = ["approve_once", "deny"],
+            PromptId = "1779898078.594569",
+            ToolName = "shell_execute",
+            DisplayText = "gh pr create --base master --head feature/foo"
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.CallId, result.CallId);
+        Assert.Equal(original.RequesterSenderId, result.RequesterSenderId);
+        Assert.Equal(original.RequesterPrincipal, result.RequesterPrincipal);
+        Assert.Equal(original.OptionKeys, result.OptionKeys);
+        Assert.Equal(original.PromptId, result.PromptId);
+        Assert.Equal(original.ToolName, result.ToolName);
+        Assert.Equal(original.DisplayText, result.DisplayText);
+    }
+
+    [Fact]
+    public void PendingApprovalPromptTracked_round_trips_when_tool_name_and_display_text_are_null()
+    {
+        // Backward-compat with pre-0.21.1 journals: the new fields are optional
+        // and a recovered record must come back with nulls intact so the binding
+        // falls through to the generic cold-spawn banner.
+        var original = new PendingApprovalPromptTracked
+        {
+            CallId = "call-legacy",
+            RequesterSenderId = null,
+            RequesterPrincipal = null,
+            OptionKeys = ["approve_once"],
+            PromptId = "1779898078.594569",
+            ToolName = null,
+            DisplayText = null
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Null(result.ToolName);
+        Assert.Null(result.DisplayText);
+        Assert.Equal(original.PromptId, result.PromptId);
+    }
+
+    [Fact]
     public void Unknown_manifest_throws_on_deserialize()
     {
         var serializer = new Serialization.NetclawProtobufSerializer((Akka.Actor.ExtendedActorSystem)Sys);

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -865,7 +865,10 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         // Drain through the redriven shell_execute result, the LLM continuation
         // call that produces the read_file batch, and the read_file result.
         // TurnCompleted comes last when the model returns a plain text reply.
-        var completed = await ExpectTurnCompletedAsync(subscriberB, TimeSpan.FromSeconds(10));
+        var completed = await subscriberB.FishForMessageAsync<TurnCompleted>(
+            _ => true,
+            TimeSpan.FromSeconds(10),
+            cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(TurnOutcome.Completed, completed.Outcome);
 
         // Both tool calls executed: the redriven shell_execute AND the
@@ -882,29 +885,6 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         Assert.Equal(TrustBoundary.Team, _toolExecutor.LastExecutionBoundary);
         Assert.Equal(ChannelType.Slack.ToWireValue(), _toolExecutor.LastExecutionChannelType);
         Assert.True(_toolExecutor.LastSupportsInteractiveApproval);
-    }
-
-    private static async Task<TurnCompleted> ExpectTurnCompletedAsync(
-        Akka.TestKit.TestProbe probe,
-        TimeSpan timeout)
-    {
-        // The recovered turn emits a sequence of ToolResultOutput / TextOutput /
-        // ToolCallOutput messages in addition to the final TurnCompleted; drain
-        // anything that isn't TurnCompleted within the same overall budget.
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            var remaining = deadline - DateTime.UtcNow;
-            if (remaining <= TimeSpan.Zero)
-                break;
-
-            var next = await probe.ReceiveOneAsync(remaining, TestContext.Current.CancellationToken);
-            if (next is TurnCompleted completed)
-                return completed;
-        }
-
-        throw new TimeoutException(
-            $"TurnCompleted was not received within {timeout}.");
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -789,6 +789,125 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
     }
 
     [Fact]
+    public async Task Cold_recovered_continuation_tool_calls_run_at_original_turn_audience()
+    {
+        // Regression for the 0.21 cold-recovery audience bug (session
+        // D0AC6CKBK5K/1779897736.065949): RedriveToolBatchForApproval correctly
+        // passes pending.Audience as the audienceOverride for the parked batch
+        // itself, but the LLM iteration that follows (the model's NEXT tool call
+        // in the same recovered turn) re-enters DispatchToolBatch with no
+        // override and previously fell through to TrustAudience.Public, silently
+        // blocking shell_execute and any other tool the audience profile
+        // doesn't list for Public. RedriveToolBatchForApproval now rehydrates
+        // _currentTurnSource from the pending record so every subsequent
+        // dispatch in the recovered turn reads the original audience.
+        const string parkedCallId = "call-shell-parked";
+        const string continuationCallId = "call-read-continuation";
+        _toolExecutor.GatedTools.Add("shell_execute");
+
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(parkedCallId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git status" })
+        ];
+
+        // After the redriven shell_execute returns its result, the LLM emits a
+        // continuation tool call (read_file). read_file is NOT gated, so it
+        // runs immediately — and its execution context is what we use to pin
+        // whether the rehydrated _currentTurnSource carried the audience.
+        _fakeChatClient.PlannedResponses.Enqueue(new AIContent[]
+        {
+            new FunctionCallContent(continuationCallId, "read_file",
+                new Dictionary<string, object?> { ["path"] = "/tmp/example.txt" })
+        });
+
+        var sessionId = new SessionId("test-channel/redrive-continuation-audience");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("redrive-cont-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run git status then read a file",
+            Source = RequesterSource("U-requester")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        await ColdRespawnAsync(sessionId);
+
+        var subscriberB = CreateTestProbe("redrive-cont-sub-b");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriberB)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        sessionManager.Tell(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(parkedCallId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.ApproveOnce),
+            SenderId = new SenderId("U-requester")
+        }, ActorRefs.Nobody);
+
+        // Drain through the redriven shell_execute result, the LLM continuation
+        // call that produces the read_file batch, and the read_file result.
+        // TurnCompleted comes last when the model returns a plain text reply.
+        var completed = await ExpectTurnCompletedAsync(subscriberB, TimeSpan.FromSeconds(10));
+        Assert.Equal(TurnOutcome.Completed, completed.Outcome);
+
+        // Both tool calls executed: the redriven shell_execute AND the
+        // continuation read_file.
+        Assert.Equal(2, _toolExecutor.SuccessfulExecutions);
+        Assert.Equal(1, _toolExecutor.ExecutionsFor("shell_execute"));
+        Assert.Equal(1, _toolExecutor.ExecutionsFor("read_file"));
+
+        // The CONTINUATION call's execution context carries the original turn's
+        // Team audience. Without the synthesized _currentTurnSource fix this
+        // would be Public — the broken path that blocks shell_execute and other
+        // tools the audience profile doesn't list for Public.
+        Assert.Equal(TrustAudience.Team, _toolExecutor.LastExecutionAudience);
+        Assert.Equal(TrustBoundary.Team, _toolExecutor.LastExecutionBoundary);
+        Assert.Equal(ChannelType.Slack.ToWireValue(), _toolExecutor.LastExecutionChannelType);
+        Assert.True(_toolExecutor.LastSupportsInteractiveApproval);
+    }
+
+    private static async Task<TurnCompleted> ExpectTurnCompletedAsync(
+        Akka.TestKit.TestProbe probe,
+        TimeSpan timeout)
+    {
+        // The recovered turn emits a sequence of ToolResultOutput / TextOutput /
+        // ToolCallOutput messages in addition to the final TurnCompleted; drain
+        // anything that isn't TurnCompleted within the same overall budget.
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            var next = await probe.ReceiveOneAsync(remaining, TestContext.Current.CancellationToken);
+            if (next is TurnCompleted completed)
+                return completed;
+        }
+
+        throw new TimeoutException(
+            $"TurnCompleted was not received within {timeout}.");
+    }
+
+    [Fact]
     public async Task Cold_recovered_denied_approval_returns_denial_result_without_reprompting()
     {
         const string callId = "call-shell-denied";

--- a/src/Netclaw.Actors/Channels/PendingApprovalPromptState.cs
+++ b/src/Netclaw.Actors/Channels/PendingApprovalPromptState.cs
@@ -16,13 +16,12 @@ namespace Netclaw.Actors.Channels;
 public sealed record PendingApprovalPromptTracked : INetclawSerializableMessage
 {
     /// <summary>
-    /// Hard cap on persisted display text. Per-channel render-time truncation
-    /// (Slack 2500, Discord 1700, Mattermost 12000) still applies on top — this
-    /// is only the journal-side ceiling to keep snapshots from ballooning when a
-    /// model emits a multi-KB shell command body. Large enough to fit every
-    /// supported transport's cap with margin.
+    /// Hard cap on persisted display text. Sized to match the most permissive
+    /// renderer cap (Mattermost 12000) so the journal never carries bytes no
+    /// channel could ever render. Per-channel render-time truncation (Slack
+    /// 2500, Discord 1700, Mattermost 12000) still applies on top.
     /// </summary>
-    public const int MaxPersistedDisplayTextChars = 16_384;
+    public const int MaxPersistedDisplayTextChars = 12_000;
 
     public string CallId { get; init; } = string.Empty;
 

--- a/src/Netclaw.Actors/Channels/PendingApprovalPromptState.cs
+++ b/src/Netclaw.Actors/Channels/PendingApprovalPromptState.cs
@@ -15,6 +15,15 @@ namespace Netclaw.Actors.Channels;
 /// </summary>
 public sealed record PendingApprovalPromptTracked : INetclawSerializableMessage
 {
+    /// <summary>
+    /// Hard cap on persisted display text. Per-channel render-time truncation
+    /// (Slack 2500, Discord 1700, Mattermost 12000) still applies on top — this
+    /// is only the journal-side ceiling to keep snapshots from ballooning when a
+    /// model emits a multi-KB shell command body. Large enough to fit every
+    /// supported transport's cap with margin.
+    /// </summary>
+    public const int MaxPersistedDisplayTextChars = 16_384;
+
     public string CallId { get; init; } = string.Empty;
 
     public string? RequesterSenderId { get; init; }
@@ -28,6 +37,20 @@ public sealed record PendingApprovalPromptTracked : INetclawSerializableMessage
     /// message id, or Mattermost post id.
     /// </summary>
     public string PromptId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Tool name from the original <c>ToolInteractionRequest</c>. Null on journal
+    /// entries written before this field was added — the cold-spawn redraw then
+    /// falls back to the generic resolution banner.
+    /// </summary>
+    public string? ToolName { get; init; }
+
+    /// <summary>
+    /// Display text from the original <c>ToolInteractionRequest</c>, truncated
+    /// to <see cref="MaxPersistedDisplayTextChars"/> before persistence. Null on
+    /// journal entries written before this field was added.
+    /// </summary>
+    public string? DisplayText { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -648,6 +648,10 @@ internal static class NetclawProtoMapper
         if (evt.RequesterPrincipal is not null)
             proto.RequesterPrincipal = (int)evt.RequesterPrincipal.Value;
         proto.OptionKeys.AddRange(evt.OptionKeys);
+        if (evt.ToolName is not null)
+            proto.ToolName = evt.ToolName;
+        if (evt.DisplayText is not null)
+            proto.DisplayText = evt.DisplayText;
         return proto;
     }
 
@@ -659,7 +663,9 @@ internal static class NetclawProtoMapper
             ? (Configuration.PrincipalClassification)proto.RequesterPrincipal
             : null,
         OptionKeys = proto.OptionKeys.ToArray(),
-        PromptId = proto.PromptId
+        PromptId = proto.PromptId,
+        ToolName = proto.HasToolName ? proto.ToolName : null,
+        DisplayText = proto.HasDisplayText ? proto.DisplayText : null
     };
 
     internal static Proto.PendingApprovalPromptClearedProto ToProto(PendingApprovalPromptCleared evt) => new()

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -283,6 +283,8 @@ message PendingApprovalPromptTrackedProto {
   optional int32 requester_principal = 3;
   repeated string option_keys = 4;
   string prompt_id = 5;
+  optional string tool_name = 6;
+  optional string display_text = 7;
 }
 
 message PendingApprovalPromptClearedProto {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3770,6 +3770,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             "Re-driving parked tool batch ({Count} call(s)) after approval response for {CallId}",
             toolCalls.Count, callId);
 
+        // On cold recovery _currentTurnSource is null because MessageSource is
+        // never persisted. The audienceOverride below carries the parked turn's
+        // trust context to THIS dispatch, but the LLM iteration that follows
+        // (continuation tool calls in the same recovered turn) re-enters
+        // DispatchToolBatch with no override and would otherwise fall through to
+        // SessionToolExecutionPipeline's TrustAudience.Public fail-closed default
+        // — silently blocking shell_execute and any other tools the audience
+        // profile doesn't list for Public. Rehydrate _currentTurnSource from
+        // pending.* so every subsequent dispatch in the recovered turn reads the
+        // correct audience/boundary/channel-type without needing per-call
+        // overrides. Only synthesizes when null; preserves live _currentTurnSource
+        // on the non-recovery idle-redrive path.
+        if (_currentTurnSource is null)
+            _currentTurnSource = SynthesizeTurnSourceFromPending(pending);
+
         TransitionTo(SessionPhase.Processing);
         DispatchToolBatch(
             toolCalls,
@@ -3781,6 +3796,45 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             requesterPrincipalOverride: pending.RequesterPrincipal,
             oneTimeApprovalPreSeed: redrivePlan.OneTimeApprovalPreSeed,
             decisionOverride: redrivePlan.DecisionOverride);
+    }
+
+    /// <summary>
+    /// Reconstructs a minimal <see cref="MessageSource"/> from a parked
+    /// <see cref="PendingToolInteraction"/>'s persisted trust fields. Used only
+    /// during cold-recovery re-drive to rehydrate <see cref="_currentTurnSource"/>
+    /// so subsequent tool dispatches in the recovered turn read the correct
+    /// audience/boundary/channel-type. The runtime-only fields on
+    /// <see cref="MessageSource"/> (AckTarget, ReminderId, BackgroundJobId,
+    /// adopted-context window) are left at their defaults — they belong to the
+    /// original live transport invocation and cannot be reconstructed from
+    /// journal state. Returns null when the pending record lacks enough state
+    /// to construct a usable source (no channel type, no requester sender id).
+    /// </summary>
+    private MessageSource? SynthesizeTurnSourceFromPending(PendingToolInteraction pending)
+    {
+        if (!ChannelTypeExtensions.TryFromWireValue(pending.ChannelType, out var channelType))
+            return null;
+
+        if (string.IsNullOrEmpty(pending.RequesterSenderId))
+            return null;
+
+        return new MessageSource
+        {
+            ChannelType = channelType,
+            SenderId = new SenderId(pending.RequesterSenderId),
+            Audience = pending.Audience,
+            Boundary = pending.Boundary
+                ?? SecurityPolicyDefaults.ResolveBoundaryFromAudience(pending.Audience),
+            Principal = pending.RequesterPrincipal ?? PrincipalClassification.UntrustedExternal,
+            // The original transport was authenticated when the prompt was first
+            // posted (the binding actor only journals PendingToolInteraction
+            // after a successful inbound). Preserve that authenticity marker so
+            // downstream policy gates see Verified rather than the defensive
+            // Unverified fallback.
+            Provenance = new SourceProvenance(
+                TransportAuthenticity.Verified,
+                PayloadTaint.Public)
+        };
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3771,29 +3771,57 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             toolCalls.Count, callId);
 
         // On cold recovery _currentTurnSource is null because MessageSource is
-        // never persisted. The audienceOverride below carries the parked turn's
-        // trust context to THIS dispatch, but the LLM iteration that follows
-        // (continuation tool calls in the same recovered turn) re-enters
-        // DispatchToolBatch with no override and would otherwise fall through to
-        // SessionToolExecutionPipeline's TrustAudience.Public fail-closed default
-        // — silently blocking shell_execute and any other tools the audience
-        // profile doesn't list for Public. Rehydrate _currentTurnSource from
-        // pending.* so every subsequent dispatch in the recovered turn reads the
-        // correct audience/boundary/channel-type without needing per-call
-        // overrides. Only synthesizes when null; preserves live _currentTurnSource
-        // on the non-recovery idle-redrive path.
+        // never persisted. Rehydrate it (and the paired _currentTrustContext +
+        // turn telemetry) from pending.* so every subsequent dispatch in the
+        // recovered turn reads the correct audience/boundary/channel-type. The
+        // LLM iteration that follows the parked batch re-enters DispatchToolBatch
+        // with no override; without rehydration it would fall through to
+        // SessionToolExecutionPipeline's TrustAudience.Public fail-closed default,
+        // silently blocking shell_execute and any other tool the audience profile
+        // doesn't list for Public. ResolveExposedToolsForCurrentTurn separately
+        // reads _currentTrustContext, so that field must be rehydrated too or the
+        // continuation LLM call gets a Public-audience tool list.
+        // Only rehydrates when null; preserves live _currentTurnSource on the
+        // non-recovery idle-redrive path.
         if (_currentTurnSource is null)
-            _currentTurnSource = SynthesizeTurnSourceFromPending(pending);
+        {
+            var synthesized = SynthesizeTurnSourceFromPending(pending);
+            if (synthesized is null)
+            {
+                // Fail loud per the no-silent-fallbacks rule: the override on this
+                // dispatch alone covers the parked batch, but any continuation tool
+                // call in the recovered turn will fall through to Public. Log so
+                // an operator investigating a still-broken cold-recovery has a
+                // breadcrumb instead of an apparently-applied fix that no-ops.
+                _log.Warning(
+                    "Cold-recovery redrive could not synthesize turn source for call {CallId} "
+                    + "(channelType={ChannelType}, requesterSenderId={Requester}); "
+                    + "continuation tool calls in this turn will fall back to TrustAudience.Public.",
+                    callId,
+                    pending.ChannelType ?? "<null>",
+                    pending.RequesterSenderId ?? "<null>");
+            }
+            else
+            {
+                _currentTurnSource = synthesized;
+                _currentTrustContext = _trustContextDeriver?.Derive(synthesized);
+                BindTurnTelemetry(synthesized);
+            }
+        }
 
         TransitionTo(SessionPhase.Processing);
+        // Only supportsInteractiveApprovalOverride is materially distinct from
+        // what the synthesized source carries — pending persists the bool? the
+        // transport actually returned at prompt time, while the synthesized
+        // source can only re-derive it from ChannelType. The other audience /
+        // boundary / channel-type / sender / principal overrides duplicate fields
+        // the synthesized _currentTurnSource now carries; SessionToolExecutionPipeline's
+        // `override ?? source?.X ?? default` fallback resolves to the same value
+        // either way. Carrying both creates two parallel mechanisms that will
+        // drift on the next maintenance edit — single source of truth wins.
         DispatchToolBatch(
             toolCalls,
-            audienceOverride: pending.Audience,
-            boundaryOverride: pending.Boundary,
-            channelTypeOverride: pending.ChannelType,
             supportsInteractiveApprovalOverride: pending.SupportsInteractiveApproval,
-            requesterSenderIdOverride: pending.RequesterSenderId is null ? null : new SenderId(pending.RequesterSenderId),
-            requesterPrincipalOverride: pending.RequesterPrincipal,
             oneTimeApprovalPreSeed: redrivePlan.OneTimeApprovalPreSeed,
             decisionOverride: redrivePlan.DecisionOverride);
     }
@@ -3805,10 +3833,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// so subsequent tool dispatches in the recovered turn read the correct
     /// audience/boundary/channel-type. The runtime-only fields on
     /// <see cref="MessageSource"/> (AckTarget, ReminderId, BackgroundJobId,
-    /// adopted-context window) are left at their defaults — they belong to the
-    /// original live transport invocation and cannot be reconstructed from
-    /// journal state. Returns null when the pending record lacks enough state
-    /// to construct a usable source (no channel type, no requester sender id).
+    /// adopted-context window, MessageId, TurnId) are left at their defaults —
+    /// they belong to the original live transport invocation and cannot be
+    /// reconstructed from journal state. Returns null when the pending record
+    /// lacks enough state to construct a usable source (no channel type, no
+    /// requester sender id); the caller surfaces a warning per the
+    /// no-silent-fallbacks rule.
     /// </summary>
     private MessageSource? SynthesizeTurnSourceFromPending(PendingToolInteraction pending)
     {
@@ -3823,17 +3853,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ChannelType = channelType,
             SenderId = new SenderId(pending.RequesterSenderId),
             Audience = pending.Audience,
-            Boundary = pending.Boundary
-                ?? SecurityPolicyDefaults.ResolveBoundaryFromAudience(pending.Audience),
+            // ResolveBoundary is the canonical helper: when pending.Boundary is
+            // null it consults channelType so slack/discord pendings resolve to
+            // TrustedInstance rather than the audience-only fallback.
+            Boundary = SecurityPolicyDefaults.ResolveBoundary(
+                pending.Boundary, pending.ChannelType, pending.Audience),
             Principal = pending.RequesterPrincipal ?? PrincipalClassification.UntrustedExternal,
             // The original transport was authenticated when the prompt was first
-            // posted (the binding actor only journals PendingToolInteraction
-            // after a successful inbound). Preserve that authenticity marker so
-            // downstream policy gates see Verified rather than the defensive
-            // Unverified fallback.
+            // posted (the binding actor only journals PendingToolInteraction after
+            // a successful inbound), so Verified is honest. PayloadTaint, however,
+            // is never persisted — Unknown is the honest sentinel for "we don't
+            // know what the original taint was" and lets downstream gates branch
+            // safely without us falsely claiming Public.
             Provenance = new SourceProvenance(
                 TransportAuthenticity.Verified,
-                PayloadTaint.Public)
+                PayloadTaint.Unknown)
         };
     }
 

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -107,9 +107,18 @@ internal static class DiscordApprovalPromptBuilder
     /// <see cref="ToolInteractionRequest"/> is no longer available — e.g. the
     /// binding actor was passivated between posting the prompt and the user
     /// clicking a button. Sender's component payload still carries enough
-    /// state (message ID + decision) to clear the buttons. See issue #939.
+    /// state (message ID + decision) to clear the buttons. When the persisted
+    /// <see cref="Netclaw.Actors.Channels.PendingApprovalPromptTracked"/>
+    /// carried <paramref name="toolName"/> + <paramref name="displayText"/>,
+    /// the redraw includes the original tool name and request text; otherwise
+    /// it falls back to a generic banner (pre-field journal entries). See
+    /// issue #939.
     /// </summary>
-    public static string BuildResolvedPromptTextWithoutRequest(string selectedKey, string senderId)
+    public static string BuildResolvedPromptTextWithoutRequest(
+        string selectedKey,
+        string senderId,
+        string? toolName = null,
+        string? displayText = null)
     {
         var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
@@ -117,6 +126,15 @@ internal static class DiscordApprovalPromptBuilder
 
         var sb = new StringBuilder();
         sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+
+        if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
+        {
+            sb.Append("**Tool:** `").Append(toolName).AppendLine("`");
+            sb.Append("**Action:** `")
+                .Append(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))
+                .AppendLine("`");
+        }
+
         sb.Append("**").Append(BuildGenericResolutionLine(selectedKey)).Append("**");
         sb.Append(" (by <@").Append(senderId).Append(">)");
 

--- a/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
+++ b/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
@@ -72,6 +72,8 @@ internal sealed class PendingApprovalRequest
         RequesterPrincipal = request.RequesterPrincipal;
         Options = request.Options;
         OptionKeys = request.Options.Select(option => option.Key.Value).ToArray();
+        ToolName = request.ToolName.Value;
+        DisplayText = request.DisplayText;
     }
 
     public PendingApprovalRequest(
@@ -79,7 +81,9 @@ internal sealed class PendingApprovalRequest
         string? requesterSenderId,
         PrincipalClassification? requesterPrincipal,
         IReadOnlyList<string> optionKeys,
-        DiscordMessageId? promptMessageId)
+        DiscordMessageId? promptMessageId,
+        string? toolName = null,
+        string? displayText = null)
     {
         Request = null;
         CallId = callId;
@@ -90,6 +94,8 @@ internal sealed class PendingApprovalRequest
             .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
             .ToArray();
         PromptMessageId = promptMessageId;
+        ToolName = toolName;
+        DisplayText = displayText;
     }
 
     public ToolInteractionRequest? Request { get; }
@@ -100,5 +106,19 @@ internal sealed class PendingApprovalRequest
     public PrincipalClassification? RequesterPrincipal { get; }
     public IReadOnlyList<ToolInteractionOption> Options { get; }
     public IReadOnlyList<string> OptionKeys { get; }
+
+    /// <summary>
+    /// Tool name carried through cold-spawn recovery so the redraw can render
+    /// the original tool name without round-tripping to the session. Null on
+    /// pre-field journal entries.
+    /// </summary>
+    public string? ToolName { get; }
+
+    /// <summary>
+    /// Display text carried through cold-spawn recovery (already truncated to
+    /// the persisted ceiling). Null on pre-field journal entries.
+    /// </summary>
+    public string? DisplayText { get; }
+
     public DiscordMessageId? PromptMessageId { get; set; }
 }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -800,7 +800,9 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             pending!.Request,
             pending!.CallId,
             selectedKey,
-            message.SenderId.Value);
+            message.SenderId.Value,
+            persistedToolName: pending.ToolName,
+            persistedDisplayText: pending.DisplayText);
         return true;
     }
 
@@ -913,11 +915,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 pending.Request,
                 pending.CallId,
                 message.SelectedKey,
-                message.SenderId.Value);
+                message.SenderId.Value,
+                persistedToolName: pending.ToolName,
+                persistedDisplayText: pending.DisplayText);
         }
         else if (message.PromptMessageId is { } payloadPromptMessageId)
         {
-            // Cold-spawn redraw — session has accepted; redraw via payload ID.
+            // Cold-spawn redraw — no local pending entry. The journal either has no
+            // PendingApprovalPromptTracked for this call, or one from before tool name
+            // + display text were persisted. Render the generic banner so buttons clear.
             await TryResolveApprovalPromptAsync(
                 payloadPromptMessageId,
                 request: null,
@@ -945,16 +951,26 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         ToolInteractionRequest? request,
         Netclaw.Tools.ToolCallId callId,
         string selectedKey,
-        string senderId)
+        string senderId,
+        string? persistedToolName = null,
+        string? persistedDisplayText = null)
     {
         if (promptMessageId is not { } messageId)
             return;
 
         try
         {
+            // Hot path uses the in-memory request. Cold-spawn path uses the persisted
+            // tool name + display text when present (PendingApprovalPromptTracked
+            // carried them); legacy journals without the fields fall back to the
+            // generic banner.
             var resolvedText = request is not null
                 ? DiscordApprovalPromptBuilder.BuildResolvedPromptText(request, selectedKey, senderId)
-                : DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(selectedKey, senderId);
+                : DiscordApprovalPromptBuilder.BuildResolvedPromptTextWithoutRequest(
+                    selectedKey,
+                    senderId,
+                    toolName: persistedToolName,
+                    displayText: persistedDisplayText);
 
             using var cts = new CancellationTokenSource(OperationTimeout);
             await _dependencies.ReplyClient.UpdateMessageAsync(
@@ -1097,7 +1113,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                         RequesterSenderId = pendingApproval.RequesterSenderId,
                         RequesterPrincipal = pendingApproval.RequesterPrincipal,
                         OptionKeys = pendingApproval.OptionKeys,
-                        PromptId = promptMessageId.Value.Value
+                        PromptId = promptMessageId.Value.Value,
+                        ToolName = pendingApproval.ToolName,
+                        DisplayText = ApprovalDisplayTextFormatter.Truncate(
+                            pendingApproval.DisplayText,
+                            PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
                     }, ApplyPendingApprovalPromptTracked);
                 }
                 else
@@ -1626,7 +1646,9 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             tracked.RequesterSenderId,
             tracked.RequesterPrincipal,
             tracked.OptionKeys,
-            new DiscordMessageId(tracked.PromptId)));
+            new DiscordMessageId(tracked.PromptId),
+            toolName: tracked.ToolName,
+            displayText: tracked.DisplayText));
     }
 
     private void ApplyPendingApprovalPromptCleared(PendingApprovalPromptCleared cleared)

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -921,9 +921,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         else if (message.PromptMessageId is { } payloadPromptMessageId)
         {
-            // Cold-spawn redraw — no local pending entry. The journal either has no
-            // PendingApprovalPromptTracked for this call, or one from before tool name
-            // + display text were persisted. Render the generic banner so buttons clear.
+            // Cold-spawn redraw — no local pending entry for this CallId (no
+            // PendingApprovalPromptTracked replayed, or the entry was already
+            // cleared). The click payload still carries the prompt's message id
+            // and the session has accepted the response; render the generic
+            // banner so the buttons clear. Pre-0.21 journals that DO replay take
+            // the upper `pending is not null` branch — they render generically
+            // via the !IsNullOrEmpty fallback inside the builder, not here.
             await TryResolveApprovalPromptAsync(
                 payloadPromptMessageId,
                 request: null,
@@ -1115,9 +1119,14 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                         OptionKeys = pendingApproval.OptionKeys,
                         PromptId = promptMessageId.Value.Value,
                         ToolName = pendingApproval.ToolName,
-                        DisplayText = ApprovalDisplayTextFormatter.Truncate(
-                            pendingApproval.DisplayText,
-                            PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
+                        // Preserve null-vs-set semantics on the wire: Truncate
+                        // returns string.Empty for null input, which would round-
+                        // trip as DisplayText="" with HasDisplayText=true.
+                        DisplayText = string.IsNullOrEmpty(pendingApproval.DisplayText)
+                            ? null
+                            : ApprovalDisplayTextFormatter.Truncate(
+                                pendingApproval.DisplayText,
+                                PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
                     }, ApplyPendingApprovalPromptTracked);
                 }
                 else

--- a/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
@@ -124,10 +124,18 @@ internal static class MattermostApprovalPromptBuilder
     /// <see cref="ToolInteractionRequest"/> is no longer available — e.g. the
     /// binding actor was passivated between posting the prompt and the user
     /// clicking a button. The callback payload still carries the prompt's
-    /// post ID, which is enough to redraw the post with a generic decision
-    /// banner and drop the action buttons. See issue #939.
+    /// post ID, which is enough to redraw the post with a decision banner
+    /// and drop the action buttons. When the persisted
+    /// <see cref="Netclaw.Actors.Channels.PendingApprovalPromptTracked"/>
+    /// carried <paramref name="toolName"/> + <paramref name="displayText"/>,
+    /// the redraw includes the original tool name and request text;
+    /// otherwise it falls back to a generic banner. See issue #939.
     /// </summary>
-    public static MattermostAttachment BuildResolvedAttachmentWithoutRequest(string selectedKey, string senderId)
+    public static MattermostAttachment BuildResolvedAttachmentWithoutRequest(
+        string selectedKey,
+        string senderId,
+        string? toolName = null,
+        string? displayText = null)
     {
         var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
@@ -136,6 +144,15 @@ internal static class MattermostApprovalPromptBuilder
 
         var sb = new StringBuilder();
         sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+
+        if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
+        {
+            sb.Append("**Tool:** `").Append(toolName).AppendLine("`");
+            sb.Append("**Action:** `")
+                .Append(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))
+                .AppendLine("`");
+        }
+
         sb.Append("**Decision:** ").Append(decisionLabel);
         sb.Append(" (by @").Append(senderId).Append(')');
 

--- a/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
@@ -58,6 +58,8 @@ internal sealed class PendingApprovalRequest
         RequesterPrincipal = request.RequesterPrincipal;
         Options = request.Options;
         OptionKeys = request.Options.Select(option => option.Key.Value).ToArray();
+        ToolName = request.ToolName.Value;
+        DisplayText = request.DisplayText;
     }
 
     public PendingApprovalRequest(
@@ -65,7 +67,9 @@ internal sealed class PendingApprovalRequest
         string? requesterSenderId,
         PrincipalClassification? requesterPrincipal,
         IReadOnlyList<string> optionKeys,
-        MattermostPostId? promptPostId)
+        MattermostPostId? promptPostId,
+        string? toolName = null,
+        string? displayText = null)
     {
         Request = null;
         CallId = callId;
@@ -76,6 +80,8 @@ internal sealed class PendingApprovalRequest
             .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
             .ToArray();
         PromptPostId = promptPostId;
+        ToolName = toolName;
+        DisplayText = displayText;
     }
 
     public ToolInteractionRequest? Request { get; }
@@ -86,5 +92,18 @@ internal sealed class PendingApprovalRequest
     public PrincipalClassification? RequesterPrincipal { get; }
     public IReadOnlyList<ToolInteractionOption> Options { get; }
     public IReadOnlyList<string> OptionKeys { get; }
+
+    /// <summary>
+    /// Tool name carried through cold-spawn recovery. Null on pre-field
+    /// journal entries.
+    /// </summary>
+    public string? ToolName { get; }
+
+    /// <summary>
+    /// Display text carried through cold-spawn recovery (already truncated to
+    /// the persisted ceiling). Null on pre-field journal entries.
+    /// </summary>
+    public string? DisplayText { get; }
+
     public MattermostPostId? PromptPostId { get; set; }
 }

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -895,10 +895,13 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
         else if (message.PromptPostId is { } payloadPromptPostId)
         {
-            // Cold-spawn path with no local pending entry — either no journal record
-            // for this call, or one from before tool name + display text were
-            // persisted. The Mattermost action callback always carries the prompt's
-            // post_id; render the generic banner so buttons clear. See issue #939.
+            // Cold-spawn path with no local pending entry for this CallId (no
+            // journal record replayed, or the entry was already cleared). The
+            // Mattermost action callback always carries the prompt's post_id;
+            // render the generic banner so the buttons clear. Pre-0.21 journals
+            // that DO replay take the upper `pending is not null` branch — they
+            // render generically via the !IsNullOrEmpty fallback inside the
+            // builder, not here. See issue #939.
             await TryResolveApprovalPromptAsync(
                 payloadPromptPostId,
                 request: null,
@@ -1093,9 +1096,14 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                         OptionKeys = pendingApproval.OptionKeys,
                         PromptId = promptPostId.Value.Value,
                         ToolName = pendingApproval.ToolName,
-                        DisplayText = ApprovalDisplayTextFormatter.Truncate(
-                            pendingApproval.DisplayText,
-                            PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
+                        // Preserve null-vs-set semantics on the wire: Truncate
+                        // returns string.Empty for null input, which would round-
+                        // trip as DisplayText="" with HasDisplayText=true.
+                        DisplayText = string.IsNullOrEmpty(pendingApproval.DisplayText)
+                            ? null
+                            : ApprovalDisplayTextFormatter.Truncate(
+                                pendingApproval.DisplayText,
+                                PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
                     }, ApplyPendingApprovalPromptTracked);
                 }
                 else

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -773,7 +773,9 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             pending!.Request,
             pending!.CallId,
             selectedKey,
-            message.SenderId.Value);
+            message.SenderId.Value,
+            persistedToolName: pending.ToolName,
+            persistedDisplayText: pending.DisplayText);
         return true;
     }
 
@@ -887,15 +889,16 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 pending.Request,
                 pending.CallId,
                 message.SelectedKey,
-                message.SenderId.Value);
+                message.SenderId.Value,
+                persistedToolName: pending.ToolName,
+                persistedDisplayText: pending.DisplayText);
         }
         else if (message.PromptPostId is { } payloadPromptPostId)
         {
-            // Cold-spawn path with a payload-provided post ID: the binding has no
-            // original ToolInteractionRequest to render the full resolved attachment,
-            // but the Mattermost action callback always carries the prompt's post_id.
-            // Use it to redraw with a generic "Resolved: <decision>" banner and drop
-            // the buttons. See issue #939.
+            // Cold-spawn path with no local pending entry — either no journal record
+            // for this call, or one from before tool name + display text were
+            // persisted. The Mattermost action callback always carries the prompt's
+            // post_id; render the generic banner so buttons clear. See issue #939.
             await TryResolveApprovalPromptAsync(
                 payloadPromptPostId,
                 request: null,
@@ -927,16 +930,26 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         ToolInteractionRequest? request,
         Netclaw.Tools.ToolCallId callId,
         string selectedKey,
-        string senderId)
+        string senderId,
+        string? persistedToolName = null,
+        string? persistedDisplayText = null)
     {
         if (promptPostId is not { } postId)
             return;
 
         try
         {
+            // Hot path uses the in-memory request. Cold-spawn path uses the persisted
+            // tool name + display text when present (PendingApprovalPromptTracked
+            // carried them); legacy journals without the fields fall back to the
+            // generic banner.
             var resolvedAttachment = request is not null
                 ? MattermostApprovalPromptBuilder.BuildResolvedAttachment(request, selectedKey, senderId)
-                : MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(selectedKey, senderId);
+                : MattermostApprovalPromptBuilder.BuildResolvedAttachmentWithoutRequest(
+                    selectedKey,
+                    senderId,
+                    toolName: persistedToolName,
+                    displayText: persistedDisplayText);
 
             using var cts = new CancellationTokenSource(OperationTimeout);
             await _dependencies.ReplyClient.UpdatePostAsync(
@@ -1078,7 +1091,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                         RequesterSenderId = pendingApproval.RequesterSenderId,
                         RequesterPrincipal = pendingApproval.RequesterPrincipal,
                         OptionKeys = pendingApproval.OptionKeys,
-                        PromptId = promptPostId.Value.Value
+                        PromptId = promptPostId.Value.Value,
+                        ToolName = pendingApproval.ToolName,
+                        DisplayText = ApprovalDisplayTextFormatter.Truncate(
+                            pendingApproval.DisplayText,
+                            PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
                     }, ApplyPendingApprovalPromptTracked);
                 }
                 else
@@ -1615,7 +1632,9 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             tracked.RequesterSenderId,
             tracked.RequesterPrincipal,
             tracked.OptionKeys,
-            new MattermostPostId(tracked.PromptId)));
+            new MattermostPostId(tracked.PromptId),
+            toolName: tracked.ToolName,
+            displayText: tracked.DisplayText));
     }
 
     private void ApplyPendingApprovalPromptCleared(PendingApprovalPromptCleared cleared)

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -194,6 +194,13 @@ internal static class SlackApprovalBlockBuilder
         string? toolName = null,
         string? displayText = null)
     {
+        // Match the hot-path text variant (BuildResolvedApprovalText) formatting
+        // so the same approval renders identically pre-passivation and post-
+        // recovery: no escape on the tool/request code-fenced fields, no bold or
+        // escape on the resolution line. Block-Kit variants escape because they
+        // render inside markdown SectionBlocks; the text variant is the
+        // notification body which Slack already treats as code-fence-safe inside
+        // the backticks.
         var statusPrefix = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
             : ":white_check_mark:";
@@ -206,10 +213,10 @@ internal static class SlackApprovalBlockBuilder
         if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
         {
             lines.Add(
-                $"> `{EscapeMarkdown(toolName)}`: `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))}`");
+                $"> `{toolName}`: `{ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars)}`");
         }
 
-        lines.Add($"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*");
+        lines.Add(BuildGenericResolutionLine(selectedKey));
 
         return string.Join("\n", lines);
     }

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -181,44 +181,82 @@ internal static class SlackApprovalBlockBuilder
     /// <see cref="ToolInteractionRequest"/> is no longer available — e.g. the
     /// binding actor was passivated between posting the prompt and the user
     /// clicking a button. The button payload still carries enough state to
-    /// redraw the prompt with a decision banner; we just can't reconstruct
-    /// the verb/location detail without the original request. Better than
-    /// leaving the buttons live indefinitely. See issue #939.
+    /// redraw the prompt with a decision banner. When the persisted
+    /// <see cref="Netclaw.Actors.Channels.PendingApprovalPromptTracked"/>
+    /// carried <paramref name="toolName"/> + <paramref name="displayText"/>,
+    /// the redraw includes the original tool name and request text; otherwise
+    /// it falls back to a generic banner (pre-field journal entries). See
+    /// issue #939.
     /// </summary>
-    public static string BuildResolvedApprovalTextWithoutRequest(string selectedKey, string senderId)
+    public static string BuildResolvedApprovalTextWithoutRequest(
+        string selectedKey,
+        string senderId,
+        string? toolName = null,
+        string? displayText = null)
     {
         var statusPrefix = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
             : ":white_check_mark:";
 
-        return string.Join("\n", new[]
+        var lines = new List<string>(3)
         {
-            $"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>",
-            $"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*"
-        });
+            $"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>"
+        };
+
+        if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
+        {
+            lines.Add(
+                $"> `{EscapeMarkdown(toolName)}`: `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))}`");
+        }
+
+        lines.Add($"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*");
+
+        return string.Join("\n", lines);
     }
 
     /// <summary>
     /// Block-Kit variant of <see cref="BuildResolvedApprovalTextWithoutRequest"/>.
     /// Renders without buttons so the prompt UI clears on the cold-spawn path.
+    /// Includes the persisted tool name + request text when supplied.
     /// </summary>
-    public static IReadOnlyList<Block> BuildResolvedApprovalBlocksWithoutRequest(string selectedKey, string senderId)
+    public static IReadOnlyList<Block> BuildResolvedApprovalBlocksWithoutRequest(
+        string selectedKey,
+        string senderId,
+        string? toolName = null,
+        string? displayText = null)
     {
         var statusPrefix = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
             : ":white_check_mark:";
 
-        return
-        [
+        var blocks = new List<Block>(3)
+        {
             new SectionBlock
             {
                 Text = new Markdown($"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>")
-            },
-            new SectionBlock
+            }
+        };
+
+        if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
+        {
+            blocks.Add(new SectionBlock
+            {
+                Text = new Markdown(
+                    $"*Tool:* `{EscapeMarkdown(toolName)}`\n"
+                    + $"*Request:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))}`\n"
+                    + $"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*"),
+                Expand = true
+            });
+        }
+        else
+        {
+            blocks.Add(new SectionBlock
             {
                 Text = new Markdown($"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*")
-            }
-        ];
+            });
+        }
+
+        return blocks;
     }
 
     private static string BuildGenericResolutionLine(string selectedKey)

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1203,9 +1203,14 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                         OptionKeys = pendingApproval.OptionKeys,
                         PromptId = promptMessageTs.Value.Value,
                         ToolName = pendingApproval.ToolName,
-                        DisplayText = ApprovalDisplayTextFormatter.Truncate(
-                            pendingApproval.DisplayText,
-                            PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
+                        // Preserve null-vs-set semantics on the wire: Truncate
+                        // returns string.Empty for null input, which would round-
+                        // trip as DisplayText="" with HasDisplayText=true.
+                        DisplayText = string.IsNullOrEmpty(pendingApproval.DisplayText)
+                            ? null
+                            : ApprovalDisplayTextFormatter.Truncate(
+                                pendingApproval.DisplayText,
+                                PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
                     }, ApplyPendingApprovalPromptTracked);
                 }
                 else
@@ -1504,11 +1509,16 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
         else if (message.PromptMessageTs is { } payloadPromptTs)
         {
-            // Cold-spawn redraw — the binding has no local pending entry at all (no
-            // journal record found, or the journal preceded the tool-name/display-text
-            // fields). The click payload still carries the prompt's message TS and the
-            // session has now accepted the response; render the generic banner so
-            // buttons clear.
+            // Cold-spawn redraw — no local pending entry exists for this CallId
+            // (the journal didn't replay a PendingApprovalPromptTracked event for
+            // it, typically because the binding was re-created without recovery
+            // or the entry was cleared before the click landed). The click
+            // payload still carries the prompt's message TS and the session has
+            // accepted the response; render the generic banner so the buttons
+            // clear. NOTE: pre-0.21 journals that DO replay (with no tool name /
+            // display text) take the upper `pending is not null` branch instead
+            // — they render the generic banner via the !IsNullOrEmpty fallback
+            // inside the builder, not via this branch.
             await TryResolveApprovalPromptAsync(
                 payloadPromptTs,
                 request: null,

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1138,7 +1138,9 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             tracked.RequesterSenderId,
             tracked.RequesterPrincipal,
             tracked.OptionKeys,
-            new SlackEventTs(tracked.PromptId)));
+            new SlackEventTs(tracked.PromptId),
+            toolName: tracked.ToolName,
+            displayText: tracked.DisplayText));
     }
 
     private void ApplyPendingApprovalPromptCleared(PendingApprovalPromptCleared cleared)
@@ -1199,7 +1201,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                         RequesterSenderId = pendingApproval.RequesterSenderId,
                         RequesterPrincipal = pendingApproval.RequesterPrincipal,
                         OptionKeys = pendingApproval.OptionKeys,
-                        PromptId = promptMessageTs.Value.Value
+                        PromptId = promptMessageTs.Value.Value,
+                        ToolName = pendingApproval.ToolName,
+                        DisplayText = ApprovalDisplayTextFormatter.Truncate(
+                            pendingApproval.DisplayText,
+                            PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
                     }, ApplyPendingApprovalPromptTracked);
                 }
                 else
@@ -1341,7 +1347,9 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 pending.Request,
                 pending.CallId,
                 selectedKey,
-                message.SenderId.Value);
+                message.SenderId.Value,
+                persistedToolName: pending.ToolName,
+                persistedDisplayText: pending.DisplayText);
 
             _log.Info(
                 "Recorded Slack approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
@@ -1484,7 +1492,9 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 pending.Request,
                 pending.CallId,
                 message.SelectedKey,
-                message.SenderId.Value);
+                message.SenderId.Value,
+                persistedToolName: pending.ToolName,
+                persistedDisplayText: pending.DisplayText);
 
             _log.Info(
                 "Recorded Slack button approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
@@ -1494,9 +1504,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
         else if (message.PromptMessageTs is { } payloadPromptTs)
         {
-            // Cold-spawn redraw — the binding has no original request but the click
-            // payload carries the prompt's message TS, and the session has now
-            // accepted the response. Render a generic banner that clears the buttons.
+            // Cold-spawn redraw — the binding has no local pending entry at all (no
+            // journal record found, or the journal preceded the tool-name/display-text
+            // fields). The click payload still carries the prompt's message TS and the
+            // session has now accepted the response; render the generic banner so
+            // buttons clear.
             await TryResolveApprovalPromptAsync(
                 payloadPromptTs,
                 request: null,
@@ -1640,7 +1652,9 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         ToolInteractionRequest? request,
         ToolCallId callId,
         string selectedKey,
-        string senderId)
+        string senderId,
+        string? persistedToolName = null,
+        string? persistedDisplayText = null)
     {
         if (promptMessageTs is not { } promptTs)
             return;
@@ -1664,14 +1678,20 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             }
             else
             {
-                // Cold-spawn path: only the payload-provided message TS is known.
-                // Strip the buttons; show a generic resolution banner.
+                // Cold-spawn path: only the payload-provided message TS plus what was
+                // journaled with PendingApprovalPromptTracked. When the journal carried
+                // tool name + display text, the builder renders them; otherwise it
+                // falls back to a generic banner (pre-field journal entries).
                 text = SlackApprovalBlockBuilder.BuildResolvedApprovalTextWithoutRequest(
                     selectedKey,
-                    senderId);
+                    senderId,
+                    toolName: persistedToolName,
+                    displayText: persistedDisplayText);
                 blocks = SlackApprovalBlockBuilder.BuildResolvedApprovalBlocksWithoutRequest(
                     selectedKey,
-                    senderId);
+                    senderId,
+                    toolName: persistedToolName,
+                    displayText: persistedDisplayText);
             }
 
             using var cts = new CancellationTokenSource(OperationTimeout);
@@ -1749,6 +1769,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             RequesterPrincipal = request.RequesterPrincipal;
             Options = request.Options;
             OptionKeys = request.Options.Select(option => option.Key.Value).ToArray();
+            ToolName = request.ToolName.Value;
+            DisplayText = request.DisplayText;
         }
 
         public PendingApprovalRequest(
@@ -1756,7 +1778,9 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             string? requesterSenderId,
             PrincipalClassification? requesterPrincipal,
             IReadOnlyList<string> optionKeys,
-            SlackEventTs? promptMessageTs)
+            SlackEventTs? promptMessageTs,
+            string? toolName = null,
+            string? displayText = null)
         {
             Request = null;
             CallId = callId;
@@ -1767,6 +1791,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
                 .ToArray();
             PromptMessageTs = promptMessageTs;
+            ToolName = toolName;
+            DisplayText = displayText;
         }
 
         public ToolInteractionRequest? Request { get; }
@@ -1775,6 +1801,21 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         public PrincipalClassification? RequesterPrincipal { get; }
         public IReadOnlyList<ToolInteractionOption> Options { get; }
         public IReadOnlyList<string> OptionKeys { get; }
+
+        /// <summary>
+        /// Tool name. Populated from <see cref="ToolInteractionRequest.ToolName"/>
+        /// on the hot path and from the persisted
+        /// <see cref="PendingApprovalPromptTracked.ToolName"/> on the cold-spawn
+        /// recovery path. Null only for journal entries written before the field
+        /// was added.
+        /// </summary>
+        public string? ToolName { get; }
+
+        /// <summary>
+        /// Display text (already truncated to the persisted ceiling on the
+        /// cold-spawn path). Null only for legacy journal entries.
+        /// </summary>
+        public string? DisplayText { get; }
 
         public SlackEventTs? PromptMessageTs { get; set; }
     }


### PR DESCRIPTION
Two regressions surfaced in production after 0.21.0:

**Tool calls blocked after daemon restart.** When a restart lands mid-turn and the user clicks Approve on a parked tool prompt, the recovered session correctly runs that one tool — then silently blocks every continuation tool call with `tool_not_allowed_for_audience_profile`. Cause: the redrive path threaded the parked turn's audience to the one batch but left `_currentTurnSource` and `_currentTrustContext` null, so the next LLM iteration fell through to `TrustAudience.Public`. Fix: synthesize a `MessageSource` from the persisted `PendingToolInteraction` and rehydrate the trust context plus turn telemetry so the whole recovered turn inherits the original audience.

**Approval redraws lost detail after passivation.** If the channel binding actor passivated between posting the prompt and the click, the cold-spawn redraw added in #1187 cleared the buttons but collapsed the body to a generic "Saved for this chat" banner — no tool name, no command. Cause: `PendingApprovalPromptTracked` only carried the prompt locator, not the presentation summary. Fix: add optional `ToolName` + `DisplayText` to the persisted record (proto3 optional — pre-0.21 journals recover cleanly as nulls and fall back to the generic banner). All three adapters (Slack, Discord, Mattermost) now retain the Tool/Request detail across passivation.

The branch also contains the hardening pass from an internal review (synth fail-loud, `BindTurnTelemetry`, canonical `ResolveBoundary` helper, drop redundant override params, null-vs-empty preservation, persisted cap fix, Slack hot/cold format symmetry, test helper replaced with `FishForMessageAsync`).

## Test plan

- [x] `dotnet build` — clean
- [x] Netclaw.Actors.Tests — 2040 pass, 0 fail
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all headers present
- [x] New regression test `Cold_recovered_continuation_tool_calls_run_at_original_turn_audience` verified to fail against unpatched code, pass with the fix
- [x] New round-trip + builder + contract tests cover the persisted-summary cold-spawn path across all three adapters