### PR TITLE
fix(subagents): ignore streaming keepalives for progress

### DIFF
--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -825,6 +825,30 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public void Keepalive_only_streaming_updates_are_not_substantive_progress()
+    {
+        Assert.False(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant
+        }));
+        Assert.False(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new UsageContent(new UsageDetails())]
+        }));
+        Assert.True(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("working")]
+        }));
+        Assert.True(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-1", "inspect_context")]
+        }));
+    }
+
+    [Fact]
     public async Task LLM_failure_returns_failure()
     {
         var throwingClient = new ThrowingChatClient();

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -569,9 +569,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             {
                 updates.Add(update);
 
-                // Throttled liveness ping so the actor re-arms its inactivity
-                // watchdog and surfaces activity during a long streaming call.
-                if (pingThrottle.Elapsed >= StreamPingInterval)
+                // Content-free keepalives only prove the socket is alive; they
+                // do not prove the model is making progress. Re-arm the
+                // watchdog only for substantive deltas so provider heartbeat
+                // loops cannot keep a sub-agent alive forever.
+                if (IsSubstantiveStreamingUpdate(update) && pingThrottle.Elapsed >= StreamPingInterval)
                 {
                     pingThrottle.Restart();
                     self.Tell(SubAgentStreamPing.Instance);
@@ -590,6 +592,29 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             self.Tell(new LlmCallFailed(ex));
         }
+    }
+
+    internal static bool IsSubstantiveStreamingUpdate(ChatResponseUpdate update)
+    {
+        if (update.FinishReason is not null)
+            return true;
+
+        foreach (var content in update.Contents)
+        {
+            switch (content)
+            {
+                case TextContent text when !string.IsNullOrEmpty(text.Text):
+                case TextReasoningContent reasoning when !string.IsNullOrEmpty(reasoning.Text):
+                case FunctionCallContent:
+                    return true;
+                case UsageContent:
+                    break;
+                default:
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     private static async Task ExecuteToolsAsync(


### PR DESCRIPTION
## Summary
- prevent content-free streaming keepalives from re-arming the sub-agent inactivity watchdog
- keep substantive text, reasoning, tool-call, and finish updates as progress
- add deterministic coverage for keepalive vs substantive streaming updates

## Validation
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --filter FullyQualifiedName~SubAgentActorTests.Keepalive_only_streaming_updates_are_not_substantive_progress
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --filter FullyQualifiedName~SubAgent
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify