### PR TITLE
fix(memory): keep compaction-boundary summaries out of automatic recall

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
@@ -27,6 +27,43 @@ public sealed class MemoryRulesFirstExtractorTests
         RecallMode: "auto",
         Confidence: 0.88);
 
+    private static MemoryCheckpointPayload MakeCompactionPayload(string summary) => new(
+        SessionId: "D0AC6CKBK5K/1774370274.953879",
+        TriggerType: "compaction-boundary",
+        Source: "compaction",
+        Content: summary,
+        UserContent: null,
+        AssistantContent: summary,
+        IsExplicitRequest: false,
+        HasVerifiedToolFinding: false,
+        IsCompactionBoundary: true,
+        HasAcceptedSubAgentFinding: false,
+        Sensitivity: "normal",
+        RecallMode: MemoryRecallMode.Auto.ToWireValue(),
+        Confidence: 0.8,
+        Kind: MemoryKind.Document.ToWireValue(),
+        Title: "compaction-boundary",
+        UpdateSemantics: "append-document");
+
+    [Fact]
+    public void Compaction_boundary_is_retained_but_not_auto_recallable()
+    {
+        // Regression guard for issue 1224: compaction summaries are whole-session
+        // blobs that pollute automatic recall. They must be retained but kept out
+        // of the auto-recall pool (which fetches only Auto/Searchable). Manual does
+        // that; the summary compaction relies on lives in the session record.
+        var summary = "## 1. Primary Request and Intent\n"
+                      + "The user wanted to deploy the agent fleet across the test lab. "
+                      + "Decisions: use Kata containers for isolation; PostgreSQL for persistence.";
+
+        var candidate = Assert.Single(_extractor.Extract(MakeCompactionPayload(summary), new HashSet<string>()));
+
+        Assert.Equal(MemoryClass.Evidence, candidate.MemoryClass);
+        Assert.Equal(MemoryRecallMode.Manual, candidate.RecallMode);
+        Assert.NotEqual(MemoryRecallMode.Auto, candidate.RecallMode);
+        Assert.NotEqual(MemoryRecallMode.Searchable, candidate.RecallMode);
+    }
+
     [Theory]
     [InlineData("Well I was going to has You do some Netclaw work for me if")]
     [InlineData("Want to know if I needs To edit that or not")]

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -230,6 +230,15 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
 
     private static MemoryRecallMode ResolveRecallMode(MemoryCheckpointPayload payload, MemoryClass memoryClass)
     {
+        // Compaction-boundary memories are whole-session summary blobs. They
+        // lexically match almost any query in the session's topic area, so when
+        // auto-recallable they dominate the candidate pool and crowd out atomic
+        // memories. Keep the record (Manual) but out of the automatic recall pool.
+        // The summary compaction itself relies on lives in the SessionCompacted
+        // event / in-session history — a separate path that is unaffected.
+        if (payload.IsCompactionBoundary)
+            return MemoryRecallMode.Manual;
+
         if (memoryClass == MemoryClass.Trace)
             return MemoryRecallMode.Never;
 


### PR DESCRIPTION
Fixes #1224.

## What

Compaction-boundary session summaries were persisted as `Evidence` / `Searchable` memories, which put them in the automatic recall pool. Each one is a multi-KB digest of a whole session, so it lexically matched almost any query in that session's topic and sorted to the top of the candidate pool on unrelated queries, crowding out atomic memories.

## Change

One special-case in `MemoryCurationPipeline.ResolveRecallMode`: compaction-boundary checkpoints resolve to `MemoryRecallMode.Manual` (before the `Evidence -> Searchable` branch). `Manual` is excluded from every recall query (auto-recall and explicit search both fetch only `Auto`/`Searchable`), so the record is retained but never auto-recalled.

Compaction is unaffected. The summary it relies on for continuity lives in the `SessionCompacted` event / in-session history (`SessionCompactionPipeline` + `ObservationPromptBuilder.ExtractPriorSummary`); this memory is a fire-and-forget side-channel written in `LlmSessionActor.HandleCompactionWorkCompleted` that nothing reads back.

## Test

Adds a regression test asserting a compaction-boundary checkpoint extracts as `Evidence` with `RecallMode == Manual` (not `Auto`/`Searchable`). Existing memory/recall/curation tests still pass.

## Follow-up (not in this PR)

Existing stores still hold `compaction-boundary` rows with `recall_mode = searchable`. A one-time migration or `netclaw doctor` pass could declass them; tracked in the issue.
