### PR TITLE
fix(subagents): harden approval lifecycle

### DIFF
--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -232,7 +232,7 @@ If a subagent hits an approval-gated tool, the prompt is routed through the
 parent session's approval channel and requester context. Human approval time does
 not count as subagent inactivity; the watchdog resumes after the approval wait
 settles. If no parent approval bridge is available, the gated tool fails closed
-with an explicit denial result and is not executed.
+as a failed subagent run and is not executed.
 
 ## Built-in agents
 

--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -230,9 +230,10 @@ the inherited project root for future runs.
 
 If a subagent hits an approval-gated tool, the prompt is routed through the
 parent session's approval channel and requester context. Human approval time does
-not count as subagent inactivity; the watchdog resumes after the approval wait
-settles. If no parent approval bridge is available, the gated tool fails closed
-as a failed subagent run and is not executed.
+not count as subagent inactivity or parent `spawn_agent` tool inactivity; both
+watchdogs resume after the approval wait settles. If no parent approval bridge or
+requester authority context is available, the gated tool fails closed as a failed
+subagent run and is not executed.
 
 ## Built-in agents
 

--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -228,6 +228,12 @@ Spawned subagents inherit the parent session's `session_dir` and current
 same session directory snapshot, and project-scoped instructions are loaded from
 the inherited project root for future runs.
 
+If a subagent hits an approval-gated tool, the prompt is routed through the
+parent session's approval channel and requester context. Human approval time does
+not count as subagent inactivity; the watchdog resumes after the approval wait
+settles. If no parent approval bridge is available, the gated tool fails closed
+with an explicit denial result and is not executed.
+
 ## Built-in agents
 
 Three agents are seeded during `netclaw init`. They are regular file-based

--- a/openspec/changes/redesign-subagent-approval-lifecycle/.openspec.yaml
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/redesign-subagent-approval-lifecycle/design.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/design.md
@@ -49,7 +49,7 @@ Alternative considered: let the sub-agent synthesize a fresh requester or audien
 
 ### Decision 3: Parent bridge is the only interactive approval path
 
-If `IParentApprovalBridge` is present, approval-gated sub-agent tools route through it. If absent, the sub-agent must fail closed: the gated tool must not execute, and the child should receive a denial-shaped tool result or terminal failure rather than hanging.
+If `IParentApprovalBridge` is present, approval-gated sub-agent tools route through it. If absent, the sub-agent must fail closed: the gated tool must not execute, and the child run completes with a terminal failed result rather than hanging or continuing as if the denial were user-driven.
 
 The bridge emits the same channel-agnostic `ToolInteractionRequest` shape used by parent session tools, including the computed button options, candidate verbs, per-candidate directories, cwd, requester identity, principal, and adopted-context metadata.
 
@@ -87,7 +87,7 @@ Alternative considered: rely on actor stop ordering. Rejected because thread-poo
 ## Migration Plan
 
 1. Add the #1212 OpenSpec delta requirements for `netclaw-subagents` and `tool-approval-gates`.
-2. Tighten `SubAgentActor` approval-gated no-bridge and denied/timed-out paths so they return explicit denial-shaped tool results and never execute gated tools.
+2. Tighten `SubAgentActor` approval-gated no-bridge and denied/timed-out paths so missing bridges produce terminal failed results, denied/timed-out approvals produce explicit tool results, and gated tools never execute without approval.
 3. Add or update tests for approve, deny, timeout, no bridge, cancellation, parallel waits, and approve-once isolation.
 4. Update runbook or operational guidance only if user-visible sub-agent approval behavior changes.
 

--- a/openspec/changes/redesign-subagent-approval-lifecycle/design.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/design.md
@@ -57,9 +57,9 @@ Alternative considered: let sub-agents display their own approval UI. Rejected b
 
 ### Decision 4: Approval wait pauses the inactivity watchdog
 
-Waiting for a human approval decision is intentional suspension, not sub-agent inactivity. The sub-agent should cancel or suppress the inactivity timer while one or more approval waits are active, then re-baseline the timer when the last wait completes.
+Waiting for a human approval decision is intentional suspension, not sub-agent inactivity. The sub-agent should cancel or suppress the inactivity timer while one or more approval waits are active, then re-baseline the timer when the last wait completes. The streaming `spawn_agent` tool call in the parent session must receive the same signal, otherwise the parent tool-call watchdog can cancel a healthy child that is only waiting on a human.
 
-Parallel tool calls may produce parallel approval waits. The actor therefore needs a count or equivalent keyed state rather than a single boolean. Underflow or double-completion is a bug and should be logged loudly rather than silently clamped.
+Parallel tool calls may produce parallel approval waits. The actor therefore needs a count or equivalent keyed state rather than a single boolean. Underflow or double-completion is a bug and should be logged loudly rather than silently clamped. The parent stream watchdog should suspend on the child "awaiting approval" activity and resume on the next non-suspending activity or terminal completion.
 
 Alternative considered: keep the watchdog active while waiting. Rejected because it turns slow human approval into a false sub-agent timeout.
 

--- a/openspec/changes/redesign-subagent-approval-lifecycle/design.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The merged `redesign-session-approval-state-machine` change for #1213 defines durable approval recovery for `LlmSessionActor`. It also draws the boundary this change should preserve: session approval state is journal/recovery driven, while sub-agent approval waiting is live child-actor lifecycle management.
+
+`SubAgentActor` is ephemeral: it receives one `RunSubAgent`, runs an autonomous LLM/tool loop, returns one `SubAgentResult`, and stops. When one of its tools is approval-gated, the tool executor raises `ToolApprovalRequiredException`. If the parent session supplied an `IParentApprovalBridge`, the sub-agent can route the prompt back to the parent session's interactive approval channel and wait for the human decision.
+
+Recent tactical fixes already introduced the bridge, cancellation tokens, and watchdog suppression while approval is pending. This change formalizes that behavior so implementation can close the remaining gaps without blending sub-agents into the session recovery state machine.
+
+The session `TurnContext`/execution-authority model from #1213 is the intended source of truth for trust-bearing data. If that model is available when this change is implemented, sub-agent spawn should receive the relevant `TurnContext` subset directly. If this change lands before the #1213 implementation, the code should keep the current `RunSubAgent`/`ToolExecutionContext` field mapping aligned with the #1213 field list and avoid inventing a second incompatible authority model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a small sub-agent approval lifecycle that is owned by `SubAgentActor`, not by `LlmSessionActor` journal recovery.
+- Preserve the parent session's execution authority context when a sub-agent approval prompt is emitted.
+- Ensure every pending sub-agent approval wait settles exactly once as approved, denied, timed out, cancelled, or abandoned by actor termination.
+- Keep the sub-agent inactivity watchdog from cancelling a legitimate human approval wait, while resuming watchdog enforcement after approval settles.
+- Return a terminal `SubAgentResult` and parent `spawn_agent` tool result for every non-crash outcome.
+- Add tests for the approval lifecycle's meaningful state transitions and race-prone paths.
+
+**Non-Goals:**
+
+- Persisting `SubAgentActor` state or making sub-agents recover after daemon restart.
+- Reusing the session approval redrive state machine from #1213.
+- Changing channel-specific approval rendering for Slack, Discord, or Mattermost.
+- Changing persistent approval grant matching or storage semantics.
+- Allowing sub-agents to spawn other sub-agents.
+
+## Decisions
+
+### Decision 1: Keep sub-agent approval lifecycle actor-local
+
+Sub-agent approval lifecycle state stays inside `SubAgentActor`. The actor can track whether it is running approval-capable tools, waiting for parent approval, resolving the post-approval retry, or completing. It should not write approval wait state to the session journal and should not participate in session cold redrive.
+
+Rationale: sub-agents are child actors tied to a live `spawn_agent` tool call. If the parent session stops, the child should be cancelled and the prompt should expire; it should not become independent durable work.
+
+Alternative considered: reuse the #1213 session approval state model. Rejected because that state exists to recover persisted parent turns, while a sub-agent wait is scoped to a live child actor and parent tool call.
+
+### Decision 2: Reuse session turn authority context, not lifecycle state
+
+The reusable boundary from #1213 is the authority/provenance data needed to emit and authorize a prompt: session id, requester identity, audience, boundary, channel type, cwd/project/session directories, and adopted-context safety flags.
+
+`RunSubAgent` and `ToolExecutionContext` may carry the subset the child needs, and `ParentSessionApprovalBridge` should project it into `ToolInteractionRequest`. That projection is shared in meaning with session approval prompts, but the child actor's wait counters, watchdog state, and cancellation behavior remain separate.
+
+When the session `TurnContext` implementation exists, `SubAgentSpawner` should prefer mapping from that object (or a shared `ExecutionAuthorityContext` inside it) over copying individual `MessageSource` fields. Until then, the implementation should keep all context-copying isolated at the parent-to-child boundary.
+
+Alternative considered: let the sub-agent synthesize a fresh requester or audience. Rejected because it can drift from the parent turn and silently elevate or misroute approval authority.
+
+### Decision 3: Parent bridge is the only interactive approval path
+
+If `IParentApprovalBridge` is present, approval-gated sub-agent tools route through it. If absent, the sub-agent must fail closed: the gated tool must not execute, and the child should receive a denial-shaped tool result or terminal failure rather than hanging.
+
+The bridge emits the same channel-agnostic `ToolInteractionRequest` shape used by parent session tools, including the computed button options, candidate verbs, per-candidate directories, cwd, requester identity, principal, and adopted-context metadata.
+
+Alternative considered: let sub-agents display their own approval UI. Rejected because channels and requester authorization belong to the parent session.
+
+### Decision 4: Approval wait pauses the inactivity watchdog
+
+Waiting for a human approval decision is intentional suspension, not sub-agent inactivity. The sub-agent should cancel or suppress the inactivity timer while one or more approval waits are active, then re-baseline the timer when the last wait completes.
+
+Parallel tool calls may produce parallel approval waits. The actor therefore needs a count or equivalent keyed state rather than a single boolean. Underflow or double-completion is a bug and should be logged loudly rather than silently clamped.
+
+Alternative considered: keep the watchdog active while waiting. Rejected because it turns slow human approval into a false sub-agent timeout.
+
+### Decision 5: Approval outcomes produce normal tool-loop inputs
+
+Approved decisions retry the exact blocked tool call with retry-local approval state. Denied and timed-out decisions produce tool-result messages that explain the denial and are returned to the sub-agent LLM like any other tool result. External cancellation, parent stop, and actor termination cancel pending waits and complete the sub-agent once with failure if the caller is still awaiting a result.
+
+Approved-once retry state must be per tool call and per retry. It must not leak to sibling calls, later iterations, or later sub-agent runs.
+
+Alternative considered: terminate the sub-agent immediately on denial. Rejected because a denied tool is still a valid tool result; the sub-agent may be able to finish with a useful explanation or alternate approach.
+
+### Decision 6: Completion is idempotent
+
+Sub-agent completion should be guarded so stale timeout, cancellation, or tool-failure messages cannot send duplicate `SubAgentResult` messages. The first terminal path wins; later terminal messages are ignored.
+
+Alternative considered: rely on actor stop ordering. Rejected because thread-pool continuations and mailbox messages can race around actor stop.
+
+## Risks / Trade-offs
+
+- [Risk] A parent-session approval response can arrive after the sub-agent has been cancelled. -> Mitigation: cancellation must cancel the bridge wait; parent response handling should treat missing pending calls as expired rather than executing the child tool.
+- [Risk] Approval wait counters can drift on exception paths. -> Mitigation: start/complete notifications must be paired with try/finally and tested for cancellation and parallel waits.
+- [Risk] Denial as a tool result lets the sub-agent continue and potentially ask again. -> Mitigation: the approval policy still gates every retry, and max tool iterations bound loops.
+- [Risk] Sharing too much context with #1213 creates a common model that fits neither actor. -> Mitigation: share only execution authority data; do not share lifecycle state or persistence mechanics.
+
+## Migration Plan
+
+1. Add the #1212 OpenSpec delta requirements for `netclaw-subagents` and `tool-approval-gates`.
+2. Tighten `SubAgentActor` approval-gated no-bridge and denied/timed-out paths so they return explicit denial-shaped tool results and never execute gated tools.
+3. Add or update tests for approve, deny, timeout, no bridge, cancellation, parallel waits, and approve-once isolation.
+4. Update runbook or operational guidance only if user-visible sub-agent approval behavior changes.
+
+Rollback is straightforward: revert the actor/test changes and remove this change directory before archive. No persisted data migration is expected because sub-agent approval waits are not durable.
+
+## Open Questions
+
+- Should the implementation expose a named `SubAgentApprovalLifecycleState` type, or is the existing wait counter plus watchdog enum sufficient once covered by tests?
+- Should a denied sub-agent approval always continue the LLM loop, or should some high-risk denial categories terminate the sub-agent immediately in a future change?

--- a/openspec/changes/redesign-subagent-approval-lifecycle/proposal.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Sub-agents inherit the parent session's tool policy and can encounter interactive approval gates while running as child actors. The current behavior needs an explicit lifecycle contract so approved, denied, cancelled, timed-out, or parent-terminated approval waits cannot leave hung sub-agents, orphaned prompts, or incomplete `spawn_agent` tool calls.
+
+Source PRDs: PRD-001, PRD-002, PRD-006, PRD-007, PRD-009.
+
+This change builds on the merged `redesign-session-approval-state-machine` OpenSpec for #1213. It reuses the execution-authority context boundary where semantics match, but keeps sub-agent approval waiting as a separate actor/watchdog lifecycle rather than session journal redrive state.
+
+## What Changes
+
+- Define the sub-agent approval lifecycle for tool calls that require parent-user approval while a `SubAgentActor` is running.
+- Require pending sub-agent approvals to be owned by the parent session's `spawn_agent` call and to settle exactly once on approve, deny, cancellation, timeout, or actor termination.
+- Require sub-agent inactivity watchdogs to treat approval waits as intentional suspension rather than progress or a wedge.
+- Require parent-session notifications and terminal tool results for every approval outcome, including expired prompts and abandoned runs.
+- Require implementation tests for approve, deny, cancellation, parent stop, timeout, and late approval response paths.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `netclaw-subagents`: define sub-agent approval wait states, parent ownership, watchdog behavior, and terminal result semantics.
+- `tool-approval-gates`: define how approval prompts and responses are correlated for sub-agent tool calls without reusing session recovery/redrive state.
+
+## Impact
+
+- Affected code: `SubAgentActor`, `spawn_agent` tool execution, sub-agent tool execution context, parent session notification/result handling, approval response routing, sub-agent lifecycle tests.
+- Security impact: sub-agent tools must never execute without the same requester-only approval checks and grant-persistence rules as parent-session tools; missing authority context must fail loudly.
+- Operational impact: operators should see clear completion or expiration behavior instead of sub-agents silently hanging behind stale approval prompts.
+- Compatibility impact: no persistence migration is expected for this change; sub-agent approval waits are scoped to live actor execution and parent `spawn_agent` call lifecycle.
+- Out of scope: redesigning `LlmSessionActor` durable approval recovery, changing channel approval rendering, changing persistent approval grant matching, adding sub-agent session persistence, or merging session and sub-agent approval state machines.

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Sub-agent approval lifecycle is actor-local
+
+Sub-agent approval waits SHALL be owned by the live `SubAgentActor` run that encountered the approval-gated tool call. The sub-agent SHALL NOT persist approval wait state or reuse the session approval recovery/redrive lifecycle from `LlmSessionActor`.
+
+#### Scenario: Approval wait belongs to live child actor
+- **GIVEN** a sub-agent tool call requires approval
+- **WHEN** the sub-agent enters an approval wait
+- **THEN** the wait is tracked by the live `SubAgentActor`
+- **AND** no sub-agent approval wait state is written to the session journal
+
+#### Scenario: Parent stop cancels sub-agent approval wait
+- **GIVEN** a sub-agent is waiting for parent approval
+- **WHEN** the parent session stops or cancels the `spawn_agent` tool call
+- **THEN** the sub-agent approval wait is cancelled
+- **AND** the sub-agent completes at most once with a failed `SubAgentResult`
+- **AND** the gated tool is not executed after cancellation
+
+### Requirement: Sub-agent approval uses parent turn authority
+
+Sub-agent approval prompts SHALL use the parent session turn's execution authority context for approval requester, principal, audience, boundary, channel capability, provenance, adopted-context safety, and filesystem grounding. The implementation SHALL reuse the `TurnContext` or shared execution-authority subset from #1213 when available, and SHALL keep any interim field mapping isolated to the parent-to-child spawn boundary.
+
+#### Scenario: Approval prompt carries parent requester context
+- **GIVEN** a sub-agent spawned from a parent turn with a requester sender id and principal
+- **WHEN** the sub-agent emits an approval prompt
+- **THEN** the prompt carries the parent requester sender id and principal
+- **AND** approval authorization is evaluated as if the parent turn had requested the tool
+
+#### Scenario: Missing authority fails closed
+- **GIVEN** a sub-agent approval-gated tool call has no parent approval bridge or required authority context
+- **WHEN** approval is required
+- **THEN** the gated tool is not executed
+- **AND** the sub-agent receives an explicit denial-shaped result or terminal failure
+- **AND** no default `Personal` audience or synthetic requester is substituted
+
+### Requirement: Sub-agent watchdog pauses during human approval
+
+The sub-agent inactivity watchdog SHALL treat parent approval waits as intentional suspension. While one or more approval waits are active, watchdog timeout ticks SHALL NOT complete the sub-agent as inactive. When the last approval wait settles, the watchdog SHALL be re-baselined so future inactivity is still bounded.
+
+#### Scenario: Slow approval does not trigger inactivity timeout
+- **GIVEN** a sub-agent with an active approval wait
+- **AND** the human approval decision takes longer than the sub-agent inactivity budget
+- **WHEN** the approval eventually arrives
+- **THEN** the sub-agent applies the approval outcome
+- **AND** the sub-agent is not failed for inactivity during the wait
+
+#### Scenario: Parallel approval waits keep watchdog paused until all settle
+- **GIVEN** a sub-agent tool batch with two approval-gated calls
+- **WHEN** both calls are waiting for parent approval
+- **THEN** the watchdog remains paused until both approval waits have settled
+- **AND** the watchdog is re-armed only after the final wait completes
+
+### Requirement: Sub-agent approval outcomes settle exactly once
+
+Each sub-agent approval-gated tool call SHALL settle exactly once as approved, denied, timed out, or cancelled. Approved decisions SHALL retry only the blocked call with retry-local approval state. Denied and timed-out decisions SHALL become tool-result messages visible to the sub-agent LLM. Cancellation and actor termination SHALL not produce duplicate `SubAgentResult` messages.
+
+#### Scenario: Approve once is retry-local
+- **GIVEN** a sub-agent approval-gated tool call is approved once
+- **WHEN** the sub-agent retries the blocked call
+- **THEN** the retry-local approval applies only to that tool call
+- **AND** sibling calls, later tool iterations, and later sub-agent runs still require approval when policy requires it
+
+#### Scenario: Denied approval becomes tool result
+- **GIVEN** a sub-agent approval-gated tool call is denied by the user
+- **WHEN** the approval decision is delivered
+- **THEN** the tool is not executed
+- **AND** the sub-agent receives a tool-result message explaining that approval was denied
+- **AND** the sub-agent may continue or finish within the normal tool-iteration limit
+
+#### Scenario: Timed-out approval becomes tool result
+- **GIVEN** a sub-agent approval-gated tool call receives an expired or timed-out approval decision
+- **WHEN** the decision is delivered to the sub-agent
+- **THEN** the tool is not executed
+- **AND** the sub-agent receives a tool-result message explaining that approval timed out
+
+#### Scenario: Terminal races complete once
+- **GIVEN** a sub-agent has an in-flight approval wait
+- **WHEN** cancellation, timeout, and approval completion messages race
+- **THEN** the sub-agent sends at most one `SubAgentResult` to the caller
+- **AND** the first terminal path wins

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
@@ -17,6 +17,12 @@ Sub-agent approval waits SHALL be owned by the live `SubAgentActor` run that enc
 - **AND** the sub-agent completes at most once with a failed `SubAgentResult`
 - **AND** the gated tool is not executed after cancellation
 
+#### Scenario: Parent session recovery expires live-only prompt
+- **GIVEN** a sub-agent is waiting for parent approval
+- **WHEN** the parent session cold-recovers before the user responds
+- **THEN** the sub-agent approval prompt has no durable redrive state
+- **AND** a later approval response is rejected as expired
+
 ### Requirement: Sub-agent approval uses parent turn authority
 
 Sub-agent approval prompts SHALL use the parent session turn's execution authority context for approval requester, principal, audience, boundary, channel capability, provenance, adopted-context safety, and filesystem grounding. The implementation SHALL reuse the `TurnContext` or shared execution-authority subset from #1213 when available, and SHALL keep any interim field mapping isolated to the parent-to-child spawn boundary.

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
@@ -34,6 +34,14 @@ Sub-agent approval prompts SHALL use the parent session turn's execution authori
 - **AND** the sub-agent completes with a failed `SubAgentResult`
 - **AND** no default `Personal` audience or synthetic requester is substituted
 
+#### Scenario: Human approval requires requester binding
+- **GIVEN** a sub-agent approval-gated tool call has a parent approval bridge
+- **AND** the parent turn is not verified automation
+- **AND** the parent turn has no requester sender identity or no requester principal
+- **WHEN** approval is required
+- **THEN** no approval prompt is emitted
+- **AND** the sub-agent completes with a failed `SubAgentResult`
+
 ### Requirement: Sub-agent watchdog pauses during human approval
 
 The sub-agent inactivity watchdog SHALL treat parent approval waits as intentional suspension. While one or more approval waits are active, watchdog timeout ticks SHALL NOT complete the sub-agent as inactive. When the last approval wait settles, the watchdog SHALL be re-baselined so future inactivity is still bounded.
@@ -44,6 +52,13 @@ The sub-agent inactivity watchdog SHALL treat parent approval waits as intention
 - **WHEN** the approval eventually arrives
 - **THEN** the sub-agent applies the approval outcome
 - **AND** the sub-agent is not failed for inactivity during the wait
+
+#### Scenario: Parent spawn-agent watchdog pauses during approval
+- **GIVEN** a parent session is consuming a streaming `spawn_agent` tool call
+- **AND** the child sub-agent is waiting for human approval longer than the parent tool inactivity budget
+- **WHEN** the approval wait is still active
+- **THEN** the parent `spawn_agent` tool call is not timed out for inactivity
+- **AND** the parent tool watchdog resumes after the approval wait settles
 
 #### Scenario: Parallel approval waits keep watchdog paused until all settle
 - **GIVEN** a sub-agent tool batch with two approval-gated calls

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/netclaw-subagents/spec.md
@@ -31,7 +31,7 @@ Sub-agent approval prompts SHALL use the parent session turn's execution authori
 - **GIVEN** a sub-agent approval-gated tool call has no parent approval bridge or required authority context
 - **WHEN** approval is required
 - **THEN** the gated tool is not executed
-- **AND** the sub-agent receives an explicit denial-shaped result or terminal failure
+- **AND** the sub-agent completes with a failed `SubAgentResult`
 - **AND** no default `Personal` audience or synthetic requester is substituted
 
 ### Requirement: Sub-agent watchdog pauses during human approval

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Sub-agent approval bridge preserves prompt correlation
+
+Sub-agent approval prompts SHALL use the same channel-agnostic `ToolInteractionRequest` contract as parent-session tool prompts. The request SHALL preserve call id, tool name, display text, exact blocked patterns, candidate verbs, per-candidate directories, cwd, messy-command flag, computed approval options, requester identity, principal, audience-derived authority, and adopted-context safety metadata from the parent turn authority context.
+
+#### Scenario: Sub-agent prompt includes approval candidates and options
+- **GIVEN** a sub-agent shell tool call requires approval
+- **WHEN** the parent approval bridge emits the prompt
+- **THEN** the prompt includes the exact blocked patterns shown to the user
+- **AND** the prompt includes candidate verbs and per-candidate directories for grant persistence
+- **AND** the prompt includes the same computed approval options the parent approval gate produced
+
+#### Scenario: Sub-agent prompt carries adopted-context safety metadata
+- **GIVEN** a sub-agent was spawned from a parent turn with adopted context
+- **WHEN** the sub-agent emits an approval prompt
+- **THEN** the prompt includes adopted-context and third-party adopted-context flags
+- **AND** the prompt includes adopted speaker ids when present
+
+### Requirement: Sub-agent approval responses do not execute expired work
+
+Approval responses for sub-agent prompts SHALL execute a tool only while the originating sub-agent wait is still live and correlated to the pending call id. A response that arrives after the sub-agent wait was cancelled, completed, or abandoned SHALL fail closed as expired and SHALL NOT execute the gated tool.
+
+#### Scenario: Late approval after cancellation is expired
+- **GIVEN** a sub-agent approval prompt is pending
+- **AND** the parent cancels the `spawn_agent` call before the user responds
+- **WHEN** the user later approves the stale prompt
+- **THEN** the sub-agent tool is not executed
+- **AND** the response is treated as expired or no-longer-pending
+
+#### Scenario: No bridge fails closed
+- **GIVEN** a sub-agent tool call requires approval
+- **AND** no parent approval bridge is available
+- **WHEN** the tool executor reports that approval is required
+- **THEN** no approval prompt is emitted
+- **AND** the gated tool is not executed
+- **AND** the sub-agent receives an explicit denial-shaped tool result or terminal failure

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
@@ -34,4 +34,4 @@ Approval responses for sub-agent prompts SHALL execute a tool only while the ori
 - **WHEN** the tool executor reports that approval is required
 - **THEN** no approval prompt is emitted
 - **AND** the gated tool is not executed
-- **AND** the sub-agent receives an explicit denial-shaped tool result or terminal failure
+- **AND** the sub-agent completes with a failed `SubAgentResult`

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
@@ -28,6 +28,13 @@ Approval responses for sub-agent prompts SHALL execute a tool only while the ori
 - **THEN** the sub-agent tool is not executed
 - **AND** the response is treated as expired or no-longer-pending
 
+#### Scenario: Live session response requires live approval wait
+- **GIVEN** the parent session still has persisted prompt metadata for a sub-agent approval
+- **AND** the child sub-agent approval wait has already been cancelled or completed
+- **WHEN** an approval response arrives while the parent session is processing
+- **THEN** the response is rejected as expired
+- **AND** no approval grant is applied to execute stale sub-agent work
+
 #### Scenario: No bridge fails closed
 - **GIVEN** a sub-agent tool call requires approval
 - **AND** no parent approval bridge is available

--- a/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/specs/tool-approval-gates/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Sub-agent approval bridge preserves prompt correlation
 
-Sub-agent approval prompts SHALL use the same channel-agnostic `ToolInteractionRequest` contract as parent-session tool prompts. The request SHALL preserve call id, tool name, display text, exact blocked patterns, candidate verbs, per-candidate directories, cwd, messy-command flag, computed approval options, requester identity, principal, audience-derived authority, and adopted-context safety metadata from the parent turn authority context.
+Sub-agent approval prompts SHALL use the same channel-agnostic `ToolInteractionRequest` contract as parent-session tool prompts. The request SHALL use a parent-scoped correlation call id that is unique per bridged approval request while preserving the child call id as part of the correlation value. The request SHALL preserve tool name, display text, exact blocked patterns, candidate verbs, per-candidate directories, cwd, messy-command flag, computed approval options, requester identity, principal, audience-derived authority, and adopted-context safety metadata from the parent turn authority context.
 
 #### Scenario: Sub-agent prompt includes approval candidates and options
 - **GIVEN** a sub-agent shell tool call requires approval
@@ -16,6 +16,12 @@ Sub-agent approval prompts SHALL use the same channel-agnostic `ToolInteractionR
 - **WHEN** the sub-agent emits an approval prompt
 - **THEN** the prompt includes adopted-context and third-party adopted-context flags
 - **AND** the prompt includes adopted speaker ids when present
+
+#### Scenario: Duplicate child call ids do not share approval state
+- **GIVEN** two bridged sub-agent approval waits have the same child-local tool call id
+- **WHEN** the parent approval bridge emits prompts for both waits
+- **THEN** each prompt uses a distinct parent-scoped call id
+- **AND** approving one prompt cannot complete or authorize the other wait
 
 ### Requirement: Sub-agent approval responses do not execute expired work
 
@@ -34,6 +40,13 @@ Approval responses for sub-agent prompts SHALL execute a tool only while the ori
 - **WHEN** an approval response arrives while the parent session is processing
 - **THEN** the response is rejected as expired
 - **AND** no approval grant is applied to execute stale sub-agent work
+
+#### Scenario: Durable grant is written only after live wait is claimed
+- **GIVEN** a sub-agent approval response requests a session or persistent grant
+- **AND** the child approval wait is cancelled before the parent claims the response
+- **WHEN** the response is handled
+- **THEN** no durable approval grant is written
+- **AND** the response is rejected as expired
 
 #### Scenario: No bridge fails closed
 - **GIVEN** a sub-agent tool call requires approval

--- a/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
@@ -6,10 +6,13 @@
 ## 2. Approval Lifecycle Implementation
 
 - [x] 2.1 Ensure approval-gated sub-agent calls without a parent approval bridge fail closed with a terminal failed result, and never execute the gated tool.
+- [x] 2.1a Ensure approval-gated sub-agent calls with incomplete parent requester/principal context fail closed before emitting prompts.
 - [x] 2.2 Ensure approved decisions retry only the original blocked tool call with retry-local approval state.
 - [x] 2.3 Ensure denied and timed-out decisions produce tool-result messages and do not execute the gated tool.
 - [x] 2.4 Ensure external cancellation, parent stop, and stale terminal messages complete the sub-agent at most once and cancel pending approval waits.
 - [x] 2.5 Ensure the inactivity watchdog remains paused while one or more parent approval waits are active and is re-baselined when the last wait settles.
+- [x] 2.6 Ensure the parent `spawn_agent` streaming tool watchdog is suspended while the child is waiting for human approval and resumes afterward.
+- [x] 2.7 Ensure live-session approval responses for prompts with no live approval wait are rejected as expired before stale work can execute.
 
 ## 3. Tests
 
@@ -18,6 +21,7 @@
 - [x] 3.3 Add or update sub-agent actor tests for denied and timed-out approval decisions.
 - [x] 3.4 Add or update sub-agent actor tests for cancellation and terminal-race idempotence during approval waits.
 - [x] 3.5 Add or update sub-agent actor tests proving parallel approval waits pause the watchdog until all waits settle.
+- [x] 3.6 Add or update tests for missing parent authority context, cancelled approval-channel waits, parent watchdog suspension, and session-integrated sub-agent approval authority.
 
 ## 4. Validation
 

--- a/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
@@ -1,0 +1,27 @@
+## 1. Context And Contract
+
+- [x] 1.1 Verify current sub-agent approval code maps the parent session authority context from the #1213 field list without synthesizing requester or audience defaults.
+- [x] 1.2 Keep parent-to-child context copying isolated at the `SubAgentSpawner` / `RunSubAgent` boundary so a future `TurnContext` implementation can replace the interim mapping cleanly.
+
+## 2. Approval Lifecycle Implementation
+
+- [x] 2.1 Ensure approval-gated sub-agent calls without a parent approval bridge fail closed with an explicit denial-shaped result or terminal failure, and never execute the gated tool.
+- [x] 2.2 Ensure approved decisions retry only the original blocked tool call with retry-local approval state.
+- [x] 2.3 Ensure denied and timed-out decisions produce tool-result messages and do not execute the gated tool.
+- [x] 2.4 Ensure external cancellation, parent stop, and stale terminal messages complete the sub-agent at most once and cancel pending approval waits.
+- [x] 2.5 Ensure the inactivity watchdog remains paused while one or more parent approval waits are active and is re-baselined when the last wait settles.
+
+## 3. Tests
+
+- [x] 3.1 Add or update sub-agent actor tests for no-bridge fail-closed approval behavior.
+- [x] 3.2 Add or update sub-agent actor tests for approve-once isolation across sibling calls, later iterations, and later sub-agent runs.
+- [x] 3.3 Add or update sub-agent actor tests for denied and timed-out approval decisions.
+- [x] 3.4 Add or update sub-agent actor tests for cancellation and terminal-race idempotence during approval waits.
+- [x] 3.5 Add or update sub-agent actor tests proving parallel approval waits pause the watchdog until all waits settle.
+
+## 4. Validation
+
+- [x] 4.1 Run targeted sub-agent and approval-gate tests.
+- [x] 4.2 Run `openspec validate redesign-subagent-approval-lifecycle --strict`.
+- [x] 4.3 Run `dotnet slopwatch analyze`.
+- [x] 4.4 Run `./scripts/Add-FileHeaders.ps1 -Verify`.

--- a/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Approval Lifecycle Implementation
 
-- [x] 2.1 Ensure approval-gated sub-agent calls without a parent approval bridge fail closed with an explicit denial-shaped result or terminal failure, and never execute the gated tool.
+- [x] 2.1 Ensure approval-gated sub-agent calls without a parent approval bridge fail closed with a terminal failed result, and never execute the gated tool.
 - [x] 2.2 Ensure approved decisions retry only the original blocked tool call with retry-local approval state.
 - [x] 2.3 Ensure denied and timed-out decisions produce tool-result messages and do not execute the gated tool.
 - [x] 2.4 Ensure external cancellation, parent stop, and stale terminal messages complete the sub-agent at most once and cancel pending approval waits.

--- a/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
+++ b/openspec/changes/redesign-subagent-approval-lifecycle/tasks.md
@@ -13,6 +13,9 @@
 - [x] 2.5 Ensure the inactivity watchdog remains paused while one or more parent approval waits are active and is re-baselined when the last wait settles.
 - [x] 2.6 Ensure the parent `spawn_agent` streaming tool watchdog is suspended while the child is waiting for human approval and resumes afterward.
 - [x] 2.7 Ensure live-session approval responses for prompts with no live approval wait are rejected as expired before stale work can execute.
+- [x] 2.8 Ensure bridged sub-agent approval call ids are parent-scoped and unique per request, even when child-local tool call ids collide.
+- [x] 2.9 Ensure durable approval grants are written only after the live approval wait is atomically claimed.
+- [x] 2.10 Ensure direct parent-session approval waits are cancellable by the active tool-execution token.
 
 ## 3. Tests
 
@@ -22,6 +25,7 @@
 - [x] 3.4 Add or update sub-agent actor tests for cancellation and terminal-race idempotence during approval waits.
 - [x] 3.5 Add or update sub-agent actor tests proving parallel approval waits pause the watchdog until all waits settle.
 - [x] 3.6 Add or update tests for missing parent authority context, cancelled approval-channel waits, parent watchdog suspension, and session-integrated sub-agent approval authority.
+- [x] 3.7 Add or update tests for duplicate approval wait rejection, parent-scoped sub-agent call ids, claimed wait lifecycle, and cancellable direct approval waits.
 
 ## 4. Validation
 

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
@@ -87,6 +87,38 @@ public sealed class ApprovalChannelTests
     }
 
     [Fact]
+    public async Task Duplicate_wait_for_same_call_id_fails_loudly()
+    {
+        var channel = new ApprovalChannel();
+        var callId = new ToolCallId("call-duplicate");
+
+        var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None));
+        Assert.Contains(callId.Value, ex.Message, StringComparison.Ordinal);
+
+        Assert.True(channel.Complete(callId, ApprovalDecision.Denied));
+        Assert.Equal(ApprovalDecision.Denied, await waitTask);
+    }
+
+    [Fact]
+    public async Task Claimed_wait_is_no_longer_pending_but_can_still_complete_waiter()
+    {
+        var channel = new ApprovalChannel();
+        var callId = new ToolCallId("call-claim");
+
+        var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        Assert.True(channel.TryClaim(callId, out var wait));
+        Assert.False(channel.IsPending(callId));
+        Assert.False(channel.Complete(callId, ApprovalDecision.Denied));
+
+        Assert.True(wait.Complete(ApprovalDecision.ApprovedAlways));
+        Assert.Equal(ApprovalDecision.ApprovedAlways, await waitTask);
+    }
+
+    [Fact]
     public async Task Multiple_concurrent_waits()
     {
         var channel = new ApprovalChannel();

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
@@ -22,9 +22,11 @@ public sealed class ApprovalChannelTests
         var callId = new ToolCallId($"call-{decision}");
 
         var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
-        channel.Complete(callId, decision);
+        Assert.True(channel.IsPending(callId));
+        Assert.True(channel.Complete(callId, decision));
 
         Assert.Equal(decision, await waitTask);
+        Assert.False(channel.IsPending(callId));
     }
 
     [Fact]
@@ -64,8 +66,24 @@ public sealed class ApprovalChannelTests
     public void Complete_unknown_callId_is_noop()
     {
         var channel = new ApprovalChannel();
-        // Should not throw
-        channel.Complete(new ToolCallId("nonexistent"), ApprovalDecision.Denied);
+        Assert.False(channel.Complete(new ToolCallId("nonexistent"), ApprovalDecision.Denied));
+    }
+
+    [Fact]
+    public async Task Cancelled_wait_is_no_longer_pending_or_completable()
+    {
+        var channel = new ApprovalChannel();
+        var callId = new ToolCallId("call-cancelled-late");
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), cts.Token);
+        Assert.True(channel.IsPending(callId));
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask);
+
+        Assert.False(channel.IsPending(callId));
+        Assert.False(channel.Complete(callId, ApprovalDecision.ApprovedOnce));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
@@ -22,11 +22,10 @@ public sealed class ApprovalChannelTests
         var callId = new ToolCallId($"call-{decision}");
 
         var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
-        Assert.True(channel.IsPending(callId));
         Assert.True(channel.Complete(callId, decision));
 
         Assert.Equal(decision, await waitTask);
-        Assert.False(channel.IsPending(callId));
+        Assert.False(channel.Complete(callId, decision));
     }
 
     [Fact]
@@ -77,12 +76,10 @@ public sealed class ApprovalChannelTests
         using var cts = new CancellationTokenSource();
 
         var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), cts.Token);
-        Assert.True(channel.IsPending(callId));
 
         await cts.CancelAsync();
         await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask);
 
-        Assert.False(channel.IsPending(callId));
         Assert.False(channel.Complete(callId, ApprovalDecision.ApprovedOnce));
     }
 
@@ -111,7 +108,6 @@ public sealed class ApprovalChannelTests
         var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
 
         Assert.True(channel.TryClaim(callId, out var wait));
-        Assert.False(channel.IsPending(callId));
         Assert.False(channel.Complete(callId, ApprovalDecision.Denied));
 
         Assert.True(wait.Complete(ApprovalDecision.ApprovedAlways));

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -105,4 +105,45 @@ public sealed class ParentSessionApprovalBridgeTests
         Assert.False(emitted.HasThirdPartyAdoptedContext);
         Assert.Equal(["user-123"], emitted.AdoptedSpeakerIds);
     }
+
+    [Fact]
+    public async Task Cancelled_bridge_wait_ignores_late_approval_response()
+    {
+        var channel = new ApprovalChannel();
+        ToolInteractionRequest? emitted = null;
+        var callId = new ToolCallId("call-late");
+        using var cts = new CancellationTokenSource();
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            request => emitted = request,
+            new SessionId("signalr/thread-late"),
+            requesterSenderId: new SenderId("user-123"),
+            requesterPrincipal: PrincipalClassification.Operator,
+            hasAdoptedContext: false,
+            hasThirdPartyAdoptedContext: false,
+            adoptedSpeakerIds: []);
+
+        var waitTask = bridge.RequestApprovalAsync(
+            callId,
+            "shell_execute",
+            "git push origin main",
+            ["git push origin main"],
+            ["git push origin main"],
+            [new ParentApprovalCandidate("git push origin main", "/home/user/repos/foo")],
+            "/home/user/repos/foo",
+            [new ParentApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)],
+            isMessy: false,
+            cts.Token);
+        Assert.NotNull(emitted);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask);
+
+        channel.Complete(callId, ApprovalDecision.ApprovedOnce);
+        var lateWaitResult = await channel.WaitForApprovalAsync(
+            callId,
+            TimeSpan.FromMilliseconds(25),
+            TestContext.Current.CancellationToken);
+        Assert.Equal(ApprovalDecision.TimedOut, lateWaitResult);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -143,7 +143,7 @@ public sealed class ParentSessionApprovalBridgeTests
             TestContext.Current.CancellationToken));
 
         Assert.False(emitted);
-        Assert.False(channel.IsPending(callId));
+        Assert.False(channel.Complete(callId, ApprovalDecision.ApprovedOnce));
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public sealed class ParentSessionApprovalBridgeTests
             TestContext.Current.CancellationToken));
 
         Assert.False(emitted);
-        Assert.False(channel.IsPending(callId));
+        Assert.False(channel.Complete(callId, ApprovalDecision.ApprovedOnce));
     }
 
     [Fact]
@@ -262,7 +262,7 @@ public sealed class ParentSessionApprovalBridgeTests
             Assert.NotEqual(childCallId, dispatch.Request.CallId);
             Assert.Contains(childCallId.Value, dispatch.Request.CallId.Value, StringComparison.Ordinal);
         });
-        Assert.False(channel.IsPending(childCallId));
+        Assert.False(channel.Complete(childCallId, ApprovalDecision.ApprovedOnce));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -18,14 +18,17 @@ public sealed class ParentSessionApprovalBridgeTests
     {
         var channel = new ApprovalChannel();
         ToolInteractionRequest? emitted = null;
+        bool? persistApprovalState = null;
         var bridge = new ParentSessionApprovalBridge(
             channel,
-            request =>
+            dispatch =>
             {
-                emitted = request;
-                channel.Complete(request.CallId, ApprovalDecision.ApprovedOnce);
+                emitted = dispatch.Request;
+                persistApprovalState = dispatch.PersistApprovalState;
+                channel.Complete(dispatch.Request.CallId, ApprovalDecision.ApprovedOnce);
             },
             new SessionId("signalr/thread-1"),
+            approvalScopeId: "spawn-call-1",
             requesterSenderId: new SenderId("user-123"),
             requesterPrincipal: PrincipalClassification.Operator,
             hasAdoptedContext: true,
@@ -57,7 +60,9 @@ public sealed class ParentSessionApprovalBridgeTests
         Assert.True(emitted.HasAdoptedContext);
         Assert.True(emitted.HasThirdPartyAdoptedContext);
         Assert.True(emitted.PersistedAdoptedContext);
-        Assert.False(emitted.PersistApprovalState);
+        Assert.False(persistApprovalState);
+        Assert.NotEqual("call-1", emitted.CallId.Value);
+        Assert.Contains("call-1", emitted.CallId.Value, StringComparison.Ordinal);
         Assert.Equal(["user-123", "user-456"], emitted.AdoptedSpeakerIds);
         Assert.Equal(["grep timeout logs/app.log | wc -l"], emitted.Patterns);
         Assert.Equal(["grep timeout logs/app.log"], emitted.CandidateVerbs);
@@ -76,12 +81,13 @@ public sealed class ParentSessionApprovalBridgeTests
         ToolInteractionRequest? emitted = null;
         var bridge = new ParentSessionApprovalBridge(
             channel,
-            request =>
+            dispatch =>
             {
-                emitted = request;
-                channel.Complete(request.CallId, ApprovalDecision.ApprovedOnce);
+                emitted = dispatch.Request;
+                channel.Complete(dispatch.Request.CallId, ApprovalDecision.ApprovedOnce);
             },
             new SessionId("signalr/thread-2"),
+            approvalScopeId: "spawn-call-2",
             requesterSenderId: new SenderId("user-123"),
             requesterPrincipal: PrincipalClassification.Operator,
             hasAdoptedContext: true,
@@ -117,6 +123,7 @@ public sealed class ParentSessionApprovalBridgeTests
             channel,
             _ => emitted = true,
             new SessionId("signalr/thread-missing-sender"),
+            approvalScopeId: "spawn-call-missing-sender",
             requesterSenderId: null,
             requesterPrincipal: PrincipalClassification.Operator,
             hasAdoptedContext: false,
@@ -149,6 +156,7 @@ public sealed class ParentSessionApprovalBridgeTests
             channel,
             _ => emitted = true,
             new SessionId("signalr/thread-missing-principal"),
+            approvalScopeId: "spawn-call-missing-principal",
             requesterSenderId: new SenderId("user-123"),
             requesterPrincipal: null,
             hasAdoptedContext: false,
@@ -178,12 +186,13 @@ public sealed class ParentSessionApprovalBridgeTests
         ToolInteractionRequest? emitted = null;
         var bridge = new ParentSessionApprovalBridge(
             channel,
-            request =>
+            dispatch =>
             {
-                emitted = request;
-                channel.Complete(request.CallId, ApprovalDecision.ApprovedOnce);
+                emitted = dispatch.Request;
+                channel.Complete(dispatch.Request.CallId, ApprovalDecision.ApprovedOnce);
             },
             new SessionId("reminder/thread-automation"),
+            approvalScopeId: "spawn-call-automation",
             requesterSenderId: null,
             requesterPrincipal: PrincipalClassification.VerifiedAutomation,
             hasAdoptedContext: false,
@@ -209,6 +218,54 @@ public sealed class ParentSessionApprovalBridgeTests
     }
 
     [Fact]
+    public async Task Bridge_namespaces_duplicate_child_call_ids_per_request()
+    {
+        var channel = new ApprovalChannel();
+        var emitted = new List<ToolInteractionRequestDispatch>();
+        var gate = new object();
+        var childCallId = new ToolCallId("call-duplicate-child");
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            dispatch =>
+            {
+                lock (gate)
+                {
+                    emitted.Add(dispatch);
+                    if (emitted.Count == 2)
+                    {
+                        channel.Complete(emitted[0].Request.CallId, ApprovalDecision.ApprovedOnce);
+                        channel.Complete(emitted[1].Request.CallId, ApprovalDecision.Denied);
+                    }
+                }
+            },
+            new SessionId("signalr/thread-duplicates"),
+            approvalScopeId: "spawn-call-duplicates",
+            requesterSenderId: new SenderId("user-123"),
+            requesterPrincipal: PrincipalClassification.Operator,
+            hasAdoptedContext: false,
+            hasThirdPartyAdoptedContext: false,
+            adoptedSpeakerIds: []);
+
+        var first = RequestShellApprovalAsync(bridge, childCallId);
+        var second = RequestShellApprovalAsync(bridge, childCallId);
+
+        var decisions = await Task.WhenAll(first, second).WaitAsync(
+            TimeSpan.FromSeconds(3),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal([ParentApprovalDecision.ApprovedOnce, ParentApprovalDecision.Denied], decisions);
+        Assert.Equal(2, emitted.Count);
+        Assert.NotEqual(emitted[0].Request.CallId, emitted[1].Request.CallId);
+        Assert.All(emitted, dispatch =>
+        {
+            Assert.False(dispatch.PersistApprovalState);
+            Assert.NotEqual(childCallId, dispatch.Request.CallId);
+            Assert.Contains(childCallId.Value, dispatch.Request.CallId.Value, StringComparison.Ordinal);
+        });
+        Assert.False(channel.IsPending(childCallId));
+    }
+
+    [Fact]
     public async Task Cancelled_bridge_wait_ignores_late_approval_response()
     {
         var channel = new ApprovalChannel();
@@ -217,8 +274,9 @@ public sealed class ParentSessionApprovalBridgeTests
         using var cts = new CancellationTokenSource();
         var bridge = new ParentSessionApprovalBridge(
             channel,
-            request => emitted = request,
+            dispatch => emitted = dispatch.Request,
             new SessionId("signalr/thread-late"),
+            approvalScopeId: "spawn-call-late",
             requesterSenderId: new SenderId("user-123"),
             requesterPrincipal: PrincipalClassification.Operator,
             hasAdoptedContext: false,
@@ -241,11 +299,26 @@ public sealed class ParentSessionApprovalBridgeTests
         await cts.CancelAsync();
         await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask);
 
-        Assert.False(channel.Complete(callId, ApprovalDecision.ApprovedOnce));
+        Assert.False(channel.Complete(emitted!.CallId, ApprovalDecision.ApprovedOnce));
         var lateWaitResult = await channel.WaitForApprovalAsync(
             callId,
             TimeSpan.FromMilliseconds(25),
             TestContext.Current.CancellationToken);
         Assert.Equal(ApprovalDecision.TimedOut, lateWaitResult);
     }
+
+    private static Task<ParentApprovalDecision> RequestShellApprovalAsync(
+        ParentSessionApprovalBridge bridge,
+        ToolCallId callId)
+        => bridge.RequestApprovalAsync(
+            callId,
+            "shell_execute",
+            "git push origin main",
+            ["git push origin main"],
+            ["git push origin main"],
+            [new ParentApprovalCandidate("git push origin main", "/home/user/repos/foo")],
+            "/home/user/repos/foo",
+            [new ParentApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)],
+            isMessy: false,
+            TestContext.Current.CancellationToken);
 }

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -57,6 +57,7 @@ public sealed class ParentSessionApprovalBridgeTests
         Assert.True(emitted.HasAdoptedContext);
         Assert.True(emitted.HasThirdPartyAdoptedContext);
         Assert.True(emitted.PersistedAdoptedContext);
+        Assert.False(emitted.PersistApprovalState);
         Assert.Equal(["user-123", "user-456"], emitted.AdoptedSpeakerIds);
         Assert.Equal(["grep timeout logs/app.log | wc -l"], emitted.Patterns);
         Assert.Equal(["grep timeout logs/app.log"], emitted.CandidateVerbs);
@@ -107,6 +108,107 @@ public sealed class ParentSessionApprovalBridgeTests
     }
 
     [Fact]
+    public async Task Bridge_without_human_requester_sender_fails_without_emitting_prompt()
+    {
+        var channel = new ApprovalChannel();
+        var emitted = false;
+        var callId = new ToolCallId("call-missing-sender");
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            _ => emitted = true,
+            new SessionId("signalr/thread-missing-sender"),
+            requesterSenderId: null,
+            requesterPrincipal: PrincipalClassification.Operator,
+            hasAdoptedContext: false,
+            hasThirdPartyAdoptedContext: false,
+            adoptedSpeakerIds: []);
+
+        await Assert.ThrowsAsync<ParentApprovalUnavailableException>(() => bridge.RequestApprovalAsync(
+            callId,
+            "shell_execute",
+            "git push origin main",
+            ["git push origin main"],
+            ["git push origin main"],
+            [new ParentApprovalCandidate("git push origin main", "/home/user/repos/foo")],
+            "/home/user/repos/foo",
+            [new ParentApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)],
+            isMessy: false,
+            TestContext.Current.CancellationToken));
+
+        Assert.False(emitted);
+        Assert.False(channel.IsPending(callId));
+    }
+
+    [Fact]
+    public async Task Bridge_without_requester_principal_fails_without_emitting_prompt()
+    {
+        var channel = new ApprovalChannel();
+        var emitted = false;
+        var callId = new ToolCallId("call-missing-principal");
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            _ => emitted = true,
+            new SessionId("signalr/thread-missing-principal"),
+            requesterSenderId: new SenderId("user-123"),
+            requesterPrincipal: null,
+            hasAdoptedContext: false,
+            hasThirdPartyAdoptedContext: false,
+            adoptedSpeakerIds: []);
+
+        await Assert.ThrowsAsync<ParentApprovalUnavailableException>(() => bridge.RequestApprovalAsync(
+            callId,
+            "shell_execute",
+            "git push origin main",
+            ["git push origin main"],
+            ["git push origin main"],
+            [new ParentApprovalCandidate("git push origin main", "/home/user/repos/foo")],
+            "/home/user/repos/foo",
+            [new ParentApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)],
+            isMessy: false,
+            TestContext.Current.CancellationToken));
+
+        Assert.False(emitted);
+        Assert.False(channel.IsPending(callId));
+    }
+
+    [Fact]
+    public async Task Verified_automation_bridge_allows_missing_sender()
+    {
+        var channel = new ApprovalChannel();
+        ToolInteractionRequest? emitted = null;
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            request =>
+            {
+                emitted = request;
+                channel.Complete(request.CallId, ApprovalDecision.ApprovedOnce);
+            },
+            new SessionId("reminder/thread-automation"),
+            requesterSenderId: null,
+            requesterPrincipal: PrincipalClassification.VerifiedAutomation,
+            hasAdoptedContext: false,
+            hasThirdPartyAdoptedContext: false,
+            adoptedSpeakerIds: []);
+
+        var decision = await bridge.RequestApprovalAsync(
+            new ToolCallId("call-automation"),
+            "shell_execute",
+            "git push origin main",
+            ["git push origin main"],
+            ["git push origin main"],
+            [new ParentApprovalCandidate("git push origin main", "/home/user/repos/foo")],
+            "/home/user/repos/foo",
+            [new ParentApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)],
+            isMessy: false,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ParentApprovalDecision.ApprovedOnce, decision);
+        Assert.NotNull(emitted);
+        Assert.Null(emitted!.RequesterSenderId);
+        Assert.Equal(PrincipalClassification.VerifiedAutomation, emitted.RequesterPrincipal);
+    }
+
+    [Fact]
     public async Task Cancelled_bridge_wait_ignores_late_approval_response()
     {
         var channel = new ApprovalChannel();
@@ -139,7 +241,7 @@ public sealed class ParentSessionApprovalBridgeTests
         await cts.CancelAsync();
         await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask);
 
-        channel.Complete(callId, ApprovalDecision.ApprovedOnce);
+        Assert.False(channel.Complete(callId, ApprovalDecision.ApprovedOnce));
         var lateWaitResult = await channel.WaitForApprovalAsync(
             callId,
             TimeSpan.FromMilliseconds(25),

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
@@ -52,7 +52,8 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
-            backgroundJobManager: jobManagerProbe.Ref);
+            backgroundJobManager: jobManagerProbe.Ref,
+            ct: TestContext.Current.CancellationToken);
 
         var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
             TimeSpan.FromSeconds(5),
@@ -98,7 +99,8 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
-            backgroundJobManager: fakeJobManager);
+            backgroundJobManager: fakeJobManager,
+            ct: TestContext.Current.CancellationToken);
 
         var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
             TimeSpan.FromSeconds(5),
@@ -146,7 +148,8 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
-            backgroundJobManager: fakeJobManager);
+            backgroundJobManager: fakeJobManager,
+            ct: TestContext.Current.CancellationToken);
 
         await probe.ExpectMsgAsync<ToolExecutionCompleted>(
             TimeSpan.FromSeconds(5),
@@ -187,7 +190,8 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
-            backgroundJobManager: jobManagerProbe.Ref);
+            backgroundJobManager: jobManagerProbe.Ref,
+            ct: TestContext.Current.CancellationToken);
 
         var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
             TimeSpan.FromSeconds(5),
@@ -229,7 +233,8 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
-            backgroundJobManager: jobManagerProbe.Ref);
+            backgroundJobManager: jobManagerProbe.Ref,
+            ct: TestContext.Current.CancellationToken);
 
         var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
             TimeSpan.FromSeconds(5),

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/StreamingToolCallTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/StreamingToolCallTests.cs
@@ -150,9 +150,10 @@ public sealed class StreamingToolCallTests
             },
             TestContext.Current.CancellationToken);
 
-        channel.Writer.TryWrite(new ToolActivityUpdate(
-            "awaiting human approval",
-            SuspendsInactivityWatchdog: true));
+        channel.Writer.TryWrite(new ToolActivityUpdate("awaiting human approval")
+        {
+            SuspendsInactivityWatchdog = true
+        });
         await firstActivitySeen.Task;
 
         time.Advance(TimeSpan.FromMinutes(5));

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/StreamingToolCallTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/StreamingToolCallTests.cs
@@ -128,6 +128,44 @@ public sealed class StreamingToolCallTests
     }
 
     [Fact]
+    public async Task Suspended_activity_pauses_watchdog_until_next_activity()
+    {
+        var time = new FakeTimeProvider();
+        var channel = Channel.CreateUnbounded<ToolCallUpdate>();
+        var activityCount = 0;
+        var firstActivitySeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondActivitySeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = StreamingToolWatchdog.ConsumeAsync(
+            channel.Reader.ReadAllAsync(TestContext.Current.CancellationToken),
+            "spawn_agent",
+            FiveSeconds,
+            time,
+            onActivity: _ =>
+            {
+                if (Interlocked.Increment(ref activityCount) == 1)
+                    firstActivitySeen.TrySetResult();
+                else
+                    secondActivitySeen.TrySetResult();
+            },
+            TestContext.Current.CancellationToken);
+
+        channel.Writer.TryWrite(new ToolActivityUpdate(
+            "awaiting human approval",
+            SuspendsInactivityWatchdog: true));
+        await firstActivitySeen.Task;
+
+        time.Advance(TimeSpan.FromMinutes(5));
+        Assert.False(task.IsCompleted);
+
+        channel.Writer.TryWrite(new ToolActivityUpdate("approval resolved"));
+        await secondActivitySeen.Task;
+        time.Advance(TimeSpan.FromSeconds(6));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => task);
+    }
+
+    [Fact]
     public async Task Concurrent_calls_are_bounded_independently()
     {
         var time = new FakeTimeProvider();

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -232,7 +232,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             TimeSpan.FromSeconds(3),
             cancellationToken: TestContext.Current.CancellationToken);
         Assert.IsType<TimeoutException>(failed.Cause);
-        Assert.False(approvalChannel.IsPending(approvalRequest.CallId));
+        Assert.False(approvalChannel.Complete(approvalRequest.CallId, ApprovalDecision.ApprovedOnce));
         await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -59,8 +59,9 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
             approvalChannel: approvalChannel,
-            emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request),
-            approvalTimeout: Timeout.InfiniteTimeSpan);
+            emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request.Request),
+            approvalTimeout: Timeout.InfiniteTimeSpan,
+            ct: TestContext.Current.CancellationToken);
 
         var approvalRequest = await approvalRequestTcs.Task.WaitAsync(
             TimeSpan.FromSeconds(3),
@@ -112,8 +113,9 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
             approvalChannel: approvalChannel,
-            emitApprovalRequest: request => approvals.Add(request),
-            approvalTimeout: Timeout.InfiniteTimeSpan);
+            emitApprovalRequest: request => approvals.Add(request.Request),
+            approvalTimeout: Timeout.InfiniteTimeSpan,
+            ct: TestContext.Current.CancellationToken);
 
         await AwaitAssertAsync(() =>
         {
@@ -168,8 +170,9 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
             approvalChannel: approvalChannel,
-            emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request),
-            approvalTimeout: Timeout.InfiniteTimeSpan);
+            emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request.Request),
+            approvalTimeout: Timeout.InfiniteTimeSpan,
+            ct: TestContext.Current.CancellationToken);
 
         var approvalRequest = await approvalRequestTcs.Task.WaitAsync(
             TimeSpan.FromSeconds(3),
@@ -181,6 +184,55 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         await probe.ExpectMsgAsync<ToolExecutionCompleted>(
             TimeSpan.FromSeconds(3),
             cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Approval_wait_is_cancelled_by_tool_execution_token()
+    {
+        var executor = new ApprovalThenSuccessExecutor();
+        var approvalChannel = new ApprovalChannel();
+        var probe = CreateTestProbe("approval-cancel-probe");
+        var approvalRequestTcs = new TaskCompletionSource<ToolInteractionRequest>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var executionCts = new CancellationTokenSource();
+
+        var toolCalls = new List<FunctionCallContent>
+        {
+            new("call-cancel", "shell_execute", new Dictionary<string, object?>
+            {
+                ["command"] = "git push origin dev"
+            })
+        };
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            toolCalls,
+            new SessionId("D1/approval-cancel-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: Path.GetTempPath(),
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(5),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            approvalChannel: approvalChannel,
+            emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request.Request),
+            approvalTimeout: Timeout.InfiniteTimeSpan,
+            ct: executionCts.Token);
+
+        var approvalRequest = await approvalRequestTcs.Task.WaitAsync(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await executionCts.CancelAsync();
+
+        var failed = await probe.ExpectMsgAsync<ToolExecutionFailed>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.IsType<TimeoutException>(failed.Cause);
+        Assert.False(approvalChannel.IsPending(approvalRequest.CallId));
         await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
     }
 
@@ -208,7 +260,8 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             timeout: TimeSpan.FromSeconds(1),
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
-            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()));
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            ct: TestContext.Current.CancellationToken);
 
         // Real-time: the slow tool's per-call watchdog trips ~1-2s in (1s budget
         // plus the 1s poll interval). The ceiling stays tight so a regression —

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -29,6 +29,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
 
     private readonly RecordingRoleChatClientProvider _clientProvider = new();
     private RecordingContextTool? _recordingFileReadTool;
+    private RecordingContextTool? _recordingShellTool;
 
     public SubAgentSpawnIntegrationTests(ITestOutputHelper output) : base(output)
     {
@@ -127,8 +128,16 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         services.AddSingleton(skillRegistry);
 
         var registry = new ToolRegistry();
+        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Approval
+            }
+        };
         var toolAccessPolicy = new ToolAccessPolicy(
-            new ToolConfig(),
+            toolConfig,
             new EffectivePolicyDefaults(
                 DeploymentPosture.Personal,
                 TrustAudience.Personal,
@@ -148,6 +157,16 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             Visibility = SubAgentVisibility.UserFacing,
             EmitStructuredFindings = false
         });
+        subAgentRegistry.Register(new SubAgentProfile
+        {
+            Name = "sheller",
+            Description = "Run approved shell commands",
+            SystemPrompt = "You run shell commands when approved.",
+            ToolNames = ["shell_execute"],
+            ModelRole = ModelRole.Compaction,
+            Visibility = SubAgentVisibility.UserFacing,
+            EmitStructuredFindings = false
+        });
 
         var spawner = new SubAgentSpawner(
             _clientProvider,
@@ -160,6 +179,8 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         registry.Register(new SpawnAgentTool(subAgentRegistry, spawner, subAgentPaths));
         _recordingFileReadTool = new RecordingContextTool("file_read", "stub file content", "file");
         registry.Register(_recordingFileReadTool);
+        _recordingShellTool = new RecordingContextTool("shell_execute", "shell ok", "shell");
+        registry.Register(_recordingShellTool);
 
         services.AddSingleton(registry);
         services.AddSingleton(subAgentRegistry);
@@ -237,6 +258,163 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             m.Role == Microsoft.Extensions.AI.ChatRole.System && (m.Text?.Contains("test assistant with subagent support", StringComparison.Ordinal) ?? false));
         Assert.DoesNotContain(subagentCall, m =>
             m.Role == Microsoft.Extensions.AI.ChatRole.User && (m.Text?.Contains("Use a subagent to summarize the file", StringComparison.Ordinal) ?? false));
+    }
+
+    [Fact]
+    public async Task Spawn_agent_subagent_approval_uses_parent_authority_and_resumes_after_approval()
+    {
+        _clientProvider.Main.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-spawn-shell",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "sheller",
+                    ["task"] = "Push the current branch"
+                })
+        ];
+        _clientProvider.Compaction.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-subagent-shell",
+                "shell_execute",
+                new Dictionary<string, object?>
+                {
+                    ["Command"] = "git push origin main"
+                })
+        ];
+
+        var sessionId = new SessionId("console/subagent-approval-integration");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-approval-events");
+        var source = BuildPersonalSource();
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use a subagent to push the branch",
+            Source = source
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("spawn_agent", toolCall.ToolName.Value);
+
+        var started = await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(SubAgentPhase.Started, started.Phase);
+
+        var request = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("call-subagent-shell", request.CallId.Value);
+        Assert.Equal("shell_execute", request.ToolName.Value);
+        Assert.Equal(source.SenderId, request.RequesterSenderId);
+        Assert.Equal(source.Principal, request.RequesterPrincipal);
+        Assert.False(request.PersistApprovalState);
+        Assert.Contains(request.Options, o => o.Key.Value == ApprovalOptionKeys.ApproveOnce);
+
+        var approvalReply = await sessionManager.Ask<ICommandReply>(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = request.CallId,
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.ApproveOnce),
+            SenderId = source.SenderId!
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.IsType<CommandAck>(approvalReply);
+
+        var completed = await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(SubAgentPhase.Completed, completed.Phase);
+        Assert.True(completed.Success);
+
+        var result = await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("spawn_agent", result.ToolName.Value);
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(_recordingShellTool);
+        Assert.True(_recordingShellTool!.WasCalled);
+        Assert.Equal(TrustAudience.Personal, _recordingShellTool.LastContext?.Audience);
+    }
+
+    [Fact]
+    public async Task Spawn_agent_subagent_approval_expires_after_parent_session_recovery()
+    {
+        _clientProvider.Main.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-spawn-shell-expire",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "sheller",
+                    ["task"] = "Push the current branch"
+                })
+        ];
+        _clientProvider.Compaction.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-subagent-shell-expire",
+                "shell_execute",
+                new Dictionary<string, object?>
+                {
+                    ["Command"] = "git push origin main"
+                })
+        ];
+
+        var sessionId = new SessionId("console/subagent-approval-expired");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-approval-expired-events");
+        var source = BuildPersonalSource();
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use a subagent to push the branch",
+            Source = source
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        var request = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(request.PersistApprovalState);
+        Assert.False(_recordingShellTool!.WasCalled);
+
+        await ColdRespawnAsync(sessionId);
+
+        var subscriberB = CreateTestProbe("subagent-approval-expired-events-b");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriberB)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        var reply = await sessionManager.Ask<ICommandReply>(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = request.CallId,
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.ApproveOnce),
+            SenderId = source.SenderId!
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var nack = Assert.IsType<CommandNack>(reply);
+        Assert.Equal(ApprovalNackReasons.PromptExpired, nack.Reason);
+        var notice = await subscriberB.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains("expired", notice.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.False(_recordingShellTool.WasCalled);
     }
 
     [Fact]
@@ -554,6 +732,16 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         }
 
         throw new Xunit.Sdk.XunitException("Expected TurnCompleted but only received other session outputs.");
+    }
+
+    private async Task ColdRespawnAsync(SessionId sessionId)
+    {
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}")
+            .ResolveOne(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Watch(child);
+        Sys.Stop(child);
+        await ExpectTerminatedAsync(child, cancellationToken: TestContext.Current.CancellationToken);
     }
 
     private sealed class RecordingRoleChatClientProvider : IChatClientProvider

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -311,11 +311,11 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Assert.Equal(SubAgentPhase.Started, started.Phase);
 
         var request = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal("call-subagent-shell", request.CallId.Value);
+        Assert.NotEqual("call-subagent-shell", request.CallId.Value);
+        Assert.Contains("call-subagent-shell", request.CallId.Value, StringComparison.Ordinal);
         Assert.Equal("shell_execute", request.ToolName.Value);
         Assert.Equal(source.SenderId, request.RequesterSenderId);
         Assert.Equal(source.Principal, request.RequesterPrincipal);
-        Assert.False(request.PersistApprovalState);
         Assert.Contains(request.Options, o => o.Key.Value == ApprovalOptionKeys.ApproveOnce);
 
         var approvalReply = await sessionManager.Ask<ICommandReply>(new ToolInteractionResponse
@@ -389,7 +389,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         var request = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.False(request.PersistApprovalState);
+        Assert.Contains("call-subagent-shell-expire", request.CallId.Value, StringComparison.Ordinal);
         Assert.False(_recordingShellTool!.WasCalled);
 
         await ColdRespawnAsync(sessionId);

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -335,25 +335,10 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
-    public async Task Approval_gated_tool_is_denied_inside_subagent()
+    public async Task Approval_gated_tool_without_bridge_returns_explicit_denial_result()
     {
         var fakeTool = new FakeNetclawTool("shell_execute", "should not run");
-        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
-        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
-        {
-            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
-            {
-                ["shell_execute"] = ToolApprovalMode.Approval
-            }
-        };
-        var policy = new ToolAccessPolicy(
-            toolConfig,
-            new EffectivePolicyDefaults(
-                DeploymentPosture.Personal,
-                TrustAudience.Personal,
-                ShellExecutionMode.HostAllowed,
-                UsedStrictFallback: false),
-            new ShellCommandPolicy());
+        var policy = CreateApprovalRequiredPolicy();
         var fakeClient = new FakeChatClient
         {
             ToolCallsOnFirstCall =
@@ -373,6 +358,9 @@ public class SubAgentActorTests : TestKit
         Assert.True(result.Success);
         Assert.False(fakeTool.WasCalled);
         Assert.Contains("Response #2", result.Output);
+        Assert.Equal(
+            "Tool access denied: approval_required_without_parent_bridge",
+            GetLastToolResult(fakeClient, "call-approval"));
     }
 
     [Fact]
@@ -384,22 +372,7 @@ public class SubAgentActorTests : TestKit
         // the Always-anywhere button regardless of what the sub-agent's
         // resolved cwd was.
         var fakeTool = new FakeNetclawTool("shell_execute", "ok");
-        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
-        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
-        {
-            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
-            {
-                ["shell_execute"] = ToolApprovalMode.Approval
-            }
-        };
-        var policy = new ToolAccessPolicy(
-            toolConfig,
-            new EffectivePolicyDefaults(
-                DeploymentPosture.Personal,
-                TrustAudience.Personal,
-                ShellExecutionMode.HostAllowed,
-                UsedStrictFallback: false),
-            new ShellCommandPolicy());
+        var policy = CreateApprovalRequiredPolicy();
 
         var fakeClient = new FakeChatClient
         {
@@ -441,22 +414,7 @@ public class SubAgentActorTests : TestKit
     public async Task Approve_once_does_not_leak_between_subagent_tool_calls()
     {
         var fakeTool = new FakeNetclawTool("shell_execute", "ok");
-        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
-        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
-        {
-            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
-            {
-                ["shell_execute"] = ToolApprovalMode.Approval
-            }
-        };
-        var policy = new ToolAccessPolicy(
-            toolConfig,
-            new EffectivePolicyDefaults(
-                DeploymentPosture.Personal,
-                TrustAudience.Personal,
-                ShellExecutionMode.HostAllowed,
-                UsedStrictFallback: false),
-            new ShellCommandPolicy());
+        var policy = CreateApprovalRequiredPolicy();
         var fakeClient = new SequencedToolCallChatClient(
             [
                 new FunctionCallContent(
@@ -494,7 +452,7 @@ public class SubAgentActorTests : TestKit
         // Regression: the sub-agent's inactivity watchdog must not abort a
         // legitimate approval wait. A slow human approver (here, ~1s for a
         // budget of 250ms) should still see the approval delivered and the
-        // sub-agent complete successfully.
+        // sub-agent complete successfully and run the approved tool retry.
         var fakeTool = new FakeNetclawTool("shell_execute", "ok");
         var policy = CreateApprovalRequiredPolicy();
         var fakeClient = new FakeChatClient
@@ -525,17 +483,18 @@ public class SubAgentActorTests : TestKit
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         // Deterministic sync: wait until the sub-agent has actually entered
-        // the approval wait, then hold the wait well past the 250ms budget
-        // (4x) to prove the watchdog stays suppressed. Task.Delay is required
-        // here because the property under test IS that real time elapses
-        // without the watchdog firing — there is no observable condition to
-        // poll on.
+        // the approval wait, then prove the run stays incomplete well past the
+        // 250ms budget before releasing the human decision.
         await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
-        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        await AwaitAssertAsync(
+            () => Assert.False(runTask.IsCompleted),
+            duration: TimeSpan.FromSeconds(1),
+            cancellationToken: TestContext.Current.CancellationToken);
         releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
 
         var result = await runTask;
         Assert.True(result.Success, $"Expected success but got: {result.Output}");
+        Assert.True(fakeTool.WasCalled, "Tool retry after approval did not run");
         Assert.Equal(1, approvalBridge.RequestCount);
     }
 
@@ -593,51 +552,6 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
-    public async Task SubAgent_completes_normally_after_long_approval_wait()
-    {
-        // After the approval clears, the post-approval retry must execute and
-        // the watchdog must resume — i.e. the counter must decrement back to
-        // zero so a subsequent stall would still be caught.
-        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
-        var policy = CreateApprovalRequiredPolicy();
-        var fakeClient = new FakeChatClient
-        {
-            ToolCallsOnFirstCall =
-            [
-                new FunctionCallContent("call-long-wait", "shell_execute",
-                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
-            ]
-        };
-
-        var releaseSignal = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var approvalBridge = new DelayingParentApprovalBridge(releaseSignal.Task);
-
-        var definition = CreateDefinition([fakeTool]);
-        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
-
-        var runTask = agent.Ask<SubAgentResult>(
-            new RunSubAgent
-            {
-                Task = "Push to origin",
-                Timeout = TimeSpan.FromMilliseconds(300),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge
-            },
-            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-
-        // Wait for entry, then hold ~3x the budget (real time required —
-        // verifying the watchdog stays suppressed for that span — there is
-        // no observable to poll on).
-        await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
-        await Task.Delay(TimeSpan.FromMilliseconds(900), TestContext.Current.CancellationToken);
-        releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
-
-        var result = await runTask;
-        Assert.True(result.Success, $"Expected success but got: {result.Output}");
-        Assert.True(fakeTool.WasCalled, "Tool retry after approval did not run");
-    }
-
-    [Fact]
     public async Task SubAgent_parallel_tool_calls_each_awaiting_approval()
     {
         // Two parallel approvals in one assistant batch. The counter must hit
@@ -656,11 +570,56 @@ public class SubAgentActorTests : TestKit
             ]
         };
 
-        // Auto-approves but with a small per-call delay so the two waits
-        // overlap in time. The previous fix would fail this case if a single
-        // wait could exhaust the budget before the second completed.
-        var approvalBridge = new DelayingParentApprovalBridge(
-            decisionFactory: () => Task.Delay(TimeSpan.FromMilliseconds(400)).ContinueWith(_ => ParentApprovalDecision.ApprovedOnce));
+        var releaseSignal = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var approvalBridge = new DelayingParentApprovalBridge(releaseSignal.Task);
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var runTask = agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin twice",
+                // 200ms budget — shorter than the assertion window below, so
+                // a non-paused watchdog would abort before release.
+                Timeout = TimeSpan.FromMilliseconds(200),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge
+            },
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        await AwaitAssertAsync(
+            () => Assert.Equal(2, approvalBridge.RequestCount),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await AwaitAssertAsync(
+            () => Assert.False(runTask.IsCompleted),
+            duration: TimeSpan.FromMilliseconds(500),
+            cancellationToken: TestContext.Current.CancellationToken);
+        releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
+
+        var result = await runTask;
+        Assert.True(result.Success, $"Expected success but got: {result.Output}");
+        Assert.Equal(2, approvalBridge.RequestCount);
+    }
+
+    [Theory]
+    [InlineData(ParentApprovalDecision.Denied, "Tool access denied: approval_denied_by_user")]
+    [InlineData(ParentApprovalDecision.TimedOut, "Tool access denied: approval_timed_out")]
+    public async Task Rejected_approval_returns_tool_result_without_executing_tool(
+        ParentApprovalDecision decision,
+        string expectedToolResult)
+    {
+        var fakeTool = new FakeNetclawTool("shell_execute", "should not run");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-rejected", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+        var approvalBridge = new RecordingParentApprovalBridge(decision);
 
         var definition = CreateDefinition([fakeTool]);
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
@@ -668,17 +627,54 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
-                Task = "Push to origin twice",
-                // 200ms budget — strictly shorter than each approval delay,
-                // so a non-paused watchdog would abort.
-                Timeout = TimeSpan.FromMilliseconds(200),
+                Task = "Push to origin",
+                Timeout = TimeSpan.FromSeconds(5),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge
+            },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.False(fakeTool.WasCalled);
+        Assert.Equal(expectedToolResult, GetLastToolResult(fakeClient, "call-rejected"));
+    }
+
+    [Fact]
+    public async Task External_stop_during_approval_wait_replies_once_and_cancels_wait()
+    {
+        var fakeTool = new FakeNetclawTool("shell_execute", "should not run");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-stop", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+        var neverReleased = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var approvalBridge = new DelayingParentApprovalBridge(neverReleased.Task);
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var runTask = agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin",
+                Timeout = TimeSpan.FromSeconds(10),
                 Audience = TrustAudience.Personal,
                 ApprovalBridge = approvalBridge
             },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
-        Assert.True(result.Success, $"Expected success but got: {result.Output}");
-        Assert.Equal(2, approvalBridge.RequestCount);
+        await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
+        agent.Tell(PoisonPill.Instance);
+
+        var result = await runTask;
+        Assert.False(result.Success);
+        Assert.Contains("stopped", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.False(fakeTool.WasCalled);
     }
 
     private static ToolAccessPolicy CreateApprovalRequiredPolicy()
@@ -699,6 +695,15 @@ public class SubAgentActorTests : TestKit
                 ShellExecutionMode.HostAllowed,
                 UsedStrictFallback: false),
             new ShellCommandPolicy());
+    }
+
+    private static string? GetLastToolResult(FakeChatClient fakeClient, string callId)
+    {
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+        return fakeClient.LastReceivedMessages!
+            .SelectMany(m => m.Contents.OfType<FunctionResultContent>())
+            .Single(r => r.CallId == callId)
+            .Result?.ToString();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -335,7 +335,7 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
-    public async Task Approval_gated_tool_without_bridge_returns_explicit_denial_result()
+    public async Task Approval_gated_tool_without_bridge_fails_subagent_without_executing_tool()
     {
         var fakeTool = new FakeNetclawTool("shell_execute", "should not run");
         var policy = CreateApprovalRequiredPolicy();
@@ -355,12 +355,9 @@ public class SubAgentActorTests : TestKit
             new RunSubAgent { Task = "Try the shell tool", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(result.Success);
+        Assert.False(result.Success);
         Assert.False(fakeTool.WasCalled);
-        Assert.Contains("Response #2", result.Output);
-        Assert.Equal(
-            "Tool access denied: approval_required_without_parent_bridge",
-            GetLastToolResult(fakeClient, "call-approval"));
+        Assert.Contains("approval bridge", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -9,6 +9,7 @@ using Akka.Hosting.TestKit;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Threading.Channels;
 using Netclaw.Actors.SubAgents;
 using Netclaw.Actors.Tools;
 using Netclaw.Actors.Tests.Memory;
@@ -496,6 +497,56 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public async Task SubAgent_approval_wait_activity_suspends_parent_tool_watchdog()
+    {
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var policy = CreateApprovalRequiredPolicy();
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-activity-approval", "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]
+        };
+
+        var releaseSignal = new TaskCompletionSource<ParentApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var approvalBridge = new DelayingParentApprovalBridge(releaseSignal.Task);
+        var activityChannel = Channel.CreateUnbounded<ToolActivityUpdate>();
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy));
+
+        var runTask = agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Push to origin",
+                Timeout = TimeSpan.FromSeconds(5),
+                Audience = TrustAudience.Personal,
+                ApprovalBridge = approvalBridge,
+                ActivitySink = activityChannel.Writer
+            },
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
+        var waitingActivity = await ReadActivityAsync(
+            activityChannel.Reader,
+            "awaiting human approval",
+            TestContext.Current.CancellationToken);
+        Assert.True(waitingActivity.SuspendsInactivityWatchdog);
+
+        releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
+        var resolvedActivity = await ReadActivityAsync(
+            activityChannel.Reader,
+            "approval resolved",
+            TestContext.Current.CancellationToken);
+        Assert.False(resolvedActivity.SuspendsInactivityWatchdog);
+
+        var result = await runTask;
+        Assert.True(result.Success, $"Expected success but got: {result.Output}");
+    }
+
+    [Fact]
     public async Task SubAgent_cancels_promptly_on_external_cancellation_during_approval_wait()
     {
         // External cancellation (parent passivation, daemon restart, user
@@ -701,6 +752,23 @@ public class SubAgentActorTests : TestKit
             .SelectMany(m => m.Contents.OfType<FunctionResultContent>())
             .Single(r => r.CallId == callId)
             .Result?.ToString();
+    }
+
+    private static async Task<ToolActivityUpdate> ReadActivityAsync(
+        ChannelReader<ToolActivityUpdate> reader,
+        string phase,
+        CancellationToken ct)
+    {
+        while (await reader.WaitToReadAsync(ct))
+        {
+            while (reader.TryRead(out var activity))
+            {
+                if (string.Equals(activity.Phase, phase, StringComparison.Ordinal))
+                    return activity;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"Expected activity phase '{phase}'.");
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -484,10 +484,7 @@ public class SubAgentActorTests : TestKit
         // the approval wait, then prove the run stays incomplete well past the
         // 250ms budget before releasing the human decision.
         await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
-        await AwaitAssertAsync(
-            () => Assert.False(runTask.IsCompleted),
-            duration: TimeSpan.FromSeconds(1),
-            cancellationToken: TestContext.Current.CancellationToken);
+        await AssertNotCompletedWithinAsync(runTask, TimeSpan.FromSeconds(1));
         releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
 
         var result = await runTask;
@@ -639,10 +636,7 @@ public class SubAgentActorTests : TestKit
         await AwaitAssertAsync(
             () => Assert.Equal(2, approvalBridge.RequestCount),
             cancellationToken: TestContext.Current.CancellationToken);
-        await AwaitAssertAsync(
-            () => Assert.False(runTask.IsCompleted),
-            duration: TimeSpan.FromMilliseconds(500),
-            cancellationToken: TestContext.Current.CancellationToken);
+        await AssertNotCompletedWithinAsync(runTask, TimeSpan.FromMilliseconds(500));
         releaseSignal.SetResult(ParentApprovalDecision.ApprovedOnce);
 
         var result = await runTask;
@@ -769,6 +763,20 @@ public class SubAgentActorTests : TestKit
         }
 
         throw new Xunit.Sdk.XunitException($"Expected activity phase '{phase}'.");
+    }
+
+    private static async Task AssertNotCompletedWithinAsync(Task<SubAgentResult> task, TimeSpan duration)
+    {
+        try
+        {
+            var result = await task.WaitAsync(duration, TestContext.Current.CancellationToken);
+            throw new Xunit.Sdk.XunitException(
+                $"Expected sub-agent run to remain pending for {duration}, but it completed: {result.Output}");
+        }
+        catch (TimeoutException)
+        {
+            return;
+        }
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -391,13 +391,6 @@ public sealed record ToolInteractionRequest : SessionOutput
     public required IReadOnlyList<ToolInteractionOption> Options { get; init; }
 
     /// <summary>
-    /// Whether the session actor should journal this approval request for cold
-    /// re-drive. Parent-session tool approvals are durable; sub-agent approvals
-    /// are live child-actor waits and must expire on restart instead.
-    /// </summary>
-    public bool PersistApprovalState { get; init; } = true;
-
-    /// <summary>
     /// True when the executable request was accompanied by quoted adopted context.
     /// </summary>
     public bool HasAdoptedContext { get; init; }

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -391,6 +391,13 @@ public sealed record ToolInteractionRequest : SessionOutput
     public required IReadOnlyList<ToolInteractionOption> Options { get; init; }
 
     /// <summary>
+    /// Whether the session actor should journal this approval request for cold
+    /// re-drive. Parent-session tool approvals are durable; sub-agent approvals
+    /// are live child-actor waits and must expire on restart instead.
+    /// </summary>
+    public bool PersistApprovalState { get; init; } = true;
+
+    /// <summary>
     /// True when the executable request was accompanied by quoted adopted context.
     /// </summary>
     public bool HasAdoptedContext { get; init; }

--- a/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
+++ b/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
@@ -57,10 +57,16 @@ internal interface IApprovalChannel
     Task<ApprovalDecision> WaitForApprovalAsync(ToolCallId callId, TimeSpan timeout, CancellationToken ct);
 
     /// <summary>
-    /// Completes a pending approval request. Called by the session actor when a
-    /// <see cref="Protocol.ToolInteractionResponse"/> message arrives.
+    /// Returns true when a live tool task is still waiting on <paramref name="callId"/>.
     /// </summary>
-    void Complete(ToolCallId callId, ApprovalDecision decision);
+    bool IsPending(ToolCallId callId);
+
+    /// <summary>
+    /// Completes a pending approval request. Called by the session actor when a
+    /// <see cref="Protocol.ToolInteractionResponse"/> message arrives. Returns
+    /// false when the prompt is no longer backed by a live wait.
+    /// </summary>
+    bool Complete(ToolCallId callId, ApprovalDecision decision);
 }
 
 /// <summary>
@@ -97,9 +103,14 @@ internal sealed class ApprovalChannel : IApprovalChannel
         }
     }
 
-    public void Complete(ToolCallId callId, ApprovalDecision decision)
+    public bool IsPending(ToolCallId callId)
+        => _pending.ContainsKey(callId);
+
+    public bool Complete(ToolCallId callId, ApprovalDecision decision)
     {
         if (_pending.TryGetValue(callId, out var tcs))
-            tcs.TrySetResult(decision);
+            return tcs.TrySetResult(decision);
+
+        return false;
     }
 }

--- a/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
+++ b/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
@@ -58,11 +58,6 @@ internal interface IApprovalChannel
     Task<ApprovalDecision> WaitForApprovalAsync(ToolCallId callId, TimeSpan timeout, CancellationToken ct);
 
     /// <summary>
-    /// Returns true when a live tool task is still waiting on <paramref name="callId"/>.
-    /// </summary>
-    bool IsPending(ToolCallId callId);
-
-    /// <summary>
     /// Atomically claims a pending approval request so no later response can use
     /// the same prompt while the session persists any required grant state.
     /// Returns false when the prompt is no longer backed by a live wait.
@@ -127,9 +122,6 @@ internal sealed class ApprovalChannel : IApprovalChannel
             TryRemoveExact(callId, tcs);
         }
     }
-
-    public bool IsPending(ToolCallId callId)
-        => _pending.ContainsKey(callId);
 
     public bool TryClaim(ToolCallId callId, out ClaimedApprovalWait wait)
     {

--- a/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
+++ b/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Sessions;
@@ -62,11 +63,33 @@ internal interface IApprovalChannel
     bool IsPending(ToolCallId callId);
 
     /// <summary>
-    /// Completes a pending approval request. Called by the session actor when a
-    /// <see cref="Protocol.ToolInteractionResponse"/> message arrives. Returns
-    /// false when the prompt is no longer backed by a live wait.
+    /// Atomically claims a pending approval request so no later response can use
+    /// the same prompt while the session persists any required grant state.
+    /// Returns false when the prompt is no longer backed by a live wait.
+    /// </summary>
+    bool TryClaim(ToolCallId callId, out ClaimedApprovalWait wait);
+
+    /// <summary>
+    /// Completes a pending approval request. Called by tests and simple callers
+    /// that do not need a separate claim/persist/complete sequence.
     /// </summary>
     bool Complete(ToolCallId callId, ApprovalDecision decision);
+}
+
+/// <summary>
+/// A live approval wait that has been removed from the pending map but has not
+/// yet been completed. This lets the session claim the user response before
+/// writing durable grant state, closing stale-click races.
+/// </summary>
+internal sealed class ClaimedApprovalWait
+{
+    private readonly TaskCompletionSource<ApprovalDecision> _completion;
+
+    public ClaimedApprovalWait(TaskCompletionSource<ApprovalDecision> completion)
+        => _completion = completion;
+
+    public bool Complete(ApprovalDecision decision)
+        => _completion.TrySetResult(decision);
 }
 
 /// <summary>
@@ -79,7 +102,9 @@ internal sealed class ApprovalChannel : IApprovalChannel
 
     public async Task<ApprovalDecision> WaitForApprovalAsync(ToolCallId callId, TimeSpan timeout, CancellationToken ct)
     {
-        var tcs = _pending.GetOrAdd(callId, _ => new TaskCompletionSource<ApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously));
+        var tcs = new TaskCompletionSource<ApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_pending.TryAdd(callId, tcs))
+            throw new InvalidOperationException($"Approval wait for call '{callId}' is already pending.");
 
         try
         {
@@ -99,18 +124,31 @@ internal sealed class ApprovalChannel : IApprovalChannel
         }
         finally
         {
-            _pending.TryRemove(callId, out _);
+            TryRemoveExact(callId, tcs);
         }
     }
 
     public bool IsPending(ToolCallId callId)
         => _pending.ContainsKey(callId);
 
-    public bool Complete(ToolCallId callId, ApprovalDecision decision)
+    public bool TryClaim(ToolCallId callId, out ClaimedApprovalWait wait)
     {
-        if (_pending.TryGetValue(callId, out var tcs))
-            return tcs.TrySetResult(decision);
+        if (_pending.TryRemove(callId, out var tcs))
+        {
+            wait = new ClaimedApprovalWait(tcs);
+            return true;
+        }
 
+        wait = null!;
         return false;
+    }
+
+    public bool Complete(ToolCallId callId, ApprovalDecision decision)
+        => TryClaim(callId, out var wait) && wait.Complete(decision);
+
+    private bool TryRemoveExact(ToolCallId callId, TaskCompletionSource<ApprovalDecision> tcs)
+    {
+        var pair = new KeyValuePair<ToolCallId, TaskCompletionSource<ApprovalDecision>>(callId, tcs);
+        return ((ICollection<KeyValuePair<ToolCallId, TaskCompletionSource<ApprovalDecision>>>)_pending).Remove(pair);
     }
 }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3588,7 +3588,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            if (!_approvalChannel.TryClaim(msg.CallId, out claimedWait))
+            if (!_approvalChannel.TryClaim(msg.CallId, out var approvalWait))
             {
                 _log.Warning(
                     "Ignoring tool interaction response for call {CallId}: prompt no longer has a live approval wait",
@@ -3597,13 +3597,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 TryReplyNack(ApprovalNackReasons.PromptExpired);
                 return;
             }
+            claimedWait = approvalWait;
 
             if (!pending.PersistApprovalState)
                 _pendingToolInteractions.Remove(msg.CallId.Value);
 
             await PersistApprovalGrantIfNeededAsync(pending, decision, CancellationToken.None);
-            var approvalWait = claimedWait
-                ?? throw new InvalidOperationException("Approval wait claim succeeded without a wait handle.");
 
             if (!pending.PersistApprovalState)
             {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -131,6 +131,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // HTTP layer so timed-out connections are released.
     private CancellationTokenSource? _activeLlmCts;
 
+    // Actor-owned CTS for active tool execution. Cancels direct approval waits
+    // and tool calls when the session stops, restarts, or fails the turn.
+    private CancellationTokenSource? _activeToolExecutionCts;
+
     // Correlation ID for the active LLM call. Incremented in FireLlmCall.
     // Stale LlmResponseReceived/LlmCallFailed/LlmResponseDeltaReceived messages
     // from cancelled calls are ignored when their CallId doesn't match.
@@ -512,6 +516,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<ToolExecutionBatchCompleted>(_ =>
         {
             _watchdog.Stop(Timers);
+            CancelAndDisposeToolExecutionCts();
             _activeToolBatch.MarkExecutionTaskCompleted();
             TryCompleteStreamedToolBatch();
         });
@@ -521,6 +526,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<ToolExecutionFailed>(msg =>
         {
             _watchdog.Stop(Timers);
+            CancelAndDisposeToolExecutionCts();
             TurnLog().Error(msg.Cause, "turn_tool_execution_failed");
 
             const string errorMessage = "I encountered an error executing a tool. Please try again.";
@@ -528,48 +534,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             FailCurrentTurn(errorMessage, msg.Cause, category);
         });
 
-        Command<ToolInteractionRequest>(msg =>
-        {
-            var evt = new ToolApprovalRequested
-            {
-                SessionId = _sessionId,
-                CallId = msg.CallId.Value,
-                ToolName = msg.ToolName.Value,
-                Patterns = msg.Patterns,
-                CandidateVerbs = msg.CandidateVerbs,
-                Audience = CurrentTurnAudience(),
-                Boundary = _currentTurnSource?.Boundary,
-                ChannelType = _currentTurnSource?.ChannelType.ToWireValue(),
-                SupportsInteractiveApproval = _currentTurnSource?.ChannelType.SupportsInteractiveApproval(),
-                RequesterSenderId = msg.RequesterSenderId,
-                RequesterPrincipal = msg.RequesterPrincipal,
-                HasThirdPartyAdoptedContext = msg.HasThirdPartyAdoptedContext,
-                AdoptedSpeakerIds = msg.AdoptedSpeakerIds,
-                Cwd = msg.Cwd,
-                OptionKeys = msg.Options.Select(o => o.Key.Value).ToArray(),
-                Candidates = msg.Candidates
-                    .Select(c => new ToolApprovalRequested.ApprovalCandidateRecord
-                    {
-                        Verb = c.Verb,
-                        Directory = c.Directory
-                    })
-                    .ToArray(),
-                RequestedAtMs = NowMs()
-            };
-
-            if (!msg.PersistApprovalState)
-            {
-                ApplyToolApprovalRequested(evt, persistApprovalState: false);
-                EmitOutput(msg);
-                return;
-            }
-
-            Persist(evt, e =>
-            {
-                ApplyToolApprovalRequested(e);
-                EmitOutput(msg);
-            });
-        });
+        Command<ToolInteractionRequest>(msg => HandleToolInteractionRequestDispatch(
+            new ToolInteractionRequestDispatch(msg, PersistApprovalState: true)));
+        Command<ToolInteractionRequestDispatch>(HandleToolInteractionRequestDispatch);
 
         CommandAsync<ToolInteractionResponse>(HandleProcessingApprovalResponseAsync);
 
@@ -818,6 +785,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private void HandleToolExecutionCompleted(ToolExecutionCompleted msg)
     {
         _watchdog.Stop(Timers);
+        CancelAndDisposeToolExecutionCts();
 
         var emittedRunIds = new HashSet<string>(StringComparer.Ordinal);
         foreach (var finding in msg.AcceptedSubAgentFindings)
@@ -1896,6 +1864,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // (Public, audience profiles that explicitly drop it).
         var setWorkingDirectoryAvailable = IsSetWorkingDirectoryAvailable();
 
+        CancelAndDisposeToolExecutionCts();
+        _activeToolExecutionCts = new CancellationTokenSource();
+        var toolExecutionCt = _activeToolExecutionCts.Token;
+
         _ = SessionToolExecutionPipeline.ExecuteToolsAsync(executor, toolCalls, sessionId, _currentTurnSource, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput, spawnChildActor,
             approvalChannel: _approvalChannel,
             emitApprovalRequest: request => self.Tell(request),
@@ -1913,7 +1885,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             supportsInteractiveApprovalOverride: supportsInteractiveApprovalOverride,
             requesterSenderIdOverride: requesterSenderIdOverride,
             requesterPrincipalOverride: requesterPrincipalOverride,
-            decisionOverride: decisionOverride);
+            decisionOverride: decisionOverride,
+            ct: toolExecutionCt);
     }
 
     private void HandleTextResponse(
@@ -2410,6 +2383,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
         _buffer.Clear();
         CancelAndDisposeLlmCts();
+        CancelAndDisposeToolExecutionCts();
 
         base.PreRestart(reason, message);
     }
@@ -2417,6 +2391,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     protected override void PostStop()
     {
         CancelAndDisposeLlmCts();
+        CancelAndDisposeToolExecutionCts();
 
         // Safety net for non-graceful stop paths (shutdown timeout, OOM, etc.).
         if (!_passivationCompleted)
@@ -2430,6 +2405,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _activeLlmCts?.Cancel();
         _activeLlmCts?.Dispose();
         _activeLlmCts = null;
+    }
+
+    private void CancelAndDisposeToolExecutionCts()
+    {
+        _activeToolExecutionCts?.Cancel();
+        _activeToolExecutionCts?.Dispose();
+        _activeToolExecutionCts = null;
     }
 
     // ── Helpers ──
@@ -3161,6 +3143,50 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _state = _state with { History = _state.History.Add(evt.ToolResult) };
     }
 
+    private void HandleToolInteractionRequestDispatch(ToolInteractionRequestDispatch dispatch)
+    {
+        var msg = dispatch.Request;
+        var evt = new ToolApprovalRequested
+        {
+            SessionId = _sessionId,
+            CallId = msg.CallId.Value,
+            ToolName = msg.ToolName.Value,
+            Patterns = msg.Patterns,
+            CandidateVerbs = msg.CandidateVerbs,
+            Audience = CurrentTurnAudience(),
+            Boundary = _currentTurnSource?.Boundary,
+            ChannelType = _currentTurnSource?.ChannelType.ToWireValue(),
+            SupportsInteractiveApproval = _currentTurnSource?.ChannelType.SupportsInteractiveApproval(),
+            RequesterSenderId = msg.RequesterSenderId,
+            RequesterPrincipal = msg.RequesterPrincipal,
+            HasThirdPartyAdoptedContext = msg.HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = msg.AdoptedSpeakerIds,
+            Cwd = msg.Cwd,
+            OptionKeys = msg.Options.Select(o => o.Key.Value).ToArray(),
+            Candidates = msg.Candidates
+                .Select(c => new ToolApprovalRequested.ApprovalCandidateRecord
+                {
+                    Verb = c.Verb,
+                    Directory = c.Directory
+                })
+                .ToArray(),
+            RequestedAtMs = NowMs()
+        };
+
+        if (!dispatch.PersistApprovalState)
+        {
+            ApplyToolApprovalRequested(evt, persistApprovalState: false);
+            EmitOutput(msg);
+            return;
+        }
+
+        Persist(evt, e =>
+        {
+            ApplyToolApprovalRequested(e);
+            EmitOutput(msg);
+        });
+    }
+
     private void ApplyToolApprovalRequested(ToolApprovalRequested evt)
         => ApplyToolApprovalRequested(evt, persistApprovalState: true);
 
@@ -3385,7 +3411,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// responsible for journaling <see cref="ToolApprovalResolved"/>.
     /// </summary>
     private async Task<(ApprovalDecision? Decision, string? NackReason)> AuthorizeApprovalResponseAsync(
-        PendingToolInteraction pending, ToolInteractionResponse msg)
+        PendingToolInteraction pending,
+        ToolInteractionResponse msg,
+        bool persistApprovalGrant)
     {
         // Only the user who triggered the request may approve it — verified
         // automation requests can be approved by any channel member.
@@ -3417,6 +3445,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var decision = MapApprovalDecision(msg.SelectedKey.Value);
         _log.Info("Approval response for {CallId}: {Decision}", msg.CallId, decision);
 
+        if (persistApprovalGrant)
+            await PersistApprovalGrantIfNeededAsync(pending, decision, CancellationToken.None);
+
+        return (decision, null);
+    }
+
+    private async Task PersistApprovalGrantIfNeededAsync(
+        PendingToolInteraction pending,
+        ApprovalDecision decision,
+        CancellationToken ct)
+    {
         // Persistent scopes write a durable grant so future invocations — and
         // the re-driven call itself — pass the gate without another prompt.
         if (decision is ApprovalDecision.ApprovedSession
@@ -3424,10 +3463,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 or ApprovalDecision.ApprovedEverywhere
             && _approvalService is not null)
         {
-            await PersistApprovalCandidatesAsync(pending, decision, CancellationToken.None);
+            await PersistApprovalCandidatesAsync(pending, decision, ct);
         }
-
-        return (decision, null);
     }
 
     private void EmitWrongRequesterApprovalNotice()
@@ -3538,58 +3575,52 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        if (!_approvalChannel.IsPending(msg.CallId))
-        {
-            _log.Warning(
-                "Ignoring tool interaction response for call {CallId}: prompt no longer has a live approval wait",
-                msg.CallId);
-            EmitExpiredPromptNotice();
-            TryReplyNack(ApprovalNackReasons.PromptExpired);
-            return;
-        }
-
+        ClaimedApprovalWait? claimedWait = null;
         try
         {
-            var authorization = await AuthorizeApprovalResponseAsync(pending, msg);
+            var authorization = await AuthorizeApprovalResponseAsync(
+                pending,
+                msg,
+                persistApprovalGrant: false);
             if (authorization.Decision is not { } decision)
             {
                 TryReplyNack(authorization.NackReason ?? ApprovalNackReasons.WrongRequester);
                 return;
             }
 
+            if (!_approvalChannel.TryClaim(msg.CallId, out claimedWait))
+            {
+                _log.Warning(
+                    "Ignoring tool interaction response for call {CallId}: prompt no longer has a live approval wait",
+                    msg.CallId);
+                EmitExpiredPromptNotice();
+                TryReplyNack(ApprovalNackReasons.PromptExpired);
+                return;
+            }
+
+            if (!pending.PersistApprovalState)
+                _pendingToolInteractions.Remove(msg.CallId.Value);
+
+            await PersistApprovalGrantIfNeededAsync(pending, decision, CancellationToken.None);
+            var approvalWait = claimedWait
+                ?? throw new InvalidOperationException("Approval wait claim succeeded without a wait handle.");
+
             if (!pending.PersistApprovalState)
             {
-                if (!_approvalChannel.Complete(msg.CallId, decision))
-                {
-                    _log.Warning(
-                        "Ignoring tool interaction response for call {CallId}: approval wait expired before completion",
-                        msg.CallId);
-                    EmitExpiredPromptNotice();
-                    TryReplyNack(ApprovalNackReasons.PromptExpired);
-                    return;
-                }
-
+                approvalWait.Complete(decision);
                 TryReplyAck();
                 return;
             }
 
             PersistApprovalResolved(msg, decision, () =>
             {
-                if (!_approvalChannel.Complete(msg.CallId, decision))
-                {
-                    _log.Warning(
-                        "Ignoring tool interaction response for call {CallId}: approval wait expired before completion",
-                        msg.CallId);
-                    EmitExpiredPromptNotice();
-                    TryReplyNack(ApprovalNackReasons.PromptExpired);
-                    return;
-                }
-
+                approvalWait.Complete(decision);
                 TryReplyAck();
             });
         }
         catch (Exception ex)
         {
+            claimedWait?.Complete(ApprovalDecision.Denied);
             FailCurrentTurn("I couldn't persist that approval decision. Please try again.", ex, ErrorCategory.ToolFailure);
             TryReplyNack(ApprovalNackReasons.PersistFailed);
         }
@@ -3653,7 +3684,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         ApprovalDecision decision;
         try
         {
-            var authorization = await AuthorizeApprovalResponseAsync(pending, msg);
+            var authorization = await AuthorizeApprovalResponseAsync(
+                pending,
+                msg,
+                persistApprovalGrant: true);
             if (authorization.Decision is not { } authorizedDecision)
             {
                 TryReplyNack(authorization.NackReason ?? ApprovalNackReasons.WrongRequester);
@@ -3968,6 +4002,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         CompleteReminderInFlight(_currentTurnSource?.ReminderId);
         CompleteBackgroundJobInFlight(_currentTurnSource?.BackgroundJobId);
+        CancelAndDisposeToolExecutionCts();
         _deliveryRetry.Clear();
         _pendingToolInteractions.Clear();
         _resolvedToolApprovals.Clear();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3175,6 +3175,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         if (!dispatch.PersistApprovalState)
         {
+            // Live sub-agent approvals need the prompt in the in-memory pending
+            // map so responses can be authorized, but there is no durable child
+            // actor/tool batch to redrive after restart.
             ApplyToolApprovalRequested(evt, persistApprovalState: false);
             EmitOutput(msg);
             return;
@@ -3588,6 +3591,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
+            // Claim the live wait before writing any broader grant. A response
+            // can be authorized and still be stale; only a claimed wait proves
+            // the prompt still corresponds to a blocked tool call.
             if (!_approvalChannel.TryClaim(msg.CallId, out var approvalWait))
             {
                 _log.Warning(
@@ -3606,6 +3612,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             if (!pending.PersistApprovalState)
             {
+                // Live-only prompts should release the blocked child task, not
+                // journal ToolApprovalResolved. After restart the child actor is
+                // gone, so a durable redrive would be misleading.
                 approvalWait.Complete(decision);
                 TryReplyAck();
                 return;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -557,6 +557,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 RequestedAtMs = NowMs()
             };
 
+            if (!msg.PersistApprovalState)
+            {
+                ApplyToolApprovalRequested(evt, persistApprovalState: false);
+                EmitOutput(msg);
+                return;
+            }
+
             Persist(evt, e =>
             {
                 ApplyToolApprovalRequested(e);
@@ -3155,6 +3162,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     private void ApplyToolApprovalRequested(ToolApprovalRequested evt)
+        => ApplyToolApprovalRequested(evt, persistApprovalState: true);
+
+    private void ApplyToolApprovalRequested(ToolApprovalRequested evt, bool persistApprovalState)
     {
         _pendingToolInteractions[evt.CallId] = new PendingToolInteraction(
             evt.CallId,
@@ -3171,6 +3181,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             evt.AdoptedSpeakerIds,
             evt.Cwd,
             evt.RequestedAtMs,
+            persistApprovalState,
             evt.OptionKeys,
             evt.Candidates.Select(c => new ApprovalCandidate(c.Verb, c.Directory)).ToArray());
         _resolvedToolApprovals.Remove(evt.CallId);
@@ -3527,6 +3538,16 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
+        if (!_approvalChannel.IsPending(msg.CallId))
+        {
+            _log.Warning(
+                "Ignoring tool interaction response for call {CallId}: prompt no longer has a live approval wait",
+                msg.CallId);
+            EmitExpiredPromptNotice();
+            TryReplyNack(ApprovalNackReasons.PromptExpired);
+            return;
+        }
+
         try
         {
             var authorization = await AuthorizeApprovalResponseAsync(pending, msg);
@@ -3536,9 +3557,34 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
+            if (!pending.PersistApprovalState)
+            {
+                if (!_approvalChannel.Complete(msg.CallId, decision))
+                {
+                    _log.Warning(
+                        "Ignoring tool interaction response for call {CallId}: approval wait expired before completion",
+                        msg.CallId);
+                    EmitExpiredPromptNotice();
+                    TryReplyNack(ApprovalNackReasons.PromptExpired);
+                    return;
+                }
+
+                TryReplyAck();
+                return;
+            }
+
             PersistApprovalResolved(msg, decision, () =>
             {
-                _approvalChannel.Complete(msg.CallId, decision);
+                if (!_approvalChannel.Complete(msg.CallId, decision))
+                {
+                    _log.Warning(
+                        "Ignoring tool interaction response for call {CallId}: approval wait expired before completion",
+                        msg.CallId);
+                    EmitExpiredPromptNotice();
+                    TryReplyNack(ApprovalNackReasons.PromptExpired);
+                    return;
+                }
+
                 TryReplyAck();
             });
         }

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -18,18 +18,21 @@ namespace Netclaw.Actors.Sessions;
 internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
 {
     private readonly IApprovalChannel _channel;
-    private readonly Action<ToolInteractionRequest> _emitRequest;
+    private readonly Action<ToolInteractionRequestDispatch> _emitRequest;
     private readonly SessionId _sessionId;
+    private readonly string _approvalScopeId;
     private readonly SenderId? _requesterSenderId;
     private readonly PrincipalClassification? _requesterPrincipal;
     private readonly bool _hasAdoptedContext;
     private readonly bool _hasThirdPartyAdoptedContext;
     private readonly IReadOnlyList<string> _adoptedSpeakerIds;
+    private int _nextApprovalRequestId;
 
     public ParentSessionApprovalBridge(
         IApprovalChannel channel,
-        Action<ToolInteractionRequest> emitRequest,
+        Action<ToolInteractionRequestDispatch> emitRequest,
         SessionId sessionId,
+        string approvalScopeId,
         SenderId? requesterSenderId,
         PrincipalClassification? requesterPrincipal,
         bool hasAdoptedContext,
@@ -39,6 +42,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
         _channel = channel;
         _emitRequest = emitRequest;
         _sessionId = sessionId;
+        _approvalScopeId = approvalScopeId;
         _requesterSenderId = requesterSenderId;
         _requesterPrincipal = requesterPrincipal;
         _hasAdoptedContext = hasAdoptedContext;
@@ -60,18 +64,19 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
     {
         EnsureAuthorityContext();
 
-        var waitTask = _channel.WaitForApprovalAsync(callId, Timeout.InfiniteTimeSpan, ct);
+        var parentCallId = CreateParentCallId(callId);
+        var waitTask = _channel.WaitForApprovalAsync(parentCallId, Timeout.InfiniteTimeSpan, ct);
 
         // Emit verbatim from the gate's computed options so persistent-grant
         // buttons (Always here / Always anywhere) and the messy-command
         // four-button fallback stay in lock-step with the parent path. The
         // earlier hardcoded list silently dropped "Always anywhere" for
         // sub-agents.
-        _emitRequest(new ToolInteractionRequest
+        _emitRequest(new ToolInteractionRequestDispatch(new ToolInteractionRequest
         {
             SessionId = _sessionId,
             Kind = "approval",
-            CallId = callId,
+            CallId = parentCallId,
             ToolName = new Netclaw.Tools.ToolName(toolName),
             DisplayText = displayText,
             RequesterSenderId = _requesterSenderId,
@@ -81,7 +86,6 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             Candidates = candidates.Select(c => new ApprovalCandidate(c.Verb, c.Directory)).ToList(),
             Cwd = cwd,
             IsMessy = isMessy,
-            PersistApprovalState = false,
             HasAdoptedContext = _hasAdoptedContext,
             HasThirdPartyAdoptedContext = _hasThirdPartyAdoptedContext,
             AdoptedSpeakerIds = _adoptedSpeakerIds,
@@ -89,7 +93,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             Options = options
                 .Select(o => new ToolInteractionOption(new ApprovalOptionKey(o.Key), o.Label))
                 .ToList()
-        });
+        }, PersistApprovalState: false));
 
         var decision = await waitTask;
 
@@ -102,6 +106,12 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             ApprovalDecision.TimedOut => ParentApprovalDecision.TimedOut,
             _ => ParentApprovalDecision.Denied
         };
+    }
+
+    private ToolCallId CreateParentCallId(ToolCallId childCallId)
+    {
+        var requestId = Interlocked.Increment(ref _nextApprovalRequestId);
+        return new ToolCallId($"{_approvalScopeId}/subagent-approval/{requestId}/{childCallId.Value}");
     }
 
     private void EnsureAuthorityContext()

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -110,12 +110,22 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
 
     private ToolCallId CreateParentCallId(ToolCallId childCallId)
     {
+        // This bridge is created by the session actor but used by thread-pool
+        // tool tasks. Multiple child tool calls can request approval at once,
+        // so the sequence allocation is not actor-mailbox confined.
         var requestId = Interlocked.Increment(ref _nextApprovalRequestId);
+
+        // Child call ids are only unique inside the sub-agent's tool loop. The
+        // parent approval channel is session-wide, so include the spawning tool
+        // call scope plus a per-bridge sequence before the child-local id.
         return new ToolCallId($"{_approvalScopeId}/subagent-approval/{requestId}/{childCallId.Value}");
     }
 
     private void EnsureAuthorityContext()
     {
+        // Approval responses are authorized against the parent requester. If we
+        // cannot reconstruct that authority context, emitting a prompt would let
+        // the channel decide without a safe requester binding.
         if (_requesterPrincipal is null)
             throw new ParentApprovalUnavailableException(
                 "Sub-agent approval requires parent requester principal context.");

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -58,6 +58,8 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
         bool isMessy,
         CancellationToken ct)
     {
+        EnsureAuthorityContext();
+
         var waitTask = _channel.WaitForApprovalAsync(callId, Timeout.InfiniteTimeSpan, ct);
 
         // Emit verbatim from the gate's computed options so persistent-grant
@@ -79,6 +81,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             Candidates = candidates.Select(c => new ApprovalCandidate(c.Verb, c.Directory)).ToList(),
             Cwd = cwd,
             IsMessy = isMessy,
+            PersistApprovalState = false,
             HasAdoptedContext = _hasAdoptedContext,
             HasThirdPartyAdoptedContext = _hasThirdPartyAdoptedContext,
             AdoptedSpeakerIds = _adoptedSpeakerIds,
@@ -99,5 +102,19 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             ApprovalDecision.TimedOut => ParentApprovalDecision.TimedOut,
             _ => ParentApprovalDecision.Denied
         };
+    }
+
+    private void EnsureAuthorityContext()
+    {
+        if (_requesterPrincipal is null)
+            throw new ParentApprovalUnavailableException(
+                "Sub-agent approval requires parent requester principal context.");
+
+        if (_requesterPrincipal is not PrincipalClassification.VerifiedAutomation
+            && _requesterSenderId is null)
+        {
+            throw new ParentApprovalUnavailableException(
+                "Sub-agent approval requires parent requester sender context.");
+        }
     }
 }

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -47,7 +47,7 @@ internal static class SessionToolExecutionPipeline
         Action<SubAgentOutput> emitSubAgentOutput,
         Func<object, string, CancellationToken, Task<object>> spawnChildActor,
         IApprovalChannel? approvalChannel = null,
-        Action<ToolInteractionRequest>? emitApprovalRequest = null,
+        Action<ToolInteractionRequestDispatch>? emitApprovalRequest = null,
         TimeSpan? approvalTimeout = null,
         int maxToolTimeoutSeconds = 600,
         ILogger? logger = null,
@@ -63,7 +63,8 @@ internal static class SessionToolExecutionPipeline
         bool? supportsInteractiveApprovalOverride = null,
         SenderId? requesterSenderIdOverride = null,
         PrincipalClassification? requesterPrincipalOverride = null,
-        IReadOnlyDictionary<string, ApprovalDecision>? decisionOverride = null)
+        IReadOnlyDictionary<string, ApprovalDecision>? decisionOverride = null,
+        CancellationToken ct = default)
     {
         try
         {
@@ -85,7 +86,7 @@ internal static class SessionToolExecutionPipeline
                 emitSubAgentOutput,
                 spawnChildActor,
                 timeout,
-                CancellationToken.None,
+                ct,
                 approvalChannel,
                 emitApprovalRequest,
                 approvalTimeout ?? Timeout.InfiniteTimeSpan,
@@ -162,7 +163,7 @@ internal static class SessionToolExecutionPipeline
         TimeSpan timeout,
         CancellationToken ct,
         IApprovalChannel? approvalChannel = null,
-        Action<ToolInteractionRequest>? emitApprovalRequest = null,
+        Action<ToolInteractionRequestDispatch>? emitApprovalRequest = null,
         TimeSpan? approvalTimeout = null,
         int maxToolTimeoutSeconds = 600,
         ILogger? logger = null,
@@ -221,6 +222,7 @@ internal static class SessionToolExecutionPipeline
                 approvalChannel,
                 emitApprovalRequest,
                 sessionId,
+                tc.CallId,
                 requesterSenderIdOverride ?? source?.SenderId,
                 requesterPrincipalOverride ?? source?.Principal,
                 source?.HasAdoptedContext ?? false,
@@ -373,9 +375,9 @@ internal static class SessionToolExecutionPipeline
             var waitTask = approvalChannel.WaitForApprovalAsync(
                 new ToolCallId(tc.CallId),
                 approvalWaitTimeout,
-                CancellationToken.None);
+                ct);
 
-            emitApprovalRequest(new ToolInteractionRequest
+            emitApprovalRequest(new ToolInteractionRequestDispatch(new ToolInteractionRequest
             {
                 SessionId = sessionId,
                 Kind = "approval",
@@ -396,7 +398,7 @@ internal static class SessionToolExecutionPipeline
                 Options = ctx.Options
                     .Select(o => new ToolInteractionOption(o.Key, o.Label))
                     .ToList()
-            });
+            }, PersistApprovalState: true));
 
             var decision = await waitTask;
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/StreamingToolWatchdog.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/StreamingToolWatchdog.cs
@@ -101,6 +101,8 @@ internal static class StreamingToolWatchdog
                     case ToolCompletedUpdate completed:
                         return completed.Result;
                     case ToolActivityUpdate activity:
+                        if (activity.SuspendsInactivityWatchdog)
+                            Volatile.Write(ref budgetTicks, TimeSpan.Zero.Ticks);
                         onActivity?.Invoke(activity);
                         break;
                 }

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -27,6 +27,7 @@ internal sealed record PendingToolInteraction(
     IReadOnlyList<string> AdoptedSpeakerIds,
     string? Cwd,
     long RequestedAtMs,
+    bool PersistApprovalState,
     // Option keys that were actually offered to the user when the prompt was
     // rendered. Persisted so a later response cannot select a pruned scope.
     IReadOnlyList<string> OptionKeys,

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -36,6 +36,10 @@ internal sealed record PendingToolInteraction(
     // path arguments the agent originally passed, rather than collapsing to cwd.
     IReadOnlyList<ApprovalCandidate> Candidates) : INoSerializationVerificationNeeded;
 
+internal sealed record ToolInteractionRequestDispatch(
+    Protocol.ToolInteractionRequest Request,
+    bool PersistApprovalState) : INoSerializationVerificationNeeded;
+
 internal sealed record ApprovalRedrivePlan(
     IReadOnlyDictionary<string, IReadOnlyList<string>>? OneTimeApprovalPreSeed,
     IReadOnlyDictionary<string, ApprovalDecision>? DecisionOverride);

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -36,6 +36,9 @@ internal sealed record PendingToolInteraction(
     // path arguments the agent originally passed, rather than collapsing to cwd.
     IReadOnlyList<ApprovalCandidate> Candidates) : INoSerializationVerificationNeeded;
 
+// Internal actor message for approval prompts. The request is the public output
+// shape; PersistApprovalState is session routing policy that decides whether the
+// prompt becomes durable parent-session approval state.
 internal sealed record ToolInteractionRequestDispatch(
     Protocol.ToolInteractionRequest Request,
     bool PersistApprovalState) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -462,7 +462,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     /// <summary>Emit a liveness/progress item to the spawning tool's stream, if any.</summary>
     private void EmitActivity(string phase, bool suspendsInactivityWatchdog = false)
-        => _activitySink?.TryWrite(new ToolActivityUpdate(phase, SuspendsInactivityWatchdog: suspendsInactivityWatchdog));
+        => _activitySink?.TryWrite(new ToolActivityUpdate(phase)
+        {
+            SuspendsInactivityWatchdog = suspendsInactivityWatchdog
+        });
 
     /// <summary>Record forward progress: re-arm the inactivity watchdog and emit activity.</summary>
     private void RecordProgress(string phase)

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -688,13 +688,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (ToolApprovalRequiredException)
                 {
-                    return new SerializableChatMessage
-                    {
-                        Role = Protocol.ChatRole.Tool,
-                        Content = "Tool access denied: approval_required_without_parent_bridge",
-                        ToolCallId = new ToolCallId(tc.CallId),
-                        Name = tc.Name
-                    };
+                    throw new InvalidOperationException(
+                        $"Tool '{tc.Name}' requires interactive approval, but no parent approval bridge is available.");
                 }
                 catch (OperationCanceledException) when (externalCt.IsCancellationRequested)
                 {

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -691,6 +691,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (ToolApprovalRequiredException)
                 {
+                    // Missing bridge wiring is a security/configuration failure,
+                    // not a recoverable tool error for the model to continue past.
                     throw new ParentApprovalUnavailableException(
                         $"Tool '{tc.Name}' requires interactive approval, but no parent approval bridge is available.");
                 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -117,14 +117,26 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     /// <summary>
     /// Final cleanup if the actor is stopped externally (parent supervision,
     /// <c>PoisonPill</c>) without going through <see cref="Complete"/>. Cancels
-    /// and disposes both CTSes so any in-flight approval wait running on the
-    /// thread pool unblocks promptly. <see cref="Complete"/> already nulls the
-    /// CTSes, so the null-conditional access is intentional.
+    /// both CTSes so any in-flight approval wait running on the thread pool
+    /// unblocks promptly, then replies once to any outstanding ask. <see cref="Complete"/>
+    /// already nulls the CTSes, so the null-conditional access is intentional.
     /// </summary>
     protected override void PostStop()
     {
         _executionCts?.Cancel();
         _externalCts?.Cancel();
+        if (!_completed)
+        {
+            _completed = true;
+            _replyTo.Tell(new SubAgentResult
+            {
+                Success = false,
+                Output = "Subagent stopped before completion.",
+                AgentName = _definition.Name,
+                Findings = [],
+                FindingsCount = 0
+            });
+        }
         _executionCts?.Dispose();
         _externalCts?.Dispose();
         _externalCancellationRegistration.Dispose();
@@ -670,6 +682,16 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     {
                         Role = Protocol.ChatRole.Tool,
                         Content = reason,
+                        ToolCallId = new ToolCallId(tc.CallId),
+                        Name = tc.Name
+                    };
+                }
+                catch (ToolApprovalRequiredException)
+                {
+                    return new SerializableChatMessage
+                    {
+                        Role = Protocol.ChatRole.Tool,
+                        Content = "Tool access denied: approval_required_without_parent_bridge",
                         ToolCallId = new ToolCallId(tc.CallId),
                         Name = tc.Name
                     };

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -331,7 +331,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
             _toolExecutionWatchdogState = ToolExecutionWatchdogState.WaitingForParentApproval;
             _pendingApprovalWaits++;
-            EmitActivity("awaiting human approval");
+            EmitActivity("awaiting human approval", suspendsInactivityWatchdog: true);
         });
 
         Receive<SubAgentApprovalWaitCompleted>(_ =>
@@ -461,8 +461,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         => Timers.StartSingleTimer(TimeoutTimerKey, SubAgentTimeout.Instance, _inactivityBudget);
 
     /// <summary>Emit a liveness/progress item to the spawning tool's stream, if any.</summary>
-    private void EmitActivity(string phase)
-        => _activitySink?.TryWrite(new ToolActivityUpdate(phase));
+    private void EmitActivity(string phase, bool suspendsInactivityWatchdog = false)
+        => _activitySink?.TryWrite(new ToolActivityUpdate(phase, SuspendsInactivityWatchdog: suspendsInactivityWatchdog));
 
     /// <summary>Record forward progress: re-arm the inactivity watchdog and emit activity.</summary>
     private void RecordProgress(string phase)
@@ -688,8 +688,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (ToolApprovalRequiredException)
                 {
-                    throw new InvalidOperationException(
+                    throw new ParentApprovalUnavailableException(
                         $"Tool '{tc.Name}' requires interactive approval, but no parent approval bridge is available.");
+                }
+                catch (ParentApprovalUnavailableException)
+                {
+                    throw;
                 }
                 catch (OperationCanceledException) when (externalCt.IsCancellationRequested)
                 {

--- a/src/Netclaw.Tools.Abstractions/IParentApprovalBridge.cs
+++ b/src/Netclaw.Tools.Abstractions/IParentApprovalBridge.cs
@@ -20,6 +20,17 @@ public enum ParentApprovalDecision
 }
 
 /// <summary>
+/// Thrown when a sub-agent needs parent approval but the parent session cannot
+/// safely emit an approval prompt with complete authority context.
+/// </summary>
+public sealed class ParentApprovalUnavailableException : InvalidOperationException
+{
+    public ParentApprovalUnavailableException(string message) : base(message)
+    {
+    }
+}
+
+/// <summary>
 /// One per-clause <c>(verb, directory)</c> pair extracted from a sub-agent's
 /// invocation. Mirrors the persisted <c>ApprovalEntry</c> shape so the parent
 /// session can record folder-scoped grants from the actual paths the sub-agent

--- a/src/Netclaw.Tools.Abstractions/ToolCallUpdate.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolCallUpdate.cs
@@ -21,7 +21,15 @@ public interface ToolCallUpdate;
 /// <param name="OutputChunk">
 /// Optional incremental output (e.g. streamed shell stdout) for live display.
 /// </param>
-public sealed record ToolActivityUpdate(string Phase, string? OutputChunk = null) : ToolCallUpdate;
+/// <param name="SuspendsInactivityWatchdog">
+/// True when the tool is intentionally blocked on external input, such as a
+/// human approval prompt. The watchdog resumes on the next non-suspending
+/// activity item or terminal completion.
+/// </param>
+public sealed record ToolActivityUpdate(
+    string Phase,
+    string? OutputChunk = null,
+    bool SuspendsInactivityWatchdog = false) : ToolCallUpdate;
 
 /// <summary>
 /// The terminal item of a tool-call stream. Its <see cref="Result"/> is the only

--- a/src/Netclaw.Tools.Abstractions/ToolCallUpdate.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolCallUpdate.cs
@@ -21,15 +21,15 @@ public interface ToolCallUpdate;
 /// <param name="OutputChunk">
 /// Optional incremental output (e.g. streamed shell stdout) for live display.
 /// </param>
-/// <param name="SuspendsInactivityWatchdog">
-/// True when the tool is intentionally blocked on external input, such as a
-/// human approval prompt. The watchdog resumes on the next non-suspending
-/// activity item or terminal completion.
-/// </param>
-public sealed record ToolActivityUpdate(
-    string Phase,
-    string? OutputChunk = null,
-    bool SuspendsInactivityWatchdog = false) : ToolCallUpdate;
+public sealed record ToolActivityUpdate(string Phase, string? OutputChunk = null) : ToolCallUpdate
+{
+    /// <summary>
+    /// True when the tool is intentionally blocked on external input, such as a
+    /// human approval prompt. The watchdog resumes on the next non-suspending
+    /// activity item or terminal completion.
+    /// </summary>
+    public bool SuspendsInactivityWatchdog { get; init; }
+}
 
 /// <summary>
 /// The terminal item of a tool-call stream. Its <see cref="Result"/> is the only


### PR DESCRIPTION
## Summary
- Add the `redesign-subagent-approval-lifecycle` OpenSpec change for #1212.
- Fail missing parent approval bridges closed as terminal failed subagent runs without executing gated tools.
- Harden subagent approval waits for watchdog pause/resume, approve-once isolation, denied/timed-out tool results, cancellation, external stop, parallel waits, and late approval expiry.
- Update the subagents runbook with user-visible approval behavior.

## Validation
- `dotnet test "src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj" --filter "FullyQualifiedName~SubAgentActorTests|FullyQualifiedName~ParentSessionApprovalBridgeTests|FullyQualifiedName~ToolApprovalGateTests"`
- `openspec validate "redesign-subagent-approval-lifecycle" --strict`
- `dotnet slopwatch analyze`
- `pwsh "./scripts/Add-FileHeaders.ps1" -Verify`
- `git diff --check`

Fixes #1212