### PR TITLE
fix(shell): verify working directory exists before launching process

### DIFF
--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs
@@ -53,9 +53,10 @@ public class BackgroundJobIntegrationTests : TestKit
 
     private IActorRef GetManager() => ActorRegistry.For(Sys).Get<BackgroundJobManagerActorKey>();
 
-    private StartBackgroundJob MakeStartCommand(string command, ChannelType channelType = ChannelType.Slack) => new()
+    private StartBackgroundJob MakeStartCommand(string command, ChannelType channelType = ChannelType.Slack, string? workingDirectory = null) => new()
     {
         Command = command,
+        WorkingDirectory = workingDirectory,
         SessionId = new SessionId("C0123ABC/1712000000.000001"),
         Rationale = "integration test",
         Audience = TrustAudience.Personal,
@@ -102,6 +103,42 @@ public class BackgroundJobIntegrationTests : TestKit
             Assert.NotNull(def);
             Assert.Equal(BackgroundJobStatus.Completed, def!.Status);
             Assert.NotNull(def.CompletedAtMs);
+            return Task.CompletedTask;
+        }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task BackgroundJob_WithMissingWorkingDirectory_FailsWithHelpfulError()
+    {
+        // #1286: a non-existent working directory must fail loudly with the mkdir remedy
+        // instead of an opaque "Failed to start: ..." from Process.Start.
+        var manager = GetManager();
+
+        var gatewayProbe = CreateTestProbe("fake-slack-gateway-missing-cwd");
+        var autoAckRef = Sys.ActorOf(
+            Props.Create(() => new AutoAckTrustedGateway(gatewayProbe.Ref)),
+            "auto-ack-slack-gateway-missing-cwd");
+        ActorRegistry.For(Sys).Register<SlackGatewayActorKey>(autoAckRef);
+
+        var missingDir = Path.Combine(_dir.Path, "does", "not", "exist");
+
+        var started = await manager.Ask<BackgroundJobStarted>(
+            MakeStartCommand("echo hi", workingDirectory: missingDir),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        var delivered = await gatewayProbe.ExpectMsgAsync<DeliverTrustedSessionTurn>(
+            TimeSpan.FromSeconds(15), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Contains("does not exist", delivered.Content);
+        Assert.Contains("mkdir", delivered.Content);
+        Assert.Contains("failed", delivered.Content.ToLowerInvariant());
+
+        await AwaitAssertAsync(() =>
+        {
+            var def = _store.Get(started.JobId);
+            Assert.NotNull(def);
+            Assert.Equal(BackgroundJobStatus.Failed, def!.Status);
             return Task.CompletedTask;
         }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
     }

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -276,6 +276,72 @@ public class ShellToolTests
         }
     }
 
+    // ── Working directory must exist (#1286): fail loudly with the mkdir remedy ──
+    // instead of letting Process.Start surface an opaque, platform-specific error.
+
+    [Fact]
+    public async Task Missing_explicit_working_directory_returns_helpful_error()
+    {
+        var missingDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var args = ToolInput.Create("Command", "echo hi", "WorkingDirectory", missingDir);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("does not exist", result);
+        Assert.Contains(missingDir, result);
+        Assert.Contains("mkdir", result);
+        // The process must never start with a missing cwd...
+        Assert.DoesNotContain("Exit code", result);
+        // ...and the tool must not silently create the directory either.
+        Assert.False(Directory.Exists(missingDir));
+    }
+
+    [Fact]
+    public async Task Working_directory_that_is_a_file_returns_not_a_directory_error()
+    {
+        var filePath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        File.WriteAllText(filePath, "not a dir");
+        try
+        {
+            var args = ToolInput.Create("Command", "echo hi", "WorkingDirectory", filePath);
+
+            var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+            Assert.Contains("is a file, not a directory", result);
+            Assert.Contains(filePath, result);
+            Assert.DoesNotContain("Exit code", result);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task Missing_project_directory_returns_helpful_error()
+    {
+        // No explicit arg, so the resolution chain falls back to ProjectDirectory —
+        // proving the existence guard covers the fallback paths, not just explicit args.
+        var sessionDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var missingProjectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        Directory.CreateDirectory(sessionDir);
+        try
+        {
+            var context = new ToolExecutionContext("session-1", sessionDir) { Audience = TrustAudience.Personal, ProjectDirectory = missingProjectDir };
+            var args = ToolInput.Create("Command", "echo hi");
+
+            var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+            Assert.Contains("does not exist", result);
+            Assert.Contains(missingProjectDir, result);
+            Assert.DoesNotContain("Exit code", result);
+        }
+        finally
+        {
+            if (Directory.Exists(sessionDir)) Directory.Delete(sessionDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task Null_arguments_returns_error()
     {

--- a/src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs
@@ -84,7 +84,31 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
         }
 
         if (!string.IsNullOrWhiteSpace(_definition.WorkingDirectory))
+        {
+            // ProcessStartInfo.WorkingDirectory must point at an existing directory or
+            // Process.Start throws an opaque, platform-specific error that surfaces as a
+            // cryptic "Failed to start: ...". Report the missing directory with the mkdir
+            // remedy so the agent creates it instead of retry-looping on the opaque error.
+            if (!Directory.Exists(_definition.WorkingDirectory))
+            {
+                if (File.Exists(_definition.WorkingDirectory))
+                {
+                    ReportCompletion(BackgroundJobStatus.Failed, -1,
+                        $"Working directory '{_definition.WorkingDirectory}' is a file, not a directory.");
+                    return;
+                }
+
+                var mkdirHint = isWindows
+                    ? $"mkdir \"{_definition.WorkingDirectory}\""
+                    : $"mkdir -p \"{_definition.WorkingDirectory}\"";
+                ReportCompletion(BackgroundJobStatus.Failed, -1,
+                    $"Working directory '{_definition.WorkingDirectory}' does not exist. "
+                    + $"Create it first, e.g.: {mkdirHint}");
+                return;
+            }
+
             psi.WorkingDirectory = _definition.WorkingDirectory;
+        }
 
         _process = Process.Start(psi);
         if (_process is null)

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -106,6 +106,22 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
                     return $"Error preparing session working directory: {ex.Message}";
                 }
             }
+            else if (!Directory.Exists(resolvedCwd))
+            {
+                // ProcessStartInfo.WorkingDirectory must point at an existing directory or
+                // Process.Start throws an opaque, platform-specific error. Only the session
+                // scratch dir is auto-created (above); every other resolved cwd — explicit
+                // arg, project dir, inherited cwd — must already exist. Fail loudly with the
+                // remedy so the agent creates it instead of retry-looping on a cryptic error.
+                // Any approval for this cwd is existence-agnostic, so it still matches once
+                // the agent runs the mkdir.
+                if (File.Exists(resolvedCwd))
+                    return $"Error: Working directory '{resolvedCwd}' is a file, not a directory.";
+
+                var mkdirHint = isWindows ? $"mkdir \"{resolvedCwd}\"" : $"mkdir -p \"{resolvedCwd}\"";
+                return $"Error: Working directory '{resolvedCwd}' does not exist. "
+                     + $"Create it first, e.g.: {mkdirHint}";
+            }
 
             psi.WorkingDirectory = resolvedCwd;
         }


### PR DESCRIPTION
## Problem

Closes #1286.

`ShellTool` and `BackgroundJobExecutionActor` set `ProcessStartInfo.WorkingDirectory` without verifying the path exists. Only the session scratch dir was auto-created; any other resolved cwd (explicit arg, project dir, inherited cwd, or a background job's working directory) was passed straight to `Process.Start`, which throws an opaque, platform-specific error when the directory is missing. Agents couldn't tell *why* the command failed and retry-looped instead of creating the directory.

## Fix

Both process-launch paths now fail loudly **before** `Process.Start` with an actionable message:

- missing dir → `Working directory '<path>' does not exist. Create it first, e.g.: mkdir -p "<path>"` (platform-aware — no `-p` on Windows `cmd.exe`)
- path is a file → `Working directory '<path>' is a file, not a directory.`

No silent auto-creation: the cwd is a security-relevant, approval-gated input, so we fail loud per the constitution's "no silent fallbacks" rule. The session scratch dir keeps its existing auto-create behavior.

### Why this is loop-free

Approvals are existence-agnostic — saved and matched as normalized path strings (`Path.GetFullPath`, no `Directory.Exists`, no TTL). So an approval granted for a not-yet-existent cwd still matches *after* the agent runs `mkdir`. The cryptic error was the only thing keeping the agent stuck.

## Changes

| File | Change |
|------|--------|
| `src/Netclaw.Actors/Tools/ShellTool.cs` | Existence guard in the cwd-resolution block (returns the error string). |
| `src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs` | Same guard before `Process.Start`, reported via the existing `ReportCompletion(Failed, …)` idiom. |
| `src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs` | +3 tests: missing explicit dir (asserts no process start, no silent auto-create), path-is-a-file, missing project dir via fallback chain. |
| `src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs` | +1 end-to-end test: missing working dir → helpful failure delivered + persisted `Failed`. |

## Verification

- ✅ `ShellToolTests` + `BackgroundJobIntegrationTests` — all green (4 new)
- ✅ `dotnet slopwatch analyze` — 0 issues
- ✅ `Add-FileHeaders.ps1 -Verify` — all headers present

## Review notes (follow-ups, not blocking)

A multi-angle review found no functional bug in the diff. Minor items left as potential follow-ups:
- An existing-but-inaccessible (permission-denied) directory reports "does not exist" since `Directory.Exists` returns false for ACL failures.
- Pre-existing asymmetry: background jobs with a null `WorkingDirectory` inherit the daemon cwd, which `ShellTool` deliberately never does.
- The guard logic is duplicated across the two sites (candidate for a shared `PathUtility` helper); the `mkdir` hint isn't shell-escaped (cosmetic).