### PR TITLE
fix(sessions): persist approval turn context

### DIFF
--- a/openspec/changes/redesign-session-approval-state-machine/tasks.md
+++ b/openspec/changes/redesign-session-approval-state-machine/tasks.md
@@ -1,42 +1,42 @@
 ## 1. Turn Context Model
 
-- [ ] 1.1 Add an internal turn authority context model with only durable execution/security fields.
-- [ ] 1.2 Add a persistence-safe turn context record for journaled approval events.
-- [ ] 1.3 Add focused tests for building turn context from live `MessageSource`.
-- [ ] 1.4 Document which `MessageSource` fields remain transport-only and are not part of turn context.
+- [x] 1.1 Add an internal turn authority context model with only durable execution/security fields.
+- [x] 1.2 Add a persistence-safe turn context record for journaled approval events.
+- [x] 1.3 Add focused tests for building turn context from live `MessageSource`.
+- [x] 1.4 Document which `MessageSource` fields remain transport-only and are not part of turn context.
 
 ## 2. Session Approval State
 
-- [ ] 2.1 Add explicit approval turn state owned by `LlmSessionActor` beneath the coarse `SessionPhase` lifecycle.
-- [ ] 2.2 Record waiting approval state when a live tool approval request is emitted.
-- [ ] 2.3 Restore recovered waiting approval state during journal replay.
-- [ ] 2.4 Transition through redrive and abandoned states when approval responses or new user messages arrive.
+- [x] 2.1 Add explicit approval turn state owned by `LlmSessionActor` beneath the coarse `SessionPhase` lifecycle.
+- [x] 2.2 Record waiting approval state when a live tool approval request is emitted.
+- [x] 2.3 Restore recovered waiting approval state during journal replay.
+- [x] 2.4 Transition through redrive and abandoned states when approval responses or new user messages arrive.
 
 ## 3. Persistence And Compatibility
 
-- [ ] 3.1 Persist turn context with new `ToolApprovalRequested` events using additive protobuf fields only.
-- [ ] 3.2 Map persisted turn context into `PendingToolInteraction` without duplicating authority fields as the normal path.
-- [ ] 3.3 Add legacy compatibility restoration for pre-change approval events that only carry old trust fields.
-- [ ] 3.4 Add serialization and recovery tests for new and legacy approval events.
+- [x] 3.1 Persist turn context with new `ToolApprovalRequested` events using additive protobuf fields only.
+- [x] 3.2 Map persisted turn context into `PendingToolInteraction` without duplicating authority fields as the normal path.
+- [x] 3.3 Add legacy compatibility restoration for pre-change approval events that only carry old trust fields.
+- [x] 3.4 Add serialization and recovery tests for new and legacy approval events.
 
 ## 4. Redrive And Consumers
 
-- [ ] 4.1 Replace cold-recovery `MessageSource` synthesis as the normal authority restoration path.
-- [ ] 4.2 Project restored turn context into `ToolExecutionContext` for parked batch redrive.
-- [ ] 4.3 Keep restored turn context active through continuation LLM calls and continuation tool calls.
-- [ ] 4.4 Route memory recall, curation, and checkpoint audience/boundary/adopted-context decisions through turn context.
-- [ ] 4.5 Remove redundant redrive override parameters once turn context projection is authoritative.
+- [x] 4.1 Replace cold-recovery `MessageSource` synthesis as the normal authority restoration path.
+- [x] 4.2 Project restored turn context into `ToolExecutionContext` for parked batch redrive.
+- [x] 4.3 Keep restored turn context active through continuation LLM calls and continuation tool calls.
+- [x] 4.4 Route memory recall, curation, and checkpoint audience/boundary/adopted-context decisions through turn context.
+- [x] 4.5 Remove redundant redrive override parameters once turn context projection is authoritative.
 
 ## 5. Test Consolidation
 
-- [ ] 5.1 Keep end-to-end tests for recovered approval click, no duplicate prompt, sibling tool no-reexecution, wrong requester, and expired prompt behavior.
-- [ ] 5.2 Replace field-by-field cold-recovery tests with focused turn-context construction, persistence, restoration, and projection tests.
-- [ ] 5.3 Add memory safety regression coverage for recovered turns with third-party adopted context.
-- [ ] 5.4 Add a test proving shared context model does not include session-only or sub-agent-only lifecycle state.
+- [x] 5.1 Keep end-to-end tests for recovered approval click, no duplicate prompt, sibling tool no-reexecution, wrong requester, and expired prompt behavior.
+- [x] 5.2 Replace field-by-field cold-recovery tests with focused turn-context construction, persistence, restoration, and projection tests.
+- [x] 5.3 Add memory safety regression coverage for recovered turns with third-party adopted context.
+- [x] 5.4 Add a test proving shared context model does not include session-only or sub-agent-only lifecycle state.
 
 ## 6. Validation
 
-- [ ] 6.1 Run targeted actor approval recovery and serialization tests.
-- [ ] 6.2 Run `dotnet slopwatch analyze`.
-- [ ] 6.3 Run `./scripts/Add-FileHeaders.ps1 -Verify`.
-- [ ] 6.4 Run `openspec validate redesign-session-approval-state-machine --strict`.
+- [x] 6.1 Run targeted actor approval recovery and serialization tests.
+- [x] 6.2 Run `dotnet slopwatch analyze`.
+- [x] 6.3 Run `./scripts/Add-FileHeaders.ps1 -Verify`.
+- [x] 6.4 Run `openspec validate redesign-session-approval-state-machine --strict`.

--- a/src/Netclaw.Actors.Tests/Channels/TurnContextTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TurnContextTests.cs
@@ -57,8 +57,10 @@ public sealed class TurnContextTests
         Assert.Equal(PrincipalClassification.TrustedInternal, context.RequesterPrincipal);
         Assert.Equal(TransportAuthenticity.Verified, context.Provenance.TransportAuthenticity);
         Assert.Equal(PayloadTaint.Community, context.Provenance.PayloadTaint);
-        Assert.Equal("slack-workspace:T123", context.Provenance.SourceScope?.Value);
-        Assert.Equal("slack", context.Provenance.SourceKind?.Value);
+        var sourceScope = Assert.NotNull(context.Provenance.SourceScope);
+        var sourceKind = Assert.NotNull(context.Provenance.SourceKind);
+        Assert.Equal("slack-workspace:T123", sourceScope.Value);
+        Assert.Equal("slack", sourceKind.Value);
         Assert.True(context.HasAdoptedContext);
         Assert.True(context.HasThirdPartyAdoptedContext);
         Assert.Equal(["U12345", "U67890"], context.AdoptedSpeakerIds);
@@ -172,7 +174,8 @@ public sealed class TurnContextTests
         Assert.Equal(PrincipalClassification.TrustedInternal, context.RequesterPrincipal);
         Assert.Equal(TransportAuthenticity.Verified, context.Provenance.TransportAuthenticity);
         Assert.Equal(PayloadTaint.Unknown, context.Provenance.PayloadTaint);
-        Assert.Equal(ChannelType.Slack.ToWireValue(), context.Provenance.SourceKind?.Value);
+        var sourceKind = Assert.NotNull(context.Provenance.SourceKind);
+        Assert.Equal(ChannelType.Slack.ToWireValue(), sourceKind.Value);
         Assert.True(context.HasAdoptedContext);
         Assert.True(context.HasThirdPartyAdoptedContext);
         Assert.Equal(["U67890"], context.AdoptedSpeakerIds);

--- a/src/Netclaw.Actors.Tests/Channels/TurnContextTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TurnContextTests.cs
@@ -1,0 +1,222 @@
+// -----------------------------------------------------------------------
+// <copyright file="TurnContextTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Actor;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class TurnContextTests
+{
+    [Fact]
+    public void FromMessageSource_captures_durable_authority_fields()
+    {
+        var sessionId = new SessionId("C123/1700000000.000001");
+        var turnId = new TurnId("turn-1");
+        var source = new MessageSource
+        {
+            ChannelType = ChannelType.Slack,
+            SenderId = new SenderId("U12345"),
+            ChannelId = "C123",
+            MessageId = "1700000000.000001",
+            TurnId = turnId,
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            Principal = PrincipalClassification.TrustedInternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community)
+            {
+                SourceScope = new SourceScope("slack-workspace:T123"),
+                SourceKind = new SourceKind("slack")
+            },
+            ReceivedAt = new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero),
+            ExecutableText = "run git status",
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["U12345", "U67890"],
+            AdoptedContextProjection = "quoted context",
+            AdoptedContextLowerBound = "1700000000.000000",
+            AdoptedContextUpperBound = "1700000000.000001",
+            ReminderId = "reminder:1700000000000",
+            BackgroundJobId = "bg-job:42",
+            AckTarget = ActorRefs.Nobody
+        };
+
+        var context = TurnContext.FromMessageSource(sessionId, turnId, source);
+
+        Assert.Equal(sessionId, context.SessionId);
+        Assert.Equal(turnId, context.TurnId);
+        Assert.Equal(TrustAudience.Team, context.Audience);
+        Assert.Equal(TrustBoundary.Team, context.Boundary);
+        Assert.Equal(ChannelType.Slack, context.ChannelType);
+        Assert.Equal(new SenderId("U12345"), context.RequesterSenderId);
+        Assert.Equal(PrincipalClassification.TrustedInternal, context.RequesterPrincipal);
+        Assert.Equal(TransportAuthenticity.Verified, context.Provenance.TransportAuthenticity);
+        Assert.Equal(PayloadTaint.Community, context.Provenance.PayloadTaint);
+        Assert.Equal("slack-workspace:T123", context.Provenance.SourceScope?.Value);
+        Assert.Equal("slack", context.Provenance.SourceKind?.Value);
+        Assert.True(context.HasAdoptedContext);
+        Assert.True(context.HasThirdPartyAdoptedContext);
+        Assert.Equal(["U12345", "U67890"], context.AdoptedSpeakerIds);
+        Assert.True(context.SupportsInteractiveApproval);
+        Assert.True(context.HasApprovalRequester);
+    }
+
+    [Fact]
+    public void FromMessageSource_without_source_fails_closed_without_synthesizing_requester()
+    {
+        var context = TurnContext.FromMessageSource(
+            new SessionId("unknown-channel/thread-1"),
+            new TurnId("turn-1"),
+            source: null);
+
+        Assert.Equal(TrustAudience.Public, context.Audience);
+        Assert.Equal(TrustBoundary.Public, context.Boundary);
+        Assert.Null(context.ChannelType);
+        Assert.Null(context.RequesterSenderId);
+        Assert.Equal(PrincipalClassification.UntrustedExternal, context.RequesterPrincipal);
+        Assert.Equal(TransportAuthenticity.Unverified, context.Provenance.TransportAuthenticity);
+        Assert.Equal(PayloadTaint.Public, context.Provenance.PayloadTaint);
+        Assert.False(context.SupportsInteractiveApproval);
+        Assert.False(context.HasApprovalRequester);
+    }
+
+    [Fact]
+    public void TurnContext_excludes_transport_and_lifecycle_only_fields()
+    {
+        var durableFields = typeof(TurnContext).GetProperties()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.DoesNotContain(nameof(MessageSource.AckTarget), durableFields);
+        Assert.DoesNotContain(nameof(MessageSource.BackgroundJobId), durableFields);
+        Assert.DoesNotContain(nameof(MessageSource.ReminderId), durableFields);
+        Assert.DoesNotContain(nameof(MessageSource.ExecutableText), durableFields);
+        Assert.DoesNotContain(nameof(MessageSource.MessageId), durableFields);
+        Assert.DoesNotContain(nameof(MessageSource.ChannelId), durableFields);
+        Assert.DoesNotContain(nameof(MessageSource.ReceivedAt), durableFields);
+    }
+
+    [Fact]
+    public void Record_round_trip_preserves_authority_context()
+    {
+        var original = new TurnContext
+        {
+            SessionId = new SessionId("C123/1700000000.000001"),
+            TurnId = new TurnId("turn-1"),
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            ChannelType = ChannelType.Slack,
+            RequesterSenderId = new SenderId("U12345"),
+            RequesterPrincipal = PrincipalClassification.Operator,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community)
+            {
+                SourceScope = new SourceScope("slack-workspace:T123"),
+                SourceKind = new SourceKind("slack")
+            },
+            HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["U12345", "U67890"],
+            SupportsInteractiveApproval = true
+        };
+
+        var success = TurnContext.TryFromRecord(original.ToRecord(), out var restored, out var reason);
+
+        Assert.True(success, reason);
+        Assert.NotNull(restored);
+        Assert.Equal(original.SessionId, restored.SessionId);
+        Assert.Equal(original.TurnId, restored.TurnId);
+        Assert.Equal(original.Audience, restored.Audience);
+        Assert.Equal(original.Boundary, restored.Boundary);
+        Assert.Equal(original.ChannelType, restored.ChannelType);
+        Assert.Equal(original.RequesterSenderId, restored.RequesterSenderId);
+        Assert.Equal(original.RequesterPrincipal, restored.RequesterPrincipal);
+        Assert.Equal(original.Provenance, restored.Provenance);
+        Assert.Equal(original.HasAdoptedContext, restored.HasAdoptedContext);
+        Assert.Equal(original.HasThirdPartyAdoptedContext, restored.HasThirdPartyAdoptedContext);
+        Assert.Equal(original.AdoptedSpeakerIds, restored.AdoptedSpeakerIds);
+        Assert.Equal(original.SupportsInteractiveApproval, restored.SupportsInteractiveApproval);
+    }
+
+    [Fact]
+    public void Restore_legacy_approval_event_builds_turn_context_from_legacy_fields()
+    {
+        var evt = new ToolApprovalRequested
+        {
+            SessionId = new SessionId("C123/1700000000.000001"),
+            CallId = "call-legacy-1",
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            ChannelType = ChannelType.Slack.ToWireValue(),
+            SupportsInteractiveApproval = true,
+            RequesterSenderId = new SenderId("U12345"),
+            RequesterPrincipal = PrincipalClassification.TrustedInternal,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["U67890"]
+        };
+
+        var context = ToolApprovalTurnContext.Restore(evt, out var failure);
+
+        Assert.Null(failure);
+        Assert.NotNull(context);
+        Assert.Equal(evt.SessionId, context.SessionId);
+        Assert.Equal(new TurnId("recovered-approval/call-legacy-1"), context.TurnId);
+        Assert.Equal(TrustAudience.Team, context.Audience);
+        Assert.Equal(TrustBoundary.Team, context.Boundary);
+        Assert.Equal(ChannelType.Slack, context.ChannelType);
+        Assert.Equal(new SenderId("U12345"), context.RequesterSenderId);
+        Assert.Equal(PrincipalClassification.TrustedInternal, context.RequesterPrincipal);
+        Assert.Equal(TransportAuthenticity.Verified, context.Provenance.TransportAuthenticity);
+        Assert.Equal(PayloadTaint.Unknown, context.Provenance.PayloadTaint);
+        Assert.Equal(ChannelType.Slack.ToWireValue(), context.Provenance.SourceKind?.Value);
+        Assert.True(context.HasAdoptedContext);
+        Assert.True(context.HasThirdPartyAdoptedContext);
+        Assert.Equal(["U67890"], context.AdoptedSpeakerIds);
+        Assert.True(context.SupportsInteractiveApproval);
+    }
+
+    [Fact]
+    public void Restore_legacy_approval_event_defaults_missing_principal_without_broadening_approval()
+    {
+        var evt = new ToolApprovalRequested
+        {
+            SessionId = new SessionId("C123/1700000000.000001"),
+            CallId = "call-legacy-no-principal",
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            ChannelType = ChannelType.Slack.ToWireValue(),
+            RequesterSenderId = new SenderId("U12345")
+        };
+
+        var context = ToolApprovalTurnContext.Restore(evt, out var failure);
+
+        Assert.Null(failure);
+        Assert.NotNull(context);
+        Assert.Equal(PrincipalClassification.UntrustedExternal, context.RequesterPrincipal);
+        Assert.Equal(new SenderId("U12345"), context.RequesterSenderId);
+        Assert.True(context.HasApprovalRequester);
+    }
+
+    [Fact]
+    public void Restore_legacy_approval_event_fails_closed_without_requester_sender()
+    {
+        var evt = new ToolApprovalRequested
+        {
+            SessionId = new SessionId("C123/1700000000.000001"),
+            CallId = "call-legacy-missing-requester",
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            ChannelType = ChannelType.Slack.ToWireValue(),
+            RequesterPrincipal = PrincipalClassification.TrustedInternal
+        };
+
+        var context = ToolApprovalTurnContext.Restore(evt, out var failure);
+
+        Assert.Null(context);
+        Assert.Equal("legacy approval event is missing requester sender", failure);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -771,6 +771,24 @@ public sealed class SerializationRoundTripTests : TestKit
                 new ToolApprovalRequested.ApprovalCandidateRecord { Verb = "git", Directory = "/home/user/project" },
                 new ToolApprovalRequested.ApprovalCandidateRecord { Verb = "ls", Directory = null }
             ],
+            TurnContext = new TurnContextRecord
+            {
+                SessionId = new SessionId("C123/1700000000.000001"),
+                TurnId = "turn-approval-1",
+                Audience = Netclaw.Configuration.TrustAudience.Team,
+                Boundary = Netclaw.Configuration.TrustBoundary.Team,
+                ChannelType = "slack",
+                RequesterSenderId = new SenderId("U12345"),
+                RequesterPrincipal = Netclaw.Configuration.PrincipalClassification.Operator,
+                TransportAuthenticity = Netclaw.Configuration.TransportAuthenticity.Verified,
+                PayloadTaint = Netclaw.Configuration.PayloadTaint.Community,
+                SourceScope = "slack-workspace:T123",
+                SourceKind = "slack",
+                HasAdoptedContext = true,
+                HasThirdPartyAdoptedContext = true,
+                AdoptedSpeakerIds = ["U12345", "U-observer"],
+                SupportsInteractiveApproval = true
+            },
             RequestedAtMs = 1700000000000
         };
 
@@ -796,6 +814,60 @@ public sealed class SerializationRoundTripTests : TestKit
         Assert.Equal("/home/user/project", result.Candidates[0].Directory);
         Assert.Equal("ls", result.Candidates[1].Verb);
         Assert.Null(result.Candidates[1].Directory);
+        Assert.NotNull(result.TurnContext);
+        Assert.Equal(wrapped.TurnContext.SessionId, result.TurnContext.SessionId);
+        Assert.Equal(wrapped.TurnContext.TurnId, result.TurnContext.TurnId);
+        Assert.Equal(wrapped.TurnContext.Audience, result.TurnContext.Audience);
+        Assert.Equal(wrapped.TurnContext.Boundary, result.TurnContext.Boundary);
+        Assert.Equal(wrapped.TurnContext.ChannelType, result.TurnContext.ChannelType);
+        Assert.Equal(wrapped.TurnContext.RequesterSenderId, result.TurnContext.RequesterSenderId);
+        Assert.Equal(wrapped.TurnContext.RequesterPrincipal, result.TurnContext.RequesterPrincipal);
+        Assert.Equal(wrapped.TurnContext.TransportAuthenticity, result.TurnContext.TransportAuthenticity);
+        Assert.Equal(wrapped.TurnContext.PayloadTaint, result.TurnContext.PayloadTaint);
+        Assert.Equal(wrapped.TurnContext.SourceScope, result.TurnContext.SourceScope);
+        Assert.Equal(wrapped.TurnContext.SourceKind, result.TurnContext.SourceKind);
+        Assert.Equal(wrapped.TurnContext.HasAdoptedContext, result.TurnContext.HasAdoptedContext);
+        Assert.Equal(wrapped.TurnContext.HasThirdPartyAdoptedContext, result.TurnContext.HasThirdPartyAdoptedContext);
+        Assert.Equal(wrapped.TurnContext.AdoptedSpeakerIds, result.TurnContext.AdoptedSpeakerIds);
+        Assert.Equal(wrapped.TurnContext.SupportsInteractiveApproval, result.TurnContext.SupportsInteractiveApproval);
+        Assert.Equal(wrapped.RequestedAtMs, result.RequestedAtMs);
+    }
+
+    [Fact]
+    public void ToolApprovalRequested_legacy_event_round_trips_without_turn_context()
+    {
+        var wrapped = new ToolApprovalRequested
+        {
+            SessionId = new SessionId("C123/1700000000.000001"),
+            CallId = "call-legacy-approval",
+            ToolName = "shell_execute",
+            Patterns = ["git status"],
+            CandidateVerbs = ["git"],
+            Audience = Netclaw.Configuration.TrustAudience.Team,
+            Boundary = Netclaw.Configuration.TrustBoundary.Team,
+            ChannelType = "slack",
+            SupportsInteractiveApproval = true,
+            RequesterSenderId = new SenderId("U12345"),
+            RequesterPrincipal = Netclaw.Configuration.PrincipalClassification.TrustedInternal,
+            OptionKeys = [ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.Deny],
+            RequestedAtMs = 1700000000000
+        };
+
+        var result = RoundTrip(wrapped);
+
+        Assert.Equal(wrapped.SessionId, result.SessionId);
+        Assert.Equal(wrapped.CallId, result.CallId);
+        Assert.Equal(wrapped.ToolName, result.ToolName);
+        Assert.Equal(wrapped.Patterns, result.Patterns);
+        Assert.Equal(wrapped.CandidateVerbs, result.CandidateVerbs);
+        Assert.Equal(wrapped.Audience, result.Audience);
+        Assert.Equal(wrapped.Boundary, result.Boundary);
+        Assert.Equal(wrapped.ChannelType, result.ChannelType);
+        Assert.Equal(wrapped.SupportsInteractiveApproval, result.SupportsInteractiveApproval);
+        Assert.Equal(wrapped.RequesterSenderId, result.RequesterSenderId);
+        Assert.Equal(wrapped.RequesterPrincipal, result.RequesterPrincipal);
+        Assert.Equal(wrapped.OptionKeys, result.OptionKeys);
+        Assert.Null(result.TurnContext);
         Assert.Equal(wrapped.RequestedAtMs, result.RequestedAtMs);
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -93,7 +93,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Run git status"
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // The tool batch is announced (ToolCallOutput) then parks on the
@@ -176,7 +177,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Run git status"
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -245,7 +247,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Run git status"
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -312,7 +315,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Read and then run git status"
+            Content = "Read and then run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -400,7 +404,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Read the file and run git status"
+            Content = "Read the file and run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -502,7 +507,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Run git status"
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -592,7 +598,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "List the directory"
+            Content = "List the directory",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -792,15 +799,10 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
     public async Task Cold_recovered_continuation_tool_calls_run_at_original_turn_audience()
     {
         // Regression for the 0.21 cold-recovery audience bug (session
-        // D0AC6CKBK5K/1779897736.065949): RedriveToolBatchForApproval correctly
-        // passes pending.Audience as the audienceOverride for the parked batch
-        // itself, but the LLM iteration that follows (the model's NEXT tool call
-        // in the same recovered turn) re-enters DispatchToolBatch with no
-        // override and previously fell through to TrustAudience.Public, silently
-        // blocking shell_execute and any other tool the audience profile
-        // doesn't list for Public. RedriveToolBatchForApproval now rehydrates
-        // _currentTurnSource from the pending record so every subsequent
-        // dispatch in the recovered turn reads the original audience.
+        // D0AC6CKBK5K/1779897736.065949): the parked batch and any continuation
+        // tool calls must execute from the same persisted turn context. A null
+        // recovered source used to fall through to TrustAudience.Public,
+        // silently blocking tools the audience profile doesn't list for Public.
         const string parkedCallId = "call-shell-parked";
         const string continuationCallId = "call-read-continuation";
         _toolExecutor.GatedTools.Add("shell_execute");
@@ -1001,7 +1003,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Run git status"
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(
@@ -1133,7 +1136,8 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
             SessionId = sessionId,
-            Content = "Run git status"
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -573,6 +573,159 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
     }
 
     [Fact]
+    public async Task Recovered_resolved_batch_heals_history_when_next_message_arrives_without_join()
+    {
+        const string callId = "call-shell-crash-no-join";
+        _toolExecutor.GatedTools.Add("shell_execute");
+
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(callId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git status" })
+        ];
+
+        var sessionId = new SessionId("test-channel/crash-after-resolve-no-join");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("crash-no-join-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        await ColdRespawnAsync(sessionId);
+
+        var subscriberB = CreateTestProbe("crash-no-join-sub-b");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriberB)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        _toolExecutor.BlockNextSuccessfulExecution("shell_execute");
+        sessionManager.Tell(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(callId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.ApproveOnce),
+            SenderId = new SenderId("local-user")
+        }, ActorRefs.Nobody);
+
+        await _toolExecutor.BlockedExecutionStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await ColdRespawnAsync(sessionId);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Never mind, just say hello"
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_fakeChatClient.ReceivedMessages.Count >= 2);
+        }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, _toolExecutor.SuccessfulExecutions);
+
+        var lastCall = _fakeChatClient.ReceivedMessages[^1];
+        var healed = lastCall.Any(m => m.Role == Microsoft.Extensions.AI.ChatRole.Tool
+            && m.Contents.OfType<FunctionResultContent>().Any(r => r.CallId == callId));
+        Assert.True(healed, "resolved-but-interrupted tool_use should be closed before direct user ingress");
+    }
+
+    [Fact]
+    public async Task Join_during_live_approved_tool_execution_does_not_abandon_batch()
+    {
+        const string callId = "call-shell-live-join";
+        _toolExecutor.GatedTools.Add("shell_execute");
+        _toolExecutor.BlockNextSuccessfulExecution("shell_execute");
+
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(callId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git status" })
+        ];
+
+        var sessionId = new SessionId("test-channel/live-approved-join");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("live-join-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        sessionManager.Tell(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(callId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.ApproveOnce),
+            SenderId = new SenderId("local-user")
+        }, ActorRefs.Nobody);
+
+        await _toolExecutor.BlockedExecutionStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var subscriberB = CreateTestProbe("live-join-sub-b");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriberB)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        _toolExecutor.ReleaseBlockedExecution();
+
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        var lastCall = _fakeChatClient.ReceivedMessages[^1];
+        var toolResult = lastCall
+            .Where(m => m.Role == Microsoft.Extensions.AI.ChatRole.Tool)
+            .SelectMany(m => m.Contents.OfType<FunctionResultContent>())
+            .Single(r => r.CallId == callId)
+            .Result?.ToString();
+        Assert.NotNull(toolResult);
+        Assert.Contains("[executed shell_execute]", toolResult);
+        Assert.DoesNotContain("session restarted", toolResult!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Idle_session_with_pending_interaction_redrives_when_approval_arrives()
     {
         const string callId = "call-shell-idle";
@@ -1375,6 +1528,12 @@ internal sealed class ApprovalGateToolExecutor : IToolExecutor
     public void FailBlockedExecution()
     {
         _blockedExecutionRelease?.TrySetException(new InvalidOperationException("Simulated actor crash during tool execution."));
+        _blockedExecutionRelease = null;
+    }
+
+    public void ReleaseBlockedExecution()
+    {
+        _blockedExecutionRelease?.TrySetResult(null);
         _blockedExecutionRelease = null;
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionActorMemorySafetyTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionActorMemorySafetyTests.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmSessionActorMemorySafetyTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public sealed class LlmSessionActorMemorySafetyTests
+{
+    [Fact]
+    public void Memory_curation_skip_uses_recovered_turn_context_when_source_is_absent()
+    {
+        var turnContext = BuildTurnContext(hasThirdPartyAdoptedContext: true);
+
+        var skip = LlmSessionActor.ShouldSkipMemoryCurationForThirdPartyAdoptedContext(
+            turnContext,
+            turnSource: null);
+
+        Assert.True(skip);
+    }
+
+    [Fact]
+    public void Memory_curation_skip_prefers_turn_context_over_stale_source()
+    {
+        var turnContext = BuildTurnContext(hasThirdPartyAdoptedContext: false);
+        var source = new MessageSource
+        {
+            ChannelType = ChannelType.Slack,
+            SenderId = new SenderId("U12345"),
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            Principal = PrincipalClassification.TrustedInternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community),
+            HasThirdPartyAdoptedContext = true
+        };
+
+        var skip = LlmSessionActor.ShouldSkipMemoryCurationForThirdPartyAdoptedContext(
+            turnContext,
+            source);
+
+        Assert.False(skip);
+    }
+
+    private static TurnContext BuildTurnContext(bool hasThirdPartyAdoptedContext) => new()
+    {
+        SessionId = new SessionId("slack/thread-1"),
+        TurnId = new TurnId("turn-1"),
+        Audience = TrustAudience.Team,
+        Boundary = TrustBoundary.Team,
+        ChannelType = ChannelType.Slack,
+        RequesterSenderId = new SenderId("U12345"),
+        RequesterPrincipal = PrincipalClassification.TrustedInternal,
+        Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community),
+        HasAdoptedContext = hasThirdPartyAdoptedContext,
+        HasThirdPartyAdoptedContext = hasThirdPartyAdoptedContext,
+        AdoptedSpeakerIds = hasThirdPartyAdoptedContext ? ["U67890"] : [],
+        SupportsInteractiveApproval = true
+    };
+}

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/SessionRecallManagerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/SessionRecallManagerTests.cs
@@ -117,6 +117,49 @@ public class SessionRecallManagerTests
         Assert.Equal(0, coordinator.CallCount);
     }
 
+    [Fact]
+    public void ResolveForTurn_uses_turn_context_over_live_source_for_recovered_turns()
+    {
+        var manager = new SessionRecallManager();
+        var coordinator = new TrackingCoordinator();
+        var source = new MessageSource
+        {
+            ChannelType = ChannelType.Slack,
+            SenderId = new SenderId("U123"),
+            Audience = TrustAudience.Public,
+            Boundary = TrustBoundary.Public,
+            Principal = PrincipalClassification.UntrustedExternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
+        };
+        var turnContext = new TurnContext
+        {
+            SessionId = new SessionId("slack/thread-1"),
+            TurnId = new TurnId("turn-1"),
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            ChannelType = ChannelType.Slack,
+            RequesterSenderId = new SenderId("U123"),
+            RequesterPrincipal = PrincipalClassification.TrustedInternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community),
+            SupportsInteractiveApproval = true
+        };
+        var state = SessionState.Empty.AddUserMessage("Search the team memory");
+
+        manager.ResolveForTurn(
+            recallQuery: null,
+            state,
+            new SessionId("slack/thread-1"),
+            source,
+            coordinator,
+            memoryEnabled: true,
+            turnContext: turnContext);
+
+        Assert.Equal(1, coordinator.CallCount);
+        Assert.NotNull(coordinator.LastRequest);
+        Assert.Equal(TrustAudience.Team, coordinator.LastRequest.Audience);
+        Assert.Equal(TrustBoundary.Team.Value, coordinator.LastRequest.Boundary);
+    }
+
     /// <summary>
     /// Tracking coordinator that counts invocations and returns empty results.
     /// </summary>
@@ -124,9 +167,12 @@ public class SessionRecallManagerTests
     {
         public int CallCount { get; private set; }
 
+        public AutomaticRecallRequest? LastRequest { get; private set; }
+
         public Task<AutomaticRecallResult> RecallAsync(AutomaticRecallRequest request, CancellationToken ct = default)
         {
             CallCount++;
+            LastRequest = request;
             return Task.FromResult(new AutomaticRecallResult([]));
         }
     }

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -10,10 +10,12 @@ using Akka.Hosting.TestKit;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
 using Netclaw.Tools;
 using Xunit;
 
@@ -29,6 +31,19 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     {
     }
 
+    private static TurnContext InteractiveTurnContext(SessionId sessionId) => new()
+    {
+        SessionId = sessionId,
+        TurnId = new TurnId("test-turn"),
+        Audience = TrustAudience.Personal,
+        Boundary = TrustBoundary.Personal,
+        ChannelType = ChannelType.SignalR,
+        RequesterSenderId = new SenderId("local-user"),
+        RequesterPrincipal = PrincipalClassification.Operator,
+        Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Trusted),
+        SupportsInteractiveApproval = true
+    };
+
     [Fact]
     public async Task Approval_wait_does_not_consume_tool_execution_timeout_budget()
     {
@@ -36,6 +51,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var approvalChannel = new ApprovalChannel();
         var probe = CreateTestProbe("tool-pipeline-probe");
         var approvalRequestTcs = new TaskCompletionSource<ToolInteractionRequest>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionId = new SessionId("D1/approval-timeout-test");
 
         var toolCalls = new List<FunctionCallContent>
         {
@@ -48,7 +64,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
             executor,
             toolCalls,
-            new SessionId("D1/approval-timeout-test"),
+            sessionId,
             source: null,
             auditLogger: null,
             timeProvider: TimeProvider.System,
@@ -61,6 +77,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             approvalChannel: approvalChannel,
             emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request.Request),
             approvalTimeout: Timeout.InfiniteTimeSpan,
+            turnContext: InteractiveTurnContext(sessionId),
             ct: TestContext.Current.CancellationToken);
 
         var approvalRequest = await approvalRequestTcs.Task.WaitAsync(
@@ -84,12 +101,58 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     }
 
     [Fact]
+    public async Task Source_less_approval_required_turn_fails_closed_without_prompt()
+    {
+        var executor = new ApprovalThenSuccessExecutor();
+        var approvalChannel = new ApprovalChannel();
+        var probe = CreateTestProbe("source-less-approval-probe");
+        var approvals = new List<ToolInteractionRequest>();
+
+        var toolCalls = new List<FunctionCallContent>
+        {
+            new("call-no-source", "shell_execute", new Dictionary<string, object?>
+            {
+                ["command"] = "git push origin dev"
+            })
+        };
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            toolCalls,
+            new SessionId("D1/source-less-approval-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: Path.GetTempPath(),
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(1),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            approvalChannel: approvalChannel,
+            emitApprovalRequest: request => approvals.Add(request.Request),
+            approvalTimeout: Timeout.InfiniteTimeSpan,
+            ct: TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(completed.ToolResults);
+        Assert.Contains("no interactive approval requester is available", result.Content);
+        Assert.Empty(approvals);
+    }
+
+    [Fact]
     public async Task Approve_once_does_not_reprompt_on_retry_execution()
     {
         var executor = new ApprovalThenSuccessExecutor();
         var approvalChannel = new ApprovalChannel();
         var probe = CreateTestProbe("approve-once-no-reprompt-probe");
         var approvals = new List<ToolInteractionRequest>();
+        var sessionId = new SessionId("signalr/approve-once-no-reprompt");
 
         var toolCalls = new List<FunctionCallContent>
         {
@@ -102,7 +165,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
             executor,
             toolCalls,
-            new SessionId("signalr/approve-once-no-reprompt"),
+            sessionId,
             source: null,
             auditLogger: null,
             timeProvider: TimeProvider.System,
@@ -115,6 +178,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             approvalChannel: approvalChannel,
             emitApprovalRequest: request => approvals.Add(request.Request),
             approvalTimeout: Timeout.InfiniteTimeSpan,
+            turnContext: InteractiveTurnContext(sessionId),
             ct: TestContext.Current.CancellationToken);
 
         await AwaitAssertAsync(() =>
@@ -147,6 +211,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var approvalChannel = new ApprovalChannel();
         var probe = CreateTestProbe("cwd-propagation-probe");
         var approvalRequestTcs = new TaskCompletionSource<ToolInteractionRequest>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionId = new SessionId("D1/cwd-propagation-test");
 
         var toolCalls = new List<FunctionCallContent>
         {
@@ -159,7 +224,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
             executor,
             toolCalls,
-            new SessionId("D1/cwd-propagation-test"),
+            sessionId,
             source: null,
             auditLogger: null,
             timeProvider: TimeProvider.System,
@@ -172,6 +237,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             approvalChannel: approvalChannel,
             emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request.Request),
             approvalTimeout: Timeout.InfiniteTimeSpan,
+            turnContext: InteractiveTurnContext(sessionId),
             ct: TestContext.Current.CancellationToken);
 
         var approvalRequest = await approvalRequestTcs.Task.WaitAsync(
@@ -194,6 +260,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var approvalChannel = new ApprovalChannel();
         var probe = CreateTestProbe("approval-cancel-probe");
         var approvalRequestTcs = new TaskCompletionSource<ToolInteractionRequest>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionId = new SessionId("D1/approval-cancel-test");
         using var executionCts = new CancellationTokenSource();
 
         var toolCalls = new List<FunctionCallContent>
@@ -207,7 +274,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
             executor,
             toolCalls,
-            new SessionId("D1/approval-cancel-test"),
+            sessionId,
             source: null,
             auditLogger: null,
             timeProvider: TimeProvider.System,
@@ -220,6 +287,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             approvalChannel: approvalChannel,
             emitApprovalRequest: request => approvalRequestTcs.TrySetResult(request.Request),
             approvalTimeout: Timeout.InfiniteTimeSpan,
+            turnContext: InteractiveTurnContext(sessionId),
             ct: executionCts.Token);
 
         var approvalRequest = await approvalRequestTcs.Task.WaitAsync(

--- a/src/Netclaw.Actors/Channels/TrustContextDeriver.cs
+++ b/src/Netclaw.Actors/Channels/TrustContextDeriver.cs
@@ -83,6 +83,39 @@ public sealed class TrustContextDeriver
             downgradeReason);
     }
 
+    public EffectiveTrustContext DeriveFromTurnContext(TurnContext context, WorkingContextOverride? workingContext = null)
+    {
+        var effectiveAudience = Narrowest(_defaults.Audience, context.Audience);
+        var downgradeReason = (string?)null;
+        var wasDowngraded = effectiveAudience != context.Audience || effectiveAudience != _defaults.Audience;
+
+        if (workingContext?.Audience is { } workingAudience)
+        {
+            var narrowed = Narrowest(effectiveAudience, workingAudience);
+            if (narrowed != effectiveAudience)
+            {
+                effectiveAudience = narrowed;
+                wasDowngraded = true;
+                downgradeReason = workingContext.Reason;
+            }
+        }
+
+        return new EffectiveTrustContext(
+            _defaults.DeploymentPosture,
+            _defaults.Audience,
+            context.Audience,
+            effectiveAudience,
+            context.Boundary,
+            context.RequesterPrincipal,
+            context.Provenance.TransportAuthenticity,
+            context.Provenance.PayloadTaint,
+            context.Provenance.SourceScope,
+            context.Provenance.SourceKind,
+            _defaults.UsedStrictFallback,
+            wasDowngraded,
+            downgradeReason);
+    }
+
     private static TrustAudience Narrowest(TrustAudience left, TrustAudience right)
         => left < right ? left : right;
 }

--- a/src/Netclaw.Actors/Channels/TurnContext.cs
+++ b/src/Netclaw.Actors/Channels/TurnContext.cs
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------
+// <copyright file="TurnContext.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Durable execution authority for a session turn. Transport delivery details
+/// stay on <see cref="MessageSource"/>; this model carries only security and
+/// provenance fields that must survive approval pause and recovery.
+/// </summary>
+public sealed record TurnContext
+{
+    public required SessionId SessionId { get; init; }
+
+    public required TurnId TurnId { get; init; }
+
+    public required TrustAudience Audience { get; init; }
+
+    public required TrustBoundary Boundary { get; init; }
+
+    public ChannelType? ChannelType { get; init; }
+
+    public SenderId? RequesterSenderId { get; init; }
+
+    public required PrincipalClassification RequesterPrincipal { get; init; }
+
+    public required SourceProvenance Provenance { get; init; }
+
+    public bool HasAdoptedContext { get; init; }
+
+    public bool HasThirdPartyAdoptedContext { get; init; }
+
+    public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = [];
+
+    public bool SupportsInteractiveApproval { get; init; }
+
+    public bool HasApprovalRequester
+        => RequesterPrincipal == PrincipalClassification.VerifiedAutomation
+           || RequesterSenderId is not null;
+
+    public static TurnContext FromMessageSource(SessionId sessionId, TurnId turnId, MessageSource? source)
+    {
+        var audience = source?.Audience ?? SecurityPolicyDefaults.ResolveAudienceFromSessionId(sessionId.Value);
+        var boundary = source?.Boundary ?? SecurityPolicyDefaults.ResolveBoundaryFromSessionId(sessionId.Value, audience);
+        var provenance = source?.Provenance
+            ?? new SourceProvenance(TransportAuthenticity.Unverified, PayloadTaint.Public);
+
+        return new TurnContext
+        {
+            SessionId = sessionId,
+            TurnId = turnId,
+            Audience = audience,
+            Boundary = boundary,
+            ChannelType = source?.ChannelType,
+            RequesterSenderId = source?.SenderId,
+            RequesterPrincipal = source?.Principal ?? PrincipalClassification.UntrustedExternal,
+            Provenance = provenance,
+            HasAdoptedContext = source?.HasAdoptedContext ?? false,
+            HasThirdPartyAdoptedContext = source?.HasThirdPartyAdoptedContext ?? false,
+            AdoptedSpeakerIds = source?.AdoptedSpeakerIds ?? [],
+            SupportsInteractiveApproval = source?.ChannelType.SupportsInteractiveApproval() ?? false
+        };
+    }
+
+    public TurnContextRecord ToRecord() => new()
+    {
+        SessionId = SessionId,
+        TurnId = TurnId.Value,
+        Audience = Audience,
+        Boundary = Boundary,
+        ChannelType = ChannelType?.ToWireValue(),
+        RequesterSenderId = RequesterSenderId,
+        RequesterPrincipal = RequesterPrincipal,
+        TransportAuthenticity = Provenance.TransportAuthenticity,
+        PayloadTaint = Provenance.PayloadTaint,
+        SourceScope = Provenance.SourceScope?.Value,
+        SourceKind = Provenance.SourceKind?.Value,
+        HasAdoptedContext = HasAdoptedContext,
+        HasThirdPartyAdoptedContext = HasThirdPartyAdoptedContext,
+        AdoptedSpeakerIds = [.. AdoptedSpeakerIds],
+        SupportsInteractiveApproval = SupportsInteractiveApproval
+    };
+
+    public static bool TryFromRecord(TurnContextRecord? record, out TurnContext? context, out string? reason)
+    {
+        context = null;
+        reason = null;
+
+        if (record is null)
+        {
+            reason = "missing turn context record";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(record.SessionId.Value))
+        {
+            reason = "missing session id";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(record.TurnId))
+        {
+            reason = "missing turn id";
+            return false;
+        }
+
+        if (record.Boundary is not { } boundary)
+        {
+            reason = "missing trust boundary";
+            return false;
+        }
+
+        if (record.RequesterPrincipal is not { } requesterPrincipal)
+        {
+            reason = "missing requester principal";
+            return false;
+        }
+
+        ChannelType? channelType = null;
+        if (!string.IsNullOrWhiteSpace(record.ChannelType))
+        {
+            if (!ChannelTypeExtensions.TryFromWireValue(record.ChannelType, out var parsed))
+            {
+                reason = $"invalid channel type '{record.ChannelType}'";
+                return false;
+            }
+
+            channelType = parsed;
+        }
+
+        context = new TurnContext
+        {
+            SessionId = record.SessionId,
+            TurnId = new TurnId(record.TurnId),
+            Audience = record.Audience,
+            Boundary = boundary,
+            ChannelType = channelType,
+            RequesterSenderId = record.RequesterSenderId,
+            RequesterPrincipal = requesterPrincipal,
+            Provenance = new SourceProvenance(record.TransportAuthenticity, record.PayloadTaint)
+            {
+                SourceScope = string.IsNullOrWhiteSpace(record.SourceScope) ? null : new SourceScope(record.SourceScope),
+                SourceKind = string.IsNullOrWhiteSpace(record.SourceKind) ? null : new SourceKind(record.SourceKind)
+            },
+            HasAdoptedContext = record.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = record.HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = record.AdoptedSpeakerIds,
+            SupportsInteractiveApproval = record.SupportsInteractiveApproval
+        };
+        return true;
+    }
+}

--- a/src/Netclaw.Actors/Channels/TurnContext.cs
+++ b/src/Netclaw.Actors/Channels/TurnContext.cs
@@ -67,24 +67,30 @@ public sealed record TurnContext
         };
     }
 
-    public TurnContextRecord ToRecord() => new()
+    public TurnContextRecord ToRecord()
     {
-        SessionId = SessionId,
-        TurnId = TurnId.Value,
-        Audience = Audience,
-        Boundary = Boundary,
-        ChannelType = ChannelType?.ToWireValue(),
-        RequesterSenderId = RequesterSenderId,
-        RequesterPrincipal = RequesterPrincipal,
-        TransportAuthenticity = Provenance.TransportAuthenticity,
-        PayloadTaint = Provenance.PayloadTaint,
-        SourceScope = Provenance.SourceScope?.Value,
-        SourceKind = Provenance.SourceKind?.Value,
-        HasAdoptedContext = HasAdoptedContext,
-        HasThirdPartyAdoptedContext = HasThirdPartyAdoptedContext,
-        AdoptedSpeakerIds = [.. AdoptedSpeakerIds],
-        SupportsInteractiveApproval = SupportsInteractiveApproval
-    };
+        var sourceScope = Provenance.SourceScope;
+        var sourceKind = Provenance.SourceKind;
+
+        return new TurnContextRecord
+        {
+            SessionId = SessionId,
+            TurnId = TurnId.Value,
+            Audience = Audience,
+            Boundary = Boundary,
+            ChannelType = ChannelType?.ToWireValue(),
+            RequesterSenderId = RequesterSenderId,
+            RequesterPrincipal = RequesterPrincipal,
+            TransportAuthenticity = Provenance.TransportAuthenticity,
+            PayloadTaint = Provenance.PayloadTaint,
+            SourceScope = sourceScope is null ? null : sourceScope.Value.Value,
+            SourceKind = sourceKind is null ? null : sourceKind.Value.Value,
+            HasAdoptedContext = HasAdoptedContext,
+            HasThirdPartyAdoptedContext = HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = [.. AdoptedSpeakerIds],
+            SupportsInteractiveApproval = SupportsInteractiveApproval
+        };
+    }
 
     public static bool TryFromRecord(TurnContextRecord? record, out TurnContext? context, out string? reason)
     {

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -74,6 +74,39 @@ public sealed record ToolCallRecorded : INetclawSerializableMessage
     public long RecordedAtMs { get; init; }
 }
 
+public sealed record TurnContextRecord
+{
+    public SessionId SessionId { get; init; }
+
+    public string TurnId { get; init; } = string.Empty;
+
+    public TrustAudience Audience { get; init; }
+
+    public TrustBoundary? Boundary { get; init; }
+
+    public string? ChannelType { get; init; }
+
+    public SenderId? RequesterSenderId { get; init; }
+
+    public PrincipalClassification? RequesterPrincipal { get; init; }
+
+    public TransportAuthenticity TransportAuthenticity { get; init; }
+
+    public PayloadTaint PayloadTaint { get; init; }
+
+    public string? SourceScope { get; init; }
+
+    public string? SourceKind { get; init; }
+
+    public bool HasAdoptedContext { get; init; }
+
+    public bool HasThirdPartyAdoptedContext { get; init; }
+
+    public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = Array.Empty<string>();
+
+    public bool SupportsInteractiveApproval { get; init; }
+}
+
 public sealed record ToolApprovalRequested : INetclawSerializableMessage
 {
     public sealed record ApprovalCandidateRecord
@@ -115,6 +148,8 @@ public sealed record ToolApprovalRequested : INetclawSerializableMessage
 
     public IReadOnlyList<ApprovalCandidateRecord> Candidates { get; init; } =
         Array.Empty<ApprovalCandidateRecord>();
+
+    public TurnContextRecord? TurnContext { get; init; }
 
     public long RequestedAtMs { get; init; }
 }

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -277,6 +277,8 @@ internal static class NetclawProtoMapper
         proto.Candidates.AddRange(evt.Candidates.Select(ToApprovalCandidateProto));
         proto.HasThirdPartyAdoptedContext = evt.HasThirdPartyAdoptedContext;
         proto.AdoptedSpeakerIds.AddRange(evt.AdoptedSpeakerIds);
+        if (evt.TurnContext is not null)
+            proto.TurnContext = ToProto(evt.TurnContext);
         return proto;
     }
 
@@ -300,6 +302,7 @@ internal static class NetclawProtoMapper
         AdoptedSpeakerIds = proto.AdoptedSpeakerIds.ToArray(),
         OptionKeys = proto.OptionKeys.ToArray(),
         Candidates = proto.Candidates.Select(FromApprovalCandidateProto).ToArray(),
+        TurnContext = proto.TurnContext is null ? null : FromProto(proto.TurnContext),
         RequestedAtMs = proto.RequestedAtMs
     };
 
@@ -355,6 +358,58 @@ internal static class NetclawProtoMapper
         Verb = proto.Verb,
         Directory = proto.HasDirectory ? proto.Directory : null
     };
+
+    private static Proto.ToolApprovalRequestedProto.Types.TurnContextRecordProto ToProto(TurnContextRecord record)
+    {
+        var proto = new Proto.ToolApprovalRequestedProto.Types.TurnContextRecordProto
+        {
+            SessionId = ToProto(record.SessionId),
+            TurnId = record.TurnId,
+            Audience = (Proto.TrustAudience)(int)record.Audience,
+            TransportAuthenticity = (int)record.TransportAuthenticity,
+            PayloadTaint = (int)record.PayloadTaint,
+            HasAdoptedContext = record.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = record.HasThirdPartyAdoptedContext,
+            SupportsInteractiveApproval = record.SupportsInteractiveApproval
+        };
+
+        if (record.Boundary is not null)
+            proto.Boundary = record.Boundary.Value.Value;
+        if (record.ChannelType is not null)
+            proto.ChannelType = record.ChannelType;
+        if (record.RequesterSenderId is not null)
+            proto.RequesterSenderId = record.RequesterSenderId.Value.Value;
+        if (record.RequesterPrincipal is not null)
+            proto.RequesterPrincipal = (int)record.RequesterPrincipal.Value;
+        if (record.SourceScope is not null)
+            proto.SourceScope = record.SourceScope;
+        if (record.SourceKind is not null)
+            proto.SourceKind = record.SourceKind;
+        proto.AdoptedSpeakerIds.AddRange(record.AdoptedSpeakerIds);
+        return proto;
+    }
+
+    private static TurnContextRecord FromProto(Proto.ToolApprovalRequestedProto.Types.TurnContextRecordProto proto)
+        => new()
+        {
+            SessionId = FromProto(proto.SessionId),
+            TurnId = proto.TurnId,
+            Audience = (Configuration.TrustAudience)(int)proto.Audience,
+            Boundary = proto.HasBoundary ? new Configuration.TrustBoundary(proto.Boundary) : null,
+            ChannelType = proto.HasChannelType ? proto.ChannelType : null,
+            RequesterSenderId = proto.HasRequesterSenderId ? new SenderId(proto.RequesterSenderId) : null,
+            RequesterPrincipal = proto.HasRequesterPrincipal
+                ? (Configuration.PrincipalClassification)proto.RequesterPrincipal
+                : null,
+            TransportAuthenticity = (Configuration.TransportAuthenticity)proto.TransportAuthenticity,
+            PayloadTaint = (Configuration.PayloadTaint)proto.PayloadTaint,
+            SourceScope = proto.HasSourceScope ? proto.SourceScope : null,
+            SourceKind = proto.HasSourceKind ? proto.SourceKind : null,
+            HasAdoptedContext = proto.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = proto.HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = proto.AdoptedSpeakerIds.ToArray(),
+            SupportsInteractiveApproval = proto.SupportsInteractiveApproval
+        };
 
     // ── SessionSnapshot ──
 

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -131,6 +131,24 @@ message ToolApprovalRequestedProto {
     optional string directory = 2;
   }
 
+  message TurnContextRecordProto {
+    SessionIdProto session_id = 1;
+    string turn_id = 2;
+    TrustAudience audience = 3;
+    optional string boundary = 4;
+    optional string channel_type = 5;
+    optional string requester_sender_id = 6;
+    optional int32 requester_principal = 7;
+    int32 transport_authenticity = 8;
+    int32 payload_taint = 9;
+    optional string source_scope = 10;
+    optional string source_kind = 11;
+    bool has_adopted_context = 12;
+    bool has_third_party_adopted_context = 13;
+    repeated string adopted_speaker_ids = 14;
+    bool supports_interactive_approval = 15;
+  }
+
   SessionIdProto session_id = 1;
   string call_id = 2;
   string tool_name = 3;
@@ -148,6 +166,7 @@ message ToolApprovalRequestedProto {
   repeated string option_keys = 15;
   bool has_third_party_adopted_context = 16;
   repeated string adopted_speaker_ids = 17;
+  TurnContextRecordProto turn_context = 18;
 }
 
 message ToolApprovalResolvedProto {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3664,13 +3664,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (pending.TurnContext is { } context)
         {
             requesterPrincipal = context.RequesterPrincipal;
-            requesterSenderId = context.RequesterSenderId?.Value;
             if (!context.HasApprovalRequester)
             {
+                requesterSenderId = null;
                 failure = "turn context has no requester sender for a non-automation principal";
                 return false;
             }
 
+            requesterSenderId = context.RequesterSenderId is { } senderId ? senderId.Value : null;
             failure = null;
             return true;
         }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2090,6 +2090,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
+        if (_resolvedToolApprovals.Count > 0)
+        {
+            var abandoned = BuildResolvedToolBatchInterruptedByRestartEvent();
+            Persist(abandoned, evt =>
+            {
+                ApplyToolBatchAbandoned(evt);
+                ContinueIncomingUserMessage(cmd);
+            });
+            return;
+        }
+
         ContinueIncomingUserMessage(cmd);
     }
 
@@ -2350,7 +2361,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // If replay found an approval decision but no durable tool result,
             // do not replay the approved side effect after restart. Close the
             // orphaned tool_use blocks so the next user turn has valid history.
-            AbandonResolvedToolBatchAfterRecovery();
+            if (_currentPhase == SessionPhase.Ready)
+                AbandonResolvedToolBatchAfterRecovery();
         });
 
         Command<LeaveSession>(cmd =>
@@ -3917,12 +3929,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _log.Info(
             "Abandoning recovered parked tool batch with {ResolvedApprovalCount} resolved approval(s) after restart",
             _resolvedToolApprovals.Count);
-        var abandoned = BuildToolBatchAbandonedEvent(
-            "Tool call was not completed — the session restarted after approval before the action completed.");
+        var abandoned = BuildResolvedToolBatchInterruptedByRestartEvent();
         Persist(abandoned, ApplyToolBatchAbandoned);
 
         return true;
     }
+
+    private ToolBatchAbandoned BuildResolvedToolBatchInterruptedByRestartEvent()
+        => BuildToolBatchAbandonedEvent(
+            "Tool call was not completed — the session restarted after approval before the action completed.");
 
     private ApprovalRedrivePlan BuildApprovalRedrivePlan(SerializableChatMessage assistantMessage)
     {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -79,6 +79,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Durable recovery derives unanswered calls from _state.History.
     private readonly ActiveToolBatchTracker _activeToolBatch = new();
     private MessageSource? _currentTurnSource;
+    private TurnContext? _currentTurnContext;
+    private ApprovalTurnState _approvalTurnState = ApprovalTurnState.None;
     private readonly ToolRegistry? _fullRegistry;
     private readonly ToolAccessPolicy? _toolAccessPolicy;
     private readonly TrustContextDeriver? _trustContextDeriver;
@@ -248,6 +250,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ApplyTurnRecorded(evt);
             _pendingToolInteractions.Clear();
             _resolvedToolApprovals.Clear();
+            ClearApprovalTurnState();
             ClearActiveToolBatchTracking();
         });
         Recover<SessionTitleSet>(evt => _state = _state.Apply(evt));
@@ -256,6 +259,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _state = _state.Apply(evt);
             _pendingToolInteractions.Clear();
             _resolvedToolApprovals.Clear();
+            ClearApprovalTurnState();
             ClearActiveToolBatchTracking();
         });
         Recover<ToolBatchStarted>(ApplyToolBatchStarted);
@@ -964,6 +968,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _resolvedToolApprovals.Clear();
         TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
             _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolIterationsPerTurn, msg.ToolResults.Count);
+        MarkApprovalRunningAfterRedrive();
         FireLlmCall();
     }
 
@@ -998,7 +1003,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (msg.Proposals.Count > 0 && _curationActor is not null
             && CurrentTurnAudience() != TrustAudience.Public && _memoryConfig.Enabled)
         {
-            if (_currentTurnSource?.HasThirdPartyAdoptedContext == true)
+            if (ShouldSkipMemoryCurationForThirdPartyAdoptedContext(_currentTurnContext, _currentTurnSource))
             {
                 TurnLog().Info("memory_curation_skipped third-party adopted-context present; waiting for explicit elevation");
                 if (stopAfterAcceptedProposalPersistence)
@@ -1051,6 +1056,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             CompletePassivation();
         }
     }
+
+    internal static bool ShouldSkipMemoryCurationForThirdPartyAdoptedContext(
+        TurnContext? turnContext,
+        MessageSource? turnSource)
+        => (turnContext?.HasThirdPartyAdoptedContext ?? turnSource?.HasThirdPartyAdoptedContext) == true;
 
     private void Compacting()
     {
@@ -1344,6 +1354,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
         else
         {
+            ClearApprovalTurnState();
             TransitionTo(SessionPhase.Ready);
         }
 
@@ -1504,7 +1515,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
 
         _passivationFinalStopScheduled = true;
-        SaveSnapshot(BuildSnapshot());
+        SaveSnapshotIfSafe();
         Timers.StartSingleTimer(
             PassivationFinalStopTimerKey,
             new PassivationFinalStop(),
@@ -1780,14 +1791,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// re-drive path (<see cref="RedriveToolBatchForApproval"/>) runs the exact
     /// same dispatch logic — there is no divergent second copy.
     /// </summary>
-    /// <param name="audienceOverride">
-    /// Audience the batch must run under when there is no live
-    /// <see cref="_currentTurnSource"/>. The post-approval re-drive of a
-    /// cold-recovered session passes the parked turn's persisted audience so
-    /// the re-driven call runs under the audience its approval grant was
-    /// recorded against — instead of the fail-closed <see cref="TrustAudience.Public"/>
-    /// a null source would otherwise force. Null on the live-turn path.
-    /// </param>
     /// <param name="oneTimeApprovalPreSeed">
     /// Optional map of <c>callId → approved patterns</c>. For each entry, the
     /// pipeline pre-seeds the one-time approval bypass on that call's execution
@@ -1797,12 +1800,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// </param>
     private void DispatchToolBatch(
         List<FunctionCallContent> toolCalls,
-        TrustAudience? audienceOverride = null,
-        TrustBoundary? boundaryOverride = null,
-        string? channelTypeOverride = null,
-        bool? supportsInteractiveApprovalOverride = null,
-        SenderId? requesterSenderIdOverride = null,
-        PrincipalClassification? requesterPrincipalOverride = null,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? oneTimeApprovalPreSeed = null,
         IReadOnlyDictionary<string, ApprovalDecision>? decisionOverride = null)
     {
@@ -1879,13 +1876,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             setWorkingDirectoryAvailable: setWorkingDirectoryAvailable,
             streamToolResults: true,
             oneTimeApprovalPreSeed: oneTimeApprovalPreSeed,
-            audienceOverride: audienceOverride,
-            boundaryOverride: boundaryOverride,
-            channelTypeOverride: channelTypeOverride,
-            supportsInteractiveApprovalOverride: supportsInteractiveApprovalOverride,
-            requesterSenderIdOverride: requesterSenderIdOverride,
-            requesterPrincipalOverride: requesterPrincipalOverride,
             decisionOverride: decisionOverride,
+            turnContext: _currentTurnContext,
             ct: toolExecutionCt);
     }
 
@@ -1999,6 +1991,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
+        ClearApprovalTurnState();
         TransitionTo(SessionPhase.Ready);
     }
 
@@ -2086,6 +2079,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // API, which would otherwise wedge every subsequent turn.
         if (_pendingToolInteractions.Count > 0)
         {
+            if (_approvalTurnState is WaitingApprovalTurn waiting)
+                _approvalTurnState = new AbandoningApprovalTurn(waiting.Context, "superseded_by_new_message");
             var abandoned = BuildToolBatchAbandonedEvent();
             Persist(abandoned, evt =>
             {
@@ -2102,8 +2097,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         _deliveryRetry.Clear();
         _currentTurnSource = cmd.Source;
-        _currentTrustContext = _trustContextDeriver?.Derive(cmd.Source);
         BindTurnTelemetry(cmd.Source);
+        _currentTurnContext = TurnContext.FromMessageSource(
+            _sessionId,
+            _activeTurnId ?? new Protocol.TurnId(IdGen.ShortId()),
+            cmd.Source);
+        _approvalTurnState = new RunningApprovalTurn(_currentTurnContext);
+        _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(_currentTurnContext);
         PersistAdoptedContextIfNeeded(cmd.Source);
 
         // Sessions created from Slack/Discord start without transport-derived
@@ -2518,7 +2518,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (_recallManager.TurnRecallCache is null)
         {
             var recallSw = Stopwatch.StartNew();
-            var resolved = _recallManager.ResolveForTurn(recallQuery, _state, _sessionId, _currentTurnSource, _memoryRecallCoordinator, _memoryConfig.Enabled);
+            var resolved = _recallManager.ResolveForTurn(
+                recallQuery,
+                _state,
+                _sessionId,
+                _currentTurnSource,
+                _memoryRecallCoordinator,
+                _memoryConfig.Enabled,
+                turnContext: _currentTurnContext);
             recallSw.Stop();
 
             resolved = _recallManager.ApplyProgressiveRecall(resolved, _log);
@@ -2639,15 +2646,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
 
     private TrustAudience CurrentTurnAudience()
-        => _currentTurnSource?.Audience
+        => _currentTurnContext?.Audience
+           ?? _currentTurnSource?.Audience
            ?? SecurityPolicyDefaults.ResolveAudienceFromSessionId(_sessionId.Value);
 
     private string CurrentMemoryAudience()
-        => (_currentTurnSource?.Audience ?? TrustAudience.Public).ToWireValue();
+        => (_currentTurnContext?.Audience ?? _currentTurnSource?.Audience ?? TrustAudience.Public).ToWireValue();
 
     private string CurrentMemoryBoundary()
-        => _currentTurnSource?.Boundary.Value
-           ?? SecurityPolicyDefaults.ResolveBoundaryFromSessionId(_sessionId.Value, _currentTurnSource?.Audience ?? TrustAudience.Public).Value;
+        => _currentTurnContext?.Boundary.Value
+           ?? _currentTurnSource?.Boundary.Value
+           ?? SecurityPolicyDefaults.ResolveBoundaryFromSessionId(_sessionId.Value, CurrentTurnAudience()).Value;
 
     private IReadOnlyList<AITool> ResolveExposedToolsForCurrentTurn()
     {
@@ -2900,10 +2909,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             var context = new ToolExecutionContext(_sessionId.Value, GetSessionDirectory())
             {
-                // No active turn source carries no trust context — fall closed.
-                Audience = _currentTurnSource?.Audience ?? TrustAudience.Public,
-                Boundary = _currentTurnSource?.Boundary,
-                ChannelType = _currentTurnSource is null ? null : _currentTurnSource.ChannelType.ToWireValue(),
+                // No active turn context/source carries no trust context — fall closed.
+                Audience = _currentTurnContext?.Audience ?? _currentTurnSource?.Audience ?? TrustAudience.Public,
+                Boundary = _currentTurnContext?.Boundary ?? _currentTurnSource?.Boundary,
+                ChannelType = _currentTurnContext?.ChannelType?.ToWireValue()
+                              ?? (_currentTurnSource is null ? null : _currentTurnSource.ChannelType.ToWireValue()),
                 ProjectDirectory = _state.WorkingContext.ProjectDirectory,
                 SupportsInteractiveApproval = false,
             };
@@ -3153,10 +3163,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ToolName = msg.ToolName.Value,
             Patterns = msg.Patterns,
             CandidateVerbs = msg.CandidateVerbs,
-            Audience = CurrentTurnAudience(),
-            Boundary = _currentTurnSource?.Boundary,
-            ChannelType = _currentTurnSource?.ChannelType.ToWireValue(),
-            SupportsInteractiveApproval = _currentTurnSource?.ChannelType.SupportsInteractiveApproval(),
+            Audience = _currentTurnContext?.Audience ?? CurrentTurnAudience(),
+            Boundary = _currentTurnContext?.Boundary ?? _currentTurnSource?.Boundary,
+            ChannelType = _currentTurnContext?.ChannelType?.ToWireValue() ?? _currentTurnSource?.ChannelType.ToWireValue(),
+            SupportsInteractiveApproval = _currentTurnContext?.SupportsInteractiveApproval
+                                          ?? _currentTurnSource?.ChannelType.SupportsInteractiveApproval(),
             RequesterSenderId = msg.RequesterSenderId,
             RequesterPrincipal = msg.RequesterPrincipal,
             HasThirdPartyAdoptedContext = msg.HasThirdPartyAdoptedContext,
@@ -3170,6 +3181,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     Directory = c.Directory
                 })
                 .ToArray(),
+            TurnContext = _currentTurnContext?.ToRecord(),
             RequestedAtMs = NowMs()
         };
 
@@ -3195,6 +3207,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void ApplyToolApprovalRequested(ToolApprovalRequested evt, bool persistApprovalState)
     {
+        var turnContext = ToolApprovalTurnContext.Restore(evt, out var restoreFailure);
         _pendingToolInteractions[evt.CallId] = new PendingToolInteraction(
             evt.CallId,
             evt.ToolName,
@@ -3211,9 +3224,51 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             evt.Cwd,
             evt.RequestedAtMs,
             persistApprovalState,
+            turnContext,
+            restoreFailure,
             evt.OptionKeys,
             evt.Candidates.Select(c => new ApprovalCandidate(c.Verb, c.Directory)).ToArray());
         _resolvedToolApprovals.Remove(evt.CallId);
+
+        if (persistApprovalState && turnContext is not null)
+            RecordWaitingApprovalState(turnContext, evt.CallId, recovered: _currentPhase == SessionPhase.Recovering);
+        else if (persistApprovalState && restoreFailure is not null)
+            _log.Warning(
+                "Approval request {CallId} could not restore turn context: {Reason}",
+                evt.CallId,
+                restoreFailure);
+    }
+
+    private void RecordWaitingApprovalState(TurnContext context, string callId, bool recovered)
+    {
+        var pendingCallIds = _approvalTurnState is WaitingApprovalTurn waiting
+            ? new HashSet<string>(waiting.PendingCallIds, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
+        pendingCallIds.Add(callId);
+
+        _currentTurnContext = context;
+        _approvalTurnState = new WaitingApprovalTurn(context, pendingCallIds, recovered);
+    }
+
+    private void MarkApprovalRedrive(PendingToolInteraction pending, string callId)
+    {
+        if (pending.TurnContext is null)
+            return;
+
+        _currentTurnContext = pending.TurnContext;
+        _approvalTurnState = new RedrivingApprovalTurn(pending.TurnContext, callId);
+    }
+
+    private void MarkApprovalRunningAfterRedrive()
+    {
+        if (_approvalTurnState is RedrivingApprovalTurn redriving)
+            _approvalTurnState = new RunningApprovalTurn(redriving.Context);
+    }
+
+    private void ClearApprovalTurnState()
+    {
+        _approvalTurnState = ApprovalTurnState.None;
+        _currentTurnContext = null;
     }
 
     private void ApplyToolApprovalResolved(ToolApprovalResolved evt)
@@ -3223,7 +3278,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             : ApprovalDecision.Denied;
 
         if (_pendingToolInteractions.Remove(evt.CallId, out var pending))
+        {
             _resolvedToolApprovals[evt.CallId] = new ResolvedToolApproval(pending, decision);
+
+            if (_pendingToolInteractions.Count == 0 && pending.TurnContext is not null)
+                _approvalTurnState = new RunningApprovalTurn(pending.TurnContext);
+        }
     }
 
     private void ApplyToolBatchAbandoned(ToolBatchAbandoned evt)
@@ -3237,6 +3297,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             });
         _pendingToolInteractions.Clear();
         _resolvedToolApprovals.Clear();
+        ClearApprovalTurnState();
         ClearActiveToolBatchTracking();
     }
 
@@ -3248,9 +3309,23 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private void MaybeSnapshot()
     {
         if (_config.Tuning.SnapshotInterval > 0 && LastSequenceNr % _config.Tuning.SnapshotInterval == 0)
+            SaveSnapshotIfSafe();
+    }
+
+    private void SaveSnapshotIfSafe()
+    {
+        // SessionSnapshot intentionally excludes parked approval state. Writing a
+        // snapshot while an assistant tool_use is unanswered would let recovery
+        // skip the journal event that rehydrates pending approval context.
+        if (_pendingToolInteractions.Count > 0
+            || _resolvedToolApprovals.Count > 0
+            || ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, null) is not null)
         {
-            SaveSnapshot(BuildSnapshot());
+            _log.Info("Skipping snapshot while approval-paused tool batch is still unresolved");
+            return;
         }
+
+        SaveSnapshot(BuildSnapshot());
     }
 
     private void EmitResponseOutputs(
@@ -3418,14 +3493,24 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         ToolInteractionResponse msg,
         bool persistApprovalGrant)
     {
+        if (!TryGetApprovalAuthority(pending, out var requesterPrincipal, out var requesterSenderId, out var authorityFailure))
+        {
+            _log.Warning(
+                "Ignoring tool interaction response for call {CallId}: approval authority context is not recoverable ({Reason})",
+                msg.CallId,
+                authorityFailure);
+            EmitExpiredPromptNotice();
+            return (null, ApprovalNackReasons.PromptExpired);
+        }
+
         // Only the user who triggered the request may approve it — verified
         // automation requests can be approved by any channel member.
         if (!ApprovalButtonValueCodec.CanApprove(
-                pending.RequesterPrincipal, pending.RequesterSenderId, msg.SenderId.Value))
+                requesterPrincipal, requesterSenderId, msg.SenderId.Value))
         {
             _log.Warning(
                 "Ignoring tool interaction response for call {CallId} from sender {SenderId}; expected {ExpectedSenderId}",
-                msg.CallId, msg.SenderId, pending.RequesterSenderId);
+                msg.CallId, msg.SenderId, requesterSenderId);
             EmitWrongRequesterApprovalNotice();
             return (null, ApprovalNackReasons.WrongRequester);
         }
@@ -3562,12 +3647,52 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private PendingToolInteraction? ResolveLatestPendingApprovalForSender(SenderId senderId)
         => _pendingToolInteractions.Values
-            .Where(pending => ApprovalButtonValueCodec.CanApprove(
-                pending.RequesterPrincipal,
-                pending.RequesterSenderId,
-                senderId.Value))
+            .Where(pending => CanApprovePending(pending, senderId))
             .OrderBy(pending => pending.RequestedAtMs)
             .LastOrDefault();
+
+    private static bool CanApprovePending(PendingToolInteraction pending, SenderId senderId)
+        => TryGetApprovalAuthority(pending, out var principal, out var requesterSenderId, out _)
+           && ApprovalButtonValueCodec.CanApprove(principal, requesterSenderId, senderId.Value);
+
+    private static bool TryGetApprovalAuthority(
+        PendingToolInteraction pending,
+        out PrincipalClassification? requesterPrincipal,
+        out string? requesterSenderId,
+        out string? failure)
+    {
+        if (pending.TurnContext is { } context)
+        {
+            requesterPrincipal = context.RequesterPrincipal;
+            requesterSenderId = context.RequesterSenderId?.Value;
+            if (!context.HasApprovalRequester)
+            {
+                failure = "turn context has no requester sender for a non-automation principal";
+                return false;
+            }
+
+            failure = null;
+            return true;
+        }
+
+        requesterPrincipal = pending.RequesterPrincipal;
+        requesterSenderId = pending.RequesterSenderId;
+        if (pending.TurnContextRestoreFailure is not null)
+        {
+            failure = pending.TurnContextRestoreFailure;
+            return false;
+        }
+
+        if (requesterPrincipal is not PrincipalClassification.VerifiedAutomation
+            && string.IsNullOrWhiteSpace(requesterSenderId))
+        {
+            failure = "legacy approval state has no requester sender for a non-automation principal";
+            return false;
+        }
+
+        failure = null;
+        return true;
+    }
 
     private async Task HandleProcessingApprovalResponseAsync(ToolInteractionResponse msg)
     {
@@ -3665,8 +3790,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         if (!_pendingToolInteractions.TryGetValue(callId, out var pending))
         {
-            // No persisted pending record — there is no trust context to
-            // re-synthesize a faithful MessageSource, and no Patterns to
+            // No persisted pending record — there is no turn context and no Patterns to
             // pre-seed an ApprovedOnce re-drive. Whether or not the history
             // tail still carries the tool_use block, treat the prompt as
             // expired and fail loud with a channel-visible message rather
@@ -3719,7 +3843,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         PersistApprovalResolved(msg, decision, () =>
         {
-            TryRedriveToolBatchAfterApproval(callId);
+            var outcome = TryRedriveToolBatchAfterApproval(callId);
+            if (outcome == ApprovalRedriveOutcome.Failed)
+            {
+                TryReplyNack(ApprovalNackReasons.PromptExpired);
+                return;
+            }
+
             TryReplyAck();
         });
     }
@@ -3736,7 +3866,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         await HandleToolInteractionResponseWhenIdle(structured);
     }
 
-    private bool TryRedriveToolBatchAfterApproval(string callId)
+    private ApprovalRedriveOutcome TryRedriveToolBatchAfterApproval(string callId)
     {
         var assistantMsg = ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, callId);
         if (assistantMsg is null)
@@ -3745,7 +3875,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 "Cannot re-drive tool batch for call {CallId}: no unanswered assistant tool batch in history",
                 callId);
             EmitExpiredPromptNotice();
-            return false;
+            return ApprovalRedriveOutcome.Failed;
         }
 
         if (assistantMsg.ToolCalls.Any(tc => _pendingToolInteractions.ContainsKey(tc.CallId.Value)))
@@ -3753,7 +3883,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _log.Info(
                 "Deferring parked tool batch re-drive for call {CallId}: sibling approval(s) still pending",
                 callId);
-            return false;
+            return ApprovalRedriveOutcome.Deferred;
         }
 
         if (!_resolvedToolApprovals.TryGetValue(callId, out var resolved))
@@ -3762,12 +3892,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 "Cannot re-drive tool batch for call {CallId}: approval decision was not recoverable",
                 callId);
             EmitExpiredPromptNotice();
-            return false;
+            return ApprovalRedriveOutcome.Failed;
         }
 
         var redrivePlan = BuildApprovalRedrivePlan(assistantMsg);
-        RedriveToolBatchForApproval(callId, resolved.Pending, redrivePlan);
-        return true;
+        if (RedriveToolBatchForApproval(callId, resolved.Pending, redrivePlan))
+            return ApprovalRedriveOutcome.Started;
+
+        var abandoned = BuildToolBatchAbandonedEvent(
+            "Tool call was not completed — approval state could not be recovered safely.");
+        Persist(abandoned, ApplyToolBatchAbandoned);
+        return ApprovalRedriveOutcome.Failed;
     }
 
     private bool AbandonResolvedToolBatchAfterRecovery()
@@ -3831,7 +3966,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// <see cref="_currentTurnSource"/> is null, so the persisted trust fields
     /// are what keep the re-driven call faithful to the original turn.
     /// </summary>
-    private void RedriveToolBatchForApproval(
+    private bool RedriveToolBatchForApproval(
         string callId,
         PendingToolInteraction pending,
         ApprovalRedrivePlan redrivePlan)
@@ -3843,7 +3978,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 "Cannot re-drive tool batch for call {CallId}: no unanswered assistant tool batch in history",
                 callId);
             EmitExpiredPromptNotice();
-            return;
+            return false;
         }
 
         // Rebuild the FunctionCallContent batch from the persisted assistant
@@ -3860,116 +3995,34 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 "Cannot re-drive tool batch for call {CallId}: assistant message has no tool calls",
                 callId);
             EmitExpiredPromptNotice();
-            return;
+            return false;
         }
 
         _log.Info(
             "Re-driving parked tool batch ({Count} call(s)) after approval response for {CallId}",
             toolCalls.Count, callId);
 
-        // On cold recovery _currentTurnSource is null because MessageSource is
-        // never persisted. Rehydrate it (and the paired _currentTrustContext +
-        // turn telemetry) from pending.* so every subsequent dispatch in the
-        // recovered turn reads the correct audience/boundary/channel-type. The
-        // LLM iteration that follows the parked batch re-enters DispatchToolBatch
-        // with no override; without rehydration it would fall through to
-        // SessionToolExecutionPipeline's TrustAudience.Public fail-closed default,
-        // silently blocking shell_execute and any other tool the audience profile
-        // doesn't list for Public. ResolveExposedToolsForCurrentTurn separately
-        // reads _currentTrustContext, so that field must be rehydrated too or the
-        // continuation LLM call gets a Public-audience tool list.
-        // Only rehydrates when null; preserves live _currentTurnSource on the
-        // non-recovery idle-redrive path.
-        if (_currentTurnSource is null)
+        if (pending.TurnContext is not { } turnContext)
         {
-            var synthesized = SynthesizeTurnSourceFromPending(pending);
-            if (synthesized is null)
-            {
-                // Fail loud per the no-silent-fallbacks rule: the override on this
-                // dispatch alone covers the parked batch, but any continuation tool
-                // call in the recovered turn will fall through to Public. Log so
-                // an operator investigating a still-broken cold-recovery has a
-                // breadcrumb instead of an apparently-applied fix that no-ops.
-                _log.Warning(
-                    "Cold-recovery redrive could not synthesize turn source for call {CallId} "
-                    + "(channelType={ChannelType}, requesterSenderId={Requester}); "
-                    + "continuation tool calls in this turn will fall back to TrustAudience.Public.",
-                    callId,
-                    pending.ChannelType ?? "<null>",
-                    pending.RequesterSenderId ?? "<null>");
-            }
-            else
-            {
-                _currentTurnSource = synthesized;
-                _currentTrustContext = _trustContextDeriver?.Derive(synthesized);
-                BindTurnTelemetry(synthesized);
-            }
+            _log.Warning(
+                "Cannot re-drive tool batch for call {CallId}: turn context is not recoverable ({Reason})",
+                callId,
+                pending.TurnContextRestoreFailure ?? "missing turn context");
+            EmitExpiredPromptNotice();
+            return false;
         }
 
+        _currentTurnContext = turnContext;
+        _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(turnContext);
+        BindTurnTelemetry(turnContext);
+        MarkApprovalRedrive(pending, callId);
+
         TransitionTo(SessionPhase.Processing);
-        // Only supportsInteractiveApprovalOverride is materially distinct from
-        // what the synthesized source carries — pending persists the bool? the
-        // transport actually returned at prompt time, while the synthesized
-        // source can only re-derive it from ChannelType. The other audience /
-        // boundary / channel-type / sender / principal overrides duplicate fields
-        // the synthesized _currentTurnSource now carries; SessionToolExecutionPipeline's
-        // `override ?? source?.X ?? default` fallback resolves to the same value
-        // either way. Carrying both creates two parallel mechanisms that will
-        // drift on the next maintenance edit — single source of truth wins.
         DispatchToolBatch(
             toolCalls,
-            supportsInteractiveApprovalOverride: pending.SupportsInteractiveApproval,
             oneTimeApprovalPreSeed: redrivePlan.OneTimeApprovalPreSeed,
             decisionOverride: redrivePlan.DecisionOverride);
-    }
-
-    /// <summary>
-    /// Reconstructs a minimal <see cref="MessageSource"/> from a parked
-    /// <see cref="PendingToolInteraction"/>'s persisted trust fields. Used only
-    /// during cold-recovery re-drive to rehydrate <see cref="_currentTurnSource"/>
-    /// so subsequent tool dispatches in the recovered turn read the correct
-    /// audience/boundary/channel-type. The stable adopted-context provenance
-    /// needed by downstream safety checks also survives here, but the runtime-only
-    /// fields on <see cref="MessageSource"/> (AckTarget, ReminderId,
-    /// BackgroundJobId, adopted-context window/projection entries, MessageId,
-    /// TurnId) are left at their defaults — they belong to the original live
-    /// transport invocation and cannot be reconstructed from journal state.
-    /// Returns null when the pending record
-    /// lacks enough state to construct a usable source (no channel type, no
-    /// requester sender id); the caller surfaces a warning per the
-    /// no-silent-fallbacks rule.
-    /// </summary>
-    private MessageSource? SynthesizeTurnSourceFromPending(PendingToolInteraction pending)
-    {
-        if (!ChannelTypeExtensions.TryFromWireValue(pending.ChannelType, out var channelType))
-            return null;
-
-        if (string.IsNullOrEmpty(pending.RequesterSenderId))
-            return null;
-
-        return new MessageSource
-        {
-            ChannelType = channelType,
-            SenderId = new SenderId(pending.RequesterSenderId),
-            Audience = pending.Audience,
-            // ResolveBoundary is the canonical helper: when pending.Boundary is
-            // null it consults channelType so slack/discord pendings resolve to
-            // TrustedInstance rather than the audience-only fallback.
-            Boundary = SecurityPolicyDefaults.ResolveBoundary(
-                pending.Boundary, pending.ChannelType, pending.Audience),
-            Principal = pending.RequesterPrincipal ?? PrincipalClassification.UntrustedExternal,
-            HasThirdPartyAdoptedContext = pending.HasThirdPartyAdoptedContext,
-            AdoptedSpeakerIds = pending.AdoptedSpeakerIds,
-            // The original transport was authenticated when the prompt was first
-            // posted (the binding actor only journals PendingToolInteraction after
-            // a successful inbound), so Verified is honest. PayloadTaint, however,
-            // is never persisted — Unknown is the honest sentinel for "we don't
-            // know what the original taint was" and lets downstream gates branch
-            // safely without us falsely claiming Public.
-            Provenance = new SourceProvenance(
-                TransportAuthenticity.Verified,
-                PayloadTaint.Unknown)
-        };
+        return true;
     }
 
     /// <summary>
@@ -4014,6 +4067,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _deliveryRetry.Clear();
         _pendingToolInteractions.Clear();
         _resolvedToolApprovals.Clear();
+        ClearApprovalTurnState();
         Timers.Cancel(StreamingRetryTimerKey);
         _state = _state.AddErrorReply(errorMessage);
 
@@ -4069,6 +4123,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var persistent = decision is ApprovalDecision.ApprovedAlways
             or ApprovalDecision.ApprovedEverywhere;
         var globalWildcard = decision == ApprovalDecision.ApprovedEverywhere;
+        var audience = pending.TurnContext?.Audience ?? pending.Audience;
 
         // Prefer per-clause Candidates so we can use each clause's extracted
         // path argument as the directory half. Fall back to the verb-only
@@ -4079,7 +4134,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var fallbackCwd = globalWildcard ? null : pending.Cwd;
             await _approvalService.RecordApprovalAsync(
                 (ToolApprovalSessionId)_sessionId.Value,
-                pending.Audience,
+                audience,
                 new ToolName(pending.ToolName),
                 pending.CandidateVerbs,
                 persistent,
@@ -4121,7 +4176,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             await _approvalService.RecordApprovalAsync(
                 (ToolApprovalSessionId)_sessionId.Value,
-                pending.Audience,
+                audience,
                 new ToolName(pending.ToolName),
                 verbs,
                 persistent,
@@ -4307,6 +4362,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         ClearActiveToolBatchTracking();
         TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
             _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolIterationsPerTurn, resultCount);
+        MarkApprovalRunningAfterRedrive();
         FireLlmCall();
     }
 
@@ -4373,6 +4429,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         TimeSpan? Duration,
         int FindingsCount) : INoSerializationVerificationNeeded;
 
+    private enum ApprovalRedriveOutcome
+    {
+        Started,
+        Deferred,
+        Failed
+    }
+
     private void BindTurnTelemetry(MessageSource? source)
     {
         var sourceMessageId = source?.MessageId;
@@ -4380,6 +4443,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _activeTurnId = source?.TurnId
             ?? new Protocol.TurnId(sourceMessageId ?? IdGen.ShortId());
         _activeChannelType = source?.ChannelType;
+
+        CrashContextSnapshot.Update(
+            _sessionId.Value,
+            _activeTurnId?.Value,
+            _activeMessageId,
+            _activeChannelType?.ToWireValue(),
+            _timeProvider.GetUtcNow());
+    }
+
+    private void BindTurnTelemetry(TurnContext context)
+    {
+        _activeMessageId = null;
+        _activeTurnId = context.TurnId;
+        _activeChannelType = context.ChannelType;
 
         CrashContextSnapshot.Update(
             _sessionId.Value,

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionRecallManager.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionRecallManager.cs
@@ -37,9 +37,11 @@ internal sealed class SessionRecallManager
         SessionId sessionId,
         MessageSource? turnSource,
         IMemoryRecallCoordinator coordinator,
-        bool memoryEnabled = true)
+        bool memoryEnabled = true,
+        TurnContext? turnContext = null)
     {
-        var audience = turnSource?.Audience
+        var audience = turnContext?.Audience
+            ?? turnSource?.Audience
             ?? SecurityPolicyDefaults.ResolveAudienceFromSessionId(sessionId.Value);
 
         // Memory recall is disabled for Public audience or when the subsystem is off
@@ -65,7 +67,8 @@ internal sealed class SessionRecallManager
             recentUser,
             3,
             Audience: audience,
-            Boundary: turnSource?.Boundary.Value
+            Boundary: turnContext?.Boundary.Value
+                      ?? turnSource?.Boundary.Value
                       ?? SecurityPolicyDefaults.ResolveBoundaryFromSessionId(sessionId.Value, audience).Value,
             RecentAssistantMessages: state.History
                 .Where(x => x.Role == Protocol.ChatRole.Assistant)

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -57,13 +57,8 @@ internal static class SessionToolExecutionPipeline
         bool setWorkingDirectoryAvailable = false,
         bool streamToolResults = false,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? oneTimeApprovalPreSeed = null,
-        TrustAudience? audienceOverride = null,
-        TrustBoundary? boundaryOverride = null,
-        string? channelTypeOverride = null,
-        bool? supportsInteractiveApprovalOverride = null,
-        SenderId? requesterSenderIdOverride = null,
-        PrincipalClassification? requesterPrincipalOverride = null,
         IReadOnlyDictionary<string, ApprovalDecision>? decisionOverride = null,
+        TurnContext? turnContext = null,
         CancellationToken ct = default)
     {
         try
@@ -75,40 +70,35 @@ internal static class SessionToolExecutionPipeline
             var tasks = toolCalls.Select(async tc =>
             {
                 var result = await ExecuteSingleToolAsync(
-                executor,
-                tc,
-                sessionId,
-                source,
-                auditLogger,
-                timeProvider,
-                sessionDir,
-                maxInlineToolResultChars,
-                emitSubAgentOutput,
-                spawnChildActor,
-                timeout,
-                ct,
-                approvalChannel,
-                emitApprovalRequest,
-                approvalTimeout ?? Timeout.InfiniteTimeSpan,
-                maxToolTimeoutSeconds,
-                logger,
-                shellTimeoutSeconds,
-                backgroundJobManager,
-                projectDirectory,
-                setWorkingDirectoryAvailable,
-                oneTimeApprovalPreSeed is not null
-                && oneTimeApprovalPreSeed.TryGetValue(tc.CallId, out var preSeedPatterns)
-                    ? preSeedPatterns
-                    : null,
-                audienceOverride,
-                boundaryOverride,
-                channelTypeOverride,
-                supportsInteractiveApprovalOverride,
-                requesterSenderIdOverride,
-                requesterPrincipalOverride,
-                decisionOverride is not null && decisionOverride.TryGetValue(tc.CallId, out var overrideDecision)
-                    ? overrideDecision
-                    : null);
+                    executor,
+                    tc,
+                    sessionId,
+                    source,
+                    auditLogger,
+                    timeProvider,
+                    sessionDir,
+                    maxInlineToolResultChars,
+                    emitSubAgentOutput,
+                    spawnChildActor,
+                    timeout,
+                    ct,
+                    approvalChannel,
+                    emitApprovalRequest,
+                    approvalTimeout ?? Timeout.InfiniteTimeSpan,
+                    maxToolTimeoutSeconds,
+                    logger,
+                    shellTimeoutSeconds,
+                    backgroundJobManager,
+                    projectDirectory,
+                    setWorkingDirectoryAvailable,
+                    oneTimeApprovalPreSeed is not null
+                    && oneTimeApprovalPreSeed.TryGetValue(tc.CallId, out var preSeedPatterns)
+                        ? preSeedPatterns
+                        : null,
+                    decisionOverride is not null && decisionOverride.TryGetValue(tc.CallId, out var overrideDecision)
+                        ? overrideDecision
+                        : null,
+                    turnContext);
                 if (streamToolResults)
                     self.Tell(new ToolExecutionSingleCompleted(result));
                 return result;
@@ -172,13 +162,8 @@ internal static class SessionToolExecutionPipeline
         string? projectDirectory = null,
         bool setWorkingDirectoryAvailable = false,
         IReadOnlyList<string>? oneTimeApprovalPreSeed = null,
-        TrustAudience? audienceOverride = null,
-        TrustBoundary? boundaryOverride = null,
-        string? channelTypeOverride = null,
-        bool? supportsInteractiveApprovalOverride = null,
-        SenderId? requesterSenderIdOverride = null,
-        PrincipalClassification? requesterPrincipalOverride = null,
-        ApprovalDecision? decisionOverride = null)
+        ApprovalDecision? decisionOverride = null,
+        TurnContext? turnContext = null)
     {
         var (meta, cleanedTc) = ToolCallMetaExtractor.Extract(tc);
         tc = cleanedTc;
@@ -197,10 +182,7 @@ internal static class SessionToolExecutionPipeline
             sessionDir,
             spawnChildActor,
             projectDirectory,
-            audienceOverride,
-            boundaryOverride,
-            channelTypeOverride,
-            supportsInteractiveApprovalOverride);
+            turnContext);
         context.RequestedTimeoutSeconds = (int)timeout.TotalSeconds;
 
         // Re-drive of an ApprovedOnce approval: the user already clicked
@@ -223,11 +205,11 @@ internal static class SessionToolExecutionPipeline
                 emitApprovalRequest,
                 sessionId,
                 tc.CallId,
-                requesterSenderIdOverride ?? source?.SenderId,
-                requesterPrincipalOverride ?? source?.Principal,
-                source?.HasAdoptedContext ?? false,
-                source?.HasThirdPartyAdoptedContext ?? false,
-                source?.AdoptedSpeakerIds ?? []);
+                turnContext?.RequesterSenderId ?? source?.SenderId,
+                turnContext?.RequesterPrincipal ?? source?.Principal,
+                turnContext?.HasAdoptedContext ?? source?.HasAdoptedContext ?? false,
+                turnContext?.HasThirdPartyAdoptedContext ?? source?.HasThirdPartyAdoptedContext ?? false,
+                turnContext?.AdoptedSpeakerIds ?? source?.AdoptedSpeakerIds ?? []);
         }
         var completedRuns = new List<CompletedSubAgentRun>();
         var acceptedFindings = new List<AcceptedSubAgentFinding>();
@@ -348,6 +330,7 @@ internal static class SessionToolExecutionPipeline
                     sw.Stop();
                     return await RouteToBackgroundJobAsync(
                         tc, sessionId, source, auditLogger, timeProvider,
+                        turnContext,
                         meta, backgroundJobManager,
                         meta.TimeoutHintSeconds ?? shellTimeoutSeconds,
                         sw.Elapsed, logger,
@@ -369,6 +352,26 @@ internal static class SessionToolExecutionPipeline
         catch (ToolApprovalRequiredException approvalEx)
             when (approvalChannel is not null && emitApprovalRequest is not null)
         {
+            if (!CanRequestInteractiveApproval(source, turnContext))
+            {
+                sw.Stop();
+                resultText = $"Tool requires approval but no interactive approval requester is available: {approvalEx.ApprovalContext.ToolName}";
+
+                auditLogger?.Log(BuildAuditEntry(sessionId, tc, timeProvider, sw.Elapsed, meta) with
+                {
+                    Allowed = false,
+                    DenyReason = "interactive_approval_unavailable"
+                });
+
+                return new ToolCallResult(new SerializableChatMessage
+                {
+                    Role = Protocol.ChatRole.Tool,
+                    Content = ClampToolResult(resultText, maxInlineToolResultChars),
+                    ToolCallId = new ToolCallId(tc.CallId),
+                    Name = tc.Name
+                }, context.FileAttachments, completedRuns, acceptedFindings);
+            }
+
             // Mid-turn approval pause: emit request to channel, block on TCS
             var ctx = approvalEx.ApprovalContext;
             var approvalWaitTimeout = approvalTimeout ?? Timeout.InfiniteTimeSpan;
@@ -384,12 +387,12 @@ internal static class SessionToolExecutionPipeline
                 CallId = new ToolCallId(tc.CallId),
                 ToolName = new ToolName(ctx.ToolName),
                 DisplayText = ctx.DisplayText,
-                RequesterSenderId = source?.SenderId,
-                RequesterPrincipal = source?.Principal,
-                HasAdoptedContext = source?.HasAdoptedContext ?? false,
-                HasThirdPartyAdoptedContext = source?.HasThirdPartyAdoptedContext ?? false,
-                AdoptedSpeakerIds = source?.AdoptedSpeakerIds ?? [],
-                PersistedAdoptedContext = source?.HasAdoptedContext ?? false,
+                RequesterSenderId = turnContext?.RequesterSenderId ?? source?.SenderId,
+                RequesterPrincipal = turnContext?.RequesterPrincipal ?? source?.Principal,
+                HasAdoptedContext = turnContext?.HasAdoptedContext ?? source?.HasAdoptedContext ?? false,
+                HasThirdPartyAdoptedContext = turnContext?.HasThirdPartyAdoptedContext ?? source?.HasThirdPartyAdoptedContext ?? false,
+                AdoptedSpeakerIds = turnContext?.AdoptedSpeakerIds ?? source?.AdoptedSpeakerIds ?? [],
+                PersistedAdoptedContext = turnContext?.HasAdoptedContext ?? source?.HasAdoptedContext ?? false,
                 Patterns = ctx.Patterns,
                 CandidateVerbs = ctx.CandidateVerbs,
                 Candidates = ctx.Candidates ?? [],
@@ -427,6 +430,7 @@ internal static class SessionToolExecutionPipeline
                     sw.Stop();
                     return await RouteToBackgroundJobAsync(
                         tc, sessionId, source, auditLogger, timeProvider,
+                        turnContext,
                         meta, backgroundJobManager,
                         meta.TimeoutHintSeconds ?? shellTimeoutSeconds,
                         sw.Elapsed, logger,
@@ -642,6 +646,7 @@ internal static class SessionToolExecutionPipeline
         MessageSource? source,
         IToolAuditLogger? auditLogger,
         TimeProvider timeProvider,
+        TurnContext? turnContext,
         ToolCallMeta meta,
         IActorRef backgroundJobManager,
         int timeoutSeconds,
@@ -665,12 +670,16 @@ internal static class SessionToolExecutionPipeline
             return new ToolCallResult(message, [], [], []);
         }
 
-        // A background job inherits the submitting turn's trust context. There is
-        // no safe default — defaulting a missing source to Personal would silently
-        // escalate the job's audience. A null source here is a programming error.
-        if (source is null)
+        // A background job inherits the submitting turn's authority context.
+        // There is no safe default — defaulting a missing context to Personal
+        // would silently escalate the job's audience.
+        var audience = turnContext?.Audience ?? source?.Audience;
+        var boundary = turnContext?.Boundary ?? source?.Boundary;
+        var channelType = turnContext?.ChannelType ?? source?.ChannelType;
+        var senderId = turnContext?.RequesterSenderId ?? source?.SenderId;
+        if (audience is null || boundary is null || channelType is null)
             throw new InvalidOperationException(
-                "Background-job submission requires a turn source; trust context cannot be defaulted.");
+                "Background-job submission requires turn authority context; trust context cannot be defaulted.");
 
         var startCmd = new StartBackgroundJob
         {
@@ -678,11 +687,11 @@ internal static class SessionToolExecutionPipeline
             WorkingDirectory = workingDirectory,
             SessionId = sessionId,
             Rationale = meta.Rationale ?? "background shell execution",
-            Audience = source.Audience,
-            Boundary = source.Boundary,
-            OriginChannelType = source.ChannelType,
+            Audience = audience.Value,
+            Boundary = boundary.Value,
+            OriginChannelType = channelType.Value,
             TimeoutSeconds = timeoutSeconds,
-            SenderId = source.SenderId
+            SenderId = senderId
         };
 
         try
@@ -741,31 +750,31 @@ internal static class SessionToolExecutionPipeline
         string sessionDir,
         Func<object, string, CancellationToken, Task<object>> spawnChildActor,
         string? projectDirectory,
-        TrustAudience? audienceOverride = null,
-        TrustBoundary? boundaryOverride = null,
-        string? channelTypeOverride = null,
-        bool? supportsInteractiveApprovalOverride = null)
+        TurnContext? turnContext)
     {
-        // A turn with no source carries no trust context — fall closed to the
-        // most-restrictive audience. The default is resolved once, here, so every
-        // downstream tool gate reads a guaranteed audience.
-        //
-        // audienceOverride is set only by the post-approval re-drive of a
-        // cold-recovered session: the live MessageSource is gone, but the
-        // parked turn's audience was persisted, so the re-driven call runs
-        // under the audience its approval grant was recorded against rather
-        // than the fail-closed Public default. It is never an escalation —
-        // the override carries the parked turn's own audience.
+        // A turn with no authority context carries no trust context — fall closed
+        // to the most-restrictive audience. The default is resolved once, here,
+        // so every downstream tool gate reads a guaranteed audience.
         var context = new ToolExecutionContext(sessionId.Value, sessionDir)
         {
-            Audience = audienceOverride ?? source?.Audience ?? TrustAudience.Public,
+            Audience = turnContext?.Audience ?? source?.Audience ?? TrustAudience.Public,
         };
-        context.Boundary = boundaryOverride ?? source?.Boundary;
-        context.ChannelType = channelTypeOverride ?? (source is null ? null : source.ChannelType.ToWireValue());
-        context.SupportsInteractiveApproval = supportsInteractiveApprovalOverride ?? source?.ChannelType.SupportsInteractiveApproval();
+        context.Boundary = turnContext?.Boundary ?? source?.Boundary;
+        context.ChannelType = turnContext?.ChannelType?.ToWireValue()
+                              ?? (source is null ? null : source.ChannelType.ToWireValue());
+        context.SupportsInteractiveApproval = turnContext?.SupportsInteractiveApproval
+                                              ?? source?.ChannelType.SupportsInteractiveApproval();
         context.SpawnChildActor = spawnChildActor;
         context.ProjectDirectory = projectDirectory;
         return context;
+    }
+
+    private static bool CanRequestInteractiveApproval(MessageSource? source, TurnContext? turnContext)
+    {
+        if (turnContext is not null)
+            return turnContext.SupportsInteractiveApproval && turnContext.HasApprovalRequester;
+
+        return source is not null && source.ChannelType.SupportsInteractiveApproval();
     }
 
     private static ToolAuditEntry BuildAuditEntry(

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 
@@ -28,6 +30,8 @@ internal sealed record PendingToolInteraction(
     string? Cwd,
     long RequestedAtMs,
     bool PersistApprovalState,
+    TurnContext? TurnContext,
+    string? TurnContextRestoreFailure,
     // Option keys that were actually offered to the user when the prompt was
     // rendered. Persisted so a later response cannot select a pruned scope.
     IReadOnlyList<string> OptionKeys,
@@ -43,6 +47,24 @@ internal sealed record ToolInteractionRequestDispatch(
     Protocol.ToolInteractionRequest Request,
     bool PersistApprovalState) : INoSerializationVerificationNeeded;
 
+internal abstract record ApprovalTurnState : INoSerializationVerificationNeeded
+{
+    public static ApprovalTurnState None { get; } = new NoActiveApprovalTurn();
+}
+
+internal sealed record NoActiveApprovalTurn : ApprovalTurnState;
+
+internal sealed record RunningApprovalTurn(TurnContext Context) : ApprovalTurnState;
+
+internal sealed record WaitingApprovalTurn(
+    TurnContext Context,
+    ISet<string> PendingCallIds,
+    bool Recovered) : ApprovalTurnState;
+
+internal sealed record RedrivingApprovalTurn(TurnContext Context, string CallId) : ApprovalTurnState;
+
+internal sealed record AbandoningApprovalTurn(TurnContext Context, string Reason) : ApprovalTurnState;
+
 internal sealed record ApprovalRedrivePlan(
     IReadOnlyDictionary<string, IReadOnlyList<string>>? OneTimeApprovalPreSeed,
     IReadOnlyDictionary<string, ApprovalDecision>? DecisionOverride);
@@ -50,3 +72,57 @@ internal sealed record ApprovalRedrivePlan(
 internal sealed record ResolvedToolApproval(
     PendingToolInteraction Pending,
     ApprovalDecision Decision);
+
+internal static class ToolApprovalTurnContext
+{
+    public static TurnContext? Restore(ToolApprovalRequested evt, out string? failure)
+    {
+        if (evt.TurnContext is not null)
+        {
+            if (TurnContext.TryFromRecord(evt.TurnContext, out var context, out failure))
+                return context;
+
+            return null;
+        }
+
+        return RestoreLegacy(evt, out failure);
+    }
+
+    private static TurnContext? RestoreLegacy(ToolApprovalRequested evt, out string? failure)
+    {
+        failure = null;
+
+        if (!ChannelTypeExtensions.TryFromWireValue(evt.ChannelType, out var channelType))
+        {
+            failure = "legacy approval event is missing channel type";
+            return null;
+        }
+
+        var requesterPrincipal = evt.RequesterPrincipal ?? PrincipalClassification.UntrustedExternal;
+        if (requesterPrincipal is not PrincipalClassification.VerifiedAutomation
+            && evt.RequesterSenderId is null)
+        {
+            failure = "legacy approval event is missing requester sender";
+            return null;
+        }
+
+        return new TurnContext
+        {
+            SessionId = evt.SessionId,
+            TurnId = new TurnId($"recovered-approval/{evt.CallId}"),
+            Audience = evt.Audience,
+            Boundary = SecurityPolicyDefaults.ResolveBoundary(evt.Boundary, evt.ChannelType, evt.Audience),
+            ChannelType = channelType,
+            RequesterSenderId = evt.RequesterSenderId,
+            RequesterPrincipal = requesterPrincipal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Unknown)
+            {
+                SourceKind = new SourceKind(channelType.ToWireValue())
+            },
+            HasAdoptedContext = evt.HasThirdPartyAdoptedContext || evt.AdoptedSpeakerIds.Count > 0,
+            HasThirdPartyAdoptedContext = evt.HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = evt.AdoptedSpeakerIds,
+            SupportsInteractiveApproval = evt.SupportsInteractiveApproval ?? channelType.SupportsInteractiveApproval()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds durable TurnContext persistence for approval-paused session turns.
- Redrives recovered approvals from persisted authority instead of synthesized MessageSource.
- Fails closed for approval-required source-less turns and unsafe legacy recovery gaps.
- Adds focused turn-context, serialization, recall, approval recovery, and memory-safety coverage.

## Validation
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
- openspec validate redesign-session-approval-state-machine --strict
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- git diff --check

Fixes #1213