### PR TITLE
chore: release 0.23.0-beta.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.23.0</VersionPrefix>
-    <VersionSuffix>beta.3</VersionSuffix>
+    <VersionSuffix>beta.4</VersionSuffix>
     <PackageReleaseNotes>Netclaw v0.23.0-beta.3 — beta channel fix release for non-root container operations
 
 This is a prerelease on the beta channel. Stable installs are unaffected and remain on 0.22.1; only opt-in beta testers are offered this build.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,9 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.23.0</VersionPrefix>
+    <VersionPrefix>0.23.0-beta.4</VersionPrefix>
     <VersionSuffix>beta.4</VersionSuffix>
-    <PackageReleaseNotes>Netclaw v0.23.0-beta.3 — beta channel fix release for non-root container operations
+    <PackageReleaseNotes>Netclaw v0.23.0-beta.4 — streaming-native chat stack, composable routing, and spinner standardization
 
 This is a prerelease on the beta channel. Stable installs are unaffected and remain on 0.22.1; only opt-in beta testers are offered this build.
 
@@ -20,10 +20,13 @@ This is a prerelease on the beta channel. Stable installs are unaffected and rem
 * Windows: download `install.ps1`, then `./install.ps1 -Channel beta`
 * Docker: `docker pull ghcr.io/netclaw-dev/netclaw:beta`
 
+**Features**
+
+* **Streaming-native chat-client stack with composable routing** — the `IChatClient` stack has been redesigned so the streaming-vs-non-streaming transport distinction no longer leaks into callers. Netclaw now issues only streaming requests across all 8 providers, eliminating the OpenAI Codex `400 "Stream must be set to true"` error and preventing reasoning content drops on some providers. Resilience and observability are compositional via `Microsoft.Extensions.AI.ChatClientBuilder` — each (provider, model) pipeline is assembled as `Logging → Retry → VendorOptions → raw`. A `RoutingChatClient` walks ordered candidate lists for failover, and `LoggingChatClient` is now stateless with session-correlated log tags (`SessionId`). The transport-level retry policy is configurable via `Session:Tuning:StreamingRetryPolicy`, replacing the previous overlapping actor-level retry. ([#1313](https://github.com/netclaw-dev/netclaw/pull/1313))
+
 **Bug Fixes**
 
-* **`docker exec`/`kubectl exec -- netclaw` works again as root** — the daemon runs as the unprivileged `netclaw` user, but `exec` defaults to the image's root user, and `netclaw init` is invoked that way. A root-context CLI run extracted the .NET single-file bundle into a per-`$HOME` dir locked `root:root` (and wrote config root-owned), after which the non-root daemon could no longer run its own CLI (`Failed to create directory ... Error code: 13`). `/usr/local/bin/netclaw` is now a self-dropping launcher that re-execs as the `netclaw` user when invoked as root, so exec'd CLI usage just works on any orchestrator. See ADR-004; locked in by a standalone-`docker` regression test. ([#1322](https://github.com/netclaw-dev/netclaw/pull/1322))
-</PackageReleaseNotes>
+* **Standardized self-animating spinner across probe surfaces** — replaced five hand-rolled, drifted probe/validation spinners with Termina's shared `SpinnerNode` helper. Fixes the frozen ModelManager spinner, the ~1fps crawl on provider validation/probe spinners, and inconsistent animation cadence. Views now just drop in the spinner node — no per-surface tick field or hand-wired redraw subscription. ([#1312](https://github.com/netclaw-dev/netclaw/pull/1312), [#1327](https://github.com/netclaw-dev/netclaw/pull/1327))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+#### 0.23.0-beta.4 2026-06-04 ####
+
+Netclaw v0.23.0-beta.4 — streaming-native chat stack, composable routing, and spinner standardization
+
+This is a prerelease on the beta channel. Stable installs are unaffected and remain on 0.22.1; only opt-in beta testers are offered this build.
+
+**Try the beta**
+
+* Linux / macOS: `curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta`
+* Windows: download `install.ps1`, then `./install.ps1 -Channel beta`
+* Docker: `docker pull ghcr.io/netclaw-dev/netclaw:beta`
+
+**Features**
+
+* **Streaming-native chat-client stack with composable routing** — the `IChatClient` stack has been redesigned so the streaming-vs-non-streaming transport distinction no longer leaks into callers. Netclaw now issues only streaming requests across all 8 providers, eliminating the OpenAI Codex `400 "Stream must be set to true"` error and preventing reasoning content drops on some providers. Resilience and observability are compositional via `Microsoft.Extensions.AI.ChatClientBuilder` — each (provider, model) pipeline is assembled as `Logging → Retry → VendorOptions → raw`. A `RoutingChatClient` walks ordered candidate lists for failover, and `LoggingChatClient` is now stateless with session-correlated log tags (`SessionId`). The transport-level retry policy is configurable via `Session:Tuning:StreamingRetryPolicy`, replacing the previous overlapping actor-level retry. ([#1313](https://github.com/netclaw-dev/netclaw/pull/1313))
+
+**Bug Fixes**
+
+* **Standardized self-animating spinner across probe surfaces** — replaced five hand-rolled, drifted probe/validation spinners with Termina's shared `SpinnerNode` helper. Fixes the frozen ModelManager spinner, the ~1fps crawl on provider validation/probe spinners, and inconsistent animation cadence. Views now just drop in the spinner node — no per-surface tick field or hand-wired redraw subscription. ([#1312](https://github.com/netclaw-dev/netclaw/pull/1312), [#1327](https://github.com/netclaw-dev/netclaw/pull/1327))
+
 #### 0.23.0-beta.3 2026-06-04 ####
 
 Netclaw v0.23.0-beta.3 — beta channel fix release for non-root container operations


### PR DESCRIPTION
## What's New

Beta.4 introduces the new streaming-native chat-client stack with composable routing, plus spinner standardization.

### Features

- **Streaming-native chat-client stack with composable routing** — redesigned the `IChatClient` stack so streaming is the only transport path. Eliminates the Codex 400 error and prevents reasoning content drops. Uses `Microsoft.Extensions.AI.ChatClientBuilder` for compositional pipelines (`Logging → Retry → VendorOptions → raw`) with configurable `Session:Tuning:StreamingRetryPolicy`. ([#1313](https://github.com/netclaw-dev/netclaw/pull/1313))

### Bug Fixes

- **Standardized self-animating spinner across probe surfaces** — consolidated five hand-rolled spinners into Termina's shared `SpinnerNode`, fixing frozen/crawling spinners and inconsistent animation. ([#1312](https://github.com/netclaw-dev/netclaw/pull/1312), [#1327](https://github.com/netclaw-dev/netclaw/pull/1327))

### Other

- OpenSpec: archived 8 completed changes and synced delta specs ([#1325](https://github.com/netclaw-dev/netclaw/pull/1325))
- Docs: documented beta/stable release process ([#1323](https://github.com/netclaw-dev/netclaw/pull/1323))
- Bumped Aspire.Hosting.AppHost from 13.3.5 to 13.4.2 ([#1318](https://github.com/netclaw-dev/netclaw/pull/1318))