### PR TITLE
fix(subagents): harden headless execution contract

### DIFF
--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -232,7 +232,10 @@ parent session's approval channel and requester context. Human approval time doe
 not count as subagent inactivity or parent `spawn_agent` tool inactivity; both
 watchdogs resume after the approval wait settles. If no parent approval bridge or
 requester authority context is available, the gated tool fails closed as a failed
-subagent run and is not executed.
+subagent run and is not executed. Subagent approval waits are live-only: if the
+daemon or parent session restarts before the user responds, the stale prompt is
+expired and the interrupted parent `spawn_agent` call is closed before the next
+turn continues.
 
 ## Built-in agents
 

--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -1,11 +1,11 @@
 # Subagents
 
 Subagents are specialist workers that the main Netclaw agent can delegate tasks
-to. Each subagent runs autonomously with its own system prompt, tool set, and
-timeout — then returns a synthesized result to the main agent. The delegation
-protects the main session's context window from token-heavy work (deep research,
-broad exploration, long summarization) and lets the main agent stay focused on
-conversation and coordination.
+to. Each subagent runs autonomously with its own system prompt, inherited
+audience-scoped tool surface, and timeout — then returns a synthesized result to
+the main agent. The delegation protects the main session's context window from
+token-heavy work (deep research, broad exploration, long summarization) and lets
+the main agent stay focused on conversation and coordination.
 
 ## How it works
 
@@ -13,24 +13,24 @@ conversation and coordination.
 
 On every LLM turn, the main agent's system prompt includes an
 `[available-subagents]` section that enumerates every user-facing subagent along
-with its description, tools, and timeout:
+with its description, inherited tool policy, and timeout:
 
 ```
 [available-subagents — use spawn_agent to delegate]
 
 ## research-assistant
 Deep web research with search and citation
-Tools: web_search, web_fetch, file_read, attach_file
+Tools: inherited from parent audience policy, except denied sub-agent tools
 Timeout: 120s
 
 ## code-analyst
 Analyze code, run commands, and review files
-Tools: (inherits all)
+Tools: inherited from parent audience policy, except denied sub-agent tools
 Timeout: 120s
 
 ## summarizer
 Summarize documents and content concisely
-Tools: file_read
+Tools: inherited from parent audience policy, except denied sub-agent tools
 Timeout: 60s
 
 ## How to delegate
@@ -40,7 +40,7 @@ Call `spawn_agent(agent: "<name>", task: "<specific task>", context: "<optional 
 - `context` is optional per-invocation background (workspace details, the user's broader goal,
   facts the subagent would otherwise have to rediscover). Do NOT duplicate the agent's built-in
   instructions — use this for THIS invocation's situation.
-- Subagents run autonomously with their own tools and return a synthesized result, not a transcript.
+- Subagents run autonomously with audience-scoped tools and return a synthesized result, not a transcript.
 ```
 
 The main agent sees this on every turn, so it always knows what subagents are
@@ -85,14 +85,14 @@ first user message is just the raw task, identical to the pre-context protocol.
 ### Execution
 
 1. The `spawn_agent` tool resolves the named agent from the definition registry.
-2. Tools listed in the agent's definition are resolved from the tool registry.
-   Subagents inherit the parent session's runtime tool policy, then
-   `SubAgentToolPolicy` removes tools that are statically denied to subagents
-   (`spawn_agent`).
+2. The runtime starts from tools exposed by the parent session's audience/profile
+   policy, then `SubAgentToolPolicy` removes tools that are statically denied to
+   subagents (`spawn_agent`). Agent definition `tools:` metadata is advisory and
+   does not narrow runtime authorization.
 3. A `SubAgentActor` is spawned as a **child of the session actor** (supervised,
    lifecycle-managed — stops when the session stops).
 4. The subagent runs an autonomous LLM loop: call tools, process results, repeat.
-5. After at most 10 tool iterations, a final response, or an inactivity timeout,
+5. After at most 30 tool iterations, a final response, or an inactivity timeout,
    the subagent returns its final text response.
 6. The main agent receives this response as the `spawn_agent` tool result.
 
@@ -106,12 +106,13 @@ responsive subagent is not stopped merely because wall-clock time has elapsed.
 Subagent start/complete events are emitted as `SubAgentOutput` session events:
 
 ```
-[subagent:start] research-assistant (4 tools)
+[subagent:start] research-assistant (N tools)
 [subagent:done]  research-assistant (success, 23.4s)
 ```
 
-These appear in the headless CLI output and session logs. They are suppressed
-in Slack.
+The start event reports the number of tools exposed for that parent audience and
+profile. These events appear in the headless CLI output and session logs. They
+are suppressed in Slack.
 
 Completion events are emitted for every finished subagent run, even when the
 subagent returns no structured findings. In that case `FindingsCount` is `0`
@@ -146,7 +147,6 @@ the authoritative agent name comes from the `name` field in the frontmatter.
 ---
 name: research-assistant
 description: Deep web research with search and citation
-tools: [web_search, web_fetch, file_read, attach_file]
 modelRole: Compaction
 timeoutSeconds: 120
 visibility: user-facing
@@ -171,7 +171,7 @@ findings into clear, well-organized summaries.
 |-------|----------|---------|-------------|
 | `name` | Yes | — | Unique identifier. Used in `spawn_agent(agent: "<name>")`. Duplicate names across files are rejected with a warning. |
 | `description` | Yes | — | One-line description shown in the `[available-subagents]` discovery block. |
-| `tools` | No | (inherit all except denied) | List of tool names. When omitted, the runtime starts from all registered tools available to the parent session, then removes statically denied subagent tools. When specified, it acts as a whitelist before the same denylist is applied. |
+| `tools` | No | `[]` | Advisory tool metadata retained for file-format compatibility. It does not constrain runtime tool access. |
 | `modelRole` | No | `Compaction` | `Compaction` (cheaper/faster) or `Main` (full model). |
 | `timeoutSeconds` | No | `60` | Inactivity timeout in seconds. The watchdog resets when the subagent makes progress. |
 | `visibility` | No | `user-facing` | `user-facing` (visible to `spawn_agent`) or `internal` (platform-owned, hidden). Accepts both hyphenated and PascalCase. |
@@ -202,8 +202,9 @@ ignored at the glob layer and never logged.
 
 - **Be specific about the output format.** The main agent receives the
   subagent's final text response — make sure it's structured and useful.
-- **Reference tools by name.** The subagent only has the tools listed in its
-  definition. Tell it which tools to use and when.
+- **Reference capabilities by name.** The subagent sees tools exposed by the
+  parent audience/profile policy. Tell it which capabilities to use and when,
+  but keep prompts robust when a tool is unavailable.
 - **Set boundaries.** Tell the subagent what NOT to do (e.g., "do not modify
   code unless explicitly asked").
 - **Keep it focused.** A subagent with a narrow, clear purpose works better
@@ -213,15 +214,13 @@ ignored at the glob layer and never logged.
 
 ### Tool access
 
-When `tools` is omitted from the frontmatter, the runtime starts from all
-registered tools available under the parent session's audience, boundary,
-approval, and shell policies. It then applies the subagent denylist, which
-prevents recursive delegation through `spawn_agent`.
+Runtime tool access is derived from the parent session's audience/profile policy,
+boundary, approval, and shell policies. The subagent denylist is then applied to
+prevent recursive delegation through `spawn_agent`.
 
-When `tools` is specified, it acts as a whitelist limiting which tools the
-subagent can access before the same subagent denylist and runtime policy checks
-are applied. Use this when you want to restrict a subagent to specific
-capabilities (e.g., read-only access via `tools: [file_read, web_search]`).
+The `tools:` frontmatter field is advisory metadata only. It may be useful when
+sharing definitions with other agent systems, but Netclaw does not use it as a
+runtime whitelist.
 
 Spawned subagents inherit the parent session's `session_dir` and current
 `project_dir` as read-only grounding. That means file tools resolve against the
@@ -241,13 +240,13 @@ Three agents are seeded during `netclaw init`. They are regular file-based
 definitions — you can edit or delete them.
 
 **research-assistant** — Deep web research with search and citation.
-Tools: `web_search`, `web_fetch`, `file_read`, `attach_file`. Timeout: 120s.
+Timeout: 120s. Tools are inherited from the parent audience/profile policy.
 
 **code-analyst** — Analyze code and review files.
-Tools: filtered to the user-facing safe set when loaded from disk. Timeout: 120s.
+Timeout: 120s. Tools are inherited from the parent audience/profile policy.
 
 **summarizer** — Summarize documents and content concisely.
-Tools: `file_read`. Timeout: 60s.
+Timeout: 60s. Tools are inherited from the parent audience/profile policy.
 
 ## Creating a custom agent
 
@@ -257,7 +256,6 @@ Create a single `.md` file in `~/.netclaw/agents/`:
 ---
 name: github-reviewer
 description: Read local PR notes and summarize next steps for the parent session
-tools: [file_read]
 modelRole: Compaction
 timeoutSeconds: 90
 visibility: user-facing
@@ -276,10 +274,9 @@ parent session should do next.
 Save the file. The next turn or subagent lookup reloads the on-disk definitions
 and refreshes the `[available-subagents]` discovery block.
 
-If a tool name in your frontmatter doesn't match any registered tool, or falls
-outside the user-facing allowlist, the agent is skipped with a specific
-warning in the daemon log naming both the file and the disallowed tool — look
-there first when a new agent "doesn't show up."
+If a spawned subagent cannot access a tool it expected, inspect the parent
+session audience/profile policy and runtime tool discovery output. Frontmatter
+`tools:` values do not grant or remove tool access.
 
 If you edit a previously valid agent into an invalid state, the runtime drops it
 from the active catalog on the next reload instead of serving the stale last
@@ -290,7 +287,7 @@ known-good version.
 - Subagents are **single-turn**: they receive a task, run their tool loop, and
   return a result. They do not maintain conversation history or support
   back-and-forth interaction with the user.
-- Subagents have a **maximum of 10 tool iterations** before being forced to
+- Subagents have a **maximum of 30 tool iterations** before being forced to
   produce a text response.
 - Subagents run on the **compaction model** by default (cheaper/faster). Set
   `modelRole: Main` in frontmatter if the task requires the full model's

--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -268,8 +268,12 @@ A: Yes. Add the tool name to `ToolOverrides`:
 ```
 
 **Q: What happens if I don't respond to an approval prompt?**
-A: The prompt times out after 5 minutes and auto-denies. The LLM receives
-"Approval timed out" as the tool result.
+A: While the daemon and session remain alive, approval waits remain pending until
+you approve, deny, or the blocked run is cancelled. Parent-session approvals have
+durable recovery state and can be redriven after cold recovery. Subagent approval
+waits are live-only; if the daemon or parent session restarts before you respond,
+the stale prompt is rejected as expired and the interrupted `spawn_agent` call is
+closed before the next turn continues.
 
 **Q: Can I pre-approve common commands?**
 A: Yes. Edit `~/.netclaw/config/tool-approvals.json` directly to add patterns.

--- a/evals/README.md
+++ b/evals/README.md
@@ -67,6 +67,7 @@ log patterns** (skill loading, memory recall, checkpoint formation).
 | Tool Discovery & Use | 4 | Progressive tool discovery and invocation |
 | Grounding & Alignment | 3 | Uses tools to verify facts, admits uncertainty |
 | Autonomy & Execution | 2 | Executes tasks rather than describing them |
+| Subagents | 1 | Delegates through `spawn_agent` and verifies headless subagents complete ambiguous work without clarification loops |
 | Complex Task Execution | 3 | Multi-step tool chains complete successfully |
 | Multi-Turn Conversation | 7 | Session resume and speaker attribution recall |
 

--- a/evals/fixtures/agents/headless-analyst.md
+++ b/evals/fixtures/agents/headless-analyst.md
@@ -1,0 +1,19 @@
+---
+name: headless-analyst
+description: Eval fixture subagent that resolves ambiguous release-note style tasks without interactive follow-up.
+tools: []
+timeoutSeconds: 60
+---
+
+You are a headless analysis worker used by the Netclaw eval suite.
+
+When a task has ambiguous inclusion criteria, do not ask the user what to do.
+Make a reasonable assumption, state it briefly, and produce a final answer.
+
+For release-note style tasks, include every item that appears user-facing and
+exclude purely internal test or refactoring details unless they affect users.
+
+Return concise output with:
+
+1. Assumptions
+2. Final output

--- a/evals/fixtures/agents/headless-analyst.md
+++ b/evals/fixtures/agents/headless-analyst.md
@@ -1,7 +1,6 @@
 ---
 name: headless-analyst
 description: Eval fixture subagent that resolves ambiguous release-note style tasks without interactive follow-up.
-tools: []
 timeoutSeconds: 60
 ---
 

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -826,6 +826,17 @@ stdout_not_contains() {
     ! grep -qi "$1" "$STDOUT_FILE" 2>/dev/null
 }
 
+stdout_response_contains() {
+    grep -v '^\[tool:call\]' "$STDOUT_FILE" 2>/dev/null | grep -qi "$1"
+}
+
+stdout_response_not_contains() {
+    if grep -v '^\[tool:call\]' "$STDOUT_FILE" 2>/dev/null | grep -qi "$1"; then
+        return 1
+    fi
+    return 0
+}
+
 daemon_log_tail() {
     if [[ -f "$DAEMON_LOG" ]]; then
         tail -n +"$((DAEMON_LOG_LINES_BEFORE + 1))" "$DAEMON_LOG" 2>/dev/null
@@ -1022,11 +1033,11 @@ assert_autonomy_web_fetch() {
 assert_subagent_headless_ambiguous_task() {
     stdout_tool_called 'spawn_agent' && \
         daemon_log_contains 'SubAgent \[headless-analyst\] completed \(success=True' && \
-        stdout_contains 'assumption' && \
-        stdout_not_contains 'which.*include' && \
-        stdout_not_contains 'what.*include' && \
-        stdout_not_contains 'please.*clarify' && \
-        stdout_not_contains 'need.*more.*information'
+        stdout_response_contains 'assumption' && \
+        stdout_response_not_contains 'which.*include' && \
+        stdout_response_not_contains 'what.*include' && \
+        stdout_response_not_contains 'please.*clarify' && \
+        stdout_response_not_contains 'need.*more.*information'
 }
 
 # Category 7: Complex Task Execution

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -323,7 +323,7 @@ start_eval_daemon() {
     # — host files can be contaminated with user-specific names (e.g., "ArdyBot")
     # that break identity evals. Templates have {{PLACEHOLDER}} tokens that we
     # substitute with eval defaults.
-    mkdir -p "$EVAL_HOME/identity" "$EVAL_HOME/logs" "$EVAL_HOME/data"
+    mkdir -p "$EVAL_HOME/identity" "$EVAL_HOME/logs" "$EVAL_HOME/data" "$EVAL_HOME/data/agents"
     local template_dir="$REPO_ROOT/src/Netclaw.Cli/Resources/identity"
     if [[ -d "$template_dir" ]]; then
         # Substitute placeholders with eval-appropriate defaults
@@ -350,6 +350,12 @@ start_eval_daemon() {
     # Copy user skills from eval fixtures (non-system skills for activation testing).
     if [[ -d "$REPO_ROOT/evals/fixtures/skills" ]]; then
         cp -r "$REPO_ROOT/evals/fixtures/skills/." "$EVAL_HOME/skills/"
+    fi
+
+    # Copy eval-only subagent definitions into the mounted NETCLAW_HOME so
+    # spawn_agent behavior can be exercised without touching the host install.
+    if [[ -d "$REPO_ROOT/evals/fixtures/agents" ]]; then
+        cp -r "$REPO_ROOT/evals/fixtures/agents/." "$EVAL_HOME/data/agents/"
     fi
 
     # The eval container runs as the non-root `netclaw` user and needs write
@@ -1012,6 +1018,17 @@ assert_autonomy_web_fetch() {
     stdout_contains '\[tool:call\] web_search' || stdout_contains '\[tool:call\] web_fetch'
 }
 
+# Category 6b: Subagents
+assert_subagent_headless_ambiguous_task() {
+    stdout_tool_called 'spawn_agent' && \
+        daemon_log_contains 'SubAgent \[headless-analyst\] completed \(success=True' && \
+        stdout_contains 'assumption' && \
+        stdout_not_contains 'which.*include' && \
+        stdout_not_contains 'what.*include' && \
+        stdout_not_contains 'please.*clarify' && \
+        stdout_not_contains 'need.*more.*information'
+}
+
 # Category 7: Complex Task Execution
 assert_complex_write_and_run() {
     stdout_contains '\[tool:call\] file_write' && \
@@ -1414,6 +1431,15 @@ run_all() {
 
     run_case autonomy_web_fetch "web_search or web_fetch called" \
         "What's on the front page of Hacker News right now?"
+
+    end_category
+
+    # ── Category 6b: Subagents ──
+    print_category "Subagents"
+
+    run_case subagent_headless_ambiguous_task "spawned subagent completes ambiguous task without clarification" \
+        "Use spawn_agent with agent headless-analyst. Ask it to prepare final release notes from these candidate changes without asking follow-up questions. Include everything that looks user-facing: fixed arrow-key input decoding; updated an internal test helper; improved file trace listener encoding. Return the subagent's assumptions and final notes." \
+        "Delegate this to the headless-analyst subagent using spawn_agent: decide what belongs in release notes from this ambiguous list without asking me for clarification: legacy CSI key decoding fix; private test fixture cleanup; file trace listener writes UTF-8 correctly. Include all user-facing items and return assumptions plus final notes."
 
     end_category
 

--- a/feeds/skills/.system/files/subagent-authoring/SKILL.md
+++ b/feeds/skills/.system/files/subagent-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: subagent-authoring
 description: "How to create and troubleshoot file-defined subagents in ~/.netclaw/agents. Load when the user asks to add, edit, or debug subagent definitions, or when a skill routes via metadata.subagent."
 metadata:
   author: netclaw
-  version: "1.2.2"
+  version: "1.2.3"
 ---
 
 # Subagent Authoring
@@ -109,6 +109,25 @@ Summarize the latest planning notes and highlight next actions.
 This agent inherits the parent session's runtime tool policy. User-facing
 subagents then apply the static subagent denylist, which blocks recursive
 delegation through `spawn_agent` even when `tools` is omitted.
+
+## Runtime contract
+
+Subagents run as headless workers on behalf of the parent session:
+- do the delegated work as far as possible with the task, context, and tools
+  available
+- do not ask the user clarifying questions or wait for conversational replies
+- make reasonable assumptions when safe, and state them in the final output
+- if blocked, return a final result describing what was found, what remains,
+  and what decision the parent session needs
+
+Parent-mediated tool approval is still allowed for concrete tool calls when the
+parent channel supports it. Treat approval as a security gate, not as a dialogue
+channel.
+
+Subagents share the same tool-loop budget strategy as parent sessions: budget
+nudges, duplicate-call nudges, and force-no-tools wrap-up. The current
+subagent budget is 30 tool iterations per run, where one LLM response with any
+number of parallel tool calls counts as one iteration.
 
 ## Fail-loud loader behavior
 

--- a/feeds/skills/.system/files/subagent-authoring/SKILL.md
+++ b/feeds/skills/.system/files/subagent-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: subagent-authoring
 description: "How to create and troubleshoot file-defined subagents in ~/.netclaw/agents. Load when the user asks to add, edit, or debug subagent definitions, or when a skill routes via metadata.subagent."
 metadata:
   author: netclaw
-  version: "1.2.3"
+  version: "1.2.4"
 ---
 
 # Subagent Authoring
@@ -27,7 +27,7 @@ Both gates must pass for subagent features to be available.
 
 Load this when the user asks to:
 - create a new subagent
-- edit tools, timeout, or behavior for an existing subagent
+- edit advisory tool metadata, timeout, or behavior for an existing subagent
 - diagnose why a subagent does not appear in `[available-subagents]`
 - route a slash skill through `metadata.subagent`
 
@@ -51,7 +51,7 @@ description: What this agent does
 You are a specialist assistant. Your job is to...
 ```
 
-With tools restricted to a specific set:
+With advisory tool metadata for compatibility with other agent systems:
 
 ```markdown
 ---
@@ -75,10 +75,10 @@ The markdown body below the closing `---` must also be non-empty.
 
 | Field | Default | Notes |
 |------|---------|-------|
-| `tools` | (inherit all except denied) | List of tool names. When omitted, the runtime starts from all registered tools available to the parent session, then removes statically denied subagent tools. When specified, it acts as a whitelist before the same denylist is applied. |
-| `modelRole` | `Compaction` | `Main` or `Compaction` (case-insensitive). Invalid values fall back to `Compaction`. |
+| `tools` | `[]` | Advisory tool metadata retained for file-format compatibility. Netclaw does not use this as a runtime whitelist. |
+| `modelRole` | `Compaction` | `Main` or `Compaction` (case-insensitive). Invalid values make the file fail loud and skip loading. |
 | `timeoutSeconds` | `60` | Inactivity timeout for subagent execution. The watchdog resets when the subagent makes progress. |
-| `visibility` | `user-facing` | Accepts `user-facing`, `UserFacing`, `internal`, or `Internal`. Invalid values fall back to `user-facing`. |
+| `visibility` | `user-facing` | Accepts `user-facing`, `UserFacing`, `internal`, or `Internal`. Invalid values make the file fail loud and skip loading. |
 | `emitStructuredFindings` | `false` | When true, successful output is emitted as findings for parent-session review. |
 
 Unknown fields are ignored.
@@ -90,7 +90,6 @@ Unknown fields are ignored.
 name: notion-planner
 description: Summarizes local daily planning notes for the parent session
 timeoutSeconds: 120
-tools: [file_read]
 ---
 
 You are a planning assistant that reviews daily planning notes.
@@ -106,15 +105,15 @@ Summarize the latest planning notes and highlight next actions.
 - Follow the user's existing plan format and structure
 ```
 
-This agent inherits the parent session's runtime tool policy. User-facing
+This agent inherits the parent session's audience/profile tool policy. User-facing
 subagents then apply the static subagent denylist, which blocks recursive
-delegation through `spawn_agent` even when `tools` is omitted.
+delegation through `spawn_agent`. Frontmatter `tools:` values are advisory only.
 
 ## Runtime contract
 
 Subagents run as headless workers on behalf of the parent session:
 - do the delegated work as far as possible with the task, context, and tools
-  available
+  exposed by the parent audience/profile policy
 - do not ask the user clarifying questions or wait for conversational replies
 - make reasonable assumptions when safe, and state them in the final output
 - if blocked, return a final result describing what was found, what remains,
@@ -174,7 +173,7 @@ the same way. There is no separate code path for routed execution.
 After creating or editing a subagent file:
 1. save the file and trigger the next turn or subagent lookup
 2. confirm the agent appears in `[available-subagents]`
-3. run a small `spawn_agent` task to verify tools, inherited context, and output
+3. run a small `spawn_agent` task to verify inherited context, tool exposure, and output
 4. if missing, check daemon logs for the rejection reason
 
 If the user has no agent files yet, `netclaw init` seeds starter definitions.

--- a/openspec/changes/streaming-tool-call-execution/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/streaming-tool-call-execution/specs/netclaw-subagents/spec.md
@@ -48,8 +48,8 @@ wall-clock cap on a sub-agent run that is continuously producing activity.
 
 The `spawn_agent` tool SHALL be denied to sub-agents by a single tool-policy
 denylist applied when a sub-agent's tool set is resolved. A sub-agent's resolved
-tool set SHALL never include `spawn_agent`, regardless of what its profile lists
-or inherits.
+tool set SHALL never include `spawn_agent`, regardless of parent audience policy
+or advisory definition metadata.
 
 #### Scenario: spawn_agent is absent from a resolved sub-agent tool set
 

--- a/openspec/specs/netclaw-subagents/spec.md
+++ b/openspec/specs/netclaw-subagents/spec.md
@@ -34,7 +34,7 @@ A `RunSubAgent` spawn message SHALL carry the spawning session's audience as a
 parsed `TrustAudience`. The sub-agent actor SHALL NOT default a missing
 audience to `TrustAudience.Personal`; a sub-agent spawned from a live session
 always has a parent audience, so an absent audience is a programming error and
-SHALL raise an explicit exception.
+SHALL fail loudly with an unsuccessful sub-agent result.
 
 #### Scenario: Sub-agent inherits the parent session audience
 
@@ -47,5 +47,30 @@ SHALL raise an explicit exception.
 
 - **WHEN** a `RunSubAgent` message reaches the sub-agent actor without an
   audience
-- **THEN** the actor throws an explicit exception
+- **THEN** the actor returns an unsuccessful sub-agent result that names the
+  missing audience problem
 - **AND** no `Personal` audience is substituted
+
+### Requirement: Sub-agent tool exposure inherits parent audience policy
+
+Sub-agent runtime tool exposure SHALL be derived from the parent session's
+effective audience/profile policy. Agent definition `tools` metadata MAY be
+parsed for file-format compatibility, but SHALL NOT narrow or grant runtime tool
+authorization. After audience/profile filtering, Netclaw SHALL apply the static
+sub-agent denylist to prevent recursive delegation through `spawn_agent`.
+
+#### Scenario: Definition tool metadata does not restrict runtime access
+
+- **GIVEN** a sub-agent definition declares `tools: [web_fetch]`
+- **AND** the parent session audience/profile exposes `file_read`
+- **WHEN** the sub-agent is spawned and calls `file_read`
+- **THEN** the call is authorized or denied only by the parent audience/profile
+  policy and normal invocation checks
+- **AND** the definition `tools` metadata does not deny the call
+
+#### Scenario: Static sub-agent denylist still blocks recursive delegation
+
+- **GIVEN** a parent session audience/profile exposes `spawn_agent`
+- **WHEN** a sub-agent is spawned
+- **THEN** `spawn_agent` is removed from the sub-agent's exposed tool surface
+- **AND** the sub-agent cannot recursively delegate to another sub-agent

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -260,7 +260,8 @@ public sealed class ParentSessionApprovalBridgeTests
         {
             Assert.False(dispatch.PersistApprovalState);
             Assert.NotEqual(childCallId, dispatch.Request.CallId);
-            Assert.Contains(childCallId.Value, dispatch.Request.CallId.Value, StringComparison.Ordinal);
+            Assert.StartsWith("spawn-call-duplicates/subagent-approval/", dispatch.Request.CallId.Value, StringComparison.Ordinal);
+            Assert.DoesNotContain(childCallId.Value, dispatch.Request.CallId.Value, StringComparison.Ordinal);
         });
         Assert.False(channel.Complete(childCallId, ApprovalDecision.ApprovedOnce));
     }

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -265,10 +265,13 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
     [Fact]
     public async Task Spawn_agent_subagent_approval_uses_parent_authority_and_resumes_after_approval()
     {
+        const string parentCallId = "call_5aaea0c7afec4e47bbc062d8";
+        const string childCallId = "call_6f11cdf0c19746c59e778331";
+
         _clientProvider.Main.ToolCallsOnFirstCall =
         [
             new FunctionCallContent(
-                "call-spawn-shell",
+                parentCallId,
                 "spawn_agent",
                 new Dictionary<string, object?>
                 {
@@ -279,7 +282,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         _clientProvider.Compaction.ToolCallsOnFirstCall =
         [
             new FunctionCallContent(
-                "call-subagent-shell",
+                childCallId,
                 "shell_execute",
                 new Dictionary<string, object?>
                 {
@@ -313,8 +316,11 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Assert.Equal(SubAgentPhase.Started, started.Phase);
 
         var request = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.NotEqual("call-subagent-shell", request.CallId.Value);
-        Assert.Contains("call-subagent-shell", request.CallId.Value, StringComparison.Ordinal);
+        Assert.NotEqual(childCallId, request.CallId.Value);
+        Assert.StartsWith($"{parentCallId}/subagent-approval/", request.CallId.Value, StringComparison.Ordinal);
+        Assert.Contains("subagent-approval", request.CallId.Value, StringComparison.Ordinal);
+        Assert.DoesNotContain(childCallId, request.CallId.Value, StringComparison.Ordinal);
+        AssertApprovalButtonValuesRoundTrip(request);
         Assert.Equal("shell_execute", request.ToolName.Value);
         Assert.Equal(source.SenderId, request.RequesterSenderId);
         Assert.Equal(source.Principal, request.RequesterPrincipal);
@@ -391,7 +397,9 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         var request = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Contains("call-subagent-shell-expire", request.CallId.Value, StringComparison.Ordinal);
+        Assert.Contains("subagent-approval", request.CallId.Value, StringComparison.Ordinal);
+        Assert.DoesNotContain("call-subagent-shell-expire", request.CallId.Value, StringComparison.Ordinal);
+        AssertApprovalButtonValuesRoundTrip(request);
         Assert.False(_recordingShellTool!.WasCalled);
 
         await ColdRespawnAsync(sessionId);
@@ -744,6 +752,21 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Watch(child);
         Sys.Stop(child);
         await ExpectTerminatedAsync(child, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private static void AssertApprovalButtonValuesRoundTrip(ToolInteractionRequest request)
+    {
+        foreach (var option in request.Options)
+        {
+            var encoded = ApprovalButtonValueCodec.Encode(request, option);
+            Assert.True(
+                encoded.Length <= ApprovalButtonValueCodec.MaxEncodedLength,
+                $"Approval button value exceeded {ApprovalButtonValueCodec.MaxEncodedLength} chars: {encoded.Length}");
+            Assert.True(ApprovalButtonValueCodec.TryDecode(encoded, out var callId, out var selectedKey, out var requesterSenderId));
+            Assert.Equal(request.CallId.Value, callId);
+            Assert.Equal(option.Key.Value, selectedKey);
+            Assert.Equal(request.RequesterSenderId?.Value, requesterSenderId);
+        }
     }
 
     private sealed class RecordingRoleChatClientProvider : IChatClientProvider

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -251,7 +251,9 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
 
         var subagentCall = Assert.Single(_clientProvider.Compaction.ReceivedMessages);
         Assert.Contains(subagentCall, m =>
-            m.Role == Microsoft.Extensions.AI.ChatRole.System && string.Equals(m.Text, "You are a summarizer.", StringComparison.Ordinal));
+            m.Role == Microsoft.Extensions.AI.ChatRole.System
+            && m.Text.Contains("You are a summarizer.", StringComparison.Ordinal)
+            && m.Text.Contains("headless, non-interactive worker", StringComparison.Ordinal));
         Assert.Contains(subagentCall, m =>
             m.Role == Microsoft.Extensions.AI.ChatRole.User && string.Equals(m.Text, "Summarize src/README.md", StringComparison.Ordinal));
         Assert.DoesNotContain(subagentCall, m =>

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -425,6 +425,23 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         var notice = await subscriberB.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("expired", notice.Text, StringComparison.OrdinalIgnoreCase);
         Assert.False(_recordingShellTool.WasCalled);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Never mind, just say hello",
+            Source = source
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await subscriberB.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriberB.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        var resumedCall = _clientProvider.Main.ReceivedMessages[^1];
+        Assert.Contains(resumedCall, message =>
+            message.Role == Microsoft.Extensions.AI.ChatRole.Tool
+            && message.Contents.OfType<FunctionResultContent>().Any(result =>
+                result.CallId == "call-spawn-shell-expire"
+                && result.Result?.ToString()?.Contains("session restarted", StringComparison.OrdinalIgnoreCase) == true));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -229,7 +229,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         var started = await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(SubAgentPhase.Started, started.Phase);
         Assert.Equal("summarizer", started.AgentName.Value);
-        Assert.Equal(1, started.ToolCount);
+        Assert.Equal(2, started.ToolCount);
 
         var completed = await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(SubAgentPhase.Completed, completed.Phase);

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -41,6 +41,15 @@ public class SubAgentActorTests : TestKit
         };
     }
 
+    private static string MalformedToolCallMarkup() => """
+        <function=shell_execute>
+        <parameter=Command>
+        gh pr list --repo example/repo --state open
+        </parameter>
+        </function>
+        </tool_call>
+        """;
+
     [Fact]
     public async Task Text_response_returns_success_result()
     {
@@ -56,6 +65,58 @@ public class SubAgentActorTests : TestKit
         Assert.Contains("Response #1", result.Output);
         Assert.Equal("test-agent", result.AgentName.Value);
         Assert.Empty(result.Findings);
+    }
+
+    [Fact]
+    public async Task Malformed_final_tool_markup_gets_one_repair_turn()
+    {
+        var fakeClient = new FakeChatClient
+        {
+            ResponseTextsByCall =
+            [
+                MalformedToolCallMarkup(),
+                "Final report based on executed results."
+            ]
+        };
+        var definition = CreateDefinition();
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent { Task = "Analyze repos", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal("Final report based on executed results.", result.Output);
+        Assert.Equal(2, fakeClient.CallCount);
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+        Assert.Contains(fakeClient.LastReceivedMessages,
+            message => message.Role == ChatRole.User
+                       && message.Text.Contains("unexecuted tool-call markup", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Repeated_malformed_final_tool_markup_fails_without_timeout_error()
+    {
+        var fakeClient = new FakeChatClient
+        {
+            ResponseTextsByCall =
+            [
+                MalformedToolCallMarkup(),
+                MalformedToolCallMarkup()
+            ]
+        };
+        var definition = CreateDefinition();
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent { Task = "Analyze repos", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(2, fakeClient.CallCount);
+        Assert.Contains("malformed final output", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not a timeout", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("timed out", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -854,6 +915,30 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public void Keepalive_only_streaming_updates_are_not_substantive_progress()
+    {
+        Assert.False(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant
+        }));
+        Assert.False(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new UsageContent(new UsageDetails())]
+        }));
+        Assert.True(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("working")]
+        }));
+        Assert.True(SubAgentActor.IsSubstantiveStreamingUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-1", "inspect_context")]
+        }));
+    }
+
+    [Fact]
     public async Task LLM_failure_returns_failure()
     {
         var throwingClient = new ThrowingChatClient();
@@ -1084,6 +1169,8 @@ internal sealed class FakeChatClient : IChatClient
 
     public string? ResponseText { get; set; }
 
+    public IReadOnlyList<string>? ResponseTextsByCall { get; set; }
+
     public async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
@@ -1110,9 +1197,13 @@ internal sealed class FakeChatClient : IChatClient
             }
         }
 
+        var responseText = ResponseTextsByCall is { Count: > 0 } responses && _callCount <= responses.Count
+            ? responses[_callCount - 1]
+            : ResponseText ?? $"[fake] Response #{_callCount}";
+
         var responseMessage = new ChatMessage(
             ChatRole.Assistant,
-            [new TextContent(ResponseText ?? $"[fake] Response #{_callCount}")]);
+            [new TextContent(responseText)]);
         return new ChatResponse(responseMessage);
     }
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -120,6 +120,50 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public async Task Fenced_tool_markup_example_is_accepted_as_final_output()
+    {
+        const string finalOutput = """
+            The failed model output looked like this:
+
+            ```xml
+            <function=shell_execute>
+            <parameter=Command>
+            gh pr list --repo example/repo --state open
+            </parameter>
+            </function>
+            </tool_call>
+            ```
+
+            No tool call was executed from that quoted example.
+            """;
+        var fakeClient = new FakeChatClient
+        {
+            ResponseTextsByCall = [finalOutput]
+        };
+        var definition = CreateDefinition();
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent { Task = "Explain malformed output", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal(finalOutput, result.Output);
+        Assert.Equal(1, fakeClient.CallCount);
+    }
+
+    [Theory]
+    [InlineData("<function=shell_execute>\n<parameter=Command>\nls\n</parameter>\n</function>", true)]
+    [InlineData("<tool_call>\n<function=shell_execute>\n</function>\n</tool_call>", true)]
+    [InlineData("> <function=shell_execute>\n> <parameter=Command>\n> ls\n> </parameter>\n> </function>", false)]
+    [InlineData("```xml\n<function=shell_execute>\n<parameter=Command>\nls\n</parameter>\n</function>\n```", false)]
+    [InlineData("The literal token <function=shell_execute> appeared in the transcript.", false)]
+    public void Tool_call_markup_detection_ignores_quoted_examples(string text, bool expected)
+    {
+        Assert.Equal(expected, SubAgentActor.ContainsUnexecutedToolCallMarkup(text));
+    }
+
+    [Fact]
     public async Task System_prompt_includes_headless_subagent_contract()
     {
         var fakeClient = new FakeChatClient();

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -59,6 +59,25 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public async Task System_prompt_includes_headless_subagent_contract()
+    {
+        var fakeClient = new FakeChatClient();
+        var definition = CreateDefinition();
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent { Task = "Say hello", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+        Assert.Equal(ChatRole.System, fakeClient.LastReceivedMessages[0].Role);
+        Assert.Contains("headless, non-interactive worker", fakeClient.LastReceivedMessages[0].Text);
+        Assert.Contains("Do not ask the user clarifying questions", fakeClient.LastReceivedMessages[0].Text);
+        Assert.Contains("Parent-mediated tool approval", fakeClient.LastReceivedMessages[0].Text);
+    }
+
+    [Fact]
     public async Task Spawn_without_audience_fails_fast_with_unsuccessful_result()
     {
         var fakeClient = new FakeChatClient();
@@ -332,7 +351,8 @@ public class SubAgentActorTests : TestKit
         Assert.True(result.Success);
         Assert.NotNull(fakeClient.LastReceivedMessages);
         var systemMessage = fakeClient.LastReceivedMessages!.Single(m => m.Role == ChatRole.System);
-        Assert.Equal("You are a test agent.", systemMessage.Text);
+        Assert.Contains("You are a test agent.", systemMessage.Text);
+        Assert.DoesNotContain("Project rules:", systemMessage.Text);
     }
 
     [Fact]
@@ -793,16 +813,25 @@ public class SubAgentActorTests : TestKit
         };
 
         var definition = CreateDefinition([fakeTool]);
-        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(
+            definition,
+            fakeClient,
+            maxToolIterations: 3));
 
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent { Task = "Loop forever", Timeout = TimeSpan.FromSeconds(10) , Audience = TrustAudience.Personal },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
-        // After 10 tool iterations, forces a no-tools call which returns text
+        // After the configured tool budget, force a no-tools call which returns text.
         Assert.True(result.Success);
-        // Should have made multiple calls: 10 tool calls + 1 initial + 1 forced text
-        Assert.True(fakeClient.CallCount >= 11);
+        Assert.Equal(4, fakeClient.CallCount);
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+        Assert.Contains(fakeClient.LastReceivedMessages,
+            message => message.Role == ChatRole.User
+                       && message.Text.Contains("Start wrapping up your tool usage", StringComparison.Ordinal));
+        Assert.Contains(fakeClient.LastReceivedMessages,
+            message => message.Role == ChatRole.User
+                       && message.Text.Contains("Do NOT request any more tools", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
@@ -88,6 +88,67 @@ public sealed class SubAgentSpawnerTests : TestKit
         Assert.True(result.Success);
     }
 
+    [Fact]
+    public async Task Spawn_async_ignores_definition_tool_metadata_for_runtime_tool_resolution()
+    {
+        var toolRegistry = new ToolRegistry();
+        toolRegistry.Register(new FakeNetclawTool("inspect_context", "ok"));
+
+        var spawner = new SubAgentSpawner(
+            new SingleClientProvider(new NoOpChatClient()),
+            toolRegistry,
+            new ToolAccessPolicy(
+                new ToolConfig(),
+                new EffectivePolicyDefaults(
+                    DeploymentPosture.Personal,
+                    TrustAudience.Personal,
+                    ShellExecutionMode.HostAllowed,
+                    UsedStrictFallback: false),
+                new ShellCommandPolicy()),
+            approvalService: null,
+            new StaticSystemPromptProvider("You are a summarizer."),
+            NullLogger<SubAgentSpawner>.Instance);
+
+        var notifications = new List<SubAgentNotificationInfo>();
+        var childProbe = CreateTestProbe("subagent-tool-metadata-child");
+        var context = new ToolExecutionContext("console/subagent-parent", "/tmp/netclaw/sessions/parent")
+        {
+            Audience = TrustAudience.Personal,
+            OnSubAgentActivity = notifications.Add
+        };
+        context.SpawnChildActor = (_, _, _) => Task.FromResult<object>(childProbe.Ref);
+
+        var profile = new SubAgentProfile
+        {
+            Name = "summarizer",
+            Description = "Summarize content",
+            SystemPrompt = "You are a summarizer.",
+            ToolNames = ["not_registered"],
+            Visibility = SubAgentVisibility.UserFacing
+        };
+
+        var spawnTask = spawner.SpawnAsync(
+            profile,
+            "Summarize the repo.",
+            runtimeContext: null,
+            context,
+            TestContext.Current.CancellationToken);
+
+        await childProbe.ExpectMsgAsync<RunSubAgent>(cancellationToken: TestContext.Current.CancellationToken);
+        childProbe.Reply(new SubAgentResult
+        {
+            Success = true,
+            Output = "ok",
+            AgentName = new AgentName(profile.Name)
+        });
+
+        var result = await spawnTask;
+
+        Assert.True(result.Success);
+        var started = Assert.Single(notifications, n => n.IsStarted);
+        Assert.Equal(1, started.ToolCount);
+    }
+
     private sealed class NoOpChatClient : IChatClient
     {
         public Task<ChatResponse> GetResponseAsync(

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -191,6 +191,28 @@ public class ShellToolTests
     }
 
     [Fact]
+    public async Task Cwd_creates_missing_session_directory_when_used_as_default()
+    {
+        var sessionDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        try
+        {
+            var context = new ToolExecutionContext("session-1", sessionDir) { Audience = TrustAudience.Personal };
+            var args = ToolInput.Create("Command", OperatingSystem.IsWindows() ? "cd" : "pwd");
+
+            var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+            Assert.True(Directory.Exists(sessionDir));
+            Assert.Contains("Exit code: 0", result);
+            var resolved = sessionDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            Assert.Contains(resolved, result, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(sessionDir)) Directory.Delete(sessionDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Cwd_explicit_arg_overrides_project_and_session_directories()
     {
         var explicitDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));

--- a/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
@@ -108,7 +108,7 @@ internal sealed class TurnStateTracker
             return new ToolBudgetStatus.Exhausted(
                 $"You have reached the tool iteration limit for this turn. "
                 + "Do NOT request any more tools. "
-                + "Summarize the work you completed and answer the user's question "
+                + "Summarize the work you completed and produce your final response "
                 + "based on the information you have gathered so far. "
                 + "If you could not complete the task, explain what you found and what remains.");
         }
@@ -122,7 +122,7 @@ internal sealed class TurnStateTracker
                 remaining,
                 $"You have used {ToolIterationCount} of {maxToolIterationsPerTurn} tool iterations for this turn. "
                 + $"You have approximately {remaining} iterations remaining. "
-                + "Start wrapping up your tool usage and prepare to answer the user's question.");
+                + "Start wrapping up your tool usage and prepare to produce your final response.");
         }
 
         return ToolBudgetStatus.Ok.Instance;
@@ -149,7 +149,7 @@ internal sealed class TurnStateTracker
                 $"You have called the tool '{fingerprint.ToolName}' with the same arguments {count} times this turn. "
                 + "This strongly indicates you are repeating work you already completed. "
                 + "Review your prior tool results — the information you need is already in the conversation. "
-                + "If the task is complete, produce your final response to the user.");
+                + "If the task is complete, produce your final response.");
         }
 
         return null;
@@ -194,7 +194,7 @@ internal sealed class TurnStateTracker
         return new EmptyResponseAction.Retry(hasThinking
             ? ThinkingOnlyNudge
             : "You received tool results but did not respond. "
-              + "Continue working or answer the user's question.");
+              + "Continue working or produce your final response.");
     }
 }
 

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -30,6 +30,20 @@ internal sealed record LlmResponseReceived : INoSerializationVerificationNeeded
     /// Stale responses from cancelled calls are ignored.
     /// </summary>
     public long CallId { get; init; }
+
+    public int StreamUpdateCount { get; init; }
+
+    public int EmptyStreamUpdateCount { get; init; }
+
+    public int StreamTextDeltaCount { get; init; }
+
+    public int StreamTextChars { get; init; }
+
+    public int StreamThinkingDeltaCount { get; init; }
+
+    public int StreamThinkingChars { get; init; }
+
+    public int StreamToolCallDeltaCount { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2101,6 +2101,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
+        if (HasInterruptedToolBatchAfterRecovery())
+        {
+            var abandoned = BuildInterruptedToolBatchAfterRecoveryEvent();
+            Persist(abandoned, evt =>
+            {
+                ApplyToolBatchAbandoned(evt);
+                ContinueIncomingUserMessage(cmd);
+            });
+            return;
+        }
+
         ContinueIncomingUserMessage(cmd);
     }
 
@@ -2362,7 +2373,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // do not replay the approved side effect after restart. Close the
             // orphaned tool_use blocks so the next user turn has valid history.
             if (_currentPhase == SessionPhase.Ready)
-                AbandonResolvedToolBatchAfterRecovery();
+            {
+                if (!AbandonResolvedToolBatchAfterRecovery())
+                    AbandonInterruptedToolBatchAfterRecovery();
+            }
         });
 
         Command<LeaveSession>(cmd =>
@@ -3935,9 +3949,29 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         return true;
     }
 
+    private bool AbandonInterruptedToolBatchAfterRecovery()
+    {
+        if (!HasInterruptedToolBatchAfterRecovery())
+            return false;
+
+        _log.Info("Abandoning recovered interrupted tool batch with no recoverable approval state");
+        Persist(BuildInterruptedToolBatchAfterRecoveryEvent(), ApplyToolBatchAbandoned);
+
+        return true;
+    }
+
+    private bool HasInterruptedToolBatchAfterRecovery()
+        => _pendingToolInteractions.Count == 0
+        && _resolvedToolApprovals.Count == 0
+        && ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, null) is not null;
+
     private ToolBatchAbandoned BuildResolvedToolBatchInterruptedByRestartEvent()
         => BuildToolBatchAbandonedEvent(
             "Tool call was not completed — the session restarted after approval before the action completed.");
+
+    private ToolBatchAbandoned BuildInterruptedToolBatchAfterRecoveryEvent()
+        => BuildToolBatchAbandonedEvent(
+            "Tool call was not completed — the session restarted before the action completed.");
 
     private ApprovalRedrivePlan BuildApprovalRedrivePlan(SerializableChatMessage assistantMessage)
     {

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -64,7 +64,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
     {
         EnsureAuthorityContext();
 
-        var parentCallId = CreateParentCallId(callId);
+        var parentCallId = CreateParentCallId();
         var waitTask = _channel.WaitForApprovalAsync(parentCallId, Timeout.InfiniteTimeSpan, ct);
 
         // Emit verbatim from the gate's computed options so persistent-grant
@@ -108,7 +108,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
         };
     }
 
-    private ToolCallId CreateParentCallId(ToolCallId childCallId)
+    private ToolCallId CreateParentCallId()
     {
         // This bridge is created by the session actor but used by thread-pool
         // tool tasks. Multiple child tool calls can request approval at once,
@@ -117,8 +117,9 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
 
         // Child call ids are only unique inside the sub-agent's tool loop. The
         // parent approval channel is session-wide, so include the spawning tool
-        // call scope plus a per-bridge sequence before the child-local id.
-        return new ToolCallId($"{_approvalScopeId}/subagent-approval/{requestId}/{childCallId.Value}");
+        // call scope plus a per-bridge sequence. Keep this short: approval
+        // button payloads are capped by the most restrictive channel adapter.
+        return new ToolCallId($"{_approvalScopeId}/subagent-approval/{requestId}");
     }
 
     private void EnsureAuthorityContext()

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -54,7 +54,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private readonly IToolApprovalService? _approvalService;
     private readonly int _maxToolIterations;
     private readonly ToolRegistry _toolRegistry;
-    private readonly IReadOnlyList<AITool> _aiTools;
+    private IReadOnlyList<AITool> _aiTools = [];
     private readonly ILoggingAdapter _log;
     private readonly MemoryPolicyEvaluator _policyEvaluator = new();
     private readonly TurnStateTracker _turnState = new();
@@ -117,10 +117,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _toolRegistry = new ToolRegistry();
         foreach (var tool in definition.Tools)
         {
+            if (!SubAgentToolPolicy.IsAllowedForSubAgent(tool.Name))
+                continue;
+
             _toolRegistry.Register(tool);
         }
-
-        _aiTools = _toolRegistry.GetAllTools();
 
         Become(Idle);
     }
@@ -207,6 +208,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _toolExecutionContext.ChannelType = msg.ChannelType;
             _toolExecutionContext.ProjectDirectory = msg.ParentProjectDirectory;
             _toolExecutionContext.SupportsInteractiveApproval = _approvalBridge is not null;
+            _aiTools = ResolveExposedAiTools();
             _executionCts = new CancellationTokenSource();
             _externalCts = new CancellationTokenSource();
             var self = Self; // Capture before callback — Self requires active actor context
@@ -534,6 +536,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             options?.Tools?.Count > 0,
             forceNoTools);
         _ = InvokeLlmAsync(client, messages, options, sessionId, self, callId, _executionCts?.Token ?? CancellationToken.None);
+    }
+
+    private IReadOnlyList<AITool> ResolveExposedAiTools()
+    {
+        var tools = _toolRegistry.GetAllRegistrations().Select(r => r.Tool);
+        return _toolAccessPolicy
+            .FilterDiscoverableTools(tools, _toolExecutionContext)
+            .Select(tool => tool.ToAITool())
+            .ToList();
     }
 
     private bool _completed;

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -5,12 +5,14 @@
 // -----------------------------------------------------------------------
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Channels;
 using Akka.Actor;
 using Akka.Event;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Sessions.Handlers;
 using Netclaw.Actors.Tools;
 using Netclaw.Actors.Memory;
 using Netclaw.Configuration;
@@ -31,23 +33,34 @@ namespace Netclaw.Actors.SubAgents;
 /// </summary>
 public sealed class SubAgentActor : ReceiveActor, IWithTimers
 {
-    private const int MaxToolIterations = 10;
+    internal const int DefaultMaxToolIterations = 30;
     private const string EmptyResponseMarker = "(no response)";
     private const string TimeoutTimerKey = "subagent-timeout";
+    private const string HeadlessExecutionContract = """
+        [Subagent Execution Contract]
+        You are a headless, non-interactive worker running on behalf of a parent Netclaw session.
+        Do not ask the user clarifying questions, request conversational input, or wait for a reply.
+        Do the best work you can with the task, context, and tools available.
+        If the task is ambiguous, make reasonable assumptions and state them in your final output.
+        If you are blocked, return a final result that explains what you found, what remains, and what decision the parent session needs.
+        Parent-mediated tool approval may occur only for concrete tool calls; it is a security gate, not a dialogue channel.
+        Always end by emitting a final output for the parent session.
+        """;
     private static readonly TimeSpan StreamPingInterval = TimeSpan.FromSeconds(2);
 
     private readonly SubAgentDefinition _definition;
     private readonly IChatClient _chatClient;
     private readonly ToolAccessPolicy _toolAccessPolicy;
     private readonly IToolApprovalService? _approvalService;
+    private readonly int _maxToolIterations;
     private readonly ToolRegistry _toolRegistry;
     private readonly IReadOnlyList<AITool> _aiTools;
     private readonly ILoggingAdapter _log;
     private readonly MemoryPolicyEvaluator _policyEvaluator = new();
+    private readonly TurnStateTracker _turnState = new();
 
     // Conversation state (not persisted — ephemeral)
     private readonly List<AiChatMessage> _history = [];
-    private int _toolIterationCount;
     private long _llmCallId;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
@@ -79,8 +92,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         SubAgentDefinition definition,
         IChatClient chatClient,
         ToolAccessPolicy? toolAccessPolicy = null,
-        IToolApprovalService? approvalService = null)
+        IToolApprovalService? approvalService = null,
+        int maxToolIterations = DefaultMaxToolIterations)
     {
+        if (maxToolIterations <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxToolIterations), maxToolIterations,
+                "Sub-agent tool iteration budget must be greater than zero.");
+
         _definition = definition;
         _chatClient = chatClient;
         _toolAccessPolicy = toolAccessPolicy ?? new ToolAccessPolicy(
@@ -92,6 +110,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 UsedStrictFallback: false),
             new ShellCommandPolicy());
         _approvalService = approvalService;
+        _maxToolIterations = maxToolIterations;
         _log = Context.GetLogger();
 
         // Build a private ToolRegistry for this subagent's tool subset
@@ -110,9 +129,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         SubAgentDefinition definition,
         IChatClient chatClient,
         ToolAccessPolicy? toolAccessPolicy = null,
-        IToolApprovalService? approvalService = null)
+        IToolApprovalService? approvalService = null,
+        int maxToolIterations = DefaultMaxToolIterations)
     {
-        return Props.Create(() => new SubAgentActor(definition, chatClient, toolAccessPolicy, approvalService));
+        return Props.Create(() => new SubAgentActor(
+            definition,
+            chatClient,
+            toolAccessPolicy,
+            approvalService,
+            maxToolIterations));
     }
 
     /// <summary>
@@ -217,6 +242,18 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             var lastMessage = response.Messages[^1];
             var analysis = LlmResponseClassifier.Analyze(lastMessage);
 
+            if (analysis.Kind == LlmResponseKind.ToolCalls && _turnState.ForceNoToolsActive)
+            {
+                _log.Warning(
+                    "SubAgent [{AgentName}] requested {ToolCallCount} tool(s) after tool execution was disabled (budgetUsed={BudgetUsed}, max={Max})",
+                    _definition.Name,
+                    analysis.ToolCalls.Count,
+                    _turnState.ToolCallCount,
+                    _maxToolIterations);
+                Complete(false, "Subagent exceeded its tool iteration budget and continued requesting tools after tools were disabled.");
+                return;
+            }
+
             _log.Info(
                 $"SubAgent [{_definition.Name}] LLM response callId={msg.CallId} kind={analysis.Kind} "
                 + $"text={analysis.TextChars}ch thinking={analysis.ThinkingChars}ch "
@@ -235,7 +272,30 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 return;
             }
 
-            // Final text response — we're done
+            if (analysis.Kind is LlmResponseKind.ThinkingOnly or LlmResponseKind.Empty)
+            {
+                switch (_turnState.EvaluateEmptyResponse(analysis.Kind))
+                {
+                    case EmptyResponseAction.Retry retry:
+                        _log.Warning(
+                            "SubAgent [{AgentName}] produced {Kind} response ({ThinkingChars} reasoning chars) — retrying with nudge",
+                            _definition.Name,
+                            analysis.Kind,
+                            analysis.ThinkingChars);
+                        AddSystemNudge(retry.NudgeText);
+                        FireLlmCall();
+                        return;
+                    case EmptyResponseAction.Fail fail:
+                        _log.Warning(
+                            "SubAgent [{AgentName}] produced repeated {Kind} responses — reporting failure",
+                            _definition.Name,
+                            analysis.Kind);
+                        Complete(false, fail.ErrorMessage);
+                        return;
+                }
+            }
+
+            // Final text response — we're done.
             var text = ExtractText(lastMessage);
             if (string.IsNullOrWhiteSpace(text) || text == EmptyResponseMarker)
             {
@@ -243,10 +303,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 // so the parent session sees a real error instead of fabricating
                 // "subagent still working" from an empty tool result.
                 _log.Warning(
-                    "SubAgent [{AgentName}] LLM returned empty response (no text content, no tool calls) — reporting as failure",
+                    "SubAgent [{AgentName}] LLM returned empty text after non-empty analysis — reporting as failure",
                     _definition.Name);
-                Complete(false, "Subagent returned an empty response (no text content and no tool calls). "
-                    + "The provider may have dropped reasoning content or the model produced no output.");
+                Complete(false, "Subagent returned an empty final response.");
                 return;
             }
             Complete(true, text);
@@ -268,18 +327,40 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     _definition.Name, result.Name ?? "unknown", preview);
             }
 
-            _toolIterationCount++;
-
-            if (_toolIterationCount >= MaxToolIterations)
+            var budgetStatus = _turnState.RecordToolCompletion(msg.ToolResults.Count, _maxToolIterations);
+            var dupNudge = _turnState.CheckForDuplicates();
+            if (dupNudge is not null)
             {
-                _log.Warning("SubAgent [{AgentName}] hit tool iteration limit ({Count}), forcing text response",
-                    _definition.Name, _toolIterationCount);
-                FireLlmCall(forceNoTools: true);
-                return;
+                _log.Warning(
+                    "SubAgent [{AgentName}] duplicate tool detected tool={ToolName} count={Count} iteration={Iteration}",
+                    _definition.Name,
+                    dupNudge.ToolName,
+                    dupNudge.Count,
+                    _turnState.ToolIterationCount);
+                AddSystemNudge(dupNudge.NudgeText);
+            }
+
+            switch (budgetStatus)
+            {
+                case ToolBudgetStatus.Exhausted exhausted:
+                    _log.Warning("SubAgent [{AgentName}] hit tool iteration limit ({Count}), forcing text response",
+                        _definition.Name, _turnState.ToolIterationCount);
+                    AddSystemNudge(exhausted.NudgeText);
+                    FireLlmCall(forceNoTools: true);
+                    return;
+                case ToolBudgetStatus.NudgeNeeded nudge:
+                    _log.Info(
+                        "SubAgent [{AgentName}] nearing tool iteration limit ({Used}/{Max}, remaining={Remaining})",
+                        _definition.Name,
+                        _turnState.ToolIterationCount,
+                        _maxToolIterations,
+                        nudge.Remaining);
+                    AddSystemNudge(nudge.NudgeText);
+                    break;
             }
 
             _log.Debug("SubAgent [{AgentName}] tool iteration {Count}, continuing",
-                _definition.Name, _toolIterationCount);
+                _definition.Name, _turnState.ToolIterationCount);
             FireLlmCall();
         });
 
@@ -328,7 +409,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _executionCts?.Cancel();
             _log.Warning(
                 "SubAgent [{AgentName}] timed out: no activity for {Budget}s after {Iterations} tool iterations",
-                _definition.Name, _inactivityBudget.TotalSeconds, _toolIterationCount);
+                _definition.Name, _inactivityBudget.TotalSeconds, _turnState.ToolIterationCount);
             Complete(false, $"Subagent timed out: no activity for {_inactivityBudget.TotalSeconds:F0}s.");
         });
 
@@ -391,8 +472,18 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     private void HandleToolCalls(AiChatMessage assistantMessage, List<FunctionCallContent> toolCalls)
     {
+        _turnState.ResetEmptyResponseGuards();
+
         // Add assistant message (with tool calls) to history
         _history.Add(assistantMessage);
+
+        foreach (var toolCall in toolCalls)
+        {
+            var argsJson = toolCall.Arguments is not null
+                ? JsonSerializer.Serialize(toolCall.Arguments)
+                : null;
+            _turnState.TrackToolCall(toolCall.Name, argsJson);
+        }
 
         var toolNames = string.Join(", ", toolCalls.Select(tc => tc.Name));
         RecordProgress($"running tools: {toolNames}");
@@ -417,6 +508,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     private void FireLlmCall(bool forceNoTools = false)
     {
+        _turnState.ForceNoToolsActive = forceNoTools;
         RecordProgress("calling the model");
         var self = Self;
         var client = _chatClient;
@@ -437,7 +529,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             "SubAgent [{AgentName}] LLM call start callId={CallId} iteration={Iteration} messages={MessageCount} toolsEnabled={ToolsEnabled} forceNoTools={ForceNoTools}",
             _definition.Name,
             callId,
-            _toolIterationCount,
+            _turnState.ToolIterationCount,
             messages.Count,
             options?.Tools?.Count > 0,
             forceNoTools);
@@ -469,7 +561,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _pendingApprovalWaits = 0;
 
         _log.Info("SubAgent [{AgentName}] completed (success={Success}, output={OutputLength} chars, iterations={Iterations})",
-            _definition.Name, success, output.Length, _toolIterationCount);
+            _definition.Name, success, output.Length, _turnState.ToolIterationCount);
 
         var findings = success && _definition.EmitStructuredFindings
             ? BuildFindings(output, _toolExecutionContext.SessionId)
@@ -545,6 +637,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 Evidence = []
             }
         ];
+    }
+
+    private void AddSystemNudge(string nudge)
+    {
+        _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, $"[system: {nudge}]"));
     }
 
     /// <summary>
@@ -875,10 +972,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     private static string BuildSystemPrompt(SubAgentDefinition definition)
     {
-        if (string.IsNullOrWhiteSpace(definition.ProjectInstructions))
-            return definition.SystemPrompt;
+        var basePrompt = string.IsNullOrWhiteSpace(definition.ProjectInstructions)
+            ? definition.SystemPrompt
+            : SystemPromptAssembler.Assemble(agents: definition.SystemPrompt, projectInstructions: definition.ProjectInstructions);
 
-        return SystemPromptAssembler.Assemble(agents: definition.SystemPrompt, projectInstructions: definition.ProjectInstructions);
+        return string.Concat(basePrompt.TrimEnd(), "\n\n", HeadlessExecutionContract);
     }
 
     /// <summary>Singleton inactivity-watchdog marker message.</summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -272,7 +272,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 + $"streamText={msg.StreamTextDeltaCount}/{msg.StreamTextChars}ch "
                 + $"streamThinking={msg.StreamThinkingDeltaCount}/{msg.StreamThinkingChars}ch "
                 + $"streamToolCalls={msg.StreamToolCallDeltaCount} "
-                + $"textPreview={PreviewText(ExtractText(lastMessage), 300)} "
+                + $"textPreview={PreviewForLog(ExtractText(lastMessage), 300)} "
                 + $"toolCallPreview={FormatToolCallPreview(analysis.ToolCalls)}");
 
             var toolCalls = analysis.ToolCalls;
@@ -355,7 +355,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     ? result.Content[..200] + "..."
                     : result.Content ?? "(null)";
                 _log.Info("SubAgent [{AgentName}] tool [{ToolName}] result: {Result}",
-                    _definition.Name, result.Name ?? "unknown", preview);
+                    _definition.Name, result.Name ?? "unknown", SecretOutputRedactor.Redact(preview));
             }
 
             var budgetStatus = _turnState.RecordToolCompletion(msg.ToolResults.Count, _maxToolIterations);
@@ -841,9 +841,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             return "no-args";
 
         var rendered = string.Join(", ", arguments.Select(kvp =>
-            $"{kvp.Key}={PreviewText(kvp.Value?.ToString() ?? "null", 160)}"));
-        return PreviewText(rendered, 500);
+            $"{kvp.Key}={PreviewForLog(kvp.Value?.ToString() ?? "null", 160)}"));
+        return PreviewForLog(rendered, 500);
     }
+
+    private static string PreviewForLog(string? text, int maxChars)
+        => SecretOutputRedactor.Redact(PreviewText(text, maxChars));
 
     private static string PreviewText(string? text, int maxChars)
     {
@@ -882,15 +885,52 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         if (string.IsNullOrWhiteSpace(text))
             return false;
 
-        if (text.Contains("</tool_call>", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("<tool_call", StringComparison.OrdinalIgnoreCase))
+        var outsideQuotedExamples = StripFencedAndQuotedBlocks(text);
+        var lines = outsideQuotedExamples
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var line in lines)
         {
-            return true;
+            if (line.StartsWith("<tool_call", StringComparison.OrdinalIgnoreCase)
+                || line.StartsWith("</tool_call>", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (line.StartsWith("<function=", StringComparison.OrdinalIgnoreCase)
+                || line.StartsWith("<parameter=", StringComparison.OrdinalIgnoreCase)
+                || line.StartsWith("</function>", StringComparison.OrdinalIgnoreCase)
+                || line.StartsWith("</parameter>", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
         }
 
-        return text.Contains("<function=", StringComparison.OrdinalIgnoreCase)
-            && (text.Contains("<parameter=", StringComparison.OrdinalIgnoreCase)
-                || text.Contains("</function>", StringComparison.OrdinalIgnoreCase));
+        return false;
+    }
+
+    private static string StripFencedAndQuotedBlocks(string text)
+    {
+        var builder = new StringBuilder(text.Length);
+        var inFence = false;
+
+        foreach (var rawLine in text.ReplaceLineEndings("\n").Split('\n'))
+        {
+            var trimmed = rawLine.TrimStart();
+            if (trimmed.StartsWith("```", StringComparison.Ordinal)
+                || trimmed.StartsWith("~~~", StringComparison.Ordinal))
+            {
+                inFence = !inFence;
+                continue;
+            }
+
+            if (inFence || trimmed.StartsWith('>'))
+                continue;
+
+            builder.AppendLine(rawLine);
+        }
+
+        return builder.ToString();
     }
 
     private static async Task ExecuteToolsAsync(

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -36,6 +36,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     internal const int DefaultMaxToolIterations = 30;
     private const string EmptyResponseMarker = "(no response)";
     private const string TimeoutTimerKey = "subagent-timeout";
+    private const string MalformedFinalOutputMessage = "Subagent produced malformed final output: it emitted unexecuted tool calls as text. This was not a timeout.";
+    private const string MalformedFinalOutputNudge =
+        "The previous response emitted unexecuted tool-call markup as plain text. "
+        + "That text was not executed and cannot be returned as a successful final output. "
+        + "If tools are available and you still need those operations, call the tools using structured tool calls now. "
+        + "Otherwise provide a final answer based only on executed tool results. "
+        + "Do not include <function=...>, <parameter=...>, or </tool_call> markup in final text.";
     private const string HeadlessExecutionContract = """
         [Subagent Execution Contract]
         You are a headless, non-interactive worker running on behalf of a parent Netclaw session.
@@ -87,6 +94,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     public ITimerScheduler Timers { get; set; } = null!;
     private CancellationTokenRegistration _externalCancellationRegistration;
     private ToolExecutionContext _toolExecutionContext = ToolExecutionContext.Empty;
+    private bool _malformedFinalOutputRepairAttempted;
 
     public SubAgentActor(
         SubAgentDefinition definition,
@@ -310,6 +318,27 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 Complete(false, "Subagent returned an empty final response.");
                 return;
             }
+
+            if (ContainsUnexecutedToolCallMarkup(text))
+            {
+                if (!_malformedFinalOutputRepairAttempted)
+                {
+                    _malformedFinalOutputRepairAttempted = true;
+                    _log.Warning(
+                        "SubAgent [{AgentName}] emitted unexecuted tool-call markup as final text; retrying with repair nudge",
+                        _definition.Name);
+                    AddSystemNudge(MalformedFinalOutputNudge);
+                    FireLlmCall(forceNoTools: _turnState.ForceNoToolsActive);
+                    return;
+                }
+
+                _log.Warning(
+                    "SubAgent [{AgentName}] repeatedly emitted unexecuted tool-call markup as final text; reporting failure",
+                    _definition.Name);
+                Complete(false, MalformedFinalOutputMessage);
+                return;
+            }
+
             Complete(true, text);
         });
 
@@ -754,9 +783,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     }
                 }
 
-                // Throttled liveness ping so the actor re-arms its inactivity
-                // watchdog and surfaces activity during a long streaming call.
-                if (pingThrottle.Elapsed >= StreamPingInterval)
+                // Content-free keepalives only prove the socket is alive; they
+                // do not prove the model is making progress. Re-arm the
+                // watchdog only for substantive deltas so provider heartbeat
+                // loops cannot keep a sub-agent alive forever.
+                if (IsSubstantiveStreamingUpdate(update) && pingThrottle.Elapsed >= StreamPingInterval)
                 {
                     pingThrottle.Restart();
                     self.Tell(new SubAgentStreamPing(
@@ -821,6 +852,45 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         var normalized = text.ReplaceLineEndings("\\n");
         return normalized.Length <= maxChars ? normalized : normalized[..maxChars] + "...";
+    }
+
+    internal static bool IsSubstantiveStreamingUpdate(ChatResponseUpdate update)
+    {
+        if (update.FinishReason is not null)
+            return true;
+
+        foreach (var content in update.Contents)
+        {
+            switch (content)
+            {
+                case TextContent text when !string.IsNullOrEmpty(text.Text):
+                case TextReasoningContent reasoning when !string.IsNullOrEmpty(reasoning.Text):
+                case FunctionCallContent:
+                    return true;
+                case UsageContent:
+                    break;
+                default:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool ContainsUnexecutedToolCallMarkup(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        if (text.Contains("</tool_call>", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("<tool_call", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return text.Contains("<function=", StringComparison.OrdinalIgnoreCase)
+            && (text.Contains("<parameter=", StringComparison.OrdinalIgnoreCase)
+                || text.Contains("</function>", StringComparison.OrdinalIgnoreCase));
     }
 
     private static async Task ExecuteToolsAsync(

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -48,6 +48,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     // Conversation state (not persisted — ephemeral)
     private readonly List<AiChatMessage> _history = [];
     private int _toolIterationCount;
+    private long _llmCallId;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
 
@@ -214,8 +215,20 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             ArmInactivityTimer();
             var response = msg.Response;
             var lastMessage = response.Messages[^1];
+            var analysis = LlmResponseClassifier.Analyze(lastMessage);
 
-            var toolCalls = lastMessage.Contents.OfType<FunctionCallContent>().ToList();
+            _log.Info(
+                $"SubAgent [{_definition.Name}] LLM response callId={msg.CallId} kind={analysis.Kind} "
+                + $"text={analysis.TextChars}ch thinking={analysis.ThinkingChars}ch "
+                + $"toolCalls={analysis.ToolCalls.Count} finishReason={response.FinishReason?.ToString() ?? "null"} "
+                + $"streamUpdates={msg.StreamUpdateCount} emptyUpdates={msg.EmptyStreamUpdateCount} "
+                + $"streamText={msg.StreamTextDeltaCount}/{msg.StreamTextChars}ch "
+                + $"streamThinking={msg.StreamThinkingDeltaCount}/{msg.StreamThinkingChars}ch "
+                + $"streamToolCalls={msg.StreamToolCallDeltaCount} "
+                + $"textPreview={PreviewText(ExtractText(lastMessage), 300)} "
+                + $"toolCallPreview={FormatToolCallPreview(analysis.ToolCalls)}");
+
+            var toolCalls = analysis.ToolCalls;
             if (toolCalls.Count > 0)
             {
                 HandleToolCalls(lastMessage, toolCalls);
@@ -279,7 +292,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<LlmCallFailed>(msg =>
         {
-            _log.Error(msg.Cause, "SubAgent [{AgentName}] LLM call failed", _definition.Name);
+            _log.Error(msg.Cause, "SubAgent [{AgentName}] LLM call failed callId={CallId}", _definition.Name, msg.CallId);
             Complete(false, $"LLM call failed: {msg.Cause.Message}");
         });
 
@@ -364,7 +377,16 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         // Throttled liveness ping from a streaming LLM call — progress, even
         // before the full response message arrives.
-        Receive<SubAgentStreamPing>(_ => RecordProgress("the model is responding"));
+        Receive<SubAgentStreamPing>(msg =>
+        {
+            _log.Debug(
+                $"SubAgent [{_definition.Name}] LLM stream progress callId={msg.CallId} "
+                + $"updates={msg.UpdateCount} emptyUpdates={msg.EmptyUpdateCount} "
+                + $"text={msg.TextDeltaCount}/{msg.TextChars}ch "
+                + $"thinking={msg.ThinkingDeltaCount}/{msg.ThinkingChars}ch "
+                + $"toolCalls={msg.ToolCallDeltaCount} finishReason={msg.FinishReason ?? "null"}");
+            RecordProgress("the model is responding");
+        });
     }
 
     private void HandleToolCalls(AiChatMessage assistantMessage, List<FunctionCallContent> toolCalls)
@@ -399,6 +421,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         var self = Self;
         var client = _chatClient;
         var messages = new List<AiChatMessage>(_history);
+        var callId = ++_llmCallId;
 
         ChatOptions? options = null;
         if (!forceNoTools && _aiTools.Count > 0)
@@ -410,7 +433,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         }
 
         var sessionId = _toolExecutionContext.SessionId is null ? (SessionId?)null : new SessionId(_toolExecutionContext.SessionId);
-        _ = InvokeLlmAsync(client, messages, options, sessionId, self, _executionCts?.Token ?? CancellationToken.None);
+        _log.Info(
+            "SubAgent [{AgentName}] LLM call start callId={CallId} iteration={Iteration} messages={MessageCount} toolsEnabled={ToolsEnabled} forceNoTools={ForceNoTools}",
+            _definition.Name,
+            callId,
+            _toolIterationCount,
+            messages.Count,
+            options?.Tools?.Count > 0,
+            forceNoTools);
+        _ = InvokeLlmAsync(client, messages, options, sessionId, self, callId, _executionCts?.Token ?? CancellationToken.None);
     }
 
     private bool _completed;
@@ -548,8 +579,23 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     // ── Static async helpers (same pattern as LlmSessionActor) ──
 
+    internal static Task InvokeLlmAsync(
+        IChatClient client,
+        List<AiChatMessage> messages,
+        ChatOptions? options,
+        SessionId? sessionId,
+        IActorRef self,
+        CancellationToken ct)
+        => InvokeLlmAsync(client, messages, options, sessionId, self, callId: 0, ct);
+
     internal static async Task InvokeLlmAsync(
-        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, SessionId? sessionId, IActorRef self, CancellationToken ct)
+        IChatClient client,
+        List<AiChatMessage> messages,
+        ChatOptions? options,
+        SessionId? sessionId,
+        IActorRef self,
+        long callId,
+        CancellationToken ct)
     {
         try
         {
@@ -565,16 +611,56 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             // TextContent and causing the subagent to report empty "(no response)".
             var updates = new List<ChatResponseUpdate>();
             var pingThrottle = Stopwatch.StartNew();
+            int updateCount = 0;
+            int emptyUpdateCount = 0;
+            int textDeltaCount = 0;
+            int textChars = 0;
+            int thinkingDeltaCount = 0;
+            int thinkingChars = 0;
+            int toolCallDeltaCount = 0;
+            string? finishReason = null;
             await foreach (var update in client.GetStreamingResponseAsync(messages, options, ct))
             {
                 updates.Add(update);
+                updateCount++;
+                if (update.Contents.Count == 0 && update.FinishReason is null)
+                    emptyUpdateCount++;
+                if (update.FinishReason is not null)
+                    finishReason = update.FinishReason.ToString();
+
+                foreach (var content in update.Contents)
+                {
+                    switch (content)
+                    {
+                        case TextContent text:
+                            textDeltaCount++;
+                            textChars += text.Text?.Length ?? 0;
+                            break;
+                        case TextReasoningContent reasoning:
+                            thinkingDeltaCount++;
+                            thinkingChars += reasoning.Text?.Length ?? 0;
+                            break;
+                        case FunctionCallContent:
+                            toolCallDeltaCount++;
+                            break;
+                    }
+                }
 
                 // Throttled liveness ping so the actor re-arms its inactivity
                 // watchdog and surfaces activity during a long streaming call.
                 if (pingThrottle.Elapsed >= StreamPingInterval)
                 {
                     pingThrottle.Restart();
-                    self.Tell(SubAgentStreamPing.Instance);
+                    self.Tell(new SubAgentStreamPing(
+                        callId,
+                        updateCount,
+                        emptyUpdateCount,
+                        textDeltaCount,
+                        textChars,
+                        thinkingDeltaCount,
+                        thinkingChars,
+                        toolCallDeltaCount,
+                        finishReason));
                 }
             }
 
@@ -584,12 +670,49 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 response = new ChatResponse(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.Assistant, []));
             }
 
-            self.Tell(new LlmResponseReceived { Response = response });
+            self.Tell(new LlmResponseReceived
+            {
+                Response = response,
+                CallId = callId,
+                StreamUpdateCount = updateCount,
+                EmptyStreamUpdateCount = emptyUpdateCount,
+                StreamTextDeltaCount = textDeltaCount,
+                StreamTextChars = textChars,
+                StreamThinkingDeltaCount = thinkingDeltaCount,
+                StreamThinkingChars = thinkingChars,
+                StreamToolCallDeltaCount = toolCallDeltaCount
+            });
         }
         catch (Exception ex)
         {
-            self.Tell(new LlmCallFailed(ex));
+            self.Tell(new LlmCallFailed(ex) { CallId = callId });
         }
+    }
+
+    private static string FormatToolCallPreview(IEnumerable<FunctionCallContent> toolCalls)
+    {
+        var summaries = toolCalls.Select(tc =>
+            $"{tc.Name}#{tc.CallId}({PreviewArguments(tc.Arguments)})");
+        return string.Join("; ", summaries);
+    }
+
+    private static string PreviewArguments(IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+            return "no-args";
+
+        var rendered = string.Join(", ", arguments.Select(kvp =>
+            $"{kvp.Key}={PreviewText(kvp.Value?.ToString() ?? "null", 160)}"));
+        return PreviewText(rendered, 500);
+    }
+
+    private static string PreviewText(string? text, int maxChars)
+    {
+        if (string.IsNullOrEmpty(text))
+            return "";
+
+        var normalized = text.ReplaceLineEndings("\\n");
+        return normalized.Length <= maxChars ? normalized : normalized[..maxChars] + "...";
     }
 
     private static async Task ExecuteToolsAsync(
@@ -803,11 +926,16 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     }
 
     /// <summary>Throttled self-message: the streaming LLM call is still producing output.</summary>
-    private sealed class SubAgentStreamPing
-    {
-        public static readonly SubAgentStreamPing Instance = new();
-        private SubAgentStreamPing() { }
-    }
+    private sealed record SubAgentStreamPing(
+        long CallId,
+        int UpdateCount,
+        int EmptyUpdateCount,
+        int TextDeltaCount,
+        int TextChars,
+        int ThinkingDeltaCount,
+        int ThinkingChars,
+        int ToolCallDeltaCount,
+        string? FinishReason);
 
     // ── Reuse LlmSessionActor's internal message types ──
     // These are internal to Netclaw.Actors so accessible here.

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -12,7 +12,7 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.SubAgents;
 
 /// <summary>
-/// Defines a subagent's identity: system prompt, tools, and model.
+/// Defines a subagent's identity: system prompt, resolved runtime tools, and model.
 /// Can be constructed from built-in definitions or authored dynamically.
 /// </summary>
 public sealed record SubAgentDefinition
@@ -23,7 +23,7 @@ public sealed record SubAgentDefinition
     /// <summary>System prompt for the subagent's LLM context.</summary>
     public required string SystemPrompt { get; init; }
 
-    /// <summary>Tools available to the subagent during execution.</summary>
+    /// <summary>Runtime tools available to the subagent after audience-policy filtering.</summary>
     public required IReadOnlyList<INetclawTool> Tools { get; init; }
 
     /// <summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -22,6 +22,8 @@ namespace Netclaw.Actors.SubAgents;
 /// </summary>
 public sealed class SubAgentSpawner
 {
+    private const int SubAgentMaxToolIterations = 30;
+
     private readonly IChatClientProvider _chatClientProvider;
     private readonly ToolRegistry _toolRegistry;
     private readonly ToolAccessPolicy _toolAccessPolicy;
@@ -114,7 +116,12 @@ public sealed class SubAgentSpawner
             : $"subagent/{definition.Name}/{runId}";
 
         // Spawn as child of the session actor via the context factory
-        var props = SubAgentActor.CreateProps(definition, chatClient, _toolAccessPolicy, _approvalService);
+        var props = SubAgentActor.CreateProps(
+            definition,
+            chatClient,
+            _toolAccessPolicy,
+            _approvalService,
+            SubAgentMaxToolIterations);
         var actorName = $"subagent-{definition.Name}-{runId}";
         var subAgent = (IActorRef)await context.SpawnChildActor(props, actorName, ct);
 

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -16,7 +16,7 @@ namespace Netclaw.Actors.SubAgents;
 
 /// <summary>
 /// Shared utility that encapsulates the subagent spawn-ask-report lifecycle.
-/// Resolves tools by name, spawns a <see cref="SubAgentActor"/> as a child of the
+/// Resolves audience-scoped runtime tools, spawns a <see cref="SubAgentActor"/> as a child of the
 /// owning session actor, awaits results, and emits observability notifications.
 /// Singleton — registered in DI.
 /// </summary>
@@ -75,15 +75,17 @@ public sealed class SubAgentSpawner
             };
         }
 
-        var tools = ResolveTools(profile);
+        var tools = ResolveTools(profile, context);
         if (tools.Count == 0)
         {
-            _logger.LogWarning("SubAgent [{AgentName}] has no resolvable tools — cannot spawn", profile.Name);
+            _logger.LogWarning(
+                "SubAgent [{AgentName}] has no tools available under the parent audience policy — cannot spawn",
+                profile.Name);
             activitySink?.TryComplete();
             return new SubAgentResult
             {
                 Success = false,
-                Output = $"Cannot spawn subagent '{profile.Name}': none of its tools are currently available.",
+                Output = $"Cannot spawn subagent '{profile.Name}': no tools are available under the parent audience policy.",
                 AgentName = new AgentName(profile.Name)
             };
         }
@@ -205,38 +207,12 @@ public sealed class SubAgentSpawner
         }
     }
 
-    private IReadOnlyList<INetclawTool> ResolveTools(SubAgentProfile profile)
+    private IReadOnlyList<INetclawTool> ResolveTools(SubAgentProfile profile, ToolExecutionContext context)
     {
-        // When no tools specified, inherit all registered tools (matches Claude Code behavior).
-        // When tools are specified, use them as a whitelist to limit access.
-        IEnumerable<INetclawTool> candidates;
-        if (profile.ToolNames.Count == 0)
-        {
-            candidates = _toolRegistry.GetAllRegistrations().Select(r => r.Tool);
-        }
-        else
-        {
-            var resolved = new List<INetclawTool>();
-            foreach (var name in profile.ToolNames)
-            {
-                var tool = _toolRegistry.GetByName(name);
-                if (tool is not null)
-                {
-                    resolved.Add(tool);
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "SubAgent [{AgentName}] references tool '{ToolName}' which is not registered — skipping",
-                        profile.Name, name);
-                }
-            }
-
-            candidates = resolved;
-        }
-
-        // Sub-agents inherit the parent session's runtime tool policy; the only
-        // static sub-agent-specific filter denies recursive spawn_agent delegation.
+        // Sub-agents inherit the parent session's runtime tool policy. Agent
+        // definition tool metadata is advisory only; the only static
+        // sub-agent-specific filter denies recursive spawn_agent delegation.
+        var candidates = _toolRegistry.GetAllRegistrations().Select(r => r.Tool);
         var tools = new List<INetclawTool>();
         foreach (var tool in candidates)
         {
@@ -252,7 +228,7 @@ public sealed class SubAgentSpawner
             }
         }
 
-        return tools;
+        return _toolAccessPolicy.FilterDiscoverableTools(tools, context);
     }
 
     private static void TryStopSubAgent(IActorRef subAgent)

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -90,7 +90,25 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         // records against the directory the spawned process will run in.
         var resolvedCwd = context.ResolveShellCwd(args.WorkingDirectory);
         if (!string.IsNullOrWhiteSpace(resolvedCwd))
+        {
+            if (IsResolvedSessionDirectory(resolvedCwd, context.SessionDirectory))
+            {
+                try
+                {
+                    Directory.CreateDirectory(resolvedCwd);
+                }
+                catch (Exception ex) when (ex is ArgumentException
+                                           or IOException
+                                           or NotSupportedException
+                                           or UnauthorizedAccessException
+                                           or System.Security.SecurityException)
+                {
+                    return $"Error preparing session working directory: {ex.Message}";
+                }
+            }
+
             psi.WorkingDirectory = resolvedCwd;
+        }
 
         var effectiveTimeoutSeconds = context.RequestedTimeoutSeconds is > 0
             ? context.RequestedTimeoutSeconds.Value
@@ -201,4 +219,8 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 
         return string.Concat(output.AsSpan(0, maxChars), $"{Environment.NewLine}... [output truncated]");
     }
+
+    private static bool IsResolvedSessionDirectory(string resolvedCwd, string? sessionDirectory)
+        => !string.IsNullOrWhiteSpace(sessionDirectory)
+           && PathUtility.AreEquivalentPaths(resolvedCwd, sessionDirectory);
 }

--- a/src/Netclaw.Cli/Resources/identity/AGENTS.template.md
+++ b/src/Netclaw.Cli/Resources/identity/AGENTS.template.md
@@ -119,9 +119,8 @@ subagent returns a synthesized summary, not a transcript.
 
 **When NOT to delegate:**
 - Simple single searches (use web_search directly)
-- Tasks requiring MCP tools (subagents only have web_search, web_fetch,
-  file_read, attach_file)
-- Interactive browser tasks (subagents cannot use browser MCP tools)
+- Tasks requiring tools outside the current audience/profile policy
+- Interactive browser tasks when the current audience/profile does not expose browser tools
 - Tasks where coordination overhead outweighs parallelization benefits
 
 **Per-call specialization:** spawn_agent accepts an optional `context`

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
@@ -216,7 +216,6 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
             ---
             name: research-assistant
             description: Deep web research with search and citation
-            tools: [web_search, web_fetch, file_read, attach_file]
             modelRole: Compaction
             timeoutSeconds: 120
             visibility: user-facing
@@ -263,7 +262,6 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
             ---
             name: summarizer
             description: Summarize documents and content concisely
-            tools: [file_read]
             modelRole: Compaction
             timeoutSeconds: 60
             visibility: user-facing

--- a/src/Netclaw.Configuration/FileSubAgentDefinitionLoader.cs
+++ b/src/Netclaw.Configuration/FileSubAgentDefinitionLoader.cs
@@ -128,7 +128,7 @@ public sealed class FileSubAgentDefinitionLoader
 
             results.Add(profile);
             _logger.LogInformation(
-                "Loaded agent definition: {Name} ({ToolCount} tools, timeout={Timeout}s)",
+                "Loaded agent definition: {Name} (tool metadata={ToolCount}, timeout={Timeout}s)",
                 profile.Name, profile.ToolNames.Count, profile.TimeoutSeconds);
         }
 
@@ -199,8 +199,8 @@ public sealed class FileSubAgentDefinitionLoader
             return null;
         }
 
-        // Tools are optional. When omitted, the subagent inherits session tools at spawn time.
-        // This matches Claude Code's agent format where tools are not specified.
+        // Tool metadata is optional and advisory. Runtime access is resolved from
+        // the parent session audience at spawn time.
         var tools = frontmatter.Tools ?? [];
 
         if (!TryParseModelRole(frontmatter.ModelRole, out var modelRole))

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -164,9 +164,8 @@ subagent returns a synthesized summary, not a transcript.
 
 **When NOT to delegate:**
 - Simple single searches (use web_search directly)
-- Tasks requiring MCP tools (subagents only have web_search, web_fetch,
-  file_read, attach_file)
-- Interactive browser tasks (subagents cannot use browser MCP tools)
+- Tasks requiring tools outside the current audience/profile policy
+- Interactive browser tasks when the current audience/profile does not expose browser tools
 - Tasks where coordination overhead outweighs parallelization benefits
 
 **Per-call specialization:** spawn_agent accepts an optional `context`

--- a/src/Netclaw.Configuration/SubAgentDiscoveryContextLayer.cs
+++ b/src/Netclaw.Configuration/SubAgentDiscoveryContextLayer.cs
@@ -61,7 +61,7 @@ public sealed class SubAgentDiscoveryContextLayer : IContextLayerProvider
                 string.Empty,
                 "No user-facing subagents are currently registered.",
                 $"Agents directory: {agentsDirectory}",
-                "Sub-agents inherit the parent session's tool policy.",
+                "Sub-agents inherit the parent audience policy.",
                 $"Denied tools for sub-agents: {deniedTools}",
                 string.Empty,
                 "To add one: create an agent definition at <agents-directory>/<name>.md. The next turn or subagent lookup reloads it automatically.",
@@ -79,9 +79,7 @@ public sealed class SubAgentDiscoveryContextLayer : IContextLayerProvider
         {
             lines.Add($"## {agent.Name}");
             lines.Add(agent.Description);
-            lines.Add(agent.ToolNames.Count == 0
-                ? "Tools: inherited from parent session policy, except denied sub-agent tools"
-                : $"Tools: {string.Join(", ", agent.ToolNames)} (except denied sub-agent tools)");
+            lines.Add("Tools: inherited from parent audience policy, except denied sub-agent tools");
             lines.Add($"Timeout: {agent.TimeoutSeconds}s");
             lines.Add(string.Empty);
         }

--- a/src/Netclaw.Configuration/SubAgentProfile.cs
+++ b/src/Netclaw.Configuration/SubAgentProfile.cs
@@ -19,10 +19,9 @@ public enum SubAgentVisibility
 }
 
 /// <summary>
-/// Declarative subagent identity — name, system prompt, allowed tools, model role,
-/// timeout, and visibility. Profiles store tool <b>names</b> (not resolved instances)
-/// so they can be defined in code or loaded from disk without coupling to runtime tool state.
-/// Tools are resolved from <see cref="Netclaw.Actors.Tools.ToolRegistry"/> at spawn time.
+/// Declarative subagent identity — name, system prompt, advisory tool metadata,
+/// model role, timeout, and visibility. Runtime tool access is resolved from the
+/// parent session's audience policy at spawn time.
 /// </summary>
 public sealed record SubAgentProfile
 {
@@ -36,8 +35,8 @@ public sealed record SubAgentProfile
     public required string SystemPrompt { get; init; }
 
     /// <summary>
-    /// Tool names resolved from <see cref="Netclaw.Actors.Tools.ToolRegistry"/> at spawn time.
-    /// Names must match registered tool names (e.g., "web_search", "shell", "memorizer/store").
+    /// Advisory tool names parsed from frontmatter for compatibility with agent
+    /// file formats. These names do not constrain runtime tool access.
     /// </summary>
     public required IReadOnlyList<string> ToolNames { get; init; }
 

--- a/src/Netclaw.Daemon.Tests/Mcp/ToolIndexUpdaterTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/ToolIndexUpdaterTests.cs
@@ -48,7 +48,7 @@ public sealed class ToolIndexUpdaterTests
         Assert.Contains("available-subagents", discovery, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(paths.AgentsDirectory, discovery, StringComparison.Ordinal);
 
-        Assert.Contains("Sub-agents inherit the parent session's tool policy", discovery, StringComparison.Ordinal);
+        Assert.Contains("Sub-agents inherit the parent audience policy", discovery, StringComparison.Ordinal);
         foreach (var tool in SubAgentToolPolicy.GetDeniedSubAgentTools())
             Assert.Contains(tool, discovery, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary
- Enforce the subagent headless-worker contract with audience-policy tool inheritance, shared tool budgets, recursive spawn denial, and approval lifecycle fixes.
- Harden subagent final-output handling by detecting unexecuted tool markup, giving one repair turn, and failing explicitly instead of misreporting a timeout.
- Add diagnostics, docs, eval coverage, and regression tests for subagent execution and approval behavior.

## Verification
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --filter FullyQualifiedName~SubAgentActorTests
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --filter FullyQualifiedName~SubAgent
- git diff --check
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- Local swapped-binary smoke: daemon healthy on commit f9fde3e; Slack rerun spawned code-analyst, completed successfully, and posted the reply.

close #1211

## Notes
- Draft PR for review of the full subagent stabilization stack before merge.