### PR TITLE
fix(installer): use User-scope PATH in Windows install instruction

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -204,17 +204,21 @@ try {
         return
     }
 
-    # Check PATH
+    # Check PATH and offer to add if missing
     Write-Host ""
-    $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-    if ($currentPath -split ";" | Where-Object { $_ -eq $InstallDir }) {
+    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $pathEntries = $userPath -split ';' | ForEach-Object { $_.TrimEnd('\') }
+    $installDirNormalized = $InstallDir.TrimEnd('\')
+
+    if ($pathEntries -contains $installDirNormalized) {
         Write-Host "Installation complete! netclaw is already on your PATH."
     } else {
         Write-Host "Installation complete!"
         Write-Host ""
-        Write-Host "Add Netclaw to your PATH:"
+        Write-Host "Add Netclaw to your PATH by running:"
         Write-Host ""
-        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$env:PATH`", 'User')"
+        Write-Host "  `$userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')"
+        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$userPath`", 'User')"
         Write-Host ""
         Write-Host "Then restart your terminal."
     }

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -132,6 +132,22 @@ try {
             Fail "install: $name.exe missing or empty"
         }
     }
+
+    # 7. Verify PATH instruction uses User scope correctly (issue #1072)
+    # The printed instruction must NOT use $env:PATH (which merges Machine+User
+    # and corrupts the User PATH when written back). It must read User scope.
+    Write-Host ""
+    Write-Host "=== PATH instruction check ==="
+    if ($installOut -match '\$env:PATH') {
+        Fail "PATH instruction: uses `$env:PATH (corrupts User PATH by merging Machine entries)"
+    } else {
+        Pass "PATH instruction: does not use `$env:PATH"
+    }
+    if ($installOut -match "GetEnvironmentVariable\('PATH',\s*'User'\)") {
+        Pass "PATH instruction: reads from User scope"
+    } else {
+        Fail "PATH instruction: should read from User scope with GetEnvironmentVariable('PATH', 'User')"
+    }
 }
 finally {
     if ($ServerProc -and -not $ServerProc.HasExited) { $ServerProc.Kill() }


### PR DESCRIPTION
## Summary

- Fix Windows installer PATH instruction that was corrupting User PATH by using `$env:PATH` (merged Machine+User) instead of User scope
- Add smoke test assertions to prevent regression

Fixes #1072

## Changes

**scripts/install.ps1:**
- Changed printed PATH instruction to read User scope separately before modifying:
  ```powershell
  $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
  [Environment]::SetEnvironmentVariable('PATH', "...;$userPath", 'User')
  ```
- Added trailing backslash normalization for more reliable PATH detection

**scripts/smoke/install-smoke.ps1:**
- Added assertions verifying the instruction does NOT use `$env:PATH`
- Added assertions verifying the instruction reads from User scope

## Test plan

- [ ] Windows installer smoke test passes (`scripts/smoke/install-smoke.ps1`)
- [ ] Manual verification: run installer on Windows, confirm printed instruction uses User scope