### PR TITLE
fix: correct version metadata for v0.23.0-beta.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.23.0-beta.5</VersionPrefix>
-    <VersionSuffix>beta.4</VersionSuffix>
+    <VersionPrefix>0.23.0</VersionPrefix>
+    <VersionSuffix>beta.5</VersionSuffix>
     <PackageReleaseNotes>Netclaw v0.23.0-beta.5 — shell approval pattern fix and MCP SDK bump
 
 This is a prerelease on the beta channel. Stable installs are unaffected and remain on 0.22.1; only opt-in beta testers are offered this build.


### PR DESCRIPTION
## What

Fix the build script producing wrong `Directory.Build.props` version metadata.

The release script was generating:
- `VersionPrefix`: `0.23.0-beta.5` (entire version string)
- `VersionSuffix`: `beta.4` (old value)

Should be:
- `VersionPrefix`: `0.23.0`
- `VersionSuffix`: `beta.5`

This caused the `Validate tag matches VersionPrefix/VersionSuffix` step in the release workflow to fail.

## Changes

- `Directory.Build.props`: correct `VersionPrefix` and `VersionSuffix`
