### PR TITLE
fix(memory): harden curation tier — no silent LLM no-op + lossless update guard

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/CurationPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/CurationPromptBuilderTests.cs
@@ -73,6 +73,34 @@ public sealed class CurationPromptBuilderTests
         Assert.Null(CurationPromptBuilder.ParseResponse("UNKNOWN_COMMAND"));
     }
 
+    [Fact]
+    public void ParseResponse_strips_think_block_before_keyword()
+    {
+        // Reasoning models prepend hidden chain-of-thought; the decision must still parse.
+        var decision = CurationPromptBuilder.ParseResponse(
+            "<think>These look similar but the dates differ, so they're distinct.</think>\nCREATE");
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Create, decision.Kind);
+    }
+
+    [Fact]
+    public void ParseResponse_strips_multiline_think_block_with_inline_keyword()
+    {
+        var decision = CurationPromptBuilder.ParseResponse(
+            "<think>\nstep 1\nstep 2\n</think>UPDATE doc-42");
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Update, decision.Kind);
+        Assert.Equal("doc-42", decision.TargetDocumentId);
+    }
+
+    [Fact]
+    public void ParseResponse_returns_null_for_unclosed_think_block()
+    {
+        // A truncated reasoning trace (budget exhausted mid-think) yields no decision —
+        // the caller must treat this as "no decision", not parse it into garbage.
+        Assert.Null(CurationPromptBuilder.ParseResponse("<think>reasoning with no closing tag and no answer"));
+    }
+
     // ── BuildUserMessage ────────────────────────────────────────────
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Memory/CurationRulesEvaluatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/CurationRulesEvaluatorTests.cs
@@ -316,4 +316,68 @@ public sealed class CurationRulesEvaluatorTests
 
         Assert.Null(decision);
     }
+
+    // ── GuardDestructiveUpdate (lossless update guard) ──────────────
+
+    [Fact]
+    public void GuardDestructiveUpdate_downgrades_to_skip_when_proposal_drops_existing_content()
+    {
+        // Existing memory is rich; proposal is narrower and would clobber it.
+        var target = MakeCandidate(docId: "doc-rich",
+            content: "Widget specs: 16 cores, 64GB RAM, 2 NICs. Pricing on file. Vendor contacts listed.");
+        var proposal = MakeProposal(content: "Widget pricing is TBD as of Q2.");
+        var update = new CurationDecision(CurationDecisionKind.Update, "doc-rich", null, null, "rules: newer");
+
+        var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(update, proposal, [target]);
+
+        Assert.Equal(CurationDecisionKind.Skip, guarded.Kind);
+        Assert.Equal("doc-rich", guarded.TargetDocumentId);
+    }
+
+    [Fact]
+    public void GuardDestructiveUpdate_allows_update_when_proposal_is_a_superset()
+    {
+        var target = MakeCandidate(docId: "doc-1", content: "Latest version is 1.5.62.");
+        var proposal = MakeProposal(content: "Latest version is 1.5.62. Released with the new serializer.");
+        var update = new CurationDecision(CurationDecisionKind.Update, "doc-1", null, null, "rules: newer");
+
+        var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(update, proposal, [target]);
+
+        Assert.Equal(CurationDecisionKind.Update, guarded.Kind);
+    }
+
+    [Fact]
+    public void GuardDestructiveUpdate_ignores_whitespace_and_case_when_checking_preservation()
+    {
+        var target = MakeCandidate(docId: "doc-1", content: "Config   path:\n/etc/app/config");
+        var proposal = MakeProposal(content: "config path: /etc/app/config and it is read-only.");
+        var update = new CurationDecision(CurationDecisionKind.Update, "doc-1", null, null, "rules: newer");
+
+        var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(update, proposal, [target]);
+
+        Assert.Equal(CurationDecisionKind.Update, guarded.Kind);
+    }
+
+    [Fact]
+    public void GuardDestructiveUpdate_passes_non_update_decisions_through_unchanged()
+    {
+        var proposal = MakeProposal();
+        var target = MakeCandidate();
+        foreach (var kind in new[] { CurationDecisionKind.Create, CurationDecisionKind.Skip, CurationDecisionKind.Consolidate })
+        {
+            var decision = new CurationDecision(kind, target.DocumentId, null, null, "test");
+            Assert.Equal(kind, CurationRulesEvaluator.GuardDestructiveUpdate(decision, proposal, [target]).Kind);
+        }
+    }
+
+    [Fact]
+    public void GuardDestructiveUpdate_leaves_update_unchanged_when_target_not_in_candidates()
+    {
+        var proposal = MakeProposal(content: "anything");
+        var update = new CurationDecision(CurationDecisionKind.Update, "doc-missing", null, null, "test");
+
+        var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(update, proposal, [MakeCandidate(docId: "doc-other")]);
+
+        Assert.Equal(CurationDecisionKind.Update, guarded.Kind);
+    }
 }

--- a/src/Netclaw.Actors/Memory/CurationPromptBuilder.cs
+++ b/src/Netclaw.Actors/Memory/CurationPromptBuilder.cs
@@ -101,7 +101,13 @@ public static class CurationPromptBuilder
         if (string.IsNullOrWhiteSpace(response))
             return null;
 
-        var trimmed = response.Trim();
+        // Reasoning models may inline hidden chain-of-thought wrapped in
+        // <think>...</think>; strip it so the bare decision keyword is what we parse.
+        // When the serving stack emits reasoning on a separate channel, the text is
+        // already just the keyword and this is a no-op.
+        var trimmed = StripThinkBlocks(response).Trim();
+        if (trimmed.Length == 0)
+            return null;
 
         // SKIP
         if (trimmed.StartsWith("SKIP", StringComparison.OrdinalIgnoreCase))
@@ -142,6 +148,16 @@ public static class CurationPromptBuilder
         }
 
         return null;
+    }
+
+    private static string StripThinkBlocks(string text)
+    {
+        // Remove complete <think>...</think> spans (case-insensitive, across newlines),
+        // then drop any dangling unclosed <think> left by a truncated reasoning trace.
+        var stripped = Regex.Replace(text, "<think>.*?</think>", string.Empty,
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        var openIndex = stripped.IndexOf("<think>", StringComparison.OrdinalIgnoreCase);
+        return openIndex >= 0 ? stripped[..openIndex] : stripped;
     }
 
     private static string TruncateContent(string content)

--- a/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
@@ -221,4 +221,57 @@ public static class CurationRulesEvaluator
             null,
             $"auto-resolved ambiguous: content overlap ({contentOverlap:P0}) + anchor similarity ({anchorJaccard:F2})");
     }
+
+    /// <summary>
+    /// Lossless guard for UPDATE decisions. Applying an UPDATE overwrites the target
+    /// memory's body with the proposal's, so it is only safe when the proposal
+    /// preserves the existing content (the existing body is wholly contained in the
+    /// proposal). When it is not preserved, overwriting would silently drop information
+    /// the existing memory holds — so downgrade to <see cref="CurationDecisionKind.Skip"/>
+    /// and keep the existing memory instead. The cost is dropping a narrower or
+    /// divergent proposal's new detail, which is recoverable; destroying accumulated
+    /// content is not. Non-UPDATE decisions pass through unchanged.
+    /// </summary>
+    public static CurationDecision GuardDestructiveUpdate(
+        CurationDecision decision,
+        SQLiteMemoryCurationOperation proposal,
+        IReadOnlyList<ExistingMemoryCandidate> candidates)
+    {
+        if (decision.Kind != CurationDecisionKind.Update)
+            return decision;
+
+        var target = candidates.FirstOrDefault(
+            c => string.Equals(c.DocumentId, decision.TargetDocumentId, StringComparison.Ordinal));
+
+        // No identifiable target (e.g., an LLM-returned id not in the candidate set):
+        // nothing to overwrite and nothing to verify, so leave the decision unchanged.
+        if (target is null || PreservesContent(proposal.Content, target.Content))
+            return decision;
+
+        return new CurationDecision(
+            CurationDecisionKind.Skip,
+            target.DocumentId,
+            null,
+            null,
+            $"update guarded: proposal would not preserve existing content — kept {target.DocumentId}");
+    }
+
+    private static bool PreservesContent(string proposed, string existing)
+    {
+        var existingNorm = NormalizeForContainment(existing);
+        if (existingNorm.Length == 0)
+            return true; // nothing to preserve
+
+        return NormalizeForContainment(proposed).Contains(existingNorm, StringComparison.Ordinal);
+    }
+
+    private static string NormalizeForContainment(string value)
+    {
+        // Lowercase and collapse all whitespace runs to single spaces so formatting
+        // differences don't hide a genuine containment. Case folding happens here so
+        // the Contains check can stay Ordinal.
+        return string.Join(' ', (value ?? string.Empty)
+            .ToLowerInvariant()
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
 }

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -252,12 +252,13 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
             var llmDecision = await TryLlmEvaluationAsync(_llmClient, _sessionId, operation, candidates, _log);
             if (llmDecision is not null)
             {
+                var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(llmDecision, operation, candidates);
                 _log.Info(
                     "curation_llm_decision anchor={0} decision={1} reason={2}",
                     operation.AnchorCanonicalName,
-                    llmDecision.Kind,
-                    llmDecision.Reason);
-                return llmDecision;
+                    guarded.Kind,
+                    guarded.Reason);
+                return guarded;
             }
 
             // LLM failed — fall through to deterministic auto-resolution below
@@ -283,7 +284,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 "ambiguous: auto-resolve insufficient, defaulting to create");
         }
 
-        return rulesDecision;
+        return CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates);
     }
 
     internal static async Task<CurationDecision?> TryLlmEvaluationAsync(
@@ -306,16 +307,34 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 
             var options = new ChatOptions
             {
-                MaxOutputTokens = 50
+                // Headroom for reasoning models: with a tight cap a thinking model
+                // spends the whole budget on hidden reasoning and returns empty
+                // content, silently disabling this LLM tier. Non-reasoning models
+                // still stop after the bare keyword the prompt asks for, so they pay
+                // nothing extra. (Fully suppressing reasoning is a provider-level follow-up.)
+                MaxOutputTokens = 512
             };
 
             var response = await llmClient.GetResponseAsync(messages, options, cts.Token);
             var responseText = response.Text?.Trim();
+            var decision = string.IsNullOrWhiteSpace(responseText)
+                ? null
+                : CurationPromptBuilder.ParseResponse(responseText);
 
-            if (string.IsNullOrWhiteSpace(responseText))
+            if (decision is null)
+            {
+                // No silent fallback: a curation LLM that yields nothing parseable is a
+                // real signal (empty/garbled output, or a reasoning model that consumed
+                // its token budget). Surface it so the deterministic fallback that
+                // follows is observable rather than invisible.
+                log.Warning(
+                    "curation_llm_no_decision anchor={0} responseLength={1} — using deterministic fallback",
+                    operation.AnchorCanonicalName,
+                    responseText?.Length ?? 0);
                 return null;
+            }
 
-            return CurationPromptBuilder.ParseResponse(responseText);
+            return decision;
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
Two safety fixes to the memory curation tier (`MemoryCurationActor` + helpers), both about the tier failing quietly. Surfaced while measuring the dedup path against a real store — context and the broader plan in #1241.

## 1. The LLM curation tier silently no-ops on reasoning models

`TryLlmEvaluationAsync` called the model with `MaxOutputTokens = 50`. A reasoning model spends that budget on hidden thinking and returns empty content, so `ParseResponse` got nothing and the tier silently fell through to deterministic auto-resolution — the curation LLM effectively disabled, with no signal. That's a "no silent fallback" violation.

**Fix**
- Bump the curation call to `MaxOutputTokens = 512` so a thinking model has room to emit the bare keyword the prompt asks for; non-reasoning models stop after the keyword and pay nothing extra.
- `ParseResponse` strips inline `<think>…</think>` traces before matching, for stacks that inline reasoning in the content.
- When nothing parses, log `curation_llm_no_decision` (Warning) instead of returning `null` silently — the deterministic fallback is now observable.

Fully suppressing reasoning at the provider level is a follow-up; this hardens the failure mode.

## 2. UPDATE can silently overwrite richer memories with narrower proposals

The UPDATE path does `markdown_body = excluded.markdown_body` — a wholesale replace. When a proposal is narrower or divergent than the memory it updates, the existing content is destroyed. I measured this clobbering dated point-in-time readings (newer overwriting older) — real, irreversible data loss.

**Fix** — `CurationRulesEvaluator.GuardDestructiveUpdate`, applied to both rules- and LLM-tier UPDATE decisions: an UPDATE only proceeds when the proposal *preserves* the existing content (the existing body is wholly contained in the proposal). Otherwise it downgrades to `Skip` and keeps the existing memory.

**Deliberate tradeoff (Option A):** when a proposal isn't a superset, its new detail is dropped in favor of keeping the existing memory intact — a dropped line is recoverable, destroyed content is not. Note this also means a genuine value-replace ("v1.0" → "v2.0") will now `Skip` rather than overwrite (keeping the old value), since "2.0" doesn't contain "1.0". Clean handling of value-replacements and lossless enrich both need the LLM-synthesis / record-classification work tracked in #1241; this is the minimal stop-the-data-loss guard until then.

## Relation to #1241 — partial step, does **not** close it

This is intentionally **not** a resolution of #1241; it stays open after this merges. It ships only the data-loss *stopgap* from #1241's Problem 2 — the destructive-overwrite guard (Option A), which keeps the existing memory rather than letting a narrower auto-curation proposal clobber it.

Still open in #1241:
- **Problem 1 (coverage)** — embedding-based candidate retrieval so paraphrase duplicates reach the gate at all. Untouched here.
- **Problem 2, next tranche** — the lossless merge/enrich that lets the agent *reword and consolidate* without dropping facts. The guard here deliberately blocks reword-overwrites in the automatic pipeline; proper consolidation needs LLM synthesis + a fact-preservation check, not a string guard.

(Scope note: the guard applies only to the automatic curation pipeline. Explicit `update_memory` edits go through a separate find-and-replace path and are not affected.)

## Tests / gates
- New unit tests: `CurationPromptBuilderTests` (think-block stripping, unclosed think), `CurationRulesEvaluatorTests` (guard: drops-content→skip, superset→allow, whitespace/case-insensitive, non-update passthrough, missing-target passthrough).
- `slopwatch analyze` clean; copyright headers present.
- Touches the memory pipeline, so `./evals/run-evals.sh` should run in CI before merge.