### PR TITLE
chore: bump Termina to 0.10.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.10.1" />
+    <PackageVersion Include="Termina" Version="0.10.2" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>


### PR DESCRIPTION
## Summary
  
Bumps the Termina package from `0.10.1` to `0.10.2` in `Directory.Packages.props`.
  
## Changes
  
- `Directory.Packages.props`: Termina 0.10.1 → 0.10.2
  
## Build
  
Confirmed build passes cleanly.