### PR TITLE
fix(session-log): fix Windows test flake from dropped log lines

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionLogActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionLogActorTests.cs
@@ -113,32 +113,40 @@ public sealed class SessionLogActorTests : TestKit
 
         try
         {
-            var dispatcher1 = SpawnDispatcher(Sys, basePath, timeProvider);
-            dispatcher1.Tell(new TextOutput("first") { SessionId = sessionId }, ActorRefs.NoSender);
-
-            await AwaitAssertAsync(async () =>
+            // If the writer ever drops an audit line (SessionLogActor logs a
+            // "Dropped ... audit line" warning when AppendLine exhausts its retry
+            // budget), the polling assertions below would otherwise spin until the
+            // AwaitAssert deadline and fail with an opaque "substring not found".
+            // Assert zero such warnings so a drop fails fast with the real cause.
+            await EventFilter.Warning(contains: "Dropped").ExpectAsync(0, async () =>
             {
-                var logFile = SessionLogFile.GetLogPath(sessionId, basePath);
-                var text = await ReadLogAsync(logFile, TestContext.Current.CancellationToken);
-                Assert.Contains("Assistant: first", text, StringComparison.Ordinal);
-            }, cancellationToken: TestContext.Current.CancellationToken);
+                var dispatcher1 = SpawnDispatcher(Sys, basePath, timeProvider);
+                dispatcher1.Tell(new TextOutput("first") { SessionId = sessionId }, ActorRefs.NoSender);
 
-            Watch(dispatcher1);
-            Sys.Stop(dispatcher1);
-            await ExpectTerminatedAsync(dispatcher1, cancellationToken: TestContext.Current.CancellationToken);
+                await AwaitAssertAsync(async () =>
+                {
+                    var logFile = SessionLogFile.GetLogPath(sessionId, basePath);
+                    var text = await ReadLogAsync(logFile, TestContext.Current.CancellationToken);
+                    Assert.Contains("Assistant: first", text, StringComparison.Ordinal);
+                }, cancellationToken: TestContext.Current.CancellationToken);
 
-            var dispatcher2 = SpawnDispatcher(Sys, basePath, timeProvider);
-            dispatcher2.Tell(new TextOutput("second") { SessionId = sessionId }, ActorRefs.NoSender);
+                Watch(dispatcher1);
+                Sys.Stop(dispatcher1);
+                await ExpectTerminatedAsync(dispatcher1, cancellationToken: TestContext.Current.CancellationToken);
 
-            await AwaitAssertAsync(async () =>
-            {
-                var logFile = SessionLogFile.GetLogPath(sessionId, basePath);
-                Assert.True(File.Exists(logFile));
-                Assert.Single(Directory.GetFiles(Path.GetDirectoryName(logFile)!, "*.log", SearchOption.TopDirectoryOnly));
+                var dispatcher2 = SpawnDispatcher(Sys, basePath, timeProvider);
+                dispatcher2.Tell(new TextOutput("second") { SessionId = sessionId }, ActorRefs.NoSender);
 
-                var text = await ReadLogAsync(logFile, TestContext.Current.CancellationToken);
-                Assert.Contains("Assistant: first", text, StringComparison.Ordinal);
-                Assert.Contains("Assistant: second", text, StringComparison.Ordinal);
+                await AwaitAssertAsync(async () =>
+                {
+                    var logFile = SessionLogFile.GetLogPath(sessionId, basePath);
+                    Assert.True(File.Exists(logFile));
+                    Assert.Single(Directory.GetFiles(Path.GetDirectoryName(logFile)!, "*.log", SearchOption.TopDirectoryOnly));
+
+                    var text = await ReadLogAsync(logFile, TestContext.Current.CancellationToken);
+                    Assert.Contains("Assistant: first", text, StringComparison.Ordinal);
+                    Assert.Contains("Assistant: second", text, StringComparison.Ordinal);
+                }, cancellationToken: TestContext.Current.CancellationToken);
             }, cancellationToken: TestContext.Current.CancellationToken);
         }
         finally

--- a/src/Netclaw.Actors/Protocol/SessionLogFile.cs
+++ b/src/Netclaw.Actors/Protocol/SessionLogFile.cs
@@ -19,15 +19,16 @@ public static class SessionLogFile
 {
     public const string FileName = "session.log";
 
-    // Bounded retry budget for transient Windows file-sharing conflicts. On NTFS
-    // a concurrent reader holding the file with FileShare.Read (e.g. File.ReadAllText*,
-    // tail-f tools, Search Indexer, AV scan-on-close) blocks any FileAccess.Write
-    // open regardless of the writer's own share mask — share-mode intersection is
-    // bidirectional and the reader's mask must permit Write. The kernel/AV hand-off
-    // window is typically sub-10ms; 10/20/40/80ms backoff covers the long tail
-    // without exceeding an actor's per-message processing budget.
-    private const int MaxAttempts = 4;
-    private static readonly int[] BackoffMs = [10, 20, 40, 80];
+    // Bounded retry budget for transient Windows file-sharing conflicts. On NTFS a
+    // concurrent handle that excludes write (Windows Defender scan-on-close of the
+    // just-written file, Search Indexer, a reader opened with FileShare.Read) blocks
+    // the next FileMode.Append / FileAccess.Write open — share-mode intersection is
+    // mandatory and bidirectional, so the other holder's mask must permit Write.
+    // The AV scan-on-close hand-off is usually sub-100ms but spikes under loaded CI,
+    // so the schedule below waits ~585ms (plus jitter) before giving up — one retry
+    // per backoff entry. Jitter de-correlates retries from a periodic scanner's
+    // cadence; the wait still stays within an actor's per-message processing budget.
+    private static readonly int[] BackoffMs = [10, 25, 50, 100, 200, 200];
 
     public static string GetLogsDirectory(SessionId sessionId, string sessionLogsBasePath)
     {
@@ -61,9 +62,14 @@ public static class SessionLogFile
             }
             catch (Exception ex) when (
                 (ex is IOException || ex is UnauthorizedAccessException)
-                && attempt < MaxAttempts - 1)
+                && attempt < BackoffMs.Length)
             {
-                Thread.Sleep(BackoffMs[attempt]);
+                // Waiting on an external OS resource (the AV/indexer handle) to be
+                // released — the legitimate use of a bounded blocking backoff on the
+                // actor's mailbox thread. Jitter spreads retries so a fixed scanner
+                // cadence cannot phase-lock with the schedule.
+                var baseMs = BackoffMs[attempt];
+                Thread.Sleep(baseMs + Random.Shared.Next(baseMs / 2 + 1));
             }
         }
     }


### PR DESCRIPTION
## What's wrong

One test — `SessionLogActorTests.Successive_dispatchers_append_to_same_canonical_file` — randomly fails on the Windows CI runner. It never fails on Linux or macOS.

## Why

The session log is written one line at a time: open the file, write a line, close it. On Windows, antivirus (Defender) scans a file right after it's closed, and while scanning it briefly locks the file. If the next log line tries to write during that scan, the write is blocked.

The writer retries when that happens, but two problems combined:

1. The retry budget was too short — the comment said it waited ~150ms, but a bug meant it actually only waited ~70ms.
2. When the retries ran out, the log line was quietly **dropped** (with a warning).

So under a slow/busy Windows runner the line got dropped, and the test then waited ~17 seconds for a line that was never coming and failed with a confusing "substring not found".

(Linux and macOS don't lock files this way, which is why it only happens on Windows.)

## The fix

- **Retry long enough.** Fixed the off-by-one so every backoff step actually runs, extended the total wait to ~585ms, and added a little randomness so retries don't keep landing on the same scan. That comfortably outlasts a Defender scan even on a busy CI machine.
- **Fail clearly if a line is still dropped.** The test now watches for the "dropped line" warning and fails immediately with the real reason, instead of timing out 17 seconds later with a vague message.

## Not in this PR

The cleaner long-term fix is to keep the log file open for the life of the session instead of opening and closing it for every line — that avoids the antivirus collision entirely. Left out here to keep this change small and low-risk; happy to do it separately.

## Testing

- Ran the test repeatedly — stable.
- `slopwatch` and copyright-header checks clean; no baseline changes.
