### PR TITLE
Fix reminder list endpoint to include disabled reminders

### DIFF
--- a/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class ReminderEndpointRouteBuilderExtensions
         {
             var manager = await actor.GetAsync(ct);
             var response = await manager.Ask<ReminderListResponse>(
-                new ListRemindersCommand(IncludeDisabled: false), TimeSpan.FromSeconds(10), ct);
+                new ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
             var projected = response.Reminders.Select(r => new ReminderSummaryDto(
                 Id: r.Id.Value,
                 Title: r.Title,
@@ -46,7 +46,7 @@ public static class ReminderEndpointRouteBuilderExtensions
             return TypedResults.Ok(projected);
         })
         .WithName("ListReminders")
-        .WithSummary("List all active reminders.");
+        .WithSummary("List all reminders.");
 
         reminders.MapPost("", async ValueTask<Results<Ok<ReminderMessageResponse>, BadRequest<ReminderErrorResponse>, ProblemHttpResult>> (
             CreateReminderRequest request,


### PR DESCRIPTION
## Summary

- Update `GET /api/reminders` to request all reminder definitions from the reminder manager instead of active-only reminders.
- Update the endpoint summary from “List all active reminders” to “List all reminders.”

## Behavior

Disabled reminders remain persisted and can be re-enabled by ID, so the REST list endpoint now returns them in the default list response. This keeps the CLI-backed list output useful after a reminder has been disabled but not permanently deleted.

## Validation

- Not run; change is limited to the reminder list endpoint request flag and OpenAPI summary text.
