### PR TITLE
fix(docker): repair bind mount ownership

### DIFF
--- a/.github/workflows/validate_docker_image.yml
+++ b/.github/workflows/validate_docker_image.yml
@@ -15,6 +15,7 @@ on:
       - main
     paths:
       - 'docker/Dockerfile'
+      - 'docker/entrypoint.sh'
       - 'scripts/docker/build-image.sh'
       - 'src/**'
       - 'global.json'
@@ -28,6 +29,7 @@ on:
       - main
     paths:
       - 'docker/Dockerfile'
+      - 'docker/entrypoint.sh'
       - 'scripts/docker/build-image.sh'
       - 'src/**'
       - 'global.json'
@@ -120,6 +122,88 @@ jobs:
           docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
           exit 1
 
+      - name: "Verify bind-mounted state ownership is repaired"
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker rm -f netclaw-validate-bind-mount >/dev/null 2>&1 || true
+
+          tmpdir="$(mktemp -d)"
+          state_dir="$tmpdir/data"
+          tools_dir="$tmpdir/tools"
+          mkdir -p "$state_dir" "$tools_dir"
+          chmod 755 "$state_dir" "$tools_dir"
+
+          cleanup() {
+            docker rm -f netclaw-validate-bind-mount >/dev/null 2>&1 || true
+            if ! rm -rf "$tmpdir" 2>/dev/null; then
+              docker run --rm \
+                -v "$tmpdir:/target" \
+                ubuntu:24.04 sh -c 'rm -rf /target/..?* /target/.[!.]* /target/*' \
+                >/dev/null 2>&1 || true
+              rmdir "$tmpdir" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          owner_before="$(stat -c '%u:%g' "$state_dir")"
+          if [[ "$owner_before" == "1654:1654" ]]; then
+            echo "ERROR: bind-mount fixture unexpectedly starts with runtime ownership" >&2
+            exit 1
+          fi
+
+          docker run -d --name netclaw-validate-bind-mount \
+            -v "$state_dir:/home/netclaw/.netclaw" \
+            -v "$tools_dir:/tools" \
+            -e NETCLAW_Daemon__Port=5199 \
+            -e NETCLAW_Providers__validate__Type=ollama \
+            -e NETCLAW_Providers__validate__Endpoint=http://127.0.0.1:11434 \
+            -e NETCLAW_Models__Main__Provider=validate \
+            -e NETCLAW_Models__Main__ModelId=qwen2:0.5b \
+            "netclawd-pr:${{ steps.tag.outputs.tag }}" >/dev/null
+
+          for i in $(seq 1 60); do
+            if docker exec netclaw-validate-bind-mount curl -fsS http://127.0.0.1:5199/api/health/ready >/dev/null 2>&1; then
+              echo "✓ Bind-mounted daemon reported healthy after ${i}s"
+              break
+            fi
+
+            running="$(docker inspect -f '{{.State.Running}}' netclaw-validate-bind-mount 2>/dev/null || echo "false")"
+            if [[ "$running" != "true" ]]; then
+              echo "ERROR: bind-mounted daemon container exited during health probe" >&2
+              docker logs netclaw-validate-bind-mount >&2 2>&1 || true
+              exit 1
+            fi
+
+            if [[ "$i" == "60" ]]; then
+              echo "ERROR: bind-mounted daemon did not report healthy within 60s" >&2
+              docker logs netclaw-validate-bind-mount >&2 2>&1 || true
+              exit 1
+            fi
+
+            sleep 1
+          done
+
+          docker exec netclaw-validate-bind-mount test -d /home/netclaw/.netclaw/identity
+
+          state_owner="$(docker exec netclaw-validate-bind-mount stat -c '%u:%g' /home/netclaw/.netclaw)"
+          if [[ "$state_owner" != "1654:1654" ]]; then
+            echo "ERROR: /home/netclaw/.netclaw owner is $state_owner, expected 1654:1654" >&2
+            exit 1
+          fi
+
+          tools_owner="$(docker exec netclaw-validate-bind-mount stat -c '%u:%g' /tools)"
+          if [[ "$tools_owner" != "1654:1654" ]]; then
+            echo "ERROR: /tools owner is $tools_owner, expected 1654:1654" >&2
+            exit 1
+          fi
+
+          daemon_uid="$(docker exec netclaw-validate-bind-mount sh -c 'pid=$(pgrep -o -x netclawd); stat -c %u /proc/$pid')"
+          if [[ "$daemon_uid" != "1654" ]]; then
+            echo "ERROR: netclawd is running as uid $daemon_uid, expected 1654" >&2
+            exit 1
+          fi
+
       - name: "Lint: ARG TARGETARCH must have no default (#1091)"
         shell: bash
         run: |
@@ -164,3 +248,4 @@ jobs:
         shell: bash
         run: |
           docker rm -f netclaw-validate-ok 2>/dev/null || true
+          docker rm -f netclaw-validate-bind-mount 2>/dev/null || true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,7 @@ ARG NETCLAW_VERSION=unknown
 #   Data/JSON:   jq, sqlite3
 #   VCS/GitHub:  git, gh
 #   Python:      python3, python3-pip, python3-venv
+#   Privileges:  gosu (entrypoint ownership repair, then drop to netclaw)
 #   Crypto:      libsodium23 (required by NSec for Ed25519 signature verification)
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -60,6 +61,7 @@ RUN apt-get update \
       curl \
       wget \
       procps \
+      gosu \
       git \
       jq \
       sqlite3 \
@@ -83,14 +85,18 @@ RUN chmod +x /opt/netclaw/cli/netclaw /opt/netclaw/daemon/netclawd /opt/netclaw/
  && ln -s /opt/netclaw/cli/netclaw /usr/local/bin/netclaw \
  && ln -s /opt/netclaw/daemon/netclawd /usr/local/bin/netclawd
 
-# Non-root runtime user — limits blast radius of tool execution and
-# satisfies CIS Docker Benchmark / K8s PodSecurityStandards.
-# Pre-create the data directory so VOLUME inherits correct ownership.
+# Non-root runtime user — limits blast radius of daemon-owned tool execution.
+# The entrypoint starts as root only to repair bind-mount ownership, then
+# re-execs itself as this user before launching netclawd.
+# Pre-create the data and tools directories so image-owned paths inherit
+# correct ownership when operators use Docker named volumes.
 RUN groupadd --gid 1654 netclaw \
  && useradd --uid 1654 --gid netclaw --create-home netclaw \
- && mkdir -p /home/netclaw/.netclaw \
- && chown netclaw:netclaw /home/netclaw/.netclaw
+ && mkdir -p /home/netclaw/.netclaw /tools \
+ && chown -R netclaw:netclaw /home/netclaw/.netclaw /tools
 
+ENV HOME=/home/netclaw
+ENV NETCLAW_HOME=/home/netclaw/.netclaw
 ENV NETCLAW_DAEMON_PATH=/opt/netclaw/daemon/netclawd
 # Block in-place binary self-update — the image tag IS the version.
 # Update availability checks still run so operators see when a new version exists.
@@ -107,7 +113,9 @@ EXPOSE 5199
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
   CMD curl -sf http://127.0.0.1:5199/api/health/ready || exit 1
 
-USER netclaw
+# Keep the image entrypoint root so it can repair host bind-mount ownership.
+# docker/entrypoint.sh drops privileges before starting the daemon supervisor.
+USER root
 
 LABEL org.opencontainers.image.source="https://github.com/netclaw-dev/netclaw" \
       org.opencontainers.image.title="netclawd" \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,52 @@
 # the daemon has run for a healthy stretch.
 set -u
 
+NETCLAW_USER=netclaw
+NETCLAW_UID=1654
+NETCLAW_GID=1654
+NETCLAW_USER_HOME=/home/netclaw
+NETCLAW_DATA_DIR="${NETCLAW_HOME:-$NETCLAW_USER_HOME/.netclaw}"
+
+ensure_runtime_ownership() {
+    local path="$1"
+
+    if ! mkdir -p "$path"; then
+        echo "[entrypoint] ERROR: failed to create $path before dropping privileges." >&2
+        echo "[entrypoint] Check that the parent path exists and is writable by container root." >&2
+        exit 1
+    fi
+
+    local owner
+    owner="$(stat -c '%u:%g' "$path" 2>/dev/null || true)"
+    if [[ "$owner" == "${NETCLAW_UID}:${NETCLAW_GID}" ]]; then
+        return 0
+    fi
+
+    echo "[entrypoint] Taking ownership of $path for ${NETCLAW_USER} (${NETCLAW_UID}:${NETCLAW_GID})..."
+    if chown -R "${NETCLAW_UID}:${NETCLAW_GID}" "$path"; then
+        return 0
+    fi
+
+    if gosu "$NETCLAW_USER" test -w "$path"; then
+        echo "[entrypoint] WARN: recursive chown failed for $path, but the top-level directory is writable by ${NETCLAW_USER}. Continuing." >&2
+        return 0
+    fi
+
+    echo "[entrypoint] ERROR: failed to chown $path for ${NETCLAW_USER} (${NETCLAW_UID}:${NETCLAW_GID})." >&2
+    echo "[entrypoint] If this is a read-only bind mount, make it writable or pre-create it with uid/gid ${NETCLAW_UID}:${NETCLAW_GID}." >&2
+    exit 1
+}
+
+if [[ "$(id -u)" == "0" ]]; then
+    export HOME="$NETCLAW_USER_HOME"
+    export NETCLAW_HOME="$NETCLAW_DATA_DIR"
+
+    ensure_runtime_ownership "$NETCLAW_DATA_DIR"
+    ensure_runtime_ownership /tools
+
+    exec gosu "$NETCLAW_USER" "$0" "$@"
+fi
+
 PID=""
 trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null; exit 0' SIGTERM SIGINT
 

--- a/docs/spec/SPEC-011-daemon-architecture.md
+++ b/docs/spec/SPEC-011-daemon-architecture.md
@@ -392,13 +392,15 @@ Recommended production deployment:
 ```bash
 docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v ~/.netclaw:/root/.netclaw \
+  -v ~/.netclaw:/home/netclaw/.netclaw \
   -p 127.0.0.1:5199:5199 \
   netclaw-daemon
 ```
 
 - Docker socket mount enables host container management
-- Config volume persists across container restarts
+- Config volume persists across container restarts. The image entrypoint repairs
+  writable bind-mount ownership to the dedicated `netclaw` runtime UID before
+  starting the daemon.
 - Port binding on loopback only (SEC-005 default)
 - Container includes Docker CLI, git, and other management tools
 - Only the daemon runs in Docker — the CLI runs on the host and connects

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.8.8"
+  version: "2.8.9"
 ---
 
 # Netclaw Operations
@@ -819,6 +819,7 @@ What to expect inside `session.log`:
 | Missing tools | `netclaw mcp list`; check MCP connection state |
 | Memory recall degraded | `netclaw status` memory section |
 | Daemon won't start | crash logs at `~/.netclaw/logs/crash-*.log` |
+| Docker daemon cannot create `/home/netclaw/.netclaw/*` | Official image entrypoint repairs writable bind mounts to UID/GID `1654:1654`; if bypassed or read-only, run `sudo chown -R 1654:1654 <host-data-dir>` or use a Docker named volume |
 | Discord/Slack channel offline | `netclaw status` shows the channel `disconnected` with a reason. Discord may also report `degraded` when Discord.Net says the socket is connected but the gateway is not ready, such as after a resumed session that Netclaw is replacing with a clean reconnect. A misconfigured channel (bad token, missing Discord Message Content intent) degrades only that channel — the daemon keeps running and other channels are unaffected. A transient network failure retries automatically; a config/permission failure stays offline until the operator fixes the config and restarts the daemon. |
 | `command not found` for `netclaw` from shell tool when daemon runs as systemd service | `netclaw doctor` (the **Systemd Unit PATH** check warns when the unit was installed before PATH was baked in) |
 

--- a/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
+++ b/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
@@ -134,6 +134,30 @@ public sealed class NetclawPathsTests : IDisposable
 
         Assert.Equal(expected, paths.BasePath);
     }
+
+    [Fact]
+    public void EnsureDirectoriesExist_reports_actionable_initialization_failures()
+    {
+        var basePath = Path.Combine(Path.GetTempPath(), "netclaw-path-file-" + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(basePath, "not a directory");
+
+        try
+        {
+            var paths = new NetclawPaths(basePath);
+
+            var exception = Assert.Throws<NetclawDirectoryInitializationException>(paths.EnsureDirectoriesExist);
+
+            Assert.Equal(basePath, exception.BasePath);
+            Assert.Contains(exception.Failures, failure => failure.DirectoryPath == paths.IdentityDirectory);
+            Assert.Contains("Failed to initialize Netclaw directories", exception.Message);
+            Assert.Contains("Docker bind mount", exception.Message);
+            Assert.Contains("sudo chown -R 1654:1654", exception.Message);
+        }
+        finally
+        {
+            File.Delete(basePath);
+        }
+    }
 }
 
 /// <summary>

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text;
+
 namespace Netclaw.Configuration;
 
 /// <summary>
@@ -123,30 +125,124 @@ public sealed class NetclawPaths
     /// </summary>
     public void EnsureDirectoriesExist()
     {
-        Directory.CreateDirectory(IdentityDirectory);
-        Directory.CreateDirectory(SoulDetailDirectory);
-        Directory.CreateDirectory(AgentsDetailDirectory);
-        Directory.CreateDirectory(ToolingDetailDirectory);
-        Directory.CreateDirectory(ToolingShadowDirectory);
-        Directory.CreateDirectory(McpShadowDirectory);
-        Directory.CreateDirectory(SkillsDirectory);
-        Directory.CreateDirectory(SystemSkillsDirectory);
-        Directory.CreateDirectory(ServerFeedsDirectory);
-        Directory.CreateDirectory(ProjectsDirectory);
-        Directory.CreateDirectory(ClientDirectory);
-        Directory.CreateDirectory(EnvironmentDirectory);
-        Directory.CreateDirectory(SchedulesDirectory);
-        Directory.CreateDirectory(RemindersDirectory);
-        Directory.CreateDirectory(JobsDirectory);
-        Directory.CreateDirectory(ConfigDirectory);
-        Directory.CreateDirectory(WebhooksDirectory);
-        Directory.CreateDirectory(LogsDirectory);
-        Directory.CreateDirectory(SessionLogsDirectory);
-        Directory.CreateDirectory(AgentsDirectory);
-        Directory.CreateDirectory(SessionsDirectory);
-        Directory.CreateDirectory(BinDirectory);
-        Directory.CreateDirectory(KeysDirectory);
-        Directory.CreateDirectory(CacheDirectory);
-        Directory.CreateDirectory(WorkspacesDirectory);
+        var failures = new List<NetclawDirectoryInitializationFailure>();
+
+        foreach (var directory in StandardDirectories())
+        {
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                failures.Add(new NetclawDirectoryInitializationFailure(directory, ex));
+            }
+        }
+
+        if (failures.Count > 0)
+            throw new NetclawDirectoryInitializationException(BasePath, failures);
+    }
+
+    private IEnumerable<string> StandardDirectories()
+    {
+        yield return IdentityDirectory;
+        yield return SoulDetailDirectory;
+        yield return AgentsDetailDirectory;
+        yield return ToolingDetailDirectory;
+        yield return ToolingShadowDirectory;
+        yield return McpShadowDirectory;
+        yield return SkillsDirectory;
+        yield return SystemSkillsDirectory;
+        yield return ServerFeedsDirectory;
+        yield return ProjectsDirectory;
+        yield return ClientDirectory;
+        yield return EnvironmentDirectory;
+        yield return SchedulesDirectory;
+        yield return RemindersDirectory;
+        yield return JobsDirectory;
+        yield return ConfigDirectory;
+        yield return WebhooksDirectory;
+        yield return LogsDirectory;
+        yield return SessionLogsDirectory;
+        yield return AgentsDirectory;
+        yield return SessionsDirectory;
+        yield return BinDirectory;
+        yield return KeysDirectory;
+        yield return CacheDirectory;
+        yield return WorkspacesDirectory;
     }
 }
+
+public sealed class NetclawDirectoryInitializationException : IOException
+{
+    public NetclawDirectoryInitializationException(
+        string basePath,
+        IReadOnlyList<NetclawDirectoryInitializationFailure> failures)
+        : base(BuildMessage(basePath, failures), new AggregateException(failures.Select(f => f.Exception)))
+    {
+        BasePath = basePath;
+        Failures = failures.ToArray();
+    }
+
+    public string BasePath { get; }
+
+    public IReadOnlyList<NetclawDirectoryInitializationFailure> Failures { get; }
+
+    private static string BuildMessage(string basePath, IReadOnlyList<NetclawDirectoryInitializationFailure> failures)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Failed to initialize Netclaw directories under '{basePath}'.");
+        builder.AppendLine();
+        builder.AppendLine("The following directories could not be created:");
+        foreach (var failure in failures)
+            builder.AppendLine($"- {failure.DirectoryPath}: {failure.Exception.Message}");
+
+        builder.AppendLine();
+        builder.AppendLine($"Process user: {DescribeProcessUser()}");
+        builder.AppendLine();
+        builder.AppendLine("If this is a Docker bind mount, the host directory is probably not writable by the container's netclaw user.");
+        builder.AppendLine("The official Docker entrypoint should repair writable bind mounts automatically. If it was bypassed, pre-create the host path with:");
+        builder.AppendLine("  sudo chown -R 1654:1654 <host-netclaw-data-directory>");
+        builder.AppendLine("For non-Docker installs, grant the current user write access to the Netclaw base directory.");
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string DescribeProcessUser()
+    {
+        var userName = Environment.UserName;
+        if (!OperatingSystem.IsLinux())
+            return userName;
+
+        var ids = TryReadLinuxProcessIds();
+        return ids is null
+            ? userName
+            : $"{userName} (uid={ids.Value.Uid}, gid={ids.Value.Gid})";
+    }
+
+    private static (string Uid, string Gid)? TryReadLinuxProcessIds()
+    {
+        try
+        {
+            string? uid = null;
+            string? gid = null;
+            foreach (var line in File.ReadLines("/proc/self/status"))
+            {
+                if (line.StartsWith("Uid:", StringComparison.Ordinal))
+                    uid = line.Split('\t', StringSplitOptions.RemoveEmptyEntries)[1];
+                else if (line.StartsWith("Gid:", StringComparison.Ordinal))
+                    gid = line.Split('\t', StringSplitOptions.RemoveEmptyEntries)[1];
+
+                if (uid is not null && gid is not null)
+                    return (uid, gid);
+            }
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}
+
+public sealed record NetclawDirectoryInitializationFailure(string DirectoryPath, Exception Exception);

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -51,7 +51,17 @@ using Netclaw.Security;
 using static Microsoft.Extensions.Logging.LogLevel;
 
 var bootstrapPaths = new NetclawPaths();
-bootstrapPaths.EnsureDirectoriesExist();
+try
+{
+    bootstrapPaths.EnsureDirectoriesExist();
+}
+catch (NetclawDirectoryInitializationException ex)
+{
+    Console.Error.WriteLine(ex.Message);
+    Environment.ExitCode = 1;
+    return;
+}
+
 using var crashMonitor = DaemonCrashMonitor.Register(
     bootstrapPaths,
     benignUnobservedFilters: [KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace]);
@@ -89,6 +99,12 @@ try
             await RunDaemonAsync(args, restartSignal, crashMonitor);
         } while (restartSignal.RestartRequested);
     }
+}
+catch (NetclawDirectoryInitializationException ex)
+{
+    crashMonitor.RecordTopLevelException(ex);
+    Console.Error.WriteLine(ex.Message);
+    Environment.ExitCode = 1;
 }
 catch (Exception ex)
 {


### PR DESCRIPTION
## Summary
- repair Docker bind-mount ownership in the entrypoint before dropping to the netclaw runtime user
- add actionable directory initialization errors for startup permission failures
- add a Docker image validation smoke test for host-owned bind mounts

Fixes #1277

## Validation
- dotnet test src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj
- dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj
- dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
- IMAGE_REPO=netclawd-pr scripts/docker/build-image.sh bind-mount-local
- local Docker minimal health smoke
- local Docker host-owned bind-mount smoke
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify