### PR TITLE
fix(copilot): persist provider manager additions

### DIFF
--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -4,9 +4,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json;
+using Netclaw.Cli.Config;
 using Netclaw.Cli.Provider;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
+using Netclaw.Providers.OAuth;
 using Netclaw.Tests.Utilities;
 using Xunit;
 
@@ -293,6 +295,59 @@ public sealed class ProviderCommandTests : IDisposable
         Assert.True(providers.ContainsKey("my-anthropic"));
         Assert.Equal("anthropic", providers["my-anthropic"].Type);
         Assert.Equal("sk-ant-test", providers["my-anthropic"].ApiKey?.Value);
+    }
+
+    [Fact]
+    public void WriteProvider_OAuth_MergesMultipleProviders()
+    {
+        var registry = ProviderCommand.CreateDefaultRegistry();
+        var protector = new NullSecretsProtector();
+
+        ProviderCredentialWriter.WriteProvider(
+            _paths,
+            "openai-codex",
+            "openai",
+            AuthMethod.OAuthDevice,
+            endpoint: null,
+            oauthResult: new OAuthDeviceFlowResult(
+                new SensitiveString("openai-access-token"),
+                new SensitiveString("openai-refresh-token"),
+                DateTimeOffset.UtcNow.AddHours(1),
+                new SensitiveString("openai-account")),
+            apiKey: null,
+            registry,
+            protector);
+
+        ProviderCredentialWriter.WriteProvider(
+            _paths,
+            "my-copilot",
+            "github-copilot",
+            AuthMethod.OAuthDevice,
+            endpoint: null,
+            oauthResult: new OAuthDeviceFlowResult(
+                new SensitiveString("copilot-access-token"),
+                null,
+                DateTimeOffset.UtcNow.AddHours(1),
+                null),
+            apiKey: null,
+            registry,
+            protector);
+
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var configProviders = config.RootElement.GetProperty("Providers");
+        Assert.True(configProviders.TryGetProperty("openai-codex", out _));
+        Assert.True(configProviders.TryGetProperty("my-copilot", out _));
+
+        using var secrets = ReadConfigFile(_paths.SecretsPath);
+        var secretProviders = secrets.RootElement.GetProperty("Providers");
+        Assert.Equal("openai-access-token",
+            secretProviders.GetProperty("openai-codex").GetProperty("OAuthAccessToken").GetString());
+        Assert.Equal("copilot-access-token",
+            secretProviders.GetProperty("my-copilot").GetProperty("OAuthAccessToken").GetString());
+
+        var loaded = ProviderCommand.LoadProviders(_paths);
+        Assert.Equal("openai-access-token", loaded["openai-codex"].OAuthAccessToken?.Value);
+        Assert.Equal("copilot-access-token", loaded["my-copilot"].OAuthAccessToken?.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -640,34 +640,95 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     }
 
     [Fact]
-    public async Task ConfirmAdd_OAuth_TokensPersistOnlyOnSave()
+    public async Task SubmitCredentials_OAuthSuccess_PersistsProviderImmediately()
     {
         using var vm = CreateViewModel();
-        vm.NewProviderName = "my-openai";
-        vm.NewProviderType = "openai";
+        vm.NewProviderName = "my-copilot";
+        vm.NewProviderType = "github-copilot";
         vm.NewAuthMethod = AuthMethod.OAuthDevice;
-        vm.NewEndpoint = "https://api.openai.com";
         vm.OAuth.Result = new OAuthDeviceFlowResult(
             new SensitiveString("oauth-access-token"),
-            new SensitiveString("oauth-refresh-token"),
+            null,
             DateTimeOffset.UtcNow.AddHours(1),
-            new SensitiveString("account-123"));
+            null);
 
         Assert.False(File.Exists(_paths.SecretsPath));
 
-        vm.ConfirmAdd();
-        await vm.EagerProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
+        Assert.Equal(ProviderManagerState.AddComplete, vm.CurrentState.Value);
+        Assert.True(File.Exists(_paths.NetclawConfigPath));
         Assert.True(File.Exists(_paths.SecretsPath));
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var configProvider = config.RootElement
+            .GetProperty("Providers")
+            .GetProperty("my-copilot");
+        Assert.Equal("github-copilot", configProvider.GetProperty("Type").GetString());
+        Assert.Equal("OAuthDevice", configProvider.GetProperty("AuthMethod").GetString());
+        Assert.Equal("https://api.githubcopilot.com", configProvider.GetProperty("Endpoint").GetString());
 
         var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
         var provider = secrets.RootElement
             .GetProperty("Providers")
-            .GetProperty("my-openai");
+            .GetProperty("my-copilot");
 
         Assert.StartsWith("ENC:", provider.GetProperty("OAuthAccessToken").GetString());
-        Assert.StartsWith("ENC:", provider.GetProperty("OAuthRefreshToken").GetString());
-        Assert.StartsWith("ENC:", provider.GetProperty("OAuthAccountId").GetString());
+        Assert.False(provider.TryGetProperty("OAuthRefreshToken", out _));
+        Assert.False(provider.TryGetProperty("OAuthAccountId", out _));
+    }
+
+    [Fact]
+    public async Task SubmitCredentials_OAuthSuccess_PreservesExistingOAuthProviders()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["openai-codex"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["AuthMethod"] = "OAuthDevice",
+                    ["Endpoint"] = "https://api.openai.com"
+                }
+            }
+        });
+
+        WriteSecrets(new Dictionary<string, object>
+        {
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["openai-codex"] = new Dictionary<string, object>
+                {
+                    ["OAuthAccessToken"] = "openai-access-token"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.NewProviderName = "my-copilot";
+        vm.NewProviderType = "github-copilot";
+        vm.NewAuthMethod = AuthMethod.OAuthDevice;
+        vm.OAuth.Result = new OAuthDeviceFlowResult(
+            new SensitiveString("copilot-access-token"),
+            null,
+            DateTimeOffset.UtcNow.AddHours(1),
+            null);
+
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var configProviders = config.RootElement.GetProperty("Providers");
+        Assert.True(configProviders.TryGetProperty("openai-codex", out _));
+        Assert.True(configProviders.TryGetProperty("my-copilot", out _));
+
+        var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+        var secretProviders = secrets.RootElement.GetProperty("Providers");
+        Assert.True(secretProviders.TryGetProperty("openai-codex", out _));
+        Assert.True(secretProviders.TryGetProperty("my-copilot", out _));
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -166,7 +166,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                     ProviderManagerState.RemoveConfirm =>
                         " [Enter] Confirm  [Esc] Cancel  [Ctrl+Q] Quit",
                     ProviderManagerState.AddComplete =>
-                        " [Enter] Save  [Esc] Cancel  [Ctrl+Q] Quit",
+                        " [Enter] Continue  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.AddOAuthDeviceFlow =>
                         " [Esc] Cancel  [Ctrl+Q] Quit",
                     _ =>
@@ -597,7 +597,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             return Layouts.Vertical()
                 .WithChild(new TextNode($"  \u2714 Connection successful! ({result.Models.Count} models found)")
                     .WithForeground(Color.Green))
-                .WithChild(new TextNode("  Press [Enter] to save, [Esc] to cancel.")
+                .WithChild(new TextNode("  Provider saved. Press [Enter] to continue.")
                     .WithForeground(Color.Gray));
         }
 
@@ -612,7 +612,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
     {
         var result = ViewModel.ProbeResult.Value;
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  \u2714 Provider '{ViewModel.NewProviderName}' ready to save")
+            .WithChild(new TextNode($"  \u2714 Provider '{ViewModel.NewProviderName}' added")
                 .WithForeground(Color.Green))
             .WithChild(new TextNode($"    Type: {ViewModel.Registry.Get(ViewModel.NewProviderType ?? "unknown").DisplayName}")
                 .WithForeground(Color.White))
@@ -621,7 +621,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             .WithChild(new TextNode($"    Models: {result?.Models.Count ?? 0} discovered")
                 .WithForeground(Color.White))
             .WithChild(new TextNode("").Height(1))
-            .WithChild(new TextNode("  Press [Enter] to save, [Esc] to cancel.")
+            .WithChild(new TextNode("  Press [Enter] to return to the provider list.")
                 .WithForeground(Color.Gray));
     }
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -115,6 +115,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public AuthMethod NewAuthMethod { get; set; } = AuthMethod.None;
     public string? NewApiKey { get; set; }
     public string? NewEndpoint { get; set; }
+    private bool _newProviderPersisted;
 
     // ── OAuth flow (shared coordinator) ──
     public OAuthFlowCoordinator OAuth { get; private set; } = null!; // initialized in constructor
@@ -447,6 +448,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
         NewProviderType = type;
         NewProviderName = DetailProvider.ConfiguredName;
+        NewEndpoint = DetailProvider.Entry?.Endpoint;
         IsFixFlow = true;
 
         var oauthMethod = descriptor.Auth.SupportedAuthMethods
@@ -575,11 +577,13 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     }
 
     /// <summary>
-    /// Write the new provider to config files after successful validation.
+    /// Finish a successful add flow and return to the refreshed provider list.
     /// </summary>
     public void ConfirmAdd()
     {
-        WriteProviderConfig();
+        if (!_newProviderPersisted)
+            WriteProviderConfig();
+
         StatusMessage.Value = $"Added provider '{NewProviderName}'. Restart daemon for changes to take effect.";
         ClearAddState();
         RefreshAndProbeAll();
@@ -815,7 +819,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 NotifyStateChanged();
                 break;
             case ProviderManagerState.AddComplete:
-                GoBackToList();
+                ConfirmAdd();
                 break;
             case ProviderManagerState.Details:
             case ProviderManagerState.FixCredentials:
@@ -937,6 +941,12 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         {
             if (IsFixFlow)
             {
+                if (NewProviderName is not null && OAuth.Result is not null)
+                {
+                    WriteProviderConfig();
+                    _newProviderPersisted = true;
+                }
+
                 // Fix flow: re-probe all providers so list shows fresh health
                 IsFixFlow = false;
                 StatusMessage.Value = "Credentials updated successfully. Restart daemon for changes to take effect.";
@@ -944,6 +954,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             }
             else
             {
+                WriteProviderConfig();
+                _newProviderPersisted = true;
+                StatusMessage.Value = $"Added provider '{NewProviderName}'. Restart daemon for changes to take effect.";
                 CurrentState.Value = ProviderManagerState.AddComplete;
             }
         }
@@ -1053,6 +1066,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
         IsFixFlow = false;
+        _newProviderPersisted = false;
     }
 
     private void NotifyStateChanged()

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotTokenExchangerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotTokenExchangerTests.cs
@@ -200,12 +200,10 @@ public sealed class CopilotTokenExchangerTests
             captured.Headers.GetValues("Authorization").Single());
         Assert.Contains(captured.Headers.Accept, h => h.MediaType == "application/json");
 
-        // User-Agent is deliberately not asserted here — it's stamped by
-        // NetclawHeadersHandler on the named HttpClient, which this unit
-        // test bypasses with a raw FakeHttpMessageHandler. The handler
-        // contract is covered in NetclawHeadersHandlerTests.
-        Assert.False(captured.Headers.Contains("User-Agent"),
-            "exchanger must defer User-Agent to NetclawHeadersHandler");
+        Assert.Equal(NetclawUserAgent.Value,
+            string.Join(" ", captured.Headers.GetValues("User-Agent")));
+        Assert.Equal("copilot-token",
+            captured.Headers.GetValues(NetclawUserAgent.ComponentHeader).Single());
 
         Assert.Equal($"Netclaw/{BuildInfo.Version}",
             captured.Headers.GetValues("Editor-Version").Single());

--- a/src/Netclaw.Providers/GitHubCopilot/CopilotTokenExchanger.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/CopilotTokenExchanger.cs
@@ -32,6 +32,8 @@ public sealed class CopilotTokenExchanger(HttpClient httpClient, TimeProvider? t
     private static readonly Uri TokenEndpoint =
         new("https://api.github.com/copilot_internal/v2/token");
 
+    private const string ComponentName = "copilot-token";
+
     // Refresh slightly before the server-reported expiry so chat calls in
     // flight when the cache turns over still see a valid bearer token.
     private static readonly TimeSpan RefreshBuffer = TimeSpan.FromMinutes(2);
@@ -97,10 +99,14 @@ public sealed class CopilotTokenExchanger(HttpClient httpClient, TimeProvider? t
         // integration." Cross-checked against CodeAlta's CopilotDirectAuth
         // and the Neovim Copilot plugin source; both send the same set.
         //
-        // User-Agent is intentionally NOT set here — the named HttpClient
-        // ("CopilotTokenExchange") runs through NetclawHeadersHandler, which
-        // stamps the canonical UA + X-Netclaw-Component. Setting it here
-        // would win over the handler and clobber the shared identity.
+        // Stamp the same identity the DI HttpClient handler uses. CLI one-shot
+        // paths can construct this exchanger with a raw HttpClient, and GitHub
+        // rejects this endpoint outright when User-Agent is absent.
+        if (!request.Headers.Contains("User-Agent"))
+            request.Headers.TryAddWithoutValidation("User-Agent", NetclawUserAgent.Value);
+        if (!request.Headers.Contains(NetclawUserAgent.ComponentHeader))
+            request.Headers.TryAddWithoutValidation(NetclawUserAgent.ComponentHeader, ComponentName);
+
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", oauthToken);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.TryAddWithoutValidation("Editor-Version", $"Netclaw/{BuildInfo.Version}");

--- a/tests/smoke/tapes/provider-add.tape
+++ b/tests/smoke/tapes/provider-add.tape
@@ -56,11 +56,12 @@ Backspace 32
 Type "http://localhost:11434"
 Enter
 
-# ─── Step 3: Probe + ready-to-save ───────────────────────────────────
+# ─── Step 3: Probe + persisted provider confirmation ─────────────────
 # Probe is async; with qwen2:0.5b + all-minilm baked into native
-# ollama, this resolves in seconds. Wait directly on the "ready to
-# save" success line (skips the transient "Validating..." frame).
-Wait+Screen@45s /ready to save/
+# ollama, this resolves in seconds. The provider is persisted before
+# the success screen renders, so wait directly on the persisted-provider
+# confirmation (skips the transient "Validating..." frame).
+Wait+Screen@45s /Provider 'smoke-add-ollama' added/
 Sleep 300ms
 Enter
 


### PR DESCRIPTION
## Summary
- Persist OAuth providers immediately after successful provider-manager validation
- Preserve existing OAuth provider config and secrets when adding another provider
- Stamp Copilot token-exchange requests with the canonical Netclaw User-Agent on raw HttpClient paths
- Update provider-add smoke tape text for the saved-provider confirmation

## Validation
- dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --no-restore --filter "FullyQualifiedName~ProviderManagerViewModelTests|FullyQualifiedName~ProviderCommandTests"
- dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --no-restore --filter "FullyQualifiedName~CopilotTokenExchangerTests|FullyQualifiedName~GitHubCopilotDescriptorTests"
- dotnet test Netclaw.slnx --no-restore
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- git diff --check
- NETCLAW_HOME=/tmp/netclaw-openai-oauth.69cCFJ dotnet run --project src/Netclaw.Cli/Netclaw.Cli.csproj -- model discover github-copilot
- NETCLAW_HOME=/tmp/netclaw-openai-oauth.69cCFJ dotnet run --project src/Netclaw.Cli/Netclaw.Cli.csproj -- chat -p "Reply with exactly: pong"

Provider-add smoke tape was attempted, but the local harness could not install Ollama because sudo requires an interactive password in this shell.