### PR TITLE
refactor(media): image-egress review follow-up — value objects, probe result, dedup

### DIFF
--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -330,13 +330,7 @@ public sealed class SessionPipeline : ISessionPipeline
         {
             var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId, paths.SessionsDirectory);
             foreach (var data in dataContents)
-            {
-                var write = SessionMediaStore.WriteDataContent(data, sessionDir);
-                if (write.Reference is not null)
-                    mediaRefs.Add(write.Reference);
-                else if (write.DroppedReason is not null)
-                    content = SessionMediaStore.AppendOmittedImageNote(content, write.DroppedReason);
-            }
+                content = SessionMediaStore.WriteMediaInto(data, sessionDir, mediaRefs, content);
         }
 
         return new SendUserMessage

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -160,11 +160,7 @@ public static class ChatMessageConverter
                     break;
 
                 case DataContent data when sessionDir is not null:
-                    var write = SessionMediaStore.WriteDataContent(data, sessionDir);
-                    if (write.Reference is not null)
-                        mediaRefs.Add(write.Reference);
-                    else if (write.DroppedReason is not null)
-                        content = SessionMediaStore.AppendOmittedImageNote(content, write.DroppedReason);
+                    content = SessionMediaStore.WriteMediaInto(data, sessionDir, mediaRefs, content);
                     break;
             }
         }

--- a/src/Netclaw.Actors/Protocol/SessionMediaStore.cs
+++ b/src/Netclaw.Actors/Protocol/SessionMediaStore.cs
@@ -92,10 +92,26 @@ internal static class SessionMediaStore
     }
 
     /// <summary>
-    /// Appends a visible <c>[image omitted: reason]</c> note to a message's content
-    /// so a dropped image is surfaced to the model rather than vanishing silently.
+    /// Writes one media <see cref="DataContent"/> into session media and folds the
+    /// result into a message under construction: on success the reference is added to
+    /// <paramref name="references"/>; on a drop a visible <c>[image omitted: reason]</c>
+    /// note is appended to the content. Returns the (possibly updated) content. This is
+    /// the single place that owns "turn a DataContent into a reference or an omission
+    /// note", shared by the inbound (`ChannelPipeline`) and persistence
+    /// (`ChatMessageConverter`) paths.
     /// </summary>
-    public static string AppendOmittedImageNote(string content, string reason)
+    public static string WriteMediaInto(
+        DataContent data, string sessionDir, List<SerializableMediaReference> references, string content)
+    {
+        var write = WriteDataContent(data, sessionDir);
+        if (write.Reference is not null)
+            references.Add(write.Reference);
+        else if (write.DroppedReason is not null)
+            content = AppendOmittedImageNote(content, write.DroppedReason);
+        return content;
+    }
+
+    private static string AppendOmittedImageNote(string content, string reason)
     {
         var note = $"[image omitted: {reason}]";
         return string.IsNullOrEmpty(content) ? note : content + "\n" + note;

--- a/src/Netclaw.Cli/Doctor/ImageProcessingDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ImageProcessingDoctorCheck.cs
@@ -20,14 +20,14 @@ public sealed class ImageProcessingDoctorCheck : IDoctorCheck
 
     public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
     {
-        var error = ImageNormalizerProbe.TryProbe();
-        return Task.FromResult(error is null
+        var probe = ImageNormalizerProbe.Probe();
+        return Task.FromResult(probe.IsWorking
             ? DoctorCheckResult.Pass(
                 CheckName,
                 "Native imaging library loaded; image egress normalization is available.")
             : DoctorCheckResult.Error(
                 CheckName,
-                $"Native imaging library failed to load: {error}. Image attachments and file_read "
+                $"Native imaging library failed to load: {probe.Error}. Image attachments and file_read "
                 + "images cannot be bounded for model input.",
                 "This is a packaging regression — the SkiaSharp native library is missing from the "
                 + "binary. Reinstall from an official release; if building locally, publish via "

--- a/src/Netclaw.Media.Tests/ImageNormalizerProbeTests.cs
+++ b/src/Netclaw.Media.Tests/ImageNormalizerProbeTests.cs
@@ -14,6 +14,6 @@ public sealed class ImageNormalizerProbeTests
     {
         // Exercises the full encode → normalize round-trip against the real native
         // library. A non-null result here means a packaging/native-load regression.
-        Assert.Null(ImageNormalizerProbe.TryProbe());
+        Assert.True(ImageNormalizerProbe.Probe().IsWorking);
     }
 }

--- a/src/Netclaw.Media.Tests/ImageValueObjectTests.cs
+++ b/src/Netclaw.Media.Tests/ImageValueObjectTests.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// <copyright file="ImageValueObjectTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Media.Tests;
+
+public sealed class ImageValueObjectTests
+{
+    [Theory]
+    [InlineData(500, "500B")]            // sub-KiB stays bytes (guards the old "0MB" drop-message bug)
+    [InlineData(2048, "2KB")]
+    [InlineData(5 * 1024 * 1024, "5MB")]
+    public void ByteSize_formats_human_readable(int bytes, string expected)
+        => Assert.Equal(expected, new ByteSize(bytes).ToString());
+}

--- a/src/Netclaw.Media.Tests/SkiaImageNormalizerTests.cs
+++ b/src/Netclaw.Media.Tests/SkiaImageNormalizerTests.cs
@@ -36,7 +36,7 @@ public sealed class SkiaImageNormalizerTests
         // 1400px is within the long-edge cap, so there's nothing to resize. We won't
         // transcode or quality-shrink to force a fit — so an over-budget image is dropped.
         var src = GenerateImage(1400, 1400, SKEncodedImageFormat.Png);
-        var options = new ImageNormalizationOptions { MaxBase64Bytes = 40_000 };
+        var options = new ImageNormalizationOptions { MaxBase64 = new ByteSize(40_000) };
 
         var result = _normalizer.Normalize(src, options);
 
@@ -95,7 +95,7 @@ public sealed class SkiaImageNormalizerTests
         // Oversized in dimension AND a tiny budget: it resizes to the cap but the PNG
         // still can't fit 500 bytes, and we won't transcode/quality-shrink — so it drops.
         var src = GenerateImage(2000, 2000, SKEncodedImageFormat.Png);
-        var options = new ImageNormalizationOptions { MaxBase64Bytes = 500 };
+        var options = new ImageNormalizationOptions { MaxBase64 = new ByteSize(500) };
 
         var result = _normalizer.Normalize(src, options);
 
@@ -145,7 +145,7 @@ public sealed class SkiaImageNormalizerTests
     [Fact]
     public void Gif_over_budget_is_dropped_not_transcoded()
     {
-        var options = new ImageNormalizationOptions { MaxBase64Bytes = 8 }; // smaller than any GIF
+        var options = new ImageNormalizationOptions { MaxBase64 = new ByteSize(8) }; // smaller than any GIF
 
         var result = _normalizer.Normalize(MinimalGif, options);
 

--- a/src/Netclaw.Media/ImageNormalization.cs
+++ b/src/Netclaw.Media/ImageNormalization.cs
@@ -6,6 +6,32 @@
 namespace Netclaw.Media;
 
 /// <summary>
+/// A pixel count — an image dimension or a dimension cap. A distinct type so a pixel
+/// value can never be silently passed where a byte size is expected (and vice versa).
+/// Access the underlying <see cref="Value"/> explicitly; there is no implicit conversion.
+/// </summary>
+public readonly record struct Pixels(int Value)
+{
+    public override string ToString() => $"{Value}px";
+}
+
+/// <summary>
+/// A size in bytes — an encoded payload or a payload budget. Distinct from
+/// <see cref="Pixels"/> so the two can't be confused at a call site.
+/// </summary>
+public readonly record struct ByteSize(int Value)
+{
+    public override string ToString() =>
+        Value >= 1024 * 1024 ? $"{Value / (1024 * 1024)}MB"
+        : Value >= 1024 ? $"{Value / 1024}KB"
+        : $"{Value}B";
+}
+
+/// <summary>JPEG encoder quality, 1–100. A distinct type so it isn't mistaken for a
+/// pixel or byte count among the other numeric options.</summary>
+public readonly record struct JpegQuality(int Value);
+
+/// <summary>
 /// Outcome of running an image through <see cref="IImageNormalizer"/>.
 /// </summary>
 public enum ImageNormalizationOutcome
@@ -27,18 +53,18 @@ public enum ImageNormalizationOutcome
 /// </summary>
 public sealed record ImageNormalizationOptions
 {
-    /// <summary>Longest output edge in pixels. Anthropic downscales above ~1568px server-side anyway.</summary>
-    public int MaxLongEdgePixels { get; init; } = 1568;
+    /// <summary>Longest output edge. Anthropic downscales above ~1568px server-side anyway.</summary>
+    public Pixels MaxLongEdge { get; init; } = new(1568);
 
     /// <summary>
     /// Budget on the base64-encoded payload size. The wire form of an image is base64,
     /// so this is the quantity that actually bounds request size and heap. Default 5MB
     /// matches Anthropic's hard API limit.
     /// </summary>
-    public int MaxBase64Bytes { get; init; } = 5 * 1024 * 1024;
+    public ByteSize MaxBase64 { get; init; } = new(5 * 1024 * 1024);
 
-    /// <summary>JPEG quality (1-100) used when re-encoding opaque images.</summary>
-    public int JpegQuality { get; init; } = 85;
+    /// <summary>JPEG quality used when re-encoding a resized JPEG source.</summary>
+    public JpegQuality JpegQuality { get; init; } = new(85);
 
     /// <summary>When false, the normalizer passes every image through untouched (rollback switch).</summary>
     public bool Enabled { get; init; } = true;
@@ -55,9 +81,9 @@ public sealed record ImageNormalizationResult
 {
     public required ImageNormalizationOutcome Outcome { get; init; }
     public byte[]? Bytes { get; init; }
-    public int Width { get; init; }
-    public int Height { get; init; }
-    public int EncodedByteLength { get; init; }
+    public Pixels Width { get; init; }
+    public Pixels Height { get; init; }
+    public ByteSize EncodedSize { get; init; }
     public string? MediaType { get; init; }
     public string? Reason { get; init; }
 

--- a/src/Netclaw.Media/ImageNormalizerProbe.cs
+++ b/src/Netclaw.Media/ImageNormalizerProbe.cs
@@ -17,10 +17,10 @@ namespace Netclaw.Media;
 public static class ImageNormalizerProbe
 {
     /// <summary>
-    /// Runs a tiny encode → normalize round-trip. Returns <c>null</c> when imaging
-    /// works, or a short error string describing why it does not.
+    /// Runs a tiny encode → normalize round-trip to confirm the native imaging library
+    /// is present and functional.
     /// </summary>
-    public static string? TryProbe()
+    public static ImagingProbeResult Probe()
     {
         try
         {
@@ -32,20 +32,28 @@ public static class ImageNormalizerProbe
                 using var image = SKImage.FromBitmap(bitmap);
                 using var data = image.Encode(SKEncodedImageFormat.Png, 100);
                 if (data is null || data.Size == 0)
-                    return "encode produced no output";
+                    return ImagingProbeResult.Failed("encode produced no output");
                 png = data.ToArray();
             }
 
             var result = new SkiaImageNormalizer().Normalize(png, new ImageNormalizationOptions());
             return result.Outcome == ImageNormalizationOutcome.Dropped
-                ? $"normalize failed: {result.Reason}"
-                : null;
+                ? ImagingProbeResult.Failed($"normalize failed: {result.Reason}")
+                : ImagingProbeResult.Working;
         }
         catch (Exception ex)
         {
             // DllNotFoundException / TypeInitializationException when the native lib
             // is missing; any other failure is equally a reason to fail the probe.
-            return $"{ex.GetType().Name}: {ex.Message}";
+            return ImagingProbeResult.Failed($"{ex.GetType().Name}: {ex.Message}");
         }
     }
+}
+
+/// <summary>Result of <see cref="ImageNormalizerProbe.Probe"/>: working, or a failure reason.</summary>
+public readonly record struct ImagingProbeResult(bool IsWorking, string? Error)
+{
+    public static ImagingProbeResult Working => new(true, null);
+
+    public static ImagingProbeResult Failed(string error) => new(false, error);
 }

--- a/src/Netclaw.Media/SkiaImageNormalizer.cs
+++ b/src/Netclaw.Media/SkiaImageNormalizer.cs
@@ -43,6 +43,10 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
             using var data = SKData.CreateCopy(source);
             using var codec = SKCodec.Create(data);
             if (codec is null)
+                // Skia couldn't parse the bytes as any supported image container: a corrupt
+                // or truncated file, non-image bytes carrying an image MIME, or a format Skia
+                // doesn't decode (e.g. HEIC/AVIF without a platform codec, SVG). JPEG/PNG/WebP/
+                // GIF/BMP all decode fine. Fail loud rather than ship un-vetted bytes.
                 return ImageNormalizationResult.Drop("not a decodable image");
 
             var info = codec.Info;
@@ -50,8 +54,8 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
                 return ImageNormalizationResult.Drop("image has no pixels");
 
             var format = codec.EncodedFormat;
-            var withinLongEdge = Math.Max(info.Width, info.Height) <= options.MaxLongEdgePixels;
-            var withinBudget = ImageDecodeMath.Base64Length(source.Length) <= options.MaxBase64Bytes;
+            var withinLongEdge = Math.Max(info.Width, info.Height) <= options.MaxLongEdge.Value;
+            var withinBudget = ImageDecodeMath.Base64Length(source.Length) <= options.MaxBase64.Value;
 
             // We only ever RESIZE — never transcode or quality-reduce. Skia can re-encode
             // JPEG/PNG/WebP; a format it cannot encode (GIF) is left untouched.
@@ -65,11 +69,11 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
                 return withinBudget
                     ? PassThrough(source.ToArray(), info.Width, info.Height, format)
                     : ImageNormalizationResult.Drop(
-                        $"image exceeds the {FormatBudget(options.MaxBase64Bytes)} payload budget and cannot be bounded by resizing");
+                        $"image exceeds the {options.MaxBase64} payload budget and cannot be bounded by resizing");
             }
 
             // Over the dimension cap: scaled-decode (bounding peak memory), then resize to the cap.
-            var sampleSize = ImageDecodeMath.ChooseDecodeSampleSize(info.Width, info.Height, options.MaxLongEdgePixels);
+            var sampleSize = ImageDecodeMath.ChooseDecodeSampleSize(info.Width, info.Height, options.MaxLongEdge.Value);
             var scaled = codec.GetScaledDimensions(1f / sampleSize);
             if ((long)scaled.Width * scaled.Height * 4 > MaxDecodeBytes)
                 return ImageNormalizationResult.Drop(
@@ -79,24 +83,28 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
             if (decoded is null)
                 return ImageNormalizationResult.Drop("image could not be decoded");
 
-            using var capped = ResizeToLongEdge(decoded, options.MaxLongEdgePixels);
+            using var capped = ResizeToLongEdge(decoded, options.MaxLongEdge.Value);
             var working = capped ?? decoded;
 
-            var bytes = Encode(working, format, options.JpegQuality);
+            var bytes = Encode(working, format, options.JpegQuality.Value);
             if (bytes is null)
                 return ImageNormalizationResult.Drop("image could not be re-encoded");
 
-            if (ImageDecodeMath.Base64Length(bytes.Length) > options.MaxBase64Bytes)
+            // A resized image that still blows the budget is dropped, not shrunk further.
+            // If this drop becomes common in practice, the place to reintroduce a bounded
+            // iterative size-reduction loop is right here (we deliberately kept it "just
+            // resize" for now — see PR #1345 review).
+            if (ImageDecodeMath.Base64Length(bytes.Length) > options.MaxBase64.Value)
                 return ImageNormalizationResult.Drop(
-                    $"image still exceeds the {FormatBudget(options.MaxBase64Bytes)} payload budget after resizing");
+                    $"image still exceeds the {options.MaxBase64} payload budget after resizing");
 
             return new ImageNormalizationResult
             {
                 Outcome = ImageNormalizationOutcome.Normalized,
                 Bytes = bytes,
-                Width = working.Width,
-                Height = working.Height,
-                EncodedByteLength = bytes.Length,
+                Width = new Pixels(working.Width),
+                Height = new Pixels(working.Height),
+                EncodedSize = new ByteSize(bytes.Length),
                 MediaType = MediaTypeFor(format)
             };
         }
@@ -134,9 +142,9 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
         {
             Outcome = ImageNormalizationOutcome.PassedThrough,
             Bytes = bytes,
-            Width = width,
-            Height = height,
-            EncodedByteLength = bytes.Length,
+            Width = new Pixels(width),
+            Height = new Pixels(height),
+            EncodedSize = new ByteSize(bytes.Length),
             MediaType = MediaTypeFor(format)
         };
 
@@ -145,7 +153,7 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
         {
             Outcome = ImageNormalizationOutcome.PassedThrough,
             Bytes = bytes,
-            EncodedByteLength = bytes.Length,
+            EncodedSize = new ByteSize(bytes.Length),
             MediaType = null
         };
 
@@ -156,9 +164,4 @@ public sealed class SkiaImageNormalizer : IImageNormalizer
         SKEncodedImageFormat.Gif => MimeTypeCatalog.ImageGif,
         _ => MimeTypeCatalog.ImagePng
     };
-
-    private static string FormatBudget(int bytes) =>
-        bytes >= 1024 * 1024 ? $"{bytes / (1024 * 1024)}MB"
-        : bytes >= 1024 ? $"{bytes / 1024}KB"
-        : $"{bytes}B";
 }

--- a/src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj
+++ b/src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <!-- Windows + macOS native assets come transitively from the base SkiaSharp package
+         (it depends on NativeAssets.Win32 / NativeAssets.macOS). Desktop Linux is the only
+         platform SkiaSharp doesn't pull in by default — hence the explicit headless Linux
+         asset here. Verified green on all three OS test runners (PR #1345). -->
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
   </ItemGroup>


### PR DESCRIPTION
Follow-up to #1345, addressing the review comments.

## What's in here

**Value objects (your `ImageNormalization.cs:54` note).** The options/result records used bare `int` for both pixels and bytes, which is exactly the kind of thing a future reader — human or LLM — will mix up. Wrapped them in tidy little structs: `Pixels`, `ByteSize`, `JpegQuality`. No implicit conversions (you go through `.Value`), so you can't pass a byte count where a pixel cap is expected. `ByteSize.ToString()` also absorbed the human B/KB/MB formatting, so the old `FormatBudget` helper is gone and the drop messages just interpolate the value object.

**Real result type for the probe (`ImageNormalizerProbe.cs:23`).** `TryProbe()` returned `string?` with null meaning success, which is the null-as-sentinel smell you flagged. It now returns `ImagingProbeResult { IsWorking, Error }`, and the doctor check reads `.IsWorking` / `.Error`.

**Dedup (`ChatMessageConverter.cs:163` — "why is this duplicated?").** Good catch. The "write the `DataContent`, add a reference or append an `[image omitted]` note" block was copy-pasted in `ChannelPipeline` and `ChatMessageConverter`. Pulled it into a single `SessionMediaStore.WriteMediaInto(...)` so there's one owner of that fold; `AppendOmittedImageNote` is now private since nothing outside calls it directly.

**Comments.**
- `SkiaImageNormalizer.cs:46` ("what image types are not decodeable?") — spelled it out: corrupt/truncated files, non-image bytes wearing an image MIME, or formats Skia doesn't decode (HEIC/AVIF without a platform codec, SVG). JPEG/PNG/WebP/GIF/BMP all decode fine.
- `SkiaImageNormalizer.cs:90` — left the breadcrumb you asked for: we drop an over-budget-after-resize image rather than shrink it further, and if those drops get common the place to reintroduce a bounded size-reduction loop is right there.
- `Tests.Utilities.csproj:14` ("what about Windows and OS X?") — they come transitively from the base `SkiaSharp` package (it depends on `NativeAssets.Win32`/`NativeAssets.macOS`); desktop Linux is the only one not pulled in by default, hence the explicit add. Noted it in the csproj. CI already proved it — Test-windows-latest and Test-macos-26 both passed on #1345.

## Tests

- `Netclaw.Media.Tests` (65) — added a `ByteSize.ToString` formatting test (guards the sub-MiB "0MB" case), updated the options/probe call sites.
- `Netclaw.Actors.Tests` (2211) — the seam and converter tests cover the deduped path.
- Clean build (0 warnings), slopwatch clean, headers verified.

No behavior change — this is the tidy-up pass.
