### PR TITLE
fix: interrupt active tool loops on user input

### DIFF
--- a/openspec/changes/interrupt-tool-loop-on-user-message/.openspec.yaml
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/interrupt-tool-loop-on-user-message/design.md
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/design.md
@@ -1,0 +1,116 @@
+## Context
+
+Netclaw session actors currently treat every inbound `SendUserMessage` during
+`Processing` as buffered work. That is correct while the actor is waiting for a
+normal turn to finish, but it is unsafe during an active tool-call continuation:
+after a tool result arrives, `LlmSessionActor` drains `_buffer`, appends those
+messages to `SessionState.History`, and fires another tool-enabled LLM call for
+the same turn.
+
+This creates a prompt shape where the user's correction or interruption is the
+latest user-role content, but the actor is still continuing an old tool loop.
+Small-model and strict ChatML templates can respond by acknowledging the
+correction and requesting another tool, which appears as repeated Slack preambles
+plus tool calls.
+
+The session actor already has persistence machinery for abandoned tool batches:
+`ToolBatchAbandoned`, `BuildToolBatchAbandonedEvent`,
+`ApplyToolBatchAbandoned`, and `ParkedToolBatchHistory.BuildSyntheticAbandonResults`.
+The fix should reuse those primitives instead of introducing a parallel
+interrupt persistence model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let a real user message interrupt an active tool-loop continuation.
+- Preserve provider-valid history by closing abandoned assistant tool calls with
+  synthetic tool results.
+- Start the interrupting message as a fresh turn with reset per-turn counters.
+- Prevent late callbacks from abandoned LLM/tool work from continuing the old
+  turn.
+- Preserve existing Slack preamble delivery behavior.
+
+**Non-Goals:**
+
+- Add a user-facing cancel command or UI button.
+- Change Slack delivery semantics for `TextOutput` or suppress preamble text.
+- Change tool approval policy or trust derivation.
+- Change restart-drain semantics; restart drain remains non-interruptible.
+
+## Decisions
+
+### Decision: interrupt instead of mid-loop drain
+
+When `Processing` receives a real `SendUserMessage` while the actor has an
+active tool continuation, the actor will treat it as an interrupt. It will not
+append the message into the current tool-loop history and will not call
+`FireLlmCall()` for the old turn after the interrupt.
+
+Alternative considered: defer `_buffer` until the current turn produces final
+text. That avoids the ChatML tail issue, but it prevents users from stopping a
+harmful or expensive tool loop mid-turn.
+
+### Decision: reuse `ToolBatchAbandoned`
+
+If an assistant tool-call message is open, the interrupt path will persist a
+`ToolBatchAbandoned` event with synthetic tool results for unanswered tool calls.
+This keeps history valid for providers that reject assistant tool calls without
+matching tool results.
+
+Alternative considered: delete or skip the open assistant tool call. That would
+make recovered history diverge from what happened and could corrupt auditability.
+
+### Decision: process the interrupting message as a fresh turn
+
+After abandonment/cleanup, the interrupting message will flow through the same
+fresh-turn path as a normal `Ready` message: source binding, trust derivation,
+per-turn counter reset, recall reset, and LLM invocation.
+
+Alternative considered: inject a system nudge into the existing turn telling the
+model to stop. The production failure mode already shows that adding tail input
+inside the active tool turn is the risky shape.
+
+### Decision: guard stale callbacks
+
+Cancellation is best-effort. The actor must also ignore late `LlmResponseReceived`,
+`ToolExecutionCompleted`, and batch completion callbacks that belong to abandoned
+work. The active call id and active batch tracking remain the boundary for what
+can advance the current turn.
+
+Alternative considered: rely only on cancellation tokens. That is insufficient
+because shell/tool work can finish after cancellation is requested and still
+send actor messages.
+
+## Risks / Trade-offs
+
+- [Risk] A late tool completion could be mistaken for current work and restart
+  the abandoned loop. -> Mitigation: clear active batch tracking during
+  abandonment and ignore completions that no longer match active expected call
+  ids.
+- [Risk] Approval recovery behavior could regress if the interrupt path clears
+  approval state too broadly. -> Mitigation: reuse `ApplyToolBatchAbandoned`,
+  which already clears pending/resolved approval state for abandoned tool
+  batches, and add regression coverage.
+- [Risk] Multiple user messages can arrive while interruption cleanup is running.
+  -> Mitigation: preserve existing buffering semantics after the first interrupt;
+  once cleanup completes, drain buffered messages as fresh-turn work, never as
+  the old tool continuation.
+- [Risk] A restarted actor could recover an interrupted assistant tool-call tail.
+  -> Mitigation: persisted `ToolBatchAbandoned` creates synthetic tool results
+  before the fresh user turn is processed.
+
+## Migration Plan
+
+No data migration is required. The change is additive behavior for live session
+processing. Existing persisted histories remain valid. Future interrupted tool
+batches will include synthetic abandon results in the journal.
+
+Rollback strategy: revert the actor behavior and tests. Persisted
+`ToolBatchAbandoned` events are already supported by current recovery code, so
+rollback does not require journal migration.
+
+## Open Questions
+
+None for MVP. If users later need explicit cancellation without sending a normal
+message, that should be a separate command/protocol change.

--- a/openspec/changes/interrupt-tool-loop-on-user-message/proposal.md
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Source PRDs: `PRD-001`, `PRD-009`.
+
+Netclaw must let operators interrupt an autonomous tool loop from Slack without
+turning that interruption into extra context for the still-active tool
+continuation. Production session `D0AC6CKBK5K/1780689744.134609` showed that
+mid-loop user corrections were buffered, drained into the same turn, and then
+followed by another tool-enabled LLM continuation, producing repeated preamble +
+tool-call cycles instead of a fresh response to the latest user instruction.
+
+## What Changes
+
+- Treat real user input received during an active tool-call continuation as an
+  interruption boundary, not as mid-loop context for the current turn.
+- Close or abandon any open assistant tool calls before the interrupting message
+  starts a fresh turn, preserving provider-valid tool-call/tool-result history.
+- Preserve existing buffering behavior for non-interruptible states such as
+  compaction and restart drain.
+- Ignore stale LLM/tool callbacks from abandoned work so they cannot restart the
+  interrupted loop.
+- Keep Slack preamble delivery behavior unchanged; repeated preambles are fixed
+  by stopping the old loop, not by suppressing user-visible text output.
+
+In scope for MVP: session actor turn-boundary behavior, persisted history
+integrity, regression tests, and eval coverage for interrupting tool loops.
+
+Out of scope for MVP: manual UI controls for cancelling turns, new transport
+protocol fields, global preamble suppression, or changes to approval policy.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `turn-loop-governance`: user input during an active tool loop interrupts the
+  current tool-enabled continuation instead of being appended inside it.
+- `netclaw-session`: persisted session history must remain well-formed when an
+  in-flight tool batch is interrupted by a new user message.
+- `session-state-machine`: `Processing` phase must distinguish normal tool-loop
+  continuation from user-message interruption and must not allow stale callbacks
+  from abandoned work to continue the prior turn.
+
+## Impact
+
+- Affected code:
+  - `src/Netclaw.Actors/Sessions/LlmSessionActor.cs`
+  - `src/Netclaw.Actors/Sessions/ActiveToolBatchTracker.cs` if additional stale
+    batch identity is needed
+  - session actor integration tests under `src/Netclaw.Actors.Tests/Sessions/`
+  - eval cases covering tool-loop interruption behavior
+- Security impact: positive. Authorized operator corrections can stop risky or
+  repetitive tool activity instead of being folded into the same tool loop.
+- Operational impact: Slack users can interrupt harmful or stale autonomous work
+  mid-turn; interrupted tool calls are recorded as abandoned rather than silently
+  orphaned.
+- Dependency impact: no new dependencies or external APIs.

--- a/openspec/changes/interrupt-tool-loop-on-user-message/specs/netclaw-session/spec.md
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/specs/netclaw-session/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Interrupted tool history remains provider-valid
+
+When a new user message interrupts an in-flight assistant tool-call batch, the
+session SHALL preserve provider-valid history by recording tool results for any
+assistant tool calls that would otherwise remain unanswered.
+
+Synthetic results MAY state that the tool call was abandoned because a new user
+message superseded the request. The session SHALL persist those synthetic
+results before processing the interrupting user message as a fresh turn.
+
+#### Scenario: Open tool calls are closed before fresh turn
+
+- **GIVEN** session history ends with an assistant message containing tool calls
+  that do not all have matching tool result messages
+- **WHEN** a new real user message interrupts that tool batch
+- **THEN** the session persists synthetic tool result messages for each
+  unanswered tool call
+- **AND** the interrupting user message is persisted or processed only after the
+  open tool calls are closed
+
+#### Scenario: Recovered interrupted history is valid
+
+- **GIVEN** a process restart occurs after an interrupting user message has
+  abandoned an in-flight tool batch
+- **WHEN** the session recovers from the journal
+- **THEN** no assistant tool-call message is recovered without matching tool
+  result messages
+- **AND** the session can process later turns without provider rejection caused
+  by orphaned tool calls

--- a/openspec/changes/interrupt-tool-loop-on-user-message/specs/session-state-machine/spec.md
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/specs/session-state-machine/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Processing distinguishes tool-loop interruption from buffering
+
+While in `Processing`, the session actor SHALL distinguish an active tool-loop
+continuation from other processing work. A real user message received during an
+active tool-loop continuation SHALL trigger interruption cleanup and fresh-turn
+processing rather than the normal mid-processing buffer drain path.
+
+Restart-drain processing remains non-interruptible. Compaction buffering remains
+unchanged.
+
+#### Scenario: Processing user message interrupts active tool batch
+
+- **GIVEN** the session actor is in `Processing`
+- **AND** an active tool batch or tool-loop continuation is associated with the
+  current turn
+- **WHEN** a real `SendUserMessage` is received
+- **THEN** the actor acknowledges the message
+- **AND** initiates interruption cleanup for the current tool loop
+- **AND** starts the received message through fresh-turn processing after cleanup
+
+#### Scenario: Stale callbacks cannot continue abandoned turn
+
+- **GIVEN** a user message has interrupted an active tool-loop continuation
+- **AND** the actor has cleared or abandoned the old active tool batch
+- **WHEN** a late LLM response or tool completion callback from the abandoned
+  work arrives
+- **THEN** the actor SHALL ignore the stale callback for turn-continuation
+  purposes
+- **AND** SHALL NOT call the LLM again for the abandoned turn
+
+#### Scenario: Restart drain remains non-interruptible
+
+- **GIVEN** a coordinated restart drain is pending while the session is in
+  `Processing`
+- **WHEN** a real `SendUserMessage` is received
+- **THEN** the actor SHALL preserve the existing restart-drain behavior
+- **AND** SHALL NOT start a fresh turn for that message

--- a/openspec/changes/interrupt-tool-loop-on-user-message/specs/turn-loop-governance/spec.md
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/specs/turn-loop-governance/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: User input interrupts active tool continuations
+
+When a real user message arrives while a session is continuing an active tool
+loop, the system SHALL treat that message as an interruption boundary rather
+than appending it into the current tool-loop continuation.
+
+The interrupted turn SHALL NOT perform another tool-enabled LLM continuation
+after the interrupting message has been accepted. The interrupting message SHALL
+start fresh-turn processing after the interrupted tool batch is closed or made
+inert.
+
+#### Scenario: User correction stops current tool loop
+
+- **GIVEN** a session turn is waiting for tool results after an assistant
+  response requested tools
+- **WHEN** a real user message arrives in the same session before the tool loop
+  has produced a final assistant response
+- **THEN** the session treats the new message as an interruption of the current
+  tool loop
+- **AND** the session does not append that message into the current tool-loop
+  continuation
+- **AND** the next LLM call processes the message as a fresh turn
+
+#### Scenario: Interrupted turn does not continue with tools
+
+- **GIVEN** a user message has interrupted an active tool loop
+- **WHEN** the actor finishes closing or abandoning the interrupted tool batch
+- **THEN** the actor SHALL NOT call the LLM again for the old turn with tools
+  enabled
+- **AND** any subsequent tool-enabled LLM call belongs to the fresh user turn

--- a/openspec/changes/interrupt-tool-loop-on-user-message/tasks.md
+++ b/openspec/changes/interrupt-tool-loop-on-user-message/tasks.md
@@ -1,0 +1,22 @@
+## 1. Actor Interruption Semantics
+
+- [x] 1.1 Add a `Processing`-phase interrupt path for real `SendUserMessage` commands received during an active tool-loop continuation.
+- [x] 1.2 Reuse `ToolBatchAbandoned` persistence to close unanswered assistant tool calls before fresh-turn processing starts.
+- [x] 1.3 Reset per-turn state and recall state before processing the interrupting message as a fresh turn.
+- [x] 1.4 Ensure late LLM/tool callbacks from abandoned work cannot continue the interrupted turn.
+
+## 2. Regression Tests
+
+- [x] 2.1 Add a session integration test proving an interrupting user message is not appended into the active tool-loop continuation.
+- [x] 2.2 Add a regression test proving the interrupting message starts a fresh turn after the old batch is abandoned.
+- [x] 2.3 Add stale callback coverage proving late tool completion cannot restart an abandoned tool loop.
+
+## 3. Documentation And Validation
+
+- [x] 3.1 Public session documentation reviewed; no update required because the public lifecycle description did not change.
+- [ ] 3.2 Add or update eval coverage for tool-loop interruption behavior.
+- [x] 3.3 Run focused actor tests for session/tool-loop behavior.
+- [ ] 3.4 Run `./evals/run-evals.sh`.
+- [x] 3.5 Run `dotnet slopwatch analyze` and `./scripts/Add-FileHeaders.ps1 -Verify`.
+
+Validation note: `./evals/run-evals.sh` was attempted twice against internal inference endpoints after provider details were supplied. The first run archived partial run `c0c0f07e-07c2-4f07-b369-0a086348f48e` and was stopped because the external inference service hung. The second run archived partial run `afaff694-ecd4-4db3-9ec6-2b91f26ded0c` and exceeded the 2-hour command timeout before the full suite completed.

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -12,6 +12,7 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
+using Netclaw.Tools;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Sessions;
@@ -116,6 +117,139 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         Assert.Single(_fakeAuditLogger.Entries);
         Assert.Equal("web_search", _fakeAuditLogger.Entries[0].ToolName.Value);
         Assert.True(_fakeAuditLogger.Entries[0].Allowed);
+    }
+
+    [Fact]
+    public async Task User_message_during_active_tool_continuation_interrupts_and_starts_fresh_turn()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "slow query" })
+        ];
+        _fakeToolExecutor.Results["web_search"] = "old tool result";
+        var toolStarted = new TaskCompletionSource<FunctionCallContent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var toolGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _fakeToolExecutor.NextExecutionStarted = toolStarted;
+        _fakeToolExecutor.ExecutionGate = toolGate;
+
+        var sessionId = new SessionId("test-channel/tool-interrupt");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("tool-interrupt-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Start the slow search"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("call-1", toolCall.CallId.Value);
+        Assert.Equal("call-1", (await toolStarted.Task.WaitAsync(TestContext.Current.CancellationToken)).CallId);
+
+        var ack = await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Stop searching. Answer this instead."
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        Assert.Equal(sessionId, ack.SessionId);
+
+        var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("[fake] Response #2", text.Text);
+        var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, completed.TurnNumber.Value);
+
+        Assert.Equal(2, _fakeChatClient.CallCount);
+        Assert.Equal(1, _fakeToolExecutor.CallCount);
+
+        var secondCallMessages = _fakeChatClient.ReceivedMessages[1];
+        Assert.Equal(
+            "Stop searching. Answer this instead.",
+            secondCallMessages.Last(m => m.Role == Microsoft.Extensions.AI.ChatRole.User).Text);
+        Assert.Contains(secondCallMessages, m =>
+            m.Role == Microsoft.Extensions.AI.ChatRole.Tool
+            && m.Contents.OfType<FunctionResultContent>().Any(r =>
+                r.Result?.ToString()?.Contains("interrupted by a new user message", StringComparison.Ordinal) ?? false));
+        Assert.DoesNotContain(secondCallMessages, m =>
+            m.Role == Microsoft.Extensions.AI.ChatRole.Tool
+            && m.Contents.OfType<FunctionResultContent>().Any(r =>
+                r.Result?.ToString()?.Contains("old tool result", StringComparison.Ordinal) ?? false));
+    }
+
+    [Fact]
+    public async Task Stale_tool_batch_completion_after_interrupt_is_ignored()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "slow query" })
+        ];
+        var toolStarted = new TaskCompletionSource<FunctionCallContent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var toolGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _fakeToolExecutor.NextExecutionStarted = toolStarted;
+        _fakeToolExecutor.ExecutionGate = toolGate;
+
+        var sessionId = new SessionId("test-channel/stale-tool-interrupt");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("stale-tool-interrupt-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Start the slow search"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("call-1", (await toolStarted.Task.WaitAsync(TestContext.Current.CancellationToken)).CallId);
+
+        var freshResponseGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _fakeChatClient.NextResponseGate = freshResponseGate;
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Stop searching. Answer this instead."
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        await AwaitAssertAsync(() => Assert.Equal(2, _fakeChatClient.CallCount),
+            TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        var child = await ResolveSessionActorAsync(sessionId);
+        child.Tell(new ToolExecutionCompleted
+        {
+            BatchId = 1,
+            ToolResults =
+            [
+                new SerializableChatMessage
+                {
+                    Role = Netclaw.Actors.Protocol.ChatRole.Tool,
+                    Content = "stale old tool result",
+                    ToolCallId = new ToolCallId("call-1"),
+                    Name = "web_search"
+                }
+            ]
+        });
+
+        freshResponseGate.SetResult();
+
+        var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("[fake] Response #2", text.Text);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(2, _fakeChatClient.CallCount);
     }
 
     [Fact]
@@ -335,6 +469,13 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         Assert.True(hasWorkingContextBlock,
             $"Expected turn 2's first LLM call to include a [working-context] block mentioning src/Rect.cs. All messages:\n{string.Join("\n---\n", allContent)}");
     }
+
+    private Task<IActorRef> ResolveSessionActorAsync(SessionId sessionId)
+    {
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        return Sys.ActorSelection($"/user/session-manager/{escapedId}")
+            .ResolveOne(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+    }
 }
 
 /// <summary>
@@ -352,6 +493,10 @@ internal sealed class FakeToolExecutor : IToolExecutor
     /// <summary>Tool names that should throw on execution.</summary>
     public HashSet<string> FailForTools { get; } = [];
 
+    public TaskCompletionSource<FunctionCallContent>? NextExecutionStarted { get; set; }
+
+    public TaskCompletionSource? ExecutionGate { get; set; }
+
     public Task AuthorizeAsync(FunctionCallContent toolCall, Netclaw.Tools.ToolExecutionContext? context = null, CancellationToken ct = default)
     {
         if (FailForTools.Contains(toolCall.Name))
@@ -367,6 +512,14 @@ internal sealed class FakeToolExecutor : IToolExecutor
         if (FailForTools.Contains(toolCall.Name))
         {
             throw new InvalidOperationException($"Tool '{toolCall.Name}' failed (simulated)");
+        }
+
+        NextExecutionStarted?.TrySetResult(toolCall);
+
+        if (ExecutionGate is { } gate)
+        {
+            using var registration = ct.Register(() => gate.TrySetCanceled(ct));
+            await gate.Task;
         }
 
         var result = Results.GetValueOrDefault(toolCall.Name, $"[fake result for {toolCall.Name}]");

--- a/src/Netclaw.Actors/Sessions/ActiveToolBatchTracker.cs
+++ b/src/Netclaw.Actors/Sessions/ActiveToolBatchTracker.cs
@@ -15,6 +15,8 @@ internal sealed class ActiveToolBatchTracker
 
     public int CompletedCount => _completedCallIds.Count;
 
+    public bool HasActiveBatch => _expectedCallIds.Count > 0;
+
     public bool HasAllResults => _expectedCallIds.Count > 0
         && _completedCallIds.Count >= _expectedCallIds.Count;
 
@@ -53,6 +55,9 @@ internal sealed class ActiveToolBatchTracker
 
     public void RecordCompleted(string callId)
         => _completedCallIds.Add(callId);
+
+    public bool ExpectsCall(string callId)
+        => _expectedCallIds.Contains(callId);
 
     public void MarkExecutionTaskCompleted()
         => ExecutionTaskCompleted = true;

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -73,6 +73,8 @@ internal sealed record LlmCallFailed(Exception Cause) : INoSerializationVerifica
 /// </summary>
 internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeeded
 {
+    public long BatchId { get; init; }
+
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
     public List<SerializableMediaReference> ModelInputMediaReferences { get; init; } = [];
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
@@ -80,9 +82,9 @@ internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeed
     public List<AcceptedSubAgentFinding> AcceptedSubAgentFindings { get; init; } = [];
 }
 
-internal sealed record ToolExecutionSingleCompleted(ToolCallResult Result) : INoSerializationVerificationNeeded;
+internal sealed record ToolExecutionSingleCompleted(ToolCallResult Result, long BatchId) : INoSerializationVerificationNeeded;
 
-internal sealed record ToolExecutionBatchCompleted : INoSerializationVerificationNeeded;
+internal sealed record ToolExecutionBatchCompleted(long BatchId) : INoSerializationVerificationNeeded;
 
 internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 {
@@ -124,6 +126,8 @@ internal sealed record AcceptedSubAgentFinding : INoSerializationVerificationNee
 /// </summary>
 internal sealed record ToolExecutionFailed : INoSerializationVerificationNeeded
 {
+    public long BatchId { get; init; }
+
     public required Exception Cause { get; init; }
 }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -143,6 +143,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // from cancelled calls are ignored when their CallId doesn't match.
     private long _activeCallId;
 
+    // Correlation ID for the active tool batch. Incremented when a batch starts
+    // and when a running batch is interrupted so late callbacks cannot advance
+    // a superseded turn.
+    private long _activeToolBatchId;
+
     // Tracks whether any content was streamed this call — selects the watchdog timeout
     // (the generous prefill budget before the first token vs the tighter inter-delta
     // budget after).
@@ -462,6 +467,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             _deliveryRetry.Clear();
+
+            if (ShouldInterruptActiveToolContinuation(cmd))
+            {
+                InterruptActiveToolContinuation(cmd);
+                return;
+            }
+
             _log.Info("Buffering user message (LLM call in progress)");
             _buffer.Add(cmd);
             TryReplyAck();
@@ -501,7 +513,22 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<ToolExecutionSingleCompleted>(msg =>
         {
+            if (!IsCurrentToolBatchCallback(msg.BatchId))
+            {
+                TurnLog().Info("turn_stale_tool_single_ignored batchId={BatchId} activeBatchId={ActiveBatchId}",
+                    msg.BatchId, _activeToolBatchId);
+                return;
+            }
+
             var result = msg.Result;
+            var callId = result.Message.ToolCallId?.Value;
+            if (callId is null || !_activeToolBatch.ExpectsCall(callId))
+            {
+                TurnLog().Info("turn_stale_tool_result_ignored batchId={BatchId} callId={CallId}",
+                    msg.BatchId, callId ?? "-");
+                return;
+            }
+
             Persist(new ToolCallRecorded
             {
                 SessionId = _sessionId,
@@ -515,8 +542,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             });
         });
 
-        Command<ToolExecutionBatchCompleted>(_ =>
+        Command<ToolExecutionBatchCompleted>(msg =>
         {
+            if (!IsCurrentToolBatchCallback(msg.BatchId))
+            {
+                TurnLog().Info("turn_stale_tool_batch_ignored batchId={BatchId} activeBatchId={ActiveBatchId}",
+                    msg.BatchId, _activeToolBatchId);
+                return;
+            }
+
             _watchdog.Stop(Timers);
             CancelAndDisposeToolExecutionCts();
             _activeToolBatch.MarkExecutionTaskCompleted();
@@ -527,6 +561,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<ToolExecutionFailed>(msg =>
         {
+            if (!IsCurrentToolBatchCallback(msg.BatchId))
+            {
+                TurnLog().Info("turn_stale_tool_failure_ignored batchId={BatchId} activeBatchId={ActiveBatchId}",
+                    msg.BatchId, _activeToolBatchId);
+                return;
+            }
+
             _watchdog.Stop(Timers);
             CancelAndDisposeToolExecutionCts();
             _pendingModelInputMediaReferences.Clear();
@@ -779,6 +820,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void HandleToolExecutionCompleted(ToolExecutionCompleted msg)
     {
+        if (!IsCurrentToolBatchCallback(msg.BatchId))
+        {
+            TurnLog().Info("turn_stale_tool_execution_ignored batchId={BatchId} activeBatchId={ActiveBatchId}",
+                msg.BatchId, _activeToolBatchId);
+            return;
+        }
+
         _watchdog.Stop(Timers);
         CancelAndDisposeToolExecutionCts();
 
@@ -1856,6 +1904,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         CancelAndDisposeToolExecutionCts();
         _activeToolExecutionCts = new CancellationTokenSource();
         var toolExecutionCt = _activeToolExecutionCts.Token;
+        var batchId = ++_activeToolBatchId;
 
         _ = SessionToolExecutionPipeline.ExecuteToolsAsync(executor, toolCalls, sessionId, _currentTurnSource, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput, spawnChildActor,
             approvalChannel: _approvalChannel,
@@ -1871,6 +1920,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             oneTimeApprovalPreSeed: oneTimeApprovalPreSeed,
             decisionOverride: decisionOverride,
             turnContext: _currentTurnContext,
+            batchId: batchId,
             ct: toolExecutionCt);
     }
 
@@ -1985,6 +2035,69 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         ClearApprovalTurnState();
         TransitionTo(SessionPhase.Ready);
+    }
+
+    private bool ShouldInterruptActiveToolContinuation(SendUserMessage cmd)
+        => IsRealUserMessage(cmd) && HasActiveToolContinuation();
+
+    private static bool IsRealUserMessage(SendUserMessage cmd)
+        => string.IsNullOrEmpty(cmd.Source?.ReminderId)
+           && string.IsNullOrEmpty(cmd.Source?.BackgroundJobId);
+
+    private bool HasActiveToolContinuation()
+        => _activeToolBatch.HasActiveBatch
+           || _turnState.ToolIterationCount > 0
+           || _pendingToolInteractions.Count > 0
+           || _resolvedToolApprovals.Count > 0;
+
+    private void InterruptActiveToolContinuation(SendUserMessage cmd)
+    {
+        TurnLog().Info(
+            "turn_tool_loop_interrupted_by_user_message iteration={Iteration} callCount={CallCount} activeBatchId={ActiveBatchId} pendingApprovals={PendingApprovals} resolvedApprovals={ResolvedApprovals}",
+            _turnState.ToolIterationCount,
+            _turnState.ToolCallCount,
+            _activeToolBatchId,
+            _pendingToolInteractions.Count,
+            _resolvedToolApprovals.Count);
+
+        _watchdog.Stop(Timers);
+        CancelAndDisposeLlmCts();
+        _activeCallId++;
+        CancelAndDisposeToolExecutionCts();
+        _activeToolBatchId++;
+        CompleteReminderInFlight(_currentTurnSource?.ReminderId);
+        CompleteBackgroundJobInFlight(_currentTurnSource?.BackgroundJobId);
+
+        var abandoned = BuildToolBatchAbandonedEvent(
+            "Tool call was not completed — the request was interrupted by a new user message.");
+        if (abandoned.ToolResults.Count > 0)
+        {
+            Persist(abandoned, evt =>
+            {
+                ApplyToolBatchAbandoned(evt);
+                StartFreshTurnAfterInterruptedToolLoop(cmd);
+            });
+            return;
+        }
+
+        ClearInterruptedToolContinuationState();
+        StartFreshTurnAfterInterruptedToolLoop(cmd);
+    }
+
+    private void ClearInterruptedToolContinuationState()
+    {
+        _pendingToolInteractions.Clear();
+        _resolvedToolApprovals.Clear();
+        ClearApprovalTurnState();
+        ClearActiveToolBatchTracking();
+    }
+
+    private void StartFreshTurnAfterInterruptedToolLoop(SendUserMessage cmd)
+    {
+        if (_currentPhase == SessionPhase.Processing)
+            TransitionTo(SessionPhase.Ready);
+
+        ContinueIncomingUserMessage(cmd);
     }
 
     private void HandleDeliveryFailedWhenReady(DeliveryFailed msg)
@@ -3328,6 +3441,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _activeToolBatch.Clear();
         _pendingModelInputMediaReferences.Clear();
     }
+
+    private bool IsCurrentToolBatchCallback(long batchId)
+        => batchId == _activeToolBatchId && _activeToolBatch.HasActiveBatch;
 
     private void MaybeSnapshot()
     {

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -94,6 +94,7 @@ internal static class SessionToolExecutionPipeline
         IReadOnlyDictionary<string, IReadOnlyList<string>>? oneTimeApprovalPreSeed = null,
         IReadOnlyDictionary<string, ApprovalDecision>? decisionOverride = null,
         TurnContext? turnContext = null,
+        long batchId = 0,
         CancellationToken ct = default)
     {
         try
@@ -138,14 +139,14 @@ internal static class SessionToolExecutionPipeline
                     turnContext,
                     modelInputBudget);
                 if (streamToolResults)
-                    self.Tell(new ToolExecutionSingleCompleted(result));
+                    self.Tell(new ToolExecutionSingleCompleted(result, batchId));
                 return result;
             });
             var results = await Task.WhenAll(tasks);
 
             if (streamToolResults)
             {
-                self.Tell(new ToolExecutionBatchCompleted());
+                self.Tell(new ToolExecutionBatchCompleted(batchId));
                 return;
             }
 
@@ -153,6 +154,7 @@ internal static class SessionToolExecutionPipeline
             var modelInputMediaReferences = results.SelectMany(r => r.ModelInputMediaReferences).ToList();
             self.Tell(new ToolExecutionCompleted
             {
+                BatchId = batchId,
                 ToolResults = [.. results.Select(r => r.Message)],
                 ModelInputMediaReferences = modelInputMediaReferences,
                 FileAttachments = fileAttachments,
@@ -162,12 +164,13 @@ internal static class SessionToolExecutionPipeline
         }
         catch (TimeoutException ex)
         {
-            self.Tell(new ToolExecutionFailed { Cause = ex });
+            self.Tell(new ToolExecutionFailed { BatchId = batchId, Cause = ex });
         }
         catch (OperationCanceledException ex)
         {
             self.Tell(new ToolExecutionFailed
             {
+                BatchId = batchId,
                 Cause = new TimeoutException(
                     $"Tool execution exceeded timeout of {timeout.TotalSeconds:F0}s",
                     ex)
@@ -175,7 +178,7 @@ internal static class SessionToolExecutionPipeline
         }
         catch (Exception ex)
         {
-            self.Tell(new ToolExecutionFailed { Cause = ex });
+            self.Tell(new ToolExecutionFailed { BatchId = batchId, Cause = ex });
         }
     }
 


### PR DESCRIPTION
## Summary

- Treat real user messages during active tool-loop continuation as interrupt boundaries instead of mid-loop buffered context.
- Persist synthetic abandoned tool results before processing the interrupting message as a fresh turn, preserving provider-valid history.
- Correlate tool callbacks with batch IDs so stale completions from abandoned work cannot restart the old loop.
- Add OpenSpec change artifacts and deterministic session/tool-loop regression tests.

## Validation

- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --no-restore --filter "FullyQualifiedName~ToolExecutionIntegrationTests"`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --no-restore --filter "FullyQualifiedName~MaxToolIterationTests|FullyQualifiedName~ToolLoopCompactionTests"`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --no-restore`
- `dotnet build --no-restore`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`

## Eval Attempts

- Full behavioral eval suite was attempted against one internal inference endpoint and stopped after the external service hung; partial archived run `c0c0f07e-07c2-4f07-b369-0a086348f48e`.
- Full behavioral eval suite was attempted against a second internal inference endpoint and exceeded the 2-hour command timeout before completion; partial archived run `afaff694-ecd4-4db3-9ec6-2b91f26ded0c`.

## Notes

- This fixes user interruption of an active tool loop.
- Issue #1346 appears to be a separate runaway ThinkingOnly/empty-response loop that does not require user interruption.
