### PR TITLE
fix(docker): reap orphaned subprocesses with tini; dedup smoke setup (#1287, #1303)

### DIFF
--- a/.github/workflows/validate_docker_image.yml
+++ b/.github/workflows/validate_docker_image.yml
@@ -16,8 +16,7 @@ on:
     paths:
       - 'docker/Dockerfile'
       - 'docker/entrypoint.sh'
-      - 'scripts/docker/build-image.sh'
-      - 'scripts/docker/test-daemon-lifecycle.sh'
+      - 'scripts/docker/**'
       - 'src/**'
       - 'global.json'
       - 'Directory.Build.props'
@@ -31,8 +30,7 @@ on:
     paths:
       - 'docker/Dockerfile'
       - 'docker/entrypoint.sh'
-      - 'scripts/docker/build-image.sh'
-      - 'scripts/docker/test-daemon-lifecycle.sh'
+      - 'scripts/docker/**'
       - 'src/**'
       - 'global.json'
       - 'Directory.Build.props'
@@ -83,51 +81,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          source scripts/docker/lib/smoke-lib.sh   # shared minimal-config env + health poll (#1303)
           docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
 
-          # Ollama provider type needs no API key, so this job can run
-          # without secrets. The endpoint is fake (:11434 on loopback) —
-          # the daemon doesn't actually call it during startup or health
-          # checks, so unreachable is fine.
-          # Bind loopback (Local mode default) — the health probe runs
-          # inside the container via docker exec, so no port mapping needed.
-          docker run -d --name netclaw-validate-ok \
-            -e NETCLAW_Daemon__Port=5199 \
-            -e NETCLAW_Providers__validate__Type=ollama \
-            -e NETCLAW_Providers__validate__Endpoint=http://127.0.0.1:11434 \
-            -e NETCLAW_Models__Main__Provider=validate \
-            -e NETCLAW_Models__Main__ModelId=qwen2:0.5b \
+          # Minimal config from the shared lib (no secrets; fake Ollama endpoint is never
+          # called during startup/health). Default bind port 5199; probe runs in-container.
+          docker run -d --name netclaw-validate-ok $(netclaw_smoke_env_args) \
             "netclawd-pr:${{ steps.tag.outputs.tag }}" >/dev/null
 
-          # Poll /api/health/ready for up to 60s from inside the container.
-          for i in $(seq 1 60); do
-            if docker exec netclaw-validate-ok curl -fsS http://127.0.0.1:5199/api/health/ready >/dev/null 2>&1; then
-              echo "✓ Daemon reported healthy after ${i}s"
-              docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
-              exit 0
-            fi
-
-            # Bail early if the container crashed mid-probe.
-            running=$(docker inspect -f '{{.State.Running}}' netclaw-validate-ok 2>/dev/null || echo "false")
-            if [[ "$running" != "true" ]]; then
-              echo "ERROR: daemon container exited during health probe" >&2
-              docker logs netclaw-validate-ok >&2 2>&1 || true
-              docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
-              exit 1
-            fi
-
-            sleep 1
-          done
-
-          echo "ERROR: daemon did not report healthy within 60s" >&2
-          docker logs netclaw-validate-ok >&2 2>&1 || true
+          if netclaw_wait_healthy netclaw-validate-ok 5199 60; then
+            echo "✓ Daemon reported healthy"
+          else
+            echo "ERROR: daemon did not reach a healthy state within 60s" >&2
+            docker logs netclaw-validate-ok >&2 2>&1 || true
+            docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
+            exit 1
+          fi
           docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
-          exit 1
 
       - name: "Verify bind-mounted state ownership is repaired"
         shell: bash
         run: |
           set -euo pipefail
+          source scripts/docker/lib/smoke-lib.sh   # shared minimal-config env + health poll (#1303)
           docker rm -f netclaw-validate-bind-mount >/dev/null 2>&1 || true
 
           tmpdir="$(mktemp -d)"
@@ -157,34 +133,16 @@ jobs:
           docker run -d --name netclaw-validate-bind-mount \
             -v "$state_dir:/home/netclaw/.netclaw" \
             -v "$tools_dir:/tools" \
-            -e NETCLAW_Daemon__Port=5199 \
-            -e NETCLAW_Providers__validate__Type=ollama \
-            -e NETCLAW_Providers__validate__Endpoint=http://127.0.0.1:11434 \
-            -e NETCLAW_Models__Main__Provider=validate \
-            -e NETCLAW_Models__Main__ModelId=qwen2:0.5b \
+            $(netclaw_smoke_env_args) \
             "netclawd-pr:${{ steps.tag.outputs.tag }}" >/dev/null
 
-          for i in $(seq 1 60); do
-            if docker exec netclaw-validate-bind-mount curl -fsS http://127.0.0.1:5199/api/health/ready >/dev/null 2>&1; then
-              echo "✓ Bind-mounted daemon reported healthy after ${i}s"
-              break
-            fi
-
-            running="$(docker inspect -f '{{.State.Running}}' netclaw-validate-bind-mount 2>/dev/null || echo "false")"
-            if [[ "$running" != "true" ]]; then
-              echo "ERROR: bind-mounted daemon container exited during health probe" >&2
-              docker logs netclaw-validate-bind-mount >&2 2>&1 || true
-              exit 1
-            fi
-
-            if [[ "$i" == "60" ]]; then
-              echo "ERROR: bind-mounted daemon did not report healthy within 60s" >&2
-              docker logs netclaw-validate-bind-mount >&2 2>&1 || true
-              exit 1
-            fi
-
-            sleep 1
-          done
+          if netclaw_wait_healthy netclaw-validate-bind-mount 5199 60; then
+            echo "✓ Bind-mounted daemon reported healthy"
+          else
+            echo "ERROR: bind-mounted daemon did not reach a healthy state within 60s" >&2
+            docker logs netclaw-validate-bind-mount >&2 2>&1 || true
+            exit 1
+          fi
 
           docker exec netclaw-validate-bind-mount test -d /home/netclaw/.netclaw/identity
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,10 @@
 # Docker pattern; failures when neither buildx nor --build-arg supply a
 # value are intentional ("no silent fallbacks" — see CLAUDE.md).
 #
-# A wrapper entrypoint (entrypoint.sh) runs as PID 1 and supervises the
-# netclawd process, restarting it on exit so the container survives
-# config-update restarts and `netclaw init` wizard flows.
+# tini runs as PID 1 — it reaps orphaned zombies (netclawd's tool subprocesses
+# that reparent to PID 1) and forwards signals — and launches entrypoint.sh,
+# which supervises the netclawd process, restarting it on exit so the container
+# survives config-update restarts and `netclaw init` wizard flows.
 #
 # The daemon runs as a dedicated non-root user (netclaw, UID 1654) for
 # defense-in-depth. The daemon fails loudly when required
@@ -54,6 +55,7 @@ ARG NETCLAW_VERSION=unknown
 #   VCS/GitHub:  git, gh
 #   Python:      python3, python3-pip, python3-venv
 #   Privileges:  gosu (entrypoint ownership repair, then drop to netclaw)
+#   Init/PID 1:  tini (reaps orphaned subprocess zombies, forwards signals)
 #   Crypto:      libsodium23 (required by NSec for Ed25519 signature verification)
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -62,6 +64,7 @@ RUN apt-get update \
       wget \
       procps \
       gosu \
+      tini \
       git \
       jq \
       sqlite3 \
@@ -129,4 +132,9 @@ LABEL org.opencontainers.image.source="https://github.com/netclaw-dev/netclaw" \
       org.opencontainers.image.version="${NETCLAW_VERSION}" \
       org.opencontainers.image.licenses="Apache-2.0"
 
-ENTRYPOINT ["/opt/netclaw/entrypoint.sh"]
+# tini as PID 1 reaps zombies reparented from netclawd's tool subprocesses
+# (entrypoint.sh only `wait`s its own direct child) and forwards signals for a clean
+# `docker stop` (#1287). `-g` forwards to the whole process group, not just the direct
+# child, so a stop tears down netclawd AND any in-flight tool subprocesses together
+# instead of leaving grandchildren to linger until the stop-timeout SIGKILL.
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/opt/netclaw/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,8 @@ ARG NETCLAW_VERSION=unknown
 #   VCS/GitHub:  git, gh
 #   Python:      python3, python3-pip, python3-venv
 #   Privileges:  gosu (entrypoint ownership repair, then drop to netclaw)
-#   Init/PID 1:  tini (reaps orphaned subprocess zombies, forwards signals)
+#   Init/PID 1:  tini (reaps orphaned subprocess zombies, forwards signals) — https://github.com/krallin/tini
+#                Unpinned like the rest of this apt set; ubuntu:24.04 pins it at 0.19.0 for the LTS life.
 #   Crypto:      libsodium23 (required by NSec for Ed25519 signature verification)
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/scripts/docker/lib/smoke-lib.sh
+++ b/scripts/docker/lib/smoke-lib.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Shared helpers for the Docker image smoke tests so the minimal-config contract
+# and the health-poll live in ONE place instead of being copy-pasted across
+# .github/workflows/validate_docker_image.yml and test-daemon-lifecycle.sh (#1303).
+#
+# Source it: . "$(dirname "$0")/lib/smoke-lib.sh"  (script)
+#            source "$GITHUB_WORKSPACE/scripts/docker/lib/smoke-lib.sh"  (workflow step)
+
+# Minimal provider/model config as `docker run` -e args (one per line; safe to
+# word-split — no values contain spaces). Ollama needs no API key and the endpoint
+# is never called during startup/health, so an unreachable one is fine. The bind
+# port is intentionally NOT set here: it defaults to 5199, and tests that exercise a
+# config-file port change need the file to be authoritative (env overrides file).
+netclaw_smoke_env_args() {
+    printf '%s\n' \
+        -e NETCLAW_Providers__validate__Type=ollama \
+        -e NETCLAW_Providers__validate__Endpoint=http://127.0.0.1:11434 \
+        -e NETCLAW_Models__Main__Provider=validate \
+        -e NETCLAW_Models__Main__ModelId=qwen2:0.5b
+}
+
+# Poll /api/health/ready inside a container until healthy.
+# Usage: netclaw_wait_healthy <container> <port> <timeout-seconds>
+# Returns: 0 healthy, 1 timed out, 2 container exited.
+netclaw_wait_healthy() {
+    local container="$1" port="$2" timeout="$3" i
+    for ((i = 0; i < timeout; i++)); do
+        if docker exec "$container" curl -fsS "http://127.0.0.1:$port/api/health/ready" >/dev/null 2>&1; then
+            return 0
+        fi
+        [[ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo false)" == "true" ]] \
+            || return 2
+        sleep 1
+    done
+    return 1
+}

--- a/scripts/docker/test-daemon-lifecycle.sh
+++ b/scripts/docker/test-daemon-lifecycle.sh
@@ -22,10 +22,24 @@
 #     crash-loops) rather than silently keep serving stale config; fixing the
 #     config on disk must let the supervisor's next restart recover.
 #
+#   Phase D — PID 1 reaps orphaned subprocesses (#1287):
+#     An orphaned process (its parent exits, so it reparents to PID 1) must be reaped
+#     once it dies rather than lingering as a <defunct> zombie — proving tini runs as
+#     PID 1 and reaps, which entrypoint.sh alone (it only `wait`s its direct child)
+#     would not do.
+#
+# Process tree (#1287): tini (PID 1) -> entrypoint.sh supervisor -> netclawd. netclawd
+# is therefore a child of the supervisor, NOT a direct child of PID 1 — see
+# daemon_supervision() for how the supervised-child invariant is checked.
+#
 # Usage:
 #   scripts/docker/test-daemon-lifecycle.sh <image-ref>
 #   scripts/docker/test-daemon-lifecycle.sh netclawd-pr:pr-1279
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/docker/lib/smoke-lib.sh
+. "$SCRIPT_DIR/lib/smoke-lib.sh"
 
 IMAGE="${1:?usage: test-daemon-lifecycle.sh <image-ref>}"
 CONTAINER="netclaw-lifecycle-1279"
@@ -48,27 +62,42 @@ fail() {
 daemon_count() { docker exec "$CONTAINER" sh -c 'pgrep -x netclawd | wc -l' | tr -d '[:space:]'; }
 # PID of the (first) netclawd, empty if none.
 daemon_pid()   { docker exec "$CONTAINER" sh -c 'pgrep -x netclawd | head -n1' | tr -d '[:space:]'; }
-# Parent PID of the (first) netclawd — must be 1 (entrypoint.sh), proving it is
-# the supervisor's child and not an orphaned/exec-session process. Emits empty when
-# no daemon is running (rather than letting `ps -p ""` error and trip `set -e` at the
-# capture site, which would abort before the descriptive `fail` + log dump).
-daemon_ppid()  { docker exec "$CONTAINER" sh -c 'pid=$(pgrep -x netclawd | head -n1); [ -n "$pid" ] && ps -o ppid= -p "$pid" || true' | tr -d '[:space:]'; }
+# Supervision chain of the (first) netclawd. Proves it is the supervised child of the
+# entrypoint.sh process, which is itself a child of PID 1 (tini, #1287) — NOT a detached
+# daemon from a `docker exec` session (which reparents straight to PID 1). With tini
+# inserted as PID 1, netclawd's direct parent is the entrypoint.sh supervisor (PID > 1),
+# so a bare "PPID == 1" check no longer expresses the invariant. Echoes "ok" on success,
+# "no-daemon" when none is running, or a diagnostic otherwise; always exits 0 so it never
+# trips the caller's `set -e` before the descriptive `fail` + log dump.
+daemon_supervision() {
+    docker exec "$CONTAINER" sh -c '
+        dpid=$(pgrep -x netclawd | head -n1)
+        [ -n "$dpid" ] || { echo "no-daemon"; exit 0; }
+        sup=$(ps -o ppid= -p "$dpid" 2>/dev/null | tr -d "[:space:]")
+        supargs=$(ps -o args= -p "$sup" 2>/dev/null)
+        supppid=$(ps -o ppid= -p "$sup" 2>/dev/null | tr -d "[:space:]")
+        case "$supargs" in
+            *entrypoint.sh*) ;;
+            *) echo "parent-not-supervisor(pid=$sup args=[$supargs])"; exit 0 ;;
+        esac
+        [ "$supppid" = "1" ] || { echo "supervisor-not-pid1-child(ppid=$supppid)"; exit 0; }
+        echo "ok"
+    '
+}
 # PID-file generation (line 2 = ISO start time); the daemon rewrites it on each restart.
 daemon_generation() { docker exec "$CONTAINER" sh -c "sed -n 2p $PIDFILE 2>/dev/null" | tr -d '[:space:]'; }
 # Number of times the supervisor has observed the daemon exit (proves a real exit
 # vs an in-process restart, which keeps the process alive).
 entrypoint_exit_count() { docker logs "$CONTAINER" 2>&1 | grep -c '\[entrypoint\] netclawd exited' || true; }
 
+# Wrap the shared poll so a container-exit (rc 2) becomes a descriptive failure.
 wait_healthy() {  # $1 = port, $2 = timeout-seconds
-    for _ in $(seq 1 "$2"); do
-        if docker exec "$CONTAINER" curl -fsS "http://127.0.0.1:$1/api/health/ready" >/dev/null 2>&1; then
-            return 0
-        fi
-        [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)" == "true" ]] \
-            || fail "container exited while waiting for health on :$1"
-        sleep 1
-    done
-    return 1
+    local rc=0
+    netclaw_wait_healthy "$CONTAINER" "$1" "$2" || rc=$?
+    if [[ "$rc" -eq 2 ]]; then
+        fail "container exited while waiting for health on :$1"
+    fi
+    return "$rc"
 }
 port_serving() { docker exec "$CONTAINER" curl -fsS "http://127.0.0.1:$1/api/health/ready" >/dev/null 2>&1; }
 
@@ -77,24 +106,17 @@ write_config() { docker exec -i "$CONTAINER" sh -c "cat > $CONFIG"; }
 
 echo "==> Starting supervised daemon from image: $IMAGE"
 cleanup
-# Ollama needs no API key, so this runs without secrets; the endpoint is never called
-# during startup/health, so an unreachable one is fine. Local (loopback) mode is the
-# default. NOTE: we deliberately do NOT set NETCLAW_Daemon__Port — env overrides the
-# config file (Program.cs: env is highest priority), and Phase A needs the file's
-# Daemon.Port to be authoritative. The default port is already 5199.
-docker run -d --name "$CONTAINER" \
-    -e NETCLAW_Providers__validate__Type=ollama \
-    -e NETCLAW_Providers__validate__Endpoint=http://127.0.0.1:11434 \
-    -e NETCLAW_Models__Main__Provider=validate \
-    -e NETCLAW_Models__Main__ModelId=qwen2:0.5b \
-    "$IMAGE" >/dev/null
+# Minimal provider/model config from the shared lib (deliberately no Daemon.Port — see
+# netclaw_smoke_env_args; Phase A needs the file's port to win over env).
+# shellcheck disable=SC2046  # intentional word-splitting of the -e args
+docker run -d --name "$CONTAINER" $(netclaw_smoke_env_args) "$IMAGE" >/dev/null
 
 wait_healthy "$DEFAULT_PORT" 60 || fail "supervised daemon never became healthy on :$DEFAULT_PORT"
 
-count="$(daemon_count)"; pid="$(daemon_pid)"; ppid="$(daemon_ppid)"
-echo "    initial: count=$count pid=$pid ppid=$ppid (port :$DEFAULT_PORT)"
-[[ "$count" == "1" ]]  || fail "expected exactly 1 netclawd at startup, found $count"
-[[ "$ppid" == "1" ]]   || fail "netclawd PPID is '$ppid', expected 1 (entrypoint supervisor)"
+count="$(daemon_count)"; pid="$(daemon_pid)"; sup="$(daemon_supervision)"
+echo "    initial: count=$count pid=$pid supervision=$sup (port :$DEFAULT_PORT)"
+[[ "$count" == "1" ]] || fail "expected exactly 1 netclawd at startup, found $count"
+[[ "$sup" == "ok" ]]  || fail "netclawd is not properly supervised at startup: $sup"
 
 # ── Phase A: a config write reloads in-process AND the change takes effect ──
 echo "==> Phase A: config write re-binds the daemon in-process (:$DEFAULT_PORT -> :$NEW_PORT)"
@@ -122,11 +144,11 @@ wait_healthy "$NEW_PORT" 60   || fail "daemon not healthy on the new port :$NEW_
 ! port_serving "$DEFAULT_PORT" || fail "old port :$DEFAULT_PORT still serving — the bind change did not apply"
 
 # ...and it was an in-process restart, not a respawn / duplicate.
-count_a="$(daemon_count)"; pid_a="$(daemon_pid)"; ppid_a="$(daemon_ppid)"
-echo "    after reload: count=$count_a pid=$pid_a ppid=$ppid_a (port :$NEW_PORT)"
+count_a="$(daemon_count)"; pid_a="$(daemon_pid)"; sup_a="$(daemon_supervision)"
+echo "    after reload: count=$count_a pid=$pid_a supervision=$sup_a (port :$NEW_PORT)"
 [[ "$count_a" == "1" ]]  || fail "config reload produced $count_a daemons (expected 1 — duplicate!)"
 [[ "$pid_a" == "$pid" ]] || fail "PID changed ($pid -> $pid_a): the process exited instead of restarting in-process"
-[[ "$ppid_a" == "1" ]]   || fail "netclawd PPID is '$ppid_a' after reload, expected 1"
+[[ "$sup_a" == "ok" ]]   || fail "netclawd not properly supervised after reload: $sup_a"
 [[ "$(entrypoint_exit_count)" == "0" ]] \
     || fail "entrypoint observed a daemon exit during an in-process reload (supervisor would respawn)"
 
@@ -142,10 +164,10 @@ echo "$out" | grep -qi "container supervisor" \
 # Give any erroneously-spawned daemon time to race for the lock.
 sleep 3
 
-count_b="$(daemon_count)"; ppid_b="$(daemon_ppid)"
-echo "    after daemon start: count=$count_b ppid=$ppid_b"
+count_b="$(daemon_count)"; sup_b="$(daemon_supervision)"
+echo "    after daemon start: count=$count_b supervision=$sup_b"
 [[ "$count_b" == "1" ]] || fail "'netclaw daemon start' produced $count_b daemons (split-brain!)"
-[[ "$ppid_b" == "1" ]]  || fail "netclawd PPID is '$ppid_b', expected 1 (daemon was orphaned)"
+[[ "$sup_b" == "ok" ]]  || fail "netclawd not properly supervised after 'daemon start': $sup_b"
 if docker logs "$CONTAINER" 2>&1 | grep -q "Another netclawd instance is already running (lock file held)"; then
     fail "lock-file contention detected in container logs (split-brain)"
 fi
@@ -173,9 +195,42 @@ write_config <<JSON
 { "Daemon": { "Host": "127.0.0.1", "Port": $NEW_PORT, "ExposureMode": "local" } }
 JSON
 wait_healthy "$NEW_PORT" 90 || fail "daemon did not recover on :$NEW_PORT after the bad config was fixed"
-count_c="$(daemon_count)"; ppid_c="$(daemon_ppid)"
+count_c="$(daemon_count)"; sup_c="$(daemon_supervision)"
 [[ "$count_c" == "1" ]] || fail "after recovery found $count_c daemons (expected 1)"
-[[ "$ppid_c" == "1" ]]  || fail "after recovery netclawd PPID is '$ppid_c', expected 1"
-echo "    recovered: count=$count_c ppid=$ppid_c (port :$NEW_PORT)"
+[[ "$sup_c" == "ok" ]]  || fail "after recovery netclawd not properly supervised: $sup_c"
+echo "    recovered: count=$count_c supervision=$sup_c (port :$NEW_PORT)"
 
-echo "✓ #1279: single supervised daemon; reload re-binds in-process; daemon start defers; bad config fails loud + recovers"
+# ── Phase D: PID 1 reaps orphaned subprocesses (tini) ───────────────────────
+echo "==> Phase D: orphaned subprocesses are reaped by PID 1 (tini)"
+# Spawn a process whose parent shell exits immediately, so it reparents to PID 1 —
+# exactly how netclawd's tool subprocesses orphan. entrypoint.sh alone only `wait`s its
+# direct child, so without a reaping init (#1287) these would pile up as <defunct>.
+# Capture the PID directly via `echo $!` (not `pgrep -x sleep`, which could latch onto a
+# coincidental sleep such as the supervisor's backoff). The reparent comes from the
+# parent `sh` exiting; `disown` is intentionally NOT used — it isn't a /bin/sh (dash)
+# builtin on the Ubuntu base.
+orphan="$(docker exec "$CONTAINER" sh -c 'sleep 300 >/dev/null 2>&1 & echo $!' | tr -d '[:space:]')"
+[[ -n "$orphan" ]] || fail "could not create an orphan test process"
+
+# Reparenting is async (it happens when the parent sh exits), so poll for PPID 1.
+oppid=""
+for _ in $(seq 1 10); do
+    oppid="$(docker exec "$CONTAINER" sh -c "ps -o ppid= -p $orphan 2>/dev/null" | tr -d '[:space:]')"
+    [[ "$oppid" == "1" ]] && break
+    sleep 1
+done
+[[ "$oppid" == "1" ]] || fail "orphan (pid $orphan) PPID is '$oppid', expected 1 (did not reparent to PID 1)"
+
+docker exec "$CONTAINER" kill "$orphan" >/dev/null 2>&1 || true
+reaped=false
+for _ in $(seq 1 10); do
+    # Reaped == the PID is gone entirely; a non-reaping PID 1 leaves it <defunct> (state Z),
+    # which `ps -p` would still report.
+    docker exec "$CONTAINER" sh -c "ps -o stat= -p $orphan" >/dev/null 2>&1 || { reaped=true; break; }
+    sleep 1
+done
+[[ "$reaped" == "true" ]] \
+    || fail "orphan (pid $orphan) was not reaped — PID 1 left it as a zombie (tini not reaping?)"
+echo "    orphan pid $orphan reaped by PID 1"
+
+echo "✓ #1279/#1287: single supervised daemon; reload re-binds in-process; daemon start defers; bad config fails loud + recovers; orphans reaped"


### PR DESCRIPTION
## Summary

Two follow-ups from the #1279 container-lifecycle rework (#1282):

- **#1287 — reap orphaned subprocesses.** Insert `tini` as PID 1 via the
  `ENTRYPOINT`. `entrypoint.sh` supervises `netclawd` with `netclawd & wait
  $PID`, so it only reaps its own direct child. `netclawd`'s tool subprocesses
  that orphan (their parent exits) reparent to PID 1 and, with `entrypoint.sh`
  as PID 1, were never reaped — they piled up as `<defunct>` zombies over a
  long-running container's lifetime. `tini` is the canonical tiny init that
  reaps them; `-g` forwards signals to the whole process group so `docker stop`
  reaches `netclawd` even mid-backoff.

- **#1303 — dedup the Docker smoke setup.** The minimal-provider env contract
  (`NETCLAW_Providers__validate__* / NETCLAW_Models__Main__*`) and the
  `/api/health/ready` poll were copy-pasted across the two
  `validate_docker_image.yml` verify steps and `test-daemon-lifecycle.sh`.
  Extracted them into `scripts/docker/lib/smoke-lib.sh` so the port, health
  path, provider-env contract, and crash-bail logic live in one place and
  can't silently drift.

## Changes

- `docker/Dockerfile`: add `tini` to the apt set; `ENTRYPOINT ["/usr/bin/tini",
  "-g", "--", "/opt/netclaw/entrypoint.sh"]`; update the header comments to
  describe the `tini → entrypoint.sh → netclawd` tree.
- `scripts/docker/lib/smoke-lib.sh` (new): `netclaw_smoke_env_args` and
  `netclaw_wait_healthy` (0 healthy / 1 timeout / 2 exited).
- `scripts/docker/test-daemon-lifecycle.sh`: source the lib; add **Phase D**
  (orphan reaping — spawn a process that reparents to PID 1, kill it, assert it
  is reaped not left `<defunct>`); replace the bare `PPID == 1` supervision
  assertion with a **chain check** (`netclawd → entrypoint.sh → PID 1`) that
  still expresses "supervised, not a detached exec-session daemon" now that
  `tini`, not `entrypoint.sh`, is PID 1.
- `.github/workflows/validate_docker_image.yml`: both verify steps source the
  lib; broaden the path filter to `scripts/docker/**` so a change to the shared
  lib re-runs the image gate.

## Validation

Built the image locally and ran the full lifecycle smoke test — all four
phases pass:

```
initial: count=1 pid=21 supervision=ok (port :5199)
Phase A: config write re-binds :5199 -> :5200 in-process (same pid, supervision ok)
Phase B: 'netclaw daemon start' defers — "Daemon managed by container supervisor (PID 21)"
Phase C: bad Daemon config fails loud (supervisor observes exit) + recovers
Phase D: orphan pid 346 reaped by PID 1 (tini)
```

The same `validate_docker_image` workflow runs this on the PR (it touches
`docker/**` and `scripts/docker/**`).

Closes #1287
Closes #1303
