### PR TITLE
fix(providers): ignore zero context windows

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/ModelCapabilityResolutionTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ModelCapabilityResolutionTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Xunit;
@@ -33,7 +34,7 @@ public sealed class ModelCapabilityResolutionTests
     }
 
     [Fact]
-    public void ResolveModelCapabilities_ThrowsWhenConfiguredContextExceedsDetectedWindow()
+    public void ResolveModelCapabilities_HonorsConfiguredContextAndWarnsWhenItExceedsDetectedWindow()
     {
         var models = new ModelSelection
         {
@@ -45,30 +46,40 @@ public sealed class ModelCapabilityResolutionTests
             }
         };
         var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 65536);
+        var logger = new CapturingLogger();
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            ModelCapabilityResolution.ResolveModelCapabilities(models, detected));
+        var result = ModelCapabilityResolution.ResolveModelCapabilities(
+            models, detected, logger: logger);
 
-        Assert.Contains("ContextWindow", ex.Message);
-        Assert.Contains("65536", ex.Message);
+        // Provider-reported windows are unreliable, so the operator's value wins
+        // and we warn instead of refusing to boot the daemon.
+        Assert.Equal(131072, result.ContextWindowTokens);
+        var (level, message) = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, level);
+        Assert.Contains("131072", message);
+        Assert.Contains("65536", message);
     }
 
     [Fact]
-    public void ResolveModelCapabilities_StillValidatesConfiguredContextWhenModalitiesAreManual()
+    public void ResolveModelCapabilities_DoesNotWarnWhenConfiguredContextWithinDetectedWindow()
     {
         var models = new ModelSelection
         {
             Main = new ModelReference
             {
-                ContextWindow = 131072,
-                InputModalities = ModelModality.Text | ModelModality.Image,
+                ContextWindow = 32768,
+                InputModalities = ModelModality.Text,
                 OutputModalities = ModelModality.Text
             }
         };
         var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 65536);
+        var logger = new CapturingLogger();
 
-        Assert.Throws<InvalidOperationException>(() =>
-            ModelCapabilityResolution.ResolveModelCapabilities(models, detected));
+        var result = ModelCapabilityResolution.ResolveModelCapabilities(
+            models, detected, logger: logger);
+
+        Assert.Equal(32768, result.ContextWindowTokens);
+        Assert.Empty(logger.Entries);
     }
 
     [Fact]
@@ -116,5 +127,18 @@ public sealed class ModelCapabilityResolutionTests
         var result = ModelCapabilityResolution.ResolveModelCapabilities(models, detected);
 
         Assert.Equal(32_768, result.ContextWindowTokens);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
     }
 }

--- a/src/Netclaw.Daemon.Tests/Configuration/ModelCapabilityResolutionTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ModelCapabilityResolutionTests.cs
@@ -86,4 +86,35 @@ public sealed class ModelCapabilityResolutionTests
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);
     }
+
+    [Fact]
+    public void ResolveModelCapabilities_IgnoresDetectedZeroContextWhenConfiguredContextSet()
+    {
+        var models = new ModelSelection
+        {
+            Main = new ModelReference
+            {
+                ContextWindow = 120_000
+            }
+        };
+        var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 0);
+
+        var result = ModelCapabilityResolution.ResolveModelCapabilities(models, detected);
+
+        Assert.Equal(120_000, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public void ResolveModelCapabilities_UsesDefaultContextWhenDetectedContextIsZero()
+    {
+        var models = new ModelSelection
+        {
+            Main = new ModelReference()
+        };
+        var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 0);
+
+        var result = ModelCapabilityResolution.ResolveModelCapabilities(models, detected);
+
+        Assert.Equal(32_768, result.ContextWindowTokens);
+    }
 }

--- a/src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverTests.cs
@@ -55,6 +55,26 @@ public sealed class CompositeCapabilityResolverTests
     }
 
     [Fact]
+    public async Task NonPositiveContext_DoesNotBlockLaterResolver()
+    {
+        var first = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", ModelModality.Text, null, 0));
+        var second = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", null, ModelModality.Text, 256_000));
+
+        var composite = new CompositeCapabilityResolver(
+            [first, second],
+            NullLogger<CompositeCapabilityResolver>.Instance);
+
+        var result = await composite.ResolveAsync("test-model", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+        Assert.Equal(256_000, result.ContextWindowTokens);
+    }
+
+    [Fact]
     public async Task AllResolvers_ReturnNull_CompositeReturnsNull()
     {
         // Defaulting now lives at the consumption boundary

--- a/src/Netclaw.Daemon.Tests/Providers/OllamaCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OllamaCapabilityResolverTests.cs
@@ -106,6 +106,24 @@ public sealed class OllamaCapabilityResolverTests
     }
 
     [Fact]
+    public void ParseShowResponse_ZeroContextLength_ReturnsNull()
+    {
+        const string json = """
+        {
+          "model_info": {
+            "general.architecture": "qwen35",
+            "qwen35.context_length": 0
+          }
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "qwen3.5:9b");
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+    }
+
+    [Fact]
     public void ParseShowResponse_MissingArchitecture()
     {
         const string json = """

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
@@ -34,6 +34,45 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
         Assert.Equal(expectedContextWindow, model.ContextWindowTokens);
     }
 
+    [Theory]
+    [InlineData("{\"id\":\"router-model\",\"meta\":{\"n_ctx\":0}}")]
+    [InlineData("{\"id\":\"router-model\",\"max_model_len\":0}")]
+    public void ParseModels_TreatsZeroContextMetadataAsUnknown(string modelJson)
+    {
+        var json = $$"""
+        {
+          "object": "list",
+          "data": [ {{modelJson}} ]
+        }
+        """;
+
+        var result = OpenAiCompatibleDescriptor.ParseModels(json);
+
+        var model = Assert.Single(result.Models);
+        Assert.Null(model.ContextWindowTokens);
+    }
+
+    [Fact]
+    public void ParseModels_ZeroNCtxDoesNotFallBackToTrainContext()
+    {
+        const string json = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "router-model",
+              "meta": { "n_ctx": 0, "n_ctx_train": 262144 }
+            }
+          ]
+        }
+        """;
+
+        var result = OpenAiCompatibleDescriptor.ParseModels(json);
+
+        var model = Assert.Single(result.Models);
+        Assert.Null(model.ContextWindowTokens);
+    }
+
     [Fact]
     public void ResolveFromProbe_VllmShape_DispatchesToVllmStrategy()
     {
@@ -90,6 +129,43 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
         Assert.Equal(131_072, result.ContextWindowTokens);
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public void ResolveFromProbe_LlamaCppRouterPropsZero_ReturnsUnknownContext()
+    {
+        const string modelsJson = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "router-model",
+              "object": "model",
+              "owned_by": "llamacpp"
+            }
+          ]
+        }
+        """;
+        const string propsJson = """
+        {
+          "role": "router",
+          "default_generation_settings": {
+            "params": {},
+            "n_ctx": 0
+          },
+          "modalities": {
+            "vision": false
+          }
+        }
+        """;
+
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(
+            "router-model", modelsJson, propsJson);
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Providers/OpenRouterOracleResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenRouterOracleResolverTests.cs
@@ -151,6 +151,29 @@ public sealed class OpenRouterOracleResolverTests
     }
 
     [Fact]
+    public void ParseCatalog_ZeroContextLength_ReturnsNull()
+    {
+        const string json = """
+        {
+          "data": [
+            {
+              "id": "some/model",
+              "context_length": 0,
+              "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": ["text"]
+              }
+            }
+          ]
+        }
+        """;
+
+        var catalog = OpenRouterOracleResolver.ParseCatalog(json);
+
+        Assert.Null(catalog["some/model"].ContextWindowTokens);
+    }
+
+    [Fact]
     public void ParseCatalog_EmptyData()
     {
         const string json = """{"data": []}""";

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
@@ -58,6 +58,22 @@ public sealed class LlamaCppBackendStrategyTests
         Assert.Equal(ModelModality.Text, result.OutputModalities);
     }
 
+    [Theory]
+    [InlineData("{\"default_generation_settings\":{\"n_ctx\":0},\"modalities\":{\"vision\":true}}")]
+    [InlineData("{\"default_generation_settings\":{\"params\":{\"n_ctx\":0}},\"modalities\":{\"vision\":true}}")]
+    public void Parse_IgnoresZeroPropsNCtx_UsesMetaContext(string propsJson)
+    {
+        using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
+        using var props = JsonDocument.Parse(propsJson);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, props.RootElement);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(131_072, result.ContextWindowTokens);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+    }
+
     [Fact]
     public void Parse_UsesMetaNCtx_WhenPropsAbsent()
     {
@@ -68,7 +84,104 @@ public sealed class LlamaCppBackendStrategyTests
 
         Assert.NotNull(result);
         Assert.Equal(131_072, result.ContextWindowTokens);
-        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+    }
+
+    [Fact]
+    public void Parse_ZeroMetaNCtx_ReturnsUnknownContextEvenWhenMetaTrainPresent()
+    {
+        const string modelsJson = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf",
+              "meta": { "n_ctx": 0, "n_ctx_train": 262144 }
+            }
+          ]
+        }
+        """;
+        using var models = JsonDocument.Parse(modelsJson);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+    }
+
+    [Fact]
+    public void Parse_UsesMetaTrainContext_WhenMetaNCtxAbsent()
+    {
+        const string modelsJson = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf",
+              "meta": { "n_ctx_train": 262144 }
+            }
+          ]
+        }
+        """;
+        using var models = JsonDocument.Parse(modelsJson);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(262_144, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public void Parse_AllContextMetadataZero_ReturnsNullContext()
+    {
+        const string modelsJson = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf",
+              "meta": { "n_ctx": 0, "n_ctx_train": 0 }
+            }
+          ]
+        }
+        """;
+        using var models = JsonDocument.Parse(modelsJson);
+        using var props = JsonDocument.Parse("""{"default_generation_settings":{"n_ctx":0}}""");
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, props.RootElement);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+    }
+
+    [Fact]
+    public void Parse_RouterPropsWithVisionFalse_DoesNotSetTextOnlyModalities()
+    {
+        using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
+        const string propsJson = """
+        {
+          "role": "router",
+          "default_generation_settings": { "n_ctx": 0 },
+          "modalities": { "vision": false }
+        }
+        """;
+        using var props = JsonDocument.Parse(propsJson);
+        var probe = new BackendProbe("Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf", models.RootElement, props.RootElement);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(131_072, result.ContextWindowTokens);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs
@@ -77,6 +77,21 @@ public sealed class VllmBackendStrategyTests
     }
 
     [Fact]
+    public void Parse_ZeroMaxModelLen_ReturnsUnknownContext()
+    {
+        const string json = """
+        { "object": "list", "data": [ { "id": "model-x", "owned_by": "vllm", "max_model_len": 0 } ] }
+        """;
+        using var doc = JsonDocument.Parse(json);
+        var probe = new BackendProbe("model-x", doc.RootElement, PropsRoot: null);
+
+        var result = new VllmBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+    }
+
+    [Fact]
     public void Parse_NoMatchingModelId_ReturnsNull()
     {
         // Strategy can't say anything useful when the served model is

--- a/src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs
+++ b/src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs
@@ -20,20 +20,26 @@ internal static class ModelCapabilityResolution
         int defaultContextWindow = 32_768)
     {
         var model = models.Main;
+        // Final safety net: provider parsers should normalize non-positive context
+        // metadata to null, but keep runtime capabilities valid even if an older
+        // or custom resolver reports llama.cpp-style n_ctx=0 as a sentinel.
+        var detectedContextWindow = detected?.ContextWindowTokens is > 0
+            ? detected.ContextWindowTokens
+            : null;
 
         if (model.ContextWindow is int configuredContextWindow
-            && detected?.ContextWindowTokens is int detectedContextWindow
-            && configuredContextWindow > detectedContextWindow)
+            && detectedContextWindow is int detectedWindow
+            && configuredContextWindow > detectedWindow)
         {
             throw new InvalidOperationException(
                 $"Models:Main:ContextWindow ({configuredContextWindow}) exceeds the " +
-                $"provider-reported effective context window ({detectedContextWindow}). " +
+                $"provider-reported effective context window ({detectedWindow}). " +
                 "Reduce the configured ContextWindow or adjust the provider runtime settings.");
         }
 
         var inputModalities = model.InputModalities ?? detected?.InputModalities ?? ModelModality.Text;
         var outputModalities = model.OutputModalities ?? detected?.OutputModalities ?? ModelModality.Text;
-        var contextWindow = model.ContextWindow ?? detected?.ContextWindowTokens ?? defaultContextWindow;
+        var contextWindow = model.ContextWindow ?? detectedContextWindow ?? defaultContextWindow;
 
         return new ModelCapabilities
         {

--- a/src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs
+++ b/src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 
 namespace Netclaw.Daemon.Configuration;
@@ -17,7 +18,8 @@ internal static class ModelCapabilityResolution
     public static ModelCapabilities ResolveModelCapabilities(
         ModelSelection models,
         ResolvedModelCapabilities? detected,
-        int defaultContextWindow = 32_768)
+        int defaultContextWindow = 32_768,
+        ILogger? logger = null)
     {
         var model = models.Main;
         // Final safety net: provider parsers should normalize non-positive context
@@ -31,10 +33,21 @@ internal static class ModelCapabilityResolution
             && detectedContextWindow is int detectedWindow
             && configuredContextWindow > detectedWindow)
         {
-            throw new InvalidOperationException(
-                $"Models:Main:ContextWindow ({configuredContextWindow}) exceeds the " +
-                $"provider-reported effective context window ({detectedWindow}). " +
-                "Reduce the configured ContextWindow or adjust the provider runtime settings.");
+            // The configured window exceeds what the provider reports, but
+            // provider-reported context windows are frequently wrong or absent
+            // (router placeholders, n_ctx=0 sentinels, llama.cpp started with a
+            // larger --ctx-size than it advertises). Refusing to boot on that
+            // signal takes down every session over a number we can't trust, so
+            // honor the operator's value and warn. If it really is too large the
+            // provider rejects the oversized request at runtime and the session
+            // compacts-and-retries (see LlmSessionActor), surfacing an actionable
+            // per-turn error rather than a daemon-wide startup failure.
+            logger?.LogWarning(
+                "Models:Main:ContextWindow ({ConfiguredContextWindow}) exceeds the " +
+                "provider-reported effective context window ({DetectedContextWindow}). " +
+                "Using the configured value; if requests are rejected at runtime, reduce " +
+                "ContextWindow or adjust the provider runtime settings.",
+                configuredContextWindow, detectedWindow);
         }
 
         var inputModalities = model.InputModalities ?? detected?.InputModalities ?? ModelModality.Text;

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -429,7 +429,7 @@ static void ConfigureDaemonServices(
 
         var detected = resolver.ResolveAsync(models.Main.ModelId, CancellationToken.None)
             .GetAwaiter().GetResult();
-        var resolved = ModelCapabilityResolution.ResolveModelCapabilities(models, detected);
+        var resolved = ModelCapabilityResolution.ResolveModelCapabilities(models, detected, logger: logger);
 
         if (detected is not null)
         {

--- a/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
@@ -85,7 +85,11 @@ public sealed class CompositeCapabilityResolver : IModelCapabilityResolver
             anyResultProduced = true;
             inputModalities ??= result.InputModalities;
             outputModalities ??= result.OutputModalities;
-            contextWindowTokens ??= result.ContextWindowTokens;
+            // Context windows are positive-only. A 0 from provider metadata is an
+            // unknown sentinel, not a resolved value, and must not block a later
+            // resolver from supplying the real limit.
+            if (contextWindowTokens is null && result.ContextWindowTokens is > 0)
+                contextWindowTokens = result.ContextWindowTokens;
 
             _logger.LogDebug(
                 "Resolved partial capabilities for {ModelId} via {Resolver}: input={Input}, output={Output}, ctx={Ctx}",

--- a/src/Netclaw.Providers/OpenRouter/OpenRouterOracleResolver.cs
+++ b/src/Netclaw.Providers/OpenRouter/OpenRouterOracleResolver.cs
@@ -133,11 +133,7 @@ public sealed class OpenRouterOracleResolver : IModelCapabilityResolver
                     output = ParseModalityArray(outputMods);
             }
 
-            if (model.TryGetProperty("context_length", out var ctxLen) &&
-                ctxLen.ValueKind == JsonValueKind.Number)
-            {
-                contextWindow = ctxLen.GetInt32();
-            }
+            contextWindow = ProbeHelpers.TryReadPositiveInt32(model, "context_length");
 
             result[id] = new ResolvedModelCapabilities(id, input, output, contextWindow);
         }

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -57,6 +57,29 @@ internal static class ProbeHelpers
             : null;
     }
 
+    internal static int? TryReadPositiveInt32(JsonElement element, string propertyName)
+    {
+        // Context-window metadata uses 0 as an unset sentinel in some provider APIs
+        // (notably llama.cpp router-mode /props). Runtime context windows must be
+        // positive, so callers parsing context limits should treat non-positive
+        // values as unknown and let later detection/defaulting fill the value.
+        return TryReadInt32(element, propertyName) is > 0 and var value
+            ? value
+            : null;
+    }
+
+    internal static int? TryReadPositiveInt32OrFallbackWhenMissing(
+        JsonElement element, string propertyName, string fallbackPropertyName)
+    {
+        // n_ctx is the effective runtime context. If a provider reports it as 0,
+        // it is explicitly unknown; do not promote n_ctx_train as if it were the
+        // runtime limit, because that can overstate the configured capacity.
+        if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty(propertyName, out _))
+            return TryReadPositiveInt32(element, propertyName);
+
+        return TryReadPositiveInt32(element, fallbackPropertyName);
+    }
+
     /// <summary>
     /// Common probe execution: builds URL, sends request with timeout,
     /// handles errors, and delegates parsing to the caller.

--- a/src/Netclaw.Providers/SelfHosted/OllamaCapabilityResolver.cs
+++ b/src/Netclaw.Providers/SelfHosted/OllamaCapabilityResolver.cs
@@ -85,11 +85,7 @@ public sealed class OllamaCapabilityResolver : IModelCapabilityResolver
         if (arch is not null)
         {
             // Context window: "{arch}.context_length"
-            if (modelInfo.TryGetProperty($"{arch}.context_length", out var ctxProp) &&
-                ctxProp.ValueKind == JsonValueKind.Number)
-            {
-                contextWindow = ctxProp.GetInt32();
-            }
+            contextWindow = ProbeHelpers.TryReadPositiveInt32(modelInfo, $"{arch}.context_length");
 
             // Vision: "{arch}.vision.block_count" > 0 means image input
             if (modelInfo.TryGetProperty($"{arch}.vision.block_count", out var visionProp) &&

--- a/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
@@ -91,12 +91,7 @@ internal sealed class VllmBackendStrategy : IOpenAiBackendStrategy
         if (!probe.TryFindModelEntry(out var model))
             return null;
 
-        int? contextWindow = null;
-        if (model.TryGetProperty("max_model_len", out var mml) &&
-            mml.ValueKind == JsonValueKind.Number)
-        {
-            contextWindow = mml.GetInt32();
-        }
+        var contextWindow = ProbeHelpers.TryReadPositiveInt32(model, "max_model_len");
 
         // vLLM exposes no modality information; null fields signal that
         // downstream resolvers in the chain (HuggingFace) should fill in.
@@ -133,24 +128,28 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
         if (probe.TryFindModelEntry(out var model))
             contextWindow = TryReadModelMetaContext(model);
 
-        // /props overrides — runtime-effective n_ctx and vision flag.
-        var inputModalities = ModelModality.Text;
+        // /props overrides with the runtime-effective n_ctx when it is real.
+        // llama.cpp router mode returns a router-level /props body with n_ctx=0
+        // and no per-model modality evidence. That response must not override
+        // model metadata or block later resolvers from detecting image support.
+        ModelModality? inputModalities = null;
+        ModelModality? outputModalities = null;
         if (probe.PropsRoot is JsonElement props)
         {
-            contextWindow = TryReadPropsContext(props) ?? contextWindow;
-
-            if (props.TryGetProperty("modalities", out var modalities) &&
-                modalities.ValueKind == JsonValueKind.Object &&
-                modalities.TryGetProperty("vision", out var vision) &&
-                vision.ValueKind is JsonValueKind.True or JsonValueKind.False &&
-                vision.GetBoolean())
+            if (!IsRouterProps(props))
             {
-                inputModalities |= ModelModality.Image;
+                contextWindow = TryReadPropsContext(props) ?? contextWindow;
+
+                if (TryReadInputModalities(props) is { } detectedInputModalities)
+                {
+                    inputModalities = detectedInputModalities;
+                    outputModalities = ModelModality.Text;
+                }
             }
         }
 
         return new ResolvedModelCapabilities(
-            probe.ModelId, inputModalities, ModelModality.Text, contextWindow);
+            probe.ModelId, inputModalities, outputModalities, contextWindow);
     }
 
     private static int? TryReadModelMetaContext(JsonElement model)
@@ -159,8 +158,8 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
             meta.ValueKind != JsonValueKind.Object)
             return null;
 
-        return ProbeHelpers.TryReadInt32(meta, "n_ctx") ??
-               ProbeHelpers.TryReadInt32(meta, "n_ctx_train");
+        return ProbeHelpers.TryReadPositiveInt32OrFallbackWhenMissing(
+            meta, "n_ctx", "n_ctx_train");
     }
 
     private static int? TryReadPropsContext(JsonElement props)
@@ -169,10 +168,32 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
             dgs.ValueKind != JsonValueKind.Object)
             return null;
 
-        return ProbeHelpers.TryReadInt32(dgs, "n_ctx") ??
+        return ProbeHelpers.TryReadPositiveInt32(dgs, "n_ctx") ??
                (dgs.TryGetProperty("params", out var parameters)
-                   ? ProbeHelpers.TryReadInt32(parameters, "n_ctx")
+                   ? ProbeHelpers.TryReadPositiveInt32(parameters, "n_ctx")
                    : null);
+    }
+
+    private static ModelModality? TryReadInputModalities(JsonElement props)
+    {
+        if (!props.TryGetProperty("modalities", out var modalities) ||
+            modalities.ValueKind != JsonValueKind.Object ||
+            !modalities.TryGetProperty("vision", out var vision) ||
+            vision.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+            return null;
+
+        return vision.GetBoolean()
+            ? ModelModality.Text | ModelModality.Image
+            : ModelModality.Text;
+    }
+
+    private static bool IsRouterProps(JsonElement props)
+    {
+        // Router-level /props describes the router process, not the selected model.
+        // Do not let its placeholders become authoritative per-model capabilities.
+        return props.TryGetProperty("role", out var role) &&
+               role.ValueKind == JsonValueKind.String &&
+               string.Equals(role.GetString(), "router", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
@@ -52,13 +52,13 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
 
     private static int? TryReadContextWindow(JsonElement model)
     {
-        var contextWindow = ProbeHelpers.TryReadInt32(model, "max_model_len"); // vLLM
+        var contextWindow = ProbeHelpers.TryReadPositiveInt32(model, "max_model_len"); // vLLM
         if (contextWindow is not null)
             return contextWindow;
 
         return model.TryGetProperty("meta", out var meta)
-            ? ProbeHelpers.TryReadInt32(meta, "n_ctx") ??
-              ProbeHelpers.TryReadInt32(meta, "n_ctx_train")
+            ? ProbeHelpers.TryReadPositiveInt32OrFallbackWhenMissing(
+                meta, "n_ctx", "n_ctx_train")
             : null;
     }
 }


### PR DESCRIPTION
## Summary
- Treat provider-reported non-positive context windows as unknown instead of valid runtime limits
- Ignore llama.cpp router-level /props placeholders so they do not override per-model metadata or block downstream modality detection
- Harden composite and final model capability resolution against zero context values
- **Soften the configured-vs-detected context window check from a hard startup failure to a warning** (see below)

Fixes #1280.

## Context window mismatch: warn, don't crash

Previously, when `Models:Main:ContextWindow` exceeded the provider-reported effective context window, `ModelCapabilityResolution` threw `InvalidOperationException` and the daemon refused to start. That's the wrong failure mode:

- **Provider-reported windows are unreliable** — router placeholders, `n_ctx=0` sentinels, and llama.cpp started with a larger `--ctx-size` than it advertises. This is the same unreliability the rest of this PR works around, so gating *startup* on that number takes down every session over a value we can't trust.
- **Overrun is already a handled runtime condition.** If the configured window really is too large, the provider rejects the oversized request and the session compacts-and-retries (`LlmSessionActor`), surfacing an actionable per-turn error — not a daemon-wide boot failure.

So we now **honor the operator's configured value and log a `Warning`** at startup instead of throwing. The `Netclaw.Startup` logger is threaded into the resolver so the warning surfaces.

## Validation
- dotnet test src/Netclaw.Daemon.Tests
- dotnet test src/Netclaw.Cli.Tests
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
