### PR TITLE
feat(discord): show typing indicator while processing an LLM call

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
@@ -288,6 +288,38 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
             "Expected LLM to receive DataContent (image) via real MagicByteContentScanner");
     }
 
+    [Fact]
+    public async Task Typing_indicator_triggered_while_processing_an_llm_call()
+    {
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        var httpClient = new HttpClient(_httpHandler);
+
+        var deps = CreateDependencies(pipeline, httpClient);
+
+        var gateway = Sys.ActorOf(DiscordGatewayActor.CreateProps(deps), "discord-gw-typing-test");
+
+        gateway.Tell(new DiscordGatewayMessage(
+            EventId: new DiscordEventId("msg-5000"),
+            ChannelId: new DiscordChannelId("ch-5"),
+            ReplyChannelId: new DiscordReplyChannelId("ch-5"),
+            MessageId: new DiscordMessageId("msg-5000"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("msg-5000"),
+            RootMessageId: new DiscordMessageId("msg-5000"),
+            SenderId: new DiscordUserId("u-human"),
+            IsBotMessage: false,
+            IsDirectMessage: true,
+            ContainsBotMention: false,
+            Text: "hello there",
+            ReceivedAt: TimeProvider.System.GetUtcNow()));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_replyClient.TypingTriggers.Count > 0,
+                "Expected the typing indicator to be triggered while the LLM call was in flight");
+            Assert.Contains(_replyClient.TypingTriggers, id => id.Value == "ch-5");
+        }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
     private DiscordGatewayDependencies CreateDependencies(
         ISessionPipeline pipeline,
         HttpClient? httpClient = null,
@@ -414,6 +446,7 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
     private sealed class RecordingDiscordReplyClient : IDiscordReplyClient
     {
         public List<DiscordPostMessage> Posts { get; } = [];
+        public List<DiscordReplyChannelId> TypingTriggers { get; } = [];
 
         public Task<DiscordPostResult> PostReplyAsync(DiscordPostMessage message, CancellationToken cancellationToken = default)
         {
@@ -431,6 +464,12 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
             }
 
             return Task.FromResult(result);
+        }
+
+        public Task TriggerTypingAsync(DiscordReplyChannelId channelId, CancellationToken cancellationToken = default)
+        {
+            TypingTriggers.Add(channelId);
+            return Task.CompletedTask;
         }
 
         public Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingDiscordReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingDiscordReplyClient.cs
@@ -12,7 +12,9 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
     public List<DiscordPostMessage> Posts { get; } = [];
     public List<(DiscordReplyChannelId ThreadId, string Name)> ThreadRenames { get; } = [];
     public List<(DiscordReplyChannelId ChannelId, DiscordMessageId MessageId, string Text, bool RemoveComponents)> Updates { get; } = [];
+    public List<DiscordReplyChannelId> TypingTriggers { get; } = [];
     public Exception? ThrowOnPost { get; set; }
+    public Exception? ThrowOnTyping { get; set; }
 
     private int _messageCounter;
 
@@ -36,6 +38,15 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
         }
 
         return Task.FromResult(result);
+    }
+
+    public Task TriggerTypingAsync(DiscordReplyChannelId channelId, CancellationToken cancellationToken = default)
+    {
+        if (ThrowOnTyping is { } ex)
+            throw ex;
+
+        TypingTriggers.Add(channelId);
+        return Task.CompletedTask;
     }
 
     public Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionProcessingStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionProcessingStateTests.cs
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmSessionProcessingStateTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Akka.Actor;
+using Akka.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Xunit;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Verifies the processing signal that brackets each LLM model call:
+/// <see cref="ProcessingStateOutput"/>(true) when a call starts and
+/// (false) when it ends — on success and on failure. Channels render this
+/// as a "typing" indicator.
+/// </summary>
+public sealed class LlmSessionProcessingStateTests(ITestOutputHelper output) : LlmSessionTestBase(output)
+{
+    private readonly ProcessingStateTestChatClient _chatClient = new();
+
+    protected override void ConfigureSessionServices(IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
+        services.AddSingleton(new ModelCapabilities
+        {
+            ModelId = "processing-state-test-model",
+            ContextWindowTokens = 128_000,
+        });
+        services.AddSingleton(new SessionConfig
+        {
+            Tuning = new SessionTuning
+            {
+                SnapshotInterval = 5,
+                TitleGenerationInterval = 0,
+            }
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
+    }
+
+    [Fact]
+    public async Task Processing_brackets_a_successful_call_with_started_then_stopped()
+    {
+        _chatClient.Mode = StreamMode.Succeed;
+
+        var sessionId = new SessionId("processing-state/success");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("processing-success-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Processing
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "hello"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var started = await subscriber.ExpectMsgAsync<ProcessingStateOutput>(
+            TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(started.IsProcessing, "First processing signal should be 'started'.");
+
+        var stopped = await subscriber.ExpectMsgAsync<ProcessingStateOutput>(
+            TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(stopped.IsProcessing, "Processing should stop when the response lands.");
+    }
+
+    [Fact]
+    public async Task Processing_stops_when_a_call_fails()
+    {
+        _chatClient.Mode = StreamMode.Fail;
+
+        var sessionId = new SessionId("processing-state/failure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("processing-failure-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Processing
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "hello"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var started = await subscriber.ExpectMsgAsync<ProcessingStateOutput>(
+            TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(started.IsProcessing, "First processing signal should be 'started'.");
+
+        var stopped = await subscriber.ExpectMsgAsync<ProcessingStateOutput>(
+            TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(stopped.IsProcessing, "Processing should stop even when the call fails.");
+    }
+
+    private enum StreamMode { Succeed, Fail }
+
+    private sealed class ProcessingStateTestChatClient : IChatClient
+    {
+        public StreamMode Mode { get; set; } = StreamMode.Succeed;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromException<ChatResponse>(new NotSupportedException("Streaming path only."));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => StreamAsync(cancellationToken);
+
+        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (Mode == StreamMode.Fail)
+            {
+                await Task.Yield();
+                // Non-transient failure: no streaming retry, the turn fails outright.
+                throw new InvalidOperationException("simulated provider failure");
+            }
+
+            yield return new ChatResponseUpdate
+            {
+                Role = AiChatRole.Assistant,
+                Contents = [new TextContent("success response")]
+            };
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -43,6 +43,15 @@ public sealed record TextOutput(string Text) : SessionOutput;
 public sealed record TextDeltaOutput(string Delta) : SessionOutput;
 
 /// <summary>
+/// The agent's processing state for the current model call: <c>true</c> when an
+/// LLM call starts, <c>false</c> when it ends (response received, failed, or timed
+/// out). Brackets each physical model call, so it goes off during tool execution
+/// and tool-approval waits. Channels render this as a "typing"/"thinking" indicator.
+/// Requires <see cref="OutputFilter.Processing"/>.
+/// </summary>
+public sealed record ProcessingStateOutput(bool IsProcessing) : SessionOutput;
+
+/// <summary>
 /// Thinking/reasoning tokens from the model (e.g., Claude extended thinking).
 /// Requires <see cref="OutputFilter.Thinking"/>.
 /// </summary>

--- a/src/Netclaw.Actors/Protocol/SessionSubscription.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSubscription.cs
@@ -39,6 +39,11 @@ public enum OutputFilter
     /// </summary>
     TextStreaming = 1 << 5,
 
+    /// <summary>
+    /// <see cref="ProcessingStateOutput"/> — agent processing on/off, for "typing"/"thinking" indicators.
+    /// </summary>
+    Processing = 1 << 6,
+
     // ── Convenience presets ──
 
     /// <summary>Final text replies only — suitable for adapters that post once (Slack).</summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -571,6 +571,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _watchdog.Stop(Timers);
             CancelAndDisposeLlmCts();
 
+            // Processing off: this physical call ended. Emitted early so retry paths
+            // below (context-overflow compaction, transient streaming retry) re-bracket
+            // with a fresh "on" when they re-enter FireLlmCall.
+            EmitOutput(new ProcessingStateOutput(false) { SessionId = _sessionId }, OutputFilter.Processing);
+
             // Context overflow: roll back the failed turn, buffer the user message,
             // compact the history, and let the normal buffer drain re-deliver it.
             if (IsContextOverflowError(msg.Cause))
@@ -680,6 +685,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _watchdog.Stop(Timers);
             CancelAndDisposeLlmCts();
 
+            // Processing off: only the LLM-call watchdog corresponds to an in-flight
+            // model call (the only place that emits "on"); other operations never did.
+            if (msg.OperationName == ProcessingWatchdog.LlmCall)
+                EmitOutput(new ProcessingStateOutput(false) { SessionId = _sessionId }, OutputFilter.Processing);
+
             _log.Error("Processing watchdog expired for operation {OperationName} (opId={OperationId}, noProgress={NoProgress})",
                 msg.OperationName, msg.OperationId, msg.NoProgress);
             var errorMessage = ExtractLlmErrorMessage(timeoutCause);
@@ -718,6 +728,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         _watchdog.Stop(Timers);
         CancelAndDisposeLlmCts();
+
+        // Processing off: the model call ended. Emitted before the tool-call branch
+        // so the indicator clears during tool execution / approval waits.
+        EmitOutput(new ProcessingStateOutput(false) { SessionId = _sessionId }, OutputFilter.Processing);
 
         var response = msg.Response;
         var lastMessage = response.Messages[^1];
@@ -2688,6 +2702,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             options?.Tools?.Count > 0,
             forceNoTools,
             _activeCallId);
+
+        // Processing on: brackets this physical model call so channels can show a
+        // "typing" indicator. The matching off is emitted at every call termination
+        // (response received, failure, watchdog timeout).
+        EmitOutput(new ProcessingStateOutput(true) { SessionId = _sessionId }, OutputFilter.Processing);
 
         _ = SessionLlmInvoker.InvokeAsync(client, messages, options, self, _activeCallId, _sessionId, _activeLlmCts!.Token);
     }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -62,6 +62,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static readonly TimeSpan ReinitializeDelay = TimeSpan.FromSeconds(2);
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
+    private static readonly object TypingTimerKey = new();
+    // Discord's typing indicator auto-expires after ~10s; re-trigger inside that
+    // window so it stays visible for the whole model call.
+    private static readonly TimeSpan TypingRefreshInterval = TimeSpan.FromSeconds(8);
     private bool _deliveredThisTurn;
     private Netclaw.Actors.Protocol.TurnNumber _turnNumber;
     private string? _lastSetThreadName;
@@ -153,7 +157,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private SessionPipelineOptions BuildOptions() => new()
     {
         ChannelType = ChannelType.Discord,
-        Filter = OutputFilter.Text | OutputFilter.Files
+        Filter = OutputFilter.Text | OutputFilter.Files | OutputFilter.Processing
     };
 
     private void Initializing()
@@ -212,6 +216,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         CommandAsync<DeliverTrustedSessionTurn>(HandleTrustedReminderAsync);
         CommandAsync<StartProactiveThread>(HandleProactiveThreadAsync);
         CommandAsync<OutputReceived>(HandleOutputReceivedAsync);
+        CommandAsync<TriggerTyping>(async _ => await SafeTriggerTypingAsync());
 
         Command<OutputStreamTerminated>(msg =>
         {
@@ -1103,6 +1108,21 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 _deliveredThisTurn = true;
                 break;
 
+            case ProcessingStateOutput processing:
+                // Render the model-call window as Discord's typing indicator. Not
+                // user content, so do not touch _deliveredThisTurn (it must not
+                // suppress the empty-turn fallback below).
+                if (processing.IsProcessing)
+                {
+                    await SafeTriggerTypingAsync();
+                    Timers.StartPeriodicTimer(TypingTimerKey, TriggerTyping.Instance, TypingRefreshInterval);
+                }
+                else
+                {
+                    Timers.Cancel(TypingTimerKey);
+                }
+                break;
+
             case ToolInteractionRequest request when string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase):
                 _hasObservedApprovalRequest = true;
                 var pendingApproval = new PendingApprovalRequest(request);
@@ -1142,6 +1162,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 break;
 
             case TurnCompleted completed:
+                // Backstop: clear typing in case a stop signal was missed (e.g. the
+                // turn ended without a model call).
+                Timers.Cancel(TypingTimerKey);
+
                 if (completed.Outcome == TurnOutcome.Completed && _pendingCursorSnowflake is { } pendingSnowflake)
                     AdvanceCursor(pendingSnowflake);
                 _pendingCursorSnowflake = null;
@@ -1233,6 +1257,19 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
                 return;
             }
+        }
+    }
+
+    private async Task SafeTriggerTypingAsync()
+    {
+        try
+        {
+            await _dependencies.ReplyClient.TriggerTypingAsync(_replyChannelId);
+        }
+        catch (Exception ex)
+        {
+            // Typing is a best-effort UX nicety; never fail or retry a turn over it.
+            _log.Debug(ex, "Failed to trigger Discord typing indicator for session {0}", _sessionId.Value);
         }
     }
 
@@ -1524,6 +1561,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     }
 
     private sealed record OutputReceived(SessionOutput Output);
+
+    private sealed record TriggerTyping
+    {
+        public static readonly TriggerTyping Instance = new();
+    }
 
     private sealed record OutputStreamTerminated(int Generation, Exception? Cause);
 

--- a/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
+++ b/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
@@ -84,6 +84,13 @@ public interface IDiscordReplyClient
 {
     Task<DiscordPostResult> PostReplyAsync(DiscordPostMessage message, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Triggers Discord's typing indicator on the channel. The indicator
+    /// auto-expires after ~10s, so callers re-trigger it while work is in flight.
+    /// Best-effort: typing is a UX nicety, not a delivery guarantee.
+    /// </summary>
+    Task TriggerTypingAsync(DiscordReplyChannelId channelId, CancellationToken cancellationToken = default);
+
     Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default);
 
     Task UpdateMessageAsync(
@@ -169,6 +176,10 @@ public sealed class UnconfiguredDiscordReplyClient : IDiscordReplyClient
     public Task<DiscordPostResult> PostReplyAsync(DiscordPostMessage message, CancellationToken cancellationToken = default)
         => throw new InvalidOperationException(
             "Discord channel attempted outbound delivery, but no Discord reply client is configured.");
+
+    public Task TriggerTypingAsync(DiscordReplyChannelId channelId, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Discord channel attempted to trigger typing, but no Discord reply client is configured.");
 
     public Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)
         => throw new InvalidOperationException(

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetReplyClient.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetReplyClient.cs
@@ -95,6 +95,13 @@ internal sealed class DiscordNetReplyClient : IDiscordReplyClient
         return new DiscordPostResult(CreatedThreadId: createdThreadId, MessageId: sentMessageId);
     }
 
+    public async Task TriggerTypingAsync(DiscordReplyChannelId channelId, CancellationToken cancellationToken = default)
+    {
+        var channelSnowflake = ParseSnowflake(channelId.Value, "reply channel ID");
+        var messageChannel = await ResolveMessageChannelAsync(channelSnowflake, channelId.Value);
+        await messageChannel.TriggerTypingAsync(new RequestOptions { CancelToken = cancellationToken });
+    }
+
     public async Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)
     {
         var channelId = ParseSnowflake(threadChannelId.Value, "thread channel ID");


### PR DESCRIPTION
## What

Adds a cross-channel **processing signal** that brackets each LLM model call and renders it as Discord's native **typing indicator**. The agent now gives live feedback while it is thinking, instead of staying silent until the turn finishes.

## Why

Discord currently posts once when a turn completes — no feedback during long model calls. A typing indicator signals the agent is working.

## How

**Core (channel-agnostic)**
- New `ProcessingStateOutput(bool IsProcessing)` `SessionOutput` and an **opt-in** `OutputFilter.Processing` flag.
- `LlmSessionActor` emits `IsProcessing=true` at the start of each model call (`FireLlmCall`) and `false` when it ends:
  - response received (`HandleLlmResponseReceived`),
  - call failed (emitted early, so retry/compaction paths re-bracket with a fresh `true`),
  - LLM-call watchdog timeout.
- Because the stop fires when the response lands, the indicator is naturally **off during tool execution and tool-approval waits**, and resumes on the next model call.

**Discord**
- `DiscordSessionBindingActor` subscribes to the new filter and drives typing via `TriggerTypingAsync` + an 8s periodic timer (Discord typing auto-expires ~10s). Stops on the processing-off signal and on `TurnCompleted` (backstop). Best-effort — never fails or retries a turn.
- New `IDiscordReplyClient.TriggerTypingAsync`, implemented in `DiscordNetReplyClient` (reuses existing channel resolution), stubbed in the unconfigured client.

The flag is **excluded from `OutputFilter.Full`**, so existing subscribers are unaffected. Slack can adopt the same signal later by adding the flag and a `case ProcessingStateOutput`.

## Tests

- `LlmSessionProcessingStateTests` — started→stopped on success and on failure.
- `DiscordFileFlowIntegrationTests` — typing triggered during a turn.
- Test doubles updated for the new interface method.

## Verification

- Full solution build: 29 projects, 0 errors, 0 warnings.
- Affected + adjacent suites pass (40 tests).
- `dotnet slopwatch analyze`: 0 issues.
- Copyright headers verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)