### PR TITLE
fix(providers): parse self-hosted context metadata

### DIFF
--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
@@ -16,6 +16,24 @@ namespace Netclaw.Daemon.Tests.Providers;
 /// </summary>
 public sealed class OpenAiCompatibleCapabilityResolverTests
 {
+    [Theory]
+    [InlineData("{\"id\":\"Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf\",\"meta\":{\"n_ctx\":131072,\"n_ctx_train\":262144}}", 131_072)]
+    [InlineData("{\"id\":\"Qwen/Qwen3.6-VL-30B-FP8\",\"max_model_len\":256000}", 256_000)]
+    public void ParseModels_ReadsSelfHostedContextMetadata(string modelJson, int expectedContextWindow)
+    {
+        var json = $$"""
+        {
+          "object": "list",
+          "data": [ {{modelJson}} ]
+        }
+        """;
+
+        var result = OpenAiCompatibleDescriptor.ParseModels(json);
+
+        var model = Assert.Single(result.Models);
+        Assert.Equal(expectedContextWindow, model.ContextWindowTokens);
+    }
+
     [Fact]
     public void ResolveFromProbe_VllmShape_DispatchesToVllmStrategy()
     {
@@ -51,25 +69,25 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
           "object": "list",
           "data": [
             {
-              "id": "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf",
-              "meta": { "n_ctx_train": 262144 }
+              "id": "Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf",
+              "meta": { "n_ctx": 131072, "n_ctx_train": 262144 }
             }
           ]
         }
         """;
         const string propsJson = """
         {
-          "default_generation_settings": { "params": { "n_ctx": 65536 } },
+          "default_generation_settings": { "n_ctx": 131072 },
           "modalities": { "vision": true }
         }
         """;
 
         var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(
-            "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", modelsJson, propsJson);
+            "Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", modelsJson, propsJson);
 
         Assert.NotNull(result);
-        // /props.n_ctx wins over meta.n_ctx_train when both are present.
-        Assert.Equal(65_536, result.ContextWindowTokens);
+        // /props.n_ctx wins as the runtime-effective context window.
+        Assert.Equal(131_072, result.ContextWindowTokens);
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);
     }

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
@@ -17,8 +17,8 @@ public sealed class LlamaCppBackendStrategyTests
       "object": "list",
       "data": [
         {
-          "id": "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf",
-          "meta": { "n_ctx_train": 262144 }
+          "id": "Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf",
+          "meta": { "n_ctx": 131072, "n_ctx_train": 262144 }
         }
       ]
     }
@@ -34,25 +34,21 @@ public sealed class LlamaCppBackendStrategyTests
     }
 
     [Fact]
-    public void Matches_MetaNCtxTrain_PresentEvenWithoutProps()
+    public void Matches_MetaContext_PresentEvenWithoutProps()
     {
         using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
         Assert.True(new LlamaCppBackendStrategy().Matches(probe));
     }
 
-    [Fact]
-    public void Parse_PrefersPropsNCtxOverMetaNCtxTrain()
+    [Theory]
+    [InlineData("{\"default_generation_settings\":{\"n_ctx\":65536},\"modalities\":{\"vision\":true}}")]
+    [InlineData("{\"default_generation_settings\":{\"params\":{\"n_ctx\":65536}},\"modalities\":{\"vision\":true}}")]
+    public void Parse_PrefersPropsNCtxOverMeta(string propsJson)
     {
-        const string propsJson = """
-        {
-          "default_generation_settings": { "params": { "n_ctx": 65536 } },
-          "modalities": { "vision": true }
-        }
-        """;
         using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
         using var props = JsonDocument.Parse(propsJson);
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", models.RootElement, props.RootElement);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, props.RootElement);
 
         var result = new LlamaCppBackendStrategy().Parse(probe);
 
@@ -63,15 +59,15 @@ public sealed class LlamaCppBackendStrategyTests
     }
 
     [Fact]
-    public void Parse_FallsBackToMetaNCtxTrain_WhenPropsAbsent()
+    public void Parse_UsesMetaNCtx_WhenPropsAbsent()
     {
         using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
 
         var result = new LlamaCppBackendStrategy().Parse(probe);
 
         Assert.NotNull(result);
-        Assert.Equal(262_144, result.ContextWindowTokens);
+        Assert.Equal(131_072, result.ContextWindowTokens);
         Assert.Equal(ModelModality.Text, result.InputModalities);
     }
 

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -21,6 +21,10 @@ internal static class ProbeHelpers
     /// Expects: { "data": [ { "id": "model-id" }, ... ] }
     /// </summary>
     public static ProviderProbeResult ParseOpenAiStyleModels(string json)
+        => ParseOpenAiStyleModels(json, _ => null);
+
+    internal static ProviderProbeResult ParseOpenAiStyleModels(
+        string json, Func<JsonElement, int?> readContextWindow)
     {
         using var doc = JsonDocument.Parse(json);
         var models = new List<DiscoveredModel>();
@@ -31,12 +35,26 @@ internal static class ProbeHelpers
             {
                 if (model.TryGetProperty("id", out var id))
                 {
-                    models.Add(new DiscoveredModel { ModelId = new(id.GetString()!) });
+                    models.Add(new DiscoveredModel
+                    {
+                        ModelId = new(id.GetString()!),
+                        ContextWindowTokens = readContextWindow(model)
+                    });
                 }
             }
         }
 
         return new ProviderProbeResult(true, null, models);
+    }
+
+    internal static int? TryReadInt32(JsonElement element, string propertyName)
+    {
+        return element.ValueKind == JsonValueKind.Object &&
+               element.TryGetProperty(propertyName, out var property) &&
+               property.ValueKind == JsonValueKind.Number &&
+               property.TryGetInt32(out var value)
+            ? value
+            : null;
     }
 
     /// <summary>

--- a/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
@@ -106,8 +106,8 @@ internal sealed class VllmBackendStrategy : IOpenAiBackendStrategy
 
 /// <summary>
 /// llama.cpp-specific strategy. Recognizes llama.cpp via either a
-/// successful <c>/props</c> response or a <c>meta.n_ctx_train</c> field
-/// on a <c>/v1/models</c> entry. Prefers <c>/props.default_generation_settings.params.n_ctx</c>
+/// successful <c>/props</c> response or a <c>meta.n_ctx</c>/<c>meta.n_ctx_train</c>
+/// field on a <c>/v1/models</c> entry. Prefers <c>/props.default_generation_settings.n_ctx</c>
 /// for the runtime-effective context window, and reads
 /// <c>/props.modalities.vision</c> for input modality.
 /// </summary>
@@ -123,38 +123,21 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
         if (!probe.TryFindModelEntry(out var model))
             return false;
 
-        return model.TryGetProperty("meta", out var meta) &&
-               meta.ValueKind == JsonValueKind.Object &&
-               meta.TryGetProperty("n_ctx_train", out var ctx) &&
-               ctx.ValueKind == JsonValueKind.Number;
+        return TryReadModelMetaContext(model) is not null;
     }
 
     public ResolvedModelCapabilities? Parse(BackendProbe probe)
     {
         // Start with what /v1/models tells us about context window.
         int? contextWindow = null;
-        if (probe.TryFindModelEntry(out var model) &&
-            model.TryGetProperty("meta", out var meta) &&
-            meta.ValueKind == JsonValueKind.Object &&
-            meta.TryGetProperty("n_ctx_train", out var ctx) &&
-            ctx.ValueKind == JsonValueKind.Number)
-        {
-            contextWindow = ctx.GetInt32();
-        }
+        if (probe.TryFindModelEntry(out var model))
+            contextWindow = TryReadModelMetaContext(model);
 
         // /props overrides — runtime-effective n_ctx and vision flag.
         var inputModalities = ModelModality.Text;
         if (probe.PropsRoot is JsonElement props)
         {
-            if (props.TryGetProperty("default_generation_settings", out var dgs) &&
-                dgs.ValueKind == JsonValueKind.Object &&
-                dgs.TryGetProperty("params", out var parameters) &&
-                parameters.ValueKind == JsonValueKind.Object &&
-                parameters.TryGetProperty("n_ctx", out var nCtx) &&
-                nCtx.ValueKind == JsonValueKind.Number)
-            {
-                contextWindow = nCtx.GetInt32();
-            }
+            contextWindow = TryReadPropsContext(props) ?? contextWindow;
 
             if (props.TryGetProperty("modalities", out var modalities) &&
                 modalities.ValueKind == JsonValueKind.Object &&
@@ -168,6 +151,28 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
 
         return new ResolvedModelCapabilities(
             probe.ModelId, inputModalities, ModelModality.Text, contextWindow);
+    }
+
+    private static int? TryReadModelMetaContext(JsonElement model)
+    {
+        if (!model.TryGetProperty("meta", out var meta) ||
+            meta.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return ProbeHelpers.TryReadInt32(meta, "n_ctx") ??
+               ProbeHelpers.TryReadInt32(meta, "n_ctx_train");
+    }
+
+    private static int? TryReadPropsContext(JsonElement props)
+    {
+        if (!props.TryGetProperty("default_generation_settings", out var dgs) ||
+            dgs.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return ProbeHelpers.TryReadInt32(dgs, "n_ctx") ??
+               (dgs.TryGetProperty("params", out var parameters)
+                   ? ProbeHelpers.TryReadInt32(parameters, "n_ctx")
+                   : null);
     }
 }
 

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net.Http.Headers;
+using System.Text.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Providers.SelfHosted;
@@ -42,7 +43,22 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
                 if (!string.IsNullOrWhiteSpace(apiKey))
                     request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
             },
-            ProbeHelpers.ParseOpenAiStyleModels,
+            ParseModels,
             ct);
+    }
+
+    internal static ProviderProbeResult ParseModels(string json)
+        => ProbeHelpers.ParseOpenAiStyleModels(json, TryReadContextWindow);
+
+    private static int? TryReadContextWindow(JsonElement model)
+    {
+        var contextWindow = ProbeHelpers.TryReadInt32(model, "max_model_len"); // vLLM
+        if (contextWindow is not null)
+            return contextWindow;
+
+        return model.TryGetProperty("meta", out var meta)
+            ? ProbeHelpers.TryReadInt32(meta, "n_ctx") ??
+              ProbeHelpers.TryReadInt32(meta, "n_ctx_train")
+            : null;
     }
 }


### PR DESCRIPTION
## Original Problem

OpenAI-compatible self-hosted providers could successfully list models, but Netclaw did not surface the model context window during discovery. In the CLI this showed up as a missing context window, and the runtime could fall back to the default 32K context value even when the backend reported a much larger effective context.

The issue was caused by metadata shape differences between self-hosted backends:

- vLLM reports context length as `max_model_len` on `/v1/models` entries.
- llama.cpp reports runtime context as `meta.n_ctx` on `/v1/models` entries.
- Recent llama.cpp `/props` responses can report runtime context as `default_generation_settings.n_ctx` instead of the older `default_generation_settings.params.n_ctx` shape.

Netclaw already had separate backend strategies for vLLM and llama.cpp, but the llama.cpp strategy only understood the older `n_ctx_train` and nested `/props` shape. `n_ctx_train` is the training context, not necessarily the runtime-effective context when the server splits capacity across slots.

## What Changed

- OpenAI-compatible model discovery now reads context metadata for self-hosted backends without adding those backend-specific fields to the generic OpenAI-style parser.
- vLLM discovery reads `max_model_len`.
- llama.cpp discovery and capability resolution prefer runtime `n_ctx` and fall back to `n_ctx_train` only when runtime context is unavailable.
- llama.cpp `/props` parsing supports both current top-level `default_generation_settings.n_ctx` and the older nested `params.n_ctx` shape.
- Existing strategy separation is preserved: vLLM and llama.cpp still parse capabilities through their own backend-specific paths.

## Tests

- `dotnet test "src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj" --filter "FullyQualifiedName~OpenAiCompatibleCapabilityResolverTests|FullyQualifiedName~LlamaCppBackendStrategyTests"`
- `dotnet test "src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj" --filter "FullyQualifiedName~ProbeHelpersTests"`
- `pwsh "./scripts/Add-FileHeaders.ps1" -Verify`
- `git diff --check`
