### PR TITLE
Refactor: remove hardcoded channel identity from log messages (#1247)

### DIFF
--- a/src/Netclaw.Channels.Discord/DiscordChannel.cs
+++ b/src/Netclaw.Channels.Discord/DiscordChannel.cs
@@ -30,6 +30,7 @@ public sealed class DiscordChannel : IChannel
     private readonly TimeProvider _timeProvider;
     private readonly DiscordChannelOptions _options;
     private readonly ILogger<DiscordChannel> _logger;
+
     private readonly ToolAudienceProfiles _audienceProfiles;
     private readonly ModelCapabilities _modelCapabilities;
     private readonly NetclawPaths _paths;
@@ -120,7 +121,7 @@ public sealed class DiscordChannel : IChannel
     {
         if (!_options.Enabled)
         {
-            _logger.LogInformation("Discord channel disabled by configuration.");
+            _logger.LogInformation("Channel disabled by configuration.");
             return;
         }
 
@@ -149,7 +150,7 @@ public sealed class DiscordChannel : IChannel
             EnsureGatewayReadyAfterConnect(gatewaySnapshot);
             CompleteConnectionSetup(gatewaySnapshot.BotUserId);
             _connectFailureDetail = null;
-            _logger.LogInformation("Discord channel connected.");
+            _logger.LogInformation("Channel connected.");
         }
         catch (Exception ex)
         {
@@ -266,7 +267,7 @@ public sealed class DiscordChannel : IChannel
     private Task HandleCleanReconnectRequiredAsync(string reason)
     {
         _connectFailureDetail = reason;
-        _logger.LogWarning("Discord gateway requested clean reconnect: {Reason}", reason);
+        _logger.LogWarning("Gateway requested clean reconnect: {Reason}", reason);
         StartReconnectLoop(initialDelay: TimeSpan.Zero);
         return Task.CompletedTask;
     }
@@ -311,7 +312,7 @@ public sealed class DiscordChannel : IChannel
                 EnsureGatewayReadyAfterConnect(gatewaySnapshot);
                 CompleteConnectionSetup(gatewaySnapshot.BotUserId);
                 _connectFailureDetail = null;
-                _logger.LogInformation("Discord channel reconnected after a transient failure.");
+                _logger.LogInformation("Channel reconnected after a transient failure.");
 
                 if (Interlocked.Exchange(ref _queuedCleanReconnect, 0) == 1)
                 {

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -401,7 +401,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         var channel = client.GetChannel(threadChannelId) as IMessageChannel;
         if (channel is null)
         {
-            logger.LogWarning("Discord channel {ChannelId} not found or is not a message channel", threadChannelId);
+            logger.LogWarning("Channel {ChannelId} not found or is not a message channel", threadChannelId);
             return [];
         }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostChannel.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostChannel.cs
@@ -29,6 +29,7 @@ public sealed class MattermostChannel : IChannel
     private readonly TimeProvider _timeProvider;
     private readonly MattermostChannelOptions _options;
     private readonly ILogger<MattermostChannel> _logger;
+
     private readonly ToolAudienceProfiles _audienceProfiles;
     private readonly ModelCapabilities _modelCapabilities;
     private readonly NetclawPaths _paths;
@@ -109,7 +110,7 @@ public sealed class MattermostChannel : IChannel
     {
         if (!_options.Enabled)
         {
-            _logger.LogInformation("Mattermost channel disabled by configuration.");
+            _logger.LogInformation("Channel disabled by configuration.");
             return;
         }
 
@@ -146,7 +147,7 @@ public sealed class MattermostChannel : IChannel
             await _gatewayClient.ConnectAsync(serverUrl, botToken, cancellationToken);
             CompleteConnectionSetup(serverUrl);
             _connectFailureDetail = null;
-            _logger.LogInformation("Mattermost channel connected.");
+            _logger.LogInformation("Channel connected.");
         }
         catch (Exception ex)
         {
@@ -279,7 +280,7 @@ public sealed class MattermostChannel : IChannel
                 await _gatewayClient.ConnectAsync(_options.ServerUrl, _options.BotToken.Value, cancellationToken);
                 CompleteConnectionSetup(_options.ServerUrl);
                 _connectFailureDetail = null;
-                _logger.LogInformation("Mattermost channel reconnected after a transient failure.");
+                _logger.LogInformation("Channel reconnected after a transient failure.");
                 return;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Netclaw.Channels.Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannel.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SlackChannel.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -38,6 +38,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private readonly TimeProvider _timeProvider;
     private readonly SlackChannelOptions _options;
     private readonly ILogger<SlackChannel> _logger;
+
     private readonly IThreadHistoryFetcher _threadHistoryFetcher;
     private readonly ToolAudienceProfiles _audienceProfiles;
     private readonly ModelCapabilities _modelCapabilities;
@@ -147,7 +148,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     {
         if (!_options.Enabled)
         {
-            _logger.LogInformation("Slack channel disabled by configuration.");
+            _logger.LogInformation("Channel disabled by configuration.");
             return;
         }
 
@@ -189,13 +190,13 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         try
         {
             await ConnectCoreAsync(cancellationToken);
-            _logger.LogInformation("Slack channel connected as user {BotUserId}.", _botUserId);
+            _logger.LogInformation("Channel connected as user {BotUserId}.", _botUserId);
         }
         catch (Exception ex)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                _logger.LogInformation("Slack channel connect cancelled during shutdown.");
+                _logger.LogInformation("Channel connect cancelled during shutdown.");
                 return;
             }
 
@@ -328,7 +329,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             try
             {
                 await ConnectCoreAsync(cancellationToken);
-                _logger.LogInformation("Slack channel reconnected after a transient failure.");
+                _logger.LogInformation("Channel reconnected after a transient failure.");
                 return;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
Migrate logging to use logger category (class type) for identity instead of hardcoding channel names in message templates. Changes applied to:
- SlackChannel.cs: 4 log calls simplified
- DiscordChannel.cs: 4 log calls simplified
- MattermostChannel.cs: 3 log calls simplified
- DiscordThreadHistoryFetcher.cs: 1 log call simplified

Identity is now expressed through the logger's generic type parameter (e.g. ILogger<SlackChannel>) rather than embedded in message text. This brings these classes in line with the structured logging convention established by the actor-based code which uses WithContext() and the ActorLogAdapter.