### PR TITLE
docs(providers): cite #648 at the chat-client routing seam

### DIFF
--- a/src/Netclaw.Configuration/ChatRoutingContext.cs
+++ b/src/Netclaw.Configuration/ChatRoutingContext.cs
@@ -8,8 +8,8 @@ namespace Netclaw.Configuration;
 /// <summary>
 /// The inputs a chat-client router uses to select which composed pipeline to invoke
 /// for a call. Minimal today — only <see cref="Role"/> is consulted — but shaped so
-/// per-session / per-provider routing slots in later as a new router policy without
-/// changing this type's shape or any caller.
+/// the per-role / per-agent / per-provider routing tracked in netclaw-dev/netclaw#648
+/// slots in later as a new router policy without changing this type's shape or any caller.
 /// </summary>
 public sealed record ChatRoutingContext
 {

--- a/src/Netclaw.Daemon/Configuration/ChatClientRouter.cs
+++ b/src/Netclaw.Daemon/Configuration/ChatClientRouter.cs
@@ -12,8 +12,9 @@ namespace Netclaw.Daemon.Configuration;
 /// Selects which composed chat-client pipeline(s) to invoke for a given routing
 /// context. Returns candidates in priority order; <see cref="RoutingChatClient"/>
 /// walks them, so failover is "the candidate list has more than one entry" rather
-/// than a bespoke decorator. The router is the seam where future per-session /
-/// per-provider routing slots in as a different policy.
+/// than a bespoke decorator. The router is the seam where the future per-role /
+/// per-agent / per-provider routing tracked in netclaw-dev/netclaw#648 slots in as
+/// a different policy.
 /// </summary>
 public interface IChatClientRouter
 {


### PR DESCRIPTION
## What

Comment-only change: cite **#648** (concurrent multi-model / multi-provider architecture for per-role and per-agent routing) at the two authoritative chat-client routing-seam locations — the `ChatRoutingContext` type and the `IChatClientRouter` interface.

## Why

The streaming-native chat-client stack (#1313, merged) introduced the routing seam — `IChatClientRouter.Route(ChatRoutingContext)` with failover as the first policy — explicitly as groundwork for the routing architecture #648 tracks. The seam comments already describe that future work ("per-session / per-provider routing slots in later as a new policy") but never linked the tracking issue, so the connection was discoverable only by reading the code.

This also keeps #648 coherent: that issue is written against `NetclawChatClientProvider`, which #1313 **deleted**. The seam a future contributor extends is now `IChatClientRouter` / `ChatRoutingContext` / `RoleBasedFailoverRouter`. Landing the citation in-code means whoever picks up #648 lands on the right seam.

## Scope

- **No behavior change** — doc comments only; build is clean (0 warnings).
- This establishes/links the **seam**, it does **not** implement #648's per-role / per-agent / per-session routing. Failover-as-first-policy is the only policy today.

Relates to #648 (and #1253, fast failover triggering).