### PR TITLE
fix(tui): remap approval detail toggle from Ctrl+V to Ctrl+O

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -67,7 +67,7 @@ public sealed class ChatPageTests
     }
 
     [Fact]
-    public async Task CollapsedView_ShowsEllipsisAndCtrlVHint()
+    public async Task CollapsedView_ShowsEllipsisAndCtrlOHint()
     {
         var (terminal, app, _) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
@@ -92,9 +92,9 @@ public sealed class ChatPageTests
             $"Bottom rows:\n{inputAndStatus}\nFull screen:\n{terminal}");
 
         // The user needs to know how to see the full body. Both the inline
-        // hint in the Input panel AND the status-bar hint advertise Ctrl+V.
-        Assert.True(screen.Contains("Ctrl+V", StringComparison.Ordinal),
-            $"Expected 'Ctrl+V' affordance to be visible. Screen:\n{terminal}");
+        // hint in the Input panel AND the status-bar hint advertise Ctrl+O.
+        Assert.True(screen.Contains("Ctrl+O", StringComparison.Ordinal),
+            $"Expected 'Ctrl+O' affordance to be visible. Screen:\n{terminal}");
     }
 
     /// <summary>
@@ -119,14 +119,14 @@ public sealed class ChatPageTests
     }
 
     [Fact]
-    public async Task CtrlV_TogglesFullBodyAndKeepsControlsVisible()
+    public async Task CtrlO_TogglesFullBodyAndKeepsControlsVisible()
     {
         var (terminal, app, vm) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
 
-        // Ctrl+V to expand, then quit. The toggle happens before the next
+        // Ctrl+O to expand, then quit. The toggle happens before the next
         // render, so by the time the app shuts down the terminal holds the
         // expanded frame.
-        input.EnqueueKey(ConsoleKey.V, false, false, true);
+        input.EnqueueKey(ConsoleKey.O, false, false, true);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -135,7 +135,7 @@ public sealed class ChatPageTests
         var screen = terminal.ToString();
 
         // Controls remain visible even in expanded mode — that's the whole
-        // point: Ctrl+V must not regress the original bug. Scope assertions
+        // point: Ctrl+O must not regress the original bug. Scope assertions
         // to the bottom of the screen so we're checking the Input panel,
         // not the chat history pane that always echoes the full body.
         var inputAndStatus = BottomRows(screen, terminalWidth: 120, rowCount: 14);
@@ -150,6 +150,23 @@ public sealed class ChatPageTests
             $"Expected status hint to flip to 'Collapse' after expand. Screen:\n{terminal}");
 
         Assert.True(vm.IsApprovalDetailVisible.Value);
+    }
+
+    [Fact]
+    public async Task CtrlV_DoesNotToggleDetail()
+    {
+        // Ctrl+V was the original keybinding but is intercepted as "paste" on
+        // Windows terminals (#1334). After remapping to Ctrl+O, Ctrl+V must
+        // NOT expand the approval detail.
+        var (terminal, app, vm) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+
+        input.EnqueueKey(ConsoleKey.V, false, false, true);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.False(vm.IsApprovalDetailVisible.Value);
     }
 
     [Fact]
@@ -169,11 +186,11 @@ public sealed class ChatPageTests
     }
 
     [Fact]
-    public async Task NarrowTerminal_PreservesCtrlVHint()
+    public async Task NarrowTerminal_PreservesCtrlOHint()
     {
         // 60-col terminal — narrower than the previous hard-coded 76-col
         // body budget. The pre-scaling code would wrap the body+hint to a
-        // second line and body.Height(1) would clip the Ctrl+V suffix.
+        // second line and body.Height(1) would clip the Ctrl+O suffix.
         // With width-aware sizing the hint must still be visible.
         var (terminal, app, _) = CreateHeadlessApp(
             BuildApproval(LongShellBody), out var input, width: 60, height: 30);
@@ -185,9 +202,9 @@ public sealed class ChatPageTests
         var screen = terminal.ToString();
         var bottom = BottomRows(screen, terminalWidth: 60, rowCount: 14);
 
-        Assert.True(bottom.Contains("Ctrl+V", StringComparison.Ordinal)
-                || bottom.Contains("^V", StringComparison.Ordinal),
-            $"Expected Ctrl+V affordance to be visible on a 60-col terminal. " +
+        Assert.True(bottom.Contains("Ctrl+O", StringComparison.Ordinal)
+                || bottom.Contains("^O", StringComparison.Ordinal),
+            $"Expected Ctrl+O affordance to be visible on a 60-col terminal. " +
             $"Bottom rows:\n{bottom}\nFull screen:\n{terminal}");
 
         // Confirm options are still visible — the original #1132 invariant
@@ -219,7 +236,7 @@ public sealed class ChatPageTests
             width: 120, height: 40, options: fiveOptions);
 
         // Expand first, then quit, so the assertion sees the harder layout.
-        input.EnqueueKey(ConsoleKey.V, false, false, true);
+        input.EnqueueKey(ConsoleKey.O, false, false, true);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -241,7 +258,7 @@ public sealed class ChatPageTests
         // (which uses .Fill()) still has at least a few visible rows.
         var (terminal, app, _) = CreateHeadlessApp(
             BuildApproval(LongShellBody), out var input, width: 100, height: 16);
-        input.EnqueueKey(ConsoleKey.V, false, false, true); // expand to stress
+        input.EnqueueKey(ConsoleKey.O, false, false, true); // expand to stress
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -286,9 +303,9 @@ public sealed class ChatPageTests
         var bottom = BottomRows(terminal.ToString(), terminalWidth: 50, rowCount: 12);
 
         // The narrow status bar should use the short Ctrl-prefix form
-        // (^V) or omit the longer scroll/quit hints.
-        Assert.True(bottom.Contains("^V", StringComparison.Ordinal)
-                || bottom.Contains("[Ctrl+V]", StringComparison.Ordinal),
+        // (^O) or omit the longer scroll/quit hints.
+        Assert.True(bottom.Contains("^O", StringComparison.Ordinal)
+                || bottom.Contains("[Ctrl+O]", StringComparison.Ordinal),
             $"Expected resize to re-render with the narrow status bar. Bottom rows:\n{bottom}");
     }
 
@@ -311,7 +328,7 @@ public sealed class ChatPageTests
     {
         var (terminal, app, _) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
         if (expand)
-            input.EnqueueKey(ConsoleKey.V, false, false, true);
+            input.EnqueueKey(ConsoleKey.O, false, false, true);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-collapsed.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-collapsed.txt
@@ -31,10 +31,10 @@
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │Approval required for shell_execute.                                                                                  │
-│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder /private/var/… [Ctrl+V to view full]  │
+│cd /Users/kevin/code/compiler/Diagnostics.pn compiler/Symbol.pn compiler/Binder /private/var/… [Ctrl+O to view full]  │
 │Select an option and press Enter.                                                                                     │
 │1. Once                                                                                                               │
 │2. This chat                                                                                                          │
 │3. Deny                                                                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-[Up/Down] Select [Enter] Confirm [Ctrl+V] View full [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model
+[Up/Down] Select [Enter] Confirm [Ctrl+O] View full [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-expanded.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-approval-expanded.txt
@@ -37,4 +37,4 @@
 │2. This chat                                                                                                          │
 │3. Deny                                                                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-[Up/Down] Select [Enter] Confirm [Ctrl+V] Collapse [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model
+[Up/Down] Select [Enter] Confirm [Ctrl+O] Collapse [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -270,10 +270,10 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         {
             var toggle = isApprovalDetailVisible ? "Collapse" : "View full";
             return width >= 100
-                ? $"[Up/Down] Select  [Enter] Confirm  [Ctrl+V] {toggle}  [PgUp/PgDn] Scroll  [Ctrl+Q] Quit"
+                ? $"[Up/Down] Select  [Enter] Confirm  [Ctrl+O] {toggle}  [PgUp/PgDn] Scroll  [Ctrl+Q] Quit"
                 : width >= 70
-                    ? $"[↑↓] Select  [Enter] Confirm  [Ctrl+V] {toggle}  [Ctrl+Q] Quit"
-                    : $"[↑↓] [Enter] OK  [^V] {toggle}  [^Q] Quit";
+                    ? $"[↑↓] Select  [Enter] Confirm  [Ctrl+O] {toggle}  [Ctrl+Q] Quit"
+                    : $"[↑↓] [Enter] OK  [^O] {toggle}  [^Q] Quit";
         }
 
         if (isGenerating)
@@ -312,12 +312,11 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
             return;
         }
 
-        // Ctrl+V toggles full-body view of a pending approval prompt.
-        // Routed BEFORE the selection list so the list's own Ctrl+V (paste-ish)
-        // never overrides it while an approval is pending. When no approval
-        // is pending, Ctrl+V falls through to the text area for normal paste.
+        // Ctrl+O toggles full-body view of a pending approval prompt.
+        // Was originally Ctrl+V, but that's intercepted by the OS as "paste"
+        // on Windows terminals (#1334).
         if (ViewModel.HasPendingInteraction
-            && keyInfo.Key == ConsoleKey.V
+            && keyInfo.Key == ConsoleKey.O
             && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
         {
             ViewModel.ToggleApprovalDetail();

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -21,7 +21,7 @@ namespace Netclaw.Cli.Tui;
 public partial class ChatViewModel : ReactiveViewModel
 {
     /// <summary>
-    /// Cap on the approval body shown in the expanded (Ctrl+V) view.
+    /// Cap on the approval body shown in the expanded (Ctrl+O) view.
     /// Without it, a multi-KB command handed verbatim to a TextNode can
     /// break the terminal renderer.
     /// </summary>
@@ -295,7 +295,7 @@ public partial class ChatViewModel : ReactiveViewModel
     /// approved, plus any explicit patterns). When
     /// <see cref="IsApprovalDetailVisible"/> is <c>false</c>, the body is
     /// returned as a single line truncated to <paramref name="maxLineWidth"/>
-    /// with an ellipsis and a Ctrl+V hint. When <c>true</c>, the full
+    /// with an ellipsis and a Ctrl+O hint. When <c>true</c>, the full
     /// untruncated body is returned and the caller is expected to wrap it
     /// inside a height-bounded layout node.
     /// </summary>
@@ -317,7 +317,7 @@ public partial class ChatViewModel : ReactiveViewModel
         // selection list past the panel cap, not just length.
         var singleLine = fullBody.ReplaceLineEndings(" ");
 
-        const string hint = " [Ctrl+V to view full]";
+        const string hint = " [Ctrl+O to view full]";
         var budget = Math.Max(8, maxLineWidth - hint.Length);
         if (singleLine.Length <= budget)
             return singleLine + (singleLine.Length == fullBody.Length ? string.Empty : hint);
@@ -335,7 +335,7 @@ public partial class ChatViewModel : ReactiveViewModel
 
     /// <summary>
     /// Flips <see cref="IsApprovalDetailVisible"/> and forces a re-render.
-    /// Invoked by <c>ChatPage</c> on Ctrl+V when an approval is pending.
+    /// Invoked by <c>ChatPage</c> on Ctrl+O when an approval is pending.
     /// </summary>
     public void ToggleApprovalDetail()
     {


### PR DESCRIPTION
## Summary
- Remaps the approval detail "View full" toggle from `Ctrl+V` to `Ctrl+O` — `Ctrl+V` is intercepted by the OS as "paste" on Windows terminals, so the toggle never fires (#1334)
- Updates all status bar hints (`[Ctrl+O]`, `[^O]`) and inline hint text (`[Ctrl+O to view full]`)
- Adds `CtrlV_DoesNotToggleDetail` regression test verifying the old key no longer triggers the toggle

Closes #1334

## Test plan
- [x] All 10 `ChatPageTests` pass (9 updated + 1 new regression test)
- [ ] CI green
- [ ] Manual verification on Windows terminal that Ctrl+O triggers the toggle