### PR TITLE
fix(subagents): pause inactivity watchdog while awaiting human approval

### DIFF
--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -762,6 +762,8 @@ public sealed class SerializationRoundTripTests : TestKit
             SupportsInteractiveApproval = true,
             RequesterSenderId = new SenderId("U12345"),
             RequesterPrincipal = Netclaw.Configuration.PrincipalClassification.Operator,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["U12345", "U-observer"],
             Cwd = "/home/user/project",
             OptionKeys = [ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveEverywhere, ApprovalOptionKeys.Deny],
             Candidates =
@@ -785,6 +787,8 @@ public sealed class SerializationRoundTripTests : TestKit
         Assert.Equal(wrapped.SupportsInteractiveApproval, result.SupportsInteractiveApproval);
         Assert.Equal(wrapped.RequesterSenderId, result.RequesterSenderId);
         Assert.Equal(wrapped.RequesterPrincipal, result.RequesterPrincipal);
+        Assert.Equal(wrapped.HasThirdPartyAdoptedContext, result.HasThirdPartyAdoptedContext);
+        Assert.Equal(wrapped.AdoptedSpeakerIds, result.AdoptedSpeakerIds);
         Assert.Equal(wrapped.Cwd, result.Cwd);
         Assert.Equal(wrapped.OptionKeys, result.OptionKeys);
         Assert.Equal(2, result.Candidates.Count);

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -888,6 +888,94 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
     }
 
     [Fact]
+    public async Task Cold_recovered_continuation_approval_preserves_third_party_adopted_context()
+    {
+        const string parkedCallId = "call-shell-adopted-parked";
+        const string continuationCallId = "call-shell-adopted-continuation";
+        _toolExecutor.GatedTools.Add("shell_execute");
+
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(parkedCallId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git status" })
+        ];
+        _fakeChatClient.PlannedResponses.Enqueue(new AIContent[]
+        {
+            new FunctionCallContent(continuationCallId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git diff" })
+        });
+
+        var sessionId = new SessionId("test-channel/redrive-adopted-context");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("redrive-adopted-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run git status then git diff",
+            Source = RequesterSourceWithThirdPartyAdoptedContext("U-requester", "U-observer")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var liveRequest = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(liveRequest.HasThirdPartyAdoptedContext);
+        Assert.Equal(["U-observer"], liveRequest.AdoptedSpeakerIds);
+
+        await ColdRespawnAsync(sessionId);
+
+        var subscriberB = CreateTestProbe("redrive-adopted-sub-b");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriberB)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        sessionManager.Tell(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(parkedCallId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.ApproveOnce),
+            SenderId = new SenderId("U-requester")
+        }, ActorRefs.Nobody);
+
+        await subscriberB.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var recoveredContinuationRequest = await subscriberB.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(continuationCallId, recoveredContinuationRequest.CallId.Value);
+        Assert.True(recoveredContinuationRequest.HasThirdPartyAdoptedContext);
+        Assert.Equal(["U-observer"], recoveredContinuationRequest.AdoptedSpeakerIds);
+
+        sessionManager.Tell(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(continuationCallId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.Deny),
+            SenderId = new SenderId("U-requester")
+        }, ActorRefs.Nobody);
+
+        await subscriberB.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task Cold_recovered_denied_approval_returns_denial_result_without_reprompting()
     {
         const string callId = "call-shell-denied";
@@ -1170,6 +1258,13 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
             TransportAuthenticity.Verified, PayloadTaint.Public),
         ReceivedAt = FixedReceivedAt,
     };
+
+    private MessageSource RequesterSourceWithThirdPartyAdoptedContext(string senderId, params string[] adoptedSpeakerIds)
+        => RequesterSource(senderId) with
+        {
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = adoptedSpeakerIds
+        };
 }
 
 /// <summary>

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -489,6 +489,204 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public async Task SubAgent_does_not_timeout_while_awaiting_human_approval()
+    {
+        // Regression: the sub-agent's inactivity watchdog must not abort a
+        // legitimate approval wait. A slow human approver (here, ~1s for a
+        // budget of 250ms) should still see the approval delivered and the
+        // sub-agent complete successfully.
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-slow-approval", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+
+        var releaseSignal = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var approvalBridge = new DelayingParentApprovalBridge(releaseSignal.Task);
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var runTask = agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin",
+                // 250ms inactivity budget — much smaller than the human delay
+                // below. Before this fix, this would always abort.
+                Timeout = TimeSpan.FromMilliseconds(250),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge
+            },
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        // Hold approval well past the inactivity budget, then approve.
+        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
+
+        var result = await runTask;
+        Assert.True(result.Success, $"Expected success but got: {result.Output}");
+        Assert.Equal(1, approvalBridge.RequestCount);
+    }
+
+    [Fact]
+    public async Task SubAgent_cancels_promptly_on_external_cancellation_during_approval_wait()
+    {
+        // External cancellation (parent passivation, daemon restart, user
+        // cancel) MUST still abort an in-flight approval wait — the watchdog
+        // pause does not turn the wait uncancellable.
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-cancel", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+
+        // Bridge holds forever — only external cancellation can unblock the
+        // sub-agent.
+        var neverReleased = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var approvalBridge = new DelayingParentApprovalBridge(neverReleased.Task);
+
+        using var externalCts = new CancellationTokenSource();
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var runTask = agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin",
+                Timeout = TimeSpan.FromSeconds(10),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge,
+                Cancellation = externalCts.Token
+            },
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        // Give the sub-agent a moment to enter the approval wait, then cancel.
+        await Task.Delay(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
+        externalCts.Cancel();
+
+        var result = await runTask;
+        Assert.False(result.Success);
+        Assert.Contains("cancelled", result.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SubAgent_completes_normally_after_long_approval_wait()
+    {
+        // After the approval clears, the post-approval retry must execute and
+        // the watchdog must resume — i.e. the counter must decrement back to
+        // zero so a subsequent stall would still be caught.
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-long-wait", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+
+        var releaseSignal = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var approvalBridge = new DelayingParentApprovalBridge(releaseSignal.Task);
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var runTask = agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin",
+                Timeout = TimeSpan.FromMilliseconds(300),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge
+            },
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        // Hold approval ~3x the budget, then approve. After release the
+        // sub-agent must run the tool retry, get a result, and complete.
+        await Task.Delay(TimeSpan.FromMilliseconds(900), TestContext.Current.CancellationToken);
+        releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
+
+        var result = await runTask;
+        Assert.True(result.Success, $"Expected success but got: {result.Output}");
+        Assert.True(fakeTool.WasCalled, "Tool retry after approval did not run");
+    }
+
+    [Fact]
+    public async Task SubAgent_parallel_tool_calls_each_awaiting_approval()
+    {
+        // Two parallel approvals in one assistant batch. The counter must hit
+        // 2 then decrement back to 0; the watchdog must not fire for the
+        // duration of either wait.
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-par-1", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" }),
+                new FunctionCallContent("call-par-2", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+
+        // Auto-approves but with a small per-call delay so the two waits
+        // overlap in time. The previous fix would fail this case if a single
+        // wait could exhaust the budget before the second completed.
+        var approvalBridge = new DelayingParentApprovalBridge(
+            decisionFactory: () => Task.Delay(TimeSpan.FromMilliseconds(400)).ContinueWith(_ => ParentApprovalDecision.ApprovedOnce));
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin twice",
+                // 200ms budget — strictly shorter than each approval delay,
+                // so a non-paused watchdog would abort.
+                Timeout = TimeSpan.FromMilliseconds(200),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge
+            },
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success, $"Expected success but got: {result.Output}");
+        Assert.Equal(2, approvalBridge.RequestCount);
+    }
+
+    private static ToolAccessPolicy CreateApprovalRequiredPolicy()
+    {
+        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Approval
+            }
+        };
+        return new ToolAccessPolicy(
+            toolConfig,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy());
+    }
+
+    [Fact]
     public async Task Max_iterations_forces_text_response()
     {
         var fakeTool = new FakeNetclawTool("looper", "loop result");
@@ -838,6 +1036,63 @@ internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker
         SessionId = context?.SessionId;
         Audience = context?.Audience;
         return Task.FromResult(result);
+    }
+}
+
+/// <summary>
+/// Test bridge that holds the approval decision until an external signal
+/// completes. Constructor accepts either a single shared <see cref="Task"/> (all
+/// calls await the same task) or a factory that returns a fresh task per call
+/// (for parallel-approval tests where each call needs an independent wait).
+/// </summary>
+internal sealed class DelayingParentApprovalBridge : IParentApprovalBridge
+{
+    private readonly Task<ParentApprovalDecision>? _sharedTask;
+    private readonly Func<Task<ParentApprovalDecision>>? _decisionFactory;
+    private int _requestCount;
+
+    public DelayingParentApprovalBridge(Task<ParentApprovalDecision> sharedTask)
+    {
+        _sharedTask = sharedTask;
+    }
+
+    public DelayingParentApprovalBridge(Func<Task<ParentApprovalDecision>> decisionFactory)
+    {
+        _decisionFactory = decisionFactory;
+    }
+
+    public int RequestCount => Volatile.Read(ref _requestCount);
+
+    public Task<ParentApprovalDecision> RequestApprovalAsync(
+        ToolCallId callId,
+        string toolName,
+        string displayText,
+        IReadOnlyList<string> patterns,
+        IReadOnlyList<string> candidateVerbs,
+        IReadOnlyList<ParentApprovalCandidate> candidates,
+        string? cwd,
+        IReadOnlyList<ParentApprovalOption> options,
+        bool isMessy,
+        CancellationToken ct)
+    {
+        Interlocked.Increment(ref _requestCount);
+        var pending = _sharedTask ?? _decisionFactory!();
+        return AwaitWithCancellation(pending, ct);
+    }
+
+    private static async Task<ParentApprovalDecision> AwaitWithCancellation(
+        Task<ParentApprovalDecision> pending,
+        CancellationToken ct)
+    {
+        if (!ct.CanBeCanceled)
+            return await pending.ConfigureAwait(false);
+
+        var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var reg = ct.Register(() => cancelTcs.TrySetResult(true));
+        var completed = await Task.WhenAny(pending, cancelTcs.Task).ConfigureAwait(false);
+        if (completed == cancelTcs.Task)
+            throw new OperationCanceledException(ct);
+        return await pending.ConfigureAwait(false);
     }
 }
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -489,6 +489,67 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public async Task Waiting_for_parent_approval_does_not_trip_inactivity_timeout()
+    {
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = new ToolAccessPolicy(
+            toolConfig,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy());
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-blocked-approval", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+        var approvalBridge = new BlockingParentApprovalBridge();
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy, approvalService: null));
+        var replyProbe = CreateTestProbe("approval-wait-probe");
+
+        agent.Tell(new RunSubAgent
+        {
+            Task = "Run the shell tool after approval",
+            Timeout = TimeSpan.FromMilliseconds(200),
+            ApprovalBridge = approvalBridge,
+            Audience = TrustAudience.Personal,
+        }, replyProbe.Ref);
+
+        await approvalBridge.RequestStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        await replyProbe.ExpectNoMsgAsync(
+            TimeSpan.FromMilliseconds(500),
+            TestContext.Current.CancellationToken);
+
+        approvalBridge.Complete(ParentApprovalDecision.ApprovedOnce);
+
+        var result = await replyProbe.ExpectMsgAsync<SubAgentResult>(
+            TimeSpan.FromSeconds(5),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, approvalBridge.RequestCount);
+        Assert.True(fakeTool.WasCalled);
+        Assert.Contains("Response #2", result.Output);
+    }
+
+    [Fact]
     public async Task Max_iterations_forces_text_response()
     {
         var fakeTool = new FakeNetclawTool("looper", "loop result");
@@ -868,6 +929,37 @@ internal sealed class RecordingParentApprovalBridge(ParentApprovalDecision decis
         RequestedOptions = options;
         return Task.FromResult(decisionToReturn);
     }
+}
+
+internal sealed class BlockingParentApprovalBridge : IParentApprovalBridge
+{
+    private readonly TaskCompletionSource<ParentApprovalDecision> _decision =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public int RequestCount { get; private set; }
+
+    public TaskCompletionSource<object?> RequestStarted { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public async Task<ParentApprovalDecision> RequestApprovalAsync(
+        ToolCallId callId,
+        string toolName,
+        string displayText,
+        IReadOnlyList<string> patterns,
+        IReadOnlyList<string> candidateVerbs,
+        IReadOnlyList<ParentApprovalCandidate> candidates,
+        string? cwd,
+        IReadOnlyList<ParentApprovalOption> options,
+        bool isMessy,
+        CancellationToken ct)
+    {
+        RequestCount++;
+        RequestStarted.TrySetResult(null);
+        return await _decision.Task.WaitAsync(ct);
+    }
+
+    public void Complete(ParentApprovalDecision decision)
+        => _decision.TrySetResult(decision);
 }
 
 internal sealed class SequencedToolCallChatClient(IReadOnlyList<FunctionCallContent> toolCalls) : IChatClient

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -524,7 +524,13 @@ public class SubAgentActorTests : TestKit
             },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
-        // Hold approval well past the inactivity budget, then approve.
+        // Deterministic sync: wait until the sub-agent has actually entered
+        // the approval wait, then hold the wait well past the 250ms budget
+        // (4x) to prove the watchdog stays suppressed. Task.Delay is required
+        // here because the property under test IS that real time elapses
+        // without the watchdog firing — there is no observable condition to
+        // poll on.
+        await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
         await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
 
@@ -570,13 +576,20 @@ public class SubAgentActorTests : TestKit
             },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
-        // Give the sub-agent a moment to enter the approval wait, then cancel.
-        await Task.Delay(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
+        // Deterministic: wait until the sub-agent is actually inside the
+        // approval wait before cancelling. Without this signal the cancel can
+        // race the bridge call entry and the test asserts on a window that
+        // doesn't yet exist.
+        await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
         externalCts.Cancel();
 
         var result = await runTask;
         Assert.False(result.Success);
-        Assert.Contains("cancelled", result.Output, StringComparison.OrdinalIgnoreCase);
+        // Match the canonical 'cancel' prefix rather than a specific spelling —
+        // 'cancelled' (UK, from "Subagent cancelled by parent") vs 'canceled'
+        // (US, from OperationCanceledException.Message) both flow through
+        // depending on which mailbox path wins.
+        Assert.Contains("cancel", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -612,8 +625,10 @@ public class SubAgentActorTests : TestKit
             },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
-        // Hold approval ~3x the budget, then approve. After release the
-        // sub-agent must run the tool retry, get a result, and complete.
+        // Wait for entry, then hold ~3x the budget (real time required —
+        // verifying the watchdog stays suppressed for that span — there is
+        // no observable to poll on).
+        await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
         await Task.Delay(TimeSpan.FromMilliseconds(900), TestContext.Current.CancellationToken);
         releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
 
@@ -1041,19 +1056,21 @@ internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker
 
 /// <summary>
 /// Test bridge that holds the approval decision until an external signal
-/// completes. Constructor accepts either a single shared <see cref="Task"/> (all
-/// calls await the same task) or a factory that returns a fresh task per call
-/// (for parallel-approval tests where each call needs an independent wait).
+/// completes. The factory variant returns a fresh task per call (for
+/// parallel-approval tests where each call needs an independent wait).
+/// <see cref="EnteredApprovalWait"/> signals every time the sub-agent reaches
+/// the awaited bridge call, so tests can replace `await Task.Delay(...)` race
+/// windows with a deterministic synchronization point.
 /// </summary>
 internal sealed class DelayingParentApprovalBridge : IParentApprovalBridge
 {
-    private readonly Task<ParentApprovalDecision>? _sharedTask;
-    private readonly Func<Task<ParentApprovalDecision>>? _decisionFactory;
+    private readonly Func<Task<ParentApprovalDecision>> _decisionFactory;
+    private readonly TaskCompletionSource<bool> _enteredSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _requestCount;
 
     public DelayingParentApprovalBridge(Task<ParentApprovalDecision> sharedTask)
+        : this(() => sharedTask)
     {
-        _sharedTask = sharedTask;
     }
 
     public DelayingParentApprovalBridge(Func<Task<ParentApprovalDecision>> decisionFactory)
@@ -1062,6 +1079,14 @@ internal sealed class DelayingParentApprovalBridge : IParentApprovalBridge
     }
 
     public int RequestCount => Volatile.Read(ref _requestCount);
+
+    /// <summary>
+    /// Completes the first time <see cref="RequestApprovalAsync"/> is entered.
+    /// Tests should `await EnteredApprovalWait` before cancelling or releasing
+    /// the approval, so the synchronization window is deterministic rather
+    /// than a real-time sleep.
+    /// </summary>
+    public Task EnteredApprovalWait => _enteredSignal.Task;
 
     public Task<ParentApprovalDecision> RequestApprovalAsync(
         ToolCallId callId,
@@ -1076,23 +1101,11 @@ internal sealed class DelayingParentApprovalBridge : IParentApprovalBridge
         CancellationToken ct)
     {
         Interlocked.Increment(ref _requestCount);
-        var pending = _sharedTask ?? _decisionFactory!();
-        return AwaitWithCancellation(pending, ct);
-    }
-
-    private static async Task<ParentApprovalDecision> AwaitWithCancellation(
-        Task<ParentApprovalDecision> pending,
-        CancellationToken ct)
-    {
-        if (!ct.CanBeCanceled)
-            return await pending.ConfigureAwait(false);
-
-        var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var reg = ct.Register(() => cancelTcs.TrySetResult(true));
-        var completed = await Task.WhenAny(pending, cancelTcs.Task).ConfigureAwait(false);
-        if (completed == cancelTcs.Task)
-            throw new OperationCanceledException(ct);
-        return await pending.ConfigureAwait(false);
+        _enteredSignal.TrySetResult(true);
+        // Task.WaitAsync(CancellationToken) throws OperationCanceledException on
+        // cancel and observes faults on the underlying task — replaces a
+        // hand-rolled WhenAny+Register+TCS dance.
+        return _decisionFactory().WaitAsync(ct);
     }
 }
 

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -105,6 +105,10 @@ public sealed record ToolApprovalRequested : INetclawSerializableMessage
 
     public PrincipalClassification? RequesterPrincipal { get; init; }
 
+    public bool HasThirdPartyAdoptedContext { get; init; }
+
+    public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = Array.Empty<string>();
+
     public string? Cwd { get; init; }
 
     public IReadOnlyList<string> OptionKeys { get; init; } = Array.Empty<string>();

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -275,6 +275,8 @@ internal static class NetclawProtoMapper
             proto.SupportsInteractiveApproval = evt.SupportsInteractiveApproval.Value;
         proto.OptionKeys.AddRange(evt.OptionKeys);
         proto.Candidates.AddRange(evt.Candidates.Select(ToApprovalCandidateProto));
+        proto.HasThirdPartyAdoptedContext = evt.HasThirdPartyAdoptedContext;
+        proto.AdoptedSpeakerIds.AddRange(evt.AdoptedSpeakerIds);
         return proto;
     }
 
@@ -294,6 +296,8 @@ internal static class NetclawProtoMapper
         Boundary = proto.HasBoundary ? new Configuration.TrustBoundary(proto.Boundary) : null,
         ChannelType = proto.HasChannelType ? proto.ChannelType : null,
         SupportsInteractiveApproval = proto.HasSupportsInteractiveApproval ? proto.SupportsInteractiveApproval : null,
+        HasThirdPartyAdoptedContext = proto.HasThirdPartyAdoptedContext,
+        AdoptedSpeakerIds = proto.AdoptedSpeakerIds.ToArray(),
         OptionKeys = proto.OptionKeys.ToArray(),
         Candidates = proto.Candidates.Select(FromApprovalCandidateProto).ToArray(),
         RequestedAtMs = proto.RequestedAtMs

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -146,6 +146,8 @@ message ToolApprovalRequestedProto {
   optional bool supports_interactive_approval = 13;
   int64 requested_at_ms = 14;
   repeated string option_keys = 15;
+  bool has_third_party_adopted_context = 16;
+  repeated string adopted_speaker_ids = 17;
 }
 
 message ToolApprovalResolvedProto {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -543,6 +543,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SupportsInteractiveApproval = _currentTurnSource?.ChannelType.SupportsInteractiveApproval(),
                 RequesterSenderId = msg.RequesterSenderId,
                 RequesterPrincipal = msg.RequesterPrincipal,
+                HasThirdPartyAdoptedContext = msg.HasThirdPartyAdoptedContext,
+                AdoptedSpeakerIds = msg.AdoptedSpeakerIds,
                 Cwd = msg.Cwd,
                 OptionKeys = msg.Options.Select(o => o.Key.Value).ToArray(),
                 Candidates = msg.Candidates
@@ -3160,6 +3162,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             evt.SupportsInteractiveApproval,
             evt.RequesterSenderId?.Value,
             evt.RequesterPrincipal,
+            evt.HasThirdPartyAdoptedContext,
+            evt.AdoptedSpeakerIds,
             evt.Cwd,
             evt.RequestedAtMs,
             evt.OptionKeys,
@@ -3831,11 +3835,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// <see cref="PendingToolInteraction"/>'s persisted trust fields. Used only
     /// during cold-recovery re-drive to rehydrate <see cref="_currentTurnSource"/>
     /// so subsequent tool dispatches in the recovered turn read the correct
-    /// audience/boundary/channel-type. The runtime-only fields on
-    /// <see cref="MessageSource"/> (AckTarget, ReminderId, BackgroundJobId,
-    /// adopted-context window, MessageId, TurnId) are left at their defaults —
-    /// they belong to the original live transport invocation and cannot be
-    /// reconstructed from journal state. Returns null when the pending record
+     /// audience/boundary/channel-type. The stable adopted-context provenance
+     /// needed by downstream safety checks also survives here, but the runtime-only
+     /// fields on
+     /// <see cref="MessageSource"/> (AckTarget, ReminderId, BackgroundJobId,
+     /// adopted-context window/projection entries, MessageId, TurnId) are left at their defaults —
+     /// they belong to the original live transport invocation and cannot be
+     /// reconstructed from journal state. Returns null when the pending record
     /// lacks enough state to construct a usable source (no channel type, no
     /// requester sender id); the caller surfaces a warning per the
     /// no-silent-fallbacks rule.
@@ -3859,6 +3865,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             Boundary = SecurityPolicyDefaults.ResolveBoundary(
                 pending.Boundary, pending.ChannelType, pending.Audience),
             Principal = pending.RequesterPrincipal ?? PrincipalClassification.UntrustedExternal,
+            HasThirdPartyAdoptedContext = pending.HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = pending.AdoptedSpeakerIds,
             // The original transport was authenticated when the prompt was first
             // posted (the binding actor only journals PendingToolInteraction after
             // a successful inbound), so Verified is honest. PayloadTaint, however,

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3835,13 +3835,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// <see cref="PendingToolInteraction"/>'s persisted trust fields. Used only
     /// during cold-recovery re-drive to rehydrate <see cref="_currentTurnSource"/>
     /// so subsequent tool dispatches in the recovered turn read the correct
-     /// audience/boundary/channel-type. The stable adopted-context provenance
-     /// needed by downstream safety checks also survives here, but the runtime-only
-     /// fields on
-     /// <see cref="MessageSource"/> (AckTarget, ReminderId, BackgroundJobId,
-     /// adopted-context window/projection entries, MessageId, TurnId) are left at their defaults —
-     /// they belong to the original live transport invocation and cannot be
-     /// reconstructed from journal state. Returns null when the pending record
+    /// audience/boundary/channel-type. The stable adopted-context provenance
+    /// needed by downstream safety checks also survives here, but the runtime-only
+    /// fields on <see cref="MessageSource"/> (AckTarget, ReminderId,
+    /// BackgroundJobId, adopted-context window/projection entries, MessageId,
+    /// TurnId) are left at their defaults — they belong to the original live
+    /// transport invocation and cannot be reconstructed from journal state.
+    /// Returns null when the pending record
     /// lacks enough state to construct a usable source (no channel type, no
     /// requester sender id); the caller surfaces a warning per the
     /// no-silent-fallbacks rule.

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -23,6 +23,8 @@ internal sealed record PendingToolInteraction(
     bool? SupportsInteractiveApproval,
     string? RequesterSenderId,
     PrincipalClassification? RequesterPrincipal,
+    bool HasThirdPartyAdoptedContext,
+    IReadOnlyList<string> AdoptedSpeakerIds,
     string? Cwd,
     long RequestedAtMs,
     // Option keys that were actually offered to the user when the prompt was

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -53,7 +53,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private IParentApprovalBridge? _approvalBridge;
     private ChannelWriter<ToolActivityUpdate>? _activitySink;
     private TimeSpan _inactivityBudget;
-    private bool _awaitingPotentialApproval;
+    private ToolExecutionWatchdogState _toolExecutionWatchdogState = ToolExecutionWatchdogState.None;
     private int _pendingApprovalWaits;
 
     public ITimerScheduler Timers { get; set; } = null!;
@@ -197,7 +197,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<ToolExecutionCompleted>(msg =>
         {
-            _awaitingPotentialApproval = false;
+            _toolExecutionWatchdogState = ToolExecutionWatchdogState.None;
             RecordProgress("processing tool results");
 
             // Append tool results as MEAI messages and log each result
@@ -228,7 +228,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<ToolExecutionFailed>(msg =>
         {
-            _awaitingPotentialApproval = false;
+            _toolExecutionWatchdogState = ToolExecutionWatchdogState.None;
             _log.Error(msg.Cause, "SubAgent [{AgentName}] tool execution failed", _definition.Name);
             Complete(false, $"Tool execution failed: {msg.Cause.Message}");
         });
@@ -248,7 +248,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<SubAgentTimeout>(_ =>
         {
-            if (_pendingApprovalWaits > 0)
+            if (_toolExecutionWatchdogState == ToolExecutionWatchdogState.WaitingForParentApproval)
             {
                 _log.Debug(
                     "SubAgent [{AgentName}] watchdog tick suppressed while waiting on parent approval ({WaitCount} pending)",
@@ -258,12 +258,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 return;
             }
 
-            if (_awaitingPotentialApproval)
+            if (_toolExecutionWatchdogState == ToolExecutionWatchdogState.RunningApprovalCapableTools)
             {
                 _log.Debug(
                     "SubAgent [{AgentName}] watchdog tick granted one-cycle grace while tool execution resolves whether parent approval is needed",
                     _definition.Name);
-                _awaitingPotentialApproval = false;
+                _toolExecutionWatchdogState = ToolExecutionWatchdogState.None;
                 ArmInactivityTimer();
                 return;
             }
@@ -277,17 +277,19 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<SubAgentApprovalWaitStarted>(_ =>
         {
-            _awaitingPotentialApproval = false;
+            _toolExecutionWatchdogState = ToolExecutionWatchdogState.WaitingForParentApproval;
             _pendingApprovalWaits++;
         });
 
         Receive<SubAgentApprovalWaitCompleted>(_ =>
         {
-            _awaitingPotentialApproval = false;
             if (_pendingApprovalWaits == 0)
                 return;
 
             _pendingApprovalWaits--;
+            _toolExecutionWatchdogState = _pendingApprovalWaits == 0
+                ? ToolExecutionWatchdogState.RunningApprovalCapableTools
+                : ToolExecutionWatchdogState.WaitingForParentApproval;
             RecordProgress("approval resolved");
         });
 
@@ -308,7 +310,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         var self = Self;
         var executor = new DispatchingToolExecutor(_toolRegistry, _toolAccessPolicy, _approvalService);
-        _awaitingPotentialApproval = _approvalBridge is not null;
+        _toolExecutionWatchdogState = _approvalBridge is null
+            ? ToolExecutionWatchdogState.None
+            : ToolExecutionWatchdogState.RunningApprovalCapableTools;
 
         _ = ExecuteToolsAsync(
             executor,
@@ -341,7 +345,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     private void Complete(bool success, string output)
     {
-        _awaitingPotentialApproval = false;
+        _toolExecutionWatchdogState = ToolExecutionWatchdogState.None;
         _pendingApprovalWaits = 0;
         _executionCts?.Cancel();
         Timers.Cancel(TimeoutTimerKey);
@@ -649,6 +653,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     {
         public static readonly SubAgentCancelled Instance = new();
         private SubAgentCancelled() { }
+    }
+
+    private enum ToolExecutionWatchdogState
+    {
+        None,
+        RunningApprovalCapableTools,
+        WaitingForParentApproval
     }
 
     private sealed class SubAgentApprovalWaitStarted

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -50,6 +50,18 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private int _toolIterationCount;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
+
+    // Cancelled only by explicit external triggers (parent-passed cancellation
+    // or SubAgentCancelled), never by the internal inactivity watchdog. Threaded
+    // into approval-bridge waits so a slow human approver does not let the
+    // watchdog cancel a legitimate await on user input.
+    private CancellationTokenSource? _externalCts;
+
+    // Mailbox-thread only. Incremented when ExecuteToolsAsync enters an approval
+    // wait, decremented when it exits. While > 0, SubAgentTimeout re-arms
+    // instead of cancelling: waiting for human approval is legitimate work.
+    private int _pendingApprovalWaits;
+
     private IParentApprovalBridge? _approvalBridge;
     private ChannelWriter<ToolActivityUpdate>? _activitySink;
     private TimeSpan _inactivityBudget;
@@ -98,6 +110,23 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         return Props.Create(() => new SubAgentActor(definition, chatClient, toolAccessPolicy, approvalService));
     }
 
+    /// <summary>
+    /// Final cleanup if the actor is stopped externally (parent supervision,
+    /// <c>PoisonPill</c>) without going through <see cref="Complete"/>. Cancels
+    /// and disposes both CTSes so any in-flight approval wait running on the
+    /// thread pool unblocks promptly. <see cref="Complete"/> already nulls the
+    /// CTSes, so the null-conditional access is intentional.
+    /// </summary>
+    protected override void PostStop()
+    {
+        _executionCts?.Cancel();
+        _externalCts?.Cancel();
+        _executionCts?.Dispose();
+        _externalCts?.Dispose();
+        _externalCancellationRegistration.Dispose();
+        base.PostStop();
+    }
+
     private void Idle()
     {
         Receive<RunSubAgent>(msg =>
@@ -137,6 +166,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _toolExecutionContext.ProjectDirectory = msg.ParentProjectDirectory;
             _toolExecutionContext.SupportsInteractiveApproval = _approvalBridge is not null;
             _executionCts = new CancellationTokenSource();
+            _externalCts = new CancellationTokenSource();
             var self = Self; // Capture before callback — Self requires active actor context
             _externalCancellationRegistration = msg.Cancellation.Register(() => self.Tell(SubAgentCancelled.Instance));
 
@@ -238,17 +268,45 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         Receive<SubAgentCancelled>(_ =>
         {
             _executionCts?.Cancel();
+            _externalCts?.Cancel();
             _log.Warning("SubAgent [{AgentName}] cancelled by parent", _definition.Name);
             Complete(false, "Subagent cancelled by parent");
         });
 
         Receive<SubAgentTimeout>(_ =>
         {
+            // While the sub-agent is blocked on a human approval, "no activity"
+            // is the expected state — re-arm the watchdog so it can still
+            // govern *post-approval* inactivity (e.g. the LLM call after the
+            // tool retry stalls), but never let it cancel the approval wait
+            // itself. The approval await is on _externalCts so even an
+            // accidental _executionCts cancel here would not abort it.
+            if (_pendingApprovalWaits > 0)
+            {
+                ArmInactivityTimer();
+                return;
+            }
+
             _executionCts?.Cancel();
             _log.Warning(
                 "SubAgent [{AgentName}] timed out: no activity for {Budget}s after {Iterations} tool iterations",
                 _definition.Name, _inactivityBudget.TotalSeconds, _toolIterationCount);
             Complete(false, $"Subagent timed out: no activity for {_inactivityBudget.TotalSeconds:F0}s.");
+        });
+
+        Receive<ApprovalWaitStarted>(_ =>
+        {
+            _pendingApprovalWaits++;
+            EmitActivity("awaiting human approval");
+        });
+
+        Receive<ApprovalWaitCompleted>(_ =>
+        {
+            _pendingApprovalWaits = Math.Max(0, _pendingApprovalWaits - 1);
+            // Re-baseline the watchdog so it does not fire immediately on the
+            // post-approval retry just because no progress event landed during
+            // the human wait.
+            ArmInactivityTimer();
         });
 
         // Throttled liveness ping from a streaming LLM call — progress, even
@@ -274,6 +332,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             toolCalls,
             _toolExecutionContext,
             _executionCts?.Token ?? CancellationToken.None,
+            _externalCts?.Token ?? CancellationToken.None,
             self,
             _approvalBridge);
     }
@@ -301,10 +360,14 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private void Complete(bool success, string output)
     {
         _executionCts?.Cancel();
+        _externalCts?.Cancel();
         Timers.Cancel(TimeoutTimerKey);
         _externalCancellationRegistration.Dispose();
         _executionCts?.Dispose();
+        _externalCts?.Dispose();
         _executionCts = null;
+        _externalCts = null;
+        _pendingApprovalWaits = 0;
 
         _log.Info("SubAgent [{AgentName}] completed (success={Success}, output={OutputLength} chars, iterations={Iterations})",
             _definition.Name, success, output.Length, _toolIterationCount);
@@ -463,6 +526,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         List<FunctionCallContent> toolCalls,
         ToolExecutionContext executionContext,
         CancellationToken ct,
+        CancellationToken externalCt,
         IActorRef self,
         IParentApprovalBridge? approvalBridge = null)
     {
@@ -492,17 +556,32 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     var bridgeOptions = ctx.Options
                         .Select(o => new ParentApprovalOption(o.Key.Value, o.Label))
                         .ToList();
-                    var decision = await approvalBridge.RequestApprovalAsync(
-                        new ToolCallId(tc.CallId),
-                        ctx.ToolName,
-                        ctx.DisplayText,
-                        ctx.Patterns,
-                        ctx.CandidateVerbs,
-                        bridgeCandidates,
-                        ctx.Cwd,
-                        bridgeOptions,
-                        ctx.IsMessy,
-                        ct);
+                    // Signal the actor that an approval wait is starting BEFORE
+                    // the await so the inactivity watchdog cannot cancel the
+                    // wait. The bridge call uses externalCt — only explicit
+                    // external cancellation (parent passivation, daemon
+                    // restart, user cancel) aborts the wait; the internal
+                    // watchdog cannot.
+                    self.Tell(ApprovalWaitStarted.Instance);
+                    ParentApprovalDecision decision;
+                    try
+                    {
+                        decision = await approvalBridge.RequestApprovalAsync(
+                            new ToolCallId(tc.CallId),
+                            ctx.ToolName,
+                            ctx.DisplayText,
+                            ctx.Patterns,
+                            ctx.CandidateVerbs,
+                            bridgeCandidates,
+                            ctx.Cwd,
+                            bridgeOptions,
+                            ctx.IsMessy,
+                            externalCt);
+                    }
+                    finally
+                    {
+                        self.Tell(ApprovalWaitCompleted.Instance);
+                    }
 
                     if (decision is ParentApprovalDecision.ApprovedOnce
                         or ParentApprovalDecision.ApprovedSession
@@ -596,6 +675,30 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     {
         public static readonly SubAgentCancelled Instance = new();
         private SubAgentCancelled() { }
+    }
+
+    /// <summary>
+    /// Sent by <see cref="ExecuteToolsAsync"/> immediately before awaiting the
+    /// parent approval bridge. Increments the in-flight approval-wait counter
+    /// so <see cref="SubAgentTimeout"/> re-arms instead of cancelling the run
+    /// while a human is deciding.
+    /// </summary>
+    private sealed class ApprovalWaitStarted
+    {
+        public static readonly ApprovalWaitStarted Instance = new();
+        private ApprovalWaitStarted() { }
+    }
+
+    /// <summary>
+    /// Sent by <see cref="ExecuteToolsAsync"/> in a <c>finally</c> after the
+    /// approval bridge call returns or throws. Decrements the counter and
+    /// re-baselines the inactivity watchdog so post-approval inactivity is
+    /// still governed.
+    /// </summary>
+    private sealed class ApprovalWaitCompleted
+    {
+        public static readonly ApprovalWaitCompleted Instance = new();
+        private ApprovalWaitCompleted() { }
     }
 
     /// <summary>Throttled self-message: the streaming LLM call is still producing output.</summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -51,10 +51,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
 
-    // Cancelled only by explicit external triggers (parent-passed cancellation
-    // or SubAgentCancelled), never by the internal inactivity watchdog. Threaded
-    // into approval-bridge waits so a slow human approver does not let the
-    // watchdog cancel a legitimate await on user input.
+    // Threaded into approval-bridge waits so a slow human approver does not
+    // let the internal inactivity watchdog cancel a legitimate await on user
+    // input. The watchdog itself never touches this CTS — it only cancels
+    // _executionCts. Other terminal paths (Complete, PostStop, SubAgentCancelled)
+    // cancel both for symmetric cleanup, but those paths are already heading
+    // for actor stop, so the bridge wait is being torn down anyway.
     private CancellationTokenSource? _externalCts;
 
     // Mailbox-thread only. Incremented when ExecuteToolsAsync enters an approval
@@ -296,17 +298,43 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<ApprovalWaitStarted>(_ =>
         {
+            // Cancel the inactivity timer outright on first wait — re-armed
+            // by ApprovalWaitCompleted when the last wait clears. The
+            // SubAgentTimeout handler's `_pendingApprovalWaits > 0` check is
+            // belt-and-braces for a stale timer fire that arrived ahead of
+            // this message in the mailbox.
+            if (_pendingApprovalWaits == 0)
+            {
+                Timers.Cancel(TimeoutTimerKey);
+            }
             _pendingApprovalWaits++;
             EmitActivity("awaiting human approval");
         });
 
         Receive<ApprovalWaitCompleted>(_ =>
         {
-            _pendingApprovalWaits = Math.Max(0, _pendingApprovalWaits - 1);
-            // Re-baseline the watchdog so it does not fire immediately on the
-            // post-approval retry just because no progress event landed during
-            // the human wait.
-            ArmInactivityTimer();
+            // Started/Completed are sent as a try/finally pair from
+            // ExecuteToolsAsync; FIFO mailbox delivery from a single sender
+            // guarantees Started lands first. An underflow means the pairing
+            // invariant is broken (orphan Tell, double Completed) — log loudly
+            // rather than silently clamping, since hiding the imbalance would
+            // re-introduce the watchdog-vs-approval bug this PR fixes.
+            if (_pendingApprovalWaits <= 0)
+            {
+                _log.Warning(
+                    "SubAgent [{AgentName}] received ApprovalWaitCompleted with no pending wait (counter={Counter}); ignoring",
+                    _definition.Name, _pendingApprovalWaits);
+                return;
+            }
+
+            _pendingApprovalWaits--;
+            // Re-baseline only when the last approval clears, so concurrent
+            // approval waits don't each rearm the same single-key timer
+            // (Akka's StartSingleTimer cancels-and-reschedules each call).
+            if (_pendingApprovalWaits == 0)
+            {
+                ArmInactivityTimer();
+            }
         });
 
         // Throttled liveness ping from a streaming LLM call — progress, even
@@ -357,8 +385,18 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _ = InvokeLlmAsync(client, messages, options, sessionId, self, _executionCts?.Token ?? CancellationToken.None);
     }
 
+    private bool _completed;
+
     private void Complete(bool success, string output)
     {
+        // Idempotent guard: a stale SubAgentTimeout or other handler can land
+        // after Complete has already run (Tell from a thread-pool finally races
+        // mailbox-thread Stop). The second call would send a duplicate
+        // SubAgentResult and log a misleading "completed" line. The first
+        // caller wins; subsequent calls are no-ops.
+        if (_completed) return;
+        _completed = true;
+
         _executionCts?.Cancel();
         _externalCts?.Cancel();
         Timers.Cancel(TimeoutTimerKey);
@@ -616,6 +654,17 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         ToolCallId = new ToolCallId(tc.CallId),
                         Name = tc.Name
                     };
+                }
+                catch (OperationCanceledException) when (externalCt.IsCancellationRequested)
+                {
+                    // External cancellation is not a tool error — let it propagate
+                    // so the outer try routes it via ToolExecutionFailed instead of
+                    // synthesising a fake tool result that the LLM would see as
+                    // success-with-error and continue from. SubAgentCancelled is
+                    // also enqueued via msg.Cancellation.Register, so Complete
+                    // typically wins the race; this guard covers the case where
+                    // it doesn't.
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -53,6 +53,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private IParentApprovalBridge? _approvalBridge;
     private ChannelWriter<ToolActivityUpdate>? _activitySink;
     private TimeSpan _inactivityBudget;
+    private bool _awaitingPotentialApproval;
+    private int _pendingApprovalWaits;
 
     public ITimerScheduler Timers { get; set; } = null!;
     private CancellationTokenRegistration _externalCancellationRegistration;
@@ -195,6 +197,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<ToolExecutionCompleted>(msg =>
         {
+            _awaitingPotentialApproval = false;
             RecordProgress("processing tool results");
 
             // Append tool results as MEAI messages and log each result
@@ -225,6 +228,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<ToolExecutionFailed>(msg =>
         {
+            _awaitingPotentialApproval = false;
             _log.Error(msg.Cause, "SubAgent [{AgentName}] tool execution failed", _definition.Name);
             Complete(false, $"Tool execution failed: {msg.Cause.Message}");
         });
@@ -244,11 +248,47 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<SubAgentTimeout>(_ =>
         {
+            if (_pendingApprovalWaits > 0)
+            {
+                _log.Debug(
+                    "SubAgent [{AgentName}] watchdog tick suppressed while waiting on parent approval ({WaitCount} pending)",
+                    _definition.Name,
+                    _pendingApprovalWaits);
+                ArmInactivityTimer();
+                return;
+            }
+
+            if (_awaitingPotentialApproval)
+            {
+                _log.Debug(
+                    "SubAgent [{AgentName}] watchdog tick granted one-cycle grace while tool execution resolves whether parent approval is needed",
+                    _definition.Name);
+                _awaitingPotentialApproval = false;
+                ArmInactivityTimer();
+                return;
+            }
+
             _executionCts?.Cancel();
             _log.Warning(
                 "SubAgent [{AgentName}] timed out: no activity for {Budget}s after {Iterations} tool iterations",
                 _definition.Name, _inactivityBudget.TotalSeconds, _toolIterationCount);
             Complete(false, $"Subagent timed out: no activity for {_inactivityBudget.TotalSeconds:F0}s.");
+        });
+
+        Receive<SubAgentApprovalWaitStarted>(_ =>
+        {
+            _awaitingPotentialApproval = false;
+            _pendingApprovalWaits++;
+        });
+
+        Receive<SubAgentApprovalWaitCompleted>(_ =>
+        {
+            _awaitingPotentialApproval = false;
+            if (_pendingApprovalWaits == 0)
+                return;
+
+            _pendingApprovalWaits--;
+            RecordProgress("approval resolved");
         });
 
         // Throttled liveness ping from a streaming LLM call — progress, even
@@ -268,6 +308,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         var self = Self;
         var executor = new DispatchingToolExecutor(_toolRegistry, _toolAccessPolicy, _approvalService);
+        _awaitingPotentialApproval = _approvalBridge is not null;
 
         _ = ExecuteToolsAsync(
             executor,
@@ -300,6 +341,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     private void Complete(bool success, string output)
     {
+        _awaitingPotentialApproval = false;
+        _pendingApprovalWaits = 0;
         _executionCts?.Cancel();
         Timers.Cancel(TimeoutTimerKey);
         _externalCancellationRegistration.Dispose();
@@ -492,17 +535,27 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     var bridgeOptions = ctx.Options
                         .Select(o => new ParentApprovalOption(o.Key.Value, o.Label))
                         .ToList();
-                    var decision = await approvalBridge.RequestApprovalAsync(
-                        new ToolCallId(tc.CallId),
-                        ctx.ToolName,
-                        ctx.DisplayText,
-                        ctx.Patterns,
-                        ctx.CandidateVerbs,
-                        bridgeCandidates,
-                        ctx.Cwd,
-                        bridgeOptions,
-                        ctx.IsMessy,
-                        ct);
+                    self.Tell(SubAgentApprovalWaitStarted.Instance);
+
+                    ParentApprovalDecision decision;
+                    try
+                    {
+                        decision = await approvalBridge.RequestApprovalAsync(
+                            new ToolCallId(tc.CallId),
+                            ctx.ToolName,
+                            ctx.DisplayText,
+                            ctx.Patterns,
+                            ctx.CandidateVerbs,
+                            bridgeCandidates,
+                            ctx.Cwd,
+                            bridgeOptions,
+                            ctx.IsMessy,
+                            ct);
+                    }
+                    finally
+                    {
+                        self.Tell(SubAgentApprovalWaitCompleted.Instance);
+                    }
 
                     if (decision is ParentApprovalDecision.ApprovedOnce
                         or ParentApprovalDecision.ApprovedSession
@@ -596,6 +649,18 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     {
         public static readonly SubAgentCancelled Instance = new();
         private SubAgentCancelled() { }
+    }
+
+    private sealed class SubAgentApprovalWaitStarted
+    {
+        public static readonly SubAgentApprovalWaitStarted Instance = new();
+        private SubAgentApprovalWaitStarted() { }
+    }
+
+    private sealed class SubAgentApprovalWaitCompleted
+    {
+        public static readonly SubAgentApprovalWaitCompleted Instance = new();
+        private SubAgentApprovalWaitCompleted() { }
     }
 
     /// <summary>Throttled self-message: the streaming LLM call is still producing output.</summary>


### PR DESCRIPTION
## Summary

- Sub-agents were aborting after their inactivity budget (default 60s) elapsed while a tool-call approval prompt was outstanding. Approval waits don't produce progress events, so the watchdog killed the sub-agent before the human could click Approve.
- The fix decouples the approval wait along two axes: a counter of in-flight approval waits so `SubAgentTimeout` re-arms instead of cancelling, and a dedicated external-cancel `CancellationTokenSource` so the bridge `await` is cancellable only by explicit external triggers (parent cancellation, `SubAgentCancelled`).
- External cancellation (parent passivation, daemon restart, user cancel) still aborts the wait promptly. The watchdog still governs *post-approval* inactivity.

## Changes

**`SubAgentActor`**
- New `_pendingApprovalWaits` counter (mailbox-thread only) and `_externalCts` second CTS.
- `SubAgentTimeout` re-arms (no-op cancel) while counter > 0.
- `ApprovalWaitStarted` / `ApprovalWaitCompleted` self-messages bracket the bridge call in `ExecuteToolsAsync` via `try/finally`. First Started cancels the timer outright; last Completed re-arms it.
- `PostStop` cancels and disposes both CTSes; `Complete` is idempotent via a `_completed` guard.
- The per-tool catch propagates `OperationCanceledException` when `externalCt` fires, so cancellation routes via `ToolExecutionFailed` instead of being masked as a fake tool error.
- `ApprovalWaitCompleted` logs (rather than silently clamps) any counter underflow, per the constitution's no-silent-fallbacks rule.

**Tests**
- 4 new cases in `SubAgentActorTests`: indefinite-block-on-approval, prompt-cancel-on-external-CT, post-approval retry runs, parallel approvals all paused.
- New `DelayingParentApprovalBridge` helper with an `EnteredApprovalWait` deterministic signal — replaces `Task.Delay` race windows in test orchestration. Uses `Task.WaitAsync(ct)` instead of a hand-rolled `WhenAny + Register` plumbing.
- Cancellation assertion loosened from \`Contains("cancelled")\` to \`Contains("cancel")\` so the test doesn't couple to UK/US spelling of the underlying error message.

## Out of scope (deferred)

- Persisting an \`OriginatedFromSubAgent\` flag on \`ToolApprovalRequested\` and short-circuiting cold-recovery clicks for sub-agent approvals. The existing "resolved-but-no-tool-result" abandonment path (\`LlmSessionActor.cs:392-405\`) handles this — ungracefully — and the parent session's \`Processing\` state already disables idle timeout (\`LlmSessionActor.cs:434\`), so a live parent doesn't passivate during a sub-agent run.

## Test plan

- [x] \`dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj\` — 2032 pass, 0 fail
- [x] \`dotnet slopwatch analyze\` — 0 issues
- [x] \`./scripts/Add-FileHeaders.ps1 -Verify\` — all files have headers
- [ ] Manual smoke: trigger a sub-agent that requires a Bash approval, wait ~5 minutes before clicking Approve, confirm completion