### PR TITLE
fix(cli): key Slack audience overrides by channel ID

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/SlackStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/SlackStepViewModelTests.cs
@@ -222,6 +222,37 @@ public sealed class SlackStepViewModelTests : WizardStepTestBase
     }
 
     [Fact]
+    public void ContributeConfig_UsesResolvedChannelIds_ForChannelAudienceOverrides()
+    {
+        using var step = new SlackStepViewModel(_fakeProbe)
+        {
+            SlackEnabled = true,
+            ChannelNamesInput = "netclaw-supervisor",
+            LastChannelResolution = new SlackChannelResolutionResult(
+                true,
+                null,
+                [new ResolvedSlackChannel("netclaw-supervisor", "C0B62888XAL")],
+                [])
+        };
+
+        step.OnEnter(Context, NavigationDirection.Forward);
+        step.OnLeave();
+
+        var entry = Assert.Single(Context.ChannelEntries[ChannelType.Slack]);
+        entry.Audience = TrustAudience.Personal;
+
+        var builder = new WizardConfigBuilder(Context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Slack);
+        Assert.Equal("C0B62888XAL", Assert.Single(builder.Slack!.AllowedChannelIds!));
+
+        var audience = Assert.Single(builder.Slack.ChannelAudiences!);
+        Assert.Equal("C0B62888XAL", audience.Key);
+        Assert.Equal("personal", audience.Value);
+    }
+
+    [Fact]
     public void ContributeSecrets_AddsTokens()
     {
         using var step = new SlackStepViewModel(_fakeProbe);

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
@@ -320,9 +320,20 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
 
         var audiences = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var entry in slackEntries)
-            audiences[entry.Id] = entry.Audience.ToWireValue();
+            audiences[ResolveChannelAudienceKey(entry)] = entry.Audience.ToWireValue();
 
         return audiences.Count > 0 ? audiences : null;
+    }
+
+    private string ResolveChannelAudienceKey(ChannelEntry entry)
+    {
+        if (entry.IsDmRow || LastChannelResolution is null)
+            return entry.Id;
+
+        var resolved = LastChannelResolution.Resolved.FirstOrDefault(
+            channel => string.Equals(channel.Name, entry.Id, StringComparison.OrdinalIgnoreCase));
+
+        return string.IsNullOrWhiteSpace(resolved?.Id) ? entry.Id : resolved.Id;
     }
 
     internal static IReadOnlyList<string> ParseChannelNames(string? input)


### PR DESCRIPTION
## Summary

This fixes Slack `netclaw init` config generation so channel audience overrides use resolved Slack channel IDs instead of channel names.

Changes:

- Use the resolved Slack channel ID when writing `Slack.ChannelAudiences`.
- Preserve the special `dm` audience key as-is.
- Add a regression test for the `#netclaw-supervisor` name-to-ID case.

Fixes #1230

## Validation

- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter FullyQualifiedName~SlackStepViewModelTests`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`

## Smoke Harness

`./scripts/smoke/run-smoke.sh init-wizard` could not complete in this environment because it attempted to install Ollama and `sudo` requires an interactive password.
