### PR TITLE
fix(openai): serve non-streaming Codex calls via streaming (stop-gap)

### DIFF
--- a/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
@@ -37,9 +37,15 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
             };
             options.AddPolicy(new OpenAiCodexRequestPolicy(accountId), PipelinePosition.PerCall);
 
-            return new OpenAI.Responses.ResponsesClient(
-                    new ApiKeyCredential(token.Value), options)
-                .AsIChatClient(model.ModelId);
+            // The Codex backend rejects non-streaming Responses calls with
+            // 400 {"detail":"Stream must be set to true"}. Netclaw's session loop
+            // streams, but auxiliary calls (title generation, memory extraction,
+            // compaction) use the non-streaming GetResponseAsync path. Wrap the
+            // client so those calls are served by streaming under the hood.
+            return new StreamingOnlyChatClient(
+                new OpenAI.Responses.ResponsesClient(
+                        new ApiKeyCredential(token.Value), options)
+                    .AsIChatClient(model.ModelId));
         }
 
         // API key path → standard endpoint
@@ -47,4 +53,22 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
         return new OpenAI.Responses.ResponsesClient(apiKey)
             .AsIChatClient(model.ModelId);
     }
+}
+
+/// <summary>
+/// Serves non-streaming <see cref="IChatClient.GetResponseAsync"/> calls by consuming the
+/// underlying streaming endpoint and aggregating the updates. Required for the OpenAI Codex
+/// backend, which rejects non-streaming Responses requests with
+/// <c>400 {"detail":"Stream must be set to true"}</c>. Streaming calls pass straight through.
+/// </summary>
+internal sealed class StreamingOnlyChatClient : DelegatingChatClient
+{
+    public StreamingOnlyChatClient(IChatClient innerClient) : base(innerClient) { }
+
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingResponseAsync(messages, options, cancellationToken)
+            .ToChatResponseAsync(cancellationToken);
 }


### PR DESCRIPTION
## What

Stop-gap fix so the OpenAI **Codex** backend works with auxiliary (non-streaming) LLM calls.

## Problem

The Codex backend rejects non-streaming Responses requests:

```
400 {"detail":"Stream must be set to true"}
```

Netclaw's session loop streams, but **auxiliary calls** — title generation, memory extraction, compaction — use the non-streaming `IChatClient.GetResponseAsync` path, so they fail against Codex.

## Fix

Wrap the Codex `ResponsesClient` in a new `StreamingOnlyChatClient` (a `DelegatingChatClient`) that serves `GetResponseAsync` by consuming the streaming endpoint and aggregating the updates (`GetStreamingResponseAsync(...).ToChatResponseAsync(...)`). Streaming calls pass straight through.

## Scope / status

**This is a stop-gap** while the broader streaming/non-streaming provider abstraction is being refactored. Once the structural fix lands, this wrapper should be removed in favor of it.

- Self-contained: the wrapper lives in `OpenAiProviderPlugin.cs` and uses only `Microsoft.Extensions.AI` types.
- `Netclaw.Providers` builds clean (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)