### PR TITLE
fix(cli): harden secrets upserts

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.8.0"
+  version: "2.8.1"
 ---
 
 # Netclaw Operations
@@ -30,6 +30,7 @@ problems, how to update preferences, or how to maintain itself.
 | Add or switch LLM provider, OAuth login | [LLM Providers](#llm-providers) |
 | Show / kick the tires on Netclaw end-to-end locally | [Demo AppHost](#demo-apphost) |
 | Search backend errors, configure SearXNG | [Search Providers](#search-providers) |
+| Rotate or repair secrets | [Secret Management](#secret-management) |
 
 ## Project Directory
 
@@ -616,6 +617,27 @@ full exception internally. Exception details are **never** forwarded to Slack.
 | Download timeout | bot token valid? Slack network reachable? check `daemon-{date}.log` |
 | Content scan rejection | `netclaw status` scanner section; check scan config |
 | Inbox write failure | disk space? permissions on `~/.netclaw/sessions/`? |
+
+## Secret Management
+
+Secrets live in `~/.netclaw/config/secrets.json`; never print raw values in a
+conversation, issue, PR, or log summary. Use the CLI instead of direct edits:
+
+```bash
+netclaw secrets set Discord:BotToken <replacement>
+netclaw secrets set Slack.BotToken <replacement>
+```
+
+Rules:
+
+- `.` and `:` are both accepted as path delimiters; prefer the documented dotted
+  form unless the operator provides a configuration-style colon path.
+- `netclaw secrets add` is an alias for `set` and overwrites the same effective
+  path.
+- Re-running `netclaw init` updates secret values explicitly entered in the
+  wizard while preserving unrelated secrets.
+- If a channel reports a 401 or invalid-token error, rotate the relevant secret
+  and restart the daemon so the channel reloads config.
 
 ## LLM Providers
 

--- a/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
@@ -95,6 +95,8 @@ public sealed class UpdateCommandTests : IDisposable
     {
         yield return [new[] { "init" }];
         yield return [new[] { "update" }];
+        yield return [new[] { "secrets", "set", "Discord:BotToken", "token" }];
+        yield return [new[] { "daemon", "stop" }];
         yield return [new[] { "chat" }];
         yield return [new[] { "chat", "-p", "hello" }];
         yield return [new[] { "sessions" }];

--- a/src/Netclaw.Cli.Tests/Secrets/SecretsCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Secrets/SecretsCommandTests.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="SecretsCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Netclaw.Cli.Secrets;
+using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Secrets;
+
+public sealed class SecretsCommandTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+
+    public SecretsCommandTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        _dir.Dispose();
+    }
+
+    [Theory]
+    [InlineData("set")]
+    [InlineData("add")]
+    public void Run_ColonDelimitedPath_UpsertsNestedSecretAndRemovesLiteralCollision(string subcommand)
+    {
+        File.WriteAllText(_paths.SecretsPath,
+            """
+            {
+              "Discord": {
+                "BotToken": "old-token"
+              },
+              "Discord:BotToken": "literal-collision"
+            }
+            """);
+
+        using var output = new StringWriter();
+
+        var exitCode = SecretsCommand.Run(["secrets", subcommand, "Discord:BotToken", "new-token"], _paths, output);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Set Discord.BotToken", output.ToString());
+
+        var encryptedJson = File.ReadAllText(_paths.SecretsPath);
+        Assert.DoesNotContain("\"Discord:BotToken\"", encryptedJson, StringComparison.Ordinal);
+
+        new ConfigurationBuilder()
+            .AddJsonFile(_paths.SecretsPath, optional: false, reloadOnChange: false)
+            .Build();
+
+        var protector = SecretsProtection.CreateProtector(_paths);
+        var decryptedJson = SecretsFileWriter.DecryptJsonLeaves(encryptedJson, protector);
+        using var document = JsonDocument.Parse(decryptedJson);
+
+        Assert.Equal("new-token", document.RootElement.GetProperty("Discord").GetProperty("BotToken").GetString());
+        Assert.False(document.RootElement.TryGetProperty("Discord:BotToken", out _));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
@@ -3,9 +3,11 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui.Wizard;
@@ -354,6 +356,57 @@ public sealed class WizardConfigBuilderTests : WizardStepTestBase
         var config = builder.BuildConfigDictionary();
 
         Assert.False(config.ContainsKey("ExternalSkills"));
+    }
+
+    [Fact]
+    public void WriteSecretsFile_ExistingSection_OverwritesContributedSecretsAndPreservesUnrelatedValues()
+    {
+        var priorProtector = SensitiveStringTypeConverter.Protector;
+        var protector = SecretsProtection.CreateProtector(Context.Paths);
+        SensitiveStringTypeConverter.Protector = protector;
+
+        try
+        {
+            SecretsFileWriter.Write(Context.Paths.SecretsPath,
+                """
+                {
+                  "Discord": {
+                    "BotToken": "old-token",
+                    "OtherSecret": "keep-discord"
+                  },
+                  "Discord:BotToken": "literal-collision",
+                  "Search": {
+                    "BraveApiKey": "keep-search"
+                  }
+                }
+                """,
+                protector);
+
+            var builder = new WizardSecretsBuilder(Context.Paths);
+            builder.AddSection("Discord", new Dictionary<string, object>
+            {
+                ["BotToken"] = "new-token"
+            });
+
+            builder.WriteSecretsFile();
+
+            var encryptedJson = File.ReadAllText(Context.Paths.SecretsPath);
+            Assert.DoesNotContain("\"Discord:BotToken\"", encryptedJson, StringComparison.Ordinal);
+
+            var decryptedJson = SecretsFileWriter.DecryptJsonLeaves(encryptedJson, protector);
+            using var document = JsonDocument.Parse(decryptedJson);
+
+            var root = document.RootElement;
+            var discord = root.GetProperty("Discord");
+            Assert.Equal("new-token", discord.GetProperty("BotToken").GetString());
+            Assert.Equal("keep-discord", discord.GetProperty("OtherSecret").GetString());
+            Assert.Equal("keep-search", root.GetProperty("Search").GetProperty("BraveApiKey").GetString());
+            Assert.False(root.TryGetProperty("Discord:BotToken", out _));
+        }
+        finally
+        {
+            SensitiveStringTypeConverter.Protector = priorProtector;
+        }
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Secrets/SecretsCommand.cs
+++ b/src/Netclaw.Cli/Secrets/SecretsCommand.cs
@@ -3,7 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Netclaw.Cli.Json;
 using Netclaw.Configuration;
@@ -24,14 +23,14 @@ internal static class SecretsCommand
 
         return subcommand switch
         {
-            "set" => RunSet(args, paths, writer),
+            "set" or "add" => RunSet(args, paths, writer),
             _ => RunHelp(writer),
         };
     }
 
     /// <summary>
     /// <c>netclaw secrets set Slack.BotToken xoxb-...</c>
-    /// Accepts a dotted key path (e.g. <c>Providers.ollama.ApiKey</c>),
+    /// Accepts a dotted or colon-delimited key path (e.g. <c>Providers.ollama.ApiKey</c>),
     /// upserts the value into secrets.json, encrypts all leaves, and
     /// writes with hardened permissions.
     /// </summary>
@@ -43,6 +42,7 @@ internal static class SecretsCommand
             writer.WriteLine();
             writer.WriteLine("Examples:");
             writer.WriteLine("  netclaw secrets set Slack.BotToken xoxb-...");
+            writer.WriteLine("  netclaw secrets set Discord:BotToken <token>");
             writer.WriteLine("  netclaw secrets set Providers.ollama.ApiKey sk-...");
             writer.WriteLine("  netclaw secrets set Search.BraveApiKey BSAL...");
             return 1;
@@ -63,32 +63,25 @@ internal static class SecretsCommand
             root = [];
         }
 
-        // Navigate/create the dotted key path and set the value
-        var segments = keyPath.Split('.');
-        JsonObject current = root;
-        for (var i = 0; i < segments.Length - 1; i++)
+        string[] segments;
+        try
         {
-            var seg = segments[i];
-            if (current[seg] is JsonObject child)
-            {
-                current = child;
-            }
-            else
-            {
-                var newObj = new JsonObject();
-                current[seg] = newObj;
-                current = newObj;
-            }
+            segments = SecretsJsonUpdater.ParseKeyPath(keyPath);
+        }
+        catch (InvalidOperationException ex)
+        {
+            writer.WriteLine(ex.Message);
+            return 1;
         }
 
-        current[segments[^1]] = value;
+        SecretsJsonUpdater.UpsertValue(root, segments, value);
 
         // Write with encryption — the protector encrypts all plaintext leaves
         var protector = SecretsProtection.CreateProtector(paths);
         var json = root.ToJsonString(JsonDefaults.Indented);
         SecretsFileWriter.Write(paths.SecretsPath, json, protector);
 
-        writer.WriteLine($"Set {keyPath} (encrypted).");
+        writer.WriteLine($"Set {string.Join('.', segments)} (encrypted).");
         return 0;
     }
 
@@ -98,6 +91,7 @@ internal static class SecretsCommand
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
         writer.WriteLine("  set <key> <value>   Store an encrypted secret (e.g. Slack.BotToken xoxb-...)");
+        writer.WriteLine("  add <key> <value>   Alias for set");
         return 0;
     }
 }

--- a/src/Netclaw.Cli/Secrets/SecretsJsonUpdater.cs
+++ b/src/Netclaw.Cli/Secrets/SecretsJsonUpdater.cs
@@ -1,0 +1,128 @@
+// -----------------------------------------------------------------------
+// <copyright file="SecretsJsonUpdater.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Netclaw.Cli.Json;
+
+namespace Netclaw.Cli.Secrets;
+
+internal static class SecretsJsonUpdater
+{
+    private static readonly char[] KeyPathDelimiters = ['.', ':'];
+
+    public static string[] ParseKeyPath(string keyPath)
+    {
+        var segments = keyPath.Split(KeyPathDelimiters, StringSplitOptions.None)
+            .Select(segment => segment.Trim())
+            .ToArray();
+
+        if (segments.Length == 0 || segments.Any(string.IsNullOrWhiteSpace))
+            throw new InvalidOperationException("Secret key must be a non-empty dotted or colon-delimited path.");
+
+        return segments;
+    }
+
+    public static void UpsertValue(JsonObject root, string[] segments, object value)
+    {
+        var node = JsonSerializer.SerializeToNode(value, JsonDefaults.ConfigFile);
+        UpsertNode(root, segments, node);
+    }
+
+    public static void UpsertNode(JsonObject root, string[] segments, JsonNode? value)
+    {
+        RemoveCollisionsForSubtree(root, segments, value);
+
+        var current = root;
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            var segment = segments[i];
+            if (current[segment] is JsonObject child)
+            {
+                current = child;
+                continue;
+            }
+
+            var newChild = new JsonObject();
+            current[segment] = newChild;
+            current = newChild;
+        }
+
+        current[segments[^1]] = value?.DeepClone();
+    }
+
+    public static void MergeObject(JsonObject root, string[] segments, JsonObject incoming)
+    {
+        RemoveCollisionsForSubtree(root, segments, incoming);
+
+        var target = EnsureObject(root, segments);
+        MergeObjectInto(target, incoming);
+    }
+
+    private static JsonObject EnsureObject(JsonObject root, string[] segments)
+    {
+        var current = root;
+        foreach (var segment in segments)
+        {
+            if (current[segment] is JsonObject child)
+            {
+                current = child;
+                continue;
+            }
+
+            var newChild = new JsonObject();
+            current[segment] = newChild;
+            current = newChild;
+        }
+
+        return current;
+    }
+
+    private static void MergeObjectInto(JsonObject target, JsonObject incoming)
+    {
+        foreach (var (key, value) in incoming)
+        {
+            if (value is JsonObject incomingObject && target[key] is JsonObject targetObject)
+            {
+                MergeObjectInto(targetObject, incomingObject);
+                continue;
+            }
+
+            target[key] = value?.DeepClone();
+        }
+    }
+
+    private static void RemoveCollisionsForSubtree(JsonObject root, IReadOnlyList<string> prefix, JsonNode? value)
+    {
+        if (value is JsonObject obj)
+        {
+            foreach (var (key, child) in obj)
+            {
+                var childPath = prefix.Append(key).ToArray();
+                RemoveCollisionsForSubtree(root, childPath, child);
+            }
+
+            return;
+        }
+
+        RemoveLiteralCollisionKeys(root, prefix);
+    }
+
+    private static void RemoveLiteralCollisionKeys(JsonObject root, IReadOnlyList<string> segments)
+    {
+        RemoveLiteralCollisionKeys(root, segments, offset: 0);
+    }
+
+    private static void RemoveLiteralCollisionKeys(JsonObject current, IReadOnlyList<string> segments, int offset)
+    {
+        for (var end = offset + 2; end <= segments.Count; end++)
+        {
+            current.Remove(string.Join(':', segments.Skip(offset).Take(end - offset)));
+        }
+
+        if (offset < segments.Count - 1 && current[segments[offset]] is JsonObject child)
+            RemoveLiteralCollisionKeys(child, segments, offset + 1);
+    }
+}

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Json;
 using Netclaw.Cli.Mcp;
+using Netclaw.Cli.Secrets;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
 
@@ -419,8 +420,12 @@ public sealed class WizardSecretsBuilder
             {
                 foreach (var (key, value) in _secrets)
                 {
-                    if (!existingNode.ContainsKey(key))
-                        existingNode[key] = JsonSerializer.SerializeToNode(value, JsonDefaults.ConfigFile);
+                    var segments = SecretsJsonUpdater.ParseKeyPath(key);
+                    var node = JsonSerializer.SerializeToNode(value, JsonDefaults.ConfigFile);
+                    if (node is JsonObject obj)
+                        SecretsJsonUpdater.MergeObject(existingNode, segments, obj);
+                    else
+                        SecretsJsonUpdater.UpsertNode(existingNode, segments, node);
                 }
 
                 SecretsFileWriter.Write(_paths.SecretsPath, existingNode.ToJsonString(JsonDefaults.ConfigFile),

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -24,6 +24,8 @@ internal static class UpdateCommand
         {
             case "init":
             case "update":
+            case "secrets":
+            case "daemon":
             case "chat":
             case "sessions":
             case "headless":


### PR DESCRIPTION
## Summary

- Deep-merge wizard-contributed secrets so rerunning `netclaw init` overwrites explicitly entered secret values while preserving unrelated keys.
- Normalize `netclaw secrets` key paths across `.` and `:` delimiters, remove literal colon-key collisions, and support `secrets add` as an alias for `set`.
- Skip startup update config loading for `netclaw secrets` repair commands.
- Update the operations skill with secret rotation guidance.

Closes #1232
Closes #1233

## Validation

- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~SecretsCommandTests|FullyQualifiedName~WizardConfigBuilderTests|FullyQualifiedName~UpdateCommandTests"`
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`

## Validation blockers

- `./evals/run-evals.sh` could not start because eval target environment variables are not set in this non-interactive shell.
- `./scripts/smoke/run-smoke.sh init-wizard` built CLI and daemon binaries, then stopped while trying to install Ollama via `sudo`; this shell cannot provide a sudo password.
