### PR TITLE
Fix Discord gateway zombie state after failed auto-retry

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/DiscordGatewayLifecycleRetryTimeoutTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordGatewayLifecycleRetryTimeoutTests.cs
@@ -1,0 +1,213 @@
+// -----------------------------------------------------------------------
+// <copyright file="DiscordGatewayLifecycleRetryTimeoutTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Channels.Discord;
+using Netclaw.Channels.Discord.Transport;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+/// <summary>
+/// Regression coverage for the 0.24.0-beta.2 Discord reliability incident:
+/// when an auto-retry connect attempt timed out waiting for READY, the actor
+/// treated <see cref="ActorRefs.Nobody"/> as a pending caller and silently
+/// parked itself in CleanReconnectRequired — a state with no timers and no
+/// transport-event exits — dropping all Discord traffic until restart.
+/// Runs on a virtual-time scheduler so the 30s READY timeout can be driven
+/// deterministically.
+/// </summary>
+public sealed class DiscordGatewayLifecycleRetryTimeoutTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    protected override Config? Config => ConfigurationFactory.ParseString("""
+        akka.test.default-timeout = 5s
+        akka.scheduler.implementation = "Akka.TestKit.TestScheduler, Akka.TestKit"
+        """);
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    private void AdvanceScheduler(TimeSpan offset) =>
+        ((Akka.TestKit.TestScheduler)Sys.Scheduler).Advance(offset);
+
+    [Fact]
+    public async Task Ready_timeout_during_auto_retry_keeps_recovering_instead_of_zombieing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var transport = new FakeTransport
+        {
+            ConnectionState = ConnectionState.Disconnected,
+            CurrentUserId = 42
+        };
+        var sink = new RecordingSink();
+        var actor = Sys.ActorOf(DiscordNetGatewayLifecycleActor.CreateProps(
+            transport, TimeProvider.System, sink, NullLogger.Instance));
+
+        // 1. Caller-driven connect reaches READY.
+        var connectTask = actor.Ask<DiscordGatewaySnapshot>(
+            new DiscordNetGatewayLifecycleActor.Connect("test-token"),
+            TimeSpan.FromSeconds(3), ct);
+        await AwaitAssertAsync(() => Assert.Equal(1, transport.StartCount), cancellationToken: ct);
+        transport.ConnectionState = ConnectionState.Connected;
+        await transport.RaiseReadyAsync();
+        Assert.True((await connectTask).IsReady);
+
+        // 2. Spurious Connected while Ready forces clean reconnect cycle #1:
+        //    publish, stop, and a zero-delay auto-retry is scheduled.
+        await transport.RaiseConnectedAsync();
+        await AwaitCleanReconnectSettledAsync(actor, ct);
+        Assert.Equal(1, sink.CleanReconnectCount);
+
+        // 3. Fire the auto-retry: the actor reconnects with no pending caller
+        //    (ActorRefs.Nobody) and waits for READY.
+        AdvanceScheduler(TimeSpan.FromSeconds(1));
+        await AwaitAssertAsync(() => Assert.Equal(2, transport.StartCount), cancellationToken: ct);
+
+        // 4. READY never arrives; advance past the 30s READY timeout. The
+        //    regression: Nobody passed the pending-caller null check, so the
+        //    actor silently entered CleanReconnectRequired and never emitted
+        //    a second clean-reconnect request (and never recovered).
+        AdvanceScheduler(TimeSpan.FromSeconds(31));
+        await AwaitCleanReconnectSettledAsync(actor, ct);
+        Assert.Equal(2, sink.CleanReconnectCount);
+
+        // 5. The next auto-retry fires; this time READY arrives. The actor
+        //    must fully recover AND publish ConnectionRestored — the same
+        //    Nobody-vs-null skew kept the isRetry branch from ever firing.
+        AdvanceScheduler(TimeSpan.FromSeconds(1));
+        await AwaitAssertAsync(() => Assert.Equal(3, transport.StartCount), cancellationToken: ct);
+        transport.ConnectionState = ConnectionState.Connected;
+        await transport.RaiseReadyAsync();
+        await AwaitAssertAsync(async () =>
+        {
+            var snapshot = await actor.Ask<DiscordGatewaySnapshot>(
+                DiscordNetGatewayLifecycleActor.GetSnapshot.Instance, TimeSpan.FromSeconds(3), ct);
+            Assert.True(snapshot.IsReady);
+            Assert.Equal(1, sink.ConnectionRestoredCount);
+        }, cancellationToken: ct);
+    }
+
+    /// <summary>
+    /// Settles a clean-reconnect cycle before advancing virtual time. The
+    /// "disconnected." health detail is written by the same stop-succeeded
+    /// handler that arms the auto-retry timer, so once it is observable the
+    /// timer is guaranteed to be scheduled — advancing earlier would tick
+    /// virtual time past a timer that does not exist yet and stall the test.
+    /// </summary>
+    private async Task AwaitCleanReconnectSettledAsync(IActorRef actor, CancellationToken ct)
+    {
+        await AwaitAssertAsync(async () =>
+        {
+            var snapshot = await actor.Ask<DiscordGatewaySnapshot>(
+                DiscordNetGatewayLifecycleActor.GetSnapshot.Instance, TimeSpan.FromSeconds(3), ct);
+            Assert.False(snapshot.IsConnected);
+            Assert.Equal("Discord gateway disconnected.", snapshot.HealthDetail);
+        }, cancellationToken: ct);
+    }
+
+    private sealed class RecordingSink : IDiscordGatewayEventSink
+    {
+        public int CleanReconnectCount { get; private set; }
+
+        public int ConnectionRestoredCount { get; private set; }
+
+        public Task PublishMessageAsync(DiscordGatewayMessage message) => Task.CompletedTask;
+
+        public Task PublishInteractionAsync(DiscordGatewayInteraction interaction) => Task.CompletedTask;
+
+        public Task PublishCleanReconnectRequiredAsync(string reason)
+        {
+            CleanReconnectCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task PublishConnectionRestoredAsync(DiscordGatewaySnapshot snapshot)
+        {
+            ConnectionRestoredCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTransport : IDiscordGatewayTransport
+    {
+        private Func<Task>? _connected;
+        private Func<Task>? _ready;
+
+        public event Func<LogMessage, Task> Log
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<Task> Connected
+        {
+            add => _connected += value;
+            remove => _connected -= value;
+        }
+
+        public event Func<Task> Ready
+        {
+            add => _ready += value;
+            remove => _ready -= value;
+        }
+
+        public event Func<Exception, Task> Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<SocketMessage, Task> MessageReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<SocketMessageComponent, Task> ButtonExecuted
+        {
+            add { }
+            remove { }
+        }
+
+        public ConnectionState ConnectionState { get; set; }
+
+        public ulong? CurrentUserId { get; set; }
+
+        public int StartCount { get; private set; }
+
+        public Task LoginAsync(string botToken) => Task.CompletedTask;
+
+        public Task StartAsync()
+        {
+            StartCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            ConnectionState = ConnectionState.Disconnected;
+            return Task.CompletedTask;
+        }
+
+        public Task LogoutAsync() => Task.CompletedTask;
+
+        public Task RaiseConnectedAsync() => _connected?.Invoke() ?? Task.CompletedTask;
+
+        public Task RaiseReadyAsync() => _ready?.Invoke() ?? Task.CompletedTask;
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/MattermostGatewayLifecycleActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostGatewayLifecycleActorTests.cs
@@ -138,6 +138,38 @@ public sealed class MattermostGatewayLifecycleActorTests(ITestOutputHelper outpu
             cancellationToken: TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Connection_restored_publishes_after_auto_retry_recovery()
+    {
+        // Regression: the auto-retry path connects with ActorRefs.Nobody as
+        // the reply-to, and storing it verbatim made the `is null` isRetry
+        // check misfire — ConnectionRestored never published after an
+        // auto-retry recovery.
+        var transport = new FakeMattermostGatewayTransport();
+        var sink = new RecordingGatewayEventSink();
+        var actor = CreateLifecycleActor(transport, sink);
+
+        var readySnapshot = await ConnectAsync(actor);
+        Assert.True(readySnapshot.IsReady);
+        Assert.Equal(0, sink.ConnectionRestoredCount);
+
+        await transport.RaiseDisconnectedAsync("network lost");
+
+        // Clean reconnect cycle → zero-delay auto-retry → the fake start
+        // succeeds, so the actor recovers to Ready and MUST publish
+        // ConnectionRestored exactly once.
+        await AwaitAssertAsync(async () =>
+        {
+            var snapshot = await actor.Ask<MattermostGatewaySnapshot>(
+                MattermostNetGatewayLifecycleActor.GetSnapshot.Instance,
+                TimeSpan.FromSeconds(3),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(snapshot.IsReady);
+            Assert.Equal(1, sink.ConnectionRestoredCount);
+        }, TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
     private IActorRef CreateLifecycleActor(
         FakeMattermostGatewayTransport transport,
         RecordingGatewayEventSink sink)

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayLifecycleActor.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayLifecycleActor.cs
@@ -331,7 +331,16 @@ internal sealed class DiscordNetGatewayLifecycleActor : ReceiveActor, IWithTimer
         _botMentionTag = null;
         _cleanReconnectEmitted = false;
         _fatalCloseHandled = false;
-        _pendingConnectReplyTo = replyTo;
+
+        // Normalize Nobody to null: "no pending caller" must have exactly one
+        // representation. The auto-retry path connects with ActorRefs.Nobody,
+        // and storing it verbatim made every `_pendingConnectReplyTo is null`
+        // check misfire — HandleReadyTimedOut took the caller-driven branch on
+        // retries and parked the actor in CleanReconnectRequired with nothing
+        // scheduled to ever leave it, silently dropping all Discord traffic
+        // until restart. It also kept ConnectionRestored from publishing after
+        // an auto-retry recovery (isRetry computed false).
+        _pendingConnectReplyTo = replyTo.IsNobody() ? null : replyTo;
 
         var attempt = ++_connectAttempt;
         Timers.StartSingleTimer(ReadyTimeoutTimerKey, new ReadyTimedOut(attempt), ReadyTimeout);

--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayLifecycleActor.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayLifecycleActor.cs
@@ -234,7 +234,15 @@ internal sealed class MattermostNetGatewayLifecycleActor : ReceiveActor
         _botUserId = null;
         _botUsername = null;
         _cleanReconnectEmitted = false;
-        _pendingConnectReplyTo = replyTo;
+
+        // Normalize Nobody to null: the auto-retry path connects with
+        // ActorRefs.Nobody, and storing it verbatim made the
+        // `_pendingConnectReplyTo is null` isRetry checks misfire — most
+        // visibly keeping ConnectionRestored from publishing after an
+        // auto-retry recovery. Mirrors the same fix in the Discord lifecycle
+        // actor, where the skew also produced a stuck CleanReconnectRequired
+        // state.
+        _pendingConnectReplyTo = replyTo.IsNobody() ? null : replyTo;
 
         var attempt = ++_connectAttempt;
         Become(Connecting);


### PR DESCRIPTION
## Summary

Root-causes and fixes the Discord reliability incident observed in testlab on 0.24.0-beta.2: the gateway dropped every inbound Discord message for 30+ minutes ("Dropping Discord message … while gateway is not ready: Discord gateway disconnected.") while the WebSocket was demonstrably connected and delivering events.

## Root cause

The auto-retry path connects with `ActorRefs.Nobody` as the reply-to, and `StartConnecting` stored it verbatim — so every `_pendingConnectReplyTo is null` check misfired:

1. A transport drop while Ready put the actor in Connecting awaiting Discord.Net's self-reconnect; the 30s READY timeout fired and correctly drove a clean reconnect + auto-retry (`Attempting Discord reconnect (delay was 00:00:05)` — visible in Seq at 21:15:28).
2. The **retried** connect also failed to reach READY in 30s. `HandleReadyTimedOut` saw `Nobody` pass the `is not null` pending-caller check, "failed" the pending connect by telling Nobody (silent no-op), and parked the actor in `CleanReconnectRequired` — **silently** (matching the Seq silence after 21:15:58).
3. `CleanReconnectRequired` swallows Connected/READY events, handles no `RetryConnect`, and arms no timers. When Discord.Net self-reconnected at 21:45, the actor never noticed — permanent zombie until daemon restart.

The same `Nobody`-vs-`null` skew made `isRetry` compute false on retries, so `ConnectionRestored` never published after an auto-retry recovery — in both the Discord **and** Mattermost lifecycle actors.

## Fix

Normalize `Nobody` → `null` at the single storage point in `StartConnecting` (both actors). "No pending caller" now has exactly one representation: the ready-timeout path falls through to `RequestCleanReconnect` (publish → clean stop → scheduled retry — the self-healing loop), and `ConnectionRestored` fires on retry recoveries.

## Tests (mutation-verified: both fail against the unfixed actors)

- **Discord** (`DiscordGatewayLifecycleRetryTimeoutTests`, virtual-time via `TestScheduler`): drives the exact incident sequence — ready → spurious-Connected clean reconnect → auto-retry → READY timeout → asserts a **second** clean-reconnect request is emitted and the actor recovers when READY finally arrives, publishing `ConnectionRestored`.
- **Mattermost**: auto-retry recovery must publish `ConnectionRestored` exactly once.

## Validation

- Full `Netclaw.Actors.Tests` suite: 2,282 passed
- `dotnet slopwatch analyze`: clean; headers verified

Recommend cutting 0.24.0-beta.3 once merged — beta.2's Discord channel cannot recover from this state without a daemon restart.