### PR TITLE
fix: stream everywhere for auxiliary LLM calls + session id on LLM logs

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/FailoverChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/FailoverChatClientTests.cs
@@ -151,6 +151,29 @@ public sealed class FailoverChatClientTests
         Assert.Equal(0, fallbackStreamCalls);
     }
 
+    [Fact]
+    public async Task FailoverLog_carries_session_id_from_diagnostics_context()
+    {
+        var logger = new ScopeCapturingLogger();
+        var primary = new FakeChatClient((_, _, _) =>
+            throw new HttpRequestException("primary down"));
+        var fallback = new FakeChatClient((_, _, _) =>
+            Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "fallback")])));
+        var client = new FailoverChatClient(
+            primary, fallback, logger, NullNotificationSink.Instance, TimeProvider.System);
+
+        using (SessionDiagnosticsContext.Push("ch/failover"))
+        {
+            await client.GetResponseAsync(
+                [new ChatMessage(ChatRole.User, "hi")],
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        // The failover warning is emitted outside LoggingChatClient's scope, so it
+        // must carry the session id via FailoverChatClient's own scope.
+        Assert.True(logger.HasSessionScope("ch/failover"));
+    }
+
     private static async IAsyncEnumerable<ChatResponseUpdate> ThrowBeforeFirstChunkAsync(
         [System.Runtime.CompilerServices.EnumeratorCancellation]
         CancellationToken cancellationToken)

--- a/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
@@ -244,7 +244,7 @@ public sealed class LoggingChatClientTests
                 cancellationToken: TestContext.Current.CancellationToken);
         }
 
-        AssertSessionScope(logger, "ch/thread");
+        Assert.True(logger.HasSessionScope("ch/thread"));
     }
 
     [Fact]
@@ -260,7 +260,7 @@ public sealed class LoggingChatClientTests
                 cancellationToken: TestContext.Current.CancellationToken)) { }
         }
 
-        AssertSessionScope(logger, "ch/thread");
+        Assert.True(logger.HasSessionScope("ch/thread"));
     }
 
     [Fact]
@@ -274,45 +274,7 @@ public sealed class LoggingChatClientTests
             [new ChatMessage(ChatRole.User, "hi")],
             cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.DoesNotContain(logger.Scopes, IsSessionScope);
-    }
-
-    private static void AssertSessionScope(ScopeCapturingLogger logger, string expected) =>
-        Assert.Contains(logger.Scopes, s =>
-            s is IEnumerable<KeyValuePair<string, object>> kvps
-            && kvps.Any(kv => kv.Key == "session.id" && kv.Value is string v && v == expected));
-
-    private static bool IsSessionScope(object? scope) =>
-        scope is IEnumerable<KeyValuePair<string, object>> kvps
-        && kvps.Any(kv => kv.Key == "session.id");
-
-    /// <summary>
-    /// Logger that records the state objects passed to <see cref="ILogger.BeginScope"/>
-    /// so tests can assert which scopes were opened around a call.
-    /// </summary>
-    private sealed class ScopeCapturingLogger : ILogger
-    {
-        public List<object?> Scopes { get; } = [];
-
-        public void Log<TState>(
-            LogLevel logLevel, EventId eventId, TState state,
-            Exception? exception, Func<TState, Exception?, string> formatter)
-        {
-        }
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
-        {
-            Scopes.Add(state);
-            return NoopScope.Instance;
-        }
-
-        private sealed class NoopScope : IDisposable
-        {
-            public static readonly NoopScope Instance = new();
-            public void Dispose() { }
-        }
+        Assert.False(logger.HasAnySessionScope());
     }
 
     /// <summary>

--- a/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Xunit;
 
@@ -228,6 +229,90 @@ public sealed class LoggingChatClientTests
         {
             Contents = [new UsageContent(new UsageDetails { InputTokenCount = inputTokens, OutputTokenCount = outputTokens })]
         };
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_attaches_session_id_scope_from_diagnostics_context()
+    {
+        var logger = new ScopeCapturingLogger();
+        var client = new LoggingChatClient(new FakeChatClient(), logger);
+
+        using (SessionDiagnosticsContext.Push("ch/thread"))
+        {
+            await client.GetResponseAsync(
+                [new ChatMessage(ChatRole.User, "hi")],
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        AssertSessionScope(logger, "ch/thread");
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_attaches_session_id_scope_from_diagnostics_context()
+    {
+        var logger = new ScopeCapturingLogger();
+        var client = new LoggingChatClient(new FakeChatClient(streaming: true), logger);
+
+        using (SessionDiagnosticsContext.Push("ch/thread"))
+        {
+            await foreach (var _ in client.GetStreamingResponseAsync(
+                [new ChatMessage(ChatRole.User, "hi")],
+                cancellationToken: TestContext.Current.CancellationToken)) { }
+        }
+
+        AssertSessionScope(logger, "ch/thread");
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_without_session_context_attaches_no_session_scope()
+    {
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+        var logger = new ScopeCapturingLogger();
+        var client = new LoggingChatClient(new FakeChatClient(), logger);
+
+        await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(logger.Scopes, IsSessionScope);
+    }
+
+    private static void AssertSessionScope(ScopeCapturingLogger logger, string expected) =>
+        Assert.Contains(logger.Scopes, s =>
+            s is IEnumerable<KeyValuePair<string, object>> kvps
+            && kvps.Any(kv => kv.Key == "session.id" && kv.Value is string v && v == expected));
+
+    private static bool IsSessionScope(object? scope) =>
+        scope is IEnumerable<KeyValuePair<string, object>> kvps
+        && kvps.Any(kv => kv.Key == "session.id");
+
+    /// <summary>
+    /// Logger that records the state objects passed to <see cref="ILogger.BeginScope"/>
+    /// so tests can assert which scopes were opened around a call.
+    /// </summary>
+    private sealed class ScopeCapturingLogger : ILogger
+    {
+        public List<object?> Scopes { get; } = [];
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            Scopes.Add(state);
+            return NoopScope.Instance;
+        }
+
+        private sealed class NoopScope : IDisposable
+        {
+            public static readonly NoopScope Instance = new();
+            public void Dispose() { }
+        }
     }
 
     /// <summary>

--- a/src/Netclaw.Daemon.Tests/Configuration/ScopeCapturingLogger.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ScopeCapturingLogger.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="ScopeCapturingLogger.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+/// <summary>
+/// Test logger that records the state objects passed to <see cref="ILogger.BeginScope"/>
+/// so tests can assert which scopes were opened around a logging call. Returns
+/// <c>null</c> from <c>BeginScope</c> (a valid no-op for <c>using var</c>); only the
+/// captured state matters.
+/// </summary>
+internal sealed class ScopeCapturingLogger : ILogger
+{
+    private const string SessionIdKey = "session.id";
+
+    public List<object?> Scopes { get; } = [];
+
+    public void Log<TState>(
+        LogLevel logLevel, EventId eventId, TState state,
+        Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        Scopes.Add(state);
+        return null;
+    }
+
+    /// <summary>True if a scope tagging the given session id was opened.</summary>
+    public bool HasSessionScope(string expectedId) =>
+        Scopes.Any(s => s is IEnumerable<KeyValuePair<string, object>> kvps
+            && kvps.Any(kv => kv.Key == SessionIdKey && kv.Value is string v && v == expectedId));
+
+    /// <summary>True if any session-id scope (regardless of value) was opened.</summary>
+    public bool HasAnySessionScope() =>
+        Scopes.Any(s => s is IEnumerable<KeyValuePair<string, object>> kvps
+            && kvps.Any(kv => kv.Key == SessionIdKey));
+}

--- a/src/Netclaw.Daemon.Tests/Configuration/StreamFirstChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/StreamFirstChatClientTests.cs
@@ -26,9 +26,25 @@ public sealed class StreamFirstChatClientTests
         // 400s against streaming-only backends.
         Assert.False(inner.NonStreamingInvoked);
         Assert.True(inner.StreamingInvoked);
+        Assert.Single(response.Messages); // aggregated into one assistant message, not split
         Assert.Equal("Hello world", response.Text);
         Assert.Equal(7, response.Usage?.InputTokenCount);
         Assert.Equal(3, response.Usage?.OutputTokenCount);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_on_empty_stream_yields_a_single_empty_assistant_message()
+    {
+        var client = new StreamFirstChatClient(new StreamOnlyChatClient(emptyStream: true));
+
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Callers index Messages[^1] unguarded; an empty completion must not throw.
+        var last = response.Messages[^1];
+        Assert.Equal(ChatRole.Assistant, last.Role);
+        Assert.True(string.IsNullOrEmpty(last.Text));
     }
 
     [Fact]
@@ -57,7 +73,7 @@ public sealed class StreamFirstChatClientTests
     /// that rejects non-streaming), while <see cref="GetStreamingResponseAsync"/> yields
     /// text deltas followed by usage.
     /// </summary>
-    private sealed class StreamOnlyChatClient : IChatClient
+    private sealed class StreamOnlyChatClient(bool emptyStream = false) : IChatClient
     {
         public bool StreamingInvoked { get; private set; }
         public bool NonStreamingInvoked { get; private set; }
@@ -78,6 +94,8 @@ public sealed class StreamFirstChatClientTests
         {
             StreamingInvoked = true;
             await Task.CompletedTask;
+            if (emptyStream)
+                yield break;
             yield return new ChatResponseUpdate(ChatRole.Assistant, "Hello");
             yield return new ChatResponseUpdate(ChatRole.Assistant, " world");
             yield return new ChatResponseUpdate

--- a/src/Netclaw.Daemon.Tests/Configuration/StreamFirstChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/StreamFirstChatClientTests.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------
+// <copyright file="StreamFirstChatClientTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using Netclaw.Providers;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class StreamFirstChatClientTests
+{
+    [Fact]
+    public async Task GetResponseAsync_is_served_by_aggregating_the_stream()
+    {
+        var inner = new StreamOnlyChatClient();
+        var client = new StreamFirstChatClient(inner);
+
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // The native non-streaming path must never be touched — it's the path that
+        // 400s against streaming-only backends.
+        Assert.False(inner.NonStreamingInvoked);
+        Assert.True(inner.StreamingInvoked);
+        Assert.Equal("Hello world", response.Text);
+        Assert.Equal(7, response.Usage?.InputTokenCount);
+        Assert.Equal(3, response.Usage?.OutputTokenCount);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_passes_through_unchanged()
+    {
+        var inner = new StreamOnlyChatClient();
+        var client = new StreamFirstChatClient(inner);
+
+        var texts = new List<string>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            foreach (var content in update.Contents)
+                if (content is TextContent t)
+                    texts.Add(t.Text);
+        }
+
+        Assert.True(inner.StreamingInvoked);
+        Assert.False(inner.NonStreamingInvoked);
+        Assert.Equal(new[] { "Hello", " world" }, texts);
+    }
+
+    /// <summary>
+    /// A streaming-only client: <see cref="GetResponseAsync"/> throws (mirrors a backend
+    /// that rejects non-streaming), while <see cref="GetStreamingResponseAsync"/> yields
+    /// text deltas followed by usage.
+    /// </summary>
+    private sealed class StreamOnlyChatClient : IChatClient
+    {
+        public bool StreamingInvoked { get; private set; }
+        public bool NonStreamingInvoked { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            NonStreamingInvoked = true;
+            throw new InvalidOperationException("Stream must be set to true");
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            StreamingInvoked = true;
+            await Task.CompletedTask;
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "Hello");
+            yield return new ChatResponseUpdate(ChatRole.Assistant, " world");
+            yield return new ChatResponseUpdate
+            {
+                Contents = [new UsageContent(new UsageDetails { InputTokenCount = 7, OutputTokenCount = 3 })]
+            };
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/FailoverChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/FailoverChatClient.cs
@@ -52,7 +52,7 @@ public sealed class FailoverChatClient : IChatClient
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
-            _logger.LogWarning(ex,
+            LogWithSession(LogLevel.Warning, ex,
                 "Primary LLM failed, failing over to fallback provider");
             EmitFailoverAlert(ex);
 
@@ -62,7 +62,7 @@ public sealed class FailoverChatClient : IChatClient
             }
             catch (Exception fallbackEx) when (!cancellationToken.IsCancellationRequested)
             {
-                _logger.LogError(fallbackEx,
+                LogWithSession(LogLevel.Error, fallbackEx,
                     "Fallback LLM also failed — all providers unreachable");
                 EmitUnreachableAlert(fallbackEx);
                 throw;
@@ -112,7 +112,7 @@ public sealed class FailoverChatClient : IChatClient
 
         if (primaryInitiationFailure is not null)
         {
-            _logger.LogWarning(primaryInitiationFailure,
+            LogWithSession(LogLevel.Warning, primaryInitiationFailure,
                 "Primary LLM streaming failed on initiation, failing over to fallback");
 
             await foreach (var fallbackUpdate in stream)
@@ -150,7 +150,7 @@ public sealed class FailoverChatClient : IChatClient
         if (primaryPreFirstChunkFailure is null)
             yield break;
 
-        _logger.LogWarning(primaryPreFirstChunkFailure,
+        LogWithSession(LogLevel.Warning, primaryPreFirstChunkFailure,
             "Primary LLM streaming failed before first chunk, failing over to fallback");
         EmitFailoverAlert(primaryPreFirstChunkFailure);
 
@@ -167,6 +167,15 @@ public sealed class FailoverChatClient : IChatClient
 
         await foreach (var fallbackUpdate in preChunkFallbackStream)
             yield return fallbackUpdate;
+    }
+
+    // Failover/outage events are logged outside LoggingChatClient's session scope
+    // (the delegated call has already returned or thrown), so attach the session id
+    // here too — these are the operationally most important LLM log lines.
+    private void LogWithSession(LogLevel level, Exception ex, string message)
+    {
+        using (SessionLoggingScope.Begin(_logger))
+            _logger.Log(level, ex, message);
     }
 
     private void EmitFailoverAlert(Exception ex)

--- a/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
@@ -39,12 +39,13 @@ public sealed class LoggingChatClient : DelegatingChatClient
 
     /// <summary>
     /// Opens a logging scope carrying the ambient session id (when one is in
-    /// scope) so it rides the standard MEL scope mechanism onto every sink —
-    /// notably the OTLP/Seq exporter (which has <c>IncludeScopes</c> enabled).
-    /// Without this, the exporter cannot read the
-    /// <see cref="SessionDiagnosticsContext"/> AsyncLocal (only the rolling-file
-    /// provider does, and only for file routing), so LLM logs reach Seq with no
-    /// session correlation. Returns <c>null</c> when no session is in scope
+    /// scope) so it surfaces on the OTLP log exporter, which has
+    /// <c>IncludeScopes</c> enabled and otherwise cannot read the
+    /// <see cref="SessionDiagnosticsContext"/> AsyncLocal — that is what makes
+    /// LLM logs correlatable by session in Seq. The scope only adds correlation
+    /// on the OTLP path (i.e. when telemetry export is enabled); the rolling-file
+    /// provider ignores scopes and routes <c>session.log</c> independently from
+    /// the same AsyncLocal. Returns <c>null</c> when no session is in scope
     /// (e.g. daemon-global calls), which is a no-op <c>using</c>.
     /// </summary>
     private IDisposable? BeginSessionScope()

--- a/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
 
 namespace Netclaw.Daemon.Configuration;
 
@@ -36,11 +37,30 @@ public sealed class LoggingChatClient : DelegatingChatClient
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
+    /// <summary>
+    /// Opens a logging scope carrying the ambient session id (when one is in
+    /// scope) so it rides the standard MEL scope mechanism onto every sink —
+    /// notably the OTLP/Seq exporter (which has <c>IncludeScopes</c> enabled).
+    /// Without this, the exporter cannot read the
+    /// <see cref="SessionDiagnosticsContext"/> AsyncLocal (only the rolling-file
+    /// provider does, and only for file routing), so LLM logs reach Seq with no
+    /// session correlation. Returns <c>null</c> when no session is in scope
+    /// (e.g. daemon-global calls), which is a no-op <c>using</c>.
+    /// </summary>
+    private IDisposable? BeginSessionScope()
+    {
+        var sessionId = SessionDiagnosticsContext.SessionId;
+        return sessionId is null
+            ? null
+            : _logger.BeginScope(new Dictionary<string, object> { ["session.id"] = sessionId });
+    }
+
     public override async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        using var sessionScope = BeginSessionScope();
         var messageList = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
         LogPromptDiagnostics(messageList, options);
 
@@ -66,6 +86,7 @@ public sealed class LoggingChatClient : DelegatingChatClient
         [System.Runtime.CompilerServices.EnumeratorCancellation]
         CancellationToken cancellationToken = default)
     {
+        using var sessionScope = BeginSessionScope();
         var messageList = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
         LogPromptDiagnostics(messageList, options);
 

--- a/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using Netclaw.Configuration;
 
 namespace Netclaw.Daemon.Configuration;
 
@@ -37,24 +36,9 @@ public sealed class LoggingChatClient : DelegatingChatClient
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    /// <summary>
-    /// Opens a logging scope carrying the ambient session id (when one is in
-    /// scope) so it surfaces on the OTLP log exporter, which has
-    /// <c>IncludeScopes</c> enabled and otherwise cannot read the
-    /// <see cref="SessionDiagnosticsContext"/> AsyncLocal — that is what makes
-    /// LLM logs correlatable by session in Seq. The scope only adds correlation
-    /// on the OTLP path (i.e. when telemetry export is enabled); the rolling-file
-    /// provider ignores scopes and routes <c>session.log</c> independently from
-    /// the same AsyncLocal. Returns <c>null</c> when no session is in scope
-    /// (e.g. daemon-global calls), which is a no-op <c>using</c>.
-    /// </summary>
-    private IDisposable? BeginSessionScope()
-    {
-        var sessionId = SessionDiagnosticsContext.SessionId;
-        return sessionId is null
-            ? null
-            : _logger.BeginScope(new Dictionary<string, object> { ["session.id"] = sessionId });
-    }
+    // See SessionLoggingScope: tags subsequent log lines with the ambient session
+    // id so they correlate by session in Seq (OTLP). No-op when none is in scope.
+    private IDisposable? BeginSessionScope() => SessionLoggingScope.Begin(_logger);
 
     public override async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,

--- a/src/Netclaw.Daemon/Configuration/ProviderPluginFactory.cs
+++ b/src/Netclaw.Daemon/Configuration/ProviderPluginFactory.cs
@@ -44,9 +44,16 @@ public sealed class ProviderPluginFactory
 
         var client = plugin.CreateChatClient(provider, model);
         var vendorOptions = plugin.CreateVendorOptionsSource(provider);
-        return vendorOptions is null
-            ? client
-            : new VendorOptionsChatClient(client, vendorOptions);
+        if (vendorOptions is not null)
+            client = new VendorOptionsChatClient(client, vendorOptions);
+
+        // Stream everywhere: the daemon only issues streaming requests at the provider
+        // boundary. Auxiliary calls (title gen, memory distillation, compaction) ask
+        // for a complete response via GetResponseAsync; serve it by aggregating the
+        // stream so streaming-only providers (e.g. the OpenAI Codex backend) work
+        // without a per-provider capability model. Outermost of the two wrappers so
+        // vendor options are applied to the underlying streaming call.
+        return new StreamFirstChatClient(client);
     }
 }
 

--- a/src/Netclaw.Daemon/Configuration/SessionLoggingScope.cs
+++ b/src/Netclaw.Daemon/Configuration/SessionLoggingScope.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionLoggingScope.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Configuration;
+
+/// <summary>
+/// Shared helper for tagging log lines with the ambient session id.
+///
+/// The id lives in <see cref="SessionDiagnosticsContext"/> (an AsyncLocal pushed
+/// by every session-owned path). The OTLP log exporter has <c>IncludeScopes</c>
+/// enabled but cannot read that AsyncLocal directly, so without a logging scope
+/// LLM logs reach Seq with no session correlation. Opening a scope keyed on
+/// <c>session.id</c> is what surfaces it as a filterable attribute. The scope only
+/// adds correlation on the OTLP path (i.e. when telemetry export is enabled); the
+/// rolling-file provider ignores scopes and routes <c>session.log</c> independently
+/// from the same AsyncLocal.
+///
+/// Centralized here so every logging decorator (<see cref="LoggingChatClient"/>,
+/// <see cref="FailoverChatClient"/>) attaches the id consistently and the
+/// <c>session.id</c> key has a single definition.
+/// </summary>
+internal static class SessionLoggingScope
+{
+    private const string SessionIdKey = "session.id";
+
+    /// <summary>
+    /// Opens a scope tagging subsequent log lines on <paramref name="logger"/> with
+    /// the ambient session id, or returns <c>null</c> when no session is in scope
+    /// (a no-op <c>using</c>). The single-entry array avoids a per-call dictionary
+    /// allocation while still presenting as <c>IEnumerable&lt;KeyValuePair&gt;</c>,
+    /// which is what the OTLP exporter projects into log attributes.
+    /// </summary>
+    public static IDisposable? Begin(ILogger logger)
+    {
+        var sessionId = SessionDiagnosticsContext.SessionId;
+        return sessionId is null
+            ? null
+            : logger.BeginScope(new[] { new KeyValuePair<string, object>(SessionIdKey, sessionId) });
+    }
+}

--- a/src/Netclaw.Providers/StreamFirstChatClient.cs
+++ b/src/Netclaw.Providers/StreamFirstChatClient.cs
@@ -32,10 +32,22 @@ public sealed class StreamFirstChatClient : DelegatingChatClient
 {
     public StreamFirstChatClient(IChatClient innerClient) : base(innerClient) { }
 
-    public override Task<ChatResponse> GetResponseAsync(
+    public override async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
         CancellationToken cancellationToken = default)
-        => base.GetStreamingResponseAsync(messages, options, cancellationToken)
+    {
+        var response = await base
+            .GetStreamingResponseAsync(messages, options, cancellationToken)
             .ToChatResponseAsync(cancellationToken);
+
+        // An empty stream aggregates to a response with zero messages, but callers
+        // (memory distillation, title generation, compaction) index Messages[^1].
+        // Match StreamingResponseReader's guard so an empty completion degrades to
+        // empty text instead of an unguarded index throw at the call site.
+        if (response.Messages.Count == 0)
+            response.Messages.Add(new ChatMessage(ChatRole.Assistant, []));
+
+        return response;
+    }
 }

--- a/src/Netclaw.Providers/StreamFirstChatClient.cs
+++ b/src/Netclaw.Providers/StreamFirstChatClient.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="StreamFirstChatClient.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Providers;
+
+/// <summary>
+/// Serves non-streaming <see cref="IChatClient.GetResponseAsync"/> by consuming the
+/// underlying streaming endpoint and aggregating the updates, so streaming is the
+/// single request mode the daemon ever issues at the provider boundary.
+///
+/// The interactive session loop already streams; only auxiliary calls (title
+/// generation, memory distillation, compaction, curation) use the non-streaming
+/// path. Some providers are streaming-only — notably the OpenAI Codex backend, which
+/// rejects non-streaming Responses requests with
+/// <c>400 {"detail":"Stream must be set to true"}</c>. Applying this universally at
+/// the provider boundary lets every provider serve a complete response without a
+/// per-provider/per-model capability model, since streaming is the near-universal
+/// capability among the providers Netclaw targets (and any environment that breaks
+/// streaming would already break the main session loop, which streams too).
+///
+/// Cost: <see cref="GetResponseAsync"/> consumes the whole stream before returning —
+/// the same total latency as a native non-streaming call, since the caller waits for
+/// completion either way. Microsoft.Extensions.AI's <c>ToChatResponseAsync</c>
+/// coalesces text, usage, and tool-call deltas into the aggregated response.
+/// Streaming calls pass straight through unchanged.
+/// </summary>
+public sealed class StreamFirstChatClient : DelegatingChatClient
+{
+    public StreamFirstChatClient(IChatClient innerClient) : base(innerClient) { }
+
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingResponseAsync(messages, options, cancellationToken)
+            .ToChatResponseAsync(cancellationToken);
+}


### PR DESCRIPTION
## What

Two independent fixes behind the OpenAI **Codex** memory-formation errors (`400 {"detail":"Stream must be set to true"}`).

### 1. Stream everywhere at the provider boundary (supersedes #1289)

The Codex backend is **streaming-only** — it rejects non-streaming Responses requests. Netclaw's interactive session loop streams, but auxiliary calls (title generation, memory distillation, compaction, curation) use the non-streaming `IChatClient.GetResponseAsync` path, so they 400 against Codex while the main loop works fine.

Rather than a per-provider capability model, make streaming the single request mode the daemon issues at the provider boundary: a new `StreamFirstChatClient` (`DelegatingChatClient`) serves `GetResponseAsync` by aggregating the streaming endpoint (`GetStreamingResponseAsync(...).ToChatResponseAsync(...)`), applied to every client in `ProviderPluginFactory.Create`. Streaming is near-universal among supported providers, and any environment that breaks streaming would already break the main session loop (which streams too).

- **Empty-stream guard:** an aggregated empty stream yields zero messages, but sidecar callers index `Messages[^1]`. `StreamFirstChatClient` appends an empty assistant message in that case, matching `StreamingResponseReader`'s existing guard, so an empty completion degrades to empty text instead of an unguarded index throw.

### 2. Session id on LLM logs in Seq

LLM client logs (`LoggingChatClient`, `FailoverChatClient`) reached Seq with no session correlation: the id lives in `SessionDiagnosticsContext` (an AsyncLocal pushed by every session-owned path) but the OTLP exporter never projected it onto the `LogRecord`. A shared `SessionLoggingScope` opens a `session.id` logging scope (read from the ambient context) around the LLM calls and the failover/outage log lines, riding the already-enabled `IncludeScopes` so it surfaces as a filterable Seq attribute — no telemetry-wiring change.

## Testing

- `StreamFirstChatClient`: aggregation + streaming passthrough + empty-stream guard.
- `LoggingChatClient` / `FailoverChatClient`: `session.id` scope attached (and absent when no session is in scope).
- Daemon `Configuration` suite: **119/119** passing; build clean (0 warnings); slopwatch + file headers clean.

## Notes

- **Supersedes #1289** (the Codex-specific stop-gap) — the stream→aggregate wrapper is now universal rather than a single inline special case.
- A pre-existing, separate **diagnostic-only** quirk was found and deliberately left alone: `LoggingChatClient`'s `delta`/`cumulative` token counters are mutable state on a singleton, so those two values in the `LLM call completed` debug-log line mix sessions. They feed nothing else — the real per-response usage that drives `chat -p`, OTel metrics, `stats`, the session catalog, and compaction all comes from the per-session `LlmSessionActor` and is unaffected. Worth a separate cleanup, not this PR.
