### PR TITLE
fix(wizard): gate init readiness on daemon restart generation + re-resolved endpoint (#1302, #1304)

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Config;
@@ -136,6 +137,77 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
         var endpoint = DaemonApi.ResolveEndpoint(_paths);
 
         Assert.Equal("http://override-host:6000", endpoint);
+    }
+
+    [Fact]
+    public async Task ProbeReadinessAsync_ReportsHealthyAndParsesGenerationHeader()
+    {
+        HttpRequestMessage? captured = null;
+        var api = CreateDaemonApi("http://127.0.0.1:5199", request =>
+        {
+            captured = request;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Add("X-Netclaw-Generation", "7");
+            return response;
+        });
+
+        var readiness = await api.ProbeReadinessAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(readiness.Healthy);
+        Assert.Equal(7, readiness.Generation);
+        Assert.Equal("/api/health/ready", captured!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ProbeReadinessAsync_NoGenerationHeader_ReportsHealthyWithNullGeneration()
+    {
+        // A pre-#1302 daemon answers 200 without the header — still healthy, generation unknown.
+        var api = CreateDaemonApi("http://127.0.0.1:5199",
+            _ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        var readiness = await api.ProbeReadinessAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(readiness.Healthy);
+        Assert.Null(readiness.Generation);
+    }
+
+    [Fact]
+    public async Task ProbeReadinessAsync_NonSuccess_ReportsNotHealthy()
+    {
+        var api = CreateDaemonApi("http://127.0.0.1:5199",
+            _ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        var readiness = await api.ProbeReadinessAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(readiness.Healthy);
+        Assert.Null(readiness.Generation);
+    }
+
+    [Fact]
+    public async Task ProbeReadinessAsync_ReResolvesEndpoint_AfterDaemonPortChange()
+    {
+        // NOTE: this test deliberately does NOT use CreateDaemonApi — that helper writes a
+        // client-endpoint file (ClientConfigFile.WriteEndpoint), which wins over the Daemon
+        // config section in ResolveEndpoint and would FREEZE the endpoint, defeating the
+        // re-resolution this test guards. Resolution must fall through to the Daemon section
+        // both at construction and at probe time, so no client endpoint / env override is set.
+        // Daemon bound :5199 when the client was constructed...
+        File.WriteAllText(_paths.NetclawConfigPath,
+            "{\"configVersion\":1,\"Daemon\":{\"Host\":\"127.0.0.1\",\"Port\":5199}}");
+        HttpRequestMessage? captured = null;
+        var api = new DaemonApi(
+            new FakeHttpClientFactory(request => { captured = request; return new HttpResponseMessage(HttpStatusCode.OK); }),
+            new ConfigurationBuilder().Build(),
+            _paths);
+
+        // ...then a Daemon-section change rebinds it to :5300 (as the wizard would write).
+        // A frozen endpoint would keep probing :5199; the probe must re-resolve to :5300 (#1304).
+        File.WriteAllText(_paths.NetclawConfigPath,
+            "{\"configVersion\":1,\"Daemon\":{\"Host\":\"127.0.0.1\",\"Port\":5300}}");
+
+        await api.ProbeReadinessAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(5300, captured!.RequestUri!.Port);
     }
 
     private DaemonApi CreateDaemonApi(string endpoint, Func<HttpRequestMessage, HttpResponseMessage> handler)

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Globalization;
 using System.Net;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Daemon;
@@ -135,11 +136,6 @@ public sealed class HealthCheckStepViewModelTests : IDisposable
         Assert.True(step.IsComplete.Value);
     }
 
-    // Restart-generation timestamps written to the PID file. The wizard treats a
-    // newer value as proof the daemon actually restarted onto the new config.
-    private static readonly DateTimeOffset OldGeneration = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-    private static readonly DateTimeOffset NewGeneration = new(2026, 1, 1, 0, 5, 0, TimeSpan.Zero);
-
     [Fact]
     public async Task RunWithOrchestrator_RunningDaemon_AppliesConfigViaWatcher_NotByStoppingOrRestarting()
     {
@@ -148,21 +144,26 @@ public sealed class HealthCheckStepViewModelTests : IDisposable
         // poll /health/ready — never stop the daemon, never POST a restart itself (#1279).
         //
         // Hold the lock so GetStatus() reports running (lock held → running) without a real
-        // netclawd process. With no PID file at capture, generationBefore is null, so this
-        // exercises the "a live generation appears + healthy → ready" integration path; the
-        // stale-vs-newer discrimination (current > before) is covered directly by
-        // IsRestartedGeneration_BlocksStale_AllowsNewerOrDownDaemon.
+        // netclawd process. The fake daemon reports a monotonically-increasing restart
+        // generation on each readiness probe, so the pre-write capture sees an older value
+        // than the post-reload poll — exercising the "newer generation + healthy → ready"
+        // gate end-to-end (#1302).
         using var lockHolder = new FileStream(
             _paths.LockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
         var daemonManager = new DaemonManager(_paths, TimeProvider.System);
 
-        // Fake daemon: healthy, and — simulating the in-process reload restart — stamps a
-        // fresh PID-file generation the first time readiness is probed.
+        // Fake daemon: healthy, advancing its reported generation on each /health/ready —
+        // pre-write capture → "1", first post-write poll → "2" > 1 → restarted.
+        var generation = 0;
         var handler = new StubHttpMessageHandler(req =>
         {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
             if (req.RequestUri!.AbsolutePath == "/api/health/ready")
-                WritePidFile(pid: 4321, startedAt: NewGeneration);
-            return new HttpResponseMessage(HttpStatusCode.OK);
+            {
+                generation++;
+                response.Headers.Add("X-Netclaw-Generation", generation.ToString(CultureInfo.InvariantCulture));
+            }
+            return response;
         });
         var daemonApi = new DaemonApi(new StubHttpClientFactory(handler), new ConfigurationBuilder().Build(), _paths);
 
@@ -198,21 +199,18 @@ public sealed class HealthCheckStepViewModelTests : IDisposable
     public void IsRestartedGeneration_BlocksStale_AllowsNewerOrDownDaemon()
     {
         // The generation gate is what prevents the readiness race: a healthy probe
-        // against the still-draining pre-restart daemon must NOT count as ready (#1279).
-        WritePidFile(pid: 4321, startedAt: OldGeneration); // current recorded generation
-        var daemonManager = new DaemonManager(_paths, TimeProvider.System);
-        using var step = new HealthCheckStepViewModel(daemonManager);
-
-        // Same generation as before the restart → daemon hasn't restarted → not ready.
-        Assert.False(step.IsRestartedGeneration(OldGeneration));
-        // Recorded generation is newer than the pre-restart value → restarted → ready.
-        Assert.True(step.IsRestartedGeneration(OldGeneration.AddMinutes(-1)));
-        // Daemon was down before (no pre-restart generation) → any live instance counts.
-        Assert.True(step.IsRestartedGeneration(null));
+        // against the still-draining pre-restart daemon (same generation) must NOT count
+        // as ready (#1302).
+        // Same generation as before the write → daemon hasn't restarted → not ready.
+        Assert.False(HealthCheckStepViewModel.IsRestartedGeneration(before: 1, current: 1));
+        // Reported generation is newer than the pre-write value → restarted → ready.
+        Assert.True(HealthCheckStepViewModel.IsRestartedGeneration(before: 1, current: 2));
+        // Daemon was down before the write (no baseline) → any live instance counts.
+        Assert.True(HealthCheckStepViewModel.IsRestartedGeneration(before: null, current: 5));
+        // Running before, but the daemon reported no generation (pre-#1302 / torn read) →
+        // cannot confirm a restart → not ready yet (fail safe).
+        Assert.False(HealthCheckStepViewModel.IsRestartedGeneration(before: 1, current: null));
     }
-
-    private void WritePidFile(int pid, DateTimeOffset startedAt) =>
-        File.WriteAllText(_paths.PidFilePath, $"{pid}\n{startedAt:O}");
 
     private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
     {

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -27,6 +28,7 @@ public sealed class DaemonApi
     private readonly IHttpClientFactory _factory;
     private readonly string _endpoint;
     private readonly string? _deviceToken;
+    private readonly NetclawPaths _paths;
 
     /// <summary>
     /// Default daemon endpoint when no override is configured.
@@ -36,6 +38,7 @@ public sealed class DaemonApi
     public DaemonApi(IHttpClientFactory factory, IConfiguration configuration, NetclawPaths paths)
     {
         _factory = factory;
+        _paths = paths;
         _endpoint = ResolveEndpoint(paths);
         _deviceToken = DaemonClientFactory.ResolveDeviceToken(_endpoint, paths, DaemonClientFactory.ResolveExposureMode(paths));
     }
@@ -295,12 +298,40 @@ public sealed class DaemonApi
 
     // ── Health (for init wizard polling) ──────────────────────────────
 
-    public async Task<bool> IsHealthyAsync(CancellationToken ct = default)
+    /// <summary>
+    /// Outcome of probing <c>/api/health/ready</c>: whether the daemon answered healthy,
+    /// and the monotonic restart <see cref="Generation"/> it reported (null when the
+    /// daemon predates the header or the probe failed).
+    /// </summary>
+    public readonly record struct DaemonReadiness(bool Healthy, int? Generation);
+
+    /// <summary>
+    /// Probes the daemon's anonymous readiness endpoint, returning both health and the
+    /// reported restart generation (<c>X-Netclaw-Generation</c>).
+    /// </summary>
+    /// <remarks>
+    /// The endpoint is re-resolved on every probe rather than reusing the value captured
+    /// at construction (#1304): the init wizard writes config and waits for an in-process
+    /// restart, and if that change altered <c>Daemon.Port</c> the daemon comes back on the
+    /// new port while a frozen endpoint would keep polling the dead one. Re-resolution
+    /// reads the just-written <c>Daemon</c> section (and still honors an explicit
+    /// <c>NETCLAW_DAEMON_ENDPOINT</c> / paired client endpoint when one is set).
+    /// </remarks>
+    public async Task<DaemonReadiness> ProbeReadinessAsync(CancellationToken ct = default)
     {
         using var cts = CreateTimeoutCts(DefaultTimeout, ct);
         var client = CreateHttpClient();
-        var response = await client.GetAsync($"{_endpoint}/api/health/ready", cts.Token);
-        return response.IsSuccessStatusCode;
+        var endpoint = ResolveEndpoint(_paths);
+        using var response = await client.GetAsync($"{endpoint}/api/health/ready", cts.Token);
+        if (!response.IsSuccessStatusCode)
+            return new DaemonReadiness(false, null);
+
+        int? generation = null;
+        if (response.Headers.TryGetValues("X-Netclaw-Generation", out var values)
+            && int.TryParse(values.FirstOrDefault(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            generation = parsed;
+
+        return new DaemonReadiness(true, generation);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -250,15 +250,6 @@ public sealed partial class DaemonManager
     }
 
     /// <summary>
-    /// Reads the daemon's recorded start time from the PID file, or <c>null</c> if
-    /// absent. The daemon rewrites this on every (in-process) restart, so a change
-    /// signals a fresh restart generation — letting callers tell a restarted daemon
-    /// apart from a still-draining one without an authenticated status call.
-    /// </summary>
-    internal DateTimeOffset? TryGetRecordedStartTime()
-        => TryReadPidFile(out _, out var startedAt) ? startedAt : null;
-
-    /// <summary>
     /// Installs daemon as a systemd user service (Linux only).
     /// </summary>
     public async Task<DaemonResult> InstallAsync()

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
@@ -152,12 +152,35 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
 
         // We never stop the daemon: writing the config below is the single restart
         // trigger. A running daemon's ConfigWatcherService performs a coordinated
-        // in-process restart to apply it (#1279). Capture its pre-write state first so
-        // we can confirm the reload actually happened — the PID-file generation
-        // advances on each restart, distinguishing the reloaded daemon from the
-        // still-draining old one (both answer the anonymous /health/ready).
+        // in-process restart to apply it (#1279). Capture its restart generation first so
+        // we can confirm the reload actually happened — the daemon advances a monotonic
+        // generation on each restart and reports it on /api/health/ready, distinguishing
+        // the reloaded daemon from the still-draining old one (#1302).
+        // A null baseline relaxes the gate to "any live instance counts" (see
+        // IsRestartedGeneration). That happens in two ways, both intentional and bounded:
+        //   * the daemon was not running before (nothing to confuse with — correct);
+        //   * the daemon is running but reports no generation. That only occurs against a
+        //     pre-#1302 daemon during the single upgrade where a new CLI re-runs init
+        //     against an old daemon that hasn't restarted yet. The config is still written
+        //     to disk and applied; the only cost is the wizard declaring "ready" a beat
+        //     early against the reloading daemon — cosmetic, and gone once the daemon is on
+        //     a build that emits the generation header.
         var wasRunning = _daemonManager?.GetStatus().IsRunning ?? false;
-        var generationBefore = _daemonManager?.TryGetRecordedStartTime();
+        int? generationBefore = null;
+        if (wasRunning && _daemonApi is not null)
+        {
+            try
+            {
+                generationBefore = (await _daemonApi.ProbeReadinessAsync(ct)).Generation;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException && !ct.IsCancellationRequested)
+            {
+                // Running per GetStatus but not answering the probe right now. Fall back to
+                // "any live instance counts" (null) — at worst the readiness-race guard is
+                // relaxed for this run; it never produces a false "not ready".
+                generationBefore = null;
+            }
+        }
 
         // Write config
         runner.Add(new HealthCheckItem("Writing configuration", null));
@@ -225,7 +248,7 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
     private static string ProgressLabel(bool wasRunning) =>
         wasRunning ? "Applying configuration" : "Starting daemon";
 
-    private async Task<bool> StartIfNeededAndPollAsync(bool wasRunning, DateTimeOffset? generationBefore, CancellationToken ct)
+    private async Task<bool> StartIfNeededAndPollAsync(bool wasRunning, int? generationBefore, CancellationToken ct)
     {
         if (_daemonManager is null) return false;
 
@@ -264,17 +287,17 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
         {
             ct.ThrowIfCancellationRequested();
 
-            bool ready;
+            DaemonApi.DaemonReadiness probe;
             try
             {
-                ready = await api.IsHealthyAsync(ct);
+                probe = await api.ProbeReadinessAsync(ct);
             }
             catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException && !ct.IsCancellationRequested)
             {
-                ready = false; // daemon mid-restart / per-request timeout — keep waiting
+                probe = default; // daemon mid-restart / per-request timeout — keep waiting
             }
 
-            if (ready && IsRestartedGeneration(generationBefore))
+            if (probe.Healthy && IsRestartedGeneration(generationBefore, probe.Generation))
                 return true;
 
             // Fail fast on a startup abort instead of polling the full timeout: a bad
@@ -313,21 +336,16 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
     }
 
     /// <summary>
-    /// Whether the daemon now reports a newer restart generation than
-    /// <paramref name="before"/> (the PID-file start time advances on each in-process
-    /// restart). A missing pre-restart value (daemon was down) means any live instance
-    /// qualifies; a missing current value means the restarted daemon hasn't written its
-    /// PID file yet, so it does not yet qualify. Without a daemon manager there is no
-    /// generation source to confirm a restart, so we fail safe (treat as not-yet-restarted)
-    /// rather than risk reporting the still-draining old daemon as ready.
+    /// Whether the daemon's reported <paramref name="current"/> restart generation proves
+    /// it restarted onto the freshly-written config. A missing <paramref name="before"/>
+    /// (the daemon was down before the write) means any live instance qualifies; a missing
+    /// <paramref name="current"/> (the daemon answered healthy but reported no generation —
+    /// a pre-#1302 daemon, or a torn probe) cannot confirm a restart, so it does not yet
+    /// qualify — failing safe rather than risk reporting the still-draining pre-restart
+    /// daemon as ready (#1302).
     /// </summary>
-    internal bool IsRestartedGeneration(DateTimeOffset? before)
-    {
-        if (_daemonManager is null) return false;
-        var current = _daemonManager.TryGetRecordedStartTime();
-        if (current is null) return false;
-        return before is null || current > before;
-    }
+    internal static bool IsRestartedGeneration(int? before, int? current) =>
+        before is null || (current is { } now && now > before);
 
     private void NotifyChanged()
     {

--- a/src/Netclaw.Daemon.Tests/Services/DaemonRestartSignalTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/DaemonRestartSignalTests.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonRestartSignalTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class DaemonRestartSignalTests
+{
+    [Fact]
+    public void Generation_StartsAtZero_AndAdvancesMonotonically()
+    {
+        // The wizard's readiness gate relies on a strictly-increasing generation to tell a
+        // reloaded daemon from a still-draining one (#1302) — verify the counter only ever
+        // goes up, never resets.
+        var signal = new DaemonRestartSignal();
+        Assert.Equal(0, signal.Generation);
+
+        signal.AdvanceGeneration();
+        Assert.Equal(1, signal.Generation);
+
+        signal.AdvanceGeneration();
+        Assert.Equal(2, signal.Generation);
+    }
+
+    [Fact]
+    public void Reset_ClearsRestartFlag_ButNotGeneration()
+    {
+        // Reset() clears the restart-requested flag at the top of each loop iteration; it
+        // must NOT touch the generation, or a reused signal would let a stale daemon
+        // masquerade as restarted.
+        var signal = new DaemonRestartSignal();
+        signal.AdvanceGeneration();
+        signal.RequestRestart();
+
+        signal.Reset();
+
+        Assert.False(signal.RestartRequested);
+        Assert.Equal(1, signal.Generation);
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Globalization;
 using System.Threading.RateLimiting;
 using Akka.Actor;
 using Akka.Hosting;
@@ -96,6 +97,10 @@ try
         do
         {
             restartSignal.Reset();
+            // Each pass through the loop is a new daemon generation; the counter is
+            // surfaced on /api/health/ready so the init wizard can confirm a config
+            // reload actually restarted the daemon (#1302).
+            restartSignal.AdvanceGeneration();
             await RunDaemonAsync(args, restartSignal, crashMonitor);
         } while (restartSignal.RestartRequested);
     }
@@ -238,7 +243,16 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");
-    app.MapGet("/api/health/ready", () => TypedResults.Ok("healthy"))
+    app.MapGet("/api/health/ready", (DaemonRestartSignal restartSignal, HttpResponse response) =>
+        {
+            // Surface the monotonic restart generation on the anonymous readiness probe
+            // (#1302). The init wizard reads it to confirm the daemon it is polling is the
+            // post-config-reload generation, not the still-draining pre-restart one — on
+            // the anonymous endpoint precisely so first-init needs no auth token.
+            response.Headers["X-Netclaw-Generation"] =
+                restartSignal.Generation.ToString(CultureInfo.InvariantCulture);
+            return TypedResults.Ok("healthy");
+        })
         .WithName("HealthReady")
         .WithSummary("Liveness probe reporting the daemon is accepting requests.")
         .WithTags("Health");

--- a/src/Netclaw.Daemon/Services/DaemonRestartSignal.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartSignal.cs
@@ -14,10 +14,25 @@ namespace Netclaw.Daemon.Services;
 public sealed class DaemonRestartSignal
 {
     private volatile bool _restartRequested;
+    private int _generation;
 
     public bool RestartRequested => _restartRequested;
 
     public void RequestRestart() => _restartRequested = true;
 
     public void Reset() => _restartRequested = false;
+
+    /// <summary>
+    /// Monotonically-increasing count of host (re)starts this process has driven.
+    /// The outer restart loop calls <see cref="AdvanceGeneration"/> once per iteration
+    /// and the value is surfaced on the anonymous <c>/api/health/ready</c> response so
+    /// the init wizard can tell the reloaded daemon apart from the still-draining
+    /// pre-restart one (#1302). A counter is used rather than a wall-clock start time
+    /// because it is immune to clock step-back (NTP correction, VM resume) — a step-back
+    /// could otherwise make a genuine restart look stale forever and time the wizard out.
+    /// </summary>
+    public int Generation => Volatile.Read(ref _generation);
+
+    /// <summary>Advances <see cref="Generation"/>. Called once per restart-loop iteration.</summary>
+    public void AdvanceGeneration() => Interlocked.Increment(ref _generation);
 }


### PR DESCRIPTION
## Summary

Two follow-ups from the #1279 wizard-readiness rework (#1282). The init wizard
writes config and polls `/api/health/ready` to confirm the daemon restarted onto
the new config. Both fixes harden that poll:

- **#1302 — restart signal.** The poll required the daemon's **PID-file start
  time** to advance (`current > before`). A wall-clock step-back (NTP correction,
  VM resume, container host clock adjustment) between capturing the baseline and
  the restart makes that comparison false *forever* → the wizard polls the full
  90s and falsely reports "Daemon did not become ready" on a daemon that reloaded
  fine. Coarse/equal ticks and torn PID-file reads have the same effect. Replaced
  with a **monotonic restart generation**: `DaemonRestartSignal.Generation`
  advances once per restart-loop iteration and is surfaced as an
  **`X-Netclaw-Generation`** header on the **anonymous** `/api/health/ready` —
  immune to clock movement, and on the anonymous endpoint so first-init needs no
  auth token.

- **#1304 — frozen endpoint.** `DaemonApi` resolved its endpoint once at
  construction. A `Daemon`-section **port change** brings the daemon back on the
  new port while the frozen endpoint keeps polling the dead old one until timeout.
  `ProbeReadinessAsync` now **re-resolves the endpoint on every probe**, picking
  up the just-written `Daemon.Port` (and still honoring an explicit
  `NETCLAW_DAEMON_ENDPOINT` / paired-client endpoint when set).

## Changes

- `DaemonRestartSignal`: add a monotonic `Generation` (`AdvanceGeneration()` /
  `Volatile.Read`).
- `Program.cs`: advance the generation each restart-loop iteration; emit
  `X-Netclaw-Generation` on `/api/health/ready`.
- `DaemonApi`: store `_paths`; replace `IsHealthyAsync` with `ProbeReadinessAsync`
  → `(bool Healthy, int? Generation)`, re-resolving the endpoint per probe and
  parsing the header.
- `HealthCheckStepViewModel`: capture the pre-write generation via a probe; gate
  readiness on `IsRestartedGeneration(before, current)` (now a pure static helper)
  using the daemon-reported generation.
- `DaemonManager`: remove the now-unused `TryGetRecordedStartTime`.

## Validation

- New/updated unit tests pass: `DaemonRestartSignalTests` (monotonic generation),
  `DaemonApiAuthenticationTests` (header parse + **re-resolution to a changed
  port**, proving #1304), `HealthCheckStepViewModelTests` (generation gate;
  stale-same / newer / down / no-generation cases).
- End-to-end: ran the built daemon and confirmed `GET /api/health/ready` returns
  `200` with `X-Netclaw-Generation: 1` and body `"healthy"` (backward compatible —
  the Docker HEALTHCHECK and smoke poll only check 2xx).
- `dotnet slopwatch analyze` → 0 issues; copyright headers verified.

Closes #1302
Closes #1304
