### PR TITLE
fix(daemon): use Workstation GC for netclawd (#1294)

### DIFF
--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -8,6 +8,13 @@
         <Nullable>enable</Nullable>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <InvariantGlobalization>false</InvariantGlobalization>
+        <!-- Workstation GC: netclawd is a single-tenant, low-concurrency daemon
+             usually run in a memory-limited container. Server GC (the Web SDK
+             default) inflates peak RSS and is slow to return memory to the OS,
+             which turns transient allocation spikes into cgroup OOM kills. The
+             daemon's concurrency profile doesn't benefit from Server GC. See #1294. -->
+        <ServerGarbageCollection>false</ServerGarbageCollection>
+        <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
         <!-- OpenAI Responses API (ResponsesClient) is still marked experimental -->
         <NoWarn>$(NoWarn);OPENAI001</NoWarn>
 


### PR DESCRIPTION
## Summary

Switches `netclawd` from Server GC to Workstation GC (with background collection).

`Netclaw.Daemon` builds on `Microsoft.NET.Sdk.Web`, which defaults `ServerGarbageCollection` to `true`. There was no override, so the daemon shipped with Server GC. That's the wrong trade for this process:

- `netclawd` is single-tenant and low-concurrency — one operator, a handful of sessions, a SignalR gateway and webhook listener.
- We run it in memory-limited containers (1Gi). Server GC reserves larger segments, keeps one heap per core, collects Gen2/LOH less eagerly, and is slow to return memory to the OS — so peak RSS is higher and transient allocation spikes are more likely to trip the cgroup OOM killer.
- Server GC's throughput win (saturating many cores under heavy allocation churn) doesn't apply to this workload.

This came out of investigating real OOM kills on a log-pulling daemon. The root allocation problem is tracked separately (#1293, unbounded `shell_execute` output buffering); Server GC is what turned that spike into a kill instead of a hiccup.

## Change

```xml
<ServerGarbageCollection>false</ServerGarbageCollection>
<ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
```

## Verification

- `dotnet build -c Release` clean (0 warnings, 0 errors).
- Confirmed `netclawd.runtimeconfig.json` now emits `System.GC.Server: false` and `System.GC.Concurrent: true`.

## Notes for review

Worth a sanity check that no high-throughput self-hosted deployment is leaning on Server GC. For the agent's actual concurrency profile, Workstation should be the better default. Easy to revert or make environment-conditional (`DOTNET_gcServer`) if needed.

Closes #1294.
