### PR TITLE
fix(sessions): stop tool-loop spin from volatile-context placement

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
@@ -71,37 +71,40 @@ public sealed class SessionMessageAssemblerTests
         // static block is structurally identical across them. The assembler
         // no longer wraps the last User message — it just emits the static
         // block + history verbatim. Cache prefix stability comes from the
-        // actor persisting the per-turn volatile block as a system-nudge
-        // entry in history (via SessionState.AddSystemNudge) BEFORE the
-        // assembler runs. We simulate that here by pre-populating history.
-        var turn1History = SeedHistory("first question")
+        // actor inserting the per-turn volatile block as a system-nudge
+        // entry in history (via SessionState.AddVolatileContextNudge) BEFORE
+        // the real user message, so the user message stays at the tail. We
+        // simulate that here by pre-populating history in that order.
+        var turn1History = ImmutableList.Create(
+                new SerializableChatMessage { Role = ProtocolChatRole.System, Content = PersistedSystemPrompt })
             .Add(new SerializableChatMessage
             {
                 Role = ProtocolChatRole.User,
                 Content = $"{SessionState.SystemNudgePrefix} turn-1-volatile-snapshot]",
-            });
+            })
+            .Add(new SerializableChatMessage { Role = ProtocolChatRole.User, Content = "first question" });
         var turn1 = MakeInput(turn1History, activeRecall: null, startupDone: true);
         var turn1Messages = SessionMessageAssembler.Assemble(turn1);
 
         var turn2History = turn1History
             .Add(new SerializableChatMessage { Role = ProtocolChatRole.Assistant, Content = "First answer" })
-            .Add(new SerializableChatMessage { Role = ProtocolChatRole.User, Content = "second question" })
             .Add(new SerializableChatMessage
             {
                 Role = ProtocolChatRole.User,
                 Content = $"{SessionState.SystemNudgePrefix} turn-2-volatile-snapshot]",
-            });
+            })
+            .Add(new SerializableChatMessage { Role = ProtocolChatRole.User, Content = "second question" });
         var turn2 = MakeInput(turn2History, activeRecall: null, startupDone: true);
         var turn2Messages = SessionMessageAssembler.Assemble(turn2);
 
         var prefix = LongestCommonPrefix(turn1Messages, turn2Messages);
 
-        // Turn 1 wire: [persisted, static, user "first question", nudge-1]
-        // Turn 2 wire: [persisted, static, user "first question", nudge-1, assistant, user "second", nudge-2]
+        // Turn 1 wire: [persisted, static, nudge-1, user "first question"]
+        // Turn 2 wire: [persisted, static, nudge-1, user "first question", assistant, nudge-2, user "second"]
         // Cache prefix should extend through turn 1's full content (4 messages)
-        // before turn 2 diverges with its own assistant+user2+nudge2.
+        // before turn 2 diverges with its own assistant+nudge2+user2.
         Assert.True(prefix >= 4,
-            $"Expected cache prefix ≥ 4 (persisted+static+user1+nudge1), got {prefix}. " +
+            $"Expected cache prefix ≥ 4 (persisted+static+nudge1+user1), got {prefix}. " +
             $"Turn 1: [{FormatMessages(turn1Messages)}] Turn 2: [{FormatMessages(turn2Messages)}]");
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -209,6 +209,49 @@ public class SessionStateTests
     }
 
     [Fact]
+    public void AddVolatileContextNudge_inserts_before_trailing_real_user_message()
+    {
+        // The volatile context block must NOT sit at the tail after the real
+        // user message — a trailing volatile User-role message is read by
+        // strict ChatML templates as a fresh user turn and triggers the
+        // tool-loop acknowledgement spin. It is inserted BEFORE the user
+        // message so the real user message stays at the tail.
+        var state = SessionState.Empty
+            .AddUserMessage("real user request")
+            .AddVolatileContextNudge("[memory-recall] ...");
+
+        Assert.Equal(2, state.History.Count);
+        Assert.True(SessionState.IsSystemNudge(state.History[0]));
+        Assert.Equal(ChatRole.User, state.History[1].Role);
+        Assert.Equal("real user request", state.History[1].Content);
+
+        // The last user-role content the model sees is the real request.
+        Assert.Equal("real user request", state.FindLastUserMessage()?.Content);
+    }
+
+    [Fact]
+    public void AddVolatileContextNudge_appends_when_no_trailing_real_user_message()
+    {
+        // Reminder/scheduled/cold-recovery turns have no trailing real user
+        // message to sit before — append in that case. Also covers the case
+        // where the last entry is itself a system-nudge (e.g. delivery retry).
+        var afterAssistant = SessionState.Empty
+            .AddUserMessage("first")
+            .AddErrorReply("answer")
+            .AddVolatileContextNudge("[working-context] ...");
+
+        Assert.True(SessionState.IsSystemNudge(afterAssistant.History[^1]));
+
+        var afterNudge = SessionState.Empty
+            .AddUserMessage("first")
+            .AddSystemNudge("delivery retry")
+            .AddVolatileContextNudge("[working-context] ...");
+
+        Assert.True(SessionState.IsSystemNudge(afterNudge.History[^1]));
+        Assert.Contains("[working-context]", afterNudge.History[^1].Content);
+    }
+
+    [Fact]
     public void ToSnapshot_and_FromSnapshot_round_trip()
     {
         var state = WithSystemPrompt("Prompt")

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2555,17 +2555,22 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (resolved.Items.Count > 0)
                 _sessionMetrics?.RecordMemoriesRecalled(resolved.Items.Count);
 
-            // Persist the FULL volatile context block (recall + current
+            // Insert the FULL volatile context block (recall + current
             // time + working context + skill hint + slash command body +
             // session prompt overlay + turn restart notice + active
-            // background jobs) into History via AddSystemNudge. Gated on
-            // the same first-call-of-turn sentinel as recall resolution,
-            // so tool-loop iterations don't re-nudge. By persisting at
-            // turn-start (rather than wrapping at assemble-time), the
-            // volatile bytes become part of History — every byte-prefix
-            // caching provider (llama.cpp, vLLM, OpenAI, Ollama, ...)
-            // can extend the cache prefix through this content on every
-            // subsequent turn instead of re-tokenizing it from scratch.
+            // background jobs) into History via AddVolatileContextNudge.
+            // Gated on the same first-call-of-turn sentinel as recall
+            // resolution, so tool-loop iterations don't re-nudge. The block
+            // is placed BEFORE the real user message (not after) so the user
+            // message stays at the tail of the user-portion — a trailing
+            // volatile User-role message is read by strict ChatML templates
+            // (Qwen3) as a fresh user turn and causes the tool-loop
+            // acknowledgement spin (see AddVolatileContextNudge). By living
+            // in History (rather than being wrapped at assemble-time), the
+            // volatile bytes let every byte-prefix caching provider
+            // (llama.cpp, vLLM, OpenAI, Ollama, ...) extend the cache prefix
+            // through this content on every subsequent turn instead of
+            // re-tokenizing it from scratch.
             _activeRecall = _recallManager.TurnRecallCache;
             var volatileBlock = SessionMessageAssembler.BuildVolatileContextBlock(new ContextAssemblyInput(
                 State: _state,
@@ -2582,7 +2587,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SkillHint: BuildSkillHint()));
             if (!string.IsNullOrEmpty(volatileBlock))
             {
-                _state = _state.AddSystemNudge(volatileBlock);
+                _state = _state.AddVolatileContextNudge(volatileBlock);
             }
         }
 

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -212,20 +212,60 @@ public sealed record SessionState
     }
 
     /// <summary>
-    /// Add a transient system nudge to history to correct LLM behavior (e.g., empty response recovery).
-    /// Not persisted as a turn — just injected into the conversation to guide the next LLM call.
+    /// Add a transient system nudge to the END of history to correct LLM
+    /// behavior mid-turn (empty-response retry, duplicate-tool, budget warning,
+    /// delivery retry). These are course-correcting instructions: the model is
+    /// meant to act on them, so they sit at the tail where the chat template
+    /// treats them as the most recent input. Not persisted as a turn — just
+    /// injected into the conversation to guide the next LLM call.
     /// </summary>
     public SessionState AddSystemNudge(string nudge)
     {
-        return this with
-        {
-            History = History.Add(new SerializableChatMessage
-            {
-                Role = ChatRole.User,
-                Content = $"{SystemNudgePrefix} {nudge}]"
-            })
-        };
+        return this with { History = History.Add(BuildNudgeMessage(nudge)) };
     }
+
+    /// <summary>
+    /// Insert the per-turn volatile context block (memory recall, current time,
+    /// working context, skill hint, slash-command body, session overlay, turn
+    /// restart notice, active background jobs) into history immediately BEFORE
+    /// the most recent real user message, so the real user message stays the
+    /// last user-role content the model sees before generating its reply.
+    ///
+    /// A volatile block placed AFTER the user message is read by strict ChatML
+    /// templates (Qwen3) as a fresh user turn: the model restarts its assistant
+    /// response, scans back for the last real user content, and re-narrates the
+    /// same plan on every tool-loop iteration until context fills — the
+    /// production spin observed on D0AC6CKBK5K. Inserting before the user
+    /// message keeps the tail as [..., volatile-nudge, real-user, assistant],
+    /// which every chat template anchors to correctly.
+    ///
+    /// Cache-prefix stability (the reason PR #1178 moved volatile context into
+    /// history) is preserved: the inserted message's byte position is fixed
+    /// once added, and subsequent turns only append, so a byte-prefix-caching
+    /// provider extends the cached prefix straight through it — identical
+    /// guarantee to the prior append-based placement, only the local order of
+    /// the two adjacent turn-start messages differs.
+    ///
+    /// When the last history entry is NOT a real user message (reminder /
+    /// scheduled turn, delivery-retry redrive, cold-recovery), there is no
+    /// trailing user message to sit before, so the block is appended.
+    /// </summary>
+    public SessionState AddVolatileContextNudge(string nudge)
+    {
+        var nudgeMsg = BuildNudgeMessage(nudge);
+
+        if (History.Count > 0
+            && History[^1].Role == ChatRole.User
+            && !IsSystemNudge(History[^1]))
+        {
+            return this with { History = History.Insert(History.Count - 1, nudgeMsg) };
+        }
+
+        return this with { History = History.Add(nudgeMsg) };
+    }
+
+    private static SerializableChatMessage BuildNudgeMessage(string nudge) =>
+        new() { Role = ChatRole.User, Content = $"{SystemNudgePrefix} {nudge}]" };
 
     /// <summary>
     /// Find the last user message in history (for building persistence events).


### PR DESCRIPTION
## Summary

Fixes the session "spin" (#1216) where the agent repeats a near-identical message before every tool call, re-narrating the same plan until the context window fills and the session is force-compacted.

**Root cause:** PR #1178 persisted the per-turn volatile context block (memory recall, current time, working context, etc.) into history as a `User`-role nudge placed *after* the real user message. Strict ChatML templates (Qwen3) read that trailing user-role block as a fresh user turn, so the model restarts its assistant response and re-narrates on every tool-loop iteration. Same class of bug as #634, relocated by #1178.

**Fix:** new `SessionState.AddVolatileContextNudge` inserts the volatile block *before* the most recent real user message (appending only when the last entry isn't a real user message — reminder/scheduled/cold-recovery/delivery-retry paths). The real user message stays at the tail of the user-portion, so every chat template anchors to it correctly. `AddSystemNudge` stays append-only for mid-turn corrective nudges (empty-response, duplicate-tool, budget, delivery-retry), which need the tail position to course-correct.

**Cache:** KV-cache prefix stability from #1178 is preserved — the inserted message's byte position is fixed once added and subsequent turns only append, so byte-prefix caching providers extend the cached prefix through it unchanged.

## Affected versions

0.20.3, 0.21.0, 0.21.1.

## Test plan

- [x] `Netclaw.Actors.Tests` 2042/2042 pass; updated cache-prefix assembler test + new `SessionState` unit tests (insert-before + append-fallback)
- [x] `dotnet slopwatch analyze` clean; copyright headers present
- [x] Behavioral eval suite vs Qwen3.6-27B (llm.testlab): spin signature absent — 0 context-overflow/force-compaction, 0 tool-call-limit hits, 0 duplicate-tool detections, no repeated-line output; `multi_turn_python_app` (4-turn tool loop) 3/3
- [x] KV-cache profiler: steady-state hit rates 92–99%, matching/beating #1178's published figures (no cache regression)

Closes #1216
