### PR TITLE
fix: prevent secret placeholder writeback on file read/write tools (#1333)

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -144,6 +144,97 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
+    public async Task File_read_preserves_secret_values_for_model()
+    {
+        var sessionDir = Path.Combine(Path.GetTempPath(), "nc-disp-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sessionDir);
+        try
+        {
+            // file_read suppresses output redaction so the model sees real
+            // content and can write it back without corrupting secrets (#1333).
+            var file = Path.Combine(sessionDir, "appsettings.json");
+            await File.WriteAllTextAsync(file,
+                """{"secretKey": "real-secret-value", "name": "myapp"}""",
+                CancellationToken.None);
+            var toolCall = new FunctionCallContent("call-secret", "file_read",
+                ToolInput.Create("Path", file));
+            var context = new Netclaw.Tools.ToolExecutionContext("slack/thread-1", sessionDir)
+            {
+                Audience = TrustAudience.Personal,
+            };
+
+            var result = await _executor.ExecuteAsync(toolCall, context, CancellationToken.None);
+
+            Assert.Contains("real-secret-value", result);
+            Assert.DoesNotContain("***REDACTED***", result);
+        }
+        finally
+        {
+            Directory.Delete(sessionDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Shell_output_still_redacts_secrets()
+    {
+        // Shell output continues to be redacted — only file tools suppress it.
+        var toolCall = new FunctionCallContent("call-shell-secret", "shell_execute",
+            ToolInput.Create("Command", "echo API_KEY=secret123"));
+        var context = new Netclaw.Tools.ToolExecutionContext("signalr/thread-1", null)
+        {
+            Audience = TrustAudience.Personal,
+        };
+
+        var result = await _executor.ExecuteAsync(toolCall, context, CancellationToken.None);
+
+        Assert.Contains("***REDACTED***", result);
+        Assert.DoesNotContain("secret123", result);
+    }
+
+    [Fact]
+    public async Task File_read_spill_file_is_redacted_even_when_model_result_is_not()
+    {
+        var sessionDir = Path.Combine(Path.GetTempPath(), "nc-disp-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sessionDir);
+        try
+        {
+            // Create a file with a secret that exceeds the shell's verbose
+            // budget so it spills. file_read uses the content budget (12000)
+            // so we need a bigger file. Use a custom executor with a small
+            // content budget to force a spill.
+            var file = Path.Combine(sessionDir, "big-config.json");
+            var bigContent = $$"""{"secretKey": "real-secret-value", "data": "{{new string('x', 15000)}}"}""";
+            await File.WriteAllTextAsync(file, bigContent, CancellationToken.None);
+
+            var toolCall = new FunctionCallContent("call-spill-secret", "file_read",
+                ToolInput.Create("Path", file));
+            var context = new Netclaw.Tools.ToolExecutionContext("slack/thread-1", sessionDir)
+            {
+                Audience = TrustAudience.Personal,
+                MaxInlineToolResultChars = 500,
+            };
+
+            var result = await _executor.ExecuteAsync(toolCall, context, CancellationToken.None);
+
+            // The inline result (model-facing) should NOT contain the redacted sentinel
+            Assert.DoesNotContain("***REDACTED***", result);
+            // But it should be truncated (spilled)
+            Assert.Contains("output saved to", result);
+
+            // The spill file on disk SHOULD be redacted
+            var spillPath = Path.Combine(sessionDir, "tool-calls", "call-spill-secret.log");
+            Assert.True(File.Exists(spillPath));
+            var spillContent = await File.ReadAllTextAsync(spillPath, CancellationToken.None);
+            Assert.Contains("***REDACTED***", spillContent);
+            Assert.DoesNotContain("real-secret-value", spillContent);
+        }
+        finally
+        {
+            Directory.Delete(sessionDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Content_tool_under_default_budget_not_spilled()
     {
         var sessionDir = Path.Combine(Path.GetTempPath(), "nc-disp-" + Guid.NewGuid().ToString("N"));

--- a/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
@@ -228,6 +228,30 @@ public class FileEditToolTests : IDisposable
         Assert.False(File.Exists(filePath));
     }
 
+    [Fact]
+    public async Task Content_and_NewString_are_mutually_exclusive()
+    {
+        var filePath = Path.Combine(_dir.Path, "conflict2.txt");
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create(
+            "Path", filePath, "Content", "full", "NewString", "new"), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("mutually exclusive", result);
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public async Task Content_and_ReplaceAll_are_mutually_exclusive()
+    {
+        var filePath = Path.Combine(_dir.Path, "conflict3.txt");
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create(
+            "Path", filePath, "Content", "full", "ReplaceAll", true), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("mutually exclusive", result);
+        Assert.False(File.Exists(filePath));
+    }
+
     private ToolExecutionContext CreatePersonalContext()
         => new("signalr/thread-1", _sessionDir)
         {

--- a/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
@@ -180,6 +180,54 @@ public class FileEditToolTests : IDisposable
             Assert.Contains($"slot{i} = EDITED;", content);
     }
 
+    // ── Full-write mode via Content parameter ──
+
+    [Fact]
+    public async Task Content_creates_new_file()
+    {
+        var filePath = Path.Combine(_dir.Path, "new-via-content.txt");
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "Content", "full write"), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Successfully wrote", result);
+        Assert.Equal("full write", await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Content_overwrites_existing_file()
+    {
+        var filePath = Path.Combine(_dir.Path, "existing.txt");
+        await File.WriteAllTextAsync(filePath, "old", TestContext.Current.CancellationToken);
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "Content", "new"), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Successfully wrote", result);
+        Assert.Equal("new", await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Content_creates_parent_directories()
+    {
+        var filePath = Path.Combine(_dir.Path, "sub", "dir", "deep.txt");
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "Content", "deep"), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Successfully wrote", result);
+        Assert.Equal("deep", await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Content_and_OldString_are_mutually_exclusive()
+    {
+        var filePath = Path.Combine(_dir.Path, "conflict.txt");
+
+        var result = await _tool.ExecuteAsync(ToolInput.Create(
+            "Path", filePath, "Content", "full", "OldString", "old", "NewString", "new"), CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("mutually exclusive", result);
+        Assert.False(File.Exists(filePath));
+    }
+
     private ToolExecutionContext CreatePersonalContext()
         => new("signalr/thread-1", _sessionDir)
         {

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -7,6 +7,7 @@ using Akka.Actor;
 using Akka.Event;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.SubAgents;
+using Netclaw.Security;
 
 namespace Netclaw.Actors.Sessions;
 
@@ -107,7 +108,7 @@ public sealed class SessionLogActor : ReceiveActor
             {
                 TextOutput text => $"Assistant: {TextTruncation.EllipsisAppend(text.Text, 1000)}",
                 ToolCallOutput toolCall => FormatToolCall(toolCall),
-                ToolResultOutput toolResult => $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {TextTruncation.EllipsisAppend(toolResult.Result, 1000)}",
+                ToolResultOutput toolResult => $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {TextTruncation.EllipsisAppend(SecretOutputRedactor.Redact(toolResult.Result), 1000)}",
                 ThinkingOutput thinking => $"Thinking: {TextTruncation.EllipsisAppend(thinking.Text, 1000)}",
                 ThinkingDeltaOutput thinkingDelta => $"Thinking delta: {TextTruncation.EllipsisAppend(thinkingDelta.Delta, 1000)}",
                 UsageOutput usage => $"Usage: in={usage.InputTokens} out={usage.OutputTokens} cached={usage.CachedInputTokens} reasoning={usage.ReasoningTokens} context={usage.UsagePercent:P0}",

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -149,12 +149,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor
                     yield return new ToolCompletedUpdate(modelResult);
                     break;
                 case ToolActivityUpdate { OutputChunk: not null } activity:
-                    yield return activity with
-                    {
-                        OutputChunk = tool.SuppressOutputRedaction
-                            ? activity.OutputChunk
-                            : SecretOutputRedactor.Redact(activity.OutputChunk)
-                    };
+                    yield return activity with { OutputChunk = SecretOutputRedactor.Redact(activity.OutputChunk) };
                     break;
                 default:
                     yield return update;

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -67,14 +67,21 @@ public sealed class DispatchingToolExecutor : IToolExecutor
                 ? await tool.ExecuteAsync(toolCall.Arguments, context, ct)
                 : await tool.ExecuteAsync(toolCall.Arguments, ct);
 
-            result = SecretOutputRedactor.Redact(result);
+            var redacted = SecretOutputRedactor.Redact(result);
+
+            // Tools that suppress output redaction (e.g. file_read) return the
+            // raw result to the model so read-modify-write cycles don't corrupt
+            // secret values with ***REDACTED*** placeholders. The spill file
+            // (persisted to disk) always uses the redacted version.
+            var modelFacing = tool.SuppressOutputRedaction ? result : redacted;
+
             // Single, uniform bounding+spill point for every tool (main session and
             // sub-agents both funnel through here): cap the inline result to the
             // tool's budget and, when it overflows, spill the full redacted result
             // to a session file and steer the model to read a slice. Tools only
             // bound their own capture for memory safety; they do not window or spill.
             result = await ToolOutputSpill.BoundAndSpillAsync(
-                result, toolCall.CallId, ResolveInlineBudget(tool, context), context, ct);
+                modelFacing, redacted, toolCall.CallId, ResolveInlineBudget(tool, context), context, ct);
 
             sw.Stop();
             _logger.LogInformation(
@@ -133,15 +140,21 @@ public sealed class DispatchingToolExecutor : IToolExecutor
                 case ToolCompletedUpdate completed:
                     sw.Stop();
                     var redacted = SecretOutputRedactor.Redact(completed.Result);
-                    redacted = await ToolOutputSpill.BoundAndSpillAsync(
-                        redacted, toolCall.CallId, ResolveInlineBudget(tool, context), context, ct);
+                    var modelResult = tool.SuppressOutputRedaction ? completed.Result : redacted;
+                    modelResult = await ToolOutputSpill.BoundAndSpillAsync(
+                        modelResult, redacted, toolCall.CallId, ResolveInlineBudget(tool, context), context, ct);
                     _logger.LogInformation(
                         "Tool executed: {ToolName} ({Duration}ms, {ResultLength} chars)",
-                        toolCall.Name, sw.ElapsedMilliseconds, redacted.Length);
-                    yield return new ToolCompletedUpdate(redacted);
+                        toolCall.Name, sw.ElapsedMilliseconds, modelResult.Length);
+                    yield return new ToolCompletedUpdate(modelResult);
                     break;
                 case ToolActivityUpdate { OutputChunk: not null } activity:
-                    yield return activity with { OutputChunk = SecretOutputRedactor.Redact(activity.OutputChunk) };
+                    yield return activity with
+                    {
+                        OutputChunk = tool.SuppressOutputRedaction
+                            ? activity.OutputChunk
+                            : SecretOutputRedactor.Redact(activity.OutputChunk)
+                    };
                     break;
                 default:
                     yield return update;

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -12,11 +12,14 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Makes targeted text replacements in an existing file without rewriting the entire file.
-/// Matches literal text (not regex). Fails if OldString is not found or is ambiguous.
+/// Edits files: targeted text replacement (OldString → NewString) or full content
+/// write (Content alone). When Content is supplied without OldString, the file is
+/// created or overwritten — this subsumes the former <c>file_write</c> tool.
 /// </summary>
 [NetclawTool(ToolName,
-    "Make targeted text replacements in an existing file without rewriting the entire file",
+    "Edit a file with targeted text replacement (OldString/NewString), or write entire content (Content). " +
+    "For targeted edits, matches literal text (not regex) and fails if OldString is not found or is ambiguous. " +
+    "For full writes, creates the file and parent directories if needed.",
     Grant = "file")]
 public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
 {
@@ -26,10 +29,11 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
 
     public record Params(
-        [property: Description("Absolute path to the file to edit")] string Path,
-        [property: Description("The exact text to find in the file")] string OldString,
-        [property: Description("The text to replace it with (must differ from OldString; use empty string to delete)")] string NewString,
-        [property: Description("Replace all occurrences instead of just the first (default: false)")] bool? ReplaceAll = null);
+        [property: Description("Absolute path to the file")] string Path,
+        [property: Description("The exact text to find in the file (omit when using Content for a full write)")] string? OldString = null,
+        [property: Description("The text to replace OldString with (must differ from OldString; use empty string to delete)")] string? NewString = null,
+        [property: Description("Replace all occurrences instead of just the first (default: false)")] bool? ReplaceAll = null,
+        [property: Description("Full content to write to the file, creating parent directories if needed. Mutually exclusive with OldString/NewString.")] string? Content = null);
 
     public FileEditTool(ToolPathPolicy? pathPolicy = null)
     {
@@ -51,13 +55,64 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
         if (string.IsNullOrWhiteSpace(args.Path))
             return "Error: 'Path' parameter is required.";
 
+        // Full-write mode: Content is supplied without OldString
+        if (args.Content is not null)
+        {
+            if (args.OldString is not null)
+                return "Error: 'Content' and 'OldString' are mutually exclusive. " +
+                       "Use Content for a full file write, or OldString/NewString for targeted replacement.";
+
+            return await WriteFileAsync(args.Path, args.Content, context, ct);
+        }
+
+        // Targeted edit mode: OldString → NewString
         if (string.IsNullOrEmpty(args.OldString))
-            return "Error: 'OldString' parameter is required and must not be empty.";
+            return "Error: either 'OldString' (for targeted edit) or 'Content' (for full write) is required.";
+
+        if (args.NewString is null)
+            return "Error: 'NewString' is required when using OldString for targeted replacement.";
 
         if (args.NewString == args.OldString)
             return "Error: 'NewString' must be different from 'OldString'.";
 
-        if (!_fileAccessPolicy.TryResolveWritePath(args.Path, context, out var authorizedPath, out var accessError))
+        return await EditFileAsync(args.Path, args.OldString, args.NewString, args.ReplaceAll == true, context, ct);
+    }
+
+    internal async Task<string> WriteFileAsync(string path, string content, ToolExecutionContext context, CancellationToken ct)
+    {
+        if (!_fileAccessPolicy.TryResolveWritePath(path, context, out var authorizedPath, out var accessError))
+            return accessError;
+
+        if (_pathPolicy?.IsDenied(authorizedPath) == true)
+            return FileToolErrors.ControlPlaneWriteDenied(authorizedPath);
+
+        try
+        {
+            var directory = System.IO.Path.GetDirectoryName(authorizedPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var bytes = Encoding.UTF8.GetBytes(content);
+
+            return await FileMutationGate.RunExclusiveAsync(authorizedPath, async () =>
+            {
+                await File.WriteAllBytesAsync(authorizedPath, bytes, ct);
+                return $"Successfully wrote {bytes.Length} bytes to {authorizedPath}";
+            }, ct);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return $"Error: Permission denied: {authorizedPath}";
+        }
+        catch (IOException ex)
+        {
+            return $"Error writing file: {ex.Message}";
+        }
+    }
+
+    private async Task<string> EditFileAsync(string path, string oldString, string newString, bool replaceAll, ToolExecutionContext context, CancellationToken ct)
+    {
+        if (!_fileAccessPolicy.TryResolveWritePath(path, context, out var authorizedPath, out var accessError))
             return accessError;
 
         if (_pathPolicy?.IsDenied(authorizedPath) == true)
@@ -74,8 +129,7 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
             {
                 var content = await File.ReadAllTextAsync(authorizedPath, Encoding.UTF8, ct);
 
-                var replaceAll = args.ReplaceAll == true;
-                var occurrences = CountOccurrences(content, args.OldString);
+                var occurrences = CountOccurrences(content, oldString);
 
                 if (occurrences == 0)
                     return $"Error: The specified text was not found in {authorizedPath}";
@@ -89,17 +143,16 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
 
                 if (replaceAll)
                 {
-                    newContent = content.Replace(args.OldString, args.NewString, StringComparison.Ordinal);
+                    newContent = content.Replace(oldString, newString, StringComparison.Ordinal);
                     replacementCount = occurrences;
                 }
                 else
                 {
-                    // Single replacement at first occurrence
-                    var index = content.IndexOf(args.OldString, StringComparison.Ordinal);
+                    var index = content.IndexOf(oldString, StringComparison.Ordinal);
                     newContent = string.Concat(
                         content.AsSpan(0, index),
-                        args.NewString,
-                        content.AsSpan(index + args.OldString.Length));
+                        newString,
+                        content.AsSpan(index + oldString.Length));
                     replacementCount = 1;
                 }
 

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -58,8 +58,8 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
         // Full-write mode: Content is supplied without OldString
         if (args.Content is not null)
         {
-            if (args.OldString is not null)
-                return "Error: 'Content' and 'OldString' are mutually exclusive. " +
+            if (args.OldString is not null || args.NewString is not null || args.ReplaceAll is not null)
+                return "Error: 'Content' and 'OldString'/'NewString'/'ReplaceAll' are mutually exclusive. " +
                        "Use Content for a full file write, or OldString/NewString for targeted replacement.";
 
             return await WriteFileAsync(args.Path, args.Content, context, ct);

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -33,6 +33,8 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     private static readonly Encoding StrictUtf32Be = new UTF32Encoding(bigEndian: true, byteOrderMark: true, throwOnInvalidCharacters: true);
     private static readonly Encoding Windows1252 = new Windows1252Encoding();
 
+    public override bool SuppressOutputRedaction => true;
+
     private readonly ToolConfig _config;
     private readonly ToolPathPolicy? _pathPolicy;
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -1,10 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="FileWriteTool.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using System.ComponentModel;
-using System.Text;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -12,7 +11,10 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Writes content to a file as UTF-8, creating parent directories if needed.
+/// Backward-compatible alias for <see cref="FileEditTool"/>'s full-write mode.
+/// Delegates to <see cref="FileEditTool.WriteFileAsync"/> so the write logic
+/// lives in one place. Registered under <c>file_write</c> so existing sessions,
+/// approval grants, and audience profiles continue to work.
 /// </summary>
 [NetclawTool(ToolName,
     "Write content to a file, creating parent directories if needed",
@@ -21,8 +23,7 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
 {
     public const string ToolName = "file_write";
 
-    private readonly ToolPathPolicy? _pathPolicy;
-    private readonly ScopedFileAccessPolicy _fileAccessPolicy;
+    private readonly FileEditTool _editTool;
 
     public record Params(
         [property: Description("Absolute path to the file to write")] string Path,
@@ -30,53 +31,22 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
 
     public FileWriteTool(ToolPathPolicy? pathPolicy = null)
     {
-        _pathPolicy = pathPolicy;
-        _fileAccessPolicy = new ScopedFileAccessPolicy(new ToolConfig());
+        _editTool = new FileEditTool(pathPolicy);
     }
 
     public FileWriteTool(ToolConfig config, ToolPathPolicy? pathPolicy = null)
     {
-        _pathPolicy = pathPolicy;
-        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+        _editTool = new FileEditTool(config, pathPolicy);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
         => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
 
-    protected override async Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    protected override Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return "Error: 'path' parameter is required.";
+            return Task.FromResult("Error: 'path' parameter is required.");
 
-        if (!_fileAccessPolicy.TryResolveWritePath(args.Path, context, out var authorizedPath, out var accessError))
-            return accessError;
-
-        if (_pathPolicy?.IsDenied(authorizedPath) == true)
-            return FileToolErrors.ControlPlaneWriteDenied(authorizedPath);
-
-        try
-        {
-            var directory = System.IO.Path.GetDirectoryName(authorizedPath);
-            if (!string.IsNullOrEmpty(directory))
-                Directory.CreateDirectory(directory);
-
-            var bytes = Encoding.UTF8.GetBytes(args.Content);
-
-            // Serialize with file_edit / other file_write calls on this path so
-            // a concurrent same-file write cannot clobber an in-flight edit.
-            return await FileMutationGate.RunExclusiveAsync(authorizedPath, async () =>
-            {
-                await File.WriteAllBytesAsync(authorizedPath, bytes, ct);
-                return $"Successfully wrote {bytes.Length} bytes to {authorizedPath}";
-            }, ct);
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return $"Error: Permission denied: {authorizedPath}";
-        }
-        catch (IOException ex)
-        {
-            return $"Error writing file: {ex.Message}";
-        }
+        return _editTool.WriteFileAsync(args.Path, args.Content, context, ct);
     }
 }

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -45,7 +45,7 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
     protected override Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return Task.FromResult("Error: 'path' parameter is required.");
+            return Task.FromResult("Error: 'Path' parameter is required.");
 
         return _editTool.WriteFileAsync(args.Path, args.Content, context, ct);
     }

--- a/src/Netclaw.Actors/Tools/ToolOutputSpill.cs
+++ b/src/Netclaw.Actors/Tools/ToolOutputSpill.cs
@@ -10,7 +10,7 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Bounds an already-redacted tool result to the inline budget <c>N</c>
+/// Bounds a tool result to the inline budget <c>N</c>
 /// (<see cref="ToolExecutionContext.MaxInlineToolResultChars"/>) and, when it
 /// exceeds <c>N</c>, spills the full result to
 /// <c>{SessionDirectory}/tool-calls/{toolCallId}.log</c> and steers the model to
@@ -19,12 +19,11 @@ namespace Netclaw.Actors.Tools;
 /// <remarks>
 /// Called from <c>DispatchingToolExecutor</c> for <i>every</i> tool, right after
 /// the central redaction — so bounding + spill happen once, uniformly, for the
-/// main session and sub-agents alike (both funnel through the dispatcher), and
-/// the spilled file is redacted for free. Tools only bound their own <i>capture</i>
-/// for memory safety; they do not window or spill. The input here is already
-/// redacted, so this method does NOT redact again. <c>file_read</c> keeps its
-/// result at or under <c>N</c> and steers to the original file, so it never spills
-/// here (its content is its own backing store).
+/// main session and sub-agents alike (both funnel through the dispatcher). Tools
+/// only bound their own <i>capture</i> for memory safety; they do not window or
+/// spill. The two-param overload accepts separate model-facing and spill content
+/// so that tools with <c>SuppressOutputRedaction</c> can return raw results to the
+/// model while still writing redacted content to the spill file on disk.
 /// </remarks>
 internal static class ToolOutputSpill
 {

--- a/src/Netclaw.Actors/Tools/ToolOutputSpill.cs
+++ b/src/Netclaw.Actors/Tools/ToolOutputSpill.cs
@@ -44,18 +44,30 @@ internal static class ToolOutputSpill
     /// resolves <paramref name="budget"/> from the tool's per-tool override or the
     /// session content budget.
     /// </summary>
-    public static async Task<string> BoundAndSpillAsync(
+    public static Task<string> BoundAndSpillAsync(
         string redactedResult, string? toolCallId, int budget, ToolExecutionContext? context, CancellationToken ct)
+        => BoundAndSpillAsync(modelFacingResult: redactedResult, spillContent: redactedResult,
+            toolCallId, budget, context, ct);
+
+    /// <summary>
+    /// Overload that separates the model-facing result from the spill content.
+    /// When a tool suppresses output redaction, <paramref name="modelFacingResult"/>
+    /// is the raw (unredacted) result while <paramref name="spillContent"/> is the
+    /// redacted version written to disk.
+    /// </summary>
+    public static async Task<string> BoundAndSpillAsync(
+        string modelFacingResult, string spillContent, string? toolCallId, int budget,
+        ToolExecutionContext? context, CancellationToken ct)
     {
         if (budget <= 0)
             budget = DefaultContentBudget;
 
-        if (redactedResult.Length <= budget)
-            return redactedResult;
+        if (modelFacingResult.Length <= budget)
+            return modelFacingResult;
 
-        var inline = BoundedOutputReader.Window(redactedResult, budget);
-        var spillPath = await TryWriteSpillAsync(redactedResult, toolCallId, context, ct);
-        return Compose(inline, spillPath, redactedResult.Length, budget);
+        var inline = BoundedOutputReader.Window(modelFacingResult, budget);
+        var spillPath = await TryWriteSpillAsync(spillContent, toolCallId, context, ct);
+        return Compose(inline, spillPath, modelFacingResult.Length, budget);
     }
 
     private static async Task<string?> TryWriteSpillAsync(

--- a/src/Netclaw.Tools.Abstractions/INetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/INetclawTool.cs
@@ -54,6 +54,15 @@ public interface INetclawTool
     /// </summary>
     int InlineOutputBudgetChars => 0;
 
+    /// <summary>
+    /// When <c>true</c>, the dispatcher skips <see cref="Netclaw.Security.SecretOutputRedactor"/>
+    /// on the result returned to the model. The spill file (if any) is still redacted.
+    /// Set this on tools whose output the model may need to write back verbatim
+    /// (e.g. file_read) — redacting their output corrupts the content on a
+    /// read-modify-write cycle.
+    /// </summary>
+    bool SuppressOutputRedaction => false;
+
     /// <summary>JSON Schema describing the tool's parameters.</summary>
     JsonElement ParameterSchema { get; }
 

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -129,6 +129,9 @@ public abstract partial class NetclawTool<TParams> : INetclawTool where TParams 
     /// </summary>
     public virtual int InlineOutputBudgetChars => 0;
 
+    /// <inheritdoc />
+    public virtual bool SuppressOutputRedaction => false;
+
     /// <summary>
     /// Deserialize raw LLM arguments into the typed params record.
     /// Implemented by the source generator to handle JsonElement and native CLR types.


### PR DESCRIPTION
## Summary

`SecretOutputRedactor` was replacing real secret values with `***REDACTED***` in `file_read` output before it reached the model. When the model wrote that content back via `file_write`/`file_edit`, the placeholders got persisted to disk, destroying real secrets in config files like `appsettings.json` (#1333).

The fix: redaction belongs on the observability path (spill files, session logs), not on the model-facing tool result. `FileReadTool` now opts out of model-facing redaction via a new `INetclawTool.SuppressOutputRedaction` flag while the dispatcher still writes redacted content to spill files on disk.

Separately, this consolidates `file_write` into `FileEditTool` as a `Content` parameter mode. `FileWriteTool` stays registered under the `file_write` tool name but delegates to `FileEditTool.WriteFileAsync`.

## Changes

`INetclawTool.SuppressOutputRedaction` (default `false`) tells `DispatchingToolExecutor` to skip `SecretOutputRedactor` on the result sent back to the model. `FileReadTool` sets it to `true`. The dispatcher computes both raw and redacted versions: raw goes to the model, redacted goes to `ToolOutputSpill` for the on-disk spill file. Streaming `ToolActivityUpdate` chunks always redact regardless of the flag since they're progressive display, not content the model writes back.

`FileEditTool.Params` picks up an optional `Content` parameter for full-file writes, mutually exclusive with `OldString`/`NewString`/`ReplaceAll`. The write logic lives in `FileEditTool.WriteFileAsync` (internal), and `FileWriteTool` delegates there so existing sessions, approval grants, and audience profiles keep working under the `file_write` name.

`SessionLogActor` now redacts `ToolResultOutput.Result` before writing to `session.log`, closing a leak where `SuppressOutputRedaction` would have put raw secrets into the observability log. Updated `ToolOutputSpill` doc comments to match the two-param overload.

## Test plan

- [ ] `File_read_preserves_secret_values_for_model` - reads file with secrets, verifies model result is unredacted
- [ ] `Shell_output_still_redacts_secrets` - verifies shell_execute output is still redacted
- [ ] `File_read_spill_file_is_redacted_even_when_model_result_is_not` - forces spill, verifies model sees raw content but spill file on disk is redacted
- [ ] `Content_creates_new_file`, `Content_overwrites_existing_file`, `Content_creates_parent_directories` - FileEditTool Content mode
- [ ] `Content_and_OldString_are_mutually_exclusive`, `Content_and_NewString_are_mutually_exclusive`, `Content_and_ReplaceAll_are_mutually_exclusive` - validation
- [ ] Full test suite: 2,203 Actors + 409 Config tests pass