### PR TITLE
chore(release): prepare v0.23.0-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,20 +8,50 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.22.1</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.22.1 — Quick bug-fix release on the heels of 0.22.0
+    <VersionPrefix>0.23.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
+    <PackageReleaseNotes>Netclaw v0.23.0-beta.1 — our first public beta, debuting the opt-in beta release channel itself
+
+This is a prerelease. Stable installs are unaffected — the default install, Docker `:latest`, and the GitHub "Latest" release all still point at 0.22.1, and only opt-in beta testers are ever offered this build.
+
+**Try the beta**
+
+* Linux / macOS: `curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta`
+* Windows: download `install.ps1`, then `./install.ps1 -Channel beta`
+* Docker: `docker pull ghcr.io/netclaw-dev/netclaw:beta`
+* To get update notices on the beta line, set `Daemon.UpdateChannel` to `beta` in your config.
+
+**Features**
+
+* **Opt-in beta release channel** — Netclaw can now publish and install prereleases without ever touching a default install. The release manifest gained an additive `latestPrerelease` pointer (newest of all releases) alongside `latest` (newest stable); `--channel beta` / `-Channel beta` and the rolling `:beta` Docker tag resolve to it, while stable clients structurally only ever read `latest`. ([#1314](https://github.com/netclaw-dev/netclaw/pull/1314))
+
+* **Channel-aware, SemVer-correct update check** — the binary update check now honors `Daemon.UpdateChannel` (`stable` default, or `beta`) and compares versions by SemVer 2.0.0 precedence. Beta testers are notified of the next prerelease and automatically roll onto a stable release once it supersedes their beta; stable users are never offered a prerelease. ([#1315](https://github.com/netclaw-dev/netclaw/pull/1315))
+
+* **Bounded tool output with file spill** — large tool outputs are now bounded and spilled to a file instead of flooding the session, keeping context lean while preserving the full output on disk. ([#1305](https://github.com/netclaw-dev/netclaw/pull/1305))
 
 **Bug Fixes**
 
-* **GitHub Copilot provider additions now persist** — the TUI provider manager was losing newly added Copilot providers between sessions. Additions now stick correctly. ([#1271](https://github.com/netclaw-dev/netclaw/pull/1271))
+* **Provider modality probing fixed** — Netclaw no longer persists guessed modalities, and the model-probe timeout and visibility issues are resolved. ([#1311](https://github.com/netclaw-dev/netclaw/pull/1311))
 
-* **OpenAI Codex models discovered live** — Netclaw can now probe the OpenAI API to discover Codex models at runtime, auto-populating context windows and modalities. No more waiting for a software update to access the latest Codex features. ([#1268](https://github.com/netclaw-dev/netclaw/pull/1268))
+* **OpenAI Codex calls no longer hang** — non-streaming Codex calls are now served via streaming under the hood, so they complete reliably. ([#1289](https://github.com/netclaw-dev/netclaw/pull/1289))
 
-* **ChatGPT OAuth account ID resolution restored** — the OAuth flow for ChatGPT providers was returning the wrong account identifier, breaking authentication. Fixed. ([#1263](https://github.com/netclaw-dev/netclaw/pull/1263))
+* **Docker reaps orphaned subprocesses** — the container now uses `tini` so orphaned subprocesses are reaped instead of accumulating as zombies; smoke setup was deduplicated. ([#1306](https://github.com/netclaw-dev/netclaw/pull/1306))
 
-* **Vision model images no longer dropped between turns** — when using vision-capable models, images attached via tool calls were being lost when crossing turn boundaries. Images now survive turn transitions properly. ([#1265](https://github.com/netclaw-dev/netclaw/pull/1265))
+* **Init wizard readiness race fixed** — init readiness is now gated on a daemon restart generation and a re-resolved endpoint, closing a race in the setup wizard. ([#1307](https://github.com/netclaw-dev/netclaw/pull/1307))
 
-* **CLI no longer crashes when daemon is offline** — attempting to chat while the Netclaw daemon was unreachable would crash the CLI. It now handles this gracefully and provides useful feedback. ([#1258](https://github.com/netclaw-dev/netclaw/pull/1258))</PackageReleaseNotes>
+* **Docker owns the daemon lifecycle** — the container is now the sole owner of the daemon lifecycle, fixing conflicting restart behavior. ([#1282](https://github.com/netclaw-dev/netclaw/pull/1282))
+
+* **Shell pipe reads are bounded** — pipe reads are now bounded to `MaxOutputChars` before truncating, preventing runaway memory on huge command output. ([#1298](https://github.com/netclaw-dev/netclaw/pull/1298))
+
+* **Shell verifies the working directory** — Netclaw confirms the working directory exists before launching a process, surfacing a clear error instead of a cryptic failure. ([#1299](https://github.com/netclaw-dev/netclaw/pull/1299))
+
+* **Lighter daemon memory footprint** — `netclawd` now uses Workstation GC, reducing baseline memory use. ([#1295](https://github.com/netclaw-dev/netclaw/pull/1295))
+
+* **Zero context-window models ignored** — models that report a zero context window are now ignored instead of breaking model selection. ([#1285](https://github.com/netclaw-dev/netclaw/pull/1285))
+
+* **Docker bind-mount ownership repaired** — bind-mount ownership is corrected on startup so mounted data is writable. ([#1281](https://github.com/netclaw-dev/netclaw/pull/1281))
+
+* **Windows installer uses User-scope PATH** — the Windows install instruction now updates the User-scope PATH so `netclaw` is found in new shells. ([#1274](https://github.com/netclaw-dev/netclaw/pull/1274))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,48 @@
+#### 0.23.0-beta.1 2026-06-03 ####
+
+Netclaw v0.23.0-beta.1 — our first public beta, debuting the opt-in beta release channel itself
+
+This is a prerelease. Stable installs are unaffected — the default install, Docker `:latest`, and the GitHub "Latest" release all still point at 0.22.1, and only opt-in beta testers are ever offered this build.
+
+**Try the beta**
+
+* Linux / macOS: `curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta`
+* Windows: download `install.ps1`, then `./install.ps1 -Channel beta`
+* Docker: `docker pull ghcr.io/netclaw-dev/netclaw:beta`
+* To get update notices on the beta line, set `Daemon.UpdateChannel` to `beta` in your config.
+
+**Features**
+
+* **Opt-in beta release channel** — Netclaw can now publish and install prereleases without ever touching a default install. The release manifest gained an additive `latestPrerelease` pointer (newest of all releases) alongside `latest` (newest stable); `--channel beta` / `-Channel beta` and the rolling `:beta` Docker tag resolve to it, while stable clients structurally only ever read `latest`. ([#1314](https://github.com/netclaw-dev/netclaw/pull/1314))
+
+* **Channel-aware, SemVer-correct update check** — the binary update check now honors `Daemon.UpdateChannel` (`stable` default, or `beta`) and compares versions by SemVer 2.0.0 precedence. Beta testers are notified of the next prerelease and automatically roll onto a stable release once it supersedes their beta; stable users are never offered a prerelease. ([#1315](https://github.com/netclaw-dev/netclaw/pull/1315))
+
+* **Bounded tool output with file spill** — large tool outputs are now bounded and spilled to a file instead of flooding the session, keeping context lean while preserving the full output on disk. ([#1305](https://github.com/netclaw-dev/netclaw/pull/1305))
+
+**Bug Fixes**
+
+* **Provider modality probing fixed** — Netclaw no longer persists guessed modalities, and the model-probe timeout and visibility issues are resolved. ([#1311](https://github.com/netclaw-dev/netclaw/pull/1311))
+
+* **OpenAI Codex calls no longer hang** — non-streaming Codex calls are now served via streaming under the hood, so they complete reliably. ([#1289](https://github.com/netclaw-dev/netclaw/pull/1289))
+
+* **Docker reaps orphaned subprocesses** — the container now uses `tini` so orphaned subprocesses are reaped instead of accumulating as zombies; smoke setup was deduplicated. ([#1306](https://github.com/netclaw-dev/netclaw/pull/1306))
+
+* **Init wizard readiness race fixed** — init readiness is now gated on a daemon restart generation and a re-resolved endpoint, closing a race in the setup wizard. ([#1307](https://github.com/netclaw-dev/netclaw/pull/1307))
+
+* **Docker owns the daemon lifecycle** — the container is now the sole owner of the daemon lifecycle, fixing conflicting restart behavior. ([#1282](https://github.com/netclaw-dev/netclaw/pull/1282))
+
+* **Shell pipe reads are bounded** — pipe reads are now bounded to `MaxOutputChars` before truncating, preventing runaway memory on huge command output. ([#1298](https://github.com/netclaw-dev/netclaw/pull/1298))
+
+* **Shell verifies the working directory** — Netclaw confirms the working directory exists before launching a process, surfacing a clear error instead of a cryptic failure. ([#1299](https://github.com/netclaw-dev/netclaw/pull/1299))
+
+* **Lighter daemon memory footprint** — `netclawd` now uses Workstation GC, reducing baseline memory use. ([#1295](https://github.com/netclaw-dev/netclaw/pull/1295))
+
+* **Zero context-window models ignored** — models that report a zero context window are now ignored instead of breaking model selection. ([#1285](https://github.com/netclaw-dev/netclaw/pull/1285))
+
+* **Docker bind-mount ownership repaired** — bind-mount ownership is corrected on startup so mounted data is writable. ([#1281](https://github.com/netclaw-dev/netclaw/pull/1281))
+
+* **Windows installer uses User-scope PATH** — the Windows install instruction now updates the User-scope PATH so `netclaw` is found in new shells. ([#1274](https://github.com/netclaw-dev/netclaw/pull/1274))
+
 #### 0.22.1 2026-06-01 ####
 
 Netclaw v0.22.1 — Quick bug-fix release on the heels of 0.22.0


### PR DESCRIPTION
First public **beta** — the very first exercise of the opt-in beta release channel shipped in #1314 / #1315.

## What this does
- `Directory.Build.props`: `VersionPrefix=0.23.0`, `VersionSuffix=beta.1`.
- `RELEASE_NOTES.md`: adds the `0.23.0-beta.1` section (top), which CI extracts as the GitHub prerelease body.

## After merge
Tag `0.23.0-beta.1` will be pushed to trigger `publish_release_binaries`. Expected beta-specific behavior:
- GitHub release marked **prerelease** (tag contains `-`).
- Docker gets **only** `:0.23.0-beta.1`, plus the rolling `:beta` retag — **not** `:latest` / `:major.minor`.
- Regenerated manifest: **`latest` stays `0.22.1`** (stable users unaffected), **`latestPrerelease` = `0.23.0-beta.1`**.

## Pre-flight (validated locally)
- CI version gate (prefix/suffix match + dotted-suffix convention): PASS.
- Release-notes extraction picks up the new top section: PASS.
- `generate-release-manifest.sh` dry-run against the live manifest: `latest=0.22.1`, `latestPrerelease=0.23.0-beta.1`.