### PR TITLE
docs: beta/stable release process (Releasing runbook + Release Channel Rule)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,25 @@ auto-fix common schema validation errors. To ensure smooth upgrades for existing
 - When **removing** a property, no special action is needed — the resolver detects and
   removes properties disallowed by `additionalProperties: false`.
 
+## Release Channel Rule
+
+Releases are cut by pushing a git tag (full procedure: `CONTRIBUTING.md` → Releasing).
+Two conventions the release version gate enforces — violate them and the release fails:
+
+- The tag MUST match `Directory.Build.props`: `<VersionPrefix>` for a stable tag,
+  `<VersionPrefix>` + `<VersionSuffix>` for a prerelease.
+- Prerelease tags MUST use the **dotted** `beta.N` form (`0.23.0-beta.1`, never `beta1`).
+  A mixed identifier like `beta1` is one opaque token that SemVer orders lexically, so
+  `beta10` would rank below `beta2` — in the C# comparator *and* the manifest generator.
+
+A tag with a `-` is a prerelease: it becomes a GitHub prerelease and only advances the
+Docker `:beta` tag and the manifest `latestPrerelease`. A stable tag moves `:latest`,
+`:major.minor`, and the manifest `latest`. The C# `SemVer` comparator and the bash
+generator's `feeds/scripts/semver_key.py` are two implementations of one precedence rule
+kept in lockstep by a shared fixture (`feeds/scripts/semver-order.txt`) — change both
+(and the fixture) together if precedence ever changes. Never hand-edit the release
+manifest or installer feed.
+
 ## Universal Quality Bar
 
 - secure-by-default behavior for gateway and tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,3 +172,57 @@ Or point the CLI at the daemon binary explicitly:
 export NETCLAW_DAEMON_PATH="$PWD/out/netclawd"
 alias netclaw="$PWD/out/netclaw"
 ```
+
+## Releasing
+
+Releases are cut by pushing a git tag; `.github/workflows/publish_release_binaries.yml`
+does the rest (GitHub release, signed binary manifest + archives to R2, multi-arch Docker
+image, and the system skills feed). The pushed tag MUST match `Directory.Build.props` —
+`<VersionPrefix>` for a stable tag, and `<VersionPrefix>` + `<VersionSuffix>` for a
+prerelease — or the workflow's version gate fails the release.
+
+### Stable release
+
+1. Bump `<VersionPrefix>` in `Directory.Build.props` (e.g. `0.22.1` → `0.22.2`); leave
+   `<VersionSuffix>` empty.
+2. Add a release-notes section to `RELEASE_NOTES.md` (`#### X.Y.Z YYYY-MM-DD ####`).
+3. Commit, then tag and push the bare version:
+   ```bash
+   git tag 0.22.2 && git push origin 0.22.2
+   ```
+4. The workflow publishes a normal GitHub release, moves Docker `:latest` and
+   `:major.minor`, and sets the manifest `latest` pointer to the new version.
+
+### Beta / prerelease release
+
+Prereleases ship to opt-in testers without touching any stable surface.
+
+1. Set BOTH halves in `Directory.Build.props`:
+   ```xml
+   <VersionPrefix>0.23.0</VersionPrefix>
+   <VersionSuffix>beta.1</VersionSuffix>
+   ```
+   Use the **dotted** `beta.N` form (`beta.1`, `beta.2`, … `beta.10`) — never `beta1`.
+   A non-dotted identifier compares lexically (so `beta10` would rank below `beta2`), and
+   the release version gate rejects it.
+2. Add a `RELEASE_NOTES.md` section for `0.23.0-beta.1`.
+3. Commit, then tag and push the full version (prefix `-` suffix):
+   ```bash
+   git tag 0.23.0-beta.1 && git push origin 0.23.0-beta.1
+   ```
+4. The workflow detects the `-` and: marks the GitHub release a **prerelease**; pushes
+   only the exact-version Docker tag (leaving `:latest` / `:major.minor` on the newest
+   stable); and advances the rolling `:beta` tag and the manifest `latestPrerelease`
+   pointer.
+
+Testers opt in:
+
+```bash
+curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta   # -Channel beta on Windows
+docker pull ghcr.io/netclaw-dev/netclaw:beta
+NETCLAW_VERSION=0.23.0-beta.1 curl -sSL https://releases.netclaw.dev/install.sh | bash   # pin exact
+```
+
+When the matching stable ships, beta installs and `:beta` automatically roll onto it (the
+beta channel resolves to the newest of {stable, prerelease}). Stable installs are never
+offered a prerelease.


### PR DESCRIPTION
## Summary

Documents the release process (added by #1314 + #1315), which landed in code but whose
docs got stranded after #1315 merged. Doc-only — no code changes.

- **`CONTRIBUTING.md` → new "Releasing" section**: stable + beta/prerelease steps, the
  dotted `beta.N` tag convention, and what the workflow does for each (GitHub prerelease
  flag, Docker `:latest` vs `:beta`, `latest` vs `latestPrerelease`).
- **`AGENTS.md` → short "Release Channel Rule"**: the conventions the release version gate
  enforces (tag ↔ `VersionPrefix`/`VersionSuffix`; dotted `beta.N`) plus the
  C#-comparator ↔ bash-generator lockstep note, with the step-by-step kept in the runbook
  per the constitution's "keep it small" principle.

Relates to #1027 (closed by #1315).
