### PR TITLE
fix(sessions): stop tool-loaded images from being dropped before the next LLM call

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionImageDeliveryTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionImageDeliveryTests.cs
@@ -1,0 +1,166 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmSessionImageDeliveryTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Actor;
+using Akka.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Configuration;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// End-to-end guard for the tool → model image hand-off on the streaming
+/// session path. A tool (e.g. <c>file_read</c>) that loads an image for
+/// model-visible inspection registers it via
+/// <see cref="Netclaw.Tools.ToolExecutionContext.AddModelInputFile"/>; the
+/// session actor must carry those bytes into the NEXT LLM call as
+/// <see cref="DataContent"/>.
+///
+/// Regression: the streaming completion path
+/// (<c>LlmSessionActor.ApplyToolCallRecorded</c>) handed its mutable
+/// <c>_pendingModelInputMediaReferences</c> accumulator to the media nudge and
+/// then <c>Clear()</c>ed that same instance. Because the nudge aliased the list
+/// instead of copying it, the image reference was wiped before the follow-up
+/// LLM call hydrated it — the model was told "Image loaded" but never received
+/// the bytes and hallucinated. This test drives a real streaming tool call
+/// through the actor and asserts the image bytes reach the chat client on the
+/// second call; it fails (no DataContent on call 2) without the defensive
+/// snapshot in <c>SessionState</c>. See GitHub #1264.
+/// </summary>
+public class LlmSessionImageDeliveryTests : LlmSessionTestBase
+{
+    private readonly FakeChatClient _fakeChatClient = new();
+    private readonly string _imagePath = Path.Combine(
+        Path.GetTempPath(), $"netclaw-img-delivery-{Guid.NewGuid():N}.png");
+
+    // Minimal but valid PNG header (signature + IHDR start) — enough to pass the
+    // materialization magic-byte/MIME compatibility checks. Same bytes the
+    // pipeline-level media tests use.
+    private static readonly byte[] PngBytes =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52
+    ];
+
+    public LlmSessionImageDeliveryTests(ITestOutputHelper output) : base(output) { }
+
+    protected override void ConfigureSessionServices(IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
+
+        // Vision-capable model — without Image input modality the materialization
+        // step would (correctly) skip the file, so the gate must be open for this
+        // test to exercise the delivery path.
+        services.AddSingleton(new ModelCapabilities
+        {
+            ModelId = "vision-model",
+            ContextWindowTokens = 128_000,
+            InputModalities = ModelModality.Image | ModelModality.Text,
+        });
+        services.AddSingleton(new SessionConfig
+        {
+            Tuning = new SessionTuning
+            {
+                TitleGenerationInterval = 0,
+            }
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
+            "You are a test assistant with tools."));
+        services.AddSingleton<IToolExecutor>(new ImageRegisteringToolExecutor(_imagePath));
+
+        var registry = new ToolRegistry();
+        registry.Register(
+            AIFunctionFactory.Create((string path) => $"contents of {path}", "file_read"),
+            "file_read");
+        services.AddSingleton(registry);
+    }
+
+    [Fact]
+    public async Task Tool_loaded_image_reaches_the_model_on_the_next_call()
+    {
+        await File.WriteAllBytesAsync(_imagePath, PngBytes, TestContext.Current.CancellationToken);
+        try
+        {
+            // First LLM response is a file_read tool call; the second is text.
+            _fakeChatClient.ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("call-1", "file_read",
+                    new Dictionary<string, object?> { ["Path"] = _imagePath })
+            ];
+
+            var sessionId = new SessionId("test-channel/image-delivery");
+            var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+            var subscriber = CreateTestProbe("img-sub");
+
+            await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+            {
+                SessionId = sessionId,
+                Filter = OutputFilter.Full
+            }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+            await sessionManager.Ask<CommandAck>(new SendUserMessage
+            {
+                SessionId = sessionId,
+                Content = "Describe the image."
+            }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            // Wait until the post-tool-result (second) LLM call has been issued.
+            await AwaitAssertAsync(
+                () => Assert.True(_fakeChatClient.CallCount >= 2,
+                    $"expected >= 2 LLM calls, saw {_fakeChatClient.CallCount}"),
+                TimeSpan.FromSeconds(10),
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            // The second call carries the conversation AFTER the tool loaded the
+            // image. The image bytes must be present as DataContent — this is the
+            // assertion the aliasing bug breaks.
+            var secondCall = _fakeChatClient.ReceivedMessages[1];
+            var images = secondCall
+                .SelectMany(m => m.Contents)
+                .OfType<DataContent>()
+                .ToList();
+
+            Assert.True(
+                images.Any(dc => dc.MediaType == "image/png"),
+                "Tool-loaded image never reached the model: no image/png DataContent on the " +
+                "second LLM call. The media nudge lost its attachment between tool completion " +
+                "and context assembly (see GitHub #1264).");
+        }
+        finally
+        {
+            if (File.Exists(_imagePath))
+                File.Delete(_imagePath);
+        }
+    }
+
+    /// <summary>
+    /// Stand-in for an image-loading tool (e.g. <c>file_read</c> on a PNG): it
+    /// registers the file as model-visible input, exactly as the real tool does.
+    /// </summary>
+    private sealed class ImageRegisteringToolExecutor(string imagePath) : IToolExecutor
+    {
+        public Task AuthorizeAsync(
+            FunctionCallContent toolCall,
+            Netclaw.Tools.ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<string> ExecuteAsync(
+            FunctionCallContent toolCall,
+            Netclaw.Tools.ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+        {
+            context?.AddModelInputFile(imagePath, "diagram.png", "image/png");
+            return Task.FromResult("Image loaded for model-visible inspection on the next LLM call.");
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -220,6 +220,52 @@ public class SessionStateTests
     }
 
     [Fact]
+    public void AddSystemNudge_snapshots_media_so_caller_clear_cannot_empty_it()
+    {
+        // Regression: LlmSessionActor hands its mutable
+        // _pendingModelInputMediaReferences accumulator to AddSystemNudge and then
+        // Clear()s it. Without a defensive snapshot the nudge aliased that list, so
+        // the Clear() wiped the tool-loaded image before the next LLM call hydrated
+        // it — the model was told "Image loaded" but never saw the bytes and
+        // hallucinated. The nudge must retain its own copy.
+        var media = new SerializableMediaReference
+        {
+            RelativePath = "image.png",
+            MimeType = new Netclaw.Media.MimeType("image/png"),
+            Modality = (int)MediaModality.Image,
+            FileSizeBytes = 16
+        };
+        var pending = new List<SerializableMediaReference> { media };
+
+        var state = SessionState.Empty
+            .AddUserMessage("Real user message")
+            .AddSystemNudge("Loaded media.", pending);
+
+        pending.Clear();
+
+        Assert.Single(state.History[^1].MediaReferences);
+    }
+
+    [Fact]
+    public void AddUserMessage_snapshots_media_so_caller_clear_cannot_empty_it()
+    {
+        var media = new SerializableMediaReference
+        {
+            RelativePath = "image.png",
+            MimeType = new Netclaw.Media.MimeType("image/png"),
+            Modality = (int)MediaModality.Image,
+            FileSizeBytes = 16
+        };
+        var pending = new List<SerializableMediaReference> { media };
+
+        var state = SessionState.Empty.AddUserMessage("With image", pending);
+
+        pending.Clear();
+
+        Assert.Single(state.History[^1].MediaReferences);
+    }
+
+    [Fact]
     public void FindLastUserMessage_returns_null_when_no_user_messages()
     {
         var state = WithSystemPrompt("System");

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -188,8 +188,12 @@ public sealed record SessionState
     /// </summary>
     public SessionState AddUserMessage(string content, IReadOnlyList<SerializableMediaReference>? mediaReferences = null)
     {
+        // Snapshot the caller's list: SerializableChatMessage is immutable and must
+        // own its media references, so a caller that reuses/clears its list after
+        // this call cannot retroactively empty the persisted message (see
+        // BuildNudgeMessage for the concrete hazard this guards against).
         var msg = mediaReferences is { Count: > 0 }
-            ? new SerializableChatMessage { Role = ChatRole.User, Content = content, MediaReferences = mediaReferences }
+            ? new SerializableChatMessage { Role = ChatRole.User, Content = content, MediaReferences = [.. mediaReferences] }
             : new SerializableChatMessage { Role = ChatRole.User, Content = content };
 
         return this with { History = History.Add(msg) };
@@ -275,7 +279,14 @@ public sealed record SessionState
             {
                 Role = ChatRole.User,
                 Content = $"{SystemNudgePrefix} {nudge}]",
-                MediaReferences = mediaReferences
+                // Snapshot, never alias. The model-input media nudge is built from
+                // LlmSessionActor._pendingModelInputMediaReferences, a mutable
+                // accumulator the actor Clear()s immediately after handing it off.
+                // SerializableChatMessage is an immutable persistence type that must
+                // own its media list — without this copy the subsequent Clear()
+                // empties the nudge's attachments before the next LLM call hydrates
+                // them, so a tool-loaded image silently never reaches the model.
+                MediaReferences = [.. mediaReferences]
             }
             : new() { Role = ChatRole.User, Content = $"{SystemNudgePrefix} {nudge}]" };
 


### PR DESCRIPTION
## Summary

Multimodal `file_read` shipped in v0.22.0, but on the main streaming session path a tool-loaded image **silently never reached the model** — the agent was told *"Image loaded for model-visible inspection"* and then confabulated the contents (e.g. shown the akka.net logo, it described an invented "NetClaw dashboard wireframe").

Fixes #1264.

## Root cause

The streaming tool-completion path hands its mutable accumulator to the media nudge and immediately clears it:

```csharp
// LlmSessionActor.ApplyToolCallRecorded (same shape in CompleteToolBatch)
AddModelInputMediaNudge(_pendingModelInputMediaReferences); // stores THIS list instance
_pendingModelInputMediaReferences.Clear();                  // ...then empties it
```

`SessionState.BuildNudgeMessage` / `AddUserMessage` stored that list **by reference** into `SerializableChatMessage.MediaReferences` (an `init` property with no defensive copy). The `.Clear()` then emptied the nudge's media references before `FireLlmCall → SessionMessageAssembler.Assemble → ChatMessageConverter.ToAiMessage` hydrated them into `DataContent`. Net effect: text-only message, no image, hallucination.

Why it was sneaky:
- The tool genuinely succeeded (materialization copied the file to session media), so the existing handoff-failure warning never fired.
- Sub-agents were unaffected because they hydrate the image to `DataContent` *immediately* at nudge-creation; the main session defers hydration to assembly time (for prefix-cache stability), leaving a window for the `Clear()` to corrupt the aliased list.
- The non-streaming completion path passes a fresh list and is unaffected — but the CLI/headless and normal chat use streaming, hence the "always" reproduction.

## Fix

Defensively snapshot the caller's list (`[.. mediaReferences]`) at the two `SessionState` message constructors, so the immutable persistence message owns its own copy regardless of caller behavior. Two-line production change, with comments documenting the aliasing/clear hazard.

## Verification

- **Unit regression tests** (`SessionStateTests`): build a `List`, hand it to `AddSystemNudge`/`AddUserMessage`, `.Clear()` it, assert the message still carries the media reference. Fail without the snapshot.
- **Actor-level integration test** (`LlmSessionImageDeliveryTests`): drives a streaming `file_read` image load through `LlmSessionActor` and asserts image `DataContent` reaches the chat client on the **next** LLM call. Confirmed it **fails without the fix** (exact message: *"Tool-loaded image never reached the model…"*) and passes with it — this was the missing coverage that let the bug ship.
- **End-to-end**: ran a patched daemon against a real vision model — the agent now correctly describes the image, and the trace prompt dump shows `DataContent mediaType=image/png` on the wire.
- Full `Netclaw.Actors.Tests` suite: **2175 passing**. `dotnet slopwatch analyze`: 0 issues. Copyright headers verified.

## Files

- `src/Netclaw.Actors/Sessions/SessionState.cs` — the fix
- `src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs` — unit regression tests
- `src/Netclaw.Actors.Tests/Sessions/LlmSessionImageDeliveryTests.cs` — new integration test

## Follow-up

Audio/video model input is out of scope for this fix (images only today) and is tracked separately in #1266.