### PR TITLE
chore: add .claude/worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,6 +423,7 @@ FodyWeavers.xsd
 
 # Claude worktree management
 .claude-wt/worktrees
+.claude/worktrees
 
 # Wrangler (Cloudflare CLI local state)
 .wrangler/


### PR DESCRIPTION
Fixes an issue where .claude/worktrees was not being ignored (.claude-wt/worktrees was already there but not the new path).