### PR TITLE
feat(tui): enable native text selection via Termina 0.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.11.0" />
+    <PackageVersion Include="Termina" Version="0.11.1" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -202,6 +202,7 @@ static async Task RunAsync(string[] args)
 
             builder.Services.AddTermina("/init", termina =>
             {
+                ConfigureNativeSelection(termina);
                 termina.RegisterRoute<InitWizardPage, InitWizardViewModel>("/init");
                 termina.RegisterRoute<ChatPage, ChatViewModel>("/chat");
             });
@@ -434,6 +435,7 @@ static async Task RunAsync(string[] args)
             builder.Services.AddSingleton(new StatsNavigationState { Days = statsDays ?? 7 });
             builder.Services.AddTermina("/stats", termina =>
             {
+                ConfigureNativeSelection(termina);
                 termina.RegisterRoute<StatsPage, StatsViewModel>("/stats");
             });
 
@@ -645,7 +647,10 @@ static async Task RunAsync(string[] args)
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
 
             builder.Services.AddTermina("/mcp-tools", t =>
-                t.RegisterRoute<McpToolPermissionsPage, McpToolPermissionsViewModel>("/mcp-tools"));
+            {
+                ConfigureNativeSelection(t);
+                t.RegisterRoute<McpToolPermissionsPage, McpToolPermissionsViewModel>("/mcp-tools");
+            });
 
             await RunTerminaHostAsync(builder.Build());
             return;
@@ -703,7 +708,10 @@ static async Task RunAsync(string[] args)
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
 
             builder.Services.AddTermina("/provider", t =>
-                t.RegisterRoute<ProviderManagerPage, ProviderManagerViewModel>("/provider"));
+            {
+                ConfigureNativeSelection(t);
+                t.RegisterRoute<ProviderManagerPage, ProviderManagerViewModel>("/provider");
+            });
 
             await RunTerminaHostAsync(builder.Build());
             return;
@@ -732,7 +740,10 @@ static async Task RunAsync(string[] args)
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
 
             builder.Services.AddTermina("/model", t =>
-                t.RegisterRoute<ModelManagerPage, ModelManagerViewModel>("/model"));
+            {
+                ConfigureNativeSelection(t);
+                t.RegisterRoute<ModelManagerPage, ModelManagerViewModel>("/model");
+            });
 
             await RunTerminaHostAsync(builder.Build());
             return;
@@ -761,7 +772,10 @@ static async Task RunAsync(string[] args)
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
 
             builder.Services.AddTermina("/approvals", t =>
-                t.RegisterRoute<ApprovalsManagerPage, ApprovalsManagerViewModel>("/approvals"));
+            {
+                ConfigureNativeSelection(t);
+                t.RegisterRoute<ApprovalsManagerPage, ApprovalsManagerViewModel>("/approvals");
+            });
 
             await RunTerminaHostAsync(builder.Build());
             return;
@@ -785,7 +799,10 @@ static async Task RunAsync(string[] args)
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
 
             builder.Services.AddTermina("/reminder", t =>
-                t.RegisterRoute<ReminderCreatePage, ReminderCreateViewModel>("/reminder"));
+            {
+                ConfigureNativeSelection(t);
+                t.RegisterRoute<ReminderCreatePage, ReminderCreateViewModel>("/reminder");
+            });
 
             await RunTerminaHostAsync(builder.Build());
             return;
@@ -996,6 +1013,7 @@ static async Task RunAsync(string[] args)
         case "chat":
             webBuilder.Services.AddTermina("/chat", termina =>
             {
+                ConfigureNativeSelection(termina);
                 termina.RegisterRoute<ChatPage, ChatViewModel>("/chat");
             });
             break;
@@ -1003,6 +1021,7 @@ static async Task RunAsync(string[] args)
         case "sessions":
             webBuilder.Services.AddTermina("/sessions", termina =>
             {
+                ConfigureNativeSelection(termina);
                 termina.RegisterRoute<SessionsPage, SessionsViewModel>("/sessions");
                 termina.RegisterRoute<ChatPage, ChatViewModel>("/chat");
             });
@@ -1028,6 +1047,17 @@ static async Task RunAsync(string[] args)
 
     var app = webBuilder.Build();
     await RunTerminaHostAsync(app);
+}
+
+static void ConfigureNativeSelection(TerminaBuilder termina)
+{
+    termina.ConfigureRuntime(options =>
+    {
+        options.PreferRawInput = true;
+        options.ScrollInputMode = ScrollInputMode.AlternateScroll;
+        options.KittyKeyboardMode = KittyKeyboardMode.ReportAllKeysPlusDisambiguate;
+        options.CtrlCHandlingMode = CtrlCHandlingMode.DoublePressWhenRawInput;
+    });
 }
 
 static void WriteCrashLog(Exception ex)

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1055,7 +1055,6 @@ static void ConfigureNativeSelection(TerminaBuilder termina)
     {
         options.PreferRawInput = true;
         options.ScrollInputMode = ScrollInputMode.AlternateScroll;
-        options.KittyKeyboardMode = KittyKeyboardMode.ReportAllKeysPlusDisambiguate;
         options.CtrlCHandlingMode = CtrlCHandlingMode.DoublePressWhenRawInput;
     });
 }

--- a/tests/smoke/tapes/init-wizard.tape
+++ b/tests/smoke/tapes/init-wizard.tape
@@ -130,6 +130,9 @@ Enter
 Wait+Screen@240s /Ready  \|  qwen2:0.5b/
 Ctrl+Q
 
+# VHS's screen scraper needs a beat to pick up the restored main buffer
+# after the TUI tears down the alternate screen (CSI ?1049l).
+Sleep 1s
 Wait+Screen@10s /TAPE\$/
 
 # Sanity: re-check at the prompt that init reported success.

--- a/tests/smoke/tapes/provider-add.tape
+++ b/tests/smoke/tapes/provider-add.tape
@@ -73,6 +73,10 @@ Sleep 300ms
 
 # ─── Exit TUI ────────────────────────────────────────────────────────
 Ctrl+Q
+
+# VHS's screen scraper needs a beat to pick up the restored main buffer
+# after the TUI tears down the alternate screen (CSI ?1049l).
+Sleep 1s
 Wait+Screen@10s /TAPE\$/
 
 Type "echo PROVIDER_ADD_EXIT=$?"

--- a/tests/smoke/tapes/provider-rename.tape
+++ b/tests/smoke/tapes/provider-rename.tape
@@ -67,6 +67,10 @@ Sleep 300ms
 
 # ─── Exit TUI ────────────────────────────────────────────────────────
 Ctrl+Q
+
+# VHS's screen scraper needs a beat to pick up the restored main buffer
+# after the TUI tears down the alternate screen (CSI ?1049l).
+Sleep 1s
 Wait+Screen@10s /TAPE\$/
 
 Type "echo PROVIDER_RENAME_EXIT=$?"

--- a/tests/smoke/tapes/screenshots/wizard-screens.tape
+++ b/tests/smoke/tapes/screenshots/wizard-screens.tape
@@ -64,10 +64,13 @@ Sleep 1s
 Screenshot "/tmp/shot-wizard-security-posture.png"
 Sleep 1s
 
-# Both frames captured; abandon the wizard. Ctrl+C drops out of the
-# interactive prompt back to the shell — capture-only tape, no config to
-# validate.
-Ctrl+C
+# Both frames captured; abandon the wizard. Ctrl+Q is the TUI quit
+# shortcut (Ctrl+C requires a double-press under raw input mode).
+Ctrl+Q
+
+# VHS's screen scraper needs a beat to pick up the restored main buffer
+# after the TUI tears down the alternate screen (CSI ?1049l).
+Sleep 1s
 Wait+Screen@10s /TAPE\$/
 
 Type "exit"

--- a/tests/smoke/tapes/tui-cleanup.tape
+++ b/tests/smoke/tapes/tui-cleanup.tape
@@ -67,6 +67,10 @@ Wait+Screen@5s /seed-a/
 # ─── Exit and verify clean shell post-TUI ───────────────────────────
 Ctrl+Q
 
+# VHS's screen scraper needs a beat to pick up the restored main buffer
+# after the TUI tears down the alternate screen (CSI ?1049l).
+Sleep 1s
+
 # Anchor on the prompt. If the alt screen wasn't torn down cleanly,
 # the prompt either wouldn't render or would be visually merged with
 # TUI artefacts. The TAPE$ regex must match for this tape to pass.


### PR DESCRIPTION
## Summary
- Bumps Termina from 0.10.2 to 0.11.0 and configures all TUI surfaces with raw input + alternate-scroll mode, enabling native terminal text selection without holding Shift.
- Ctrl+C now requires a double-press to exit (standard for raw-input TUI apps).
- Kitty keyboard mode intentionally omitted — unnecessary for a chat TUI and not widely supported by terminal emulators.

Closes #1340

## Test plan
- [x] 349 TUI unit tests pass
- [x] `dotnet build` clean with 0 warnings
- [x] Copyright headers verified
- [ ] Smoke harness (`./scripts/smoke/run-smoke.sh light`) — `init-wizard` tape has a pre-existing sync failure on dev (timeout on "Connect to a private skill server" step), unrelated to this change
- [ ] Manual verification: select and copy text from chat output without Shift
- [ ] Manual verification: double-press Ctrl+C exits the TUI
- [ ] Manual verification: mouse scroll still navigates chat history
- [ ] tmux verification: `set -g allow-passthrough on` enables native selection in tmux sessions