### PR TITLE
Fix OpenAI ChatGPT OAuth account ID handling

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.8.4"
+  version: "2.8.5"
 ---
 
 # Netclaw Operations
@@ -695,6 +695,13 @@ Provider-specific behavior toggles belong under
 `Providers.<name>.VendorOptions`. Netclaw keeps that bag opaque at the core
 config layer; each provider plugin deserializes and validates its own typed
 options instead of adding provider-specific properties to `ProviderEntry`.
+
+For OpenAI ChatGPT subscription auth, Netclaw persists the OAuth access token,
+refresh token, and ChatGPT account ID returned by the OpenAI ID token. The
+account ID is required by the Codex backend. If OpenAI OAuth validation reports
+that the account ID is missing, re-authenticate the provider with `netclaw
+provider fix <name>` or remove and add it again. API-key OpenAI auth does not
+use the Codex backend or this account-ID metadata.
 
 ### Adding GitHub Copilot
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.8.5"
+  version: "2.8.6"
 ---
 
 # Netclaw Operations
@@ -702,6 +702,10 @@ account ID is required by the Codex backend. If OpenAI OAuth validation reports
 that the account ID is missing, re-authenticate the provider with `netclaw
 provider fix <name>` or remove and add it again. API-key OpenAI auth does not
 use the Codex backend or this account-ID metadata.
+
+When adding an OpenAI provider from the CLI, `netclaw provider add <name>
+openai` defaults to the ChatGPT OAuth device flow. Use `--auth api-key
+--api-key <key>` to force platform API-key auth instead.
 
 ### Adding GitHub Copilot
 

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
+using System.Text;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
@@ -13,26 +15,6 @@ namespace Netclaw.Cli.Tests.Daemon;
 
 public sealed class ContextWindowResolutionTests
 {
-    [Fact]
-    public async Task ConfiguredValue_ReturnedWithoutDaemonQuery()
-    {
-        var daemon = CreateDaemonApi(_ => throw new HttpRequestException("should not be called"));
-
-        var result = await ContextWindowResolution.ResolveAsync(131_072, daemon, "test-model");
-
-        Assert.Equal(131_072, result);
-    }
-
-    [Fact]
-    public async Task NullConfig_DaemonReturnsContextWindow_ReturnsDaemonValue()
-    {
-        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(262_144)));
-
-        var result = await ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b");
-
-        Assert.Equal(262_144, result);
-    }
-
     [Fact]
     public async Task ResolveRuntime_UsesDaemonRuntimeModelWhenNoContextWindowConfigured()
     {
@@ -45,6 +27,28 @@ public sealed class ContextWindowResolutionTests
 
         Assert.Equal("gpt-5.3-codex", result.ModelId);
         Assert.Equal("openai-codex", result.Provider);
+        Assert.Equal(400_000, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public async Task ResolveRuntime_DaemonOnline_OverridesConfiguredContextWindow()
+    {
+        // The daemon is the source of truth at runtime: its live model wins over a
+        // pinned config value when reachable.
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(
+            400_000,
+            modelId: "gpt-5.3-codex",
+            provider: "openai-codex")));
+        var configured = new ModelReference
+        {
+            Provider = "local-ollama",
+            ModelId = "qwen3:30b",
+            ContextWindow = 32_768
+        };
+
+        var result = await ContextWindowResolution.ResolveRuntimeAsync(configured, daemon);
+
+        Assert.Equal("gpt-5.3-codex", result.ModelId);
         Assert.Equal(400_000, result.ContextWindowTokens);
     }
 
@@ -67,18 +71,29 @@ public sealed class ContextWindowResolutionTests
     }
 
     [Fact]
-    public async Task NullConfig_DaemonReturnsZeroContextWindow_Throws()
+    public async Task ResolveRuntime_EmptyStatusWithConfiguredContextWindow_ReturnsConfigured()
     {
-        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(0)));
+        // Regression: a reachable daemon that returns 200 with a null/empty body
+        // must fall back to the configured context window, not crash startup.
+        var daemon = CreateDaemonApi(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json")
+        });
+        var configured = new ModelReference
+        {
+            Provider = "local-ollama",
+            ModelId = "qwen3:30b",
+            ContextWindow = 32_768
+        };
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b"));
+        var result = await ContextWindowResolution.ResolveRuntimeAsync(configured, daemon);
 
-        Assert.Contains("no context window", ex.Message);
+        Assert.Equal("qwen3:30b", result.ModelId);
+        Assert.Equal(32_768, result.ContextWindowTokens);
     }
 
     [Fact]
-    public async Task NullConfig_DaemonReturnsNullModel_Throws()
+    public async Task ResolveRuntime_NullModelWithConfiguredContextWindow_ReturnsConfigured()
     {
         var response = new
         {
@@ -90,20 +105,50 @@ public sealed class ContextWindowResolutionTests
             Telemetry = new { Enabled = false },
         };
         var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(response));
+        var configured = new ModelReference
+        {
+            Provider = "local-ollama",
+            ModelId = "qwen3:30b",
+            ContextWindow = 32_768
+        };
+
+        var result = await ContextWindowResolution.ResolveRuntimeAsync(configured, daemon);
+
+        Assert.Equal(32_768, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public async Task ResolveRuntime_NoConfig_DaemonReturnsZeroContextWindow_Throws()
+    {
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(0)));
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b"));
+            () => ContextWindowResolution.ResolveRuntimeAsync(new ModelReference(), daemon));
 
         Assert.Contains("no context window", ex.Message);
     }
 
     [Fact]
-    public async Task NullConfig_DaemonOffline_ThrowsDaemonUnavailable()
+    public async Task ResolveRuntime_NoConfig_EmptyStatus_Throws()
+    {
+        var daemon = CreateDaemonApi(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json")
+        });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ContextWindowResolution.ResolveRuntimeAsync(new ModelReference(), daemon));
+
+        Assert.Contains("empty status", ex.Message);
+    }
+
+    [Fact]
+    public async Task ResolveRuntime_NoConfig_DaemonOffline_ThrowsDaemonUnavailable()
     {
         var daemon = CreateDaemonApi(_ => throw new HttpRequestException("connection refused"));
 
         var ex = await Assert.ThrowsAsync<DaemonUnavailableException>(
-            () => ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b"));
+            () => ContextWindowResolution.ResolveRuntimeAsync(new ModelReference(), daemon));
 
         Assert.Contains("Could not reach the Netclaw daemon", ex.Message);
         Assert.Contains("netclaw daemon start", ex.Message);

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -34,6 +34,39 @@ public sealed class ContextWindowResolutionTests
     }
 
     [Fact]
+    public async Task ResolveRuntime_UsesDaemonRuntimeModelWhenNoContextWindowConfigured()
+    {
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(
+            400_000,
+            modelId: "gpt-5.3-codex",
+            provider: "openai-codex")));
+
+        var result = await ContextWindowResolution.ResolveRuntimeAsync(new ModelReference(), daemon);
+
+        Assert.Equal("gpt-5.3-codex", result.ModelId);
+        Assert.Equal("openai-codex", result.Provider);
+        Assert.Equal(400_000, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public async Task ResolveRuntime_DaemonOfflineWithConfiguredContextWindow_ReturnsConfiguredModel()
+    {
+        var daemon = CreateDaemonApi(_ => throw new HttpRequestException("connection refused"));
+        var configured = new ModelReference
+        {
+            Provider = "local-ollama",
+            ModelId = "qwen3:30b",
+            ContextWindow = 32_768
+        };
+
+        var result = await ContextWindowResolution.ResolveRuntimeAsync(configured, daemon);
+
+        Assert.Equal("qwen3:30b", result.ModelId);
+        Assert.Equal("local-ollama", result.Provider);
+        Assert.Equal(32_768, result.ContextWindowTokens);
+    }
+
+    [Fact]
     public async Task NullConfig_DaemonReturnsZeroContextWindow_Throws()
     {
         var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(0)));
@@ -86,7 +119,10 @@ public sealed class ContextWindowResolutionTests
         return new DaemonApi(new StubHttpClientFactory(handler), configuration, paths);
     }
 
-    private static object BuildStatusResponse(int contextWindow) => new
+    private static object BuildStatusResponse(
+        int contextWindow,
+        string modelId = "qwen3:30b",
+        string provider = "openai-compatible") => new
     {
         Overall = "healthy",
         Build = new { Version = "1.0.0", CommitHash = "abc123", BuildTimestamp = "2026-01-01T00:00:00Z" },
@@ -96,8 +132,8 @@ public sealed class ContextWindowResolutionTests
         Telemetry = new { Enabled = false },
         Model = new
         {
-            ModelId = "qwen3:30b",
-            Provider = "openai-compatible",
+            ModelId = modelId,
+            Provider = provider,
             ContextWindow = contextWindow,
             InputModalities = "Text",
             OutputModalities = "Text"

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -65,6 +65,44 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
     }
 
     [Fact]
+    public async Task ExplicitContextWindow_DaemonReportsDifferentValue_ReturnsWarning()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "gpt-5.3-codex", Provider = "openai-codex", ContextWindow = 32768 } }
+        });
+
+        var daemonApi = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(400000)));
+        var check = CreateCheck(daemonApi);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("32,768", result.Message);
+        Assert.Contains("400,000", result.Message);
+        Assert.Contains("precedence", result.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitContextWindow_DaemonReportsSameValue_Passes()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama", ContextWindow = 262144 } }
+        });
+
+        var daemonApi = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(262144)));
+        var check = CreateCheck(daemonApi);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("explicitly set", result.Message);
+    }
+
+    [Fact]
     public async Task InvalidContextWindow_ReturnsError()
     {
         WriteConfig(new

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -123,6 +123,36 @@ public sealed class ProviderCommandTests : IDisposable
     }
 
     [Fact]
+    public void ShouldDefaultToOAuthDevice_ReturnsTrueForOpenAiWithoutExplicitCredentialChoice()
+    {
+        var result = ProviderCommand.ShouldDefaultToOAuthDevice(
+            "openai",
+            apiKey: null,
+            requestedAuthMethod: null,
+            [AuthMethod.OAuthDevice, AuthMethod.OAuthPkce, AuthMethod.ApiKey]);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("openai", "sk-test", null)]
+    [InlineData("openai", null, AuthMethod.ApiKey)]
+    [InlineData("anthropic", null, null)]
+    public void ShouldDefaultToOAuthDevice_ReturnsFalseWhenChoiceIsNotImplicitOpenAiOAuth(
+        string providerType,
+        string? apiKey,
+        AuthMethod? requestedAuthMethod)
+    {
+        var result = ProviderCommand.ShouldDefaultToOAuthDevice(
+            providerType,
+            apiKey,
+            requestedAuthMethod,
+            [AuthMethod.OAuthDevice, AuthMethod.OAuthPkce, AuthMethod.ApiKey]);
+
+        Assert.False(result);
+    }
+
+    [Fact]
     public async Task Add_WithUnknownAuthMethod_ReturnsError()
     {
         var exitCode = await ProviderCommand.RunAsync(

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -292,6 +292,7 @@ public sealed class ProviderCommandTests : IDisposable
                 ["my-openai"] = new Dictionary<string, object>
                 {
                     ["OAuthAccessToken"] = protector.Protect("oauth-access-token"),
+                    ["OAuthAccountId"] = protector.Protect("account-123"),
                     ["OAuthTokenExpiry"] = protector.Protect(expiry)
                 }
             }
@@ -300,6 +301,7 @@ public sealed class ProviderCommandTests : IDisposable
         var providers = ProviderCommand.LoadProviders(_paths);
 
         Assert.True(providers.ContainsKey("my-openai"));
+        Assert.Equal("account-123", providers["my-openai"].OAuthAccountId?.Value);
         Assert.NotNull(providers["my-openai"].OAuthTokenExpiry);
         Assert.Equal(DateTimeOffset.Parse(expiry), providers["my-openai"].OAuthTokenExpiry!.Value);
     }

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -650,7 +650,8 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         vm.OAuth.Result = new OAuthDeviceFlowResult(
             new SensitiveString("oauth-access-token"),
             new SensitiveString("oauth-refresh-token"),
-            DateTimeOffset.UtcNow.AddHours(1));
+            DateTimeOffset.UtcNow.AddHours(1),
+            new SensitiveString("account-123"));
 
         Assert.False(File.Exists(_paths.SecretsPath));
 
@@ -666,6 +667,7 @@ public sealed class ProviderManagerViewModelTests : IDisposable
 
         Assert.StartsWith("ENC:", provider.GetProperty("OAuthAccessToken").GetString());
         Assert.StartsWith("ENC:", provider.GetProperty("OAuthRefreshToken").GetString());
+        Assert.StartsWith("ENC:", provider.GetProperty("OAuthAccountId").GetString());
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -205,7 +205,11 @@ public sealed class ProviderStepViewModelTests : IDisposable
 
         public Task<ProviderProbeResult> ProbeAsync(
             ProviderEntry entry, CancellationToken ct = default)
-            => Task.FromResult(NextResult);
+        {
+            LastProviderType = entry.Type;
+            LastApiKey = entry.ApiKey?.Value ?? entry.OAuthAccessToken?.Value;
+            return Task.FromResult(NextResult);
+        }
 
         public Task<ProviderProbeResult> ProbeAsync(
             string providerType, string? endpoint, string? credential,

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -15,17 +15,14 @@ internal static class ContextWindowResolution
 {
     public static async Task<ModelRuntimeResolution> ResolveRuntimeAsync(ModelReference configuredMain, DaemonApi daemon)
     {
-        DaemonRuntimeStatus.Response? status = null;
+        DaemonRuntimeStatus.Response? status;
         try
         {
             status = await GetStatusAsync(daemon);
         }
         catch (DaemonUnavailableException) when (configuredMain.ContextWindow is > 0)
         {
-            return new ModelRuntimeResolution(
-                configuredMain.ModelId,
-                configuredMain.Provider,
-                configuredMain.ContextWindow.Value);
+            return Configured(configuredMain);
         }
 
         if (status?.Model is { ContextWindow: > 0 } daemonModel)
@@ -36,45 +33,29 @@ internal static class ContextWindowResolution
                 daemonModel.ContextWindow);
         }
 
+        // The daemon was reachable but gave us no usable context window — either an
+        // empty status body (status is null) or a model without one. Fall back to the
+        // configured value when set, exactly as the daemon-unavailable path above
+        // does; otherwise the empty-status case would crash a user who pinned a window.
         if (configuredMain.ContextWindow is > 0)
-        {
-            return new ModelRuntimeResolution(
-                configuredMain.ModelId,
-                configuredMain.Provider,
-                configuredMain.ContextWindow.Value);
-        }
+            return Configured(configuredMain);
 
         throw new InvalidOperationException(
-            $"Daemon reported no context window for model '{configuredMain.ModelId}'. " +
-            "Set Models.Main.ContextWindow in netclaw.json.");
+            status is null
+                ? "Daemon returned empty status. Cannot resolve effective context window. " +
+                  "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy."
+                : $"Daemon reported no context window for model '{configuredMain.ModelId}'. " +
+                  "Set Models.Main.ContextWindow in netclaw.json.");
     }
 
-    /// <summary>
-    /// Returns the explicit config value when set; otherwise queries the daemon
-    /// status endpoint for the auto-detected context window.
-    /// </summary>
-    public static async Task<int> ResolveAsync(int? configuredContextWindow, DaemonApi daemon, string modelId)
-    {
-        if (configuredContextWindow is > 0)
-            return configuredContextWindow.Value;
+    private static ModelRuntimeResolution Configured(ModelReference configuredMain)
+        => new(configuredMain.ModelId, configuredMain.Provider, configuredMain.ContextWindow!.Value);
 
-        var status = await GetStatusAsync(daemon);
-
-        return status.Model?.ContextWindow is > 0 and var daemonCw
-            ? daemonCw
-            : throw new InvalidOperationException(
-                $"Daemon reported no context window for model '{modelId}'. " +
-                "Set Models.Main.ContextWindow in netclaw.json.");
-    }
-
-    private static async Task<DaemonRuntimeStatus.Response> GetStatusAsync(DaemonApi daemon)
+    private static async Task<DaemonRuntimeStatus.Response?> GetStatusAsync(DaemonApi daemon)
     {
         try
         {
-            return await daemon.GetStatusAsync()
-                ?? throw new InvalidOperationException(
-                    "Daemon returned empty status. Cannot resolve effective context window. " +
-                    "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");
+            return await daemon.GetStatusAsync();
         }
         catch (HttpRequestException ex)
         {

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -13,6 +13,42 @@ namespace Netclaw.Cli.Daemon;
 /// </summary>
 internal static class ContextWindowResolution
 {
+    public static async Task<ModelRuntimeResolution> ResolveRuntimeAsync(ModelReference configuredMain, DaemonApi daemon)
+    {
+        DaemonRuntimeStatus.Response? status = null;
+        try
+        {
+            status = await GetStatusAsync(daemon);
+        }
+        catch (DaemonUnavailableException) when (configuredMain.ContextWindow is > 0)
+        {
+            return new ModelRuntimeResolution(
+                configuredMain.ModelId,
+                configuredMain.Provider,
+                configuredMain.ContextWindow.Value);
+        }
+
+        if (status?.Model is { ContextWindow: > 0 } daemonModel)
+        {
+            return new ModelRuntimeResolution(
+                daemonModel.ModelId,
+                daemonModel.Provider,
+                daemonModel.ContextWindow);
+        }
+
+        if (configuredMain.ContextWindow is > 0)
+        {
+            return new ModelRuntimeResolution(
+                configuredMain.ModelId,
+                configuredMain.Provider,
+                configuredMain.ContextWindow.Value);
+        }
+
+        throw new InvalidOperationException(
+            $"Daemon reported no context window for model '{configuredMain.ModelId}'. " +
+            "Set Models.Main.ContextWindow in netclaw.json.");
+    }
+
     /// <summary>
     /// Returns the explicit config value when set; otherwise queries the daemon
     /// status endpoint for the auto-detected context window.
@@ -22,10 +58,23 @@ internal static class ContextWindowResolution
         if (configuredContextWindow is > 0)
             return configuredContextWindow.Value;
 
-        DaemonRuntimeStatus.Response? status;
+        var status = await GetStatusAsync(daemon);
+
+        return status.Model?.ContextWindow is > 0 and var daemonCw
+            ? daemonCw
+            : throw new InvalidOperationException(
+                $"Daemon reported no context window for model '{modelId}'. " +
+                "Set Models.Main.ContextWindow in netclaw.json.");
+    }
+
+    private static async Task<DaemonRuntimeStatus.Response> GetStatusAsync(DaemonApi daemon)
+    {
         try
         {
-            status = await daemon.GetStatusAsync();
+            return await daemon.GetStatusAsync()
+                ?? throw new InvalidOperationException(
+                    "Daemon returned empty status. Cannot resolve effective context window. " +
+                    "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");
         }
         catch (HttpRequestException ex)
         {
@@ -35,19 +84,13 @@ internal static class ContextWindowResolution
         {
             throw new DaemonUnavailableException(daemon.Endpoint, ex);
         }
-
-        if (status is null)
-            throw new InvalidOperationException(
-                "Daemon returned empty status. Cannot resolve effective context window. " +
-                "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");
-
-        return status.Model?.ContextWindow is > 0 and var daemonCw
-            ? daemonCw
-            : throw new InvalidOperationException(
-                $"Daemon reported no context window for model '{modelId}'. " +
-                "Set Models.Main.ContextWindow in netclaw.json.");
     }
 }
+
+internal sealed record ModelRuntimeResolution(
+    string ModelId,
+    string Provider,
+    int ContextWindowTokens);
 
 internal sealed class DaemonUnavailableException : InvalidOperationException
 {

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -60,6 +60,19 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
 
         if (contextWindow.GetValue<int>() is var cw and > 0)
         {
+            // Runtime (ContextWindowResolution.ResolveRuntimeAsync) prefers the
+            // daemon's live context window over the pinned config when the daemon
+            // is reachable. Reconcile here so the diagnostic matches what chat uses.
+            var daemonCw = await TryGetDaemonContextWindowAsync(cancellationToken);
+            if (daemonCw is > 0 and var live && live != cw)
+            {
+                return DoctorCheckResult.Warning(
+                    "Context Window",
+                    $"Pinned to {cw:N0} tokens, but the running daemon reports {live:N0} tokens, " +
+                    "which takes precedence at runtime.",
+                    $"Update Models.Main.ContextWindow to {live:N0}, or restart the daemon on the pinned model.");
+            }
+
             return DoctorCheckResult.Pass(
                 "Context Window",
                 $"Context window explicitly set to {cw:N0} tokens.");
@@ -69,6 +82,21 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
             "Context Window",
             "Models.Main.ContextWindow must be a positive integer.",
             "Set Models.Main.ContextWindow to the effective runtime context window size in tokens.");
+    }
+
+    private async Task<int?> TryGetDaemonContextWindowAsync(CancellationToken ct)
+    {
+        try
+        {
+            var status = await _daemonApi.GetStatusAsync(ct);
+            return status?.Model?.ContextWindow is > 0 and var cw ? cw : null;
+        }
+        catch (Exception)
+        {
+            // Daemon unreachable is expected when running doctor offline; the pinned
+            // value stands and there is nothing to reconcile against.
+            return null;
+        }
     }
 
     private async Task<DoctorCheckResult> ResolveEffectiveContextWindowAsync(

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -181,11 +181,7 @@ internal static class ModelCommand
 
         writer.WriteLine($"Discovering models from '{providerName}' ({entry.Type})...");
 
-        var result = await probe.ProbeAsync(
-            entry.Type,
-            string.IsNullOrWhiteSpace(entry.Endpoint) ? null : entry.Endpoint,
-            entry.ApiKey?.Value ?? entry.OAuthAccessToken?.Value,
-            CancellationToken.None);
+        var result = await probe.ProbeAsync(entry, CancellationToken.None);
 
         if (!result.Success)
         {

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -188,15 +188,14 @@ static async Task RunAsync(string[] args)
                 var models = initConfig.GetSection("Models")
                     .Get<ModelSelection>() ?? new ModelSelection();
 
-                var contextWindow = ContextWindowResolution.ResolveAsync(
-                    models.Main.ContextWindow,
-                    sp.GetRequiredService<DaemonApi>(),
-                    models.Main.ModelId).GetAwaiter().GetResult();
+                var runtime = ContextWindowResolution.ResolveRuntimeAsync(
+                    models.Main,
+                    sp.GetRequiredService<DaemonApi>()).GetAwaiter().GetResult();
 
                 return new ModelCapabilities
                 {
-                    ModelId = models.Main.ModelId,
-                    ContextWindowTokens = contextWindow,
+                    ModelId = runtime.ModelId,
+                    ContextWindowTokens = runtime.ContextWindowTokens,
                     CompactionModelId = models.Compaction?.ModelId,
                 };
             });
@@ -1817,15 +1816,14 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
     services.AddSingleton(sessionConfig);
     services.AddSingleton(sp =>
     {
-        var contextWindow = ContextWindowResolution.ResolveAsync(
-            models.Main.ContextWindow,
-            sp.GetRequiredService<DaemonApi>(),
-            models.Main.ModelId).GetAwaiter().GetResult();
+        var runtime = ContextWindowResolution.ResolveRuntimeAsync(
+            models.Main,
+            sp.GetRequiredService<DaemonApi>()).GetAwaiter().GetResult();
 
         return new ModelCapabilities
         {
-            ModelId = models.Main.ModelId,
-            ContextWindowTokens = contextWindow,
+            ModelId = runtime.ModelId,
+            ContextWindowTokens = runtime.ContextWindowTokens,
             CompactionModelId = models.Compaction?.ModelId,
         };
     });

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -409,6 +409,12 @@ internal static class ProviderCommand
                     entry.OAuthRefreshToken = new SensitiveString(decrypted);
                 }
 
+                if (prop.Value.TryGetProperty("OAuthAccountId", out var accountId))
+                {
+                    var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, accountId.GetString());
+                    entry.OAuthAccountId = new SensitiveString(decrypted);
+                }
+
                 if (prop.Value.TryGetProperty("OAuthTokenExpiry", out var tokenExpiry))
                 {
                     var expiryStr = ConfigFileHelper.DecryptIfEncrypted(paths, tokenExpiry.GetString());

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -157,6 +157,9 @@ internal static class ProviderCommand
 
         var supportedAuth = descriptor.Auth.SupportedAuthMethods;
 
+        if (ShouldDefaultToOAuthDevice(type, apiKey, requestedAuthMethod, supportedAuth))
+            return await RunOAuthDeviceFlowAsync(name, type, endpoint, descriptor, paths, writer);
+
         // Handle --auth oauth-device explicitly
         if (requestedAuthMethod == AuthMethod.OAuthDevice)
         {
@@ -232,6 +235,16 @@ internal static class ProviderCommand
         writer.WriteLine();
         return 0;
     }
+
+    internal static bool ShouldDefaultToOAuthDevice(
+        string providerType,
+        string? apiKey,
+        AuthMethod? requestedAuthMethod,
+        IReadOnlyList<AuthMethod> supportedAuth)
+        => requestedAuthMethod is null
+           && string.IsNullOrWhiteSpace(apiKey)
+           && string.Equals(providerType, "openai", StringComparison.OrdinalIgnoreCase)
+           && supportedAuth.Contains(AuthMethod.OAuthDevice);
 
     private static async Task<int> RunOAuthDeviceFlowAsync(
         string name, string type, string? endpoint,

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -203,6 +203,8 @@ public sealed class OAuthFlowCoordinator : IDisposable
                     ? atProp.GetString() : null;
                 var refreshToken = statusResponse.TryGetProperty("refreshToken", out var rtProp)
                     ? rtProp.GetString() : null;
+                var accountId = statusResponse.TryGetProperty("accountId", out var accountIdProp)
+                    ? accountIdProp.GetString() : null;
                 var expiresAt = statusResponse.TryGetProperty("expiresAt", out var expProp)
                     ? expProp.GetString() : null;
 
@@ -211,7 +213,8 @@ public sealed class OAuthFlowCoordinator : IDisposable
                     return new OAuthDeviceFlowResult(
                         new SensitiveString(accessToken),
                         refreshToken is not null ? new SensitiveString(refreshToken) : null,
-                        expiresAt is not null ? DateTimeOffset.Parse(expiresAt) : null);
+                        expiresAt is not null ? DateTimeOffset.Parse(expiresAt) : null,
+                        accountId is not null ? new SensitiveString(accountId) : null);
                 }
 
                 return null;

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -874,6 +874,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         _probeCts = new CancellationTokenSource();
         var ct = _probeCts.Token;
         var providerType = NewProviderType ?? "unknown";
+        var probeEntry = BuildNewProviderProbeEntry(providerType);
         var probeId = IdGen.ShortId();
         var stopwatch = Stopwatch.StartNew();
         Exception? probeException = null;
@@ -896,12 +897,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
         try
         {
-            result = await _probe.ProbeAsync(
-                    providerType,
-                    NewEndpoint,
-                    NewApiKey,
-                    NewAuthMethod,
-                    ct)
+            result = await _probe.ProbeAsync(probeEntry, ct)
                 .WaitAsync(ProbeHardTimeout, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -971,6 +967,37 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
             RequestRedraw();
         }
+    }
+
+    private ProviderEntry BuildNewProviderProbeEntry(string providerType)
+    {
+        var entry = new ProviderEntry
+        {
+            Type = providerType,
+            Endpoint = NewEndpoint ?? "",
+            AuthMethod = NewAuthMethod
+        };
+
+        if (NewAuthMethod is AuthMethod.OAuthDevice or AuthMethod.OAuthPkce)
+        {
+            var result = OAuth.Result;
+            var credential = NewApiKey;
+            if (string.IsNullOrWhiteSpace(credential))
+                credential = result?.AccessToken.Value;
+
+            entry.OAuthAccessToken = !string.IsNullOrWhiteSpace(credential)
+                ? new SensitiveString(credential)
+                : null;
+            entry.OAuthRefreshToken = result?.RefreshToken;
+            entry.OAuthTokenExpiry = result?.ExpiresAt;
+            entry.OAuthAccountId = result?.AccountId;
+        }
+        else if (!string.IsNullOrWhiteSpace(NewApiKey))
+        {
+            entry.ApiKey = new SensitiveString(NewApiKey);
+        }
+
+        return entry;
     }
 
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -167,13 +167,7 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
         _probeCts = new CancellationTokenSource();
         var ct = _probeCts.Token;
         var providerType = SelectedProviderType ?? "unknown";
-        var credential = ApiKeyInput;
-        if (string.IsNullOrWhiteSpace(credential)
-            && SelectedAuthMethod is AuthMethod.OAuthDevice or AuthMethod.OAuthPkce
-            && OAuth.Result is not null)
-        {
-            credential = OAuth.Result.AccessToken.Value;
-        }
+        var probeEntry = BuildProbeEntry(providerType);
 
         IsProbing.Value = true;
         ProbeResult.Value = null;
@@ -184,12 +178,7 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
         var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
         try
         {
-            result = await _probe.ProbeAsync(
-                    providerType,
-                    EndpointInput,
-                    credential,
-                    SelectedAuthMethod,
-                    ct)
+            result = await _probe.ProbeAsync(probeEntry, ct)
                 .WaitAsync(ProbeHardTimeout, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -231,6 +220,37 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
             if (tickCount % 8 == 0)
                 ProbeElapsedSeconds.Value++;
         }
+    }
+
+    private ProviderEntry BuildProbeEntry(string providerType)
+    {
+        var entry = new ProviderEntry
+        {
+            Type = providerType,
+            Endpoint = EndpointInput ?? "",
+            AuthMethod = SelectedAuthMethod
+        };
+
+        if (SelectedAuthMethod is AuthMethod.OAuthDevice or AuthMethod.OAuthPkce)
+        {
+            var result = OAuth.Result;
+            var credential = ApiKeyInput;
+            if (string.IsNullOrWhiteSpace(credential))
+                credential = result?.AccessToken.Value;
+
+            entry.OAuthAccessToken = !string.IsNullOrWhiteSpace(credential)
+                ? new SensitiveString(credential)
+                : null;
+            entry.OAuthRefreshToken = result?.RefreshToken;
+            entry.OAuthTokenExpiry = result?.ExpiresAt;
+            entry.OAuthAccountId = result?.AccountId;
+        }
+        else if (!string.IsNullOrWhiteSpace(ApiKeyInput))
+        {
+            entry.ApiKey = new SensitiveString(ApiKeyInput);
+        }
+
+        return entry;
     }
 
     // ── OAuth ──

--- a/src/Netclaw.Configuration.Tests/ProviderConfigurationLoaderTests.cs
+++ b/src/Netclaw.Configuration.Tests/ProviderConfigurationLoaderTests.cs
@@ -115,6 +115,7 @@ public sealed class ProviderConfigurationLoaderTests : IDisposable
 
         var encryptedAccess = protector.Protect("oauth-access-abc");
         var encryptedRefresh = protector.Protect("oauth-refresh-xyz");
+        var encryptedAccountId = protector.Protect("account-123");
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -123,6 +124,7 @@ public sealed class ProviderConfigurationLoaderTests : IDisposable
                 ["Providers:anthropic:AuthMethod"] = "OAuthDevice",
                 ["Providers:anthropic:OAuthAccessToken"] = encryptedAccess,
                 ["Providers:anthropic:OAuthRefreshToken"] = encryptedRefresh,
+                ["Providers:anthropic:OAuthAccountId"] = encryptedAccountId,
             })
             .Build();
 
@@ -130,6 +132,7 @@ public sealed class ProviderConfigurationLoaderTests : IDisposable
 
         Assert.Equal("oauth-access-abc", providers["anthropic"].OAuthAccessToken?.Value);
         Assert.Equal("oauth-refresh-xyz", providers["anthropic"].OAuthRefreshToken?.Value);
+        Assert.Equal("account-123", providers["anthropic"].OAuthAccountId?.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthPkceServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthPkceServiceTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Providers.OAuth;
@@ -15,6 +16,23 @@ namespace Netclaw.Configuration.Tests.Providers.OAuth;
 
 public class OAuthPkceServiceTests
 {
+    private static string MakeJwt(object payload)
+    {
+        var json = JsonSerializer.Serialize(payload);
+        var header = Base64UrlEncode("{}");
+        var body = Base64UrlEncode(json);
+        return $"{header}.{body}.fakesig";
+    }
+
+    private static string Base64UrlEncode(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
     [Fact]
     public void GenerateCodeVerifier_Returns43CharBase64UrlString()
     {
@@ -150,6 +168,63 @@ public class OAuthPkceServiceTests
         Assert.Contains("code=auth-code-123", capturedBody);
         Assert.Contains("code_verifier=verifier-xyz", capturedBody);
         Assert.Contains("redirect_uri=", capturedBody);
+    }
+
+    [Fact]
+    public async Task ExchangeCodeForTokens_ExtractsAccountIdFromIdToken()
+    {
+        var idToken = MakeJwt(new Dictionary<string, object>
+        {
+            ["https://api.openai.com/auth"] = new Dictionary<string, object>
+            {
+                ["chatgpt_account_id"] = "account-from-id-token"
+            }
+        });
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "at-secret",
+                refresh_token = "rt-secret",
+                id_token = idToken,
+                expires_in = "3600"
+            }));
+
+        var service = new OAuthPkceService(new HttpClient(handler));
+
+        var result = await service.ExchangeCodeForTokensAsync(
+            "https://auth.example.com/token",
+            "test-client",
+            "auth-code-123",
+            "verifier-xyz",
+            "http://127.0.0.1:5199/callback", ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal("account-from-id-token", result.AccountId!.Value);
+        Assert.NotNull(result.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task ExchangeCodeForTokens_ExtractsAccountIdFromTopLevelOpenAiClaim()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new Dictionary<string, object>
+            {
+                ["access_token"] = "at-secret",
+                ["https://api.openai.com/auth"] = new Dictionary<string, object>
+                {
+                    ["chatgpt_account_id"] = "account-from-root-claim"
+                }
+            }));
+
+        var service = new OAuthPkceService(new HttpClient(handler));
+
+        var result = await service.ExchangeCodeForTokensAsync(
+            "https://auth.example.com/token",
+            "test-client",
+            "auth-code-123",
+            "verifier-xyz",
+            "http://127.0.0.1:5199/callback", ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal("account-from-root-claim", result.AccountId!.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
@@ -14,7 +14,7 @@ namespace Netclaw.Configuration.Tests.Providers.OAuth;
 public sealed class OAuthTokenPersistenceTests
 {
     [Fact]
-    public void PersistTokens_RemovesStaleAccountIdWhenResultOmitsAccountId()
+    public void PersistTokens_RemovesStaleOptionalOAuthFieldsWhenResultOmitsThem()
     {
         using var dir = new DisposableTempDir();
         var paths = new NetclawPaths(dir.Path);
@@ -26,7 +26,7 @@ public sealed class OAuthTokenPersistenceTests
             new OAuthDeviceFlowResult(
                 new SensitiveString("access-1"),
                 new SensitiveString("refresh-1"),
-                null,
+                DateTimeOffset.Parse("2026-06-01T00:00:00+00:00"),
                 new SensitiveString("account-1")));
 
         OAuthTokenPersistence.PersistTokens(
@@ -34,7 +34,7 @@ public sealed class OAuthTokenPersistenceTests
             "openai",
             new OAuthDeviceFlowResult(
                 new SensitiveString("access-2"),
-                new SensitiveString("refresh-2"),
+                null,
                 null));
 
         using var doc = JsonDocument.Parse(File.ReadAllText(paths.SecretsPath));
@@ -43,6 +43,14 @@ public sealed class OAuthTokenPersistenceTests
             .GetProperty("openai");
 
         Assert.Equal("access-2", provider.GetProperty("OAuthAccessToken").GetString());
+        Assert.False(provider.TryGetProperty("OAuthRefreshToken", out _));
         Assert.False(provider.TryGetProperty("OAuthAccountId", out _));
+
+        using var configDoc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
+        var configProvider = configDoc.RootElement
+            .GetProperty("Providers")
+            .GetProperty("openai");
+
+        Assert.False(configProvider.TryGetProperty("OAuthTokenExpiry", out _));
     }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="OAuthTokenPersistenceTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Configuration;
+using Netclaw.Providers.OAuth;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers.OAuth;
+
+public sealed class OAuthTokenPersistenceTests
+{
+    [Fact]
+    public void PersistTokens_RemovesStaleAccountIdWhenResultOmitsAccountId()
+    {
+        using var dir = new DisposableTempDir();
+        var paths = new NetclawPaths(dir.Path);
+        paths.EnsureDirectoriesExist();
+
+        OAuthTokenPersistence.PersistTokens(
+            paths,
+            "openai",
+            new OAuthDeviceFlowResult(
+                new SensitiveString("access-1"),
+                new SensitiveString("refresh-1"),
+                null,
+                new SensitiveString("account-1")));
+
+        OAuthTokenPersistence.PersistTokens(
+            paths,
+            "openai",
+            new OAuthDeviceFlowResult(
+                new SensitiveString("access-2"),
+                new SensitiveString("refresh-2"),
+                null));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(paths.SecretsPath));
+        var provider = doc.RootElement
+            .GetProperty("Providers")
+            .GetProperty("openai");
+
+        Assert.Equal("access-2", provider.GetProperty("OAuthAccessToken").GetString());
+        Assert.False(provider.TryGetProperty("OAuthAccountId", out _));
+    }
+}

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
@@ -14,7 +14,7 @@ namespace Netclaw.Configuration.Tests.Providers.OAuth;
 public sealed class OAuthTokenPersistenceTests
 {
     [Fact]
-    public void PersistTokens_RemovesStaleOptionalOAuthFieldsWhenResultOmitsThem()
+    public void PersistTokens_PreservesExistingRefreshTokenAndAccountIdWhenResultOmitsThem()
     {
         using var dir = new DisposableTempDir();
         var paths = new NetclawPaths(dir.Path);
@@ -29,6 +29,8 @@ public sealed class OAuthTokenPersistenceTests
                 DateTimeOffset.Parse("2026-06-01T00:00:00+00:00"),
                 new SensitiveString("account-1")));
 
+        // A partial refresh that returns only a new access token must NOT wipe the
+        // previously-stored refresh token or ChatGPT account id (Codex needs them).
         OAuthTokenPersistence.PersistTokens(
             paths,
             "openai",
@@ -43,14 +45,51 @@ public sealed class OAuthTokenPersistenceTests
             .GetProperty("openai");
 
         Assert.Equal("access-2", provider.GetProperty("OAuthAccessToken").GetString());
-        Assert.False(provider.TryGetProperty("OAuthRefreshToken", out _));
-        Assert.False(provider.TryGetProperty("OAuthAccountId", out _));
+        Assert.Equal("refresh-1", provider.GetProperty("OAuthRefreshToken").GetString());
+        Assert.Equal("account-1", provider.GetProperty("OAuthAccountId").GetString());
 
+        // Expiry, by contrast, IS cleared when omitted — a stale expiry would make the
+        // fresh token look already-expired.
         using var configDoc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
         var configProvider = configDoc.RootElement
             .GetProperty("Providers")
             .GetProperty("openai");
 
         Assert.False(configProvider.TryGetProperty("OAuthTokenExpiry", out _));
+    }
+
+    [Fact]
+    public void PersistTokens_OverwritesExistingFieldsWhenResultProvidesThem()
+    {
+        using var dir = new DisposableTempDir();
+        var paths = new NetclawPaths(dir.Path);
+        paths.EnsureDirectoriesExist();
+
+        OAuthTokenPersistence.PersistTokens(
+            paths,
+            "openai",
+            new OAuthDeviceFlowResult(
+                new SensitiveString("access-1"),
+                new SensitiveString("refresh-1"),
+                null,
+                new SensitiveString("account-1")));
+
+        OAuthTokenPersistence.PersistTokens(
+            paths,
+            "openai",
+            new OAuthDeviceFlowResult(
+                new SensitiveString("access-2"),
+                new SensitiveString("refresh-2"),
+                null,
+                new SensitiveString("account-2")));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(paths.SecretsPath));
+        var provider = doc.RootElement
+            .GetProperty("Providers")
+            .GetProperty("openai");
+
+        Assert.Equal("access-2", provider.GetProperty("OAuthAccessToken").GetString());
+        Assert.Equal("refresh-2", provider.GetProperty("OAuthRefreshToken").GetString());
+        Assert.Equal("account-2", provider.GetProperty("OAuthAccountId").GetString());
     }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenResponseParserTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenResponseParserTests.cs
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------
+// <copyright file="OAuthTokenResponseParserTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Providers.OAuth;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers.OAuth;
+
+public sealed class OAuthTokenResponseParserTests
+{
+    private static readonly FakeTimeProvider Clock =
+        new(DateTimeOffset.Parse("2026-06-01T00:00:00+00:00"));
+
+    private static OAuthDeviceFlowResult Parse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return OAuthTokenResponseParser.Parse(doc.RootElement, Clock);
+    }
+
+    [Fact]
+    public void Parse_ExpiresInNumber_SetsExpiry()
+    {
+        var result = Parse("""{ "access_token": "at", "expires_in": 3600 }""");
+
+        Assert.Equal(Clock.GetUtcNow().AddSeconds(3600), result.ExpiresAt);
+    }
+
+    [Fact]
+    public void Parse_ExpiresInString_SetsExpiry()
+    {
+        var result = Parse("""{ "access_token": "at", "expires_in": "3600" }""");
+
+        Assert.Equal(Clock.GetUtcNow().AddSeconds(3600), result.ExpiresAt);
+    }
+
+    [Fact]
+    public void Parse_ExpiresInNull_TreatedAsNoExpiry()
+    {
+        var result = Parse("""{ "access_token": "at", "expires_in": null }""");
+
+        Assert.Null(result.ExpiresAt);
+    }
+
+    [Fact]
+    public void Parse_ExpiresInMissing_TreatedAsNoExpiry()
+    {
+        var result = Parse("""{ "access_token": "at" }""");
+
+        Assert.Null(result.ExpiresAt);
+    }
+
+    [Fact]
+    public void Parse_ExpiresInAbsurdlyLarge_ClampsInsteadOfThrowing()
+    {
+        // A misbehaving/compromised endpoint can send a value that would overflow
+        // DateTimeOffset.AddSeconds — must clamp, not throw.
+        var result = Parse("""{ "access_token": "at", "expires_in": 1e300 }""");
+
+        Assert.Equal(DateTimeOffset.MaxValue, result.ExpiresAt);
+    }
+
+    [Fact]
+    public void Parse_MissingAccessToken_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => Parse("""{ "expires_in": 3600 }"""));
+    }
+
+    [Fact]
+    public void Parse_ExtractsAccountIdFromNestedOpenAiClaimInIdToken()
+    {
+        var idToken = MakeJwt("""{ "https://api.openai.com/auth": { "chatgpt_account_id": "acct-nested" } }""");
+        var result = Parse($$"""{ "access_token": "at", "id_token": "{{idToken}}" }""");
+
+        Assert.Equal("acct-nested", result.AccountId!.Value);
+    }
+
+    [Fact]
+    public void Parse_ExtractsTopLevelAccountId()
+    {
+        var result = Parse("""{ "access_token": "at", "account_id": "acct-top" }""");
+
+        Assert.Equal("acct-top", result.AccountId!.Value);
+    }
+
+    private static string MakeJwt(string payloadJson)
+    {
+        var header = Base64UrlEncode("{}");
+        var body = Base64UrlEncode(payloadJson);
+        return $"{header}.{body}.fakesig";
+    }
+
+    private static string Base64UrlEncode(string value)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+}

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Providers.OAuth;
@@ -21,6 +22,23 @@ public class OpenAiDeviceFlowServiceTests
         ClientId: "test-client-id",
         Scope: "openid profile email offline_access model.request api.model.read",
         PkceExchangeEndpoint: "https://auth.openai.com/oauth/token");
+
+    private static string MakeJwt(object payload)
+    {
+        var json = JsonSerializer.Serialize(payload);
+        var header = Base64UrlEncode("{}");
+        var body = Base64UrlEncode(json);
+        return $"{header}.{body}.fakesig";
+    }
+
+    private static string Base64UrlEncode(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
 
     [Fact]
     public async Task StartDeviceAuthorization_PostsJsonWithClientId_ReturnsUserCode()
@@ -57,6 +75,23 @@ public class OpenAiDeviceFlowServiceTests
         Assert.Equal("ABCD-1234", result.UserCode);
         Assert.Equal("https://auth.openai.com/codex/device", result.VerificationUri);
         Assert.Equal(1200, result.ExpiresIn);
+        Assert.Equal(5, result.Interval);
+    }
+
+    [Fact]
+    public async Task StartDeviceAuthorization_AcceptsStringInterval()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                device_auth_id = "daid-123",
+                user_code = "ABCD-1234",
+                interval = "5"
+            }));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var result = await service.StartDeviceAuthorizationAsync(TestConfig, TestContext.Current.CancellationToken);
+
         Assert.Equal(5, result.Interval);
     }
 
@@ -240,10 +275,37 @@ public class OpenAiDeviceFlowServiceTests
     }
 
     [Fact]
-    public async Task PollForToken_404_FailsFastWithConfigurationGuidance()
+    public async Task PollForToken_404Pending_ThenSuccess_ExchangesForToken()
     {
-        var handler = new FakeHttpMessageHandler(_ =>
-            new HttpResponseMessage(HttpStatusCode.NotFound));
+        var callCount = 0;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            callCount++;
+            var url = request.RequestUri!.ToString();
+
+            if (url.Contains("deviceauth/token") && callCount == 1)
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+            if (url.Contains("deviceauth/token"))
+            {
+                return JsonResponse(new
+                {
+                    authorization_code = "auth-code-123",
+                    code_verifier = "verifier-xyz"
+                });
+            }
+
+            if (url.Contains("oauth/token"))
+            {
+                return JsonResponse(new
+                {
+                    access_token = "at-secret",
+                    expires_in = 3600
+                });
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        });
 
         var timeProvider = new FakeTimeProvider();
         var service = new OpenAiDeviceFlowService(new HttpClient(handler), timeProvider);
@@ -252,10 +314,12 @@ public class OpenAiDeviceFlowServiceTests
 
         var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth, ct: TestContext.Current.CancellationToken);
         timeProvider.Advance(TimeSpan.FromSeconds(1));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => pollTask);
-        Assert.Contains("endpoint", ex.Message);
-        Assert.Contains("404", ex.Message);
+        var result = await pollTask;
+
+        Assert.Equal("at-secret", result.AccessToken.Value);
+        Assert.Equal(3, callCount);
     }
 
     [Fact]
@@ -340,6 +404,58 @@ public class OpenAiDeviceFlowServiceTests
         Assert.Equal("new-at", result!.AccessToken.Value);
         Assert.NotNull(result.RefreshToken);
         Assert.Equal("new-rt", result.RefreshToken!.Value);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ResponseWithoutRefreshToken_PreservesExistingRefreshToken()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "new-at",
+                expires_in = 3600
+            }));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.openai.com/oauth/token",
+            "client-id",
+            new SensitiveString("old-refresh-token"), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("old-refresh-token", result!.RefreshToken!.Value);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ExtractsAccountIdFromIdToken()
+    {
+        var idToken = MakeJwt(new Dictionary<string, object>
+        {
+            ["https://api.openai.com/auth"] = new Dictionary<string, object>
+            {
+                ["chatgpt_account_id"] = "account-123"
+            }
+        });
+
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "new-at",
+                refresh_token = "new-rt",
+                id_token = idToken,
+                expires_in = "3600"
+            }));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.openai.com/oauth/token",
+            "client-id",
+            new SensitiveString("old-refresh-token"), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("account-123", result!.AccountId!.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration/ProviderEntry.cs
+++ b/src/Netclaw.Configuration/ProviderEntry.cs
@@ -23,6 +23,7 @@ public sealed class ProviderEntry
     public SensitiveString? ApiKey { get; set; }
     public SensitiveString? OAuthAccessToken { get; set; }
     public SensitiveString? OAuthRefreshToken { get; set; }
+    public SensitiveString? OAuthAccountId { get; set; }
     public DateTimeOffset? OAuthTokenExpiry { get; set; }
 
     /// <summary>

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
@@ -5,6 +5,8 @@
 // -----------------------------------------------------------------------
 using System.Text;
 using System.Text.Json;
+using System.ClientModel;
+using System.ClientModel.Primitives;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration;
 using Netclaw.Providers;
@@ -109,6 +111,64 @@ public sealed class OpenAiCodexTests
 
             Assert.Null(result);
         }
+
+        [Fact]
+        public void Extract_ReturnsNestedChatGptAccountClaim()
+        {
+            var jwt = MakeJwt(new Dictionary<string, object>
+            {
+                ["https://api.openai.com/auth"] = new Dictionary<string, object>
+                {
+                    ["chatgpt_account_id"] = "account-from-id-token"
+                }
+            });
+
+            var result = JwtAccountIdExtractor.Extract(jwt);
+
+            Assert.Equal("account-from-id-token", result);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  OpenAiCodexRequestPolicy
+    // ────────────────────────────────────────────────────────────────────
+
+    public sealed class OpenAiCodexRequestPolicyTests
+    {
+        [Fact]
+        public void Process_AddsChatGptAccountIdHeader()
+        {
+            var policy = new OpenAiCodexRequestPolicy("account-123");
+            var pipeline = ClientPipeline.Create(new ClientPipelineOptions());
+            using var message = pipeline.CreateMessage();
+            message.Request.Method = "POST";
+            message.Request.Uri = new Uri("https://chatgpt.com/backend-api/codex/responses");
+
+            var terminal = new TerminalPolicy();
+            policy.Process(message, [policy, terminal], 0);
+
+            Assert.True(terminal.WasCalled);
+            message.Request.Headers.TryGetValue("ChatGPT-Account-Id", out var accountId);
+            Assert.Equal("account-123", accountId);
+        }
+
+        private sealed class TerminalPolicy : PipelinePolicy
+        {
+            public bool WasCalled { get; private set; }
+
+            public override void Process(
+                PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+            {
+                WasCalled = true;
+            }
+
+            public override ValueTask ProcessAsync(
+                PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+            {
+                WasCalled = true;
+                return ValueTask.CompletedTask;
+            }
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -135,6 +195,7 @@ public sealed class OpenAiCodexTests
         public void SupportedAuthMethods_ContainsBothOAuthAndApiKey()
         {
             Assert.Contains(AuthMethod.OAuthPkce, _descriptor.Auth.SupportedAuthMethods);
+            Assert.Contains(AuthMethod.OAuthDevice, _descriptor.Auth.SupportedAuthMethods);
             Assert.Contains(AuthMethod.ApiKey, _descriptor.Auth.SupportedAuthMethods);
         }
 
@@ -172,6 +233,7 @@ public sealed class OpenAiCodexTests
                 Type = "openai",
                 AuthMethod = AuthMethod.OAuthPkce,
                 OAuthAccessToken = new SensitiveString("fake-oauth-token"),
+                OAuthAccountId = new SensitiveString("account-1"),
             };
 
             var result = await _descriptor.ProbeAsync(entry, TestContext.Current.CancellationToken);
@@ -194,6 +256,38 @@ public sealed class OpenAiCodexTests
                     $"{m.ModelId} should accept text input");
                 Assert.Equal(ModelModality.Text, m.OutputModalities);
             });
+        }
+
+        [Fact]
+        public async Task ProbeAsync_WithLegacyJwtOAuthToken_ReturnsCuratedModels()
+        {
+            var entry = new ProviderEntry
+            {
+                Type = "openai",
+                AuthMethod = AuthMethod.OAuthPkce,
+                OAuthAccessToken = new SensitiveString(MakeJwt(new { oid = "legacy-account" })),
+            };
+
+            var result = await _descriptor.ProbeAsync(entry, TestContext.Current.CancellationToken);
+
+            Assert.True(result.Success);
+            Assert.NotEmpty(result.Models);
+        }
+
+        [Fact]
+        public async Task ProbeAsync_WithOpaqueOAuthTokenMissingAccountId_ReturnsFailure()
+        {
+            var entry = new ProviderEntry
+            {
+                Type = "openai",
+                AuthMethod = AuthMethod.OAuthPkce,
+                OAuthAccessToken = new SensitiveString("opaque-oauth-token"),
+            };
+
+            var result = await _descriptor.ProbeAsync(entry, TestContext.Current.CancellationToken);
+
+            Assert.False(result.Success);
+            Assert.Contains("account ID", result.ErrorMessage);
         }
 
         [Fact]
@@ -225,6 +319,7 @@ public sealed class OpenAiCodexTests
                 AuthMethod = AuthMethod.OAuthPkce,
                 OAuthAccessToken = new SensitiveString("fake-oauth-token"),
                 OAuthTokenExpiry = now.AddHours(-1),
+                OAuthAccountId = new SensitiveString("account-1"),
             };
 
             var result = await descriptor.ProbeAsync(entry, TestContext.Current.CancellationToken);
@@ -248,6 +343,7 @@ public sealed class OpenAiCodexTests
                 AuthMethod = AuthMethod.OAuthPkce,
                 OAuthAccessToken = new SensitiveString("fake-oauth-token"),
                 OAuthTokenExpiry = now.AddHours(1),
+                OAuthAccountId = new SensitiveString("account-1"),
             };
 
             var result = await descriptor.ProbeAsync(entry, TestContext.Current.CancellationToken);

--- a/src/Netclaw.Daemon.Tests/Providers/ProviderOAuthEndpointTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/ProviderOAuthEndpointTests.cs
@@ -83,6 +83,7 @@ public sealed class ProviderOAuthEndpointTests
         Assert.True(statusPayload.GetProperty("hasToken").GetBoolean());
         Assert.Equal("access-token", statusPayload.GetProperty("accessToken").GetString());
         Assert.Equal("refresh-token", statusPayload.GetProperty("refreshToken").GetString());
+        Assert.Equal("account-id", statusPayload.GetProperty("accountId").GetString());
     }
 
     [Fact]
@@ -104,6 +105,7 @@ public sealed class ProviderOAuthEndpointTests
         Assert.True(statusPayload.GetProperty("hasToken").GetBoolean());
         Assert.Equal(JsonValueKind.Null, statusPayload.GetProperty("accessToken").ValueKind);
         Assert.Equal(JsonValueKind.Null, statusPayload.GetProperty("refreshToken").ValueKind);
+        Assert.Equal(JsonValueKind.Null, statusPayload.GetProperty("accountId").ValueKind);
     }
 
     [Fact]
@@ -163,8 +165,32 @@ public sealed class ProviderOAuthEndpointTests
         {
             access_token = "access-token",
             refresh_token = "refresh-token",
+            id_token = MakeJwt(new Dictionary<string, object>
+            {
+                ["https://api.openai.com/auth"] = new Dictionary<string, object>
+                {
+                    ["chatgpt_account_id"] = "account-id"
+                }
+            }),
             expires_in = 3600
         });
+    }
+
+    private static string MakeJwt(object payload)
+    {
+        var json = JsonSerializer.Serialize(payload);
+        var header = Base64UrlEncode("{}");
+        var body = Base64UrlEncode(json);
+        return $"{header}.{body}.fakesig";
+    }
+
+    private static string Base64UrlEncode(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
     }
 
     private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)

--- a/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
@@ -30,6 +30,7 @@ internal sealed record ProviderOAuthStatusResponse(
     bool HasToken,
     string? AccessToken,
     string? RefreshToken,
+    string? AccountId,
     string? ExpiresAt);
 
 /// <summary>Error payload returned when a provider OAuth request is malformed or unknown.</summary>
@@ -123,6 +124,7 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
                 HasToken: result is not null,
                 AccessToken: isLoopback ? result?.AccessToken.Value : null,
                 RefreshToken: isLoopback ? result?.RefreshToken?.Value : null,
+                AccountId: isLoopback ? result?.AccountId?.Value : null,
                 ExpiresAt: result?.ExpiresAt?.ToString("o")));
         })
         .WithName("GetProviderOAuthStatus")

--- a/src/Netclaw.Providers/OAuth/OAuthDeviceFlowService.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthDeviceFlowService.cs
@@ -66,7 +66,8 @@ public sealed record DeviceAuthorizationResponse(
 public sealed record OAuthDeviceFlowResult(
     SensitiveString AccessToken,
     SensitiveString? RefreshToken,
-    DateTimeOffset? ExpiresAt);
+    DateTimeOffset? ExpiresAt,
+    SensitiveString? AccountId = null);
 
 /// <summary>
 /// Observable state of the device flow polling loop.
@@ -159,7 +160,7 @@ public sealed class OAuthDeviceFlowService : IDeviceFlowService
 
             if (response.IsSuccessStatusCode && !hasError)
             {
-                var result = ParseTokenResponse(root);
+                var result = OAuthTokenResponseParser.Parse(root, _timeProvider);
                 onStateChanged?.Invoke(DeviceFlowState.Succeeded);
                 return result;
             }
@@ -230,7 +231,7 @@ public sealed class OAuthDeviceFlowService : IDeviceFlowService
 
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        return ParseTokenResponse(doc.RootElement);
+        return OAuthTokenResponseParser.Parse(doc.RootElement, _timeProvider);
     }
 
     public Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
@@ -239,24 +240,6 @@ public sealed class OAuthDeviceFlowService : IDeviceFlowService
         string refreshToken,
         CancellationToken ct = default) =>
         RefreshTokenAsync(tokenEndpoint, clientId, new SensitiveString(refreshToken), ct);
-
-    private OAuthDeviceFlowResult ParseTokenResponse(JsonElement root)
-    {
-        var accessToken = root.GetProperty("access_token").GetString()
-            ?? throw new InvalidOperationException("Missing access_token in response.");
-
-        string? refreshToken = root.TryGetProperty("refresh_token", out var refreshProp)
-            ? refreshProp.GetString() : null;
-
-        DateTimeOffset? expiresAt = root.TryGetProperty("expires_in", out var expiresProp)
-            ? _timeProvider.GetUtcNow().AddSeconds(expiresProp.GetInt32())
-            : null;
-
-        return new OAuthDeviceFlowResult(
-            new SensitiveString(accessToken),
-            refreshToken is not null ? new SensitiveString(refreshToken) : null,
-            expiresAt);
-    }
 
     // GitHub's OAuth endpoints return application/x-www-form-urlencoded by default
     // and only switch to JSON when the request explicitly asks for it. Other providers

--- a/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
@@ -149,7 +149,7 @@ public sealed class OAuthPkceService
 
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        return ParseTokenResponse(doc.RootElement);
+        return OAuthTokenResponseParser.Parse(doc.RootElement, _timeProvider);
     }
 
     /// <summary>
@@ -188,7 +188,7 @@ public sealed class OAuthPkceService
 
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        var result = ParseTokenResponse(doc.RootElement);
+        var result = OAuthTokenResponseParser.Parse(doc.RootElement, _timeProvider);
 
         // Preserve existing refresh token if server didn't issue a new one
         result = result with
@@ -366,23 +366,6 @@ public sealed class OAuthPkceService
             .Replace('/', '_');
     }
 
-    private OAuthDeviceFlowResult ParseTokenResponse(JsonElement root)
-    {
-        var accessToken = root.GetProperty("access_token").GetString()
-            ?? throw new InvalidOperationException("Missing access_token in response.");
-
-        string? refreshToken = root.TryGetProperty("refresh_token", out var refreshProp)
-            ? refreshProp.GetString() : null;
-
-        DateTimeOffset? expiresAt = root.TryGetProperty("expires_in", out var expiresProp)
-            ? _timeProvider.GetUtcNow().AddSeconds(expiresProp.GetInt32())
-            : null;
-
-        return new OAuthDeviceFlowResult(
-            new SensitiveString(accessToken),
-            refreshToken is not null ? new SensitiveString(refreshToken) : null,
-            expiresAt);
-    }
 }
 
 /// <summary>

--- a/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
@@ -46,6 +46,11 @@ public static class OAuthTokenPersistence
         if (result.RefreshToken is not null)
             providerNode["OAuthRefreshToken"] = result.RefreshToken.Value;
 
+        if (result.AccountId is not null)
+            providerNode["OAuthAccountId"] = result.AccountId.Value;
+        else
+            providerNode.Remove("OAuthAccountId");
+
         // OAuthTokenExpiry is NOT a secret and must NOT go in secrets.json.
         // SecretsFileWriter encrypts the entire file, and encrypted DateTimeOffset
         // values break IConfiguration binding (silently drops the provider entry).
@@ -107,6 +112,14 @@ public static class OAuthTokenPersistence
                 refreshTokenStr = protector.Unprotect(refreshTokenStr);
         }
 
+        string? accountIdStr = null;
+        if (provider.TryGetProperty("OAuthAccountId", out var accountIdProp))
+        {
+            accountIdStr = accountIdProp.GetString();
+            if (protector is not null && accountIdStr is not null && ISecretsProtector.IsEncrypted(accountIdStr))
+                accountIdStr = protector.Unprotect(accountIdStr);
+        }
+
         DateTimeOffset? expiresAt = null;
         if (provider.TryGetProperty("OAuthTokenExpiry", out var expiryProp))
         {
@@ -121,6 +134,7 @@ public static class OAuthTokenPersistence
         return new OAuthDeviceFlowResult(
             new SensitiveString(accessTokenStr),
             refreshTokenStr is not null ? new SensitiveString(refreshTokenStr) : null,
-            expiresAt);
+            expiresAt,
+            accountIdStr is not null ? new SensitiveString(accountIdStr) : null);
     }
 }

--- a/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
@@ -45,6 +45,8 @@ public static class OAuthTokenPersistence
 
         if (result.RefreshToken is not null)
             providerNode["OAuthRefreshToken"] = result.RefreshToken.Value;
+        else
+            providerNode.Remove("OAuthRefreshToken");
 
         if (result.AccountId is not null)
             providerNode["OAuthAccountId"] = result.AccountId.Value;
@@ -58,19 +60,46 @@ public static class OAuthTokenPersistence
         var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
         SecretsFileWriter.Write(paths.SecretsPath, json, protector);
 
-        if (result.ExpiresAt.HasValue)
+        PersistTokenExpiry(paths, providerName, result.ExpiresAt);
+    }
+
+    private static void PersistTokenExpiry(NetclawPaths paths, string providerName, DateTimeOffset? expiresAt)
+    {
+        if (!expiresAt.HasValue && !File.Exists(paths.NetclawConfigPath))
+            return;
+
+        var configJson = File.Exists(paths.NetclawConfigPath)
+            ? File.ReadAllText(paths.NetclawConfigPath)
+            : "{}";
+        var configRoot = JsonNode.Parse(configJson)?.AsObject() ?? [];
+        var configProviders = configRoot["Providers"]?.AsObject();
+
+        if (configProviders is null)
         {
-            var configJson = File.Exists(paths.NetclawConfigPath)
-                ? File.ReadAllText(paths.NetclawConfigPath) : "{}";
-            var configRoot = JsonNode.Parse(configJson)?.AsObject() ?? [];
-            var configProviders = configRoot["Providers"]?.AsObject() ?? [];
+            if (!expiresAt.HasValue)
+                return;
+
+            configProviders = [];
             configRoot["Providers"] = configProviders;
-            var configProvider = configProviders[providerName]?.AsObject() ?? [];
-            configProviders[providerName] = configProvider;
-            configProvider["OAuthTokenExpiry"] = result.ExpiresAt.Value.ToString("o");
-            File.WriteAllText(paths.NetclawConfigPath,
-                configRoot.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
         }
+
+        var configProvider = configProviders[providerName]?.AsObject();
+        if (configProvider is null)
+        {
+            if (!expiresAt.HasValue)
+                return;
+
+            configProvider = [];
+            configProviders[providerName] = configProvider;
+        }
+
+        if (expiresAt.HasValue)
+            configProvider["OAuthTokenExpiry"] = expiresAt.Value.ToString("o");
+        else
+            configProvider.Remove("OAuthTokenExpiry");
+
+        File.WriteAllText(paths.NetclawConfigPath,
+            configRoot.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
     }
 
     /// <summary>

--- a/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
@@ -43,15 +43,17 @@ public static class OAuthTokenPersistence
 
         providerNode["OAuthAccessToken"] = result.AccessToken.Value;
 
+        // Preserve any previously-stored refresh token / account id when the new
+        // result omits them. An OAuth response that doesn't echo refresh_token means
+        // "keep using the existing one" (RFC 6749 §5.1), and a partial refresh that
+        // lacks the ChatGPT account id must not wipe a value the Codex backend still
+        // requires. (OAuthTokenExpiry below is still cleared on null — a stale expiry
+        // is worse than an absent one.)
         if (result.RefreshToken is not null)
             providerNode["OAuthRefreshToken"] = result.RefreshToken.Value;
-        else
-            providerNode.Remove("OAuthRefreshToken");
 
         if (result.AccountId is not null)
             providerNode["OAuthAccountId"] = result.AccountId.Value;
-        else
-            providerNode.Remove("OAuthAccountId");
 
         // OAuthTokenExpiry is NOT a secret and must NOT go in secrets.json.
         // SecretsFileWriter encrypts the entire file, and encrypted DateTimeOffset

--- a/src/Netclaw.Providers/OAuth/OAuthTokenResponseParser.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenResponseParser.cs
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------
+// <copyright file="OAuthTokenResponseParser.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Globalization;
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Providers.OAuth;
+
+internal static class OAuthTokenResponseParser
+{
+    public static OAuthDeviceFlowResult Parse(JsonElement root, TimeProvider timeProvider)
+    {
+        var accessToken = GetRequiredString(root, "access_token");
+        var refreshToken = GetOptionalString(root, "refresh_token");
+        DateTimeOffset? expiresAt = ReadOptionalSeconds(root, "expires_in") is { } seconds
+            ? timeProvider.GetUtcNow().AddSeconds(seconds)
+            : null;
+        var accountId = ExtractAccountId(root);
+
+        return new OAuthDeviceFlowResult(
+            new SensitiveString(accessToken),
+            refreshToken is not null ? new SensitiveString(refreshToken) : null,
+            expiresAt,
+            accountId is not null ? new SensitiveString(accountId) : null);
+    }
+
+    public static string? ExtractChatGptAccountId(string jwt)
+    {
+        if (!TryDecodeJwtPayload(jwt, out var payload))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            var root = doc.RootElement;
+
+            if (TryGetChatGptAccountId(root, out var accountId))
+                return accountId;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static string GetRequiredString(JsonElement root, string propertyName)
+    {
+        if (TryGetString(root, propertyName, out var value))
+            return value;
+
+        throw new InvalidOperationException($"Missing {propertyName} in OAuth token response.");
+    }
+
+    private static string? GetOptionalString(JsonElement root, string propertyName)
+        => TryGetString(root, propertyName, out var value) ? value : null;
+
+    private static string? ExtractAccountId(JsonElement root)
+    {
+        if (TryGetString(root, "account_id", out var accountId))
+            return accountId;
+
+        if (TryGetChatGptAccountId(root, out var chatGptAccountId))
+            return chatGptAccountId;
+
+        var idToken = GetOptionalString(root, "id_token");
+        return idToken is null ? null : ExtractChatGptAccountId(idToken);
+    }
+
+    private static bool TryGetChatGptAccountId(JsonElement root, out string accountId)
+    {
+        if (TryGetString(root, "chatgpt_account_id", out accountId))
+            return true;
+
+        if (TryGetString(root, "https://api.openai.com/auth.chatgpt_account_id", out accountId))
+            return true;
+
+        if (root.TryGetProperty("https://api.openai.com/auth", out var auth)
+            && auth.ValueKind == JsonValueKind.Object
+            && TryGetString(auth, "chatgpt_account_id", out accountId))
+        {
+            return true;
+        }
+
+        accountId = "";
+        return false;
+    }
+
+    private static bool TryGetString(JsonElement root, string propertyName, out string value)
+    {
+        value = "";
+        if (!root.TryGetProperty(propertyName, out var property)
+            || property.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var candidate = property.GetString();
+        if (string.IsNullOrWhiteSpace(candidate))
+            return false;
+
+        value = candidate;
+        return true;
+    }
+
+    private static double? ReadOptionalSeconds(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var property))
+            return null;
+
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetDouble(out var numericValue))
+            return numericValue;
+
+        if (property.ValueKind == JsonValueKind.String
+            && double.TryParse(property.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var stringValue))
+        {
+            return stringValue;
+        }
+
+        throw new InvalidOperationException($"Invalid {propertyName} in OAuth token response.");
+    }
+
+    private static bool TryDecodeJwtPayload(string jwt, out byte[] payload)
+    {
+        payload = [];
+
+        var parts = jwt.Split('.');
+        if (parts.Length < 2 || string.IsNullOrWhiteSpace(parts[1]))
+            return false;
+
+        try
+        {
+            payload = Base64UrlDecode(parts[1]);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var s = input.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+
+        return Convert.FromBase64String(s);
+    }
+}

--- a/src/Netclaw.Providers/OAuth/OAuthTokenResponseParser.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenResponseParser.cs
@@ -16,7 +16,7 @@ internal static class OAuthTokenResponseParser
         var accessToken = GetRequiredString(root, "access_token");
         var refreshToken = GetOptionalString(root, "refresh_token");
         DateTimeOffset? expiresAt = ReadOptionalSeconds(root, "expires_in") is { } seconds
-            ? timeProvider.GetUtcNow().AddSeconds(seconds)
+            ? AddSecondsClamped(timeProvider.GetUtcNow(), seconds)
             : null;
         var accountId = ExtractAccountId(root);
 
@@ -76,9 +76,6 @@ internal static class OAuthTokenResponseParser
         if (TryGetString(root, "chatgpt_account_id", out accountId))
             return true;
 
-        if (TryGetString(root, "https://api.openai.com/auth.chatgpt_account_id", out accountId))
-            return true;
-
         if (root.TryGetProperty("https://api.openai.com/auth", out var auth)
             && auth.ValueKind == JsonValueKind.Object
             && TryGetString(auth, "chatgpt_account_id", out accountId))
@@ -107,9 +104,32 @@ internal static class OAuthTokenResponseParser
         return true;
     }
 
+    // A token endpoint can return an absurd or non-finite expires_in; DateTimeOffset
+    // .AddSeconds throws ArgumentOutOfRangeException on overflow and on NaN. Clamp to
+    // the representable range so a bad value degrades to "effectively never expires"
+    // instead of aborting the whole auth/refresh flow with a non-actionable error.
+    private static DateTimeOffset AddSecondsClamped(DateTimeOffset now, double seconds)
+    {
+        if (double.IsNaN(seconds))
+            return now;
+
+        if (seconds >= (DateTimeOffset.MaxValue - now).TotalSeconds)
+            return DateTimeOffset.MaxValue;
+
+        if (seconds <= (DateTimeOffset.MinValue - now).TotalSeconds)
+            return DateTimeOffset.MinValue;
+
+        return now.AddSeconds(seconds);
+    }
+
     private static double? ReadOptionalSeconds(JsonElement root, string propertyName)
     {
         if (!root.TryGetProperty(propertyName, out var property))
+            return null;
+
+        // An explicit JSON null is treated the same as an absent property (no expiry)
+        // rather than a hard parse failure.
+        if (property.ValueKind == JsonValueKind.Null)
             return null;
 
         if (property.ValueKind == JsonValueKind.Number && property.TryGetDouble(out var numericValue))

--- a/src/Netclaw.Providers/OAuth/OpenAiDeviceFlowService.cs
+++ b/src/Netclaw.Providers/OAuth/OpenAiDeviceFlowService.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net;
+using System.Globalization;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -68,11 +69,10 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
 
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<OpenAiUserCodeResponse>(ct);
-        if (result is null)
-            throw new InvalidOperationException("Empty device authorization response from OpenAI.");
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var result = ParseUserCodeResponse(doc.RootElement);
 
-        // Map OpenAI's response to the shared DeviceAuthorizationResponse
         var expiresIn = result.ExpiresIn is > 0 ? result.ExpiresIn.Value : DefaultExpiresIn;
 
         return new DeviceAuthorizationResponse(
@@ -125,16 +125,9 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
                     ex);
             }
 
-            // 403 = authorization pending, keep polling
-            if (response.StatusCode == HttpStatusCode.Forbidden)
+            // 403/404 = authorization pending in OpenAI's proprietary flow.
+            if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
                 continue;
-
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                onStateChanged?.Invoke(DeviceFlowState.Error);
-                throw new InvalidOperationException(
-                    "OpenAI device polling endpoint was not found (HTTP 404). Check provider OAuth endpoint configuration and try again.");
-            }
 
             // 5xx = transient server error, keep polling (momentary 502/503 shouldn't kill the flow)
             if ((int)response.StatusCode >= 500)
@@ -205,7 +198,11 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
 
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        return ParseTokenResponse(doc.RootElement);
+        var result = OAuthTokenResponseParser.Parse(doc.RootElement, _timeProvider);
+        return result with
+        {
+            RefreshToken = result.RefreshToken ?? refreshToken
+        };
     }
 
     public Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
@@ -242,25 +239,52 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
 
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        return ParseTokenResponse(doc.RootElement);
+        return OAuthTokenResponseParser.Parse(doc.RootElement, _timeProvider);
     }
 
-    private OAuthDeviceFlowResult ParseTokenResponse(JsonElement root)
+    private static OpenAiUserCodeResponse ParseUserCodeResponse(JsonElement root)
     {
-        var accessToken = root.GetProperty("access_token").GetString()
-            ?? throw new InvalidOperationException("Missing access_token in response.");
+        return new OpenAiUserCodeResponse(
+            GetRequiredString(root, "device_auth_id"),
+            GetRequiredString(root, "user_code", "usercode"),
+            GetOptionalInt(root, "interval") ?? 1,
+            GetOptionalInt(root, "expires_in"));
+    }
 
-        string? refreshToken = root.TryGetProperty("refresh_token", out var refreshProp)
-            ? refreshProp.GetString() : null;
+    private static string GetRequiredString(JsonElement root, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (!root.TryGetProperty(propertyName, out var property)
+                || property.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
 
-        DateTimeOffset? expiresAt = root.TryGetProperty("expires_in", out var expiresProp)
-            ? _timeProvider.GetUtcNow().AddSeconds(expiresProp.GetInt32())
-            : null;
+            var value = property.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
 
-        return new OAuthDeviceFlowResult(
-            new SensitiveString(accessToken),
-            refreshToken is not null ? new SensitiveString(refreshToken) : null,
-            expiresAt);
+        throw new InvalidOperationException(
+            $"Missing {string.Join("/", propertyNames)} in OpenAI device authorization response.");
+    }
+
+    private static int? GetOptionalInt(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var property))
+            return null;
+
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out var numericValue))
+            return numericValue;
+
+        if (property.ValueKind == JsonValueKind.String
+            && int.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var stringValue))
+        {
+            return stringValue;
+        }
+
+        throw new InvalidOperationException($"Invalid {propertyName} in OpenAI device authorization response.");
     }
 
     // OpenAI-specific response DTOs

--- a/src/Netclaw.Providers/OpenAi/JwtAccountIdExtractor.cs
+++ b/src/Netclaw.Providers/OpenAi/JwtAccountIdExtractor.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.Text;
 using System.Text.Json;
+using Netclaw.Configuration;
 using Netclaw.Providers.OAuth;
 
 namespace Netclaw.Providers.OpenAi;
@@ -15,6 +16,18 @@ namespace Netclaw.Providers.OpenAi;
 /// </summary>
 internal static class JwtAccountIdExtractor
 {
+    /// <summary>
+    /// Resolves the ChatGPT account ID for a provider entry: prefers the explicitly
+    /// stored <see cref="ProviderEntry.OAuthAccountId"/>, falling back to extracting it
+    /// from the OAuth access token's JWT claims. Returns null when neither yields one.
+    /// </summary>
+    public static string? ResolveAccountId(ProviderEntry entry)
+        => !entry.OAuthAccountId.IsNullOrEmpty()
+            ? entry.OAuthAccountId.Value
+            : entry.OAuthAccessToken is { } token
+                ? Extract(token.Value)
+                : null;
+
     /// <summary>
     /// Extracts the organization/account ID from the JWT payload.
     /// Returns null if extraction fails (malformed token, missing claim).

--- a/src/Netclaw.Providers/OpenAi/JwtAccountIdExtractor.cs
+++ b/src/Netclaw.Providers/OpenAi/JwtAccountIdExtractor.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.Text;
 using System.Text.Json;
+using Netclaw.Providers.OAuth;
 
 namespace Netclaw.Providers.OpenAi;
 
@@ -20,6 +21,9 @@ internal static class JwtAccountIdExtractor
     /// </summary>
     public static string? Extract(string accessToken)
     {
+        if (OAuthTokenResponseParser.ExtractChatGptAccountId(accessToken) is { } chatGptAccountId)
+            return chatGptAccountId;
+
         // JWT format: header.payload.signature
         var parts = accessToken.Split('.');
         if (parts.Length < 2)

--- a/src/Netclaw.Providers/OpenAi/OpenAiCodexRequestPolicy.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiCodexRequestPolicy.cs
@@ -14,14 +14,14 @@ namespace Netclaw.Providers.OpenAi;
 /// <remarks>
 /// The Codex backend has stricter validation than <c>api.openai.com</c>:
 /// <list type="bullet">
-///   <item>Requires <c>ChatGPT-Account-Id</c> header (extracted from JWT)</item>
+///   <item>Requires <c>ChatGPT-Account-Id</c> header from OpenAI OAuth metadata</item>
 ///   <item>Requires <c>"store": false</c> in the request body</item>
 ///   <item>Requires <c>"instructions"</c> to be present (even if empty)</item>
 ///   <item>Rejects system messages in <c>"input"</c> — must be in <c>"instructions"</c></item>
 ///   <item>Rejects <c>"strict": null</c> in tool definitions (must be omitted or boolean)</item>
 /// </list>
 /// </remarks>
-internal sealed class OpenAiCodexRequestPolicy(string? accountId) : PipelinePolicy
+internal sealed class OpenAiCodexRequestPolicy(string accountId) : PipelinePolicy
 {
     public override void Process(
         PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
@@ -39,10 +39,9 @@ internal sealed class OpenAiCodexRequestPolicy(string? accountId) : PipelinePoli
 
     private void Modify(PipelineMessage message)
     {
-        // Inject ChatGPT-Account-Id header (extracted from JWT by JwtAccountIdExtractor).
-        // Set even when the body is empty/non-JSON; the header is always required.
-        if (accountId is not null)
-            message.Request.Headers.Set("ChatGPT-Account-Id", accountId);
+        // Set even when the body is empty/non-JSON; the Codex backend requires
+        // this OAuth workspace selector on every request.
+        message.Request.Headers.Set("ChatGPT-Account-Id", accountId);
 
         PipelineRequestBodyEditor.EditJsonBody(message, obj =>
         {

--- a/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
@@ -109,20 +109,13 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
             return Task.FromResult(new ProviderProbeResult(false,
                 $"OAuth token expired {expiry:g}. Re-authenticate with 'netclaw provider fix <name>'.", []));
 
-        if (ResolveAccountId(entry) is null)
+        if (JwtAccountIdExtractor.ResolveAccountId(entry) is null)
             return Task.FromResult(new ProviderProbeResult(false,
                 "OpenAI OAuth login did not return a ChatGPT account ID. Re-authenticate with 'netclaw provider fix <name>'.", []));
 
         // Codex tokens can't probe — return curated models
         return Task.FromResult(new ProviderProbeResult(true, null, CuratedModels));
     }
-
-    private static string? ResolveAccountId(ProviderEntry entry)
-        => !entry.OAuthAccountId.IsNullOrEmpty()
-            ? entry.OAuthAccountId.Value
-            : entry.OAuthAccessToken is { } token
-                ? JwtAccountIdExtractor.Extract(token.Value)
-                : null;
 
     private Task<ProviderProbeResult> ProbeApiKeyAsync(ProviderEntry entry, CancellationToken ct)
     {

--- a/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
@@ -43,11 +43,11 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
 
     public IProviderAuth Auth { get; } = new MultiAuth
     {
-        SupportedAuthMethods = [AuthMethod.OAuthPkce, AuthMethod.OAuthDevice, AuthMethod.ApiKey],
+        SupportedAuthMethods = [AuthMethod.OAuthDevice, AuthMethod.OAuthPkce, AuthMethod.ApiKey],
         GuidanceUrl = new Uri("https://platform.openai.com/api-keys"),
         OAuth = new OAuthAuth
         {
-            SupportedAuthMethods = [AuthMethod.OAuthPkce, AuthMethod.OAuthDevice],
+            SupportedAuthMethods = [AuthMethod.OAuthDevice, AuthMethod.OAuthPkce],
             TokenEndpoint = new Uri("https://auth.openai.com/oauth/token"),
             ClientId = "app_EMoamEEZ73f0CkXaXp7hrann",
             DeviceEndpoint = new Uri("https://auth.openai.com/api/accounts/deviceauth/usercode"),
@@ -60,8 +60,8 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
         },
         AuthMethodLabels = new Dictionary<AuthMethod, string>
         {
-            [AuthMethod.OAuthPkce] = "ChatGPT Subscription (recommended)",
-            [AuthMethod.OAuthDevice] = "ChatGPT Subscription (device code)",
+            [AuthMethod.OAuthDevice] = "ChatGPT Subscription (recommended)",
+            [AuthMethod.OAuthPkce] = "ChatGPT Subscription (browser)",
             [AuthMethod.ApiKey] = "API Key (platform.openai.com)",
         },
     };

--- a/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
@@ -43,11 +43,11 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
 
     public IProviderAuth Auth { get; } = new MultiAuth
     {
-        SupportedAuthMethods = [AuthMethod.OAuthPkce, AuthMethod.ApiKey],
+        SupportedAuthMethods = [AuthMethod.OAuthPkce, AuthMethod.OAuthDevice, AuthMethod.ApiKey],
         GuidanceUrl = new Uri("https://platform.openai.com/api-keys"),
         OAuth = new OAuthAuth
         {
-            SupportedAuthMethods = [AuthMethod.OAuthPkce],
+            SupportedAuthMethods = [AuthMethod.OAuthPkce, AuthMethod.OAuthDevice],
             TokenEndpoint = new Uri("https://auth.openai.com/oauth/token"),
             ClientId = "app_EMoamEEZ73f0CkXaXp7hrann",
             DeviceEndpoint = new Uri("https://auth.openai.com/api/accounts/deviceauth/usercode"),
@@ -61,6 +61,7 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
         AuthMethodLabels = new Dictionary<AuthMethod, string>
         {
             [AuthMethod.OAuthPkce] = "ChatGPT Subscription (recommended)",
+            [AuthMethod.OAuthDevice] = "ChatGPT Subscription (device code)",
             [AuthMethod.ApiKey] = "API Key (platform.openai.com)",
         },
     };
@@ -108,9 +109,20 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
             return Task.FromResult(new ProviderProbeResult(false,
                 $"OAuth token expired {expiry:g}. Re-authenticate with 'netclaw provider fix <name>'.", []));
 
+        if (ResolveAccountId(entry) is null)
+            return Task.FromResult(new ProviderProbeResult(false,
+                "OpenAI OAuth login did not return a ChatGPT account ID. Re-authenticate with 'netclaw provider fix <name>'.", []));
+
         // Codex tokens can't probe — return curated models
         return Task.FromResult(new ProviderProbeResult(true, null, CuratedModels));
     }
+
+    private static string? ResolveAccountId(ProviderEntry entry)
+        => !entry.OAuthAccountId.IsNullOrEmpty()
+            ? entry.OAuthAccountId.Value
+            : entry.OAuthAccessToken is { } token
+                ? JwtAccountIdExtractor.Extract(token.Value)
+                : null;
 
     private Task<ProviderProbeResult> ProbeApiKeyAsync(ProviderEntry entry, CancellationToken ct)
     {

--- a/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
@@ -28,7 +28,9 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
             var token = entry.OAuthAccessToken.RequireValid(
                 "OpenAI OAuth access token (run 'netclaw provider fix <name>')");
 
-            var accountId = JwtAccountIdExtractor.Extract(token.Value);
+            var accountId = ResolveAccountId(entry, token.Value)
+                ?? throw new InvalidOperationException(
+                    "OpenAI OAuth credential is missing ChatGPT account ID. Re-authenticate with 'netclaw provider fix <name>'.");
             var options = new OpenAIClientOptions
             {
                 Endpoint = new Uri("https://chatgpt.com/backend-api/codex")
@@ -45,4 +47,9 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
         return new OpenAI.Responses.ResponsesClient(apiKey)
             .AsIChatClient(model.ModelId);
     }
+
+    private static string? ResolveAccountId(ProviderEntry entry, string accessToken)
+        => !entry.OAuthAccountId.IsNullOrEmpty()
+            ? entry.OAuthAccountId.Value
+            : JwtAccountIdExtractor.Extract(accessToken);
 }

--- a/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
@@ -28,7 +28,7 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
             var token = entry.OAuthAccessToken.RequireValid(
                 "OpenAI OAuth access token (run 'netclaw provider fix <name>')");
 
-            var accountId = ResolveAccountId(entry, token.Value)
+            var accountId = JwtAccountIdExtractor.ResolveAccountId(entry)
                 ?? throw new InvalidOperationException(
                     "OpenAI OAuth credential is missing ChatGPT account ID. Re-authenticate with 'netclaw provider fix <name>'.");
             var options = new OpenAIClientOptions
@@ -47,9 +47,4 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
         return new OpenAI.Responses.ResponsesClient(apiKey)
             .AsIChatClient(model.ModelId);
     }
-
-    private static string? ResolveAccountId(ProviderEntry entry, string accessToken)
-        => !entry.OAuthAccountId.IsNullOrEmpty()
-            ? entry.OAuthAccountId.Value
-            : JwtAccountIdExtractor.Extract(accessToken);
 }


### PR DESCRIPTION
## Summary
- persist ChatGPT OAuth account IDs from OpenAI token responses
- require and send ChatGPT-Account-Id for OpenAI Codex OAuth requests
- default OpenAI CLI provider setup to OAuth device flow
- clean stale OAuth secret fields when refreshed token metadata omits them
- display daemon runtime model in chat instead of local default config fallback

## Validation
- dotnet test Netclaw.slnx --no-restore
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify

## Note
- evals/run-evals.sh could not run locally because NETCLAW_EVAL_PROVIDER_TYPE, NETCLAW_EVAL_PROVIDER_ENDPOINT, and NETCLAW_EVAL_MODEL_ID were not set in the non-interactive shell.