### PR TITLE
feat(tools): classify multimodal file reads

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.8.1"
+  version: "2.8.2"
 ---
 
 # Netclaw Operations
@@ -600,8 +600,15 @@ The `[attachment]` line format is:
 ```
 
 `inlined="true"` means the file bytes were forwarded to the model as
-`DataContent` (images and PDFs on vision-capable models). `inlined="false"`
+`DataContent` (currently image files on image-capable models). `inlined="false"`
 means the model only sees the path reference.
+
+`file_read` follows the same file taxonomy as chat attachments. It reads
+text-like files directly. For images, it can load the file for visual inspection
+when the active model supports image input. For PDFs, audio/video, archives,
+binary documents, and unknown binaries, it returns metadata plus explicit
+guidance; it does not perform PDF extraction, OCR, transcription, keyframe
+extraction, or raw binary output.
 
 **Historical thread backfill** follows the same download/scan flow for all
 file types (not just images) — PDFs and other documents from prior thread

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.8.2"
+  version: "2.8.3"
 ---
 
 # Netclaw Operations
@@ -604,11 +604,12 @@ The `[attachment]` line format is:
 means the model only sees the path reference.
 
 `file_read` follows the same file taxonomy as chat attachments. It reads
-text-like files directly. For images, it can load the file for visual inspection
-when the active model supports image input. For PDFs, audio/video, archives,
-binary documents, and unknown binaries, it returns metadata plus explicit
-guidance; it does not perform PDF extraction, OCR, transcription, keyframe
-extraction, or raw binary output.
+text-like files directly, including UTF-8, UTF-16/UTF-32 Unicode text, and
+common Windows-1252 text files. For images, it can load the file for visual
+inspection when the active model or delegated sub-agent supports image input.
+For PDFs, audio/video, archives, binary documents, and unknown binaries, it
+returns metadata plus explicit guidance; it does not perform PDF extraction,
+OCR, transcription, keyframe extraction, or raw binary output.
 
 **Historical thread backfill** follows the same download/scan flow for all
 file types (not just images) — PDFs and other documents from prior thread

--- a/openspec/changes/enable-file-read-multimodal-classification/.openspec.yaml
+++ b/openspec/changes/enable-file-read-multimodal-classification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/enable-file-read-multimodal-classification/design.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Netclaw already has a file-backed multimodal path for inbound channel content:
+channel adapters emit `DataContent`, `ChannelPipeline` writes it into the session
+`media/` directory, `SerializableMediaReference` persists a safe reference, and
+`ChatMessageConverter` rehydrates that reference into `DataContent` at the LLM
+boundary. That path is currently used for images only. PDFs are intentionally
+path-only because OpenAI-compatible providers serialize all `DataContent` as
+`image_url`, which previously broke `application/pdf` payloads.
+
+`file_read` sits in a different path. It is a first-party tool whose execution
+contract returns text. The tool pipeline wraps that text in `FunctionResultContent`.
+Trying to stuff binary data or `DataContent` into a tool result would fight both
+the current tool abstraction and provider tool-result semantics.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Stop `file_read` from returning raw binary/gibberish for non-text files.
+- Keep normal text/code-file reads working exactly as they do today.
+- Let `file_read` hand images to vision-capable models through the existing
+  session media pipeline.
+- Keep behavior aligned with chat attachment classification and inline decisions.
+- Return explicit, useful metadata/guidance for unsupported formats.
+
+**Non-Goals:**
+
+- No native PDF text extraction inside `file_read`.
+- No OCR inside `file_read`.
+- No audio transcription or video keyframe extraction.
+- No provider-specific non-image media serialization.
+- No reuse of `ChannelAttachmentPolicy` as a local file-read policy gate.
+
+## Decisions
+
+### D1. `file_read` remains a text-result tool
+
+The tool result remains a string. Non-text files return metadata and guidance;
+they do not return bytes. This keeps provider tool-call ordering valid and avoids
+binary payloads in `FunctionResultContent`.
+
+### D2. Model-visible images use a side channel
+
+When `file_read` reads an image and the active model supports image input, the
+tool registers a model-input file on `ToolExecutionContext`. The session tool
+pipeline copies that file into the session `media/` directory and returns
+`SerializableMediaReference` records alongside the normal text tool result. After
+the tool result is recorded, `LlmSessionActor` appends a system nudge carrying
+those media references so the next LLM call sees the image through the existing
+`ChatMessageConverter` path.
+
+### D3. Same taxonomy, separate policy
+
+`file_read` uses the same file categories as chat attachments:
+`Image`, `Pdf`, `Document`, `Archive`, `Media`, and `Other`. It does not use
+`ChannelAttachmentPolicy` because that policy governs untrusted chat ingress
+before download. Local file reads already run through `AllowedTools`, `ReadFiles`,
+`GlobalReadRoots`, `ToolPathPolicy`, and audience-scoped filesystem policy.
+
+### D4. Explicit unsupported responses
+
+Unsupported formats return structured metadata with next-step guidance. A PDF
+response says PDF extraction is not built into `file_read`. Audio/video responses
+say transcription or keyframe extraction requires a configured processor. Archives
+and unknown binaries say the bytes are not readable as text.
+
+## Risks / Trade-offs
+
+- A tool-result side channel adds one more shape to `ToolExecutionContext`, but it
+  mirrors the existing `FileAttachmentInfo` side channel and keeps tool results
+  string-only.
+- Text detection must not break code-file reads with unfamiliar extensions. The
+  implementation should treat valid UTF-8 without binary control bytes as text
+  even when the MIME type is unknown.
+- Image files are copied into `media/`; this duplicates bytes for files already
+  under `inbox/`, but keeps the LLM boundary simple and path-local.

--- a/openspec/changes/enable-file-read-multimodal-classification/design.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/design.md
@@ -43,10 +43,12 @@ binary payloads in `FunctionResultContent`.
 ### D2. Model-visible images use a side channel
 
 When `file_read` reads an image and the active model supports image input, the
-tool registers a model-input file on `ToolExecutionContext`. The session tool
-pipeline copies that file into the session `media/` directory and returns
-`SerializableMediaReference` records alongside the normal text tool result. After
-the tool result is recorded, `LlmSessionActor` appends a system nudge carrying
+tool registers a model-input file on `ToolExecutionContext`. The session and
+sub-agent tool pipelines copy that file into the session `media/` directory and
+return `SerializableMediaReference` records alongside the normal text tool
+result. Main-session streaming tool results persist those refs on the tool-result
+message so journal replay can recreate the media nudge. After all sibling tool
+results are present, the session or sub-agent loop appends a system nudge carrying
 those media references so the next LLM call sees the image through the existing
 `ChatMessageConverter` path.
 
@@ -70,8 +72,10 @@ and unknown binaries say the bytes are not readable as text.
 - A tool-result side channel adds one more shape to `ToolExecutionContext`, but it
   mirrors the existing `FileAttachmentInfo` side channel and keeps tool results
   string-only.
-- Text detection must not break code-file reads with unfamiliar extensions. The
-  implementation should treat valid UTF-8 without binary control bytes as text
-  even when the MIME type is unknown.
+- Text detection must not break code-file reads with unfamiliar extensions or
+  common user-authored text encodings. The implementation should treat valid
+  UTF-8 without binary control bytes as text even when the MIME type is unknown,
+  and should recognize UTF-16/UTF-32 Unicode plus Windows-1252 when the extension
+  is text-like.
 - Image files are copied into `media/`; this duplicates bytes for files already
   under `inbox/`, but keeps the LLM boundary simple and path-local.

--- a/openspec/changes/enable-file-read-multimodal-classification/proposal.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+`file_read` currently treats every file as UTF-8 text. When the agent points it
+at images, PDFs, audio, video, archives, or other binary formats, the result can
+be raw binary/gibberish in the tool response. That conflicts with Netclaw's
+existing multimodal session pipeline: chat attachments already classify file
+types, announce path-only files, and inline images only when the active model can
+consume them.
+
+The right fix is to make `file_read` follow the same file-type contract as chat
+attachments without turning it into a document-processing engine.
+
+## What Changes
+
+- `file_read` detects file type before reading content.
+- Text-like files continue to return text with the existing offset/limit and
+  truncation behavior.
+- Image files never return raw bytes. If the active model supports image input,
+  `file_read` registers the image for the next LLM call through the existing
+  session media path. If not, it returns metadata plus the canonical image
+  modality-gap note.
+- PDFs return metadata plus explicit guidance that native PDF extraction is not
+  built into `file_read`.
+- Audio/video, archives, Office-style binary documents, and unknown binary files
+  return metadata plus explicit unsupported guidance.
+- Chat attachment ingress and `file_read` share the same inline-decision helper
+  so image/PDF/media behavior does not drift.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `netclaw-tools`: defines multimodal-aware `file_read` behavior and the
+  side-channel that can add model-visible media after a tool result.
+- `netclaw-input-adapters`: clarifies that the chat attachment file taxonomy and
+  inline decision are also the canonical taxonomy for local file inspection.
+
+## Impact
+
+- **Source PRDs**: PRD-001, PRD-002, PRD-005, PRD-009.
+- **Code**: `FileReadTool`, tool execution context/pipeline, session result
+  handling, shared attachment inline decision helper.
+- **Security**: existing `file_read` path authorization remains authoritative;
+  this change does not apply chat ingress policy to local file reads.
+- **Out of scope**: PDF extraction, OCR, Whisper/audio transcription, video
+  keyframe extraction, and provider-specific non-image `DataContent` support.

--- a/openspec/changes/enable-file-read-multimodal-classification/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Attachment file taxonomy and inline decisions
+
+The system SHALL use the same canonical file taxonomy for chat attachment ingress
+and local file inspection: `Image`, `Pdf`, `Document`, `Archive`, `Media`, and
+`Other`. Inline decisions SHALL be shared so images are inlined only when image
+input is available, PDFs remain path-only unless native provider support is
+explicitly added, and all other non-image formats are path-only.
+
+#### Scenario: Chat attachment and file_read agree on image modality gap
+
+- **GIVEN** a PNG file
+- **AND** the active model does not support image input
+- **WHEN** the file arrives as a chat attachment or is inspected by `file_read`
+- **THEN** both paths use the canonical image modality-gap note
+
+#### Scenario: PDF remains path-only
+
+- **GIVEN** a PDF file
+- **WHEN** the file arrives as a chat attachment or is inspected by `file_read`
+- **THEN** the file is not emitted as `DataContent`
+- **AND** the agent receives explicit guidance that native PDF content is not
+  available through the current path

--- a/openspec/changes/enable-file-read-multimodal-classification/specs/netclaw-tools/spec.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/specs/netclaw-tools/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: File read tool
+
+The system SHALL provide a `file_read` first-party tool that authorizes the
+requested path through the audience-scoped read-file policy before inspecting or
+reading bytes. Text-like files SHALL return UTF-8 text using the existing
+offset/limit and output-truncation behavior.
+
+For non-text files, `file_read` SHALL NOT return raw binary content. It SHALL
+detect the file category using the canonical attachment taxonomy where possible
+and return structured metadata plus an explicit next-step message.
+
+Images SHALL be eligible for model-visible handoff only when the active model's
+input modalities include image support. The handoff SHALL use session media
+references and the existing `DataContent` rehydration path, not binary content in
+the tool-result string.
+
+PDF extraction, OCR, audio transcription, and video keyframe extraction SHALL NOT
+be built into `file_read`.
+
+#### Scenario: Text file read preserves existing behavior
+
+- **GIVEN** a readable UTF-8 file
+- **WHEN** the agent invokes `file_read` with optional offset and limit values
+- **THEN** the tool returns text content with the existing line pagination and
+  truncation behavior
+
+#### Scenario: Image read on image-capable model becomes model-visible
+
+- **GIVEN** a readable PNG file
+- **AND** the active model supports image input
+- **WHEN** the agent invokes `file_read`
+- **THEN** the tool returns metadata indicating the image was loaded for visual
+  inspection
+- **AND** the next LLM call includes the image through a session media reference
+
+#### Scenario: Image read on text-only model returns modality guidance
+
+- **GIVEN** a readable PNG file
+- **AND** the active model does not support image input
+- **WHEN** the agent invokes `file_read`
+- **THEN** the tool returns metadata and the canonical image modality-gap note
+- **AND** no media reference is added to the next LLM call
+
+#### Scenario: PDF read does not extract text
+
+- **GIVEN** a readable PDF file
+- **WHEN** the agent invokes `file_read`
+- **THEN** the tool returns metadata identifying the file as a PDF
+- **AND** the result says native PDF extraction is not built into `file_read`
+- **AND** no raw PDF bytes are returned
+
+#### Scenario: Unsupported binary read returns explicit guidance
+
+- **GIVEN** a readable archive, audio file, video file, binary document, or
+  unknown binary file
+- **WHEN** the agent invokes `file_read`
+- **THEN** the tool returns metadata and explicit unsupported-format guidance
+- **AND** no raw bytes are returned

--- a/openspec/changes/enable-file-read-multimodal-classification/specs/netclaw-tools/spec.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/specs/netclaw-tools/spec.md
@@ -4,8 +4,9 @@
 
 The system SHALL provide a `file_read` first-party tool that authorizes the
 requested path through the audience-scoped read-file policy before inspecting or
-reading bytes. Text-like files SHALL return UTF-8 text using the existing
-offset/limit and output-truncation behavior.
+reading bytes. Text-like files SHALL return decoded text for UTF-8, UTF-16/UTF-32
+Unicode, and common Windows-1252 text files using the existing offset/limit and
+output-truncation behavior.
 
 For non-text files, `file_read` SHALL NOT return raw binary content. It SHALL
 detect the file category using the canonical attachment taxonomy where possible
@@ -14,14 +15,15 @@ and return structured metadata plus an explicit next-step message.
 Images SHALL be eligible for model-visible handoff only when the active model's
 input modalities include image support. The handoff SHALL use session media
 references and the existing `DataContent` rehydration path, not binary content in
-the tool-result string.
+the tool-result string. Streaming tool-result persistence SHALL retain the media
+references needed to recreate the handoff nudge during recovery.
 
 PDF extraction, OCR, audio transcription, and video keyframe extraction SHALL NOT
 be built into `file_read`.
 
 #### Scenario: Text file read preserves existing behavior
 
-- **GIVEN** a readable UTF-8 file
+- **GIVEN** a readable text file using UTF-8, UTF-16/UTF-32 Unicode, or Windows-1252
 - **WHEN** the agent invokes `file_read` with optional offset and limit values
 - **THEN** the tool returns text content with the existing line pagination and
   truncation behavior
@@ -34,6 +36,14 @@ be built into `file_read`.
 - **THEN** the tool returns metadata indicating the image was loaded for visual
   inspection
 - **AND** the next LLM call includes the image through a session media reference
+
+#### Scenario: Sub-agent image read can become model-visible
+
+- **GIVEN** a sub-agent uses `file_read` on a readable PNG file
+- **AND** the sub-agent's selected model supports image input
+- **WHEN** the tool result is returned to the sub-agent loop
+- **THEN** the next sub-agent LLM call includes the image through a session media
+  reference
 
 #### Scenario: Image read on text-only model returns modality guidance
 

--- a/openspec/changes/enable-file-read-multimodal-classification/tasks.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/tasks.md
@@ -8,7 +8,7 @@
 ## 2. File-read implementation
 
 - [x] 2.1 Add MIME/category inspection to `file_read` without breaking existing
-  UTF-8 text/code reads.
+  text/code reads, including common non-UTF-8 encodings.
 - [x] 2.2 Return metadata/guidance instead of raw binary for PDF, audio/video,
   archive, binary document, and unknown binary files.
 - [x] 2.3 Add image handoff from `file_read` through `ToolExecutionContext`, the
@@ -17,7 +17,7 @@
 ## 3. Tests, docs, and verification
 
 - [x] 3.1 Add or update tests for text reads, binary guidance, image handoff, and
-  image unsupported-model behavior.
+  image unsupported-model behavior, including streaming and sub-agent handoff.
 - [x] 3.2 Update the Netclaw operations system skill guidance for inbound
   attachments and `file_read` behavior.
 - [x] 3.3 Run targeted tests for tools/session media behavior.

--- a/openspec/changes/enable-file-read-multimodal-classification/tasks.md
+++ b/openspec/changes/enable-file-read-multimodal-classification/tasks.md
@@ -1,0 +1,25 @@
+## 1. OpenSpec and shared behavior
+
+- [x] 1.1 Add change artifacts for `enable-file-read-multimodal-classification`.
+- [x] 1.2 Add delta specs for `netclaw-tools` and `netclaw-input-adapters`.
+- [x] 1.3 Extract or add a shared inline-decision helper used by chat attachments
+  and `file_read`.
+
+## 2. File-read implementation
+
+- [x] 2.1 Add MIME/category inspection to `file_read` without breaking existing
+  UTF-8 text/code reads.
+- [x] 2.2 Return metadata/guidance instead of raw binary for PDF, audio/video,
+  archive, binary document, and unknown binary files.
+- [x] 2.3 Add image handoff from `file_read` through `ToolExecutionContext`, the
+  tool execution pipeline, and `LlmSessionActor` into session media refs.
+
+## 3. Tests, docs, and verification
+
+- [x] 3.1 Add or update tests for text reads, binary guidance, image handoff, and
+  image unsupported-model behavior.
+- [x] 3.2 Update the Netclaw operations system skill guidance for inbound
+  attachments and `file_read` behavior.
+- [x] 3.3 Run targeted tests for tools/session media behavior.
+- [x] 3.4 Run required quality gates: `dotnet slopwatch analyze` and
+  `./scripts/Add-FileHeaders.ps1 -Verify`.

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
@@ -99,7 +99,7 @@ public sealed class MattermostSessionBindingContractTests(ITestOutputHelper outp
         => _replyClient.Posts.Select(p => p.Text).ToList();
 
     protected override void ClearPostedTexts()
-        => _replyClient.Posts.Clear();
+        => _replyClient.Clear();
 
     protected override void SetReplyClientThrows(Exception ex)
         => _replyClient.ThrowOnPost = ex;
@@ -272,6 +272,13 @@ public sealed class MattermostSessionBindingContractTests(ITestOutputHelper outp
 
         var firstActor = CreateBindingActor(sid, initialPipeline, detector);
         await AwaitAssertAsync(() => Assert.Single(_replyClient.Posts), cancellationToken: ct);
+        // The transport post is recorded before the actor persists prompt
+        // tracking. Round-trip through the mailbox before stopping so recovery
+        // observes the persisted post id instead of racing the persist callback.
+        await firstActor.Ask<ActorIdentity>(
+            new Identify("prompt-tracking-persisted"),
+            TimeSpan.FromSeconds(3),
+            ct);
 
         var stopProbe = CreateTestProbe("mattermost-recovered-text-stop");
         stopProbe.Watch(firstActor);

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingMattermostReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingMattermostReplyClient.cs
@@ -9,25 +9,46 @@ namespace Netclaw.Actors.Tests.Channels.TestHelpers;
 
 internal sealed class RecordingMattermostReplyClient : IMattermostReplyClient
 {
-    public List<MattermostPostMessage> Posts { get; } = [];
-    public List<(MattermostPostId PostId, string Text, IReadOnlyList<MattermostAttachment>? Attachments)> Updates { get; } = [];
+    private readonly object _lock = new();
+    private readonly List<MattermostPostMessage> _posts = [];
+    private readonly List<(MattermostPostId PostId, string Text, IReadOnlyList<MattermostAttachment>? Attachments)> _updates = [];
+
+    public IReadOnlyList<MattermostPostMessage> Posts
+    {
+        get { lock (_lock) return _posts.ToList(); }
+    }
+
+    public IReadOnlyList<(MattermostPostId PostId, string Text, IReadOnlyList<MattermostAttachment>? Attachments)> Updates
+    {
+        get { lock (_lock) return _updates.ToList(); }
+    }
+
     public Exception? ThrowOnPost { get; set; }
 
     private int _messageCounter;
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _posts.Clear();
+            _updates.Clear();
+        }
+    }
 
     public Task<MattermostPostResult> PostReplyAsync(MattermostPostMessage message, CancellationToken cancellationToken = default)
     {
         if (ThrowOnPost is { } ex)
             throw ex;
 
-        Posts.Add(message);
+        lock (_lock) _posts.Add(message);
         var postId = new MattermostPostId($"post-{Interlocked.Increment(ref _messageCounter)}");
         return Task.FromResult(new MattermostPostResult(PostId: postId));
     }
 
     public Task UpdatePostAsync(MattermostPostId postId, string text, IReadOnlyList<MattermostAttachment>? attachments, CancellationToken cancellationToken = default)
     {
-        Updates.Add((postId, text, attachments));
+        lock (_lock) _updates.Add((postId, text, attachments));
         return Task.CompletedTask;
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
@@ -16,6 +16,8 @@ namespace Netclaw.Actors.Tests.Channels.TestHelpers;
 
 public sealed class RecordingSessionPipeline : ISessionPipeline
 {
+    private readonly object _feedbackLock = new();
+    private readonly List<IWithSessionId> _recordedFeedback = [];
     private readonly Func<SessionId, IReadOnlyList<SessionOutput>> _outputFactory;
     private readonly bool _reactive;
 
@@ -44,7 +46,11 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
     }
 
     public SessionPipelineOptions? CapturedOptions { get; private set; }
-    public List<IWithSessionId> RecordedFeedback { get; } = [];
+    public IReadOnlyList<IWithSessionId> RecordedFeedback
+    {
+        get { lock (_feedbackLock) return _recordedFeedback.ToList(); }
+    }
+
     public ConcurrentQueue<ChannelInput> CapturedInputs { get; } = new();
     public Func<IWithSessionId, CancellationToken, Task<ICommandReply>>? ResponseFactory { get; set; }
 
@@ -119,13 +125,13 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
 
     public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default)
     {
-        RecordedFeedback.Add(feedback);
+        lock (_feedbackLock) _recordedFeedback.Add(feedback);
         return Task.CompletedTask;
     }
 
     public Task<ICommandReply> SendFeedbackAndWaitAsync(IWithSessionId feedback, CancellationToken ct = default)
     {
-        RecordedFeedback.Add(feedback);
+        lock (_feedbackLock) _recordedFeedback.Add(feedback);
         var response = ResponseFactory?.Invoke(feedback, ct)
             ?? Task.FromResult<ICommandReply>(CommandAck.For(feedback.SessionId));
         return response;

--- a/src/Netclaw.Actors.Tests/Memory/FakeNetclawTool.cs
+++ b/src/Netclaw.Actors.Tests/Memory/FakeNetclawTool.cs
@@ -12,13 +12,19 @@ namespace Netclaw.Actors.Tests.Memory;
 internal sealed class FakeNetclawTool : INetclawTool
 {
     private readonly string _result;
+    private readonly Action<ToolExecutionContext>? _onExecute;
 
-    public FakeNetclawTool(string name, string result, string grantCategory = "builtin")
+    public FakeNetclawTool(
+        string name,
+        string result,
+        string grantCategory = "builtin",
+        Action<ToolExecutionContext>? onExecute = null)
     {
         Name = name;
         LlmFacingName = LlmFacingToolName.FromCanonical(name);
         _result = result;
         GrantCategory = grantCategory;
+        _onExecute = onExecute;
     }
 
     public string Name { get; }
@@ -43,6 +49,7 @@ internal sealed class FakeNetclawTool : INetclawTool
     public Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, ToolExecutionContext context, CancellationToken ct = default)
     {
         LastContext = context;
+        _onExecute?.Invoke(context);
         return ExecuteAsync(arguments, ct);
     }
 }

--- a/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
@@ -405,6 +405,23 @@ public class ChatMessageConverterTests
     }
 
     [Fact]
+    public void FromAiMessage_ignores_unknown_DataContent_media_type()
+    {
+        using var tempDir = new TempSessionDir();
+        var contents = new List<AIContent>
+        {
+            new TextContent("Unknown bytes"),
+            new DataContent(new byte[] { 1, 2, 3 }, "application/octet-stream")
+        };
+        var ai = new AiChatMessage(AiChatRole.User, contents);
+
+        var msg = ChatMessageConverter.FromAiMessage(ai, sessionDir: tempDir.Path);
+
+        Assert.Equal("Unknown bytes", msg.Content);
+        Assert.Empty(msg.MediaReferences);
+    }
+
+    [Fact]
     public void MimeToExtension_maps_common_types()
     {
         Assert.Equal(".png", ChatMessageConverter.MimeToExtension("image/png"));

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -201,6 +201,25 @@ public class SessionStateTests
     }
 
     [Fact]
+    public void AddSystemNudge_can_carry_media_without_becoming_last_user_message()
+    {
+        var media = new SerializableMediaReference
+        {
+            RelativePath = "image.png",
+            MimeType = new Netclaw.Security.MimeType("image/png"),
+            Modality = (int)MediaModality.Image,
+            FileSizeBytes = 16
+        };
+        var state = SessionState.Empty
+            .AddUserMessage("Real user message")
+            .AddSystemNudge("Loaded media.", [media]);
+
+        var nudge = state.History[^1];
+        Assert.Single(nudge.MediaReferences);
+        Assert.Equal("Real user message", state.FindLastUserMessage()?.Content);
+    }
+
+    [Fact]
     public void FindLastUserMessage_returns_null_when_no_user_messages()
     {
         var state = WithSystemPrompt("System");

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -373,6 +373,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             self: probe.Ref,
             emitSubAgentOutput: _ => { },
             spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            modelInputModalities: ModelModality.Text | ModelModality.Image,
             ct: TestContext.Current.CancellationToken);
 
         var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
@@ -384,6 +385,107 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         Assert.Equal("image/png", mediaRef.MimeType.Value);
         Assert.Equal((int)MediaModality.Image, mediaRef.Modality);
         Assert.True(File.Exists(Path.Combine(dir.Path, SessionDirectoryHelper.MediaSubdirectory, mediaRef.RelativePath)));
+    }
+
+    [Fact]
+    public async Task Tool_model_input_file_without_matching_modality_is_skipped()
+    {
+        using var dir = new DisposableTempDir();
+        var imagePath = Path.Combine(dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(imagePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var executor = new ModelInputFileExecutor(imagePath);
+        var probe = CreateTestProbe("model-input-modality-probe");
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            [new FunctionCallContent("call-image", FileReadTool.ToolName, new Dictionary<string, object?>())],
+            new SessionId("D1/model-input-modality-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: dir.Path,
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(3),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            ct: TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        Assert.Empty(completed.ModelInputMediaReferences);
+    }
+
+    [Fact]
+    public async Task Tool_model_input_file_with_mismatched_magic_is_skipped()
+    {
+        using var dir = new DisposableTempDir();
+        var imagePath = Path.Combine(dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(imagePath, FakePdfBytes, TestContext.Current.CancellationToken);
+        var executor = new ModelInputFileExecutor(imagePath);
+        var probe = CreateTestProbe("model-input-magic-probe");
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            [new FunctionCallContent("call-image", FileReadTool.ToolName, new Dictionary<string, object?>())],
+            new SessionId("D1/model-input-magic-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: dir.Path,
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(3),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            modelInputModalities: ModelModality.Text | ModelModality.Image,
+            ct: TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        Assert.Empty(completed.ModelInputMediaReferences);
+    }
+
+    [Fact]
+    public async Task Tool_model_input_file_over_size_limit_is_skipped()
+    {
+        using var dir = new DisposableTempDir();
+        var imagePath = Path.Combine(dir.Path, "large.png");
+        await using (var stream = File.Create(imagePath))
+        {
+            stream.SetLength(ChannelAttachmentPolicy.DefaultMaxFileBytes + 1);
+        }
+        var executor = new ModelInputFileExecutor(imagePath);
+        var probe = CreateTestProbe("model-input-size-probe");
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            [new FunctionCallContent("call-image", FileReadTool.ToolName, new Dictionary<string, object?>())],
+            new SessionId("D1/model-input-size-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: dir.Path,
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(3),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            modelInputModalities: ModelModality.Text | ModelModality.Image,
+            ct: TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        Assert.Empty(completed.ModelInputMediaReferences);
     }
 
     /// <summary>
@@ -414,14 +516,14 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         }
     }
 
-    private sealed class ModelInputFileExecutor(string imagePath) : IToolExecutor
+    private sealed class ModelInputFileExecutor(string imagePath, string mimeType = "image/png") : IToolExecutor
     {
         public Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
             => Task.CompletedTask;
 
         public Task<string> ExecuteAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
         {
-            context?.AddModelInputFile(imagePath, "diagram.png", "image/png");
+            context?.AddModelInputFile(imagePath, "diagram.png", mimeType);
             return Task.FromResult("image loaded");
         }
     }
@@ -431,6 +533,8 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
         0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
     ];
+
+    private static readonly byte[] FakePdfBytes = "%PDF-1.7\nfake body\n%%EOF"u8.ToArray();
 
     private sealed class ApprovalThenSuccessExecutor : IToolExecutor
     {

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -16,6 +16,7 @@ using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
 
@@ -350,6 +351,41 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         Assert.Contains("no activity", slow.Content);
     }
 
+    [Fact]
+    public async Task Tool_model_input_file_is_materialized_as_session_media_reference()
+    {
+        using var dir = new DisposableTempDir();
+        var imagePath = Path.Combine(dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(imagePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var executor = new ModelInputFileExecutor(imagePath);
+        var probe = CreateTestProbe("model-input-file-probe");
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            [new FunctionCallContent("call-image", FileReadTool.ToolName, new Dictionary<string, object?>())],
+            new SessionId("D1/model-input-file-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: dir.Path,
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(3),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            ct: TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var mediaRef = Assert.Single(completed.ModelInputMediaReferences);
+        Assert.Equal("image/png", mediaRef.MimeType.Value);
+        Assert.Equal((int)MediaModality.Image, mediaRef.Modality);
+        Assert.True(File.Exists(Path.Combine(dir.Path, SessionDirectoryHelper.MediaSubdirectory, mediaRef.RelativePath)));
+    }
+
     /// <summary>
     /// Streaming executor: <c>slow_tool</c> never produces an item (its per-call
     /// watchdog must time it out); every other tool completes immediately.
@@ -377,6 +413,24 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             yield return new ToolCompletedUpdate($"{toolCall.Name}-ok");
         }
     }
+
+    private sealed class ModelInputFileExecutor(string imagePath) : IToolExecutor
+    {
+        public Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<string> ExecuteAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
+        {
+            context?.AddModelInputFile(imagePath, "diagram.png", "image/png");
+            return Task.FromResult("image loaded");
+        }
+    }
+
+    private static readonly byte[] FakePngBytes =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
+    ];
 
     private sealed class ApprovalThenSuccessExecutor : IToolExecutor
     {

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -388,6 +388,73 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     }
 
     [Fact]
+    public async Task Streaming_tool_result_persists_model_input_media_references_on_tool_message()
+    {
+        using var dir = new DisposableTempDir();
+        var imagePath = Path.Combine(dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(imagePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var executor = new ModelInputFileExecutor(imagePath);
+        var probe = CreateTestProbe("streaming-model-input-probe");
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            [new FunctionCallContent("call-image", FileReadTool.ToolName, new Dictionary<string, object?>())],
+            new SessionId("D1/streaming-model-input-file-test"),
+            source: null,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: dir.Path,
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(3),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            streamToolResults: true,
+            modelInputModalities: ModelModality.Text | ModelModality.Image,
+            ct: TestContext.Current.CancellationToken);
+
+        var single = await probe.ExpectMsgAsync<ToolExecutionSingleCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await probe.ExpectMsgAsync<ToolExecutionBatchCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var mediaRef = Assert.Single(single.Result.ModelInputMediaReferences);
+        var persistedMediaRef = Assert.Single(single.Result.Message.MediaReferences);
+        Assert.Equal(mediaRef.RelativePath, persistedMediaRef.RelativePath);
+        Assert.Equal("image/png", persistedMediaRef.MimeType.Value);
+    }
+
+    [Fact]
+    public async Task Tool_model_input_batch_limit_is_enforced_across_registered_files()
+    {
+        using var dir = new DisposableTempDir();
+        var firstImagePath = Path.Combine(dir.Path, "first.png");
+        var secondImagePath = Path.Combine(dir.Path, "second.png");
+        await File.WriteAllBytesAsync(firstImagePath, FakePngBytes, TestContext.Current.CancellationToken);
+        await File.WriteAllBytesAsync(secondImagePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var context = new ToolExecutionContext("D1/model-input-budget-test", dir.Path)
+        {
+            Audience = TrustAudience.Personal,
+            ModelInputModalities = ModelModality.Text | ModelModality.Image
+        };
+        context.AddModelInputFile(firstImagePath, "first.png", "image/png");
+        context.AddModelInputFile(secondImagePath, "second.png", "image/png");
+        var budget = new ModelInputBatchBudget(FakePngBytes.Length);
+
+        var result = SessionToolExecutionPipeline.MaterializeModelInputFiles(
+            context,
+            dir.Path,
+            logger: null,
+            batchBudget: budget);
+
+        Assert.Equal(2, result.RequestedCount);
+        Assert.Single(result.MediaReferences);
+    }
+
+    [Fact]
     public async Task Tool_model_input_file_without_matching_modality_is_skipped()
     {
         using var dir = new DisposableTempDir();

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -24,6 +24,8 @@ namespace Netclaw.Actors.Tests.SubAgents;
 
 public class SubAgentActorTests : TestKit
 {
+    private static readonly TimeSpan ApprovalAskTimeout = TimeSpan.FromSeconds(30);
+
     public SubAgentActorTests(ITestOutputHelper output) : base(output: output) { }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
@@ -643,7 +645,7 @@ public class SubAgentActorTests : TestKit
                 Audience = TrustAudience.Personal,
                 ApprovalBridge = approvalBridge
             },
-            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
         // Deterministic sync: wait until the sub-agent has actually entered
         // the approval wait, then prove the run stays incomplete well past the
@@ -688,7 +690,7 @@ public class SubAgentActorTests : TestKit
                 ApprovalBridge = approvalBridge,
                 ActivitySink = activityChannel.Writer
             },
-            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
         await approvalBridge.EnteredApprovalWait.WaitAsync(TestContext.Current.CancellationToken);
         var waitingActivity = await ReadActivityAsync(
@@ -743,7 +745,7 @@ public class SubAgentActorTests : TestKit
                 ApprovalBridge = approvalBridge,
                 Cancellation = externalCts.Token
             },
-            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
         // Deterministic: wait until the sub-agent is actually inside the
         // approval wait before cancelling. Without this signal the cancel can
@@ -796,7 +798,7 @@ public class SubAgentActorTests : TestKit
                 Audience = TrustAudience.Personal,
                 ApprovalBridge = approvalBridge
             },
-            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
         await AwaitAssertAsync(
             () => Assert.Equal(2, approvalBridge.RequestCount),
@@ -938,7 +940,7 @@ public class SubAgentActorTests : TestKit
             throw new Xunit.Sdk.XunitException(
                 $"Expected sub-agent run to remain pending for {duration}, but it completed: {result.Output}");
         }
-        catch (TimeoutException)
+        catch (TimeoutException ex) when (ex.GetType() == typeof(TimeoutException))
         {
             return;
         }

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -16,6 +16,7 @@ using Netclaw.Actors.Tests.Memory;
 using ApprovalOptionKeys = Netclaw.Actors.Protocol.ApprovalOptionKeys;
 using Netclaw.Configuration;
 using Netclaw.Security;
+using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
 
@@ -226,6 +227,45 @@ public class SubAgentActorTests : TestKit
         Assert.NotNull(fakeTool.LastContext);
         // Second LLM call returns text (tool calls only on first call)
         Assert.Contains("Response #2", result.Output);
+    }
+
+    [Fact]
+    public async Task Tool_model_input_image_is_attached_to_subagent_followup_call()
+    {
+        using var dir = new DisposableTempDir();
+        var imagePath = Path.Combine(dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(imagePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var fakeTool = new FakeNetclawTool(
+            "load_image",
+            "image loaded",
+            onExecute: context => context.AddModelInputFile(imagePath, "diagram.png", "image/png"));
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall = [new FunctionCallContent("call-image", "load_image")]
+        };
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Inspect the image.",
+                Timeout = TimeSpan.FromSeconds(5),
+                Audience = TrustAudience.Personal,
+                ParentSessionDirectory = dir.Path,
+                ModelInputModalities = ModelModality.Text | ModelModality.Image
+            },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.NotNull(fakeTool.LastContext);
+        Assert.True(fakeTool.LastContext!.ModelInputModalities.HasFlag(ModelModality.Image));
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+        var nudge = Assert.Single(fakeClient.LastReceivedMessages!, message =>
+            message.Role == ChatRole.User
+            && message.Text.Contains("media", StringComparison.OrdinalIgnoreCase));
+        var data = Assert.Single(nudge.Contents.OfType<DataContent>());
+        Assert.Equal("image/png", data.MediaType);
     }
 
     [Fact]
@@ -1179,6 +1219,12 @@ public class SubAgentActorTests : TestKit
         public object? GetService(Type serviceType, object? serviceKey = null) => null;
         public void Dispose() { }
     }
+
+    private static readonly byte[] FakePngBytes =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
+    ];
 }
 
 /// <summary>

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -86,6 +86,20 @@ public class FileReadToolTests : IDisposable
     }
 
     [Fact]
+    public async Task Image_extension_without_image_magic_returns_binary_guidance()
+    {
+        var filePath = Path.Combine(_dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(filePath, [0, 1, 2, 3, 4, 5, 6, 7], TestContext.Current.CancellationToken);
+        var context = CreatePersonalContext();
+        context.ModelInputModalities = ModelModality.Text | ModelModality.Image;
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), context, CancellationToken.None);
+
+        Assert.Contains("application/octet-stream", result);
+        Assert.Empty(context.ModelInputFiles);
+    }
+
+    [Fact]
     public async Task Pdf_read_returns_metadata_without_extracting_text()
     {
         var filePath = Path.Combine(_dir.Path, "report.pdf");
@@ -108,6 +122,30 @@ public class FileReadToolTests : IDisposable
 
         Assert.Contains("application/octet-stream", result);
         Assert.Contains("Raw binary output is not returned by file_read", result);
+    }
+
+    [Fact]
+    public async Task Text_extension_with_binary_content_returns_guidance_instead_of_raw_bytes()
+    {
+        var filePath = Path.Combine(_dir.Path, "payload.json");
+        await File.WriteAllBytesAsync(filePath, [0, 1, 2, 3, 4, 5, 6, 7], TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("application/octet-stream", result);
+        Assert.Contains("Raw binary output is not returned by file_read", result);
+    }
+
+    [Fact]
+    public async Task Legacy_office_document_returns_document_guidance()
+    {
+        var filePath = Path.Combine(_dir.Path, "report.doc");
+        await File.WriteAllBytesAsync(filePath, FakeOleDocumentBytes, TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Type: application/msword (Document)", result);
+        Assert.Contains("Binary document extraction is not built into file_read", result);
     }
 
     [Fact]
@@ -413,6 +451,12 @@ public class FileReadToolTests : IDisposable
     ];
 
     private static readonly byte[] FakePdfBytes = "%PDF-1.7\nfake body\n%%EOF"u8.ToArray();
+
+    private static readonly byte[] FakeOleDocumentBytes =
+    [
+        0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1,
+        0x00, 0x01, 0x02, 0x03
+    ];
 
     private sealed class FakeMetrics : ISessionMetrics
     {

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text;
 using Netclaw.Actors.Tools;
 using Netclaw.Actors.Skills;
 using Netclaw.Actors.Telemetry;
@@ -53,6 +54,47 @@ public class FileReadToolTests : IDisposable
         var result = await _tool.ExecuteAsync(args, CreatePersonalContext(), CancellationToken.None);
 
         Assert.Equal("public static class Program { }", result);
+    }
+
+    [Fact]
+    public async Task Read_utf16_text_with_bom_returns_content()
+    {
+        var filePath = Path.Combine(_dir.Path, "notes.txt");
+        const string expected = "first line\nsecond line";
+        await File.WriteAllTextAsync(filePath, expected, Encoding.Unicode, TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task Read_windows1252_text_extension_returns_content()
+    {
+        var filePath = Path.Combine(_dir.Path, "notes.txt");
+        var bytes = new byte[]
+        {
+            (byte)'c', (byte)'a', (byte)'f', 0xE9, (byte)' ', 0x93,
+            (byte)'q', (byte)'u', (byte)'o', (byte)'t', (byte)'e', (byte)'d',
+            0x94, (byte)' ', 0x97, (byte)' ', (byte)'d', (byte)'o', (byte)'n', (byte)'e'
+        };
+        await File.WriteAllBytesAsync(filePath, bytes, TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Equal("caf\u00E9 \u201Cquoted\u201D \u2014 done", result);
+    }
+
+    [Fact]
+    public async Task Read_utf8_text_with_split_sample_boundary_returns_content()
+    {
+        var filePath = Path.Combine(_dir.Path, "boundary.txt");
+        var expected = new string('a', 4095) + "\u20AC after boundary";
+        await File.WriteAllTextAsync(filePath, expected, StrictUtf8NoBom, TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Equal(expected, result);
     }
 
     [Fact]
@@ -457,6 +499,8 @@ public class FileReadToolTests : IDisposable
         0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1,
         0x00, 0x01, 0x02, 0x03
     ];
+
+    private static readonly Encoding StrictUtf8NoBom = new UTF8Encoding(false, true);
 
     private sealed class FakeMetrics : ISessionMetrics
     {

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -44,6 +44,73 @@ public class FileReadToolTests : IDisposable
     }
 
     [Fact]
+    public async Task Read_code_file_with_unknown_mime_returns_content()
+    {
+        var filePath = Path.Combine(_dir.Path, "Program.cs");
+        await File.WriteAllTextAsync(filePath, "public static class Program { }", TestContext.Current.CancellationToken);
+
+        var args = ToolInput.Create("Path", filePath);
+        var result = await _tool.ExecuteAsync(args, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Equal("public static class Program { }", result);
+    }
+
+    [Fact]
+    public async Task Image_read_on_image_capable_model_registers_model_input_file()
+    {
+        var filePath = Path.Combine(_dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(filePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var context = CreatePersonalContext();
+        context.ModelInputModalities = ModelModality.Text | ModelModality.Image;
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), context, CancellationToken.None);
+
+        Assert.Contains("Image loaded for model-visible inspection", result);
+        var modelInput = Assert.Single(context.ModelInputFiles);
+        Assert.Equal(filePath, modelInput.FilePath);
+        Assert.Equal("diagram.png", modelInput.FileName);
+        Assert.Equal("image/png", modelInput.MimeType);
+    }
+
+    [Fact]
+    public async Task Image_read_on_text_only_model_returns_modality_guidance()
+    {
+        var filePath = Path.Combine(_dir.Path, "diagram.png");
+        await File.WriteAllBytesAsync(filePath, FakePngBytes, TestContext.Current.CancellationToken);
+        var context = CreatePersonalContext();
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), context, CancellationToken.None);
+
+        Assert.Contains("current model has no image modality", result);
+        Assert.Empty(context.ModelInputFiles);
+    }
+
+    [Fact]
+    public async Task Pdf_read_returns_metadata_without_extracting_text()
+    {
+        var filePath = Path.Combine(_dir.Path, "report.pdf");
+        await File.WriteAllBytesAsync(filePath, FakePdfBytes, TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Type: application/pdf (Pdf)", result);
+        Assert.Contains("Native PDF extraction is not built into file_read", result);
+        Assert.DoesNotContain("fake body", result);
+    }
+
+    [Fact]
+    public async Task Unknown_binary_read_returns_guidance_instead_of_raw_bytes()
+    {
+        var filePath = Path.Combine(_dir.Path, "payload.bin");
+        await File.WriteAllBytesAsync(filePath, [0, 1, 2, 3, 4, 5, 6, 7], TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("application/octet-stream", result);
+        Assert.Contains("Raw binary output is not returned by file_read", result);
+    }
+
+    [Fact]
     public async Task Read_missing_file_returns_error()
     {
         var filePath = Path.Combine(_dir.Path, "nonexistent.txt");
@@ -338,6 +405,14 @@ public class FileReadToolTests : IDisposable
             Boundary = TrustBoundary.Public,
             ChannelType = "slack"
         };
+
+    private static readonly byte[] FakePngBytes =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
+    ];
+
+    private static readonly byte[] FakePdfBytes = "%PDF-1.7\nfake body\n%%EOF"u8.ToArray();
 
     private sealed class FakeMetrics : ISessionMetrics
     {

--- a/src/Netclaw.Actors/Channels/AttachmentInlineDecision.cs
+++ b/src/Netclaw.Actors/Channels/AttachmentInlineDecision.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+// <copyright file="AttachmentInlineDecision.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Shared inline-vs-path-only decision for channel attachments and local file inspection.
+/// </summary>
+public static class AttachmentInlineDecision
+{
+    public static (bool Inlined, string? Note) Resolve(AttachmentCategory category, bool inlineImages)
+    {
+        return category switch
+        {
+            AttachmentCategory.Image when inlineImages => (true, null),
+            AttachmentCategory.Image => (false, AttachmentNotes.ModelMissingImage),
+            AttachmentCategory.Pdf => (false, AttachmentNotes.ModelMissingPdf),
+            _ => (false, AttachmentNotes.FormatNotInlineable)
+        };
+    }
+}

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -329,29 +329,11 @@ public sealed class SessionPipeline : ISessionPipeline
         if (dataContents.Count > 0)
         {
             var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId, paths.SessionsDirectory);
-            var mediaDir = Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory);
-            Directory.CreateDirectory(mediaDir);
-
             foreach (var data in dataContents)
             {
-                var bytes = data.Data.ToArray();
-                if (bytes.Length == 0)
-                    continue;
-
-                var mimeType = data.MediaType ?? "application/octet-stream";
-                var ext = ChatMessageConverter.MimeToExtension(mimeType);
-                var fileName = $"{Guid.NewGuid():N}{ext}";
-                var fullPath = Path.Combine(mediaDir, fileName);
-
-                File.WriteAllBytes(fullPath, bytes);
-
-                mediaRefs.Add(new SerializableMediaReference
-                {
-                    RelativePath = fileName,
-                    MimeType = new Netclaw.Security.MimeType(mimeType),
-                    Modality = (int)ChatMessageConverter.MimeToModality(mimeType),
-                    FileSizeBytes = bytes.Length
-                });
+                var mediaRef = SessionMediaStore.WriteDataContent(data, sessionDir);
+                if (mediaRef is not null)
+                    mediaRefs.Add(mediaRef);
             }
         }
 

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Netclaw.Security;
 using Netclaw.Tools;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
 using AiChatRole = Microsoft.Extensions.AI.ChatRole;
@@ -88,7 +89,7 @@ public static class ChatMessageConverter
 
             foreach (var media in msg.MediaReferences)
             {
-                var fullPath = Path.Combine(sessionDir, "media", media.RelativePath);
+                var fullPath = SessionMediaStore.GetMediaPath(sessionDir, media.RelativePath);
                 if (!File.Exists(fullPath))
                 {
                     logger?.LogWarning("Media file not found, skipping: {Path}", fullPath);
@@ -159,7 +160,7 @@ public static class ChatMessageConverter
                     break;
 
                 case DataContent data when sessionDir is not null:
-                    var mediaRef = WriteMediaToSession(data, sessionDir);
+                    var mediaRef = SessionMediaStore.WriteDataContent(data, sessionDir);
                     if (mediaRef is not null)
                         mediaRefs.Add(mediaRef);
                     break;
@@ -183,54 +184,14 @@ public static class ChatMessageConverter
         };
     }
 
-    private static SerializableMediaReference? WriteMediaToSession(DataContent data, string sessionDir)
-    {
-        var mediaDir = Path.Combine(sessionDir, "media");
-        Directory.CreateDirectory(mediaDir);
-
-        var mimeType = data.MediaType ?? "application/octet-stream";
-        var ext = MimeToExtension(mimeType);
-        var fileName = $"{Guid.NewGuid():N}{ext}";
-        var fullPath = Path.Combine(mediaDir, fileName);
-
-        var bytes = data.Data.ToArray();
-        if (bytes.Length == 0)
-            return null;
-
-        File.WriteAllBytes(fullPath, bytes);
-
-        var modality = MimeToModality(mimeType);
-        return new SerializableMediaReference
-        {
-            RelativePath = fileName,
-            MimeType = new Netclaw.Security.MimeType(mimeType),
-            Modality = (int)modality,
-            FileSizeBytes = bytes.Length
-        };
-    }
-
-    internal static string MimeToExtension(string mimeType) => mimeType.ToLowerInvariant() switch
-    {
-        "image/png" => ".png",
-        "image/jpeg" or "image/jpg" => ".jpg",
-        "image/gif" => ".gif",
-        "image/webp" => ".webp",
-        "image/svg+xml" => ".svg",
-        "audio/mpeg" => ".mp3",
-        "audio/wav" => ".wav",
-        "video/mp4" => ".mp4",
-        _ => ".bin"
-    };
+    internal static string MimeToExtension(string mimeType) => MimeTypeCatalog.ExtensionFor(mimeType);
 
     internal static MediaModality MimeToModality(string mimeType)
     {
-        if (mimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-            return MediaModality.Image;
-        if (mimeType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
-            return MediaModality.Audio;
-        if (mimeType.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
-            return MediaModality.Video;
-        return MediaModality.Image; // default fallback
+        if (MediaMimeClassifier.TryGetMediaModality(mimeType, out var modality))
+            return modality;
+
+        throw new ArgumentException($"Unsupported media MIME type: {mimeType}", nameof(mimeType));
     }
 
     internal static (ToolCallMeta? Meta, IDictionary<string, object?>? CleanArgs) ExtractMeta(

--- a/src/Netclaw.Actors/Protocol/SessionMediaStore.cs
+++ b/src/Netclaw.Actors/Protocol/SessionMediaStore.cs
@@ -1,0 +1,120 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionMediaStore.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+using Netclaw.Configuration;
+using Netclaw.Security;
+
+namespace Netclaw.Actors.Protocol;
+
+internal static class MediaMimeClassifier
+{
+    public static bool TryGetMediaModality(string? mimeType, out MediaModality modality)
+    {
+        var normalized = MimeTypeCatalog.Normalize(mimeType);
+        if (normalized.StartsWith("image/", StringComparison.Ordinal))
+        {
+            modality = MediaModality.Image;
+            return true;
+        }
+
+        if (normalized.StartsWith("audio/", StringComparison.Ordinal))
+        {
+            modality = MediaModality.Audio;
+            return true;
+        }
+
+        if (normalized.StartsWith("video/", StringComparison.Ordinal))
+        {
+            modality = MediaModality.Video;
+            return true;
+        }
+
+        modality = default;
+        return false;
+    }
+
+    public static bool TryGetSupportedModelInput(
+        string? mimeType,
+        out MediaModality mediaModality,
+        out ModelModality requiredModelModality)
+    {
+        if (MimeTypeCatalog.Normalize(mimeType) is
+            MimeTypeCatalog.ImagePng or
+            MimeTypeCatalog.ImageJpeg or
+            MimeTypeCatalog.ImageGif or
+            MimeTypeCatalog.ImageWebp)
+        {
+            mediaModality = MediaModality.Image;
+            requiredModelModality = ModelModality.Image;
+            return true;
+        }
+
+        mediaModality = default;
+        requiredModelModality = default;
+        return false;
+    }
+}
+
+internal static class SessionMediaStore
+{
+    public static string GetMediaPath(string sessionDir, string relativePath)
+        => Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory, relativePath);
+
+    public static string GetOrCreateMediaDirectory(string sessionDir)
+    {
+        var mediaDir = Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory);
+        Directory.CreateDirectory(mediaDir);
+        return mediaDir;
+    }
+
+    public static SerializableMediaReference? WriteDataContent(DataContent data, string sessionDir)
+    {
+        var bytes = data.Data.ToArray();
+        if (bytes.Length == 0)
+            return null;
+
+        var mimeType = MimeTypeCatalog.Normalize(data.MediaType);
+        if (!MediaMimeClassifier.TryGetMediaModality(mimeType, out var modality))
+            return null;
+
+        var mediaDir = GetOrCreateMediaDirectory(sessionDir);
+        var fileName = CreateMediaFileName(mimeType);
+        File.WriteAllBytes(Path.Combine(mediaDir, fileName), bytes);
+
+        return CreateReference(fileName, mimeType, modality, bytes.Length);
+    }
+
+    public static SerializableMediaReference CopyFile(
+        string sourcePath,
+        string sessionDir,
+        string mimeType,
+        MediaModality modality,
+        long fileSizeBytes)
+    {
+        var normalizedMime = MimeTypeCatalog.Normalize(mimeType);
+        var mediaDir = GetOrCreateMediaDirectory(sessionDir);
+        var fileName = CreateMediaFileName(normalizedMime);
+        File.Copy(sourcePath, Path.Combine(mediaDir, fileName));
+
+        return CreateReference(fileName, normalizedMime, modality, fileSizeBytes);
+    }
+
+    private static string CreateMediaFileName(string mimeType)
+        => $"{Guid.NewGuid():N}{MimeTypeCatalog.ExtensionFor(mimeType)}";
+
+    private static SerializableMediaReference CreateReference(
+        string fileName,
+        string mimeType,
+        MediaModality modality,
+        long fileSizeBytes)
+        => new()
+        {
+            RelativePath = fileName,
+            MimeType = new MimeType(mimeType),
+            Modality = (int)modality,
+            FileSizeBytes = fileSizeBytes
+        };
+}

--- a/src/Netclaw.Actors/Sessions/ActiveToolBatchTracker.cs
+++ b/src/Netclaw.Actors/Sessions/ActiveToolBatchTracker.cs
@@ -15,8 +15,11 @@ internal sealed class ActiveToolBatchTracker
 
     public int CompletedCount => _completedCallIds.Count;
 
-    public bool CanComplete => ExecutionTaskCompleted
+    public bool HasAllResults => _expectedCallIds.Count > 0
         && _completedCallIds.Count >= _expectedCallIds.Count;
+
+    public bool CanComplete => ExecutionTaskCompleted
+        && HasAllResults;
 
     private bool ExecutionTaskCompleted { get; set; }
 

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -69,6 +69,7 @@ internal sealed record LlmCallFailed(Exception Cause) : INoSerializationVerifica
 internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeeded
 {
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
+    public List<SerializableMediaReference> ModelInputMediaReferences { get; init; } = [];
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
     public List<CompletedSubAgentRun> CompletedSubAgentRuns { get; init; } = [];
     public List<AcceptedSubAgentFinding> AcceptedSubAgentFindings { get; init; } = [];

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -78,6 +78,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Live-only coordination for the currently executing streamed tool batch.
     // Durable recovery derives unanswered calls from _state.History.
     private readonly ActiveToolBatchTracker _activeToolBatch = new();
+    private readonly List<SerializableMediaReference> _pendingModelInputMediaReferences = [];
     private MessageSource? _currentTurnSource;
     private TurnContext? _currentTurnContext;
     private ApprovalTurnState _approvalTurnState = ApprovalTurnState.None;
@@ -531,6 +532,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             _watchdog.Stop(Timers);
             CancelAndDisposeToolExecutionCts();
+            _pendingModelInputMediaReferences.Clear();
             TurnLog().Error(msg.Cause, "turn_tool_execution_failed");
 
             const string errorMessage = "I encountered an error executing a tool. Please try again.";
@@ -918,6 +920,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 MimeType = new Netclaw.Security.MimeType(file.MimeType)
             }, OutputFilter.Files);
         }
+
+        AddModelInputMediaNudge(msg.ModelInputMediaReferences);
 
         var budgetStatus = _turnState.RecordToolCompletion(msg.ToolResults.Count, _config.MaxToolIterationsPerTurn);
         var dupNudge = _turnState.CheckForDuplicates();
@@ -1875,6 +1879,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             projectDirectory: _state.WorkingContext.ProjectDirectory,
             setWorkingDirectoryAvailable: setWorkingDirectoryAvailable,
             streamToolResults: true,
+            modelInputModalities: _model.InputModalities,
             oneTimeApprovalPreSeed: oneTimeApprovalPreSeed,
             decisionOverride: decisionOverride,
             turnContext: _currentTurnContext,
@@ -3330,6 +3335,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private void ClearActiveToolBatchTracking()
     {
         _activeToolBatch.Clear();
+        _pendingModelInputMediaReferences.Clear();
     }
 
     private void MaybeSnapshot()
@@ -4349,6 +4355,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 MimeType = new Netclaw.Security.MimeType(file.MimeType)
             }, OutputFilter.Files);
         }
+
+        if (result.ModelInputMediaReferences.Count > 0)
+            _pendingModelInputMediaReferences.AddRange(result.ModelInputMediaReferences);
+    }
+
+    private void AddModelInputMediaNudge(IReadOnlyList<SerializableMediaReference> mediaReferences)
+    {
+        if (mediaReferences.Count == 0)
+            return;
+
+        var itemText = mediaReferences.Count == 1 ? "file" : "files";
+        _state = _state.AddSystemNudge(
+            $"A tool loaded {mediaReferences.Count} media {itemText} for model-visible inspection. " +
+            "Use the attached media along with the tool result to answer the user.",
+            mediaReferences);
     }
 
     private void TryCompleteStreamedToolBatch()
@@ -4361,6 +4382,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void CompleteToolBatch(int resultCount)
     {
+        AddModelInputMediaNudge(_pendingModelInputMediaReferences);
+        _pendingModelInputMediaReferences.Clear();
+
         var budgetStatus = _turnState.RecordToolCompletion(resultCount, _config.MaxToolIterationsPerTurn);
 
         var dupNudge = _turnState.CheckForDuplicates();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3173,15 +3173,27 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void ApplyToolCallRecorded(ToolCallRecorded evt)
     {
+        var alreadyRecorded = false;
         if (evt.ToolResult.ToolCallId is { } toolCallId)
         {
             _activeToolBatch.RecordCompleted(toolCallId.Value);
 
             if (ParkedToolBatchHistory.HasToolResult(_state.History, toolCallId.Value))
-                return;
+                alreadyRecorded = true;
         }
 
-        _state = _state with { History = _state.History.Add(evt.ToolResult) };
+        if (!alreadyRecorded)
+        {
+            _state = _state with { History = _state.History.Add(evt.ToolResult) };
+            if (evt.ToolResult.MediaReferences.Count > 0)
+                _pendingModelInputMediaReferences.AddRange(evt.ToolResult.MediaReferences);
+
+            if (_activeToolBatch.HasAllResults)
+            {
+                AddModelInputMediaNudge(_pendingModelInputMediaReferences);
+                _pendingModelInputMediaReferences.Clear();
+            }
+        }
     }
 
     private void HandleToolInteractionRequestDispatch(ToolInteractionRequestDispatch dispatch)
@@ -4356,8 +4368,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }, OutputFilter.Files);
         }
 
-        if (result.ModelInputMediaReferences.Count > 0)
-            _pendingModelInputMediaReferences.AddRange(result.ModelInputMediaReferences);
+        // Streaming tool results persist media references on ToolCallRecorded;
+        // ApplyToolCallRecorded recreates the nudge during journal replay.
     }
 
     private void AddModelInputMediaNudge(IReadOnlyList<SerializableMediaReference> mediaReferences)

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -803,13 +803,13 @@ internal static class SessionToolExecutionPipeline
         if (context.ModelInputFiles.Count == 0)
             return new ModelInputMaterializationResult([], 0);
 
-        var mediaDir = Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory);
         try
         {
-            Directory.CreateDirectory(mediaDir);
+            SessionMediaStore.GetOrCreateMediaDirectory(sessionDir);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            var mediaDir = Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory);
             logger?.LogWarning(ex, "Failed to create model input media directory: {Path}", mediaDir);
             return new ModelInputMaterializationResult([], context.ModelInputFiles.Count);
         }
@@ -825,8 +825,8 @@ internal static class SessionToolExecutionPipeline
                 // is safe. This is the provider-boundary guardrail that keeps
                 // future tools from smuggling arbitrary local bytes into the
                 // next LLM call by setting a convincing MIME string.
-                var mimeType = NormalizeModelInputMime(file.MimeType);
-                if (!TryGetSupportedModelInputModality(mimeType, out var mediaModality, out var requiredModelModality))
+                var mimeType = MimeTypeCatalog.Normalize(file.MimeType);
+                if (!MediaMimeClassifier.TryGetSupportedModelInput(mimeType, out var mediaModality, out var requiredModelModality))
                 {
                     logger?.LogWarning("Model input file MIME type is not supported, skipping: {MimeType}", mimeType);
                     continue;
@@ -878,19 +878,12 @@ internal static class SessionToolExecutionPipeline
                     continue;
                 }
 
-                var ext = ChatMessageConverter.MimeToExtension(mimeType);
-                var fileName = $"{Guid.NewGuid():N}{ext}";
-                var fullPath = Path.Combine(mediaDir, fileName);
-
-                File.Copy(file.FilePath, fullPath);
-
-                refs.Add(new SerializableMediaReference
-                {
-                    RelativePath = fileName,
-                    MimeType = new MimeType(mimeType),
-                    Modality = (int)mediaModality,
-                    FileSizeBytes = info.Length
-                });
+                refs.Add(SessionMediaStore.CopyFile(
+                    file.FilePath,
+                    sessionDir,
+                    mimeType,
+                    mediaModality,
+                    info.Length));
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
@@ -908,37 +901,6 @@ internal static class SessionToolExecutionPipeline
         var itemText = failedCount == 1 ? "file" : "files";
         return resultText +
                $"\n[model input media handoff warning: {failedCount} registered media {itemText} could not be attached to the next LLM call]";
-    }
-
-    private static string NormalizeModelInputMime(string? mimeType)
-    {
-        var normalized = string.IsNullOrWhiteSpace(mimeType)
-            ? MimeType.DefaultValue
-            : mimeType.Trim();
-        var semicolon = normalized.IndexOf(';', StringComparison.Ordinal);
-        if (semicolon >= 0)
-            normalized = normalized[..semicolon].Trim();
-
-        return string.Equals(normalized, "image/jpg", StringComparison.OrdinalIgnoreCase)
-            ? "image/jpeg"
-            : normalized.ToLowerInvariant();
-    }
-
-    private static bool TryGetSupportedModelInputModality(
-        string mimeType,
-        out MediaModality mediaModality,
-        out ModelModality requiredModelModality)
-    {
-        if (mimeType is "image/png" or "image/jpeg" or "image/gif" or "image/webp")
-        {
-            mediaModality = MediaModality.Image;
-            requiredModelModality = ModelModality.Image;
-            return true;
-        }
-
-        mediaModality = default;
-        requiredModelModality = default;
-        return false;
     }
 
     private static bool IsFileMagicCompatible(string path, string mimeType)

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -774,6 +774,10 @@ internal static class SessionToolExecutionPipeline
         {
             try
             {
+                // Treat tool-registered model input as a request, not proof it
+                // is safe. This is the provider-boundary guardrail that keeps
+                // future tools from smuggling arbitrary local bytes into the
+                // next LLM call by setting a convincing MIME string.
                 var mimeType = NormalizeModelInputMime(file.MimeType);
                 if (!TryGetSupportedModelInputModality(mimeType, out var mediaModality, out var requiredModelModality))
                 {

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -13,6 +13,7 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Sessions.Pipelines;
@@ -34,6 +35,9 @@ internal sealed record ToolCallResult(
 /// </summary>
 internal static class SessionToolExecutionPipeline
 {
+    private const long MaxModelInputFileBytes = ChannelAttachmentPolicy.DefaultMaxFileBytes;
+    private const long MaxModelInputBatchBytes = ChannelAttachmentPolicy.DefaultMaxFileBytes;
+
     public static async Task ExecuteToolsAsync(
         IToolExecutor executor,
         List<FunctionCallContent> toolCalls,
@@ -765,10 +769,27 @@ internal static class SessionToolExecutionPipeline
         Directory.CreateDirectory(mediaDir);
 
         var refs = new List<SerializableMediaReference>(context.ModelInputFiles.Count);
+        var totalBytes = 0L;
         foreach (var file in context.ModelInputFiles)
         {
             try
             {
+                var mimeType = NormalizeModelInputMime(file.MimeType);
+                if (!TryGetSupportedModelInputModality(mimeType, out var mediaModality, out var requiredModelModality))
+                {
+                    logger?.LogWarning("Model input file MIME type is not supported, skipping: {MimeType}", mimeType);
+                    continue;
+                }
+
+                if (!context.ModelInputModalities.HasFlag(requiredModelModality))
+                {
+                    logger?.LogWarning(
+                        "Model input file requires unavailable modality {Modality}, skipping: {Path}",
+                        requiredModelModality,
+                        file.FilePath);
+                    continue;
+                }
+
                 if (!File.Exists(file.FilePath))
                 {
                     logger?.LogWarning("Model input file not found, skipping: {Path}", file.FilePath);
@@ -779,17 +800,38 @@ internal static class SessionToolExecutionPipeline
                 if (info.Length <= 0)
                     continue;
 
-                var ext = ChatMessageConverter.MimeToExtension(file.MimeType);
+                if (info.Length > MaxModelInputFileBytes)
+                {
+                    logger?.LogWarning("Model input file exceeds size limit, skipping: {Path}", file.FilePath);
+                    continue;
+                }
+
+                if (totalBytes + info.Length > MaxModelInputBatchBytes)
+                {
+                    logger?.LogWarning("Model input file would exceed batch size limit, skipping: {Path}", file.FilePath);
+                    continue;
+                }
+
+                if (!IsFileMagicCompatible(file.FilePath, mimeType))
+                {
+                    logger?.LogWarning(
+                        "Model input file MIME type does not match detected bytes, skipping: {Path}",
+                        file.FilePath);
+                    continue;
+                }
+
+                var ext = ChatMessageConverter.MimeToExtension(mimeType);
                 var fileName = $"{Guid.NewGuid():N}{ext}";
                 var fullPath = Path.Combine(mediaDir, fileName);
 
                 File.Copy(file.FilePath, fullPath);
+                totalBytes += info.Length;
 
                 refs.Add(new SerializableMediaReference
                 {
                     RelativePath = fileName,
-                    MimeType = new Netclaw.Security.MimeType(file.MimeType),
-                    Modality = (int)ChatMessageConverter.MimeToModality(file.MimeType),
+                    MimeType = new MimeType(mimeType),
+                    Modality = (int)mediaModality,
                     FileSizeBytes = info.Length
                 });
             }
@@ -800,6 +842,46 @@ internal static class SessionToolExecutionPipeline
         }
 
         return refs;
+    }
+
+    private static string NormalizeModelInputMime(string? mimeType)
+    {
+        var normalized = string.IsNullOrWhiteSpace(mimeType)
+            ? MimeType.DefaultValue
+            : mimeType.Trim();
+        var semicolon = normalized.IndexOf(';', StringComparison.Ordinal);
+        if (semicolon >= 0)
+            normalized = normalized[..semicolon].Trim();
+
+        return string.Equals(normalized, "image/jpg", StringComparison.OrdinalIgnoreCase)
+            ? "image/jpeg"
+            : normalized.ToLowerInvariant();
+    }
+
+    private static bool TryGetSupportedModelInputModality(
+        string mimeType,
+        out MediaModality mediaModality,
+        out ModelModality requiredModelModality)
+    {
+        if (mimeType is "image/png" or "image/jpeg" or "image/gif" or "image/webp")
+        {
+            mediaModality = MediaModality.Image;
+            requiredModelModality = ModelModality.Image;
+            return true;
+        }
+
+        mediaModality = default;
+        requiredModelModality = default;
+        return false;
+    }
+
+    private static bool IsFileMagicCompatible(string path, string mimeType)
+    {
+        Span<byte> header = stackalloc byte[64];
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var read = stream.Read(header);
+        var detected = MagicByteValidator.DetectMimeType(header[..read]);
+        return string.Equals(detected, mimeType, StringComparison.OrdinalIgnoreCase);
     }
 
     private static ToolExecutionContext BuildToolExecutionContext(

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -29,6 +29,34 @@ internal sealed record ToolCallResult(
     IReadOnlyList<CompletedSubAgentRun> CompletedSubAgentRuns,
     IReadOnlyList<AcceptedSubAgentFinding> AcceptedSubAgentFindings);
 
+internal sealed record ModelInputMaterializationResult(
+    IReadOnlyList<SerializableMediaReference> MediaReferences,
+    int RequestedCount);
+
+internal sealed class ModelInputBatchBudget(long maxBytes)
+{
+    private readonly object _sync = new();
+    private long _reservedBytes;
+
+    public bool TryReserve(long sizeBytes)
+    {
+        lock (_sync)
+        {
+            if (_reservedBytes + sizeBytes > maxBytes)
+                return false;
+
+            _reservedBytes += sizeBytes;
+            return true;
+        }
+    }
+
+    public void Release(long sizeBytes)
+    {
+        lock (_sync)
+            _reservedBytes = Math.Max(0, _reservedBytes - sizeBytes);
+    }
+}
+
 /// <summary>
 /// Async pipeline for parallel tool execution. Runs on the thread pool and
 /// sends results back to the session actor via <c>self.Tell()</c>.
@@ -73,6 +101,7 @@ internal static class SessionToolExecutionPipeline
             // independent -- e.g. two file_edit calls on the same file -- so
             // file-mutating tools serialize their read-modify-write per target
             // path via FileMutationGate to avoid lost-update races here.
+            var modelInputBudget = new ModelInputBatchBudget(MaxModelInputBatchBytes);
             var tasks = toolCalls.Select(async tc =>
             {
                 var result = await ExecuteSingleToolAsync(
@@ -105,7 +134,8 @@ internal static class SessionToolExecutionPipeline
                     decisionOverride is not null && decisionOverride.TryGetValue(tc.CallId, out var overrideDecision)
                         ? overrideDecision
                         : null,
-                    turnContext);
+                    turnContext,
+                    modelInputBudget);
                 if (streamToolResults)
                     self.Tell(new ToolExecutionSingleCompleted(result));
                 return result;
@@ -173,7 +203,8 @@ internal static class SessionToolExecutionPipeline
         ModelModality modelInputModalities = ModelModality.Text,
         IReadOnlyList<string>? oneTimeApprovalPreSeed = null,
         ApprovalDecision? decisionOverride = null,
-        TurnContext? turnContext = null)
+        TurnContext? turnContext = null,
+        ModelInputBatchBudget? modelInputBudget = null)
     {
         var (meta, cleanedTc) = ToolCallMetaExtractor.Extract(tc);
         tc = cleanedTc;
@@ -529,20 +560,26 @@ internal static class SessionToolExecutionPipeline
             });
         }
 
+        modelInputBudget ??= new ModelInputBatchBudget(MaxModelInputBatchBytes);
+        var modelInputMaterialization = MaterializeModelInputFiles(context, sessionDir, logger, modelInputBudget);
         resultText = ClampToolResult(resultText, maxInlineToolResultChars);
-        var modelInputMediaReferences = MaterializeModelInputFiles(context, sessionDir, logger);
+        if (modelInputMaterialization.RequestedCount > modelInputMaterialization.MediaReferences.Count)
+            resultText = AppendModelInputHandoffWarning(
+                resultText,
+                modelInputMaterialization.RequestedCount - modelInputMaterialization.MediaReferences.Count);
 
         var message = new SerializableChatMessage
         {
             Role = Protocol.ChatRole.Tool,
             Content = resultText,
             ToolCallId = new ToolCallId(tc.CallId),
-            Name = tc.Name
+            Name = tc.Name,
+            MediaReferences = modelInputMaterialization.MediaReferences
         };
 
         return new ToolCallResult(
             message,
-            modelInputMediaReferences,
+            modelInputMaterialization.MediaReferences,
             context.FileAttachments,
             completedRuns,
             acceptedFindings);
@@ -757,21 +794,31 @@ internal static class SessionToolExecutionPipeline
         }
     }
 
-    private static IReadOnlyList<SerializableMediaReference> MaterializeModelInputFiles(
+    internal static ModelInputMaterializationResult MaterializeModelInputFiles(
         ToolExecutionContext context,
         string sessionDir,
-        ILogger? logger)
+        ILogger? logger,
+        ModelInputBatchBudget? batchBudget = null)
     {
         if (context.ModelInputFiles.Count == 0)
-            return [];
+            return new ModelInputMaterializationResult([], 0);
 
         var mediaDir = Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory);
-        Directory.CreateDirectory(mediaDir);
+        try
+        {
+            Directory.CreateDirectory(mediaDir);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger?.LogWarning(ex, "Failed to create model input media directory: {Path}", mediaDir);
+            return new ModelInputMaterializationResult([], context.ModelInputFiles.Count);
+        }
 
         var refs = new List<SerializableMediaReference>(context.ModelInputFiles.Count);
-        var totalBytes = 0L;
+        batchBudget ??= new ModelInputBatchBudget(MaxModelInputBatchBytes);
         foreach (var file in context.ModelInputFiles)
         {
+            var reservedBytes = 0L;
             try
             {
                 // Treat tool-registered model input as a request, not proof it
@@ -802,7 +849,10 @@ internal static class SessionToolExecutionPipeline
 
                 var info = new FileInfo(file.FilePath);
                 if (info.Length <= 0)
+                {
+                    logger?.LogWarning("Model input file is empty, skipping: {Path}", file.FilePath);
                     continue;
+                }
 
                 if (info.Length > MaxModelInputFileBytes)
                 {
@@ -810,17 +860,21 @@ internal static class SessionToolExecutionPipeline
                     continue;
                 }
 
-                if (totalBytes + info.Length > MaxModelInputBatchBytes)
+                if (!batchBudget.TryReserve(info.Length))
                 {
                     logger?.LogWarning("Model input file would exceed batch size limit, skipping: {Path}", file.FilePath);
                     continue;
                 }
+
+                reservedBytes = info.Length;
 
                 if (!IsFileMagicCompatible(file.FilePath, mimeType))
                 {
                     logger?.LogWarning(
                         "Model input file MIME type does not match detected bytes, skipping: {Path}",
                         file.FilePath);
+                    batchBudget.Release(reservedBytes);
+                    reservedBytes = 0;
                     continue;
                 }
 
@@ -829,7 +883,6 @@ internal static class SessionToolExecutionPipeline
                 var fullPath = Path.Combine(mediaDir, fileName);
 
                 File.Copy(file.FilePath, fullPath);
-                totalBytes += info.Length;
 
                 refs.Add(new SerializableMediaReference
                 {
@@ -841,11 +894,20 @@ internal static class SessionToolExecutionPipeline
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
+                if (reservedBytes > 0)
+                    batchBudget.Release(reservedBytes);
                 logger?.LogWarning(ex, "Failed to materialize model input file: {Path}", file.FilePath);
             }
         }
 
-        return refs;
+        return new ModelInputMaterializationResult(refs, context.ModelInputFiles.Count);
+    }
+
+    internal static string AppendModelInputHandoffWarning(string resultText, int failedCount)
+    {
+        var itemText = failedCount == 1 ? "file" : "files";
+        return resultText +
+               $"\n[model input media handoff warning: {failedCount} registered media {itemText} could not be attached to the next LLM call]";
     }
 
     private static string NormalizeModelInputMime(string? mimeType)
@@ -883,8 +945,16 @@ internal static class SessionToolExecutionPipeline
     {
         Span<byte> header = stackalloc byte[64];
         using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-        var read = stream.Read(header);
-        var detected = MagicByteValidator.DetectMimeType(header[..read]);
+        var totalRead = 0;
+        while (totalRead < header.Length)
+        {
+            var read = stream.Read(header[totalRead..]);
+            if (read == 0)
+                break;
+            totalRead += read;
+        }
+
+        var detected = MagicByteValidator.DetectMimeType(header[..totalRead]);
         return string.Equals(detected, mimeType, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -23,6 +23,7 @@ namespace Netclaw.Actors.Sessions.Pipelines;
 /// </summary>
 internal sealed record ToolCallResult(
     SerializableChatMessage Message,
+    IReadOnlyList<SerializableMediaReference> ModelInputMediaReferences,
     IReadOnlyList<FileAttachmentInfo> FileAttachments,
     IReadOnlyList<CompletedSubAgentRun> CompletedSubAgentRuns,
     IReadOnlyList<AcceptedSubAgentFinding> AcceptedSubAgentFindings);
@@ -56,6 +57,7 @@ internal static class SessionToolExecutionPipeline
         string? projectDirectory = null,
         bool setWorkingDirectoryAvailable = false,
         bool streamToolResults = false,
+        ModelModality modelInputModalities = ModelModality.Text,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? oneTimeApprovalPreSeed = null,
         IReadOnlyDictionary<string, ApprovalDecision>? decisionOverride = null,
         TurnContext? turnContext = null,
@@ -91,6 +93,7 @@ internal static class SessionToolExecutionPipeline
                     backgroundJobManager,
                     projectDirectory,
                     setWorkingDirectoryAvailable,
+                    modelInputModalities,
                     oneTimeApprovalPreSeed is not null
                     && oneTimeApprovalPreSeed.TryGetValue(tc.CallId, out var preSeedPatterns)
                         ? preSeedPatterns
@@ -112,9 +115,11 @@ internal static class SessionToolExecutionPipeline
             }
 
             var fileAttachments = results.SelectMany(r => r.FileAttachments).ToList();
+            var modelInputMediaReferences = results.SelectMany(r => r.ModelInputMediaReferences).ToList();
             self.Tell(new ToolExecutionCompleted
             {
                 ToolResults = [.. results.Select(r => r.Message)],
+                ModelInputMediaReferences = modelInputMediaReferences,
                 FileAttachments = fileAttachments,
                 CompletedSubAgentRuns = [.. results.SelectMany(r => r.CompletedSubAgentRuns)],
                 AcceptedSubAgentFindings = [.. results.SelectMany(r => r.AcceptedSubAgentFindings)]
@@ -161,6 +166,7 @@ internal static class SessionToolExecutionPipeline
         IActorRef? backgroundJobManager = null,
         string? projectDirectory = null,
         bool setWorkingDirectoryAvailable = false,
+        ModelModality modelInputModalities = ModelModality.Text,
         IReadOnlyList<string>? oneTimeApprovalPreSeed = null,
         ApprovalDecision? decisionOverride = null,
         TurnContext? turnContext = null)
@@ -182,7 +188,8 @@ internal static class SessionToolExecutionPipeline
             sessionDir,
             spawnChildActor,
             projectDirectory,
-            turnContext);
+            turnContext,
+            modelInputModalities);
         context.RequestedTimeoutSeconds = (int)timeout.TotalSeconds;
 
         // Re-drive of an ApprovedOnce approval: the user already clicked
@@ -305,7 +312,7 @@ internal static class SessionToolExecutionPipeline
                     Name = tc.Name
                 };
 
-                return new ToolCallResult(deniedMessage, [], [], []);
+                return new ToolCallResult(deniedMessage, [], [], [], []);
             }
 
             if (meta is { Background: true })
@@ -369,7 +376,7 @@ internal static class SessionToolExecutionPipeline
                     Content = ClampToolResult(resultText, maxInlineToolResultChars),
                     ToolCallId = new ToolCallId(tc.CallId),
                     Name = tc.Name
-                }, context.FileAttachments, completedRuns, acceptedFindings);
+                }, [], context.FileAttachments, completedRuns, acceptedFindings);
             }
 
             // Mid-turn approval pause: emit request to channel, block on TCS
@@ -519,6 +526,7 @@ internal static class SessionToolExecutionPipeline
         }
 
         resultText = ClampToolResult(resultText, maxInlineToolResultChars);
+        var modelInputMediaReferences = MaterializeModelInputFiles(context, sessionDir, logger);
 
         var message = new SerializableChatMessage
         {
@@ -530,6 +538,7 @@ internal static class SessionToolExecutionPipeline
 
         return new ToolCallResult(
             message,
+            modelInputMediaReferences,
             context.FileAttachments,
             completedRuns,
             acceptedFindings);
@@ -667,7 +676,7 @@ internal static class SessionToolExecutionPipeline
                 ToolCallId = new ToolCallId(tc.CallId),
                 Name = tc.Name
             };
-            return new ToolCallResult(message, [], [], []);
+            return new ToolCallResult(message, [], [], [], []);
         }
 
         // A background job inherits the submitting turn's authority context.
@@ -719,7 +728,7 @@ internal static class SessionToolExecutionPipeline
                 ToolCallId = new ToolCallId(tc.CallId),
                 Name = tc.Name
             };
-            return new ToolCallResult(resultMessage, [], [], []);
+            return new ToolCallResult(resultMessage, [], [], [], []);
         }
         catch (Exception ex)
         {
@@ -740,8 +749,57 @@ internal static class SessionToolExecutionPipeline
                 ToolCallId = new ToolCallId(tc.CallId),
                 Name = tc.Name
             };
-            return new ToolCallResult(errorMessage, [], [], []);
+            return new ToolCallResult(errorMessage, [], [], [], []);
         }
+    }
+
+    private static IReadOnlyList<SerializableMediaReference> MaterializeModelInputFiles(
+        ToolExecutionContext context,
+        string sessionDir,
+        ILogger? logger)
+    {
+        if (context.ModelInputFiles.Count == 0)
+            return [];
+
+        var mediaDir = Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory);
+        Directory.CreateDirectory(mediaDir);
+
+        var refs = new List<SerializableMediaReference>(context.ModelInputFiles.Count);
+        foreach (var file in context.ModelInputFiles)
+        {
+            try
+            {
+                if (!File.Exists(file.FilePath))
+                {
+                    logger?.LogWarning("Model input file not found, skipping: {Path}", file.FilePath);
+                    continue;
+                }
+
+                var info = new FileInfo(file.FilePath);
+                if (info.Length <= 0)
+                    continue;
+
+                var ext = ChatMessageConverter.MimeToExtension(file.MimeType);
+                var fileName = $"{Guid.NewGuid():N}{ext}";
+                var fullPath = Path.Combine(mediaDir, fileName);
+
+                File.Copy(file.FilePath, fullPath);
+
+                refs.Add(new SerializableMediaReference
+                {
+                    RelativePath = fileName,
+                    MimeType = new Netclaw.Security.MimeType(file.MimeType),
+                    Modality = (int)ChatMessageConverter.MimeToModality(file.MimeType),
+                    FileSizeBytes = info.Length
+                });
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger?.LogWarning(ex, "Failed to materialize model input file: {Path}", file.FilePath);
+            }
+        }
+
+        return refs;
     }
 
     private static ToolExecutionContext BuildToolExecutionContext(
@@ -750,7 +808,8 @@ internal static class SessionToolExecutionPipeline
         string sessionDir,
         Func<object, string, CancellationToken, Task<object>> spawnChildActor,
         string? projectDirectory,
-        TurnContext? turnContext)
+        TurnContext? turnContext,
+        ModelModality modelInputModalities)
     {
         // A turn with no authority context carries no trust context — fall closed
         // to the most-restrictive audience. The default is resolved once, here,
@@ -763,7 +822,8 @@ internal static class SessionToolExecutionPipeline
         context.ChannelType = turnContext?.ChannelType?.ToWireValue()
                               ?? (source is null ? null : source.ChannelType.ToWireValue());
         context.SupportsInteractiveApproval = turnContext?.SupportsInteractiveApproval
-                                              ?? source?.ChannelType.SupportsInteractiveApproval();
+                                               ?? source?.ChannelType.SupportsInteractiveApproval();
+        context.ModelInputModalities = modelInputModalities;
         context.SpawnChildActor = spawnChildActor;
         context.ProjectDirectory = projectDirectory;
         return context;

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -219,9 +219,12 @@ public sealed record SessionState
     /// treats them as the most recent input. Not persisted as a turn — just
     /// injected into the conversation to guide the next LLM call.
     /// </summary>
-    public SessionState AddSystemNudge(string nudge)
+    public SessionState AddSystemNudge(
+        string nudge,
+        IReadOnlyList<SerializableMediaReference>? mediaReferences = null)
     {
-        return this with { History = History.Add(BuildNudgeMessage(nudge)) };
+        var message = BuildNudgeMessage(nudge, mediaReferences);
+        return this with { History = History.Add(message) };
     }
 
     /// <summary>
@@ -264,8 +267,17 @@ public sealed record SessionState
         return this with { History = History.Add(nudgeMsg) };
     }
 
-    private static SerializableChatMessage BuildNudgeMessage(string nudge) =>
-        new() { Role = ChatRole.User, Content = $"{SystemNudgePrefix} {nudge}]" };
+    private static SerializableChatMessage BuildNudgeMessage(
+        string nudge,
+        IReadOnlyList<SerializableMediaReference>? mediaReferences = null) =>
+        mediaReferences is { Count: > 0 }
+            ? new()
+            {
+                Role = ChatRole.User,
+                Content = $"{SystemNudgePrefix} {nudge}]",
+                MediaReferences = mediaReferences
+            }
+            : new() { Role = ChatRole.User, Content = $"{SystemNudgePrefix} {nudge}]" };
 
     /// <summary>
     /// Find the last user message in history (for building persistence events).

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -10,9 +10,11 @@ using System.Threading.Channels;
 using Akka.Actor;
 using Akka.Event;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Handlers;
+using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Actors.Tools;
 using Netclaw.Actors.Memory;
 using Netclaw.Configuration;
@@ -214,6 +216,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             };
             _toolExecutionContext.Boundary = msg.Boundary;
             _toolExecutionContext.ChannelType = msg.ChannelType;
+            _toolExecutionContext.ModelInputModalities = msg.ModelInputModalities;
             _toolExecutionContext.ProjectDirectory = msg.ParentProjectDirectory;
             _toolExecutionContext.SupportsInteractiveApproval = _approvalBridge is not null;
             _aiTools = ResolveExposedAiTools();
@@ -357,6 +360,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 _log.Info("SubAgent [{AgentName}] tool [{ToolName}] result: {Result}",
                     _definition.Name, result.Name ?? "unknown", SecretOutputRedactor.Redact(preview));
             }
+
+            AddModelInputMediaNudge(msg.ModelInputMediaReferences);
 
             var budgetStatus = _turnState.RecordToolCompletion(msg.ToolResults.Count, _maxToolIterations);
             var dupNudge = _turnState.CheckForDuplicates();
@@ -684,6 +689,22 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, $"[system: {nudge}]"));
     }
 
+    private void AddModelInputMediaNudge(IReadOnlyList<SerializableMediaReference> mediaReferences)
+    {
+        if (mediaReferences.Count == 0)
+            return;
+
+        var itemText = mediaReferences.Count == 1 ? "file" : "files";
+        var message = new SerializableChatMessage
+        {
+            Role = Protocol.ChatRole.User,
+            Content = $"[system: A tool loaded {mediaReferences.Count} media {itemText} for model-visible inspection. " +
+                      "Use the attached media along with the tool result to complete the delegated task.]",
+            MediaReferences = mediaReferences
+        };
+        _history.Add(ChatMessageConverter.ToAiMessage(message, _toolExecutionContext.SessionDirectory));
+    }
+
     /// <summary>
     /// Compose the initial user message for the subagent. When <paramref name="runtimeContext"/>
     /// is present, prefixes a <c>Context:</c> block ahead of the <c>Task:</c> block so the
@@ -944,19 +965,14 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     {
         try
         {
+            var modelInputBudget = new ModelInputBatchBudget(ChannelAttachmentPolicy.DefaultMaxFileBytes);
             var tasks = toolCalls.Select(async tc =>
             {
                 var toolContext = CreatePerToolExecutionContext(executionContext);
                 try
                 {
                     var result = await executor.ExecuteAsync(tc, toolContext, ct);
-                    return new SerializableChatMessage
-                    {
-                        Role = Protocol.ChatRole.Tool,
-                        Content = result,
-                        ToolCallId = new ToolCallId(tc.CallId),
-                        Name = tc.Name
-                    };
+                    return BuildToolResult(tc, result, toolContext, modelInputBudget);
                 }
                 catch (ToolApprovalRequiredException approvalEx)
                     when (approvalBridge is not null)
@@ -1010,25 +1026,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         retryContext.SetOneTimeApprovedPatterns(ctx.Patterns);
 
                         var result = await executor.ExecuteAsync(tc, retryContext, ct);
-                        return new SerializableChatMessage
-                        {
-                            Role = Protocol.ChatRole.Tool,
-                            Content = result,
-                            ToolCallId = new ToolCallId(tc.CallId),
-                            Name = tc.Name
-                        };
+                        return BuildToolResult(tc, result, retryContext, modelInputBudget);
                     }
 
                     var reason = decision == ParentApprovalDecision.TimedOut
                         ? "Tool access denied: approval_timed_out"
                         : "Tool access denied: approval_denied_by_user";
-                    return new SerializableChatMessage
-                    {
-                        Role = Protocol.ChatRole.Tool,
-                        Content = reason,
-                        ToolCallId = new ToolCallId(tc.CallId),
-                        Name = tc.Name
-                    };
+                    return BuildToolResult(tc, reason, toolContext, modelInputBudget);
                 }
                 catch (ToolApprovalRequiredException)
                 {
@@ -1054,20 +1058,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (Exception ex)
                 {
-                    return new SerializableChatMessage
-                    {
-                        Role = Protocol.ChatRole.Tool,
-                        Content = $"Error: {ex.Message}",
-                        ToolCallId = new ToolCallId(tc.CallId),
-                        Name = tc.Name
-                    };
+                    return BuildToolResult(tc, $"Error: {ex.Message}", toolContext, modelInputBudget);
                 }
             });
 
             var results = await Task.WhenAll(tasks);
             self.Tell(new ToolExecutionCompleted
             {
-                ToolResults = [.. results]
+                ToolResults = [.. results.Select(r => r.Message)],
+                ModelInputMediaReferences = [.. results.SelectMany(r => r.ModelInputMediaReferences)]
             });
         }
         catch (Exception ex)
@@ -1083,6 +1082,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             Boundary = source.Boundary,
             RequestedTimeoutSeconds = source.RequestedTimeoutSeconds,
             ChannelType = source.ChannelType,
+            ModelInputModalities = source.ModelInputModalities,
             ProjectDirectory = source.ProjectDirectory,
             InheritedCwd = source.InheritedCwd,
             SupportsInteractiveApproval = source.SupportsInteractiveApproval,
@@ -1090,6 +1090,52 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             SpawnChildActor = source.SpawnChildActor,
             ApprovalBridge = source.ApprovalBridge
         };
+
+    private static SubAgentToolCallResult BuildToolResult(
+        FunctionCallContent toolCall,
+        string resultText,
+        ToolExecutionContext toolContext,
+        ModelInputBatchBudget modelInputBudget)
+    {
+        var materialization = MaterializeModelInputFiles(toolContext, modelInputBudget);
+        if (materialization.RequestedCount > materialization.MediaReferences.Count)
+        {
+            resultText = SessionToolExecutionPipeline.AppendModelInputHandoffWarning(
+                resultText,
+                materialization.RequestedCount - materialization.MediaReferences.Count);
+        }
+
+        return new SubAgentToolCallResult(
+            new SerializableChatMessage
+            {
+                Role = Protocol.ChatRole.Tool,
+                Content = resultText,
+                ToolCallId = new ToolCallId(toolCall.CallId),
+                Name = toolCall.Name
+            },
+            materialization.MediaReferences);
+    }
+
+    private static ModelInputMaterializationResult MaterializeModelInputFiles(
+        ToolExecutionContext toolContext,
+        ModelInputBatchBudget modelInputBudget)
+    {
+        if (toolContext.ModelInputFiles.Count == 0)
+            return new ModelInputMaterializationResult([], 0);
+
+        if (string.IsNullOrWhiteSpace(toolContext.SessionDirectory))
+            return new ModelInputMaterializationResult([], toolContext.ModelInputFiles.Count);
+
+        return SessionToolExecutionPipeline.MaterializeModelInputFiles(
+            toolContext,
+            toolContext.SessionDirectory,
+            logger: null,
+            modelInputBudget);
+    }
+
+    private sealed record SubAgentToolCallResult(
+        SerializableChatMessage Message,
+        IReadOnlyList<SerializableMediaReference> ModelInputMediaReferences);
 
     private static string BuildSystemPrompt(SubAgentDefinition definition)
     {

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -85,6 +85,12 @@ public sealed record RunSubAgent : INoSerializationVerificationNeeded
     public string? ChannelType { get; init; }
 
     /// <summary>
+    /// Input modalities supported by the model selected for this sub-agent run.
+    /// Tools use this to decide whether model-visible media handoff is allowed.
+    /// </summary>
+    public ModelModality ModelInputModalities { get; init; } = ModelModality.Text;
+
+    /// <summary>
     /// Parent session's session directory snapshot when the subagent was spawned.
     /// </summary>
     public string? ParentSessionDirectory { get; init; }

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -140,6 +140,7 @@ public sealed class SubAgentSpawner
                     Audience = context.Audience,
                     Boundary = context.Boundary,
                     ChannelType = context.ChannelType,
+                    ModelInputModalities = context.ModelInputModalities,
                     ParentSessionDirectory = context.SessionDirectory,
                     ParentProjectDirectory = context.ProjectDirectory,
                     ParentCwd = context.ResolveShellCwd(null),

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -85,7 +85,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
 
         var rawFilename = args.DisplayName ?? Path.GetFileName(attachPath);
         var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
-        var mimeType = GuessMimeType(attachPath);
+        var mimeType = MimeTypeCatalog.FromPathExtension(attachPath) ?? MimeTypeCatalog.ApplicationOctetStream;
 
         context.AddFileAttachment(attachPath, sanitizedFilename, mimeType);
         var copiedText = string.Equals(attachPath, resolvedPath, StringComparison.Ordinal)
@@ -141,26 +141,4 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         return destination;
     }
 
-    private static string GuessMimeType(string path)
-    {
-        var ext = Path.GetExtension(path).ToLowerInvariant();
-        return ext switch
-        {
-            ".png" => "image/png",
-            ".jpg" or ".jpeg" => "image/jpeg",
-            ".gif" => "image/gif",
-            ".webp" => "image/webp",
-            ".svg" => "image/svg+xml",
-            ".pdf" => "application/pdf",
-            ".txt" => "text/plain",
-            ".json" => "application/json",
-            ".csv" => "text/csv",
-            ".md" => "text/markdown",
-            ".html" or ".htm" => "text/html",
-            ".mp3" => "audio/mpeg",
-            ".wav" => "audio/wav",
-            ".mp4" => "video/mp4",
-            _ => "application/octet-stream"
-        };
-    }
 }

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -16,7 +16,7 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Reads UTF-8 text files and inspects non-text files without returning raw bytes.
+/// Reads text files and inspects non-text files without returning raw bytes.
 /// </summary>
 [NetclawTool(ToolName,
     "Read text files or inspect non-text files. Images can be loaded for visual inspection when the active model supports image input; PDFs/media/archives return metadata and guidance. For large text files, use Offset and Limit to read sections.",
@@ -26,6 +26,11 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     public const string ToolName = "file_read";
     private const long MaxModelInputFileBytes = ChannelAttachmentPolicy.DefaultMaxFileBytes;
     private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly Encoding StrictUtf16Le = new UnicodeEncoding(bigEndian: false, byteOrderMark: true, throwOnInvalidBytes: true);
+    private static readonly Encoding StrictUtf16Be = new UnicodeEncoding(bigEndian: true, byteOrderMark: true, throwOnInvalidBytes: true);
+    private static readonly Encoding StrictUtf32Le = new UTF32Encoding(bigEndian: false, byteOrderMark: true, throwOnInvalidCharacters: true);
+    private static readonly Encoding StrictUtf32Be = new UTF32Encoding(bigEndian: true, byteOrderMark: true, throwOnInvalidCharacters: true);
+    private static readonly Encoding Windows1252 = new Windows1252Encoding();
 
     private readonly ToolConfig _config;
     private readonly ToolPathPolicy? _pathPolicy;
@@ -82,23 +87,25 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             if (!inspection.IsTextLike)
                 return HandleNonTextFile(authorizedPath, inspection, context);
 
+            var encoding = inspection.TextEncoding ?? StrictUtf8;
             if (offset.HasValue || limit.HasValue)
             {
-                var lines = await ReadLinesAsync(authorizedPath, offset ?? 1, limit, _config.MaxOutputChars, ct);
+                var lines = await ReadLinesAsync(authorizedPath, encoding, offset ?? 1, limit, _config.MaxOutputChars, ct);
                 RecordSkillReadIfApplicable(authorizedPath);
                 return lines;
             }
 
-            var content = await File.ReadAllTextAsync(authorizedPath, StrictUtf8, ct);
+            var content = await File.ReadAllTextAsync(authorizedPath, encoding, ct);
             RecordSkillReadIfApplicable(authorizedPath);
             return TruncateFileOutput(content, _config.MaxOutputChars);
         }
         catch (DecoderFallbackException)
         {
+            var sizeBytes = TryGetFileLength(authorizedPath);
             return BuildMetadataResponse(
                 authorizedPath,
-                new FileInspection("application/octet-stream", AttachmentCategory.Other, new FileInfo(authorizedPath).Length, false),
-                "File is not valid UTF-8 text. Raw binary output is not returned by file_read.");
+                new FileInspection("application/octet-stream", AttachmentCategory.Other, sizeBytes, false, null),
+                "File is not valid in the detected text encoding. Raw binary output is not returned by file_read.");
         }
         catch (UnauthorizedAccessException)
         {
@@ -114,7 +121,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     {
         var info = new FileInfo(path);
         if (info.Length == 0)
-            return new FileInspection("text/plain", AttachmentCategory.Document, 0, true);
+            return new FileInspection("text/plain", AttachmentCategory.Document, 0, true, StrictUtf8);
 
         var sampleLength = (int)Math.Min(info.Length, 4096);
         var buffer = new byte[sampleLength];
@@ -127,20 +134,22 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
         var magicMime = MagicByteValidator.DetectMimeType(buffer.AsSpan(0, Math.Min(buffer.Length, 64)));
         var extensionMime = GuessMimeType(path);
-        var looksText = LooksLikeText(buffer);
-        var mimeType = ResolveMimeType(path, magicMime, extensionMime, looksText);
+        var textEncoding = DetectTextEncoding(buffer, extensionMime);
+        var looksText = textEncoding is not null;
+        var mimeType = ResolveMimeType(path, magicMime, extensionMime, textEncoding);
         var category = AttachmentCategories.FromMime(mimeType);
         var isTextLike = looksText && IsTextMime(mimeType);
 
-        return new FileInspection(mimeType, category, info.Length, isTextLike);
+        return new FileInspection(mimeType, category, info.Length, isTextLike, isTextLike ? textEncoding : null);
     }
 
     private static string ResolveMimeType(
         string path,
         string? magicMime,
         string? extensionMime,
-        bool looksText)
+        Encoding? textEncoding)
     {
+        var looksText = textEncoding is not null;
         // ZIP/OLE Office containers should be explained as documents, not as
         // generic archives or OLE blobs. The extension is only trusted after the
         // container signature proves this is the expected binary family.
@@ -149,6 +158,9 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
         if (IsOleBackedOfficeDocument(path)
             && string.Equals(magicMime, "application/x-ole-compound-document", StringComparison.OrdinalIgnoreCase))
+            return extensionMime!;
+
+        if (looksText && IsTextMime(extensionMime) && IsUtf16OrUtf32(textEncoding))
             return extensionMime!;
 
         if (magicMime is not null)
@@ -219,7 +231,149 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
                guidance;
     }
 
-    private static bool LooksLikeText(ReadOnlySpan<byte> sample)
+    private static Encoding? DetectTextEncoding(ReadOnlySpan<byte> sample, string? extensionMime)
+    {
+        if (sample.Length == 0)
+            return StrictUtf8;
+
+        if (TryDetectBomEncoding(sample, out var bomEncoding, out var bomLength))
+            return DecodedTextLooksLikeText(sample[bomLength..], bomEncoding) ? bomEncoding : null;
+
+        if (TryDetectUtf16WithoutBom(sample, out var utf16Encoding)
+            && DecodedTextLooksLikeText(sample, utf16Encoding))
+        {
+            return utf16Encoding;
+        }
+
+        if (RawTextControlsAreAcceptable(sample) && CanDecodeUtf8Sample(sample))
+            return StrictUtf8;
+
+        return IsTextMime(extensionMime)
+               && RawTextControlsAreAcceptable(sample)
+               && DecodedTextLooksLikeText(sample, Windows1252)
+            ? Windows1252
+            : null;
+    }
+
+    private static bool TryDetectBomEncoding(
+        ReadOnlySpan<byte> sample,
+        out Encoding encoding,
+        out int bomLength)
+    {
+        if (sample.Length >= 4)
+        {
+            if (sample[0] == 0xFF && sample[1] == 0xFE && sample[2] == 0x00 && sample[3] == 0x00)
+            {
+                encoding = StrictUtf32Le;
+                bomLength = 4;
+                return true;
+            }
+
+            if (sample[0] == 0x00 && sample[1] == 0x00 && sample[2] == 0xFE && sample[3] == 0xFF)
+            {
+                encoding = StrictUtf32Be;
+                bomLength = 4;
+                return true;
+            }
+        }
+
+        if (sample.Length >= 3 && sample[0] == 0xEF && sample[1] == 0xBB && sample[2] == 0xBF)
+        {
+            encoding = StrictUtf8;
+            bomLength = 3;
+            return true;
+        }
+
+        if (sample.Length >= 2)
+        {
+            if (sample[0] == 0xFF && sample[1] == 0xFE)
+            {
+                encoding = StrictUtf16Le;
+                bomLength = 2;
+                return true;
+            }
+
+            if (sample[0] == 0xFE && sample[1] == 0xFF)
+            {
+                encoding = StrictUtf16Be;
+                bomLength = 2;
+                return true;
+            }
+        }
+
+        encoding = StrictUtf8;
+        bomLength = 0;
+        return false;
+    }
+
+    private static bool TryDetectUtf16WithoutBom(ReadOnlySpan<byte> sample, out Encoding encoding)
+    {
+        var pairs = Math.Min(sample.Length / 2, 256);
+        if (pairs < 4)
+        {
+            encoding = StrictUtf8;
+            return false;
+        }
+
+        var evenNul = 0;
+        var oddNul = 0;
+        for (var i = 0; i < pairs * 2; i += 2)
+        {
+            if (sample[i] == 0)
+                evenNul++;
+            if (sample[i + 1] == 0)
+                oddNul++;
+        }
+
+        if (oddNul >= pairs / 2 && evenNul <= Math.Max(1, pairs / 20))
+        {
+            encoding = StrictUtf16Le;
+            return true;
+        }
+
+        if (evenNul >= pairs / 2 && oddNul <= Math.Max(1, pairs / 20))
+        {
+            encoding = StrictUtf16Be;
+            return true;
+        }
+
+        encoding = StrictUtf8;
+        return false;
+    }
+
+    private static bool CanDecodeUtf8Sample(ReadOnlySpan<byte> sample)
+    {
+        var decoder = StrictUtf8.GetDecoder();
+        var bytes = sample.ToArray();
+        var chars = new char[StrictUtf8.GetMaxCharCount(bytes.Length)];
+        try
+        {
+            decoder.Convert(bytes, 0, bytes.Length, chars, 0, chars.Length, flush: false, out _, out _, out _);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static bool DecodedTextLooksLikeText(ReadOnlySpan<byte> sample, Encoding encoding)
+    {
+        var decoder = encoding.GetDecoder();
+        var bytes = sample.ToArray();
+        var chars = new char[encoding.GetMaxCharCount(bytes.Length)];
+        try
+        {
+            decoder.Convert(bytes, 0, bytes.Length, chars, 0, chars.Length, flush: false, out _, out var charsUsed, out _);
+            return TextControlsAreAcceptable(chars.AsSpan(0, charsUsed));
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static bool RawTextControlsAreAcceptable(ReadOnlySpan<byte> sample)
     {
         if (sample.Length == 0)
             return true;
@@ -230,22 +384,29 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             if (b == 0)
                 return false;
 
-            if (b < 0x20 && b is not ((byte)'\n') and not ((byte)'\r') and not ((byte)'\t'))
+            if (b < 0x20 && b is not ((byte)'\n') and not ((byte)'\r') and not ((byte)'\t') and not 0x1B)
                 controlCount++;
         }
 
-        if (controlCount > Math.Max(1, sample.Length / 20))
-            return false;
+        return controlCount <= Math.Max(1, sample.Length / 20);
+    }
 
-        try
-        {
-            StrictUtf8.GetString(sample);
+    private static bool TextControlsAreAcceptable(ReadOnlySpan<char> sample)
+    {
+        if (sample.Length == 0)
             return true;
-        }
-        catch (DecoderFallbackException)
+
+        var controlCount = 0;
+        foreach (var c in sample)
         {
-            return false;
+            if (c == '\0')
+                return false;
+
+            if (char.IsControl(c) && c is not '\n' and not '\r' and not '\t' and not '\u001B')
+                controlCount++;
         }
+
+        return controlCount <= Math.Max(1, sample.Length / 20);
     }
 
     private static bool IsTextMime(string? mimeType)
@@ -264,6 +425,14 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             "application/yaml" => true,
             _ => false
         };
+    }
+
+    private static bool IsUtf16OrUtf32(Encoding? encoding)
+    {
+        return ReferenceEquals(encoding, StrictUtf16Le)
+               || ReferenceEquals(encoding, StrictUtf16Be)
+               || ReferenceEquals(encoding, StrictUtf32Le)
+               || ReferenceEquals(encoding, StrictUtf32Be);
     }
 
     private static bool RequiresBinarySignature(string? mimeType)
@@ -322,7 +491,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             ".ppt" => "application/vnd.ms-powerpoint",
             ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             ".rtf" => "application/rtf",
-            ".txt" => "text/plain",
+            ".txt" or ".log" => "text/plain",
             ".md" => "text/markdown",
             ".csv" => "text/csv",
             ".html" or ".htm" => "text/html",
@@ -358,13 +527,18 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     }
 
     private static async Task<string> ReadLinesAsync(
-        string path, int startLine, int? maxLines, int maxChars, CancellationToken ct)
+        string path,
+        Encoding encoding,
+        int startLine,
+        int? maxLines,
+        int maxChars,
+        CancellationToken ct)
     {
         var sb = new StringBuilder();
         var lineNumber = 0;
         var linesRead = 0;
 
-        using var reader = new StreamReader(path, StrictUtf8);
+        using var reader = new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true);
         while (await reader.ReadLineAsync(ct) is { } line)
         {
             lineNumber++;
@@ -390,7 +564,88 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         string MimeType,
         AttachmentCategory Category,
         long SizeBytes,
-        bool IsTextLike);
+        bool IsTextLike,
+        Encoding? TextEncoding);
+
+    private static long TryGetFileLength(string path)
+    {
+        try
+        {
+            return new FileInfo(path).Length;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return 0;
+        }
+    }
+
+    private sealed class Windows1252Encoding : Encoding
+    {
+        private static readonly char[] C1Map =
+        [
+            '\u20AC', '\u0081', '\u201A', '\u0192', '\u201E', '\u2026', '\u2020', '\u2021',
+            '\u02C6', '\u2030', '\u0160', '\u2039', '\u0152', '\u008D', '\u017D', '\u008F',
+            '\u0090', '\u2018', '\u2019', '\u201C', '\u201D', '\u2022', '\u2013', '\u2014',
+            '\u02DC', '\u2122', '\u0161', '\u203A', '\u0153', '\u009D', '\u017E', '\u0178'
+        ];
+
+        public override string WebName => "windows-1252";
+
+        public override int GetByteCount(char[] chars, int index, int count) => count;
+
+        public override int GetBytes(
+            char[] chars,
+            int charIndex,
+            int charCount,
+            byte[] bytes,
+            int byteIndex)
+        {
+            for (var i = 0; i < charCount; i++)
+                bytes[byteIndex + i] = EncodeChar(chars[charIndex + i]);
+
+            return charCount;
+        }
+
+        public override int GetCharCount(byte[] bytes, int index, int count) => count;
+
+        public override int GetChars(
+            byte[] bytes,
+            int byteIndex,
+            int byteCount,
+            char[] chars,
+            int charIndex)
+        {
+            for (var i = 0; i < byteCount; i++)
+                chars[charIndex + i] = DecodeByte(bytes[byteIndex + i]);
+
+            return byteCount;
+        }
+
+        public override int GetMaxByteCount(int charCount) => charCount;
+
+        public override int GetMaxCharCount(int byteCount) => byteCount;
+
+        private static char DecodeByte(byte b)
+        {
+            return b is >= 0x80 and <= 0x9F
+                ? C1Map[b - 0x80]
+                : (char)b;
+        }
+
+        private static byte EncodeChar(char c)
+        {
+            if (c <= 0x7F || c is >= '\u00A0' and <= '\u00FF')
+                return (byte)c;
+
+            for (var i = 0; i < C1Map.Length; i++)
+            {
+                if (C1Map[i] == c)
+                    return (byte)(0x80 + i);
+            }
+
+            return (byte)'?';
+        }
+    }
 
     private void RecordSkillReadIfApplicable(string authorizedPath)
     {

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -6,6 +6,7 @@
 using System.ComponentModel;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Skills;
 using Netclaw.Actors.Telemetry;
 using Netclaw.Configuration;
@@ -15,14 +16,16 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Reads file contents as UTF-8 text with optional line offset/limit.
+/// Reads UTF-8 text files and inspects non-text files without returning raw bytes.
 /// </summary>
 [NetclawTool(ToolName,
-    "Read the contents of a file as text. For large files, use Offset and Limit to read sections to avoid truncation. If output is truncated, the response includes the Offset value to use to continue reading.",
+    "Read text files or inspect non-text files. Images can be loaded for visual inspection when the active model supports image input; PDFs/media/archives return metadata and guidance. For large text files, use Offset and Limit to read sections.",
     Grant = "file")]
 public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 {
     public const string ToolName = "file_read";
+    private const long MaxModelInputFileBytes = ChannelAttachmentPolicy.DefaultMaxFileBytes;
+    private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     private readonly ToolConfig _config;
     private readonly ToolPathPolicy? _pathPolicy;
@@ -75,6 +78,10 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
         try
         {
+            var inspection = await InspectFileAsync(authorizedPath, ct);
+            if (!inspection.IsTextLike)
+                return HandleNonTextFile(authorizedPath, inspection, context);
+
             if (offset.HasValue || limit.HasValue)
             {
                 var lines = await ReadLinesAsync(authorizedPath, offset ?? 1, limit, _config.MaxOutputChars, ct);
@@ -82,9 +89,16 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
                 return lines;
             }
 
-            var content = await File.ReadAllTextAsync(authorizedPath, Encoding.UTF8, ct);
+            var content = await File.ReadAllTextAsync(authorizedPath, StrictUtf8, ct);
             RecordSkillReadIfApplicable(authorizedPath);
             return TruncateFileOutput(content, _config.MaxOutputChars);
+        }
+        catch (DecoderFallbackException)
+        {
+            return BuildMetadataResponse(
+                authorizedPath,
+                new FileInspection("application/octet-stream", AttachmentCategory.Other, new FileInfo(authorizedPath).Length, false),
+                "File is not valid UTF-8 text. Raw binary output is not returned by file_read.");
         }
         catch (UnauthorizedAccessException)
         {
@@ -95,6 +109,197 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             return $"Error reading file: {ex.Message}";
         }
     }
+
+    private static async Task<FileInspection> InspectFileAsync(string path, CancellationToken ct)
+    {
+        var info = new FileInfo(path);
+        if (info.Length == 0)
+            return new FileInspection("text/plain", AttachmentCategory.Document, 0, true);
+
+        var sampleLength = (int)Math.Min(info.Length, 4096);
+        var buffer = new byte[sampleLength];
+        await using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory(0, sampleLength), ct);
+            if (read < buffer.Length)
+                Array.Resize(ref buffer, read);
+        }
+
+        var magicMime = MagicByteValidator.DetectMimeType(buffer.AsSpan(0, Math.Min(buffer.Length, 64)));
+        var extensionMime = GuessMimeType(path);
+        var mimeType = ResolveMimeType(path, magicMime, extensionMime, buffer);
+        var category = AttachmentCategories.FromMime(mimeType);
+        var isTextLike = IsTextMime(mimeType) || (magicMime is null && LooksLikeText(buffer));
+
+        return new FileInspection(mimeType, category, info.Length, isTextLike);
+    }
+
+    private static string ResolveMimeType(
+        string path,
+        string? magicMime,
+        string? extensionMime,
+        ReadOnlySpan<byte> sample)
+    {
+        if (IsZipBackedOfficeDocument(path) && string.Equals(magicMime, "application/zip", StringComparison.OrdinalIgnoreCase))
+            return extensionMime!;
+
+        if (magicMime is not null)
+            return magicMime;
+
+        if (LooksLikeText(sample))
+            return IsTextMime(extensionMime) ? extensionMime! : "text/plain";
+
+        return extensionMime ?? "application/octet-stream";
+    }
+
+    private string HandleNonTextFile(
+        string authorizedPath,
+        FileInspection inspection,
+        ToolExecutionContext context)
+    {
+        var inlineImages = context.ModelInputModalities.HasFlag(ModelModality.Image);
+        var (inlined, note) = AttachmentInlineDecision.Resolve(inspection.Category, inlineImages);
+
+        if (inspection.Category == AttachmentCategory.Image && inlined)
+        {
+            if (inspection.SizeBytes > MaxModelInputFileBytes)
+            {
+                return BuildMetadataResponse(
+                    authorizedPath,
+                    inspection,
+                    $"Image exceeds the {FormatBytes(MaxModelInputFileBytes)} model-input handoff limit. Raw binary output is not returned by file_read.");
+            }
+
+            context.AddModelInputFile(authorizedPath, Path.GetFileName(authorizedPath), inspection.MimeType);
+            return BuildMetadataResponse(
+                authorizedPath,
+                inspection,
+                "Image loaded for model-visible inspection on the next LLM call.");
+        }
+
+        var guidance = inspection.Category switch
+        {
+            AttachmentCategory.Image => note ?? AttachmentNotes.ModelMissingImage,
+            AttachmentCategory.Pdf => "Native PDF extraction is not built into file_read. Use a configured document processor or shell_execute with a tool such as pdftotext where available.",
+            AttachmentCategory.Media => "Audio transcription and video keyframe extraction are not built into file_read. Use a configured media processor where available.",
+            AttachmentCategory.Archive => "Archive extraction is not built into file_read. Use a configured archive processor or shell_execute where available.",
+            AttachmentCategory.Document => "Binary document extraction is not built into file_read. Use a configured document processor where available.",
+            _ => "File is not readable as UTF-8 text. Raw binary output is not returned by file_read."
+        };
+
+        return BuildMetadataResponse(authorizedPath, inspection, guidance);
+    }
+
+    private static string BuildMetadataResponse(
+        string path,
+        FileInspection inspection,
+        string guidance)
+    {
+        return $"File is not readable as plain text.\n" +
+               $"Path: {path}\n" +
+               $"Type: {inspection.MimeType} ({inspection.Category})\n" +
+               $"Size: {FormatBytes(inspection.SizeBytes)}\n" +
+               guidance;
+    }
+
+    private static bool LooksLikeText(ReadOnlySpan<byte> sample)
+    {
+        if (sample.Length == 0)
+            return true;
+
+        var controlCount = 0;
+        foreach (var b in sample)
+        {
+            if (b == 0)
+                return false;
+
+            if (b < 0x20 && b is not ((byte)'\n') and not ((byte)'\r') and not ((byte)'\t'))
+                controlCount++;
+        }
+
+        if (controlCount > Math.Max(1, sample.Length / 20))
+            return false;
+
+        try
+        {
+            StrictUtf8.GetString(sample);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsTextMime(string? mimeType)
+    {
+        if (string.IsNullOrWhiteSpace(mimeType))
+            return false;
+
+        if (mimeType.StartsWith("text/", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return mimeType.ToLowerInvariant() switch
+        {
+            "application/json" => true,
+            "application/xml" => true,
+            "application/x-yaml" => true,
+            "application/yaml" => true,
+            _ => false
+        };
+    }
+
+    private static bool IsZipBackedOfficeDocument(string path)
+    {
+        return Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".docx" or ".xlsx" or ".pptx" or ".odt" or ".ods" or ".odp" => true,
+            _ => false
+        };
+    }
+
+    private static string? GuessMimeType(string path)
+    {
+        return Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".webp" => "image/webp",
+            ".svg" => "image/svg+xml",
+            ".pdf" => "application/pdf",
+            ".mp3" => "audio/mpeg",
+            ".wav" => "audio/wav",
+            ".ogg" => "audio/ogg",
+            ".mp4" => "video/mp4",
+            ".webm" => "video/webm",
+            ".zip" => "application/zip",
+            ".gz" => "application/gzip",
+            ".7z" => "application/x-7z-compressed",
+            ".doc" => "application/msword",
+            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ".xls" => "application/vnd.ms-excel",
+            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".ppt" => "application/vnd.ms-powerpoint",
+            ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ".rtf" => "application/rtf",
+            ".txt" => "text/plain",
+            ".md" => "text/markdown",
+            ".csv" => "text/csv",
+            ".html" or ".htm" => "text/html",
+            ".json" => "application/json",
+            ".xml" => "application/xml",
+            ".yml" or ".yaml" => "application/yaml",
+            _ => null
+        };
+    }
+
+    private static string FormatBytes(long size) => size switch
+    {
+        >= 1024L * 1024L => $"{size / (1024d * 1024d):F1} MiB",
+        >= 1024L => $"{size / 1024d:F1} KiB",
+        _ => $"{size} bytes"
+    };
 
     private static string TruncateFileOutput(string content, int maxChars)
     {
@@ -120,7 +325,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         var lineNumber = 0;
         var linesRead = 0;
 
-        using var reader = new StreamReader(path, Encoding.UTF8);
+        using var reader = new StreamReader(path, StrictUtf8);
         while (await reader.ReadLineAsync(ct) is { } line)
         {
             lineNumber++;
@@ -141,6 +346,12 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
         return sb.ToString();
     }
+
+    private sealed record FileInspection(
+        string MimeType,
+        AttachmentCategory Category,
+        long SizeBytes,
+        bool IsTextLike);
 
     private void RecordSkillReadIfApplicable(string authorizedPath)
     {

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -141,6 +141,9 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         string? extensionMime,
         bool looksText)
     {
+        // ZIP/OLE Office containers should be explained as documents, not as
+        // generic archives or OLE blobs. The extension is only trusted after the
+        // container signature proves this is the expected binary family.
         if (IsZipBackedOfficeDocument(path) && string.Equals(magicMime, "application/zip", StringComparison.OrdinalIgnoreCase))
             return extensionMime!;
 
@@ -154,6 +157,9 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         if (looksText)
             return IsTextMime(extensionMime) ? extensionMime! : "text/plain";
 
+        // Extensions are only hints. A binary file named `.json` or `.png`
+        // must stay metadata-only instead of leaking control bytes or spoofed
+        // media into a tool result / model input path.
         if (IsTextMime(extensionMime))
             return "application/octet-stream";
 

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -104,7 +104,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             var sizeBytes = TryGetFileLength(authorizedPath);
             return BuildMetadataResponse(
                 authorizedPath,
-                new FileInspection("application/octet-stream", AttachmentCategory.Other, sizeBytes, false, null),
+                new FileInspection(MimeTypeCatalog.ApplicationOctetStream, AttachmentCategory.Other, sizeBytes, false, null),
                 "File is not valid in the detected text encoding. Raw binary output is not returned by file_read.");
         }
         catch (UnauthorizedAccessException)
@@ -121,7 +121,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     {
         var info = new FileInfo(path);
         if (info.Length == 0)
-            return new FileInspection("text/plain", AttachmentCategory.Document, 0, true, StrictUtf8);
+            return new FileInspection(MimeTypeCatalog.TextPlain, AttachmentCategory.Document, 0, true, StrictUtf8);
 
         var sampleLength = (int)Math.Min(info.Length, 4096);
         var buffer = new byte[sampleLength];
@@ -133,12 +133,12 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         }
 
         var magicMime = MagicByteValidator.DetectMimeType(buffer.AsSpan(0, Math.Min(buffer.Length, 64)));
-        var extensionMime = GuessMimeType(path);
+        var extensionMime = MimeTypeCatalog.FromPathExtension(path);
         var textEncoding = DetectTextEncoding(buffer, extensionMime);
         var looksText = textEncoding is not null;
         var mimeType = ResolveMimeType(path, magicMime, extensionMime, textEncoding);
         var category = AttachmentCategories.FromMime(mimeType);
-        var isTextLike = looksText && IsTextMime(mimeType);
+        var isTextLike = looksText && MimeTypeCatalog.IsText(mimeType);
 
         return new FileInspection(mimeType, category, info.Length, isTextLike, isTextLike ? textEncoding : null);
     }
@@ -153,32 +153,33 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         // ZIP/OLE Office containers should be explained as documents, not as
         // generic archives or OLE blobs. The extension is only trusted after the
         // container signature proves this is the expected binary family.
-        if (IsZipBackedOfficeDocument(path) && string.Equals(magicMime, "application/zip", StringComparison.OrdinalIgnoreCase))
+        if (MimeTypeCatalog.IsZipBackedOfficePath(path)
+            && string.Equals(magicMime, MimeTypeCatalog.ApplicationZip, StringComparison.OrdinalIgnoreCase))
             return extensionMime!;
 
-        if (IsOleBackedOfficeDocument(path)
-            && string.Equals(magicMime, "application/x-ole-compound-document", StringComparison.OrdinalIgnoreCase))
+        if (MimeTypeCatalog.IsOleBackedOfficePath(path)
+            && string.Equals(magicMime, MimeTypeCatalog.ApplicationOleCompoundDocument, StringComparison.OrdinalIgnoreCase))
             return extensionMime!;
 
-        if (looksText && IsTextMime(extensionMime) && IsUtf16OrUtf32(textEncoding))
+        if (looksText && MimeTypeCatalog.IsText(extensionMime) && IsUtf16OrUtf32(textEncoding))
             return extensionMime!;
 
         if (magicMime is not null)
             return magicMime;
 
         if (looksText)
-            return IsTextMime(extensionMime) ? extensionMime! : "text/plain";
+            return MimeTypeCatalog.IsText(extensionMime) ? extensionMime! : MimeTypeCatalog.TextPlain;
 
         // Extensions are only hints. A binary file named `.json` or `.png`
         // must stay metadata-only instead of leaking control bytes or spoofed
         // media into a tool result / model input path.
-        if (IsTextMime(extensionMime))
-            return "application/octet-stream";
+        if (MimeTypeCatalog.IsText(extensionMime))
+            return MimeTypeCatalog.ApplicationOctetStream;
 
-        if (RequiresBinarySignature(extensionMime))
-            return "application/octet-stream";
+        if (MimeTypeCatalog.RequiresBinarySignature(extensionMime))
+            return MimeTypeCatalog.ApplicationOctetStream;
 
-        return extensionMime ?? "application/octet-stream";
+        return extensionMime ?? MimeTypeCatalog.ApplicationOctetStream;
     }
 
     private string HandleNonTextFile(
@@ -196,7 +197,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
                 return BuildMetadataResponse(
                     authorizedPath,
                     inspection,
-                    $"Image exceeds the {FormatBytes(MaxModelInputFileBytes)} model-input handoff limit. Raw binary output is not returned by file_read.");
+                    $"Image exceeds the {ByteSizeFormatter.Format(MaxModelInputFileBytes)} model-input handoff limit. Raw binary output is not returned by file_read.");
             }
 
             context.AddModelInputFile(authorizedPath, Path.GetFileName(authorizedPath), inspection.MimeType);
@@ -227,7 +228,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         return $"File is not readable as plain text.\n" +
                $"Path: {path}\n" +
                $"Type: {inspection.MimeType} ({inspection.Category})\n" +
-               $"Size: {FormatBytes(inspection.SizeBytes)}\n" +
+               $"Size: {ByteSizeFormatter.Format(inspection.SizeBytes)}\n" +
                guidance;
     }
 
@@ -248,7 +249,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         if (RawTextControlsAreAcceptable(sample) && CanDecodeUtf8Sample(sample))
             return StrictUtf8;
 
-        return IsTextMime(extensionMime)
+        return MimeTypeCatalog.IsText(extensionMime)
                && RawTextControlsAreAcceptable(sample)
                && DecodedTextLooksLikeText(sample, Windows1252)
             ? Windows1252
@@ -409,24 +410,6 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         return controlCount <= Math.Max(1, sample.Length / 20);
     }
 
-    private static bool IsTextMime(string? mimeType)
-    {
-        if (string.IsNullOrWhiteSpace(mimeType))
-            return false;
-
-        if (mimeType.StartsWith("text/", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        return mimeType.ToLowerInvariant() switch
-        {
-            "application/json" => true,
-            "application/xml" => true,
-            "application/x-yaml" => true,
-            "application/yaml" => true,
-            _ => false
-        };
-    }
-
     private static bool IsUtf16OrUtf32(Encoding? encoding)
     {
         return ReferenceEquals(encoding, StrictUtf16Le)
@@ -434,80 +417,6 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
                || ReferenceEquals(encoding, StrictUtf32Le)
                || ReferenceEquals(encoding, StrictUtf32Be);
     }
-
-    private static bool RequiresBinarySignature(string? mimeType)
-    {
-        if (string.IsNullOrWhiteSpace(mimeType))
-            return false;
-
-        return AttachmentCategories.FromMime(mimeType) is
-            AttachmentCategory.Image or
-            AttachmentCategory.Pdf or
-            AttachmentCategory.Document or
-            AttachmentCategory.Archive or
-            AttachmentCategory.Media;
-    }
-
-    private static bool IsZipBackedOfficeDocument(string path)
-    {
-        return Path.GetExtension(path).ToLowerInvariant() switch
-        {
-            ".docx" or ".xlsx" or ".pptx" or ".odt" or ".ods" or ".odp" => true,
-            _ => false
-        };
-    }
-
-    private static bool IsOleBackedOfficeDocument(string path)
-    {
-        return Path.GetExtension(path).ToLowerInvariant() switch
-        {
-            ".doc" or ".xls" or ".ppt" => true,
-            _ => false
-        };
-    }
-
-    private static string? GuessMimeType(string path)
-    {
-        return Path.GetExtension(path).ToLowerInvariant() switch
-        {
-            ".png" => "image/png",
-            ".jpg" or ".jpeg" => "image/jpeg",
-            ".gif" => "image/gif",
-            ".webp" => "image/webp",
-            ".svg" => "image/svg+xml",
-            ".pdf" => "application/pdf",
-            ".mp3" => "audio/mpeg",
-            ".wav" => "audio/wav",
-            ".ogg" => "audio/ogg",
-            ".mp4" => "video/mp4",
-            ".webm" => "video/webm",
-            ".zip" => "application/zip",
-            ".gz" => "application/gzip",
-            ".7z" => "application/x-7z-compressed",
-            ".doc" => "application/msword",
-            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            ".xls" => "application/vnd.ms-excel",
-            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            ".ppt" => "application/vnd.ms-powerpoint",
-            ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            ".rtf" => "application/rtf",
-            ".txt" or ".log" => "text/plain",
-            ".md" => "text/markdown",
-            ".csv" => "text/csv",
-            ".html" or ".htm" => "text/html",
-            ".json" => "application/json",
-            ".xml" => "application/xml",
-            ".yml" or ".yaml" => "application/yaml",
-            _ => null
-        };
-    }
-
-    private static string FormatBytes(long size) => size switch
-    {
-        >= 1024L * 1024L => $"{size / (1024d * 1024d):F1} MiB",
-        >= 1024L => $"{size / 1024d:F1} KiB",
-        _ => $"{size} bytes"
-    };
 
     private static string TruncateFileOutput(string content, int maxChars)
     {

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -127,9 +127,10 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
         var magicMime = MagicByteValidator.DetectMimeType(buffer.AsSpan(0, Math.Min(buffer.Length, 64)));
         var extensionMime = GuessMimeType(path);
-        var mimeType = ResolveMimeType(path, magicMime, extensionMime, buffer);
+        var looksText = LooksLikeText(buffer);
+        var mimeType = ResolveMimeType(path, magicMime, extensionMime, looksText);
         var category = AttachmentCategories.FromMime(mimeType);
-        var isTextLike = IsTextMime(mimeType) || (magicMime is null && LooksLikeText(buffer));
+        var isTextLike = looksText && IsTextMime(mimeType);
 
         return new FileInspection(mimeType, category, info.Length, isTextLike);
     }
@@ -138,16 +139,26 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         string path,
         string? magicMime,
         string? extensionMime,
-        ReadOnlySpan<byte> sample)
+        bool looksText)
     {
         if (IsZipBackedOfficeDocument(path) && string.Equals(magicMime, "application/zip", StringComparison.OrdinalIgnoreCase))
+            return extensionMime!;
+
+        if (IsOleBackedOfficeDocument(path)
+            && string.Equals(magicMime, "application/x-ole-compound-document", StringComparison.OrdinalIgnoreCase))
             return extensionMime!;
 
         if (magicMime is not null)
             return magicMime;
 
-        if (LooksLikeText(sample))
+        if (looksText)
             return IsTextMime(extensionMime) ? extensionMime! : "text/plain";
+
+        if (IsTextMime(extensionMime))
+            return "application/octet-stream";
+
+        if (RequiresBinarySignature(extensionMime))
+            return "application/octet-stream";
 
         return extensionMime ?? "application/octet-stream";
     }
@@ -249,11 +260,33 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         };
     }
 
+    private static bool RequiresBinarySignature(string? mimeType)
+    {
+        if (string.IsNullOrWhiteSpace(mimeType))
+            return false;
+
+        return AttachmentCategories.FromMime(mimeType) is
+            AttachmentCategory.Image or
+            AttachmentCategory.Pdf or
+            AttachmentCategory.Document or
+            AttachmentCategory.Archive or
+            AttachmentCategory.Media;
+    }
+
     private static bool IsZipBackedOfficeDocument(string path)
     {
         return Path.GetExtension(path).ToLowerInvariant() switch
         {
             ".docx" or ".xlsx" or ".pptx" or ".odt" or ".ods" or ".odp" => true,
+            _ => false
+        };
+    }
+
+    private static bool IsOleBackedOfficeDocument(string path)
+    {
+        return Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".doc" or ".xls" or ".ppt" => true,
             _ => false
         };
     }

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -153,10 +153,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             {
                 await EnsureInitializedAsync();
                 Become(Hydrating);
-                // Do NOT UnstashAll here. PerformHydration is already in the
-                // mailbox (sent from the RecoveryCompleted handler) and will be
-                // processed next by the Hydrating behavior. Stashed live
-                // inbounds stay stashed until Hydrating transitions to Active.
+                // RecoveryCompleted can beat pipeline initialization on slower
+                // dispatchers and get stashed here. Move it into Hydrating so
+                // one-shot hydration cannot strand the actor in startup; live
+                // inbounds are re-stashed by Hydrating until hydration finishes.
+                Stash.UnstashAll();
             }
             catch (Exception ex)
             {

--- a/src/Netclaw.Channels/AttachmentIngressFormatting.cs
+++ b/src/Netclaw.Channels/AttachmentIngressFormatting.cs
@@ -6,6 +6,7 @@
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using System.Text;
 
 namespace Netclaw.Channels;
@@ -69,13 +70,5 @@ public static class AttachmentIngressFormatting
         => AttachmentInlineDecision.Resolve(category, inlineImages);
 
     public static string FormatBytes(long size)
-    {
-        const long Mib = 1024 * 1024;
-        const long Kib = 1024;
-        if (size >= Mib)
-            return $"{size / (double)Mib:F1} MiB";
-        if (size >= Kib)
-            return $"{size / (double)Kib:F1} KiB";
-        return $"{size} bytes";
-    }
+        => ByteSizeFormatter.Format(size);
 }

--- a/src/Netclaw.Channels/AttachmentIngressFormatting.cs
+++ b/src/Netclaw.Channels/AttachmentIngressFormatting.cs
@@ -66,15 +66,7 @@ public static class AttachmentIngressFormatting
     public static (bool Inlined, string? Note) ResolveInlineDecision(
         AttachmentCategory category,
         bool inlineImages)
-    {
-        return category switch
-        {
-            AttachmentCategory.Image when inlineImages => (true, null),
-            AttachmentCategory.Image => (false, AttachmentNotes.ModelMissingImage),
-            AttachmentCategory.Pdf => (false, AttachmentNotes.ModelMissingPdf),
-            _ => (false, AttachmentNotes.FormatNotInlineable)
-        };
-    }
+        => AttachmentInlineDecision.Resolve(category, inlineImages);
 
     public static string FormatBytes(long size)
     {

--- a/src/Netclaw.Security/ByteSizeFormatter.cs
+++ b/src/Netclaw.Security/ByteSizeFormatter.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="ByteSizeFormatter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Security;
+
+public static class ByteSizeFormatter
+{
+    public static string Format(long size)
+    {
+        const long Mib = 1024 * 1024;
+        const long Kib = 1024;
+        if (size >= Mib)
+            return $"{size / (double)Mib:F1} MiB";
+        if (size >= Kib)
+            return $"{size / (double)Kib:F1} KiB";
+        return $"{size} bytes";
+    }
+}

--- a/src/Netclaw.Security/MimeTypeCatalog.cs
+++ b/src/Netclaw.Security/MimeTypeCatalog.cs
@@ -1,0 +1,172 @@
+// -----------------------------------------------------------------------
+// <copyright file="MimeTypeCatalog.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+
+namespace Netclaw.Security;
+
+public static class MimeTypeCatalog
+{
+    public const string ApplicationOctetStream = MimeType.DefaultValue;
+    public const string TextPlain = "text/plain";
+    public const string TextMarkdown = "text/markdown";
+    public const string TextCsv = "text/csv";
+    public const string TextHtml = "text/html";
+    public const string ApplicationJson = "application/json";
+    public const string ApplicationXml = "application/xml";
+    public const string ApplicationYaml = "application/yaml";
+    public const string ApplicationPdf = "application/pdf";
+    public const string ApplicationZip = "application/zip";
+    public const string ApplicationOleCompoundDocument = "application/x-ole-compound-document";
+    public const string ImagePng = "image/png";
+    public const string ImageJpeg = "image/jpeg";
+    public const string ImageGif = "image/gif";
+    public const string ImageWebp = "image/webp";
+
+    public static string Normalize(string? mimeType)
+    {
+        var normalized = string.IsNullOrWhiteSpace(mimeType)
+            ? ApplicationOctetStream
+            : mimeType.Trim();
+
+        var semicolon = normalized.IndexOf(';', StringComparison.Ordinal);
+        if (semicolon >= 0)
+            normalized = normalized[..semicolon].Trim();
+
+        return string.Equals(normalized, "image/jpg", StringComparison.OrdinalIgnoreCase)
+            ? ImageJpeg
+            : normalized.ToLowerInvariant();
+    }
+
+    public static bool IsText(string? mimeType)
+    {
+        if (string.IsNullOrWhiteSpace(mimeType))
+            return false;
+
+        var normalized = Normalize(mimeType);
+        if (normalized.StartsWith("text/", StringComparison.Ordinal))
+            return true;
+
+        return normalized is ApplicationJson
+            or ApplicationXml
+            or "application/x-yaml"
+            or ApplicationYaml;
+    }
+
+    public static bool RequiresBinarySignature(string? mimeType)
+    {
+        if (string.IsNullOrWhiteSpace(mimeType))
+            return false;
+
+        return AttachmentCategories.FromMime(Normalize(mimeType)) is
+            AttachmentCategory.Image or
+            AttachmentCategory.Pdf or
+            AttachmentCategory.Document or
+            AttachmentCategory.Archive or
+            AttachmentCategory.Media;
+    }
+
+    public static bool IsZipBackedOfficePath(string path)
+    {
+        return NormalizeExtension(Path.GetExtension(path)) switch
+        {
+            ".docx" or ".xlsx" or ".pptx" or ".odt" or ".ods" or ".odp" => true,
+            _ => false
+        };
+    }
+
+    public static bool IsOleBackedOfficePath(string path)
+    {
+        return NormalizeExtension(Path.GetExtension(path)) switch
+        {
+            ".doc" or ".xls" or ".ppt" => true,
+            _ => false
+        };
+    }
+
+    public static string? FromPathExtension(string path) => FromExtension(Path.GetExtension(path));
+
+    public static string? FromExtension(string? extension)
+    {
+        var ext = NormalizeExtension(extension);
+        if (ext.Length == 0)
+            return null;
+
+        return ext switch
+        {
+            ".png" => ImagePng,
+            ".jpg" or ".jpeg" => ImageJpeg,
+            ".gif" => ImageGif,
+            ".webp" => ImageWebp,
+            ".svg" => "image/svg+xml",
+            ".pdf" => ApplicationPdf,
+            ".mp3" => "audio/mpeg",
+            ".m4a" => "audio/x-m4a",
+            ".wav" => "audio/wav",
+            ".ogg" or ".oga" => "audio/ogg",
+            ".mp4" or ".m4v" => "video/mp4",
+            ".mov" => "video/quicktime",
+            ".webm" => "video/webm",
+            ".mkv" => "video/x-matroska",
+            ".avi" => "video/x-msvideo",
+            ".zip" => ApplicationZip,
+            ".gz" or ".tgz" => "application/gzip",
+            ".7z" => "application/x-7z-compressed",
+            ".bz2" => "application/x-bzip2",
+            ".xz" => "application/x-xz",
+            ".doc" => "application/msword",
+            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ".xls" => "application/vnd.ms-excel",
+            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".ppt" => "application/vnd.ms-powerpoint",
+            ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ".odt" => "application/vnd.oasis.opendocument.text",
+            ".ods" => "application/vnd.oasis.opendocument.spreadsheet",
+            ".odp" => "application/vnd.oasis.opendocument.presentation",
+            ".rtf" => "application/rtf",
+            ".txt" or ".log" => TextPlain,
+            ".md" or ".markdown" => TextMarkdown,
+            ".csv" => TextCsv,
+            ".html" or ".htm" => TextHtml,
+            ".json" => ApplicationJson,
+            ".xml" => ApplicationXml,
+            ".yml" or ".yaml" => ApplicationYaml,
+            _ => null
+        };
+    }
+
+    public static string ExtensionFor(string? mimeType)
+    {
+        return Normalize(mimeType) switch
+        {
+            ImagePng => ".png",
+            ImageJpeg => ".jpg",
+            ImageGif => ".gif",
+            ImageWebp => ".webp",
+            "image/svg+xml" => ".svg",
+            "audio/mpeg" => ".mp3",
+            "audio/mp4" or "audio/x-m4a" => ".m4a",
+            "audio/wav" or "audio/x-wav" => ".wav",
+            "audio/ogg" => ".ogg",
+            "video/mp4" => ".mp4",
+            "video/quicktime" => ".mov",
+            "video/webm" => ".webm",
+            "video/x-matroska" => ".mkv",
+            "video/x-msvideo" => ".avi",
+            _ => ".bin"
+        };
+    }
+
+    private static string NormalizeExtension(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return string.Empty;
+
+        var trimmed = extension.Trim();
+        return trimmed.StartsWith(".", StringComparison.Ordinal)
+            ? trimmed.ToLowerInvariant()
+            : "." + trimmed.ToLowerInvariant();
+    }
+}

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -8,6 +8,11 @@ using Netclaw.Configuration;
 namespace Netclaw.Tools;
 
 /// <summary>
+/// Describes a file a tool wants to add to the next LLM call as model input.
+/// </summary>
+public sealed record ModelInputFileInfo(string FilePath, string FileName, string MimeType);
+
+/// <summary>
 /// Describes a file attachment registered by a tool during execution.
 /// </summary>
 public sealed record FileAttachmentInfo(string FilePath, string FileName, string MimeType);
@@ -60,6 +65,7 @@ public sealed class ToolExecutionContext
     private static readonly IReadOnlySet<string> EmptyApprovedPatternSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     private List<FileAttachmentInfo>? _fileAttachments;
+    private List<ModelInputFileInfo>? _modelInputFiles;
     private HashSet<string>? _oneTimeApprovedPatterns;
 
     public ToolExecutionContext(string? sessionId, string? sessionDirectory)
@@ -92,6 +98,11 @@ public sealed class ToolExecutionContext
     /// When false, approval-gated tools are automatically denied.
     /// </summary>
     public bool? SupportsInteractiveApproval { get; set; }
+
+    /// <summary>
+    /// Modalities accepted by the active model for this tool call.
+    /// </summary>
+    public ModelModality ModelInputModalities { get; set; } = ModelModality.Text;
 
     /// <summary>
     /// Optional callback for tools that spawn subagents.
@@ -228,12 +239,27 @@ public sealed class ToolExecutionContext
         => _fileAttachments ?? (IReadOnlyList<FileAttachmentInfo>)[];
 
     /// <summary>
+    /// Files registered by tools for model-visible input on the next LLM call.
+    /// </summary>
+    public IReadOnlyList<ModelInputFileInfo> ModelInputFiles
+        => _modelInputFiles ?? (IReadOnlyList<ModelInputFileInfo>)[];
+
+    /// <summary>
     /// Register a file attachment to be emitted as <c>FileOutput</c> after tool execution.
     /// </summary>
     public void AddFileAttachment(string filePath, string fileName, string mimeType)
     {
         _fileAttachments ??= [];
         _fileAttachments.Add(new FileAttachmentInfo(filePath, fileName, mimeType));
+    }
+
+    /// <summary>
+    /// Register a file to be copied into session media and supplied to the model.
+    /// </summary>
+    public void AddModelInputFile(string filePath, string fileName, string mimeType)
+    {
+        _modelInputFiles ??= [];
+        _modelInputFiles.Add(new ModelInputFileInfo(filePath, fileName, mimeType));
     }
 
     public void SetOneTimeApprovedPatterns(IEnumerable<string> patterns)


### PR DESCRIPTION
## Summary
- classify file_read targets before reading bytes
- keep UTF-8 text reads and pagination behavior intact
- hand image reads to image-capable models through session media references
- return metadata and guidance for PDFs, media, archives, binary documents, and unknown binaries
- harden model-input media materialization with modality, size, and magic-byte checks

Closes #1237

## Validation
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- git diff --check
- openspec validate enable-file-read-multimodal-classification --strict

## Notes
- Draft PR, rebased on upstream dev.
- Behavioral evals were not run locally because eval target credentials were not configured.