### PR TITLE
fix(docker): don't crash on read-only /tools; writable on-PATH install dirs for non-root agent (0.23.0-beta.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,9 +22,9 @@ This is a prerelease on the beta channel. Stable installs are unaffected and rem
 
 **Bug Fixes**
 
-* **Container no longer crash-loops on a read-only `/tools` mount** — the bind-mount ownership repair added in 0.23.0-beta.1 (#1281) ran a recursive `chown` over `/tools` and aborted fatally when the mount was read-only, crash-looping the container. `/tools` is a PATH directory the agent only reads from, so the entrypoint now treats it as best-effort: it never recursively chowns it and never fails when it is read-only or already correctly owned. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+* **Container no longer crash-loops on a read-only `/tools` mount** — the bind-mount ownership repair added in 0.23.0-beta.1 (#1281) ran a recursive `chown` over `/tools` and aborted fatally when the mount was read-only, crash-looping the container. `/tools` is a PATH directory the agent only reads from, so the entrypoint now treats it as best-effort: it never recursively chowns it and never fails when it is read-only or already correctly owned. ([#1321](https://github.com/netclaw-dev/netclaw/pull/1321))
 
-* **Non-root agent can install tools at runtime again** — because the daemon runs as the unprivileged `netclaw` user it cannot write system `PATH` directories or `apt-get` without root. The image now ships user-writable, on-`PATH` install locations (`~/.local/bin`, `~/.dotnet`, `~/.dotnet/tools`, and a mounted `/tools/bin`) so a runtime-installed `dotnet`, `pip --user` tool, or .NET global tool resolves as a bare command in the agent's non-interactive shell. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+* **Non-root agent can install tools at runtime again** — because the daemon runs as the unprivileged `netclaw` user it cannot write system `PATH` directories or `apt-get` without root. The image now ships user-writable, on-`PATH` install locations (`~/.local/bin`, `~/.dotnet`, `~/.dotnet/tools`, and a mounted `/tools/bin`) so a runtime-installed `dotnet`, `pip --user` tool, or .NET global tool resolves as a bare command in the agent's non-interactive shell. ([#1321](https://github.com/netclaw-dev/netclaw/pull/1321))
 </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,49 +9,23 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.23.0</VersionPrefix>
-    <VersionSuffix>beta.1</VersionSuffix>
-    <PackageReleaseNotes>Netclaw v0.23.0-beta.1 — our first public beta, debuting the opt-in beta release channel itself
+    <VersionSuffix>beta.2</VersionSuffix>
+    <PackageReleaseNotes>Netclaw v0.23.0-beta.2 — beta channel fix release for non-root container deployments
 
-This is a prerelease. Stable installs are unaffected — the default install, Docker `:latest`, and the GitHub "Latest" release all still point at 0.22.1, and only opt-in beta testers are ever offered this build.
+This is a prerelease on the beta channel. Stable installs are unaffected and remain on 0.22.1; only opt-in beta testers are offered this build.
 
 **Try the beta**
 
 * Linux / macOS: `curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta`
 * Windows: download `install.ps1`, then `./install.ps1 -Channel beta`
 * Docker: `docker pull ghcr.io/netclaw-dev/netclaw:beta`
-* To get update notices on the beta line, set `Daemon.UpdateChannel` to `beta` in your config.
-
-**Features**
-
-* **Opt-in beta release channel** — Netclaw can now publish and install prereleases without ever touching a default install. The release manifest gained an additive `latestPrerelease` pointer (newest of all releases) alongside `latest` (newest stable); `--channel beta` / `-Channel beta` and the rolling `:beta` Docker tag resolve to it, while stable clients structurally only ever read `latest`. ([#1314](https://github.com/netclaw-dev/netclaw/pull/1314))
-
-* **Channel-aware, SemVer-correct update check** — the binary update check now honors `Daemon.UpdateChannel` (`stable` default, or `beta`) and compares versions by SemVer 2.0.0 precedence. Beta testers are notified of the next prerelease and automatically roll onto a stable release once it supersedes their beta; stable users are never offered a prerelease. ([#1315](https://github.com/netclaw-dev/netclaw/pull/1315))
-
-* **Bounded tool output with file spill** — large tool outputs are now bounded and spilled to a file instead of flooding the session, keeping context lean while preserving the full output on disk. ([#1305](https://github.com/netclaw-dev/netclaw/pull/1305))
 
 **Bug Fixes**
 
-* **Provider modality probing fixed** — Netclaw no longer persists guessed modalities, and the model-probe timeout and visibility issues are resolved. ([#1311](https://github.com/netclaw-dev/netclaw/pull/1311))
+* **Container no longer crash-loops on a read-only `/tools` mount** — the bind-mount ownership repair added in 0.23.0-beta.1 (#1281) ran a recursive `chown` over `/tools` and aborted fatally when the mount was read-only, crash-looping the container. `/tools` is a PATH directory the agent only reads from, so the entrypoint now treats it as best-effort: it never recursively chowns it and never fails when it is read-only or already correctly owned. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
 
-* **OpenAI Codex calls no longer hang** — non-streaming Codex calls are now served via streaming under the hood, so they complete reliably. ([#1289](https://github.com/netclaw-dev/netclaw/pull/1289))
-
-* **Docker reaps orphaned subprocesses** — the container now uses `tini` so orphaned subprocesses are reaped instead of accumulating as zombies; smoke setup was deduplicated. ([#1306](https://github.com/netclaw-dev/netclaw/pull/1306))
-
-* **Init wizard readiness race fixed** — init readiness is now gated on a daemon restart generation and a re-resolved endpoint, closing a race in the setup wizard. ([#1307](https://github.com/netclaw-dev/netclaw/pull/1307))
-
-* **Docker owns the daemon lifecycle** — the container is now the sole owner of the daemon lifecycle, fixing conflicting restart behavior. ([#1282](https://github.com/netclaw-dev/netclaw/pull/1282))
-
-* **Shell pipe reads are bounded** — pipe reads are now bounded to `MaxOutputChars` before truncating, preventing runaway memory on huge command output. ([#1298](https://github.com/netclaw-dev/netclaw/pull/1298))
-
-* **Shell verifies the working directory** — Netclaw confirms the working directory exists before launching a process, surfacing a clear error instead of a cryptic failure. ([#1299](https://github.com/netclaw-dev/netclaw/pull/1299))
-
-* **Lighter daemon memory footprint** — `netclawd` now uses Workstation GC, reducing baseline memory use. ([#1295](https://github.com/netclaw-dev/netclaw/pull/1295))
-
-* **Zero context-window models ignored** — models that report a zero context window are now ignored instead of breaking model selection. ([#1285](https://github.com/netclaw-dev/netclaw/pull/1285))
-
-* **Docker bind-mount ownership repaired** — bind-mount ownership is corrected on startup so mounted data is writable. ([#1281](https://github.com/netclaw-dev/netclaw/pull/1281))
-
-* **Windows installer uses User-scope PATH** — the Windows install instruction now updates the User-scope PATH so `netclaw` is found in new shells. ([#1274](https://github.com/netclaw-dev/netclaw/pull/1274))</PackageReleaseNotes>
+* **Non-root agent can install tools at runtime again** — because the daemon runs as the unprivileged `netclaw` user it cannot write system `PATH` directories or `apt-get` without root. The image now ships user-writable, on-`PATH` install locations (`~/.local/bin`, `~/.dotnet`, `~/.dotnet/tools`, and a mounted `/tools/bin`) so a runtime-installed `dotnet`, `pip --user` tool, or .NET global tool resolves as a bare command in the agent's non-interactive shell. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,9 +12,9 @@ This is a prerelease on the beta channel. Stable installs are unaffected and rem
 
 **Bug Fixes**
 
-* **Container no longer crash-loops on a read-only `/tools` mount** — the bind-mount ownership repair added in 0.23.0-beta.1 (#1281) ran a recursive `chown` over `/tools` and aborted fatally when the mount was read-only, crash-looping the container. `/tools` is a PATH directory the agent only reads from, so the entrypoint now treats it as best-effort: it never recursively chowns it and never fails when it is read-only or already correctly owned. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+* **Container no longer crash-loops on a read-only `/tools` mount** — the bind-mount ownership repair added in 0.23.0-beta.1 (#1281) ran a recursive `chown` over `/tools` and aborted fatally when the mount was read-only, crash-looping the container. `/tools` is a PATH directory the agent only reads from, so the entrypoint now treats it as best-effort: it never recursively chowns it and never fails when it is read-only or already correctly owned. ([#1321](https://github.com/netclaw-dev/netclaw/pull/1321))
 
-* **Non-root agent can install tools at runtime again** — because the daemon runs as the unprivileged `netclaw` user it cannot write system `PATH` directories or `apt-get` without root. The image now ships user-writable, on-`PATH` install locations (`~/.local/bin`, `~/.dotnet`, `~/.dotnet/tools`, and a mounted `/tools/bin`) so a runtime-installed `dotnet`, `pip --user` tool, or .NET global tool resolves as a bare command in the agent's non-interactive shell. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+* **Non-root agent can install tools at runtime again** — because the daemon runs as the unprivileged `netclaw` user it cannot write system `PATH` directories or `apt-get` without root. The image now ships user-writable, on-`PATH` install locations (`~/.local/bin`, `~/.dotnet`, `~/.dotnet/tools`, and a mounted `/tools/bin`) so a runtime-installed `dotnet`, `pip --user` tool, or .NET global tool resolves as a bare command in the agent's non-interactive shell. ([#1321](https://github.com/netclaw-dev/netclaw/pull/1321))
 
 #### 0.23.0-beta.1 2026-06-03 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+#### 0.23.0-beta.2 2026-06-03 ####
+
+Netclaw v0.23.0-beta.2 — beta channel fix release for non-root container deployments
+
+This is a prerelease on the beta channel. Stable installs are unaffected and remain on 0.22.1; only opt-in beta testers are offered this build.
+
+**Try the beta**
+
+* Linux / macOS: `curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta`
+* Windows: download `install.ps1`, then `./install.ps1 -Channel beta`
+* Docker: `docker pull ghcr.io/netclaw-dev/netclaw:beta`
+
+**Bug Fixes**
+
+* **Container no longer crash-loops on a read-only `/tools` mount** — the bind-mount ownership repair added in 0.23.0-beta.1 (#1281) ran a recursive `chown` over `/tools` and aborted fatally when the mount was read-only, crash-looping the container. `/tools` is a PATH directory the agent only reads from, so the entrypoint now treats it as best-effort: it never recursively chowns it and never fails when it is read-only or already correctly owned. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+
+* **Non-root agent can install tools at runtime again** — because the daemon runs as the unprivileged `netclaw` user it cannot write system `PATH` directories or `apt-get` without root. The image now ships user-writable, on-`PATH` install locations (`~/.local/bin`, `~/.dotnet`, `~/.dotnet/tools`, and a mounted `/tools/bin`) so a runtime-installed `dotnet`, `pip --user` tool, or .NET global tool resolves as a bare command in the agent's non-interactive shell. ([#PRNUM#](https://github.com/netclaw-dev/netclaw/pull/PRNUM#))
+
 #### 0.23.0-beta.1 2026-06-03 ####
 
 Netclaw v0.23.0-beta.1 — our first public beta, debuting the opt-in beta release channel itself

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,10 +43,18 @@ ARG NETCLAW_VERSION=unknown
 
 # Pre-install the general-purpose toolkit an autonomous agent is expected
 # to reach for via its shell_execute tool. An Ubuntu base (not a chiseled
-# runtime) is used deliberately so operators can `apt-get install`
-# additional tools at runtime for high-permissions use cases the agent
-# discovers on its own — the pre-installed set is what the agent should
-# have on hand without needing to install anything first.
+# runtime) is used deliberately so additional tools can be added at runtime
+# for high-permissions use cases the agent discovers on its own — the
+# pre-installed set is what the agent should have on hand without needing to
+# install anything first.
+#
+# NOTE: the daemon runs as the non-root `netclaw` user, so it cannot
+# `apt-get install` (no root) or write system PATH dirs at runtime. Agent-driven
+# runtime installs must target the user-writable, on-PATH locations created
+# below (~/.local/bin, ~/.dotnet, ~/.dotnet/tools) — e.g. `dotnet-install.sh`
+# defaults to ~/.dotnet, `pip install --user` lands in ~/.local/bin. System-wide
+# `apt-get install` remains an operator action (`docker exec -u root`, or baking
+# a derived image).
 #
 # Categories:
 #   TLS + HTTP:  ca-certificates, curl, wget
@@ -93,15 +101,24 @@ RUN chmod +x /opt/netclaw/cli/netclaw /opt/netclaw/daemon/netclawd /opt/netclaw/
 # The entrypoint starts as root only to repair bind-mount ownership, then
 # re-execs itself as this user before launching netclawd.
 # Pre-create the data and tools directories so image-owned paths inherit
-# correct ownership when operators use Docker named volumes.
+# correct ownership when operators use Docker named volumes. ~/.local/bin and
+# ~/.dotnet(/tools) are the user-writable, on-PATH targets for agent-driven
+# runtime tool installs (the daemon is non-root and cannot write system dirs).
 RUN groupadd --gid 1654 netclaw \
  && useradd --uid 1654 --gid netclaw --create-home netclaw \
  && mkdir -p /home/netclaw/.netclaw /tools \
- && chown -R netclaw:netclaw /home/netclaw/.netclaw /tools
+            /home/netclaw/.local/bin /home/netclaw/.dotnet/tools \
+ && chown -R netclaw:netclaw /home/netclaw/.netclaw /tools /home/netclaw/.local /home/netclaw/.dotnet
 
 ENV HOME=/home/netclaw
 ENV NETCLAW_HOME=/home/netclaw/.netclaw
 ENV NETCLAW_DAEMON_PATH=/opt/netclaw/daemon/netclawd
+# Make the user-writable install locations (and a mounted /tools/bin toolset)
+# resolve as bare commands in the non-root agent's non-interactive shells, which
+# never source ~/.bashrc/~/.profile. dotnet-install.sh -> ~/.dotnet; .NET global
+# tools -> ~/.dotnet/tools; pip --user -> ~/.local/bin; operator/init-container
+# toolsets mounted at /tools -> /tools/bin.
+ENV PATH=/home/netclaw/.local/bin:/home/netclaw/.dotnet:/home/netclaw/.dotnet/tools:/tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Block in-place binary self-update — the image tag IS the version.
 # Update availability checks still run so operators see when a new version exists.
 ENV NETCLAW_Daemon__DisableSelfUpdate=true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -47,12 +47,43 @@ ensure_runtime_ownership() {
     exit 1
 }
 
+# Best-effort accessibility for /tools — a PATH directory the agent only ever
+# READS and executes from, never writes. Unlike the data dir, /tools is commonly
+# supplied as a read-only mount carrying a large, pre-provisioned, immutable
+# toolset (e.g. a vendored .NET SDK). So this MUST NOT recursively chown it
+# (pointlessly expensive over thousands of files, and a guaranteed failure on a
+# read-only mount) and MUST NOT treat a read-only mount as fatal — doing so
+# crash-loops the container for a perfectly valid configuration. We only confirm
+# the runtime user can traverse and read it; if it happens to be writable we
+# opportunistically fix the top-level owner so a fresh named volume is usable.
+ensure_tools_accessible() {
+    local path="$1"
+
+    mkdir -p "$path" 2>/dev/null || true
+
+    if gosu "$NETCLAW_USER" test -r "$path" && gosu "$NETCLAW_USER" test -x "$path"; then
+        if [[ -w "$path" ]]; then
+            local owner
+            owner="$(stat -c '%u:%g' "$path" 2>/dev/null || true)"
+            [[ "$owner" == "${NETCLAW_UID}:${NETCLAW_GID}" ]] || \
+                chown "${NETCLAW_UID}:${NETCLAW_GID}" "$path" 2>/dev/null || true
+        fi
+        return 0
+    fi
+
+    echo "[entrypoint] WARN: $path is not readable/traversable by ${NETCLAW_USER} and is not writable (read-only mount?); continuing." >&2
+    echo "[entrypoint] Tools mounted there must be world-readable/executable, or pre-owned by uid/gid ${NETCLAW_UID}:${NETCLAW_GID}." >&2
+    return 0
+}
+
 if [[ "$(id -u)" == "0" ]]; then
     export HOME="$NETCLAW_USER_HOME"
     export NETCLAW_HOME="$NETCLAW_DATA_DIR"
 
+    # The data dir must be writable by the runtime user — fatal if we cannot
+    # deliver that. /tools only needs to be readable — never fatal (see above).
     ensure_runtime_ownership "$NETCLAW_DATA_DIR"
-    ensure_runtime_ownership /tools
+    ensure_tools_accessible /tools
 
     exec gosu "$NETCLAW_USER" "$0" "$@"
 fi


### PR DESCRIPTION
## Summary

Two regressions shipped in **0.23.0-beta.1** via the bind-mount ownership repair (#1281), both rooted in the daemon now running as the non-root `netclaw` user. This fixes both and bumps to **0.23.0-beta.2**.

### 1. Container crash-loops on a read-only `/tools` mount

The entrypoint ran `ensure_runtime_ownership /tools`, which does a recursive `chown -R 1654:1654 /tools` and `exit 1`s if it fails. When `/tools` is a **read-only** mount (a legitimate, common pattern: an immutable, pre-provisioned toolset such as a vendored .NET SDK), the `chown` fails with `EROFS` and the container crash-loops.

Observed in the wild (Kubernetes, `/tools` mounted `readOnly: true` from an init-container-populated volume):

```
[entrypoint] ERROR: failed to chown /tools for netclaw (1654:1654).
[entrypoint] If this is a read-only bind mount, make it writable or pre-create it with uid/gid 1654:1654.
```

**Fix:** `/tools` is a PATH directory the agent only ever *reads/executes* from — it never needs to own or write it. The new `ensure_tools_accessible` helper is best-effort: it never recursively chowns `/tools`, only confirms the runtime user can traverse+read it, opportunistically fixes the top-level owner *if* the mount is writable, and **never** exits fatally on a read-only mount. The writable data dir (`~/.netclaw`) keeps its existing strict, fatal ownership repair — that one genuinely must be writable.

### 2. Non-root agent can't install tools at runtime

Because the daemon dropped to non-root, it can't `apt-get` or write system `PATH` dirs (`/usr/local/bin`, `/usr/share/dotnet`). Worse, its non-interactive shells never source `~/.bashrc`/`~/.profile`, so an install into `~/.dotnet` wasn't resolvable as a bare command. Net effect: live tool installs (e.g. `dotnet-install.sh`) were effectively broken.

**Fix:** the image now pre-creates user-writable, on-`PATH` install locations and sets a default `PATH` that includes them:

- `~/.local/bin` (pip `--user`, generic)
- `~/.dotnet` + `~/.dotnet/tools` (`dotnet-install.sh` default + .NET global tools)
- `/tools/bin` (operator/init-container toolsets mounted at `/tools`)

A runtime-installed `dotnet` now resolves as a bare `dotnet` in the agent's shell, no PATH gymnastics required. The misleading Dockerfile comment about runtime `apt-get install` is corrected to reflect the non-root model.

## Why keep non-root at all?

Running an arbitrary-command agent as non-root is the right posture — it caps the blast radius of prompt-injection-driven command execution. These were implementation bugs in *how* the drop was rolled out, not a reason to revert it. This PR makes the non-root model actually usable.

## Changes

- `docker/entrypoint.sh` — `ensure_tools_accessible` for `/tools` (non-fatal, non-recursive); data dir repair unchanged.
- `docker/Dockerfile` — pre-create `~/.local/bin`, `~/.dotnet/tools`; default `PATH` includes the user-writable + `/tools/bin` locations; corrected runtime-install comment.
- `Directory.Build.props` + `RELEASE_NOTES.md` — version → `0.23.0-beta.2`.

## Test plan

- [ ] `validate_docker_image` smoke test passes (normal startup unaffected).
- [ ] Manual: mount `/tools` read-only → container starts (no crash), `WARN` logged instead of fatal.
- [ ] Manual: `dotnet-install.sh` into `~/.dotnet` → bare `dotnet --info` resolves in a non-interactive shell.

## Release

Tag `0.23.0-beta.2` after merge to fire `publish_release_binaries.yml` (builds binaries, creates the GitHub prerelease, moves the floating `:beta` Docker tag).