### PR TITLE
chore(release): prepare v0.21.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,40 +8,14 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.21.0</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.21.0 — Venice.ai provider, security hardening, approval prompt reliability, and ARM support
-
-**Features**
-
-* **Venice.ai provider support** — full end-to-end integration for the Venice.ai chat client. Venice is now discoverable in the provider picker and callable through the daemon. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
-
-* **Venice.ai system-prompt override** — by default, Venice silently prepends their own system prompt which breaks Netclaw identity grounding. This release forces `include_venice_system_prompt = false` to keep SOUL.md / AGENTS.md as the first system message. Operators can opt in to Venice's default prefix via `VendorOptions:IncludeVeniceSystemPrompt = true`. ([#1197](https://github.com/netclaw-dev/netclaw/pull/1197))
-
-* **Mattermost container ARM support** — the Mattermost Docker container now correctly pulls and runs on ARM hosts (e.g., Apple Silicon Macs) with explicit `--platform linux/amd64` specification. ([#1182](https://github.com/netclaw-dev/netclaw/pull/1182))
-
-**Security**
-
-* **Closed tunnel loopback auth bypass (SEC-005)** — the loopback authentication handler previously auto-issued Operator tickets to anyone on loopback in tunnel modes (tailscale-serve, tailscale-funnel, cloudflare-tunnel), allowing remote attackers to bypass authentication. The handler now requires remote authentication in all tunnel modes. Additionally, session pairing codes are now rejected from loopback connections in tunnel modes to prevent the local tunnel forwarder from minting new pairing codes. ([#1185](https://github.com/netclaw-dev/netclaw/pull/1185))
+    <VersionPrefix>0.21.1</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.21.1 — Bug fixes for 0.21.0 regressions
 
 **Bug Fixes**
 
-* **Provider secrets decryption restored** — provider API keys saved to secrets.json were previously sent scrambled to LLM providers, causing 401 errors across OpenRouter, Anthropic, and OpenAI. Keys are now properly decrypted before use. ([#1195](https://github.com/netclaw-dev/netclaw/pull/1195))
+* **Cold-recovered tool calls no longer blocked** — when a restart landed mid-turn and the user clicked Approve on a parked tool prompt, the recovered session would correctly run that one tool, then silently block every continuation with `tool_not_allowed_for_audience_profile`. The redrive path now rehydrates the original audience and trust context so recovered turns inherit the correct permissions. ([#1201](https://github.com/netclaw-dev/netclaw/pull/1201))
 
-* **Approval prompts redraw after passivation** — when channel binding actors passivated between posting an approval prompt and the user clicking a button, the in-memory pending-approval state was lost and buttons stayed live indefinitely. Prompts now correctly redraw (clearing to "resolved") using the prompt message identifier from the interaction payload. ([#939](https://github.com/netclaw-dev/netclaw/pull/1187))
-
-* **Approval callbacks hardened against forgery** — Mattermost callbacks now verify the post ID against the actual prompt post, preventing token holders from redirecting the bot's edit to any post they had permissions to modify. ([#1193](https://github.com/netclaw-dev/netclaw/pull/1193))
-
-* **Oversized approval prompts truncated** — multi-KB shell commands (like `gh issue create` with embedded reports) previously blew past Slack's 3000-char, Discord's 2000-char, and Mattermost's caps, causing auto-deny fallbacks. Prompts are now truncated per-platform budget (Slack 2500, Discord 1700, Mattermost 12000) so the user can see and approve them. ([#1186](https://github.com/netclaw-dev/netclaw/pull/1186))
-
-**Improvements**
-
-* **Ollama sample pinned to 0.24.0** — the Aspire demo now pins Ollama to 0.24.0 (was 0.13.0) to support qwen3.5 models, which require a newer manifest format. ([#1194](https://github.com/netclaw-dev/netclaw/pull/1194))
-
-* **Unified provider config loading** — the daemon's capability-resolver startup probe now uses the same `ProviderConfigurationLoader` as the main config path, removing an asymmetry that hid the #1195 regression. ([#1196](https://github.com/netclaw-dev/netclaw/pull/1196))
-
-**Documentation**
-
-* **Local binary swap skill updated** — the local-binary-swap skill now explicitly requires a daemon re-launch after the binary swap to prevent leaving the install in a broken state. ([#1192](https://github.com/netclaw-dev/netclaw/pull/1192))</PackageReleaseNotes>
+* **Approval prompt redraws now retain tool detail** — if the channel binding actor passivated between posting a prompt and the user clicking, the redraw previously showed only a generic "Saved for this chat" banner. All three adapters (Slack, Discord, Mattermost) now correctly show the tool name and request detail across passivation. ([#1201](https://github.com/netclaw-dev/netclaw/pull/1201))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 0.21.1 2026-05-27 ####
+
+Netclaw v0.21.1 — Bug fixes for 0.21.0 regressions
+
+**Bug Fixes**
+
+* **Cold-recovered tool calls no longer blocked** — when a restart landed mid-turn and the user clicked Approve on a parked tool prompt, the recovered session would correctly run that one tool, then silently block every continuation with `tool_not_allowed_for_audience_profile`. The redrive path now rehydrates the original audience and trust context so recovered turns inherit the correct permissions. ([#1201](https://github.com/netclaw-dev/netclaw/pull/1201))
+
+* **Approval prompt redraws now retain tool detail** — if the channel binding actor passivated between posting a prompt and the user clicking, the redraw previously showed only a generic "Saved for this chat" banner. All three adapters (Slack, Discord, Mattermost) now correctly show the tool name and request detail across passivation. ([#1201](https://github.com/netclaw-dev/netclaw/pull/1201))
+
 #### 0.21.0 2026-05-27 ####
 
 Netclaw v0.21.0 — Venice.ai provider, security hardening, approval prompt reliability, and ARM support


### PR DESCRIPTION
## Summary

This PR prepares v0.21.1, a patch release fixing two regressions introduced in v0.21.0.

### Changes

- Updated version to 0.21.1 in `Directory.Build.props`
- Updated `RELEASE_NOTES.md` with release notes
- Updated `PackageReleaseNotes` in `Directory.Build.props`

### Bug Fixes

- **Cold-recovered tool calls no longer blocked** — when a restart landed mid-turn and the user clicked Approve on a parked tool prompt, the recovered session would correctly run that one tool, then silently block every continuation with `tool_not_allowed_for_audience_profile`. The redrive path now rehydrates the original audience and trust context so recovered turns inherit the correct permissions. ([#1201](https://github.com/netclaw-dev/netclaw/pull/1201))

- **Approval prompt redraws now retain tool detail** — if the channel binding actor passivated between posting a prompt and the user clicking, the redraw previously showed only a generic "Saved for this chat" banner. All three adapters (Slack, Discord, Mattermost) now correctly show the tool name and request detail across passivation. ([#1201](https://github.com/netclaw-dev/netclaw/pull/1201))

### Build Verification

- `dotnet build` — clean (0 warnings, 0 errors)
- All commits tested and verified against upstream/dev
