### PR TITLE
OpenSpec: redesign session approval state machine

### DIFF
--- a/openspec/changes/redesign-session-approval-state-machine/.openspec.yaml
+++ b/openspec/changes/redesign-session-approval-state-machine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/redesign-session-approval-state-machine/design.md
+++ b/openspec/changes/redesign-session-approval-state-machine/design.md
@@ -6,6 +6,76 @@ The tactical fixes in #1203 closed the known bugs, but the design is fragile: ad
 
 This change is for `LlmSessionActor` only. The related `SubAgentActor` lifecycle work is tracked by #1212. Shared context models are desirable where the session and sub-agent semantics match, but approval lifecycle state should remain actor-specific.
 
+## State Machine Diagrams
+
+The current approval recovery path works, but authority and provenance are copied through several shapes before a recovered turn can continue.
+
+```mermaid
+flowchart LR
+    A[Live MessageSource] --> B[ToolInteractionRequest]
+    B --> C[ToolApprovalRequested event]
+    C --> D[PendingToolInteraction]
+    D --> E[Synthesize MessageSource]
+    E --> F[Continuation LLM / Tool Dispatch / Memory Curation]
+
+    A -. authority + provenance .-> A
+    E -. can drift if fields are missed .-> F
+```
+
+The target shape builds durable turn authority once, persists it with approval pause state, and reuses it for every resumed operation.
+
+```mermaid
+flowchart TD
+    A[Inbound MessageSource] --> B[Build TurnContext]
+    B --> C[Process turn]
+    C --> D[LLM call]
+    D --> E[Tool batch]
+    E --> F{Approval required?}
+    F -- no --> G[Tool results]
+    F -- yes --> H[Persist approval pause + TurnContext]
+    H --> I[Waiting for user approval]
+    I --> J[Recover / resume]
+    J --> K[Redrive with restored TurnContext]
+    K --> G
+    G --> L[Continuation LLM]
+    L --> M[Continuation tools use same TurnContext]
+    L --> N[Memory safety reads same TurnContext]
+```
+
+At the actor level, approval turn state should be explicit beneath `SessionPhase` instead of inferred from nullable source state and pending dictionaries.
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoActiveApprovalTurn
+    NoActiveApprovalTurn --> RunningTurn: turn accepted / build TurnContext
+    RunningTurn --> WaitingForApprovals: approval prompt emitted
+    WaitingForApprovals --> RedrivingApproval: valid approval response
+    WaitingForApprovals --> AbandoningApproval: new user message supersedes prompt
+    RecoveredWaitingForApprovals --> RedrivingApproval: valid approval response after recovery
+    RecoveredWaitingForApprovals --> AbandoningApproval: new user message supersedes prompt
+    RedrivingApproval --> RunningTurn: parked tool batch returns
+    RunningTurn --> NoActiveApprovalTurn: turn completes or fails
+    AbandoningApproval --> NoActiveApprovalTurn: transcript healed
+
+    note right of RecoveredWaitingForApprovals
+        Created from journaled approval pause state.
+        Uses persisted TurnContext, not synthesized MessageSource.
+    end note
+```
+
+The reusable boundary with #1212 is the context data, not the lifecycle machine.
+
+```mermaid
+flowchart LR
+    A[Execution authority context] --> B[LlmSessionActor approval state]
+    A --> C[Future SubAgentActor approval state]
+
+    B --> D[Journal recovery]
+    B --> E[Tool redrive]
+    C --> F[Watchdog pause]
+    C --> G[Parent approval handoff]
+```
+
 ## Goals / Non-Goals
 
 **Goals:**

--- a/openspec/changes/redesign-session-approval-state-machine/design.md
+++ b/openspec/changes/redesign-session-approval-state-machine/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`LlmSessionActor` currently treats `MessageSource` as both transport metadata and the active turn's authority context. That works on the live path, but approval pause/resume now copies the same authority fields through `ToolInteractionRequest`, `ToolApprovalRequested`, `PendingToolInteraction`, redrive overrides, and `SynthesizeTurnSourceFromPending`.
+
+The tactical fixes in #1203 closed the known bugs, but the design is fragile: adding or changing one trust-bearing field requires updating several shapes and then proving recovery behavior with long actor tests. The redesign should make approval-paused session work understandable as a small state machine and make the original turn authority a single explicit model.
+
+This change is for `LlmSessionActor` only. The related `SubAgentActor` lifecycle work is tracked by #1212. Shared context models are desirable where the session and sub-agent semantics match, but approval lifecycle state should remain actor-specific.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make approval-paused session work resume after idle passivation or restart with the original requester, audience, boundary, channel capability, principal, provenance, and adopted-context policy state.
+- Separate transport input (`MessageSource`) from durable execution authority (`TurnContext`).
+- Introduce an approval turn state model that describes running, waiting, recovered, redriving, and abandoned approval-paused turns without relying on scattered dictionaries and null checks as the primary contract.
+- Keep persistence changes additive and compatible with existing approval journals.
+- Create direct test seams for context construction, persistence, restoration, and projection into tool execution and memory safety.
+- Identify the subset of context data that #1212 can reuse for sub-agents without sharing session-specific lifecycle state.
+
+**Non-Goals:**
+
+- Redesign `SubAgentActor` approval waiting or watchdog behavior.
+- Change Slack, Discord, or Mattermost approval rendering.
+- Change persistent approval grant storage or matching semantics.
+- Merge session and sub-agent tool pipelines in this change.
+- Rewrite `LlmSessionActor` wholesale.
+
+## Decisions
+
+### Decision 1: Add a dedicated `TurnContext` model
+
+`TurnContext` represents the authority and provenance of an executable turn. It is built once when a turn is accepted and is then used by approval persistence, approval recovery, continuation tool dispatch, and memory safety decisions.
+
+The durable fields should be limited to execution/security meaning:
+
+- `SessionId`
+- `TurnId`
+- `Audience`
+- `Boundary`
+- `ChannelType`
+- `RequesterSenderId`
+- `RequesterPrincipal`
+- `Provenance`
+- `HasAdoptedContext`
+- `HasThirdPartyAdoptedContext`
+- `AdoptedSpeakerIds`
+- `SupportsInteractiveApproval`
+
+Transport-only fields stay on `MessageSource`: `AckTarget`, reminder/background dedup ids, raw adopted-context projection entries, source message id, and other delivery details.
+
+Alternative considered: keep synthesizing `MessageSource` from pending approval state. Rejected because it keeps the transport shape as the authority model and recreates the same field-drift failure mode.
+
+### Decision 2: Split shared context from actor-specific state
+
+The shared model should be the context, not the lifecycle state. A future #1212 design may reuse `TurnContext` or a smaller shared `ExecutionAuthorityContext` for sub-agent tool execution, but it should not reuse session-specific states such as recovered pending approval, journal redrive, compaction buffering, or abandonment healing.
+
+This keeps the common data model useful without forcing `SubAgentActor` into `LlmSessionActor`'s persistence and recovery rules.
+
+Alternative considered: one common approval state machine for sessions and sub-agents. Rejected for this change because session approval recovery is journal-driven while sub-agent approval waiting is primarily actor/watchdog lifecycle management.
+
+### Decision 3: Add an approval turn state beneath `SessionPhase`
+
+Keep `SessionPhase` as the coarse actor lifecycle (`Recovering`, `Ready`, `Processing`, `Compacting`, `Passivating`). Add a smaller approval turn state model owned by the session actor, for example:
+
+- `NoActiveApprovalTurn`
+- `RunningTurn(TurnContext)`
+- `WaitingForApprovals(TurnContext, pending call ids)`
+- `RecoveredWaitingForApprovals(TurnContext, pending call ids)`
+- `RedrivingApproval(TurnContext, redrive plan)`
+- `AbandoningApproval(TurnContext, reason)`
+
+The exact names can change during implementation, but the invariant should not: approval handling reads a single actor-owned state object rather than reconstructing the current turn from unrelated fields.
+
+Alternative considered: add approval states directly to `SessionPhase`. Rejected because approval state can overlap with compaction/passivation/recovery concerns and would make the coarse phase graph harder to reason about.
+
+### Decision 4: Persist a `TurnContextRecord` with approval pauses
+
+New `ToolApprovalRequested` events should persist an additive, serialization-safe `TurnContextRecord`. `PendingToolInteraction` should carry that record or the rehydrated `TurnContext` rather than duplicating each authority field.
+
+Existing journals that lack `TurnContextRecord` must still recover. The compatibility path may build a `TurnContext` from the legacy fields already present on `ToolApprovalRequested`, but that path should be isolated, logged when incomplete, and treated as migration compatibility rather than a normal fallback.
+
+Alternative considered: persist `TurnContext` only in snapshots. Rejected because outstanding approvals are journal-sourced state; snapshots are cache, not source of truth.
+
+### Decision 5: Project `TurnContext` into tool, memory, and trust-context consumers
+
+Tool dispatch should receive turn authority from `TurnContext`, not `MessageSource` plus redrive overrides. Memory recall, memory curation, checkpoint payloads, exposed tool filtering, and continuation LLM/tool calls should all read the active or restored turn context.
+
+`MessageSource` may still be passed to code that needs transport-only fields during a live turn, but security-relevant decisions should not depend on reconstructing it after recovery.
+
+Alternative considered: keep `_currentTurnSource` and add more helper methods. Rejected because helper methods hide the fact that the source can be absent after recovery.
+
+### Decision 6: Prefer direct state tests over field-by-field cold recovery tests
+
+Keep a small number of end-to-end approval recovery tests. Move field propagation coverage into smaller tests for:
+
+- building `TurnContext` from a live `MessageSource`
+- serializing and deserializing `TurnContextRecord`
+- restoring pending approval state from journal events
+- projecting `TurnContext` into `ToolExecutionContext`
+- applying memory safety decisions with third-party adopted context
+
+This should reduce long, fragile tests while preserving behavioral coverage.
+
+## Risks / Trade-offs
+
+- Persistence compatibility gaps → Add protobuf fields only; keep a narrow legacy event adapter; add round-trip and old-event recovery tests.
+- `TurnContext` becoming a dumping ground → Limit it to durable execution/security meaning; keep transport delivery and runtime-only fields on `MessageSource`.
+- Duplicate state during migration → Allow temporary coexistence of `_currentTurnSource` and `_currentTurnContext`; remove authority reads from `_currentTurnSource` before deleting compatibility helpers.
+- Over-sharing with sub-agents → Share only context data whose semantics match; keep session journal/redrive state and sub-agent watchdog/waiting state separate.
+- Behavior drift in memory curation → Add tests that prove recovered turns suppress automatic memory formation when third-party adopted context is present.
+- Hidden fallback to Public on recovery → Treat missing required turn context as a loud recovery error or user-visible expired approval, except for documented legacy compatibility paths.
+
+## Migration Plan
+
+1. Add `TurnContext` and build it at session turn acceptance, while keeping existing behavior unchanged.
+2. Replace session memory and tool-exposure authority reads with `TurnContext` reads on the live path.
+3. Add additive persistence for `TurnContextRecord` on approval pause events and map it through pending approval state.
+4. Restore `TurnContext` from pending approval state during cold approval redrive and stop synthesizing `MessageSource` for authority.
+5. Remove redundant redrive override parameters once the tool pipeline consumes `TurnContext` directly.
+6. Consolidate tests after equivalent direct context tests exist.
+
+Rollback is straightforward before step 3. After step 3, rollback must tolerate journals containing the new additive fields; older binaries will ignore unknown protobuf fields only if the serialization path supports that safely. Do not remove legacy fields until a separate archival/migration decision is made.
+
+## Open Questions
+
+- Should the shared reusable model be named `TurnContext`, or should the reusable subset be named more narrowly, such as `ExecutionAuthorityContext`, with session-specific `TurnContext` wrapping it?
+- Should `SupportsInteractiveApproval` be persisted as a nullable value for exact prompt-time fidelity, or normalized into a required bool when `TurnContext` is created?
+- What should the user-visible behavior be when a legacy pending approval lacks enough context to restore safely: expired prompt notice, recovery failure, or explicit denial?

--- a/openspec/changes/redesign-session-approval-state-machine/proposal.md
+++ b/openspec/changes/redesign-session-approval-state-machine/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Netclaw approval-paused session work should resume after idle passivation or daemon restart as the same original user request, with the same requester, audience, trust boundary, channel capabilities, and adopted-context safety state. Recent approval hardening has made this work, but the state is now copied through too many shapes in `LlmSessionActor`, making regressions hard to reason about and expensive to test outside live channel integrations.
+
+Source PRDs: PRD-001, PRD-002, PRD-006, PRD-007, PRD-009.
+
+## What Changes
+
+- Define an explicit session approval state machine for live approval waits, idle/cold recovery, redrive, continuation LLM calls, and abandonment.
+- Define a durable turn authority context for session turns so approval recovery restores the original request context instead of synthesizing transport metadata after recovery.
+- Require approval-paused session work to preserve memory-safety inputs, including third-party adopted-context state, across live and recovered paths.
+- Require test seams that verify turn-context construction, persistence, restoration, and projection directly, so every authority field does not need a full cold-recovery integration test.
+- Keep sub-agent approval lifecycle redesign out of this change except for identifying context data that can safely be shared with #1212 without sharing actor-specific lifecycle state.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `session-state-machine`: define approval-paused session states and legal resume/redrive/abandon transitions.
+- `session-resume`: require cold recovery to restore pending approval turn context and continue under the original request context.
+- `tool-approval-gates`: require approval pause persistence to carry durable turn authority context and use it during approval response handling.
+- `trust-context-integrity`: require session turn authority context to be explicit, typed, and fail-loud when required fields are missing.
+- `netclaw-agent-memory`: require memory recall and curation safety decisions after approval recovery to use the restored turn context.
+- `netclaw-session`: update persisted turn lifecycle behavior around approval pause and resumed continuation calls.
+
+## Impact
+
+- Affected code: `LlmSessionActor`, session approval state records, approval events/protobuf mapping, `SessionToolExecutionPipeline`, memory recall/curation entry points, approval recovery tests.
+- Security impact: reduces authority-context drift across approval pause/resume; resumed tools and memory curation must use the same trust context as the original request.
+- Operational impact: approval prompts should behave the same before and after restart; failures caused by missing required turn context should fail loudly rather than silently falling back to Public or another derived value.
+- Compatibility impact: any persistence changes must be additive and backward-compatible with existing journals; old pending approval events must continue to recover safely.
+- Out of scope: redesigning `SubAgentActor` approval waiting, changing channel approval rendering, changing persistent approval storage semantics, or doing a broad session actor rewrite.

--- a/openspec/changes/redesign-session-approval-state-machine/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/redesign-session-approval-state-machine/specs/netclaw-agent-memory/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Approval-resumed memory decisions use turn context
+
+Memory recall, memory curation, and memory checkpoint payloads created during an approval-resumed session turn SHALL use the active or restored turn context for audience, boundary, and adopted-context policy inputs. They SHALL NOT derive those inputs from missing live transport metadata after recovery.
+
+#### Scenario: Recovered third-party adopted context suppresses automatic curation
+
+- **GIVEN** an approval-paused turn was originally created with third-party adopted context
+- **AND** the session cold-recovers before the approval response arrives
+- **WHEN** the approved tool redrive completes and memory curation evaluates proposals for the resumed turn
+- **THEN** curation reads `HasThirdPartyAdoptedContext` from the restored turn context
+- **AND** automatic memory formation is suppressed unless the authorized user explicitly elevated the adopted fact
+
+#### Scenario: Self-only adopted context does not suppress solely by presence
+
+- **GIVEN** an approval-paused turn was originally created with self-only adopted context
+- **WHEN** the recovered turn resumes and memory policy evaluates the turn
+- **THEN** memory policy sees adopted context as present
+- **AND** `HasThirdPartyAdoptedContext` remains false
+- **AND** automatic memory suppression is not triggered solely by adopted-context presence
+
+#### Scenario: Recovered memory boundary matches original turn
+
+- **GIVEN** an approval-paused Team turn was recovered after restart
+- **WHEN** memory recall or checkpoint payloads are created during the resumed continuation
+- **THEN** their audience and boundary come from the restored turn context
+- **AND** they do not fall back to Public because live `MessageSource` is absent

--- a/openspec/changes/redesign-session-approval-state-machine/specs/netclaw-session/spec.md
+++ b/openspec/changes/redesign-session-approval-state-machine/specs/netclaw-session/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Approval-paused turn lifecycle preserves original context
+
+The persisted session turn lifecycle SHALL preserve the original turn context across approval pause, approval response, tool redrive, follow-up LLM calls, continuation tool calls, and turn completion. The context SHALL remain active until the resumed turn completes, fails, or is explicitly abandoned by a new user message.
+
+#### Scenario: Context remains active through continuation LLM call
+
+- **GIVEN** a recovered approval response redrives a parked tool batch
+- **WHEN** the tool result is appended and the session invokes the continuation LLM call
+- **THEN** the continuation call uses the restored turn context
+- **AND** the exposed tool list is filtered for the original turn audience and boundary
+
+#### Scenario: Context remains active through continuation tool call
+
+- **GIVEN** a recovered approval redrive has resumed a turn
+- **WHEN** the continuation LLM response requests another tool call
+- **THEN** that tool call is dispatched with the same restored turn context
+- **AND** approval capability and channel type match the original turn
+
+#### Scenario: Context clears when resumed turn completes
+
+- **GIVEN** a resumed approval-paused turn completes successfully
+- **WHEN** `TurnCompleted` is emitted
+- **THEN** the session clears the active approval turn context
+- **AND** the next user message starts with a new turn context
+
+### Requirement: Approval recovery tests cover context directly
+
+Session approval recovery tests SHALL include direct coverage for turn-context construction, persistence, restoration, and projection into tool and memory contexts. End-to-end cold-recovery tests SHALL remain for user-visible recovery behavior, but field-by-field context propagation SHOULD be covered through focused tests where possible.
+
+#### Scenario: Direct projection test replaces field-only integration coverage
+
+- **GIVEN** a persisted turn context has audience, boundary, channel type, requester, approval capability, and adopted-context state
+- **WHEN** the session projects that context into tool execution and memory-policy inputs
+- **THEN** the projected values match the persisted context
+- **AND** the assertion does not require a full actor cold-recovery scenario for each individual field
+
+#### Scenario: End-to-end recovery test remains for user-visible behavior
+
+- **GIVEN** a user approves a pending tool prompt after session recovery
+- **WHEN** the session redrives the parked tool batch
+- **THEN** the user observes the tool result and final assistant response
+- **AND** no duplicate approval prompt is emitted for the approved call

--- a/openspec/changes/redesign-session-approval-state-machine/specs/session-resume/spec.md
+++ b/openspec/changes/redesign-session-approval-state-machine/specs/session-resume/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Recovered pending approvals restore turn context
+
+When a session recovers pending tool approvals from the journal, it SHALL also restore the original turn context for each pending approval. The restored context SHALL include the requester, audience, boundary, channel type, approval capability, principal classification, provenance, and adopted-context safety state needed to resume the original request faithfully.
+
+#### Scenario: Pending approval restores original context
+
+- **GIVEN** a `ToolApprovalRequested` event was written with turn context while a prompt was outstanding
+- **WHEN** the session cold-recovers through the journal path
+- **THEN** the pending approval is restored with that turn context
+- **AND** approval redrive uses the restored context rather than deriving a new context from the session id
+
+#### Scenario: Legacy approval event uses compatibility restoration
+
+- **GIVEN** a pre-change `ToolApprovalRequested` event has no turn-context record but still has legacy persisted trust fields
+- **WHEN** the session recovers the event
+- **THEN** the session MAY construct turn context from those legacy fields
+- **AND** this compatibility path is isolated from the normal new-event path
+
+#### Scenario: Incomplete legacy approval fails loud
+
+- **GIVEN** a recovered pending approval lacks enough persisted context to restore the original requester and trust context
+- **WHEN** an approval response arrives for that pending call
+- **THEN** the session does not redrive the tool under a synthesized permissive context
+- **AND** the user receives an explicit expired or unrecoverable approval notice
+
+### Requirement: Restarted approvals resume as the original request
+
+An approval response received after idle passivation, cold recovery, or daemon restart SHALL resume the same original session turn. The resumed tool batch and any continuation LLM/tool calls SHALL use the restored turn context until the resumed turn completes or is abandoned.
+
+#### Scenario: Approval after cold recovery resumes original request
+
+- **GIVEN** a session has recovered a pending approval from the journal
+- **WHEN** the original requester approves the prompt
+- **THEN** the session re-drives the parked tool batch
+- **AND** the tool execution context uses the original turn audience, boundary, channel type, and approval capability
+
+#### Scenario: Continuation after redrive keeps restored context
+
+- **GIVEN** a recovered approval redrive has completed its parked tool call
+- **WHEN** the follow-up LLM response asks for another tool call in the same turn
+- **THEN** the continuation tool call uses the same restored turn context
+- **AND** it does not fall back to a context derived from missing transport metadata

--- a/openspec/changes/redesign-session-approval-state-machine/specs/session-state-machine/spec.md
+++ b/openspec/changes/redesign-session-approval-state-machine/specs/session-state-machine/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Approval turn state is explicit
+
+The session actor SHALL maintain explicit approval turn state for approval-paused work, separate from the coarse `SessionPhase` lifecycle. The approval turn state SHALL identify whether there is no active approval turn, a running turn, a turn waiting for one or more approval responses, a recovered waiting turn, a redrive in progress, or an abandoned approval turn being healed. Approval response handling SHALL consult this approval turn state instead of inferring the turn solely from nullable transport metadata or scattered pending dictionaries.
+
+#### Scenario: Live approval request records waiting state
+
+- **GIVEN** a session is processing a turn with a valid turn context
+- **WHEN** a tool call emits an approval request
+- **THEN** the session records approval turn state for the original turn context
+- **AND** the waiting state includes the pending approval call id
+
+#### Scenario: Recovered approval records recovered waiting state
+
+- **GIVEN** a session recovers journaled pending approval state
+- **WHEN** recovery completes
+- **THEN** the session records recovered approval turn state with the restored turn context
+- **AND** later approval responses are handled against that state
+
+#### Scenario: Abandoned approval state heals the transcript
+
+- **GIVEN** a recovered approval turn is waiting for a user response
+- **WHEN** the user sends a new message instead of answering the approval prompt
+- **THEN** the session transitions the approval turn state to abandoned
+- **AND** the unanswered assistant tool calls are closed with synthetic tool results before the new turn is processed
+
+### Requirement: Approval redrive uses actor-owned state transitions
+
+Approval response handling SHALL transition through actor-owned approval states when redriving a parked tool batch. A redrive SHALL use the restored turn context attached to the approval turn state, transition the coarse `SessionPhase` through legal transitions, and clear approval turn state only after the parked batch and continuation path have completed or been abandoned.
+
+#### Scenario: Ready approval response enters redrive state
+
+- **GIVEN** a recovered session is in `Ready` with approval turn state waiting for call `call-1`
+- **WHEN** a valid `ToolInteractionResponse` for `call-1` arrives
+- **THEN** the session transitions to a redrive approval state
+- **AND** the coarse phase transitions from `Ready` to `Processing`
+
+#### Scenario: Redrive completion clears approval state
+
+- **GIVEN** a session is redriving a recovered approval turn
+- **WHEN** the parked tool batch completes and the continuation turn finishes
+- **THEN** the session clears the approval turn state
+- **AND** no pending or resolved approval state remains for the completed call ids

--- a/openspec/changes/redesign-session-approval-state-machine/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/redesign-session-approval-state-machine/specs/tool-approval-gates/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Approval pause persistence carries turn context
+
+When a tool approval prompt is emitted from a session turn, the persisted approval request SHALL carry the original turn context as a single durable context record. The approval request MAY continue to carry tool-specific prompt data, option keys, candidates, and compatibility fields, but authority-bearing session context SHALL have one canonical persisted representation for new events.
+
+#### Scenario: Approval request persists context record
+
+- **GIVEN** a tool call requires approval during a session turn
+- **WHEN** the session persists the approval request
+- **THEN** the journaled event includes the turn context for the original request
+- **AND** the pending interaction restored from that event carries the same context
+
+#### Scenario: Tool-specific prompt data remains separate
+
+- **GIVEN** an approval request includes command patterns, candidate verbs, option keys, and directory candidates
+- **WHEN** the turn context is persisted with the approval request
+- **THEN** tool-specific prompt data remains separate from the turn context
+- **AND** the turn context does not become a dumping ground for approval-rendering state
+
+### Requirement: Approval responses use persisted requester context
+
+Approval response authorization SHALL use the requester and principal from the persisted turn context for the pending approval. A recovered approval response SHALL enforce the same requester-only approval rule as the live path, unless the original requester principal represents verified automation where channel-member approval is allowed.
+
+#### Scenario: Non-requester approval rejected after recovery
+
+- **GIVEN** a pending approval was restored with requester `U-requester`
+- **WHEN** sender `U-other` approves the prompt
+- **THEN** the approval response is rejected
+- **AND** the tool is not redriven
+
+#### Scenario: Verified automation approval remains approvable by channel member
+
+- **GIVEN** a pending approval was restored with a verified automation principal
+- **WHEN** a valid channel member approves the prompt
+- **THEN** the approval response is accepted according to the same rule used on the live path
+- **AND** the redrive uses the original turn context

--- a/openspec/changes/redesign-session-approval-state-machine/specs/trust-context-integrity/spec.md
+++ b/openspec/changes/redesign-session-approval-state-machine/specs/trust-context-integrity/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Session turn context is the durable authority model
+
+The session actor SHALL distinguish ephemeral transport metadata from durable turn authority. `MessageSource` SHALL remain the transport/input shape for live delivery details. Session approval pause, recovery redrive, continuation tool execution, and memory-safety decisions SHALL use an explicit turn context as the durable authority model.
+
+#### Scenario: Live turn builds explicit context
+
+- **GIVEN** a `SendUserMessage` is accepted with a valid `MessageSource`
+- **WHEN** the session starts processing the turn
+- **THEN** the session builds an explicit turn context
+- **AND** security-relevant turn decisions read from that context rather than directly from transport metadata
+
+#### Scenario: Recovered turn does not synthesize transport authority
+
+- **GIVEN** a session recovers an approval-paused turn without live transport metadata
+- **WHEN** the approval response redrives the parked tool batch
+- **THEN** the session uses the persisted turn context as authority
+- **AND** it does not synthesize a `MessageSource` as the authority source for the recovered turn
+
+### Requirement: Missing required turn context fails loud
+
+When a session path requires turn context to authorize tool execution, expose tools, or evaluate memory safety, missing or incomplete turn context SHALL fail loudly. The system SHALL NOT silently substitute a permissive or unrelated context. A documented fail-closed compatibility path MAY exist only for legacy events where partial absence is expected and safe.
+
+#### Scenario: Missing context blocks redrive
+
+- **GIVEN** a recovered pending approval has no complete turn context and cannot be safely restored from legacy persisted fields
+- **WHEN** the user approves the prompt
+- **THEN** the session does not redrive the tool under a substitute context
+- **AND** the failure is logged or surfaced explicitly
+
+#### Scenario: Tool execution reads parsed trust values
+
+- **GIVEN** a tool call is dispatched from a live or recovered session turn
+- **WHEN** the tool execution context is built
+- **THEN** the audience and boundary come from parsed turn-context values
+- **AND** tool authorization does not parse unvalidated wire strings at the point of use
+
+### Requirement: Shared context model excludes actor lifecycle state
+
+Any context model shared between session and sub-agent approval work SHALL contain only execution authority and provenance fields whose semantics are the same in both actors. Actor-specific lifecycle state, including session journal recovery state and sub-agent watchdog/approval-wait state, SHALL remain separate.
+
+#### Scenario: Shared model carries authority only
+
+- **GIVEN** session approval recovery and sub-agent approval lifecycle both need requester, audience, boundary, channel type, and approval capability
+- **WHEN** a shared model is introduced
+- **THEN** it contains those authority fields
+- **AND** it does not contain session-only redrive state or sub-agent-only watchdog state

--- a/openspec/changes/redesign-session-approval-state-machine/tasks.md
+++ b/openspec/changes/redesign-session-approval-state-machine/tasks.md
@@ -1,0 +1,42 @@
+## 1. Turn Context Model
+
+- [ ] 1.1 Add an internal turn authority context model with only durable execution/security fields.
+- [ ] 1.2 Add a persistence-safe turn context record for journaled approval events.
+- [ ] 1.3 Add focused tests for building turn context from live `MessageSource`.
+- [ ] 1.4 Document which `MessageSource` fields remain transport-only and are not part of turn context.
+
+## 2. Session Approval State
+
+- [ ] 2.1 Add explicit approval turn state owned by `LlmSessionActor` beneath the coarse `SessionPhase` lifecycle.
+- [ ] 2.2 Record waiting approval state when a live tool approval request is emitted.
+- [ ] 2.3 Restore recovered waiting approval state during journal replay.
+- [ ] 2.4 Transition through redrive and abandoned states when approval responses or new user messages arrive.
+
+## 3. Persistence And Compatibility
+
+- [ ] 3.1 Persist turn context with new `ToolApprovalRequested` events using additive protobuf fields only.
+- [ ] 3.2 Map persisted turn context into `PendingToolInteraction` without duplicating authority fields as the normal path.
+- [ ] 3.3 Add legacy compatibility restoration for pre-change approval events that only carry old trust fields.
+- [ ] 3.4 Add serialization and recovery tests for new and legacy approval events.
+
+## 4. Redrive And Consumers
+
+- [ ] 4.1 Replace cold-recovery `MessageSource` synthesis as the normal authority restoration path.
+- [ ] 4.2 Project restored turn context into `ToolExecutionContext` for parked batch redrive.
+- [ ] 4.3 Keep restored turn context active through continuation LLM calls and continuation tool calls.
+- [ ] 4.4 Route memory recall, curation, and checkpoint audience/boundary/adopted-context decisions through turn context.
+- [ ] 4.5 Remove redundant redrive override parameters once turn context projection is authoritative.
+
+## 5. Test Consolidation
+
+- [ ] 5.1 Keep end-to-end tests for recovered approval click, no duplicate prompt, sibling tool no-reexecution, wrong requester, and expired prompt behavior.
+- [ ] 5.2 Replace field-by-field cold-recovery tests with focused turn-context construction, persistence, restoration, and projection tests.
+- [ ] 5.3 Add memory safety regression coverage for recovered turns with third-party adopted context.
+- [ ] 5.4 Add a test proving shared context model does not include session-only or sub-agent-only lifecycle state.
+
+## 6. Validation
+
+- [ ] 6.1 Run targeted actor approval recovery and serialization tests.
+- [ ] 6.2 Run `dotnet slopwatch analyze`.
+- [ ] 6.3 Run `./scripts/Add-FileHeaders.ps1 -Verify`.
+- [ ] 6.4 Run `openspec validate redesign-session-approval-state-machine --strict`.


### PR DESCRIPTION
## Summary

Adds an OpenSpec change for redesigning the LlmSessionActor approval state machine and durable turn context.

## Scope

- Proposal, design, task list, and delta specs
- Covers session approval recovery, turn context, memory safety, and test consolidation
- Keeps sub-agent approval lifecycle redesign separate under #1212

Refs #1213

## Validation

- openspec validate redesign-session-approval-state-machine --strict