### PR TITLE
fix(providers): stop persisting guessed modalities; fix probe timeout & visibility (#1290, #1292)

### DIFF
--- a/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
+++ b/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="ModelEntryWriterTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Config;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Config;
+
+/// <summary>
+/// Guards the single persist path shared by `model set`, the init wizard, and the TUI
+/// model manager. The rule under test: modalities are written only when the discovery
+/// source genuinely reported them, so an unknown is never frozen into config as a
+/// permanent "Text" override (#1290).
+/// </summary>
+public class ModelEntryWriterTests
+{
+    [Fact]
+    public void BuildModelEntry_UnknownModalities_OmitsModalityKeys()
+    {
+        var entry = ModelEntryWriter.BuildModelEntry(
+            "my-vllm", "qwen-vl", ModelDiscoverySource.Live,
+            contextWindow: 32768, inputModalities: null, outputModalities: null);
+
+        Assert.Equal("my-vllm", entry["Provider"]);
+        Assert.Equal("qwen-vl", entry["ModelId"]);
+        Assert.Equal("Live", entry["Provenance"]);
+        Assert.Equal(32768, entry["ContextWindow"]);
+        Assert.False(entry.ContainsKey("InputModalities"));
+        Assert.False(entry.ContainsKey("OutputModalities"));
+    }
+
+    [Fact]
+    public void BuildModelEntry_KnownModalities_WritesThem()
+    {
+        var entry = ModelEntryWriter.BuildModelEntry(
+            "openai-codex", "gpt-x", ModelDiscoverySource.Live,
+            contextWindow: null,
+            inputModalities: ModelModality.Text | ModelModality.Image,
+            outputModalities: ModelModality.Text);
+
+        Assert.Equal("Text, Image", entry["InputModalities"]);
+        Assert.Equal("Text", entry["OutputModalities"]);
+        Assert.False(entry.ContainsKey("ContextWindow"));
+    }
+
+    [Fact]
+    public void BuildModelEntry_BlankModelIdAndNullProvenance_OmitsBoth()
+    {
+        var entry = ModelEntryWriter.BuildModelEntry(
+            "p", modelId: "", provenance: null,
+            contextWindow: null, inputModalities: null, outputModalities: null);
+
+        Assert.True(entry.ContainsKey("Provider"));
+        Assert.False(entry.ContainsKey("ModelId"));
+        Assert.False(entry.ContainsKey("Provenance"));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -163,8 +163,11 @@ public sealed class ModelManagerViewModelTests : IDisposable
         Assert.Equal("my-ollama", main.GetProperty("Provider").GetString());
         Assert.Equal("model-a", main.GetProperty("ModelId").GetString());
         Assert.Equal("Live", main.GetProperty("Provenance").GetString());
-        Assert.Equal("Text", main.GetProperty("InputModalities").GetString());
-        Assert.Equal("Text", main.GetProperty("OutputModalities").GetString());
+        // An Ollama /api/tags listing reports no modalities, so discovery must NOT
+        // persist a guessed "Text" override (#1290) — leaving them unset lets the
+        // daemon resolve real capabilities at runtime instead of being short-circuited.
+        Assert.False(main.TryGetProperty("InputModalities", out _));
+        Assert.False(main.TryGetProperty("OutputModalities", out _));
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -201,6 +201,32 @@ public sealed class ProviderStepViewModelTests : IDisposable
     }
 
     [Fact]
+    public void ContributeConfig_DiscoveredModelWithoutModalities_PersistsNone()
+    {
+        // An openai-compatible /v1/models listing reports no modalities, so the
+        // discovered model leaves them unset. The wizard must NOT bake a guessed Text
+        // into config — that override would beat real detection on every daemon boot
+        // and silently demote a multimodal model to text-only (#1290).
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+        step.SelectedProviderType = "openai-compatible";
+        step.SelectedAuthMethod = AuthMethod.None;
+        step.SelectedModelId = "qwen-vl";
+        step.DiscoveredModels.Add(new DiscoveredModel
+        {
+            ModelId = new Netclaw.Configuration.ModelId("qwen-vl"),
+            ContextWindowTokens = 32768,
+        });
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Model);
+        Assert.Equal(32768, builder.Model!.ContextWindow);
+        Assert.Null(builder.Model.InputModalities);
+        Assert.Null(builder.Model.OutputModalities);
+    }
+
+    [Fact]
     public void ContributeConfig_NoProvider_NoSection()
     {
         using var step = new ProviderStepViewModel(_registry, _fakeProbe);

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="ModelEntryWriter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Config;
+
+/// <summary>
+/// The single place a model role assignment is assembled for persistence to the
+/// "Models" section of netclaw.json. The CLI (<c>netclaw model set</c>), the init
+/// wizard, and the TUI model manager all route through here so their on-disk shape
+/// cannot drift apart — each used to hand-roll its own dictionary, which is how the
+/// same modality bug landed in three places (#1290).
+/// </summary>
+internal static class ModelEntryWriter
+{
+    /// <summary>
+    /// Builds the dictionary written under <c>Models[role]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Modalities are written ONLY when the discovery source genuinely reported them
+    /// (non-null). A null modality means "the provider did not say" — it is
+    /// deliberately omitted so the daemon's capability detection resolves it at
+    /// runtime. Writing a guessed <see cref="ModelModality.Text"/> here would bake a
+    /// permanent override into config that beats real detection on every boot, which
+    /// is exactly what silently demoted multimodal self-hosted models to text-only.
+    /// </remarks>
+    internal static Dictionary<string, object> BuildModelEntry(
+        string provider,
+        string? modelId,
+        ModelDiscoverySource? provenance,
+        int? contextWindow,
+        ModelModality? inputModalities,
+        ModelModality? outputModalities)
+    {
+        var entry = new Dictionary<string, object> { ["Provider"] = provider };
+
+        if (!string.IsNullOrWhiteSpace(modelId))
+            entry["ModelId"] = modelId;
+
+        if (provenance is { } prov)
+            entry["Provenance"] = prov.ToString();
+
+        if (contextWindow is { } window)
+            entry["ContextWindow"] = window;
+
+        if (inputModalities is { } input)
+            entry["InputModalities"] = input.ToString();
+
+        if (outputModalities is { } output)
+            entry["OutputModalities"] = output.ToString();
+
+        return entry;
+    }
+}

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -144,7 +144,9 @@ internal static class ModelCommand
         if (contextWindow is null && ShouldProbeForMetadata(providerEntry))
         {
             probe ??= ProviderCommand.CreateDefaultRegistry();
-            var probeResult = await probe.ProbeAsync(providerEntry, CancellationToken.None);
+            ProviderProbeResult probeResult;
+            await using (ProbeProgressReporter.Start(ResolveProbeEndpoint(probe, providerEntry)))
+                probeResult = await probe.ProbeAsync(providerEntry, CancellationToken.None);
             if (!probeResult.Success)
             {
                 writer.WriteLine($"Error: Could not resolve model metadata from provider: {probeResult.ErrorMessage}");
@@ -168,23 +170,13 @@ internal static class ModelCommand
         var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        var modelEntry = new Dictionary<string, object>
-        {
-            ["Provider"] = providerName,
-            ["ModelId"] = modelId,
-            ["Provenance"] = provenance.ToString()
-        };
-
-        if (contextWindow.HasValue)
-            modelEntry["ContextWindow"] = contextWindow.Value;
-        else if (discoveredModel?.ContextWindowTokens is { } discoveredContextWindow)
-            modelEntry["ContextWindow"] = discoveredContextWindow;
-
-        if (discoveredModel is not null)
-        {
-            modelEntry["InputModalities"] = discoveredModel.InputModalities.ToString();
-            modelEntry["OutputModalities"] = discoveredModel.OutputModalities.ToString();
-        }
+        var modelEntry = ModelEntryWriter.BuildModelEntry(
+            providerName,
+            modelId,
+            provenance,
+            contextWindow ?? discoveredModel?.ContextWindowTokens,
+            discoveredModel?.InputModalities,
+            discoveredModel?.OutputModalities);
 
         modelsSection[roleKey] = modelEntry;
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
@@ -196,6 +188,23 @@ internal static class ModelCommand
     private static bool ShouldProbeForMetadata(ProviderEntry entry)
         => string.Equals(entry.Type, "openai", StringComparison.OrdinalIgnoreCase)
            && entry.AuthMethod is AuthMethod.OAuthDevice or AuthMethod.OAuthPkce;
+
+    /// <summary>
+    /// The endpoint the probe will actually hit, for display. When a provider has no
+    /// explicit endpoint we surface the descriptor's default (e.g. a self-hosted
+    /// provider that silently fell back to localhost) so the target is visible rather
+    /// than hidden behind an anonymous wait (#1292).
+    /// </summary>
+    private static string ResolveProbeEndpoint(IProviderProbe probe, ProviderEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.Endpoint))
+            return entry.Endpoint;
+
+        return probe is ProviderDescriptorRegistry registry
+               && registry.TryGet(entry.Type, out var descriptor)
+            ? descriptor.DefaultEndpoint
+            : "(default endpoint)";
+    }
 
     private static async Task<int> RunDiscoverAsync(string[] args, NetclawPaths paths, IProviderProbe? probe, TextWriter writer)
     {
@@ -217,9 +226,12 @@ internal static class ModelCommand
         // Use the registry as the probe (it implements IProviderProbe)
         probe ??= ProviderCommand.CreateDefaultRegistry();
 
-        writer.WriteLine($"Discovering models from '{providerName}' ({entry.Type})...");
+        var probeEndpoint = ResolveProbeEndpoint(probe, entry);
+        writer.WriteLine($"Discovering models from '{providerName}' ({entry.Type}) at {probeEndpoint}...");
 
-        var result = await probe.ProbeAsync(entry, CancellationToken.None);
+        ProviderProbeResult result;
+        await using (ProbeProgressReporter.Start(probeEndpoint))
+            result = await probe.ProbeAsync(entry, CancellationToken.None);
 
         if (!result.Success)
         {

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -197,8 +197,11 @@ internal static class ModelCommand
     /// </summary>
     private static string ResolveProbeEndpoint(IProviderProbe probe, ProviderEntry entry)
     {
+        // Match the normalization ExecuteProbeAsync applies (it trims a trailing slash
+        // before appending the model-listing path) so the surfaced endpoint is the one
+        // actually probed, not a cosmetically different string.
         if (!string.IsNullOrWhiteSpace(entry.Endpoint))
-            return entry.Endpoint;
+            return entry.Endpoint.TrimEnd('/');
 
         return probe is ProviderDescriptorRegistry registry
                && registry.TryGet(entry.Type, out var descriptor)

--- a/src/Netclaw.Cli/Model/ProbeProgressReporter.cs
+++ b/src/Netclaw.Cli/Model/ProbeProgressReporter.cs
@@ -11,7 +11,9 @@ namespace Netclaw.Cli.Model;
 /// hang (#1292). The ticker goes to <b>stderr</b> and is suppressed entirely when
 /// stderr is redirected, so piped stdout (the discovered-model table) stays clean and
 /// machine-parseable. Start it, run the probe inside the <c>await using</c> scope, and
-/// disposal stops the ticker and erases its line.
+/// disposal stops the ticker and erases its line. Best-effort by design: terminal I/O
+/// faults (window/SSH closed mid-probe) are swallowed so the ticker can never break the
+/// command or mask the probe's real result.
 /// </summary>
 internal sealed class ProbeProgressReporter : IAsyncDisposable
 {
@@ -19,55 +21,62 @@ internal sealed class ProbeProgressReporter : IAsyncDisposable
 
     private readonly CancellationTokenSource _cts = new();
     private readonly Task _loop;
-    private readonly TextWriter _err;
 
-    private ProbeProgressReporter(string endpoint, TextWriter err, TimeProvider time)
+    // Widest line drawn so far; read only after _loop completes (so no synchronization
+    // needed) to erase exactly what was written regardless of endpoint length.
+    private int _lastLineWidth;
+
+    private ProbeProgressReporter(string endpoint)
+        => _loop = RunAsync(endpoint, _cts.Token);
+
+    internal static ProbeProgressReporter Start(string endpoint) => new(endpoint);
+
+    private async Task RunAsync(string endpoint, CancellationToken ct)
     {
-        _err = err;
-        _loop = RunAsync(endpoint, time, _cts.Token);
-    }
-
-    internal static ProbeProgressReporter Start(
-        string endpoint, TextWriter? err = null, TimeProvider? time = null)
-        => new(endpoint, err ?? System.Console.Error, time ?? TimeProvider.System);
-
-    private async Task RunAsync(string endpoint, TimeProvider time, CancellationToken ct)
-    {
-        // Redirected stderr (pipes, CI, test harnesses) must not receive carriage-return
-        // animation — it would corrupt captured logs. The probe still runs; it just
-        // tracks elapsed time silently.
         if (System.Console.IsErrorRedirected)
             return;
 
-        var start = time.GetTimestamp();
+        var start = TimeProvider.System.GetTimestamp();
         try
         {
             while (true)
             {
-                await Task.Delay(TickInterval, time, ct);
-                var seconds = (int)time.GetElapsedTime(start).TotalSeconds;
-                await _err.WriteAsync($"\r  probing {endpoint} ... {seconds}s ");
-                await _err.FlushAsync(ct);
+                await Task.Delay(TickInterval, ct);
+                var seconds = (int)TimeProvider.System.GetElapsedTime(start).TotalSeconds;
+                var line = $"  probing {endpoint} ... {seconds}s";
+                _lastLineWidth = Math.Max(_lastLineWidth, line.Length);
+                await System.Console.Error.WriteAsync("\r" + line + " ");
+                await System.Console.Error.FlushAsync(ct);
             }
         }
-        catch (OperationCanceledException)
-        {
-            return; // probe completed (or was cancelled) — stop ticking
-        }
+        catch (OperationCanceledException) { return; } // probe completed — stop ticking
+        catch (IOException) { return; }                // terminal gone — ticker must not throw
     }
 
     public async ValueTask DisposeAsync()
     {
         _cts.Cancel();
-        await _loop;
-
-        if (!System.Console.IsErrorRedirected)
+        try
         {
-            // Erase the ticker line so the result prints on a clean row.
-            await _err.WriteAsync("\r" + new string(' ', 44) + "\r");
-            await _err.FlushAsync();
+            await _loop; // RunAsync swallows its own OCE/IO faults, so this won't throw.
+            EraseLine();
         }
+        finally
+        {
+            _cts.Dispose();
+        }
+    }
 
-        _cts.Dispose();
+    private void EraseLine()
+    {
+        if (System.Console.IsErrorRedirected || _lastLineWidth == 0)
+            return;
+        try
+        {
+            // Blank exactly the width we drew (+1 for the trailing space) so the result
+            // row prints clean no matter how long the endpoint was.
+            System.Console.Error.Write("\r" + new string(' ', _lastLineWidth + 1) + "\r");
+        }
+        catch (IOException) { return; } // terminal gone — nothing left to erase
     }
 }

--- a/src/Netclaw.Cli/Model/ProbeProgressReporter.cs
+++ b/src/Netclaw.Cli/Model/ProbeProgressReporter.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProbeProgressReporter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Cli.Model;
+
+/// <summary>
+/// Emits a live "probing … (Ns)" elapsed-time ticker while a provider probe is in
+/// flight, so a slow self-hosted server reads as "working, just slow" instead of a
+/// hang (#1292). The ticker goes to <b>stderr</b> and is suppressed entirely when
+/// stderr is redirected, so piped stdout (the discovered-model table) stays clean and
+/// machine-parseable. Start it, run the probe inside the <c>await using</c> scope, and
+/// disposal stops the ticker and erases its line.
+/// </summary>
+internal sealed class ProbeProgressReporter : IAsyncDisposable
+{
+    private static readonly TimeSpan TickInterval = TimeSpan.FromMilliseconds(250);
+
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _loop;
+    private readonly TextWriter _err;
+
+    private ProbeProgressReporter(string endpoint, TextWriter err, TimeProvider time)
+    {
+        _err = err;
+        _loop = RunAsync(endpoint, time, _cts.Token);
+    }
+
+    internal static ProbeProgressReporter Start(
+        string endpoint, TextWriter? err = null, TimeProvider? time = null)
+        => new(endpoint, err ?? System.Console.Error, time ?? TimeProvider.System);
+
+    private async Task RunAsync(string endpoint, TimeProvider time, CancellationToken ct)
+    {
+        // Redirected stderr (pipes, CI, test harnesses) must not receive carriage-return
+        // animation — it would corrupt captured logs. The probe still runs; it just
+        // tracks elapsed time silently.
+        if (System.Console.IsErrorRedirected)
+            return;
+
+        var start = time.GetTimestamp();
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(TickInterval, time, ct);
+                var seconds = (int)time.GetElapsedTime(start).TotalSeconds;
+                await _err.WriteAsync($"\r  probing {endpoint} ... {seconds}s ");
+                await _err.FlushAsync(ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return; // probe completed (or was cancelled) — stop ticking
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        await _loop;
+
+        if (!System.Console.IsErrorRedirected)
+        {
+            // Erase the ticker line so the result prints on a clean row.
+            await _err.WriteAsync("\r" + new string(' ', 44) + "\r");
+            await _err.FlushAsync();
+        }
+
+        _cts.Dispose();
+    }
+}

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -177,23 +177,13 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        var modelEntry = new Dictionary<string, object>
-        {
-            ["Provider"] = SelectedProvider,
-            ["ModelId"] = SelectedModelId,
-            ["Provenance"] = provenance.ToString()
-        };
-
-        if (discoveredModel?.ContextWindowTokens is { } contextWindow)
-            modelEntry["ContextWindow"] = contextWindow;
-
-        if (discoveredModel is not null)
-        {
-            modelEntry["InputModalities"] = discoveredModel.InputModalities.ToString();
-            modelEntry["OutputModalities"] = discoveredModel.OutputModalities.ToString();
-        }
-
-        modelsSection[roleKey] = modelEntry;
+        modelsSection[roleKey] = ModelEntryWriter.BuildModelEntry(
+            SelectedProvider,
+            SelectedModelId,
+            provenance,
+            discoveredModel?.ContextWindowTokens,
+            discoveredModel?.InputModalities,
+            discoveredModel?.OutputModalities);
         ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
 
         Refresh();

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -32,7 +32,6 @@ public enum ModelManagerState
 public sealed class ModelManagerViewModel : ReactiveViewModel
 {
     private const int MaxDisplayedModels = 30;
-    private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
@@ -325,8 +324,11 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
         try
         {
+            // Whole-probe wall-clock (covers pre-request work like OAuth token exchange);
+            // ProbeTimeouts.InteractiveWallClock stays above the descriptor's per-request
+            // deadline so it never truncates a legitimately slow self-hosted probe (#1292).
             result = await _probe.ProbeAsync(provider.Entry, ct)
-                .WaitAsync(ProbeHardTimeout, ct);
+                .WaitAsync(ProbeTimeouts.InteractiveWallClock, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -335,7 +337,7 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         catch (TimeoutException)
         {
             result = new ProviderProbeResult(false,
-                $"Validation timed out after {(int)ProbeHardTimeout.TotalSeconds} seconds. Check network connectivity and try again.", []);
+                $"Validation timed out after {(int)ProbeTimeouts.InteractiveWallClock.TotalSeconds} seconds. Check network connectivity and try again.", []);
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -72,7 +72,6 @@ public sealed class ProviderDisplayItem
 /// </summary>
 public sealed class ProviderManagerViewModel : ReactiveViewModel
 {
-    private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
 
     private readonly NetclawPaths _paths;
     private readonly ProviderDescriptorRegistry _registry;
@@ -901,8 +900,11 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
         try
         {
+            // Whole-probe wall-clock (covers pre-request work like OAuth token exchange);
+            // ProbeTimeouts.InteractiveWallClock stays above the descriptor's per-request
+            // deadline so it never truncates a legitimately slow self-hosted probe (#1292).
             result = await _probe.ProbeAsync(probeEntry, ct)
-                .WaitAsync(ProbeHardTimeout, ct);
+                .WaitAsync(ProbeTimeouts.InteractiveWallClock, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -911,7 +913,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         catch (TimeoutException)
         {
             result = new ProviderProbeResult(false,
-                $"Validation timed out after {(int)ProbeHardTimeout.TotalSeconds} seconds. Check network connectivity and try again.", []);
+                $"Validation timed out after {(int)ProbeTimeouts.InteractiveWallClock.TotalSeconds} seconds. Check network connectivity and try again.", []);
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -21,8 +21,6 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class ProviderStepViewModel : IWizardStepViewModel
 {
-    private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
-
     private readonly IProviderProbe _probe;
     private readonly ProviderDescriptorRegistry _registry;
     private readonly DeviceFlowServiceFactory? _oauthFactory;
@@ -178,17 +176,15 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
         var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
         try
         {
-            result = await _probe.ProbeAsync(probeEntry, ct)
-                .WaitAsync(ProbeHardTimeout, ct);
+            // One timeout authority: the descriptor's own probe deadline (longer for
+            // self-hosted servers). Do NOT wrap this in an outer WaitAsync — a second,
+            // longer deadline is silently preempted by the inner one, which used to make
+            // this step advertise a 20s budget while actually failing at 10s (#1292).
+            result = await _probe.ProbeAsync(probeEntry, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             result = new ProviderProbeResult(false, "Validation cancelled.", []);
-        }
-        catch (TimeoutException)
-        {
-            result = new ProviderProbeResult(false,
-                $"Validation timed out after {(int)ProbeHardTimeout.TotalSeconds} seconds.", []);
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -176,15 +176,25 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
         var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
         try
         {
-            // One timeout authority: the descriptor's own probe deadline (longer for
-            // self-hosted servers). Do NOT wrap this in an outer WaitAsync — a second,
-            // longer deadline is silently preempted by the inner one, which used to make
-            // this step advertise a 20s budget while actually failing at 10s (#1292).
-            result = await _probe.ProbeAsync(probeEntry, ct);
+            // Outer wall-clock for the WHOLE probe. The descriptor's own per-request
+            // deadline covers only the /models call; it does NOT cover pre-request work
+            // such as OAuth token exchange, which would otherwise be bounded only by the
+            // HttpClient default (~100s). This budget is deliberately larger than the
+            // descriptor's self-hosted deadline (see ProbeTimeouts.InteractiveWallClock)
+            // so it bounds a hung token exchange without truncating a legitimately slow
+            // self-hosted /models probe — the truncation that was the heart of #1292.
+            result = await _probe.ProbeAsync(probeEntry, ct)
+                .WaitAsync(ProbeTimeouts.InteractiveWallClock, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             result = new ProviderProbeResult(false, "Validation cancelled.", []);
+        }
+        catch (TimeoutException)
+        {
+            result = new ProviderProbeResult(false,
+                $"Validation timed out after {(int)ProbeTimeouts.InteractiveWallClock.TotalSeconds} seconds — "
+                + "the provider did not respond. Check connectivity and try again.", []);
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -92,29 +92,15 @@ public sealed class WizardConfigBuilder
         // Models section
         if (Model is not null)
         {
-            var modelEntry = new Dictionary<string, object>
-            {
-                ["Provider"] = Model.Provider
-            };
-
-            if (!string.IsNullOrWhiteSpace(Model.ModelId))
-                modelEntry["ModelId"] = Model.ModelId;
-
-            if (Model.ContextWindow is { } contextWindow)
-                modelEntry["ContextWindow"] = contextWindow;
-
-            if (Model.Provenance is { } provenance)
-                modelEntry["Provenance"] = provenance.ToString();
-
-            if (Model.InputModalities is { } inputModalities)
-                modelEntry["InputModalities"] = inputModalities.ToString();
-
-            if (Model.OutputModalities is { } outputModalities)
-                modelEntry["OutputModalities"] = outputModalities.ToString();
-
             config["Models"] = new Dictionary<string, object>
             {
-                ["Main"] = modelEntry
+                ["Main"] = ModelEntryWriter.BuildModelEntry(
+                    Model.Provider,
+                    Model.ModelId,
+                    Model.Provenance,
+                    Model.ContextWindow,
+                    Model.InputModalities,
+                    Model.OutputModalities)
             };
         }
 

--- a/src/Netclaw.Configuration.Tests/Providers/ProbeHelpersTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/ProbeHelpersTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Netclaw.Providers;
+using Netclaw.Providers.SelfHosted;
 using Netclaw.Tests.Utilities;
 using Xunit;
 
@@ -177,7 +178,74 @@ public class ProbeHelpersTests
         Assert.Contains("credentials may lack model-listing permissions", result.ErrorMessage);
     }
 
+    // ── ParseOpenAiStyleModels: never invent modalities (#1290) ──
+
+    [Fact]
+    public void ParseOpenAiStyleModels_OmitsModalities_LeavesThemUnset()
+    {
+        // An OpenAI-style /v1/models listing carries no modality field. Discovery must
+        // report "unknown" (null), NOT default to Text — a persisted Text override would
+        // permanently demote a multimodal self-hosted model to text-only.
+        var result = ProbeHelpers.ParseOpenAiStyleModels("""{"data":[{"id":"my-model"}]}""");
+
+        Assert.True(result.Success);
+        var model = Assert.Single(result.Models);
+        Assert.Equal("my-model", model.ModelId.Value);
+        Assert.Null(model.InputModalities);
+        Assert.Null(model.OutputModalities);
+    }
+
+    [Fact]
+    public void OpenAiCompatible_ParseModels_ReadsContextWindowButNotModalities()
+    {
+        var result = OpenAiCompatibleDescriptor.ParseModels(
+            """{"data":[{"id":"qwen-vl","max_model_len":32768}]}""");
+
+        var model = Assert.Single(result.Models);
+        Assert.Equal(32768, model.ContextWindowTokens);
+        Assert.Null(model.InputModalities);
+        Assert.Null(model.OutputModalities);
+    }
+
+    // ── ExecuteProbeAsync: one caller-supplied timeout, honest message (#1292) ──
+
+    [Fact]
+    public async Task ExecuteProbeAsync_WhenServerDoesNotRespond_TimesOutNamingTheEndpoint()
+    {
+        // The server accepts the connection but never answers. The probe must honor the
+        // supplied timeout (not a buried 10s constant) and report the actual endpoint so
+        // a wrong/blank target is visible rather than failing anonymously.
+        var httpClient = new HttpClient(new HangingHandler());
+
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai-compatible", "http://localhost:11434", "/v1/models",
+            "http://my-vllm:8000", _ => { }, ProbeHelpers.ParseOpenAiStyleModels,
+            CancellationToken.None, TimeSpan.FromMilliseconds(150));
+
+        Assert.False(result.Success);
+        Assert.Contains("No response from http://my-vllm:8000", result.ErrorMessage);
+        Assert.Contains("try again", result.ErrorMessage);
+        Assert.DoesNotContain("10 seconds", result.ErrorMessage!);
+    }
+
     // ── Helpers ──
+
+    /// <summary>
+    /// Accepts the request but never responds until the probe's own timeout cancels the
+    /// token. The cancellation IS the synchronization signal — there is no arbitrary
+    /// delay — so the test is deterministic, not timing-dependent.
+    /// </summary>
+    private sealed class HangingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<HttpResponseMessage>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+            return tcs.Task;
+        }
+    }
 
     private static HttpResponseMessage JsonErrorResponse(
         object body, HttpStatusCode status = HttpStatusCode.Forbidden)

--- a/src/Netclaw.Configuration/DiscoveredModel.cs
+++ b/src/Netclaw.Configuration/DiscoveredModel.cs
@@ -27,9 +27,20 @@ public sealed record DiscoveredModel
     /// <summary>Cost per million output tokens in USD, if known.</summary>
     public decimal? CostPerMillionOutputTokens { get; init; }
 
-    /// <summary>Content types the model accepts as input.</summary>
-    public ModelModality InputModalities { get; init; } = ModelModality.Text;
+    /// <summary>
+    /// Content types the model accepts as input, when the provider reported them.
+    /// <see langword="null"/> means the discovery source did not say — leave it
+    /// unset and let runtime capability detection resolve it. Do NOT default this
+    /// to <see cref="ModelModality.Text"/>: a silent "Text" is indistinguishable
+    /// from a genuinely text-only model and, once persisted, permanently
+    /// short-circuits detection for multimodal models (see #1290).
+    /// </summary>
+    public ModelModality? InputModalities { get; init; }
 
-    /// <summary>Content types the model can produce as output.</summary>
-    public ModelModality OutputModalities { get; init; } = ModelModality.Text;
+    /// <summary>
+    /// Content types the model can produce as output, when the provider reported
+    /// them. <see langword="null"/> means unknown — let runtime detection resolve
+    /// it rather than persisting a guessed default.
+    /// </summary>
+    public ModelModality? OutputModalities { get; init; }
 }

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
@@ -271,7 +271,10 @@ public sealed class OpenAiCodexTests
             Assert.Equal("gpt-live-codex", model.ModelId.Value);
             Assert.Equal(272000, model.ContextWindowTokens);
             Assert.Equal(ModelModality.Text | ModelModality.Image, model.InputModalities);
-            Assert.Equal(ModelModality.Text, model.OutputModalities);
+            // The catalog row omits output_modalities; discovery reports it as unknown
+            // (null) rather than guessing Text, so the daemon resolves it at runtime
+            // instead of a guess being persisted as a permanent override (#1290).
+            Assert.Null(model.OutputModalities);
 
             Assert.NotNull(capturedRequest);
             Assert.Equal(

--- a/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
@@ -161,15 +161,17 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
             if (inputModalities is null)
                 missingInputModalities.Add(id);
 
-            var outputModalities = ReadModalities(model, "output_modalities")
-                                    ?? ModelModality.Text;
-
+            // Pass modalities through exactly as reported. Do NOT substitute Text for an
+            // absent value: an unknown that gets persisted as Text becomes a permanent
+            // config override that beats real detection (#1290). Input is additionally
+            // guarded below — the probe fails if any model omits it — so what we persist
+            // is always provider-reported, never guessed.
             models.Add(new DiscoveredModel
             {
                 ModelId = new(id),
                 ContextWindowTokens = contextWindow,
-                InputModalities = inputModalities ?? ModelModality.Text,
-                OutputModalities = outputModalities,
+                InputModalities = inputModalities,
+                OutputModalities = ReadModalities(model, "output_modalities"),
             });
         }
 

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -14,20 +14,8 @@ namespace Netclaw.Providers;
 /// </summary>
 internal static class ProbeHelpers
 {
-    /// <summary>
-    /// Default probe deadline for hosted/cloud providers, which answer /models fast.
-    /// </summary>
-    internal static readonly TimeSpan DefaultProbeTimeout = TimeSpan.FromSeconds(10);
-
-    /// <summary>
-    /// Longer probe deadline for self-hosted endpoints (llama.cpp, vLLM, Ollama).
-    /// A cold server loading a model — or one saturated with inference requests — can
-    /// legitimately take far longer than a hosted API to answer /models. 10s is too
-    /// tight here and produces false "timed out" failures against servers that are
-    /// fine, just busy (see #1292). The descriptor that knows it is self-hosted owns
-    /// this choice; callers do not need to thread a timeout through every probe.
-    /// </summary>
-    internal static readonly TimeSpan SelfHostedProbeTimeout = TimeSpan.FromSeconds(30);
+    // Probe timeout budgets live in the shared ProbeTimeouts type so the providers
+    // layer and the interactive CLI/TUI callers cannot drift apart (see #1292).
 
     /// <summary>
     /// Parses the OpenAI-style model listing response (used by OpenRouter, Anthropic, OpenAI).
@@ -108,7 +96,7 @@ internal static class ProbeHelpers
         CancellationToken ct,
         TimeSpan? timeout = null)
     {
-        var effectiveTimeout = timeout ?? DefaultProbeTimeout;
+        var effectiveTimeout = timeout ?? ProbeTimeouts.Default;
 
         // Resolved up front so it is in scope for the timeout message below — a probe
         // that black-holes against a wrong/blank endpoint (e.g. a self-hosted provider

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -14,7 +14,20 @@ namespace Netclaw.Providers;
 /// </summary>
 internal static class ProbeHelpers
 {
-    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+    /// <summary>
+    /// Default probe deadline for hosted/cloud providers, which answer /models fast.
+    /// </summary>
+    internal static readonly TimeSpan DefaultProbeTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Longer probe deadline for self-hosted endpoints (llama.cpp, vLLM, Ollama).
+    /// A cold server loading a model — or one saturated with inference requests — can
+    /// legitimately take far longer than a hosted API to answer /models. 10s is too
+    /// tight here and produces false "timed out" failures against servers that are
+    /// fine, just busy (see #1292). The descriptor that knows it is self-hosted owns
+    /// this choice; callers do not need to thread a timeout through every probe.
+    /// </summary>
+    internal static readonly TimeSpan SelfHostedProbeTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Parses the OpenAI-style model listing response (used by OpenRouter, Anthropic, OpenAI).
@@ -92,18 +105,25 @@ internal static class ProbeHelpers
         string? entryEndpoint,
         Action<HttpRequestMessage> configureRequest,
         Func<string, ProviderProbeResult> parseResponse,
-        CancellationToken ct)
+        CancellationToken ct,
+        TimeSpan? timeout = null)
     {
+        var effectiveTimeout = timeout ?? DefaultProbeTimeout;
+
+        // Resolved up front so it is in scope for the timeout message below — a probe
+        // that black-holes against a wrong/blank endpoint (e.g. a self-hosted provider
+        // that fell back to the localhost default) should name that endpoint instead
+        // of failing anonymously.
+        var baseUrl = string.IsNullOrWhiteSpace(entryEndpoint)
+            ? defaultEndpoint
+            : entryEndpoint.TrimEnd('/');
+        var url = $"{baseUrl}{modelListingPath}";
+
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(ProbeTimeout);
+        timeoutCts.CancelAfter(effectiveTimeout);
 
         try
         {
-            var baseUrl = string.IsNullOrWhiteSpace(entryEndpoint)
-                ? defaultEndpoint
-                : entryEndpoint.TrimEnd('/');
-            var url = $"{baseUrl}{modelListingPath}";
-
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             configureRequest(request);
 
@@ -121,7 +141,9 @@ internal static class ProbeHelpers
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             return new ProviderProbeResult(false,
-                "Connection timed out after 10 seconds. Check that the endpoint is reachable.", []);
+                $"No response from {baseUrl} after {(int)effectiveTimeout.TotalSeconds}s. "
+                + "The server may be slow, loading a model, or unreachable — "
+                + "confirm it is up, then try again.", []);
         }
         catch (OperationCanceledException)
         {

--- a/src/Netclaw.Providers/ProbeTimeouts.cs
+++ b/src/Netclaw.Providers/ProbeTimeouts.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProbeTimeouts.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Providers;
+
+/// <summary>
+/// The single source of truth for provider-probe timeout budgets, shared across the
+/// providers layer (per-request deadlines) and the interactive CLI/TUI callers
+/// (whole-operation wall-clock). Centralized deliberately: these used to be
+/// hand-copied constants in each view model, and they drifted — raising one without
+/// the others let a stale outer deadline silently truncate a longer inner one (#1292).
+/// </summary>
+public static class ProbeTimeouts
+{
+    /// <summary>
+    /// Per-request deadline for hosted/cloud providers, which answer /models fast.
+    /// </summary>
+    public static readonly TimeSpan Default = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Per-request deadline for self-hosted endpoints (llama.cpp, vLLM, Ollama). A cold
+    /// server loading a model — or one saturated with inference requests — can
+    /// legitimately take far longer than a hosted API to answer /models, so 10s is too
+    /// tight and produces false "timed out" failures against servers that are fine,
+    /// just busy.
+    /// </summary>
+    public static readonly TimeSpan SelfHosted = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Wall-clock bound on a full interactive probe, applied by the wizard/TUI callers.
+    /// Unlike the per-request deadlines above (which the descriptor applies to the
+    /// /models HTTP call only), this also covers work the descriptor does <em>before</em>
+    /// that call — notably OAuth token exchange — which would otherwise be bounded only
+    /// by the HttpClient default (~100s).
+    /// <para>
+    /// MUST stay strictly greater than <see cref="SelfHosted"/>: if it ever drops below,
+    /// it preempts a legitimate slow self-hosted probe and re-creates the truncation bug.
+    /// </para>
+    /// </summary>
+    public static readonly TimeSpan InteractiveWallClock = TimeSpan.FromSeconds(45);
+}

--- a/src/Netclaw.Providers/SelfHosted/OllamaDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OllamaDescriptor.cs
@@ -41,7 +41,7 @@ public sealed class OllamaDescriptor : IProviderDescriptor
             configureRequest: _ => { }, // No auth headers needed
             parseResponse: ParseOllamaModels,
             ct,
-            timeout: ProbeHelpers.SelfHostedProbeTimeout);
+            timeout: ProbeTimeouts.SelfHosted);
     }
 
     private static ProviderProbeResult ParseOllamaModels(string json)

--- a/src/Netclaw.Providers/SelfHosted/OllamaDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OllamaDescriptor.cs
@@ -40,7 +40,8 @@ public sealed class OllamaDescriptor : IProviderDescriptor
             entry.Endpoint,
             configureRequest: _ => { }, // No auth headers needed
             parseResponse: ParseOllamaModels,
-            ct);
+            ct,
+            timeout: ProbeHelpers.SelfHostedProbeTimeout);
     }
 
     private static ProviderProbeResult ParseOllamaModels(string json)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
@@ -45,7 +45,7 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
             },
             ParseModels,
             ct,
-            ProbeTimeouts.SelfHosted);
+            timeout: ProbeTimeouts.SelfHosted);
     }
 
     internal static ProviderProbeResult ParseModels(string json)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
@@ -45,7 +45,7 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
             },
             ParseModels,
             ct,
-            ProbeHelpers.SelfHostedProbeTimeout);
+            ProbeTimeouts.SelfHosted);
     }
 
     internal static ProviderProbeResult ParseModels(string json)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
@@ -44,7 +44,8 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
                     request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
             },
             ParseModels,
-            ct);
+            ct,
+            ProbeHelpers.SelfHostedProbeTimeout);
     }
 
     internal static ProviderProbeResult ParseModels(string json)


### PR DESCRIPTION
Fixes #1290 and #1292. Both are symptoms of one pattern in the openai-compatible discovery → probe → persist pipeline: **a silent fallback ordered ahead of the source that should win.** Fixed on one shared write path.

## #1290 — modalities silently default to `Text`, then become a permanent override
- `DiscoveredModel.{Input,Output}Modalities` are now `ModelModality?` (default **null** = "provider didn't report it") instead of non-nullable defaulting to `Text`, so "unknown" is distinguishable from "known text-only".
- New shared `ModelEntryWriter.BuildModelEntry` is the single persist path; `model set`, the init wizard, and the TUI model manager all route through it and write modalities **only when known**. (Previously three hand-rolled copies — which is how the same bug landed in multiple places.)
- `ParseCodexModels` no longer substitutes `Text` for an absent `output_modalities`.
- Net effect: an openai-compatible/Ollama model persists **no** modalities → the daemon resolves real capabilities at runtime instead of being short-circuited by a baked-in `Text`.

## #1292 — probe blocks silently / hard-fails at 10s
- **Ordering bug:** the wizard stacked a 20s `.WaitAsync` over `ExecuteProbeAsync`'s inner 10s `CancelAfter`; the inner timeout returned a *normal* failed result first, so the outer deadline + its `TimeoutException` handler were dead code (advertised 20s, failed at 10s). The same 20s wrapper also lived in `ModelManagerViewModel` and `ProviderManagerViewModel`, where — after the self-hosted timeout was raised — it would have *truncated* the longer budget.
- Centralized all probe budgets in one `ProbeTimeouts` (Default 10s, SelfHosted 30s, InteractiveWallClock 45s, documented to stay > SelfHosted). Self-hosted descriptors use the 30s per-request budget; the three interactive callers apply the 45s wall-clock, which bounds pre-request work (e.g. OAuth token exchange) **without** truncating a slow `/models` probe.
- Honest timeout message that names the actual endpoint and reads "may be slow/loading" rather than a hard failure; `model discover`/`set` surface the endpoint being probed and an elapsed-time line.

## Review-driven follow-ups (2nd commit)
A max-effort review caught that the timeout de-stacking was initially incomplete (only the wizard) and that `ProbeProgressReporter` had disposal/erase issues; both addressed.

## Validation
- `Netclaw.Configuration.Tests` (366), `Netclaw.Cli.Tests` (787), `Netclaw.Daemon.Tests` provider/capability (100) — all pass. `dotnet slopwatch analyze`: 0 issues. Copyright headers verified.
- **Interactive smoke** (`init-wizard` tape, isolated Linux container): passes end-to-end. `netclaw doctor` reports `[PASS] Config Schema` and `[PASS] Context Window: Auto-detected 32,768 tokens for qwen2:0.5b (from running daemon)` — confirming the #1290 fix: with no modalities baked into config, the daemon resolves capabilities at runtime as intended.

## Not included
Cosmetic probe-spinner animation improvements were intentionally dropped from this PR and tracked separately.