### PR TITLE
fix(logging): sweep actor logging to remove hardcoded adapter identity prefixes (#1247)

### DIFF
--- a/src/Netclaw.Channels.Discord/DiscordChannel.cs
+++ b/src/Netclaw.Channels.Discord/DiscordChannel.cs
@@ -120,7 +120,7 @@ public sealed class DiscordChannel : IChannel
     {
         if (!_options.Enabled)
         {
-            _logger.LogInformation("Discord channel disabled by configuration.");
+            _logger.LogInformation("Channel disabled by configuration.");
             return;
         }
 
@@ -149,7 +149,7 @@ public sealed class DiscordChannel : IChannel
             EnsureGatewayReadyAfterConnect(gatewaySnapshot);
             CompleteConnectionSetup(gatewaySnapshot.BotUserId);
             _connectFailureDetail = null;
-            _logger.LogInformation("Discord channel connected.");
+            _logger.LogInformation("Channel connected.");
         }
         catch (Exception ex)
         {
@@ -266,7 +266,7 @@ public sealed class DiscordChannel : IChannel
     private Task HandleCleanReconnectRequiredAsync(string reason)
     {
         _connectFailureDetail = reason;
-        _logger.LogWarning("Discord gateway requested clean reconnect: {Reason}", reason);
+        _logger.LogWarning("Gateway requested clean reconnect: {Reason}", reason);
         StartReconnectLoop(initialDelay: TimeSpan.Zero);
         return Task.CompletedTask;
     }
@@ -297,7 +297,7 @@ public sealed class DiscordChannel : IChannel
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Discord transport reset before reconnect failed; continuing.");
+                _logger.LogDebug(ex, "Transport reset before reconnect failed; continuing.");
             }
 
             try
@@ -311,7 +311,7 @@ public sealed class DiscordChannel : IChannel
                 EnsureGatewayReadyAfterConnect(gatewaySnapshot);
                 CompleteConnectionSetup(gatewaySnapshot.BotUserId);
                 _connectFailureDetail = null;
-                _logger.LogInformation("Discord channel reconnected after a transient failure.");
+                _logger.LogInformation("Channel reconnected after a transient failure.");
 
                 if (Interlocked.Exchange(ref _queuedCleanReconnect, 0) == 1)
                 {
@@ -373,7 +373,7 @@ public sealed class DiscordChannel : IChannel
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Discord reconnect loop ended with an error during shutdown.");
+                _logger.LogDebug(ex, "Reconnect loop ended with an error during shutdown.");
             }
         }
 
@@ -392,7 +392,7 @@ public sealed class DiscordChannel : IChannel
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Discord gateway actor did not stop gracefully; forcing stop");
+                _logger.LogWarning(ex, "Gateway actor did not stop gracefully; forcing stop");
                 _system.Stop(_gateway);
             }
 

--- a/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
@@ -40,7 +40,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
 
         Receive<ReceiveTimeout>(_ =>
         {
-            _log.Info("Discord conversation idle for 2 hours, passivating");
+            _log.Info("Conversation idle for 2 hours, passivating");
             Context.Stop(Self);
         });
 
@@ -74,7 +74,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         if (!aclDecision.IsAllowed)
         {
             var reason = aclDecision.DenyReason ?? "acl_denied";
-            _log.Info("discord_event_dropped event={0} reason={1}", message.EventId.Value, reason);
+            _log.Info("event_dropped event={0} reason={1}", message.EventId.Value, reason);
             ChannelTelemetry.For(ChannelType.Discord).RecordEventDropped(reason);
             return;
         }
@@ -82,7 +82,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         // --- Bot self-loop filter ---
         if (message.IsBotMessage)
         {
-            _log.Info("discord_event_filtered event={0} reason=bot_message", message.EventId.Value);
+            _log.Info("event_filtered event={0} reason=bot_message", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("bot_message");
             return;
         }
@@ -90,7 +90,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         // --- Ingress gate ---
         if (_dependencies.IngressGate?.ClosedReason is { } closedReason)
         {
-            _log.Info("discord_event_filtered event={0} reason=restart_drain_active", message.EventId.Value);
+            _log.Info("event_filtered event={0} reason=restart_drain_active", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("restart_drain_active");
             // Safe fire-and-forget: PostIngressClosedReplyAsync wraps everything in try/catch,
             // and no synchronous code precedes the first await, so exceptions cannot escape.
@@ -115,7 +115,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         {
             var ignoreReason = decision.IgnoreReason!.Value;
             _log.Info(
-                "discord_event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
+                "event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
                 message.EventId.Value,
                 ignoreReason);
             ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered(
@@ -125,7 +125,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
 
         if (decision.Kind is DiscordRoutingDecisionKind.ContinueOnly && !threadExists)
         {
-            _log.Info("discord_event_dropped event={0} reason=thread_not_initialized", message.EventId.Value);
+            _log.Info("event_dropped event={0} reason=thread_not_initialized", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Discord).RecordEventDropped("thread_not_initialized");
             return;
         }
@@ -134,14 +134,14 @@ internal sealed class DiscordConversationActor : ReceiveActor
         var normalizedText = NormalizeInboundText(message.Text);
         if (normalizedText.Length > MaxInboundTextLength)
         {
-            _log.Warning("discord_inbound_text_truncated original={OriginalLength} clamped={MaxLength}",
+            _log.Warning("inbound_text_truncated original={OriginalLength} clamped={MaxLength}",
                 normalizedText.Length, MaxInboundTextLength);
             normalizedText = normalizedText[..MaxInboundTextLength];
         }
         var hasAttachments = message.Attachments is { Count: > 0 };
         if (string.IsNullOrWhiteSpace(normalizedText) && !hasAttachments)
         {
-            _log.Info("discord_event_filtered event={0} reason=empty_text", message.EventId.Value);
+            _log.Info("event_filtered event={0} reason=empty_text", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("empty_text");
             return;
         }
@@ -167,7 +167,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
             .WithContext("TurnId", turnId)
             .WithContext("DiscordEventId", message.EventId.Value);
 
-        log.Info("discord_turn_routed event={EventId} textChars={TextLength}",
+        log.Info("turn_routed event={EventId} textChars={TextLength}",
             message.EventId.Value,
             normalizedText.Length);
 

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -222,7 +222,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 ? "completed"
                 : $"faulted: {msg.Cause.Message}";
 
-            _log.Warning("Discord output stream terminated ({Reason}); reinitializing pipeline", reason);
+            _log.Warning("Output stream terminated ({Reason}); reinitializing pipeline", reason);
             Self.Tell(new ReinitializePipeline(reason));
         });
 
@@ -241,11 +241,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             if (_pendingApprovalRequests.Count > 0)
             {
-                _log.Info("Discord session idle but {0} approval(s) pending; deferring passivation", _pendingApprovalRequests.Count);
+                _log.Info("Session idle but {0} approval(s) pending; deferring passivation", _pendingApprovalRequests.Count);
                 return;
             }
 
-            _log.Info("Discord session idle for 1 hour, passivating");
+            _log.Info("Session idle for 1 hour, passivating");
             RunTask(async () =>
             {
                 await _handle.DrainAsync();
@@ -338,7 +338,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Discord input queue is not initialized; dropping inbound message");
+            _log.Warning("Input queue is not initialized; dropping inbound message");
             return;
         }
 
@@ -389,12 +389,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         catch (OperationCanceledException)
         {
-            _log.Warning("Timed out enqueueing Discord message for session {0}", _sessionId.Value);
+            _log.Warning("Timed out enqueueing message for session {0}", _sessionId.Value);
             Self.Tell(new ReinitializePipeline("input queue write timeout"));
         }
         catch (ChannelClosedException)
         {
-            _log.Warning("Discord input queue closed for session {0}", _sessionId.Value);
+            _log.Warning("Input queue closed for session {0}", _sessionId.Value);
             Self.Tell(new ReinitializePipeline("input queue closed"));
         }
     }
@@ -524,7 +524,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Discord input queue is not initialized; skipping hydration backfill");
+            _log.Warning("Input queue is not initialized; skipping hydration backfill");
             return;
         }
 
@@ -541,7 +541,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             }
 
             _log.Info(
-                "discord_hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
+                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
                 triggerInput.MessageId, adoptedContext.Count, _sessionId.Value);
             ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
         }
@@ -719,7 +719,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             return baseInput;
 
         _log.Info(
-            "discord_deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
+            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
             classified.Gap.Count,
             baseInput.MessageId,
             _sessionId.Value);
@@ -1018,7 +1018,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Discord input queue is not initialized; rejecting Mode B reminder");
+            _log.Warning("Input queue is not initialized; rejecting Mode B reminder");
             ackTarget.Tell(CommandNack.For(_sessionId, "Discord session pipeline not initialized"));
             return;
         }
@@ -1053,7 +1053,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         catch (ChannelClosedException)
         {
-            _log.Warning("Discord input queue closed; rejecting Mode B reminder for session {0}", _sessionId.Value);
+            _log.Warning("Input queue closed; rejecting Mode B reminder for session {0}", _sessionId.Value);
             ackTarget.Tell(CommandNack.For(_sessionId, "Pipeline input queue closed"));
         }
     }
@@ -1346,7 +1346,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (files.Count > policy.MaxFilesPerMessage)
         {
             _log.Warning(
-                "discord_attachments_rejected count={Count} limit={Limit} audience={Audience} reason=too-many-files",
+                "attachments_rejected count={Count} limit={Limit} audience={Audience} reason=too-many-files",
                 files.Count,
                 policy.MaxFilesPerMessage,
                 audience);
@@ -1464,7 +1464,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     {
         if (_cursorSnowflake is { } c && candidateSnowflake <= c)
         {
-            _log.Debug("Discord session cursor did not advance session={Session} snowflake={Snowflake}",
+            _log.Debug("Session cursor did not advance session={Session} snowflake={Snowflake}",
                 _sessionId.Value, candidateSnowflake);
             return;
         }

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayLifecycleActor.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayLifecycleActor.cs
@@ -542,7 +542,7 @@ internal sealed class DiscordNetGatewayLifecycleActor : ReceiveActor, IWithTimer
             return;
 
         _fatalCloseHandled = true;
-        _logger.LogError(classified, "Discord gateway closed fatally: {Reason}", classified.Message);
+        _logger.LogError(classified, "Gateway closed fatally: {Reason}", classified.Message);
         BeginStopAfterFatalClose();
     }
 
@@ -864,7 +864,7 @@ internal sealed class DiscordNetGatewayLifecycleActor : ReceiveActor, IWithTimer
             return;
 
         _cleanReconnectEmitted = true;
-        _logger.LogWarning("Discord gateway requested clean reconnect: {Reason}", reason);
+        _logger.LogWarning("Gateway requested clean reconnect: {Reason}", reason);
         Dispatch("Discord clean reconnect", () => _eventSink.PublishCleanReconnectRequiredAsync(reason));
     }
 
@@ -883,15 +883,15 @@ internal sealed class DiscordNetGatewayLifecycleActor : ReceiveActor, IWithTimer
 
         if (previousBotUserId == botUserId)
         {
-            _logger.LogDebug("Discord bot identity refreshed from {Source}: {BotUserId}", source, currentUserId);
+            _logger.LogDebug("Bot identity refreshed from {Source}: {BotUserId}", source, currentUserId);
         }
         else if (string.Equals(source, "READY", StringComparison.Ordinal))
         {
-            _logger.LogInformation("Discord bot identity resolved: {BotUserId}", currentUserId);
+            _logger.LogInformation("Bot identity resolved: {BotUserId}", currentUserId);
         }
         else
         {
-            _logger.LogInformation("Discord bot identity resolved from {Source}: {BotUserId}", source, currentUserId);
+            _logger.LogInformation("Bot identity resolved from {Source}: {BotUserId}", source, currentUserId);
         }
 
         return true;

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -401,7 +401,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         var channel = client.GetChannel(threadChannelId) as IMessageChannel;
         if (channel is null)
         {
-            logger.LogWarning("Discord channel {ChannelId} not found or is not a message channel", threadChannelId);
+            logger.LogWarning("Channel {ChannelId} not found or is not a message channel", threadChannelId);
             return [];
         }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostChannel.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostChannel.cs
@@ -109,7 +109,7 @@ public sealed class MattermostChannel : IChannel
     {
         if (!_options.Enabled)
         {
-            _logger.LogInformation("Mattermost channel disabled by configuration.");
+            _logger.LogInformation("Channel disabled by configuration.");
             return;
         }
 
@@ -146,7 +146,7 @@ public sealed class MattermostChannel : IChannel
             await _gatewayClient.ConnectAsync(serverUrl, botToken, cancellationToken);
             CompleteConnectionSetup(serverUrl);
             _connectFailureDetail = null;
-            _logger.LogInformation("Mattermost channel connected.");
+            _logger.LogInformation("Channel connected.");
         }
         catch (Exception ex)
         {
@@ -261,7 +261,7 @@ public sealed class MattermostChannel : IChannel
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Mattermost transport reset before reconnect failed; continuing.");
+                _logger.LogDebug(ex, "Transport reset before reconnect failed; continuing.");
             }
 
             try
@@ -279,7 +279,7 @@ public sealed class MattermostChannel : IChannel
                 await _gatewayClient.ConnectAsync(_options.ServerUrl, _options.BotToken.Value, cancellationToken);
                 CompleteConnectionSetup(_options.ServerUrl);
                 _connectFailureDetail = null;
-                _logger.LogInformation("Mattermost channel reconnected after a transient failure.");
+                _logger.LogInformation("Channel reconnected after a transient failure.");
                 return;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -322,7 +322,7 @@ public sealed class MattermostChannel : IChannel
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Mattermost reconnect loop ended with an error during shutdown.");
+                _logger.LogDebug(ex, "Reconnect loop ended with an error during shutdown.");
             }
         }
 
@@ -336,7 +336,7 @@ public sealed class MattermostChannel : IChannel
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Mattermost gateway actor did not stop gracefully; forcing stop");
+                _logger.LogWarning(ex, "Gateway actor did not stop gracefully; forcing stop");
                 _system.Stop(_gateway);
             }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostConversationActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostConversationActor.cs
@@ -41,7 +41,7 @@ internal sealed class MattermostConversationActor : ReceiveActor
 
         Receive<ReceiveTimeout>(_ =>
         {
-            _log.Info("Mattermost conversation idle for 2 hours, passivating");
+            _log.Info("Conversation idle for 2 hours, passivating");
             Context.Stop(Self);
         });
 
@@ -74,21 +74,21 @@ internal sealed class MattermostConversationActor : ReceiveActor
         if (!aclDecision.IsAllowed)
         {
             var reason = aclDecision.DenyReason ?? "acl_denied";
-            _log.Info("mattermost_event_dropped event={0} reason={1}", message.EventId.Value, reason);
+            _log.Info("event_dropped event={0} reason={1}", message.EventId.Value, reason);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventDropped(reason);
             return;
         }
 
         if (message.IsBotMessage)
         {
-            _log.Info("mattermost_event_filtered event={0} reason=bot_message", message.EventId.Value);
+            _log.Info("event_filtered event={0} reason=bot_message", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventFiltered("bot_message");
             return;
         }
 
         if (_dependencies.IngressGate?.ClosedReason is { } closedReason)
         {
-            _log.Info("mattermost_event_filtered event={0} reason=restart_drain_active", message.EventId.Value);
+            _log.Info("event_filtered event={0} reason=restart_drain_active", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventFiltered("restart_drain_active");
             _ = PostIngressClosedReplyAsync(message.ChannelId, message.PostId, closedReason);
             return;
@@ -114,7 +114,7 @@ internal sealed class MattermostConversationActor : ReceiveActor
         {
             var ignoreReason = decision.IgnoreReason!.Value;
             _log.Info(
-                "mattermost_event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
+                "event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
                 message.EventId.Value,
                 ignoreReason);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventFiltered(
@@ -124,7 +124,7 @@ internal sealed class MattermostConversationActor : ReceiveActor
 
         if (decision.Kind is MattermostRoutingDecisionKind.ContinueOnly && !threadExists)
         {
-            _log.Info("mattermost_event_dropped event={0} reason=thread_not_initialized", message.EventId.Value);
+            _log.Info("event_dropped event={0} reason=thread_not_initialized", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventDropped("thread_not_initialized");
             return;
         }
@@ -132,14 +132,14 @@ internal sealed class MattermostConversationActor : ReceiveActor
         var normalizedText = NormalizeInboundText(message.Text);
         if (normalizedText.Length > MaxInboundTextLength)
         {
-            _log.Warning("mattermost_inbound_text_truncated original={OriginalLength} clamped={MaxLength}",
+            _log.Warning("inbound_text_truncated original={OriginalLength} clamped={MaxLength}",
                 normalizedText.Length, MaxInboundTextLength);
             normalizedText = normalizedText[..MaxInboundTextLength];
         }
         var hasAttachments = message.Attachments is { Count: > 0 };
         if (string.IsNullOrWhiteSpace(normalizedText) && !hasAttachments)
         {
-            _log.Info("mattermost_event_filtered event={0} reason=empty_text", message.EventId.Value);
+            _log.Info("event_filtered event={0} reason=empty_text", message.EventId.Value);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventFiltered("empty_text");
             return;
         }
@@ -159,7 +159,7 @@ internal sealed class MattermostConversationActor : ReceiveActor
             .WithContext("TurnId", turnId)
             .WithContext("MattermostEventId", message.EventId.Value);
 
-        log.Info("mattermost_turn_routed event={EventId} textChars={TextLength}",
+        log.Info("turn_routed event={EventId} textChars={TextLength}",
             message.EventId.Value,
             normalizedText.Length);
 
@@ -184,7 +184,7 @@ internal sealed class MattermostConversationActor : ReceiveActor
         if (!MattermostAclPolicy.IsAllowedUser(interaction.SenderId, _dependencies.Options))
         {
             _log.Info(
-                "mattermost_interaction_denied sender={0} reason=user_not_allowed",
+                "interaction_denied sender={0} reason=user_not_allowed",
                 interaction.SenderId.Value);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordEventDropped("interaction_user_not_allowed");
             return;
@@ -229,7 +229,7 @@ internal sealed class MattermostConversationActor : ReceiveActor
             message.RootPostId);
 
         _log.Info(
-            "mattermost_proactive_thread session={Session} channel={Channel} rootPost={RootPost}",
+            "proactive_thread session={Session} channel={Channel} rootPost={RootPost}",
             message.SessionId.Value, message.ChannelId.Value, message.RootPostId.Value);
         Sender.Tell(new MattermostProactiveThreadAck(message.SessionId));
     }

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -212,7 +212,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 ? "completed"
                 : $"faulted: {msg.Cause.Message}";
 
-            _log.Warning("Mattermost output stream terminated ({Reason}); reinitializing pipeline", reason);
+            _log.Warning("Output stream terminated ({Reason}); reinitializing pipeline", reason);
             Self.Tell(new ReinitializePipeline(reason));
         });
 
@@ -231,11 +231,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         {
             if (_pendingApprovalRequests.Count > 0)
             {
-                _log.Info("Mattermost session idle but {0} approval(s) pending; deferring passivation", _pendingApprovalRequests.Count);
+                _log.Info("Session idle but {0} approval(s) pending; deferring passivation", _pendingApprovalRequests.Count);
                 return;
             }
 
-            _log.Info("Mattermost session idle for 1 hour, passivating");
+            _log.Info("Session idle for 1 hour, passivating");
             Context.Stop(Self);
         });
 
@@ -307,7 +307,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Mattermost input queue is not initialized; dropping inbound message");
+            _log.Warning("Input queue is not initialized; dropping inbound message");
             return;
         }
 
@@ -360,12 +360,12 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
         catch (OperationCanceledException)
         {
-            _log.Warning("Timed out enqueueing Mattermost message for session {0}", _sessionId.Value);
+            _log.Warning("Timed out enqueueing message for session {0}", _sessionId.Value);
             Self.Tell(new ReinitializePipeline("input queue write timeout"));
         }
         catch (ChannelClosedException)
         {
-            _log.Warning("Mattermost input queue closed for session {0}", _sessionId.Value);
+            _log.Warning("Input queue closed for session {0}", _sessionId.Value);
             Self.Tell(new ReinitializePipeline("input queue closed"));
         }
     }
@@ -497,7 +497,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Mattermost input queue is not initialized; skipping hydration backfill");
+            _log.Warning("Input queue is not initialized; skipping hydration backfill");
             return;
         }
 
@@ -515,7 +515,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             }
 
             _log.Info(
-                "mattermost_hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
+                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
                 triggerInput.MessageId, adoptedContext.Count, _sessionId.Value);
             ChannelTelemetry.For(ChannelType.Mattermost).RecordMessageEnqueued();
         }
@@ -597,7 +597,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             return baseInput;
 
         _log.Info(
-            "mattermost_deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
+            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
             classified.Gap.Count,
             baseInput.MessageId,
             _sessionId.Value);
@@ -996,7 +996,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Mattermost input queue is not initialized; rejecting Mode B reminder");
+            _log.Warning("Input queue is not initialized; rejecting Mode B reminder");
             ackTarget.Tell(CommandNack.For(_sessionId, "Mattermost session pipeline not initialized"));
             return;
         }
@@ -1031,7 +1031,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
         catch (ChannelClosedException)
         {
-            _log.Warning("Mattermost input queue closed; rejecting Mode B reminder for session {0}", _sessionId.Value);
+            _log.Warning("Input queue closed; rejecting Mode B reminder for session {0}", _sessionId.Value);
             ackTarget.Tell(CommandNack.For(_sessionId, "Pipeline input queue closed"));
         }
     }
@@ -1329,7 +1329,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         if (files.Count > policy.MaxFilesPerMessage)
         {
             _log.Warning(
-                "mattermost_attachments_rejected count={Count} limit={Limit} audience={Audience} reason=too-many-files",
+                "attachments_rejected count={Count} limit={Limit} audience={Audience} reason=too-many-files",
                 files.Count,
                 policy.MaxFilesPerMessage,
                 audience);
@@ -1459,7 +1459,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     {
         if (_cursorPostId is not null && string.CompareOrdinal(candidatePostId, _cursorPostId) <= 0)
         {
-            _log.Debug("Mattermost session cursor did not advance session={Session} postId={PostId}",
+            _log.Debug("Session cursor did not advance session={Session} postId={PostId}",
                 _sessionId.Value, candidatePostId);
             return;
         }

--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
@@ -52,7 +52,7 @@ internal sealed class MattermostNetGatewayClient : IMattermostGatewayClient, IDi
         var me = await _client.GetMeAsync();
         BotUserId = new MattermostUserId(me.Id);
         BotUsername = me.Username;
-        _logger.LogInformation("Mattermost bot identity resolved: {BotUserId} (@{Username})",
+        _logger.LogInformation("Bot identity resolved: {BotUserId} (@{Username})",
             me.Id, me.Username);
 
         await _client.StartReceivingAsync(cancellationToken);
@@ -69,7 +69,7 @@ internal sealed class MattermostNetGatewayClient : IMattermostGatewayClient, IDi
         }
         catch (WebSocketException ex) when (ex.WebSocketErrorCode == WebSocketError.InvalidState)
         {
-            _logger.LogDebug(ex, "Mattermost WebSocket was already closed during disconnect.");
+            _logger.LogDebug(ex, "WebSocket was already closed during disconnect.");
         }
     }
 

--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostThreadHistoryFetcher.cs
@@ -416,7 +416,7 @@ public sealed class MattermostThreadHistoryFetcher : IThreadHistoryFetcher
 
         if (threadResponse.Posts.Count == 0)
         {
-            logger.LogDebug("Mattermost thread {RootPostId} returned no posts", rootPostId);
+            logger.LogDebug("Thread {RootPostId} returned no posts", rootPostId);
             return [];
         }
 

--- a/src/Netclaw.Channels.Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannel.cs
@@ -147,7 +147,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     {
         if (!_options.Enabled)
         {
-            _logger.LogInformation("Slack channel disabled by configuration.");
+            _logger.LogInformation("Channel disabled by configuration.");
             return;
         }
 
@@ -189,13 +189,13 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         try
         {
             await ConnectCoreAsync(cancellationToken);
-            _logger.LogInformation("Slack channel connected as user {BotUserId}.", _botUserId);
+            _logger.LogInformation("Channel connected as user {BotUserId}.", _botUserId);
         }
         catch (Exception ex)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                _logger.LogInformation("Slack channel connect cancelled during shutdown.");
+                _logger.LogInformation("Channel connect cancelled during shutdown.");
                 return;
             }
 
@@ -322,13 +322,13 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Slack transport reset before reconnect failed; continuing.");
+                _logger.LogDebug(ex, "Transport reset before reconnect failed; continuing.");
             }
 
             try
             {
                 await ConnectCoreAsync(cancellationToken);
-                _logger.LogInformation("Slack channel reconnected after a transient failure.");
+                _logger.LogInformation("Channel reconnected after a transient failure.");
                 return;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -371,7 +371,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Slack reconnect loop ended with an error during shutdown.");
+                _logger.LogDebug(ex, "Reconnect loop ended with an error during shutdown.");
             }
         }
 

--- a/src/Netclaw.Channels.Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackConversationActor.cs
@@ -29,7 +29,7 @@ public sealed class SlackConversationActor : ReceiveActor
         Context.SetReceiveTimeout(TimeSpan.FromHours(2));
         Receive<ReceiveTimeout>(_ =>
         {
-            _log.Info("Slack conversation idle for 2 hours, passivating");
+            _log.Info("Conversation idle for 2 hours, passivating");
             Context.Stop(Self);
         });
 
@@ -42,14 +42,14 @@ public sealed class SlackConversationActor : ReceiveActor
 
             if (!aclDecision.IsAllowed)
             {
-                _log.Info("slack_event_dropped event={0} reason={1}", message.EventId, aclDecision.DenyReason ?? "acl_denied");
+                _log.Info("event_dropped event={0} reason={1}", message.EventId, aclDecision.DenyReason ?? "acl_denied");
                 ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped(aclDecision.DenyReason ?? "acl_denied");
                 return;
             }
 
             if (IsBotMessage(message))
             {
-                _log.Info("slack_event_filtered event={0} reason=bot_message", message.EventId);
+                _log.Info("event_filtered event={0} reason=bot_message", message.EventId);
                 ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("bot_message");
                 return;
             }
@@ -74,7 +74,7 @@ public sealed class SlackConversationActor : ReceiveActor
                 // factory invariant (Ignore-kind is only constructed via Ignore(reason)).
                 var ignoreReason = decision.IgnoreReason!.Value;
                 _log.Info(
-                    "slack_event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
+                    "event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
                     message.EventId,
                     ignoreReason);
                 ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered(
@@ -84,7 +84,7 @@ public sealed class SlackConversationActor : ReceiveActor
 
             if (decision.Kind is SlackRoutingDecisionKind.ContinueOnly && !threadExists)
             {
-                _log.Info("slack_event_dropped event={0} reason=thread_not_initialized", message.EventId);
+                _log.Info("event_dropped event={0} reason=thread_not_initialized", message.EventId);
                 ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped("thread_not_initialized");
                 return;
             }
@@ -92,7 +92,7 @@ public sealed class SlackConversationActor : ReceiveActor
             if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
             {
                 var replyThreadTs = message.ThreadTs ?? SlackThreadTs.FromEventTs(message.EventTs);
-                _log.Info("slack_event_filtered event={0} reason=restart_drain_active", message.EventId);
+                _log.Info("event_filtered event={0} reason=restart_drain_active", message.EventId);
                 ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("restart_drain_active");
                 _ = PostIngressClosedReplyAsync(message.ChannelId, replyThreadTs, ingressClosedReason);
                 return;
@@ -105,7 +105,7 @@ public sealed class SlackConversationActor : ReceiveActor
             var normalized = NormalizeInboundText(message.Text);
             if (string.IsNullOrWhiteSpace(normalized) && message.Files is not { Count: > 0 })
             {
-                _log.Info("slack_event_filtered event={0} reason=empty_text", message.EventId);
+                _log.Info("event_filtered event={0} reason=empty_text", message.EventId);
                 ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("empty_text");
                 return;
             }
@@ -120,7 +120,7 @@ public sealed class SlackConversationActor : ReceiveActor
                 .WithContext("TurnId", turnId)
                 .WithContext("SlackEventId", message.EventId.Value);
 
-            log.Info("slack_turn_routed event={EventId} hasFiles={HasFiles} textChars={TextLength}",
+            log.Info("turn_routed event={EventId} hasFiles={HasFiles} textChars={TextLength}",
                 message.EventId.Value,
                 message.Files is { Count: > 0 },
                 normalized.Length);

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -194,7 +194,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 ? "completed"
                 : $"faulted: {msg.Cause.Message}";
 
-            _log.Warning("Slack output stream terminated ({Reason}); reinitializing pipeline", reason);
+            _log.Warning("Output stream terminated ({Reason}); reinitializing pipeline", reason);
             Self.Tell(new ReinitializePipeline(reason));
         });
         CommandAsync<ReinitializePipeline>(async msg => await ReinitializePipelineAsync(msg.Reason));
@@ -202,11 +202,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         {
             if (_pendingApprovalRequests.Count > 0)
             {
-                _log.Info("Slack thread idle but {0} approval(s) are pending; deferring passivation", _pendingApprovalRequests.Count);
+                _log.Info("Thread idle but {0} approval(s) are pending; deferring passivation", _pendingApprovalRequests.Count);
                 return;
             }
 
-            _log.Info("Slack thread idle for 1 hour, passivating");
+            _log.Info("Thread idle for 1 hour, passivating");
             RunTask(async () =>
             {
                 await _handle.DrainAsync();
@@ -250,7 +250,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Slack thread input queue is not initialized; rejecting Mode B reminder");
+            _log.Warning("Thread input queue is not initialized; rejecting Mode B reminder");
             ackTarget.Tell(CommandNack.For(_sessionId, "Slack thread pipeline not initialized"));
             return;
         }
@@ -285,7 +285,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
         catch (ChannelClosedException)
         {
-            _log.Warning("Slack thread input queue closed; rejecting Mode B reminder for session {0}", _sessionId.Value);
+            _log.Warning("Thread input queue closed; rejecting Mode B reminder for session {0}", _sessionId.Value);
             ackTarget.Tell(CommandNack.For(_sessionId, "Pipeline input queue closed"));
         }
     }
@@ -300,7 +300,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
         try
         {
-            inboundLog.Info("slack_turn_received textChars={TextLength} fileCount={FileCount}",
+            inboundLog.Info("turn_received textChars={TextLength} fileCount={FileCount}",
                 message.Text?.Length ?? 0,
                 message.Files?.Count ?? 0);
 
@@ -365,7 +365,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             var writer = _handle.InputQueue;
             if (writer is null)
             {
-                _log.Warning("Slack thread input queue is not initialized; dropping inbound message");
+                _log.Warning("Thread input queue is not initialized; dropping inbound message");
                 return;
             }
 
@@ -404,27 +404,27 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             }
             catch (OperationCanceledException ex)
             {
-                _log.Warning(ex, "Timed out enqueueing Slack message for session {0}", _sessionId.Value);
+                _log.Warning(ex, "Timed out enqueueing message for session {0}", _sessionId.Value);
                 Self.Tell(new ReinitializePipeline("input queue write timeout"));
                 return;
             }
             catch (ChannelClosedException ex)
             {
-                _log.Warning(ex, "Slack thread input queue closed for session {0}", _sessionId.Value);
+                _log.Warning(ex, "Thread input queue closed for session {0}", _sessionId.Value);
                 Self.Tell(new ReinitializePipeline("input queue write failed"));
                 return;
             }
 
-            inboundLog.Info("slack_turn_enqueued contentItems={ContentCount}", input.Contents.Count);
+            inboundLog.Info("turn_enqueued contentItems={ContentCount}", input.Contents.Count);
             ChannelTelemetry.For(ChannelType.Slack).RecordMessageEnqueued();
         }
         catch (OperationCanceledException ex)
         {
-            inboundLog.Warning(ex, "slack_turn_enqueue_timeout");
+            inboundLog.Warning(ex, "turn_enqueue_timeout");
         }
         catch (Exception ex)
         {
-            inboundLog.Error(ex, "slack_turn_enqueue_failed");
+            inboundLog.Error(ex, "turn_enqueue_failed");
         }
     }
 
@@ -465,7 +465,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         if (files.Count > policy.MaxFilesPerMessage)
         {
             _log.Warning(
-                "slack_attachments_rejected count={Count} limit={Limit} audience={Audience} reason=too-many-files",
+                "attachments_rejected count={Count} limit={Limit} audience={Audience} reason=too-many-files",
                 files.Count,
                 policy.MaxFilesPerMessage,
                 audience);
@@ -729,7 +729,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         var writer = _handle.InputQueue;
         if (writer is null)
         {
-            _log.Warning("Slack input queue is not initialized; skipping hydration backfill");
+            _log.Warning("Input queue is not initialized; skipping hydration backfill");
             return;
         }
 
@@ -746,7 +746,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             }
 
             _log.Info(
-                "slack_hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount}",
+                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount}",
                 triggerInput.MessageId,
                 adoptedContext.Count);
             ChannelTelemetry.For(ChannelType.Slack).RecordMessageEnqueued();
@@ -918,7 +918,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
         var mergedInput = MergeAdoptedContext(baseResult.Input, classified.Gap, cursor);
         _log.Info(
-            "slack_deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId}",
+            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId}",
             classified.Gap.Count,
             baseResult.Input.MessageId);
 
@@ -929,7 +929,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     {
         if (_cursorTs is { } c && candidateTs.CompareTo(c) <= 0)
         {
-            _log.Debug("Slack thread cursor did not advance stream={StreamKey} ts={Ts}", _sessionId.Value, candidateTs.Value);
+            _log.Debug("Thread cursor did not advance stream={StreamKey} ts={Ts}", _sessionId.Value, candidateTs.Value);
             return;
         }
 
@@ -1403,7 +1403,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
         catch (SlackMessageDeliveryException ex)
         {
-            _log.Warning("Slack delivery rejected for session {SessionId} error={ErrorCode} kind={FailureKind}",
+            _log.Warning("Delivery rejected for session {SessionId} error={ErrorCode} kind={FailureKind}",
                 _sessionId.Value, ex.ErrorCode ?? "unknown", ex.FailureKind);
             ChannelTelemetry.For(ChannelType.Slack).RecordReplyRejected(ex.ErrorCode);
             return new PostResult(ex.Message, ex.FailureKind);
@@ -1591,7 +1591,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
         catch (SlackMessageDeliveryException ex)
         {
-            _log.Warning("Slack delivery rejected for file upload {FileName} session={SessionId} error={ErrorCode} kind={FailureKind}",
+            _log.Warning("Delivery rejected for file upload {FileName} session={SessionId} error={ErrorCode} kind={FailureKind}",
                 file.FileName, _sessionId.Value, ex.ErrorCode ?? "unknown", ex.FailureKind);
             ChannelTelemetry.For(ChannelType.Slack).RecordReplyRejected(ex.ErrorCode);
             return new PostResult(ex.Message, ex.FailureKind);

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -103,7 +103,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         }
         catch (SlackException ex)
         {
-            _logger.LogWarning(ex, "Slack API error fetching thread history for {SessionId}: {Error}", sessionId.Value, ex.ErrorCode);
+            _logger.LogWarning(ex, "API error fetching thread history for {SessionId}: {Error}", sessionId.Value, ex.ErrorCode);
             return [];
         }
         catch (Exception ex) when (ex is not OperationCanceledException)


### PR DESCRIPTION
## Summary

Completes the logging sweep from issue #1247. PR #1259 addressed only the `*Channel.cs` bootstrap files (~15 cold-path lifecycle messages). This PR covers the remaining ~90 hot-path log lines across all six actor/service types in each channel adapter.

**What changed:** Strip `discord_` / `slack_` / `mattermost_` event-name prefixes and `"Discord "` / `"Slack "` / `"Mattermost "` noun prefixes from log message templates. No behavioral change — identity moves from message text to the structured context already present (`WithContext("Adapter", ...)` on `ILoggingAdapter` sites; `ILogger<T>` category on transport sites).

**Why it matters:** With prefixes removed, a log query for `event=event_dropped` returns results from all three adapters in one query instead of requiring separate queries for `discord_event_dropped`, `slack_event_dropped`, `mattermost_event_dropped`.

**Files touched (14):**
- `DiscordConversationActor.cs`, `DiscordSessionBindingActor.cs`, `DiscordChannel.cs`, `DiscordNetGatewayLifecycleActor.cs`, `DiscordThreadHistoryFetcher.cs`
- `SlackConversationActor.cs`, `SlackThreadBindingActor.cs`, `SlackChannel.cs`, `SlackThreadHistoryFetcher.cs`
- `MattermostConversationActor.cs`, `MattermostSessionBindingActor.cs`, `MattermostChannel.cs`, `MattermostNetGatewayClient.cs`, `MattermostThreadHistoryFetcher.cs`

## Test plan

- [ ] Build passes (`dotnet build Netclaw.slnx`)
- [ ] `dotnet slopwatch analyze` — 0 new violations
- [ ] `./scripts/Add-FileHeaders.ps1 -Verify` — all headers present
- [ ] No behavioral change; grep confirms zero remaining hardcoded adapter prefixes in log call sites