### PR TITLE
fix(tui): reset model manager manual entry state

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -280,6 +280,84 @@ public sealed class ModelManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task StartDiscovery_ClearsStaleManualEntryBeforeRenderingProbeResults()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["Endpoint"] = "https://api.openai.com",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+        vm.ManualModelEntry = true;
+        vm.SelectedModelId = "manual-model";
+        vm.DiscoveredModels.Add(new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("stale-model") });
+
+        vm.StartDiscovery("my-openai");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.False(vm.ManualModelEntry);
+        Assert.Null(vm.SelectedModelId);
+        Assert.Equal(2, vm.DiscoveredModels.Count);
+    }
+
+    [Fact]
+    public async Task ManualEntry_DoesNotPersistAfterReturningToProviderSelection()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["big-gpu"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai-compatible",
+                    ["Endpoint"] = "http://localhost:8000"
+                },
+                ["openai"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["Endpoint"] = "https://api.openai.com",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+
+        _fakeProbe.NextResult = new ProviderProbeResult(true, null,
+        [
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-a") },
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-b") },
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-c") },
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-d") }
+        ]);
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+        vm.StartAssignment("Main");
+        vm.SelectProvider("openai");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        vm.ManualModelEntry = true;
+        vm.GoBack();
+        Assert.Equal(ModelManagerState.SelectProvider, vm.CurrentState.Value);
+
+        vm.SelectProvider("openai");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.False(vm.ManualModelEntry);
+        Assert.Equal(4, vm.DiscoveredModels.Count);
+    }
+
+    [Fact]
     public void ClearRole_Main_IsRejected()
     {
         using var vm = CreateViewModel();

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -305,6 +305,8 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         var stopwatch = Stopwatch.StartNew();
         Exception? probeException = null;
 
+        ManualModelEntry = false;
+        SelectedModelId = null;
         IsProbing.Value = true;
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;


### PR DESCRIPTION
## Summary
- reset stale manual model-entry state before each model provider probe
- add regressions for returning from manual entry to provider selection and for stale manual state before discovery results render

## Verification
- kubectl exec -n netclaw-support deploy/netclaw-support -- netclaw model discover openai
- dotnet test src/Netclaw.Cli.Tests --filter ManualEntry_DoesNotPersistAfterReturningToProviderSelection
- dotnet test src/Netclaw.Cli.Tests --filter ModelManager
- dotnet test src/Netclaw.Cli.Tests
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- git diff --check

## Note
The native smoke harness published binaries successfully but could not proceed because this environment lacks local Ollama and the harness attempted a sudo install without a password-capable TTY.