### PR TITLE
Fix in-session reminder delivery confirmation (current-session reminders)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -101,6 +101,9 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
     protected override void SetReplyClientThrows(Exception ex)
         => _replyClient.ThrowOnPost = ex;
 
+    protected override void SetReplyClientThrowsOnce(Exception ex)
+        => _replyClient.ThrowOnceOnPost = ex;
+
     protected override void ClearReplyClientThrows()
         => _replyClient.ThrowOnPost = null;
 

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/MattermostSessionBindingContractTests.cs
@@ -104,6 +104,9 @@ public sealed class MattermostSessionBindingContractTests(ITestOutputHelper outp
     protected override void SetReplyClientThrows(Exception ex)
         => _replyClient.ThrowOnPost = ex;
 
+    protected override void SetReplyClientThrowsOnce(Exception ex)
+        => _replyClient.ThrowOnceOnPost = ex;
+
     protected override void ClearReplyClientThrows()
         => _replyClient.ThrowOnPost = null;
 

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -317,6 +317,45 @@ public abstract class SessionBindingContractTests : TestKit
         ClearReplyClientThrows();
     }
 
+    // Regression for the observer-clobber bug: two distinct reminders can target
+    // the same session concurrently. A single observer field is overwritten by
+    // the second dispatch before the first turn completes, so the first
+    // reminder's result is misrouted. Each observer must receive ITS OWN keyed
+    // result.
+    [Fact]
+    public async Task Concurrent_reminders_to_same_session_each_get_their_own_result()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-reminder-concurrent");
+        const string keyA = "reminder-A:111";
+        const string keyB = "reminder-B:222";
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput("reply A") { SessionId = sid },
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1), SourceReminderId = keyA },
+            new TextOutput("reply B") { SessionId = sid },
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(2), SourceReminderId = keyB }
+        ], reactive: true);
+
+        var observerA = CreateTestProbe();
+        var observerB = CreateTestProbe();
+        var binding = CreateBindingActor(sid, pipeline, detector);
+        await pipeline.Created;
+
+        // Both reminders dispatched before either turn completes.
+        binding.Tell(new DeliverTrustedSessionTurn(sid, "reminder A", CreateReminderSource(keyA, observerA.Ref)));
+        binding.Tell(new DeliverTrustedSessionTurn(sid, "reminder B", CreateReminderSource(keyB, observerB.Ref)));
+
+        var resultA = await observerA.ExpectMsgAsync<ReminderDeliveryResult>(
+            TimeSpan.FromSeconds(5), cancellationToken: ct);
+        Assert.Equal(keyA, resultA.ReminderDeliveryKey);
+
+        var resultB = await observerB.ExpectMsgAsync<ReminderDeliveryResult>(
+            TimeSpan.FromSeconds(5), cancellationToken: ct);
+        Assert.Equal(keyB, resultB.ReminderDeliveryKey);
+    }
+
     private MessageSource CreateReminderSource(string reminderKey, IActorRef deliveryObserver)
         => new()
         {

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -261,27 +261,78 @@ public abstract class SessionBindingContractTests : TestKit
     }
 
     [Fact]
-    public async Task Reminder_delivery_publishes_observation()
+    public async Task Reminder_delivery_reports_success_when_post_succeeds()
     {
         var ct = TestContext.Current.CancellationToken;
         var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
-        var sid = new SessionId("session-reminder");
+        var sid = new SessionId("session-reminder-success");
+        const string reminderKey = "reminder-1:123456";
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reminder output") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1), SourceReminderId = "reminder-1:123456" }
-        ]);
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1), SourceReminderId = reminderKey }
+        ], reactive: true);
 
-        var probe = CreateTestProbe();
-        Sys.EventStream.Subscribe(probe, typeof(ReminderDeliveryObserved));
+        var observer = CreateTestProbe();
+        var binding = CreateBindingActor(sid, pipeline, detector);
+        await pipeline.Created;
+        binding.Tell(new DeliverTrustedSessionTurn(sid, "run the reminder", CreateReminderSource(reminderKey, observer.Ref)));
 
-        CreateBindingActor(sid, pipeline, detector);
-
-        var observed = await probe.ExpectMsgAsync<ReminderDeliveryObserved>(
+        var result = await observer.ExpectMsgAsync<ReminderDeliveryResult>(
             TimeSpan.FromSeconds(5), cancellationToken: ct);
-        Assert.Equal("reminder-1:123456", observed.ReminderDeliveryKey);
-        Assert.Equal(ExpectedChannelType, observed.ChannelType);
+        Assert.Equal(reminderKey, result.ReminderDeliveryKey);
+        Assert.Equal(ExpectedChannelType, result.ChannelType);
+        Assert.True(result.Delivered);
     }
+
+    // Regression for the silent-loss class of bugs (Discord/Mattermost marked
+    // a reminder turn delivered even when the post threw). A failed post must
+    // report Delivered=false so the execution actor redelivers instead of
+    // acking a delivery that never happened.
+    [Fact]
+    public async Task Reminder_delivery_reports_failure_when_post_throws()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-reminder-failure");
+        const string reminderKey = "reminder-1:123456";
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput("reminder output") { SessionId = sid },
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1), SourceReminderId = reminderKey }
+        ], reactive: true);
+
+        SetReplyClientThrows(new InvalidOperationException("channel API down"));
+        var observer = CreateTestProbe();
+        var binding = CreateBindingActor(sid, pipeline, detector);
+        await pipeline.Created;
+        binding.Tell(new DeliverTrustedSessionTurn(sid, "run the reminder", CreateReminderSource(reminderKey, observer.Ref)));
+
+        var result = await observer.ExpectMsgAsync<ReminderDeliveryResult>(
+            TimeSpan.FromSeconds(5), cancellationToken: ct);
+        Assert.Equal(reminderKey, result.ReminderDeliveryKey);
+        Assert.Equal(ExpectedChannelType, result.ChannelType);
+        Assert.False(result.Delivered);
+
+        ClearReplyClientThrows();
+    }
+
+    private MessageSource CreateReminderSource(string reminderKey, IActorRef deliveryObserver)
+        => new()
+        {
+            ChannelType = ExpectedChannelType,
+            SenderId = new Netclaw.Actors.Protocol.SenderId("reminder-system"),
+            Audience = TrustAudience.Public,
+            Boundary = TrustBoundary.TrustedInstance,
+            Principal = PrincipalClassification.VerifiedAutomation,
+            Provenance = new SourceProvenance(TransportAuthenticity.LocalProcess, PayloadTaint.Trusted)
+            {
+                SourceKind = new SourceKind("reminder")
+            },
+            ReceivedAt = DateTimeOffset.UnixEpoch,
+            ReminderId = reminderKey,
+            DeliveryObserver = deliveryObserver
+        };
 
     // --- Approval Flow ---
 

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -39,6 +39,10 @@ public abstract class SessionBindingContractTests : TestKit
 
     protected abstract void SetReplyClientThrows(Exception ex);
 
+    // Fail only the next post, then recover. Lets a test fail a content post
+    // while letting a follow-up (e.g. the empty-turn fallback) succeed.
+    protected abstract void SetReplyClientThrowsOnce(Exception ex);
+
     protected abstract void ClearReplyClientThrows();
 
     protected abstract ChannelType ExpectedChannelType { get; }
@@ -354,6 +358,43 @@ public abstract class SessionBindingContractTests : TestKit
         var resultB = await observerB.ExpectMsgAsync<ReminderDeliveryResult>(
             TimeSpan.FromSeconds(5), cancellationToken: ct);
         Assert.Equal(keyB, resultB.ReminderDeliveryKey);
+    }
+
+    // Regression for the misleading-fallback bug: when the real content post
+    // fails (the model DID produce a reply, the transport rejected it), the
+    // binding must NOT then post the "I didn't manage to produce a reply"
+    // fallback. That message is for genuinely empty turns; on a failed post the
+    // session was already notified, and the fallback both misleads and doubles
+    // up with the redelivered reply. Slack already guarded this; Discord and
+    // Mattermost did not.
+    [Fact]
+    public async Task Failed_content_post_does_not_post_empty_turn_fallback()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-failed-post-no-fallback");
+        // Turn 1's content post fails; turn 2 is a barrier — once its reply is
+        // visible, turn 1 (including its fallback decision) is fully processed.
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput("real reply") { SessionId = sid },
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) },
+            new TextOutput("barrier reply") { SessionId = sid },
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(2) }
+        ]);
+
+        // Fail only the first post (the real reply); the fallback, if attempted,
+        // would succeed and be recorded.
+        SetReplyClientThrowsOnce(new InvalidOperationException("transient channel error"));
+        CreateBindingActor(sid, pipeline, detector);
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Contains(GetPostedTexts(), t => t.Contains("barrier reply", StringComparison.Ordinal));
+        }, cancellationToken: ct);
+
+        var texts = GetPostedTexts();
+        Assert.DoesNotContain(texts, t => t.Contains("didn't manage to produce a reply", StringComparison.OrdinalIgnoreCase));
     }
 
     private MessageSource CreateReminderSource(string reminderKey, IActorRef deliveryObserver)

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
@@ -82,6 +82,9 @@ public sealed class SlackSessionBindingContractTests(ITestOutputHelper output)
     protected override void SetReplyClientThrows(Exception ex)
         => _replyClient.ThrowOnPost = ex;
 
+    protected override void SetReplyClientThrowsOnce(Exception ex)
+        => _replyClient.ThrowOnceOnPost = ex;
+
     protected override void ClearReplyClientThrows()
         => _replyClient.ThrowOnPost = null;
 

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingDiscordReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingDiscordReplyClient.cs
@@ -16,6 +16,9 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
     public List<DiscordFileUpload> Uploads { get; } = [];
     public Exception? ThrowOnPost { get; set; }
     public Exception? ThrowOnUpload { get; set; }
+    // Throws on the next post only, then auto-clears. Lets a test fail a content
+    // post while letting a follow-up (e.g. fallback) succeed and be recorded.
+    public Exception? ThrowOnceOnPost { get; set; }
 
     private int _messageCounter;
 
@@ -23,6 +26,12 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
     {
         if (ThrowOnPost is { } ex)
             throw ex;
+
+        if (ThrowOnceOnPost is { } onceEx)
+        {
+            ThrowOnceOnPost = null;
+            throw onceEx;
+        }
 
         Posts.Add(message);
 

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingMattermostReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingMattermostReplyClient.cs
@@ -33,6 +33,10 @@ internal sealed class RecordingMattermostReplyClient : IMattermostReplyClient
 
     public Exception? ThrowOnUpload { get; set; }
 
+    // Throws on the next post only, then auto-clears. Lets a test fail a content
+    // post while letting a follow-up (e.g. fallback) succeed and be recorded.
+    public Exception? ThrowOnceOnPost { get; set; }
+
     private int _messageCounter;
 
     public void Clear()
@@ -49,6 +53,12 @@ internal sealed class RecordingMattermostReplyClient : IMattermostReplyClient
     {
         if (ThrowOnPost is { } ex)
             throw ex;
+
+        if (ThrowOnceOnPost is { } onceEx)
+        {
+            ThrowOnceOnPost = null;
+            throw onceEx;
+        }
 
         lock (_lock) _posts.Add(message);
         var postId = new MattermostPostId($"post-{Interlocked.Increment(ref _messageCounter)}");

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSlackReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSlackReplyClient.cs
@@ -26,6 +26,10 @@ public sealed class RecordingSlackReplyClient : ISlackReplyClient
 
     public Exception? ThrowOnPost { get; set; }
 
+    // Throws on the next post only, then auto-clears. Lets a test fail a content
+    // post while letting a follow-up (e.g. fallback) succeed and be recorded.
+    public Exception? ThrowOnceOnPost { get; set; }
+
     public void Clear()
     {
         lock (_lock)
@@ -39,6 +43,7 @@ public sealed class RecordingSlackReplyClient : ISlackReplyClient
     {
         if (ThrowOnPost is { } ex)
             throw ex;
+        ThrowOnceIfArmed();
         lock (_lock) _posts.Add(message);
         return Task.CompletedTask;
     }
@@ -47,8 +52,18 @@ public sealed class RecordingSlackReplyClient : ISlackReplyClient
     {
         if (ThrowOnPost is { } ex)
             throw ex;
+        ThrowOnceIfArmed();
         lock (_lock) _posts.Add(message);
         return Task.FromResult("fake.ts");
+    }
+
+    private void ThrowOnceIfArmed()
+    {
+        if (ThrowOnceOnPost is { } onceEx)
+        {
+            ThrowOnceOnPost = null;
+            throw onceEx;
+        }
     }
 
     public Task UpdateThreadMessageAsync(

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -666,6 +666,41 @@ public class ReminderManagerActorTests : TestKit
         }
     }
 
+    // The session dedups redeliveries by the delivery key, so the key MUST be
+    // built from the envelope's scheduled fire time (identical across
+    // redeliveries) — not the per-execution dispatch wall-clock, which drifts
+    // and would let a redelivery slip past dedup and deliver twice.
+    [Fact]
+    public async Task CurrentSession_delivery_key_is_built_from_envelope_fire_time()
+    {
+        var manager = await GetManagerAsync();
+
+        var gatewayProbe = CreateTestProbe("stable-key-gateway");
+        var autoAckRef = Sys.ActorOf(
+            Props.Create(() => new AutoAckTrustedGateway(gatewayProbe.Ref)),
+            "auto-ack-stable-key");
+        ActorRegistry.For(Sys).Register<SlackGatewayActorKey>(autoAckRef);
+
+        var definition = CreateCurrentSessionDefinition("stable-key", deliveryRequired: true);
+        _definitionStore.Save(definition);
+
+        // A distinctive fire time far from "now": a key built from the dispatch
+        // wall-clock would not match it.
+        var fireTime = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
+        var envelope = new ReminderEnvelope<ReminderPayload>(
+            entity: new ReminderEntity(ReminderManagerActor.ShardRegionName, ReminderManagerActor.EntityId),
+            key: new ReminderKey(definition.Id.Value),
+            dueTimeUtc: fireTime,
+            deadline: ReminderDeadline.Infinite,
+            message: new ReminderPayload { Id = definition.Id });
+
+        manager.Tell(envelope);
+
+        var delivered = await gatewayProbe.ExpectMsgAsync<DeliverTrustedSessionTurn>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal($"{definition.Id}:{fireTime.ToUnixTimeMilliseconds()}", delivered.Source.ReminderId);
+    }
+
     [Fact]
     public async Task CurrentSession_delivery_required_succeeds_when_delivery_is_observed()
     {

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -617,6 +617,56 @@ public class ReminderManagerActorTests : TestKit
     }
 
     [Fact]
+    public async Task CurrentSession_delivery_required_fails_fast_on_explicit_delivery_failure()
+    {
+        var manager = await GetManagerAsync();
+
+        // Generous backstop: if the explicit failure signal weren't honored,
+        // this test would hang for the full timeout rather than fail fast.
+        var originalTimeout = ReminderExecutionActor.DeliveryObservedTimeout;
+        ReminderExecutionActor.DeliveryObservedTimeout = TimeSpan.FromSeconds(30);
+        try
+        {
+            var gatewayProbe = CreateTestProbe("current-session-failed-gateway");
+            var autoAckRef = Sys.ActorOf(
+                Props.Create(() => new AutoAckTrustedGateway(gatewayProbe.Ref)),
+                "auto-ack-current-session-failed");
+            ActorRegistry.For(Sys).Register<SlackGatewayActorKey>(autoAckRef);
+
+            var definition = CreateCurrentSessionDefinition("current-session-failed", deliveryRequired: true);
+            _definitionStore.Save(definition);
+
+            manager.Tell(CreateEnvelope(definition.Id.Value));
+
+            var delivered = await gatewayProbe.ExpectMsgAsync<DeliverTrustedSessionTurn>(
+                TimeSpan.FromSeconds(5),
+                cancellationToken: TestContext.Current.CancellationToken);
+            Assert.NotNull(delivered.Source.ReminderId);
+            Assert.NotNull(delivered.Source.DeliveryObserver);
+
+            // Channel reports the post failed — execution must report failure
+            // (so Akka.Reminders redelivers) without acking the envelope.
+            delivered.Source.DeliveryObserver!.Tell(new ReminderDeliveryResult(
+                delivered.Source.ReminderId!,
+                ChannelType.Slack,
+                Delivered: false,
+                FailureReason: "channel API down"));
+
+            await AwaitAssertAsync(() =>
+            {
+                Assert.Contains(_notificationSink.Alerts, alert =>
+                    alert.Category == AlertType.ReminderExecutionFailed
+                    && alert.Source == definition.Id.Value
+                    && alert.Summary.Contains("channel API down", StringComparison.OrdinalIgnoreCase));
+            }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            ReminderExecutionActor.DeliveryObservedTimeout = originalTimeout;
+        }
+    }
+
+    [Fact]
     public async Task CurrentSession_delivery_required_succeeds_when_delivery_is_observed()
     {
         var manager = await GetManagerAsync();
@@ -640,11 +690,13 @@ public class ReminderManagerActorTests : TestKit
                 TimeSpan.FromSeconds(5),
                 cancellationToken: TestContext.Current.CancellationToken);
             Assert.NotNull(delivered.Source.ReminderId);
+            Assert.NotNull(delivered.Source.DeliveryObserver);
 
-            Sys.EventStream.Publish(new ReminderDeliveryObserved(
+            delivered.Source.DeliveryObserver!.Tell(new ReminderDeliveryResult(
                 delivered.Source.ReminderId!,
                 ChannelType.Slack,
-                TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds()));
+                Delivered: true,
+                ObservedAtMs: TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds()));
 
             await AwaitAssertAsync(async () =>
             {
@@ -922,11 +974,13 @@ public class ReminderManagerActorTests : TestKit
                 TimeSpan.FromSeconds(5),
                 cancellationToken: TestContext.Current.CancellationToken);
             Assert.NotNull(delivered.Source.ReminderId);
+            Assert.NotNull(delivered.Source.DeliveryObserver);
 
-            Sys.EventStream.Publish(new ReminderDeliveryObserved(
+            delivered.Source.DeliveryObserver!.Tell(new ReminderDeliveryResult(
                 delivered.Source.ReminderId!,
                 ChannelType.Discord,
-                TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds()));
+                Delivered: true,
+                ObservedAtMs: TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds()));
 
             await AwaitAssertAsync(async () =>
             {

--- a/src/Netclaw.Actors/Channels/MessageSource.cs
+++ b/src/Netclaw.Actors/Channels/MessageSource.cs
@@ -167,4 +167,19 @@ public sealed record MessageSource
     /// serializable and <see cref="MessageSource"/> is never persisted.
     /// </summary>
     public IActorRef? AckTarget { get; init; }
+
+    /// <summary>
+    /// Optional long-lived reply target for reminder delivery confirmation.
+    /// Unlike <see cref="AckTarget"/> (the dispatcher's <c>Ask</c> temp actor,
+    /// which completes at turn-accept time and is then dead), this is the
+    /// dispatching <c>ReminderExecutionActor</c>'s own ref, alive until the
+    /// turn delivers. When set, the channel binding actor tells it a
+    /// <see cref="Protocol.ReminderDeliveryResult"/> on turn completion,
+    /// reporting whether the assistant reply actually reached the channel.
+    /// Only populated for <c>DeliveryKind.CurrentSession</c> reminders with
+    /// <c>DeliveryRequired = true</c>; null otherwise. Runtime-only — an
+    /// <see cref="IActorRef"/> is not serializable and <see cref="MessageSource"/>
+    /// is never persisted.
+    /// </summary>
+    public IActorRef? DeliveryObserver { get; init; }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -24,8 +24,14 @@ namespace Netclaw.Actors.Reminders;
 internal sealed class ReminderExecutionActor : ReceiveActor
 {
     /// <summary>
-    /// How long CurrentSession reminders with <c>DeliveryRequired=true</c>
-    /// wait for outbound delivery observation after session <see cref="CommandAck"/>.
+    /// Backstop timeout for CurrentSession reminders with
+    /// <c>DeliveryRequired=true</c> waiting for a
+    /// <see cref="ReminderDeliveryResult"/> after session <see cref="CommandAck"/>.
+    /// The binding actor normally reports delivery success OR failure
+    /// explicitly (so failures redeliver fast); this timeout only fires when
+    /// the binding actor never responds at all — e.g. it crashed mid-turn.
+    /// It is deliberately generous: firing it early on a slow-but-live turn
+    /// would report a false failure and redeliver, duplicating the message.
     /// </summary>
     internal static TimeSpan DeliveryObservedTimeout = TimeSpan.FromHours(1);
 
@@ -43,9 +49,10 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private bool _completed;
     private string? _sessionIdValue;
     private HistoryRecord? _pendingHistory;
-    private TaskCompletionSource<ReminderDeliveryObserved>? _deliveryObservedTcs;
+    private bool _awaitingDeliveryResult;
     private string? _expectedReminderDeliveryKey;
     private ChannelType? _expectedDeliveryChannel;
+    private ICancelable? _deliveryTimeoutCancelable;
 
     private bool RoutesBackToOriginSession => _definition.Delivery.Kind == DeliveryKind.CurrentSession;
 
@@ -90,7 +97,8 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
         Receive<ExecutionOutput>(HandleOutput);
         Receive<ExecutionStarted>(_ => { });
-        Receive<ReminderDeliveryObserved>(HandleDeliveryObserved);
+        Receive<ReminderDeliveryResult>(HandleDeliveryResult);
+        Receive<DeliveryBackstopTimeout>(HandleDeliveryBackstopTimeout);
     }
 
     protected override void PreStart()
@@ -170,9 +178,14 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     /// to the originating channel's gateway and calls
     /// <c>IReminderClient.AckAsync(envelope)</c> exactly once once the
     /// target session has acknowledged receipt via the
-    /// <c>MessageSource.AckTarget</c>-propagated <c>CommandAck</c>. On
-    /// timeout, <c>CommandNack</c>, or any exception, <c>AckAsync</c> is
-    /// NOT called and Akka.Reminders redelivers per its built-in policy.
+    /// <c>MessageSource.AckTarget</c>-propagated <c>CommandAck</c>. When
+    /// <c>DeliveryRequired</c> is true, ack is further gated on a
+    /// <see cref="ReminderDeliveryResult"/> reporting an actual successful
+    /// post (the binding actor tells it directly via
+    /// <c>MessageSource.DeliveryObserver</c>). On <c>CommandNack</c>, a
+    /// delivery failure, the backstop timeout, or any exception,
+    /// <c>AckAsync</c> is NOT called and Akka.Reminders redelivers per its
+    /// built-in policy.
     /// </summary>
     private async Task InitializeCurrentSessionAsync()
     {
@@ -207,7 +220,13 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                     SourceKind = new SourceKind("reminder")
                 },
                 ReceivedAt = _dispatchedAt,
-                ReminderId = reminderDeliveryKey
+                ReminderId = reminderDeliveryKey,
+                // Only reminders that gate on delivery need a confirmation
+                // channel. The binding actor tells this ref a
+                // ReminderDeliveryResult on turn completion; leaving it null
+                // for non-required reminders avoids a dead-letter when this
+                // actor has already acked and stopped.
+                DeliveryObserver = _definition.DeliveryRequired ? Self : null
             };
 
             var gateway = ResolveGatewayFor(originChannelType);
@@ -231,12 +250,14 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
                         if (_definition.DeliveryRequired)
                         {
-                            var observed = await WaitForDeliveryObservationAsync(reminderDeliveryKey, originChannelType);
-                            if (!observed)
-                            {
-                                ReportAndStop(false, $"delivery not observed within {DeliveryObservedTimeout}");
-                                break;
-                            }
+                            // Do NOT await the delivery result here: this runs
+                            // inside RunTask, which suspends the mailbox until
+                            // the task completes — the actor could not process
+                            // the ReminderDeliveryResult message it is waiting
+                            // for. Arm state + a backstop timer and return; the
+                            // result (or timeout) is handled as a normal message.
+                            BeginAwaitingDeliveryResult(reminderDeliveryKey, originChannelType);
+                            break;
                         }
 
                         await TryAckEnvelopeAsync();
@@ -273,51 +294,74 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         }
     }
 
-    private void HandleDeliveryObserved(ReminderDeliveryObserved observed)
+    /// <summary>
+    /// Enters the message-driven "waiting for delivery confirmation" state and
+    /// schedules a backstop timeout. Runs at the tail of the dispatch
+    /// <c>RunTask</c>; once that task returns, the actor resumes normal mailbox
+    /// processing and can handle the <see cref="ReminderDeliveryResult"/> the
+    /// binding actor tells it (or the <see cref="DeliveryBackstopTimeout"/>).
+    /// </summary>
+    private void BeginAwaitingDeliveryResult(string reminderDeliveryKey, ChannelType channelType)
     {
-        if (_deliveryObservedTcs is null || _expectedReminderDeliveryKey is null)
-            return;
-
-        if (!string.Equals(observed.ReminderDeliveryKey, _expectedReminderDeliveryKey, StringComparison.Ordinal))
-            return;
-
-        if (_expectedDeliveryChannel is { } expectedChannel && observed.ChannelType != expectedChannel)
-            return;
-
-        _deliveryObservedTcs.TrySetResult(observed);
-    }
-
-    private async Task<bool> WaitForDeliveryObservationAsync(string reminderDeliveryKey, ChannelType channelType)
-    {
+        _awaitingDeliveryResult = true;
         _expectedReminderDeliveryKey = reminderDeliveryKey;
         _expectedDeliveryChannel = channelType;
-        _deliveryObservedTcs = new TaskCompletionSource<ReminderDeliveryObserved>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Context.System.EventStream.Subscribe(Self, typeof(ReminderDeliveryObserved));
+        _deliveryTimeoutCancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(
+            DeliveryObservedTimeout,
+            Self,
+            new DeliveryBackstopTimeout(reminderDeliveryKey),
+            Self);
+    }
 
-        try
+    private void HandleDeliveryResult(ReminderDeliveryResult result)
+    {
+        if (!_awaitingDeliveryResult || _expectedReminderDeliveryKey is null)
+            return;
+
+        if (!string.Equals(result.ReminderDeliveryKey, _expectedReminderDeliveryKey, StringComparison.Ordinal))
+            return;
+
+        if (_expectedDeliveryChannel is { } expectedChannel && result.ChannelType != expectedChannel)
+            return;
+
+        _awaitingDeliveryResult = false;
+        _deliveryTimeoutCancelable?.Cancel();
+        _deliveryTimeoutCancelable = null;
+
+        if (result.Delivered)
         {
-            var completed = await Task.WhenAny(_deliveryObservedTcs.Task, Task.Delay(DeliveryObservedTimeout));
-            if (completed != _deliveryObservedTcs.Task)
-            {
-                _log.Warning(
-                    "reminder_delivery_observation_timeout execution_id={ExecutionId} reminder_id={ReminderId} key={ReminderDeliveryKey} timeout={Timeout}",
-                    _executionId, _definition.Id, reminderDeliveryKey, DeliveryObservedTimeout);
-                return false;
-            }
-
-            var observed = await _deliveryObservedTcs.Task;
             _log.Info(
                 "reminder_delivery_observed execution_id={ExecutionId} reminder_id={ReminderId} key={ReminderDeliveryKey} channel={ChannelType}",
-                _executionId, _definition.Id, observed.ReminderDeliveryKey, observed.ChannelType);
-            return true;
+                _executionId, _definition.Id, result.ReminderDeliveryKey, result.ChannelType);
+            RunTask(async () =>
+            {
+                await TryAckEnvelopeAsync();
+                ReportAndStop(true);
+            });
         }
-        finally
+        else
         {
-            Context.System.EventStream.Unsubscribe(Self, typeof(ReminderDeliveryObserved));
-            _deliveryObservedTcs = null;
-            _expectedReminderDeliveryKey = null;
-            _expectedDeliveryChannel = null;
+            _log.Warning(
+                "reminder_delivery_failed execution_id={ExecutionId} reminder_id={ReminderId} key={ReminderDeliveryKey} channel={ChannelType} reason={Reason}",
+                _executionId, _definition.Id, result.ReminderDeliveryKey, result.ChannelType, result.FailureReason);
+            ReportAndStop(false, result.FailureReason ?? "channel reported delivery failure");
         }
+    }
+
+    private void HandleDeliveryBackstopTimeout(DeliveryBackstopTimeout msg)
+    {
+        if (!_awaitingDeliveryResult || _expectedReminderDeliveryKey is null)
+            return;
+
+        if (!string.Equals(msg.ReminderDeliveryKey, _expectedReminderDeliveryKey, StringComparison.Ordinal))
+            return;
+
+        _awaitingDeliveryResult = false;
+        _deliveryTimeoutCancelable = null;
+        _log.Warning(
+            "reminder_delivery_observation_timeout execution_id={ExecutionId} reminder_id={ReminderId} key={ReminderDeliveryKey} timeout={Timeout}",
+            _executionId, _definition.Id, msg.ReminderDeliveryKey, DeliveryObservedTimeout);
+        ReportAndStop(false, $"delivery not observed within {DeliveryObservedTimeout}");
     }
 
     private async Task TryAckEnvelopeAsync()
@@ -507,6 +551,9 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
     protected override void PostStop()
     {
+        _deliveryTimeoutCancelable?.Cancel();
+        _deliveryTimeoutCancelable = null;
+
         if (_pendingHistory is not null)
         {
             try
@@ -539,4 +586,11 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
     private sealed record ExecutionStarted : INoSerializationVerificationNeeded;
     private sealed record ExecutionOutput(SessionOutput Output) : INoSerializationVerificationNeeded;
+
+    /// <summary>
+    /// Self-scheduled backstop fired when no <see cref="ReminderDeliveryResult"/>
+    /// arrives within <see cref="DeliveryObservedTimeout"/> (e.g. the binding
+    /// actor crashed mid-turn).
+    /// </summary>
+    private sealed record DeliveryBackstopTimeout(string ReminderDeliveryKey) : INoSerializationVerificationNeeded;
 }

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -51,7 +51,6 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private HistoryRecord? _pendingHistory;
     private bool _awaitingDeliveryResult;
     private string? _expectedReminderDeliveryKey;
-    private ChannelType? _expectedDeliveryChannel;
     private ICancelable? _deliveryTimeoutCancelable;
 
     private bool RoutesBackToOriginSession => _definition.Delivery.Kind == DeliveryKind.CurrentSession;
@@ -256,7 +255,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                             // the ReminderDeliveryResult message it is waiting
                             // for. Arm state + a backstop timer and return; the
                             // result (or timeout) is handled as a normal message.
-                            BeginAwaitingDeliveryResult(reminderDeliveryKey, originChannelType);
+                            BeginAwaitingDeliveryResult(reminderDeliveryKey);
                             break;
                         }
 
@@ -301,11 +300,10 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     /// processing and can handle the <see cref="ReminderDeliveryResult"/> the
     /// binding actor tells it (or the <see cref="DeliveryBackstopTimeout"/>).
     /// </summary>
-    private void BeginAwaitingDeliveryResult(string reminderDeliveryKey, ChannelType channelType)
+    private void BeginAwaitingDeliveryResult(string reminderDeliveryKey)
     {
         _awaitingDeliveryResult = true;
         _expectedReminderDeliveryKey = reminderDeliveryKey;
-        _expectedDeliveryChannel = channelType;
         _deliveryTimeoutCancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(
             DeliveryObservedTimeout,
             Self,
@@ -318,10 +316,13 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         if (!_awaitingDeliveryResult || _expectedReminderDeliveryKey is null)
             return;
 
+        // Correlate on the delivery key alone. The result was told point-to-
+        // point to this actor's own Self (via MessageSource.DeliveryObserver),
+        // and the key is unique per execution — matching the reported
+        // ChannelType too would only fail closed (e.g. a cold SignalR actor
+        // reports its default Tui rather than the origin SignalR), silently
+        // dropping a valid result and stalling on the backstop.
         if (!string.Equals(result.ReminderDeliveryKey, _expectedReminderDeliveryKey, StringComparison.Ordinal))
-            return;
-
-        if (_expectedDeliveryChannel is { } expectedChannel && result.ChannelType != expectedChannel)
             return;
 
         _awaitingDeliveryResult = false;
@@ -335,8 +336,19 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 _executionId, _definition.Id, result.ReminderDeliveryKey, result.ChannelType);
             RunTask(async () =>
             {
-                await TryAckEnvelopeAsync();
-                ReportAndStop(true);
+                try
+                {
+                    await TryAckEnvelopeAsync();
+                    ReportAndStop(true);
+                }
+                catch (Exception ex)
+                {
+                    // Never let an ack fault escalate to a supervisor restart:
+                    // that would re-run PreStart and re-post the reminder turn
+                    // in a loop. Report failure (no ack) and stop instead.
+                    LogFullException(ex, "ReminderExecution AckFailed");
+                    ReportAndStop(false, ex.Message);
+                }
             });
         }
         else
@@ -366,7 +378,13 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
     private async Task TryAckEnvelopeAsync()
     {
-        var ackResponse = await _reminderClient!.AckAsync(_envelope!);
+        // No envelope to ack when the reminder was re-run from the deferred
+        // queue: that path already acked-and-dropped the envelope eagerly
+        // (ReminderManagerActor concurrency gate). Acking null would throw.
+        if (_envelope is null)
+            return;
+
+        var ackResponse = await _reminderClient!.AckAsync(_envelope);
         if (ackResponse.ResponseCode != ReminderAckResponseCode.Success)
         {
             _log.Warning(

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -197,7 +197,15 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             var audience = _definition.Audience;
             var boundary = GetPersistedBoundaryOrThrow();
 
-            var reminderDeliveryKey = $"{_definition.Id}:{_dispatchedAt.ToUnixTimeMilliseconds()}";
+            // Dedup key must be STABLE across Akka.Reminders redeliveries of the
+            // same fire, or the target session can't recognize a redelivery and
+            // re-runs it (duplicate delivery). The envelope's scheduled fire time
+            // (DueTimeUtc) is identical on every redelivery; _dispatchedAt is
+            // captured fresh per execution actor and drifts, defeating the dedup.
+            // Deferred re-runs carry no envelope and are never redelivered, so the
+            // dispatch time is a fine fallback there.
+            var fireTimeMs = (_envelope?.DueTimeUtc ?? _dispatchedAt).ToUnixTimeMilliseconds();
+            var reminderDeliveryKey = $"{_definition.Id}:{fireTimeMs}";
 
             _log.Info(
                 "ReminderExecution CurrentSession Initialized: execution_id={ExecutionId} reminder_id={ReminderId} session_id={SessionId} origin={Origin} audience={Audience}",

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -184,7 +184,7 @@ public sealed record ReminderDefinition
     /// When true, a missed delivery fails the execution and emits
     /// <see cref="OperationalAlert.ReminderExecutionFailed"/>. For
     /// <see cref="DeliveryKind.CurrentSession"/>, this gates envelope ack
-    /// on the <see cref="ReminderDeliveryObserved"/> signal. For
+    /// on the <see cref="ReminderDeliveryResult"/> signal. For
     /// <see cref="DeliveryKind.Channel"/>, this gates success on the
     /// notification tool being called. Ignored for <see cref="DeliveryKind.None"/>.
     /// </summary>
@@ -354,25 +354,41 @@ internal sealed record ReminderExecutionCompleted(
     string? ErrorMessage = null) : INoSerializationVerificationNeeded;
 
 /// <summary>
-/// Signal emitted by the outbound channel pipeline when a reminder-sourced
-/// turn's assistant reply actually flows out through the channel's subscriber
-/// sink (e.g., Slack post API returns 200). Used by
-/// <see cref="ReminderExecutionActor"/> for <see cref="DeliveryKind.CurrentSession"/>
-/// with <see cref="ReminderDefinition.DeliveryRequired"/> = true to gate
-/// envelope ack on actual delivery observation.
+/// Point-to-point delivery outcome sent by a channel binding actor directly
+/// back to the dispatching <see cref="ReminderExecutionActor"/> (carried as
+/// <see cref="Channels.MessageSource.DeliveryObserver"/> on the originating
+/// <c>DeliverTrustedSessionTurn</c>) when a reminder-sourced turn completes.
+/// Used for <see cref="DeliveryKind.CurrentSession"/> with
+/// <see cref="ReminderDefinition.DeliveryRequired"/> = true to gate envelope
+/// ack on whether the assistant reply actually reached the channel.
+/// <para>
+/// Unlike the prior EventStream-broadcast observation, this signal reports
+/// <see cref="Delivered"/> = false on a failed post, so the execution actor
+/// can report failure immediately (triggering Akka.Reminders redelivery)
+/// instead of waiting out the backstop timeout.
+/// </para>
 /// </summary>
 /// <param name="ReminderDeliveryKey">
 /// Composite key in format "{reminderId}:{fireTimestampMs}".
 /// </param>
 /// <param name="ChannelType">
-/// The channel through which the delivery was observed.
+/// The channel that attempted the delivery.
+/// </param>
+/// <param name="Delivered">
+/// True when the assistant reply was posted to the channel; false when the
+/// turn completed without a successful post.
+/// </param>
+/// <param name="FailureReason">
+/// Optional human-readable reason when <see cref="Delivered"/> is false.
 /// </param>
 /// <param name="ObservedAtMs">
-/// Optional timestamp when the outbound delivery was observed.
+/// Optional timestamp when the outbound delivery outcome was observed.
 /// </param>
-public sealed record ReminderDeliveryObserved(
+public sealed record ReminderDeliveryResult(
     string ReminderDeliveryKey,
     Channels.ChannelType ChannelType,
+    bool Delivered,
+    string? FailureReason = null,
     long? ObservedAtMs = null) : INoSerializationVerificationNeeded;
 
 // ── Health query ──

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -63,6 +63,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
+    // True when a content post/upload this turn was attempted but failed (the
+    // model produced output, the transport rejected it). Distinct from "nothing
+    // was produced" — it suppresses the empty-turn fallback so a failed post
+    // isn't followed by a misleading "I didn't manage to produce a reply".
+    private bool _postFailedThisTurn;
     // Reply targets for in-flight reminder delivery confirmations, keyed by
     // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
     // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
@@ -235,6 +240,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         CommandAsync<ReinitializePipeline>(async msg =>
         {
             _deliveredThisTurn = false;
+            _postFailedThisTurn = false;
             // A reinit aborts any in-flight reminder turn before its
             // TurnCompleted. Report those as not-delivered now so the
             // execution actor redelivers immediately instead of stalling
@@ -1121,16 +1127,22 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             case TextOutput textOutput:
                 if (await SafeReplyAsync(textOutput.Text))
                     _deliveredThisTurn = true;
+                else
+                    _postFailedThisTurn = true;
                 break;
 
             case ErrorOutput error:
                 if (await SafeReplyAsync($":warning: {error.Message}"))
                     _deliveredThisTurn = true;
+                else
+                    _postFailedThisTurn = true;
                 break;
 
             case FileOutput file:
                 if (await SafeUploadFileAsync(file))
                     _deliveredThisTurn = true;
+                else
+                    _postFailedThisTurn = true;
                 break;
 
             case ProcessingStateOutput processing:
@@ -1191,7 +1203,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                         ObservedAtMs: completed.TimestampMs));
                 }
 
-                if (!_deliveredThisTurn)
+                // Only post the empty-turn fallback when the turn genuinely
+                // produced nothing. A failed post already notified the session
+                // (SafeReplyAsync -> NotifyDeliveryFailedAsync); posting "I
+                // didn't manage to produce a reply" on top would be misleading
+                // (a reply WAS produced) and double up with the redelivered one.
+                if (!_deliveredThisTurn && !_postFailedThisTurn)
                     await SafeReplyAsync(EmptyTurnFallbackText);
 
                 _turnNumber = completed.TurnNumber;
@@ -1209,6 +1226,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 }
                 _pendingApprovalRequests.Clear();
                 _deliveredThisTurn = false;
+                _postFailedThisTurn = false;
                 break;
         }
     }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -63,6 +63,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
+    // Reply target for the current reminder turn's delivery confirmation.
+    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
+    // on TurnCompleted, then cleared.
+    private IActorRef? _reminderDeliveryObserver;
     private Netclaw.Actors.Protocol.TurnNumber _turnNumber;
     private string? _lastSetThreadName;
     private ulong? _cursorSnowflake;
@@ -1041,6 +1045,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             AckTarget = ackTarget
         };
 
+        _reminderDeliveryObserver = message.Source.DeliveryObserver;
+
         try
         {
             using var writeCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -1100,13 +1106,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         switch (msg.Output)
         {
             case TextOutput textOutput:
-                await SafeReplyAsync(textOutput.Text);
-                _deliveredThisTurn = true;
+                if (await SafeReplyAsync(textOutput.Text))
+                    _deliveredThisTurn = true;
                 break;
 
             case ErrorOutput error:
-                await SafeReplyAsync($":warning: {error.Message}");
-                _deliveredThisTurn = true;
+                if (await SafeReplyAsync($":warning: {error.Message}"))
+                    _deliveredThisTurn = true;
                 break;
 
             case FileOutput file:
@@ -1161,12 +1167,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                     AdvanceCursor(pendingSnowflake);
                 _pendingCursorSnowflake = null;
 
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _deliveredThisTurn)
+                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
                 {
-                    Context.System.EventStream.Publish(new ReminderDeliveryObserved(
+                    _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
                         completed.SourceReminderId,
                         ChannelType.Discord,
-                        completed.TimestampMs));
+                        Delivered: _deliveredThisTurn,
+                        FailureReason: _deliveredThisTurn ? null : "Discord post did not succeed",
+                        ObservedAtMs: completed.TimestampMs));
+                    _reminderDeliveryObserver = null;
                 }
 
                 if (!_deliveredThisTurn)
@@ -1187,6 +1196,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 }
                 _pendingApprovalRequests.Clear();
                 _deliveredThisTurn = false;
+                _reminderDeliveryObserver = null;
                 break;
         }
     }
@@ -1260,7 +1270,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
     }
 
-    private async Task SafeReplyAsync(string text)
+    /// <summary>
+    /// Posts <paramref name="text"/> (chunked) to Discord. Returns true only
+    /// when every chunk posted successfully; false if any chunk failed (after
+    /// notifying the session of the delivery failure). Callers that gate
+    /// reminder delivery confirmation on real delivery must honor the result.
+    /// </summary>
+    private async Task<bool> SafeReplyAsync(string text)
     {
         var chunks = ChunkMessage(text);
         foreach (var chunk in chunks)
@@ -1280,9 +1296,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 _log.Warning(ex, "Failed posting Discord reply for session {0}", _sessionId.Value);
                 ChannelTelemetry.For(ChannelType.Discord).RecordReplyFailed(duration);
                 await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-                return;
+                return false;
             }
         }
+
+        return true;
     }
 
     private DiscordPostMessage BuildPostMessage(

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -63,10 +63,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
-    // Reply target for the current reminder turn's delivery confirmation.
-    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
-    // on TurnCompleted, then cleared.
-    private IActorRef? _reminderDeliveryObserver;
+    // Reply targets for in-flight reminder delivery confirmations, keyed by
+    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
+    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
+    // Keyed (not a single field) because multiple reminders can target the
+    // same session concurrently — a single field would be clobbered.
+    private readonly Dictionary<string, IActorRef> _reminderDeliveryObservers = new(StringComparer.Ordinal);
     private Netclaw.Actors.Protocol.TurnNumber _turnNumber;
     private string? _lastSetThreadName;
     private ulong? _cursorSnowflake;
@@ -233,6 +235,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         CommandAsync<ReinitializePipeline>(async msg =>
         {
             _deliveredThisTurn = false;
+            // A reinit aborts any in-flight reminder turn before its
+            // TurnCompleted. Report those as not-delivered now so the
+            // execution actor redelivers immediately instead of stalling
+            // until the backstop timeout.
+            FailPendingReminderDeliveries($"Discord pipeline reinitialized: {msg.Reason}");
             await _handle.ReinitializeAsync(
                 msg.Reason,
                 () => Timers.StartSingleTimer(
@@ -1045,7 +1052,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             AckTarget = ackTarget
         };
 
-        _reminderDeliveryObserver = message.Source.DeliveryObserver;
+        // Only delivery-gated (DeliveryRequired) reminders carry a
+        // DeliveryObserver. Key it by the per-fire reminder delivery id so a
+        // second concurrent reminder to this session can't overwrite the
+        // first's observer before its turn reaches TurnCompleted.
+        if (message.Source.DeliveryObserver is { } deliveryObserver
+            && !string.IsNullOrWhiteSpace(message.Source.ReminderId))
+            _reminderDeliveryObservers[message.Source.ReminderId] = deliveryObserver;
 
         try
         {
@@ -1167,15 +1180,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                     AdvanceCursor(pendingSnowflake);
                 _pendingCursorSnowflake = null;
 
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
+                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId)
+                    && _reminderDeliveryObservers.Remove(completed.SourceReminderId, out var reminderObserver))
                 {
-                    _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
+                    reminderObserver.Tell(new ReminderDeliveryResult(
                         completed.SourceReminderId,
                         ChannelType.Discord,
                         Delivered: _deliveredThisTurn,
                         FailureReason: _deliveredThisTurn ? null : "Discord post did not succeed",
                         ObservedAtMs: completed.TimestampMs));
-                    _reminderDeliveryObserver = null;
                 }
 
                 if (!_deliveredThisTurn)
@@ -1196,7 +1209,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 }
                 _pendingApprovalRequests.Clear();
                 _deliveredThisTurn = false;
-                _reminderDeliveryObserver = null;
                 break;
         }
     }
@@ -1391,6 +1403,23 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _rootMessageId = null;
             _log.Info("Promoted Discord session to thread reply_channel={0}", threadId.Value);
         }
+    }
+
+    /// <summary>
+    /// Tells every in-flight reminder observer that delivery did not happen,
+    /// then clears them. Called when a turn can no longer reach TurnCompleted
+    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
+    /// rather than waiting out its backstop timeout.
+    /// </summary>
+    private void FailPendingReminderDeliveries(string reason)
+    {
+        if (_reminderDeliveryObservers.Count == 0)
+            return;
+
+        foreach (var (key, observer) in _reminderDeliveryObservers)
+            observer.Tell(new ReminderDeliveryResult(key, ChannelType.Discord, Delivered: false, FailureReason: reason));
+
+        _reminderDeliveryObservers.Clear();
     }
 
     private async Task NotifyDeliveryFailedAsync(DeliveryFailureKind failureKind, string errorMessage)

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -62,6 +62,10 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
+    // Reply target for the current reminder turn's delivery confirmation.
+    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
+    // on TurnCompleted, then cleared.
+    private IActorRef? _reminderDeliveryObserver;
     private TurnNumber _turnNumber;
     private string? _cursorPostId;
     private string? _pendingCursorPostId;
@@ -1019,6 +1023,8 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             AckTarget = ackTarget
         };
 
+        _reminderDeliveryObserver = message.Source.DeliveryObserver;
+
         try
         {
             using var writeCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -1078,13 +1084,13 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         switch (msg.Output)
         {
             case TextOutput textOutput:
-                await SafeReplyAsync(textOutput.Text);
-                _deliveredThisTurn = true;
+                if (await SafeReplyAsync(textOutput.Text))
+                    _deliveredThisTurn = true;
                 break;
 
             case ErrorOutput error:
-                await SafeReplyAsync($":warning: {error.Message}");
-                _deliveredThisTurn = true;
+                if (await SafeReplyAsync($":warning: {error.Message}"))
+                    _deliveredThisTurn = true;
                 break;
 
             case FileOutput file:
@@ -1132,12 +1138,15 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                     AdvanceCursor(pendingCursor);
                 _pendingCursorPostId = null;
 
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _deliveredThisTurn)
+                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
                 {
-                    Context.System.EventStream.Publish(new ReminderDeliveryObserved(
+                    _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
                         completed.SourceReminderId,
                         ChannelType.Mattermost,
-                        completed.TimestampMs));
+                        Delivered: _deliveredThisTurn,
+                        FailureReason: _deliveredThisTurn ? null : "Mattermost post did not succeed",
+                        ObservedAtMs: completed.TimestampMs));
+                    _reminderDeliveryObserver = null;
                 }
 
                 if (!_deliveredThisTurn)
@@ -1158,6 +1167,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 }
                 _pendingApprovalRequests.Clear();
                 _deliveredThisTurn = false;
+                _reminderDeliveryObserver = null;
                 break;
         }
     }
@@ -1234,7 +1244,13 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
     }
 
-    private async Task SafeReplyAsync(string text)
+    /// <summary>
+    /// Posts <paramref name="text"/> (chunked) to Mattermost. Returns true only
+    /// when every chunk posted successfully; false if any chunk failed (after
+    /// notifying the session of the delivery failure). Callers that gate
+    /// reminder delivery confirmation on real delivery must honor the result.
+    /// </summary>
+    private async Task<bool> SafeReplyAsync(string text)
     {
         var chunks = ChunkMessage(text);
         foreach (var chunk in chunks)
@@ -1253,9 +1269,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 _log.Warning(ex, "Failed posting Mattermost reply for session {0}", _sessionId.Value);
                 ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyFailed(duration);
                 await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-                return;
+                return false;
             }
         }
+
+        return true;
     }
 
     private MattermostPostMessage BuildPostMessage(

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -62,6 +62,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
+    // True when a content post/upload this turn was attempted but failed (the
+    // model produced output, the transport rejected it). Distinct from "nothing
+    // was produced" — it suppresses the empty-turn fallback so a failed post
+    // isn't followed by a misleading "I didn't manage to produce a reply".
+    private bool _postFailedThisTurn;
     // Reply targets for in-flight reminder delivery confirmations, keyed by
     // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
     // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
@@ -225,6 +230,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         CommandAsync<ReinitializePipeline>(async msg =>
         {
             _deliveredThisTurn = false;
+            _postFailedThisTurn = false;
             // A reinit aborts any in-flight reminder turn before its
             // TurnCompleted. Report those as not-delivered now so the
             // execution actor redelivers immediately instead of stalling
@@ -1099,16 +1105,22 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             case TextOutput textOutput:
                 if (await SafeReplyAsync(textOutput.Text))
                     _deliveredThisTurn = true;
+                else
+                    _postFailedThisTurn = true;
                 break;
 
             case ErrorOutput error:
                 if (await SafeReplyAsync($":warning: {error.Message}"))
                     _deliveredThisTurn = true;
+                else
+                    _postFailedThisTurn = true;
                 break;
 
             case FileOutput file:
                 if (await SafeUploadFileAsync(file))
                     _deliveredThisTurn = true;
+                else
+                    _postFailedThisTurn = true;
                 break;
 
             case ToolInteractionRequest request when string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase):
@@ -1162,7 +1174,12 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                         ObservedAtMs: completed.TimestampMs));
                 }
 
-                if (!_deliveredThisTurn)
+                // Only post the empty-turn fallback when the turn genuinely
+                // produced nothing. A failed post already notified the session
+                // (SafeReplyAsync -> NotifyDeliveryFailedAsync); posting "I
+                // didn't manage to produce a reply" on top would be misleading
+                // (a reply WAS produced) and double up with the redelivered one.
+                if (!_deliveredThisTurn && !_postFailedThisTurn)
                     await SafeReplyAsync(EmptyTurnFallbackText);
 
                 _turnNumber = completed.TurnNumber;
@@ -1180,6 +1197,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 }
                 _pendingApprovalRequests.Clear();
                 _deliveredThisTurn = false;
+                _postFailedThisTurn = false;
                 break;
         }
     }

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -62,10 +62,12 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
-    // Reply target for the current reminder turn's delivery confirmation.
-    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
-    // on TurnCompleted, then cleared.
-    private IActorRef? _reminderDeliveryObserver;
+    // Reply targets for in-flight reminder delivery confirmations, keyed by
+    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
+    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
+    // Keyed (not a single field) because multiple reminders can target the
+    // same session concurrently — a single field would be clobbered.
+    private readonly Dictionary<string, IActorRef> _reminderDeliveryObservers = new(StringComparer.Ordinal);
     private TurnNumber _turnNumber;
     private string? _cursorPostId;
     private string? _pendingCursorPostId;
@@ -223,6 +225,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         CommandAsync<ReinitializePipeline>(async msg =>
         {
             _deliveredThisTurn = false;
+            // A reinit aborts any in-flight reminder turn before its
+            // TurnCompleted. Report those as not-delivered now so the
+            // execution actor redelivers immediately instead of stalling
+            // until the backstop timeout.
+            FailPendingReminderDeliveries($"Mattermost pipeline reinitialized: {msg.Reason}");
             await _handle.ReinitializeAsync(
                 msg.Reason,
                 () => Timers.StartSingleTimer(
@@ -1023,7 +1030,13 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             AckTarget = ackTarget
         };
 
-        _reminderDeliveryObserver = message.Source.DeliveryObserver;
+        // Only delivery-gated (DeliveryRequired) reminders carry a
+        // DeliveryObserver. Key it by the per-fire reminder delivery id so a
+        // second concurrent reminder to this session can't overwrite the
+        // first's observer before its turn reaches TurnCompleted.
+        if (message.Source.DeliveryObserver is { } deliveryObserver
+            && !string.IsNullOrWhiteSpace(message.Source.ReminderId))
+            _reminderDeliveryObservers[message.Source.ReminderId] = deliveryObserver;
 
         try
         {
@@ -1138,15 +1151,15 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                     AdvanceCursor(pendingCursor);
                 _pendingCursorPostId = null;
 
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
+                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId)
+                    && _reminderDeliveryObservers.Remove(completed.SourceReminderId, out var reminderObserver))
                 {
-                    _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
+                    reminderObserver.Tell(new ReminderDeliveryResult(
                         completed.SourceReminderId,
                         ChannelType.Mattermost,
                         Delivered: _deliveredThisTurn,
                         FailureReason: _deliveredThisTurn ? null : "Mattermost post did not succeed",
                         ObservedAtMs: completed.TimestampMs));
-                    _reminderDeliveryObserver = null;
                 }
 
                 if (!_deliveredThisTurn)
@@ -1167,7 +1180,6 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 }
                 _pendingApprovalRequests.Clear();
                 _deliveredThisTurn = false;
-                _reminderDeliveryObserver = null;
                 break;
         }
     }
@@ -1331,6 +1343,23 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Tells every in-flight reminder observer that delivery did not happen,
+    /// then clears them. Called when a turn can no longer reach TurnCompleted
+    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
+    /// rather than waiting out its backstop timeout.
+    /// </summary>
+    private void FailPendingReminderDeliveries(string reason)
+    {
+        if (_reminderDeliveryObservers.Count == 0)
+            return;
+
+        foreach (var (key, observer) in _reminderDeliveryObservers)
+            observer.Tell(new ReminderDeliveryResult(key, ChannelType.Mattermost, Delivered: false, FailureReason: reason));
+
+        _reminderDeliveryObservers.Clear();
     }
 
     private async Task NotifyDeliveryFailedAsync(DeliveryFailureKind failureKind, string errorMessage)

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -38,10 +38,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private bool _postedThisTurn;
     private bool _uploadedFileThisTurn;
     private PostResult? _lastFailedPost;
-    // Reply target for the current reminder turn's delivery confirmation.
-    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
-    // on TurnCompleted, then cleared.
-    private IActorRef? _reminderDeliveryObserver;
+    // Reply targets for in-flight reminder delivery confirmations, keyed by
+    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
+    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
+    // Keyed (not a single field) because multiple reminders can target the
+    // same session concurrently — a single field would be clobbered.
+    private readonly Dictionary<string, IActorRef> _reminderDeliveryObservers = new(StringComparer.Ordinal);
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
     // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
@@ -276,7 +278,13 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             AckTarget = ackTarget
         };
 
-        _reminderDeliveryObserver = message.Source.DeliveryObserver;
+        // Only delivery-gated (DeliveryRequired) reminders carry a
+        // DeliveryObserver. Key it by the per-fire reminder delivery id so a
+        // second concurrent reminder to this session can't overwrite the
+        // first's observer before its turn reaches TurnCompleted.
+        if (message.Source.DeliveryObserver is { } deliveryObserver
+            && !string.IsNullOrWhiteSpace(message.Source.ReminderId))
+            _reminderDeliveryObservers[message.Source.ReminderId] = deliveryObserver;
 
         try
         {
@@ -1006,6 +1014,16 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private async Task ReinitializePipelineAsync(string reason)
     {
         _pendingCursorTs = null;
+        // Reset per-turn delivery flags: a reinit aborts the in-flight turn,
+        // and a stale _postedThisTurn=true would otherwise leak into the next
+        // turn and falsely report a later reminder as delivered.
+        _postedThisTurn = false;
+        _uploadedFileThisTurn = false;
+        _lastFailedPost = null;
+        // Report any in-flight reminder turn as not-delivered now so the
+        // execution actor redelivers immediately rather than stalling until
+        // the backstop timeout.
+        FailPendingReminderDeliveries($"Slack pipeline reinitialized: {reason}");
         await _handle.ReinitializeAsync(
             reason,
             () => Timers.StartSingleTimer(
@@ -1092,16 +1110,16 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                     AdvanceCursor(pendingTs);
                 _pendingCursorTs = null;
 
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
+                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId)
+                    && _reminderDeliveryObservers.Remove(completed.SourceReminderId, out var reminderObserver))
                 {
                     var delivered = _postedThisTurn || _uploadedFileThisTurn;
-                    _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
+                    reminderObserver.Tell(new ReminderDeliveryResult(
                         completed.SourceReminderId,
                         ChannelType.Slack,
                         Delivered: delivered,
                         FailureReason: delivered ? null : "Slack post did not succeed",
                         ObservedAtMs: _dependencies.TimeProvider.GetUtcNow().ToUnixTimeMilliseconds()));
-                    _reminderDeliveryObserver = null;
                 }
 
                 if (!_postedThisTurn && !_uploadedFileThisTurn)
@@ -1123,7 +1141,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 _postedThisTurn = false;
                 _uploadedFileThisTurn = false;
                 _lastFailedPost = null;
-                _reminderDeliveryObserver = null;
                 var clearedPrompts = _pendingApprovalRequests
                     .Select(pending => new PendingApprovalPromptCleared
                     {
@@ -1436,6 +1453,23 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             ChannelTelemetry.For(ChannelType.Slack).RecordReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             return new PostResult(ex.Message, DeliveryFailureKind.Unknown);
         }
+    }
+
+    /// <summary>
+    /// Tells every in-flight reminder observer that delivery did not happen,
+    /// then clears them. Called when a turn can no longer reach TurnCompleted
+    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
+    /// rather than waiting out its backstop timeout.
+    /// </summary>
+    private void FailPendingReminderDeliveries(string reason)
+    {
+        if (_reminderDeliveryObservers.Count == 0)
+            return;
+
+        foreach (var (key, observer) in _reminderDeliveryObservers)
+            observer.Tell(new ReminderDeliveryResult(key, ChannelType.Slack, Delivered: false, FailureReason: reason));
+
+        _reminderDeliveryObservers.Clear();
     }
 
     private async Task NotifyDeliveryFailedAsync(Actors.Protocol.TurnNumber turnNumber, DeliveryFailureKind failureKind, string errorMessage)

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -38,6 +38,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private bool _postedThisTurn;
     private bool _uploadedFileThisTurn;
     private PostResult? _lastFailedPost;
+    // Reply target for the current reminder turn's delivery confirmation.
+    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
+    // on TurnCompleted, then cleared.
+    private IActorRef? _reminderDeliveryObserver;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
     // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
@@ -271,6 +275,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             ReminderId = message.Source.ReminderId,
             AckTarget = ackTarget
         };
+
+        _reminderDeliveryObserver = message.Source.DeliveryObserver;
 
         try
         {
@@ -1086,12 +1092,16 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                     AdvanceCursor(pendingTs);
                 _pendingCursorTs = null;
 
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && (_postedThisTurn || _uploadedFileThisTurn))
+                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
                 {
-                    Context.System.EventStream.Publish(new ReminderDeliveryObserved(
+                    var delivered = _postedThisTurn || _uploadedFileThisTurn;
+                    _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
                         completed.SourceReminderId,
                         ChannelType.Slack,
-                        _dependencies.TimeProvider.GetUtcNow().ToUnixTimeMilliseconds()));
+                        Delivered: delivered,
+                        FailureReason: delivered ? null : "Slack post did not succeed",
+                        ObservedAtMs: _dependencies.TimeProvider.GetUtcNow().ToUnixTimeMilliseconds()));
+                    _reminderDeliveryObserver = null;
                 }
 
                 if (!_postedThisTurn && !_uploadedFileThisTurn)
@@ -1113,6 +1123,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 _postedThisTurn = false;
                 _uploadedFileThisTurn = false;
                 _lastFailedPost = null;
+                _reminderDeliveryObserver = null;
                 var clearedPrompts = _pendingApprovalRequests
                     .Select(pending => new PendingApprovalPromptCleared
                     {

--- a/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
+++ b/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
@@ -31,10 +31,12 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
     private SignalRConnectionId _currentConnectionId;
     private Actors.Channels.ChannelType _channelType = Actors.Channels.ChannelType.Tui;
     private bool _deliveredThisTurn;
-    // Reply target for the current reminder turn's delivery confirmation.
-    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
-    // on TurnCompleted, then cleared.
-    private IActorRef? _reminderDeliveryObserver;
+    // Reply targets for in-flight reminder delivery confirmations, keyed by
+    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
+    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
+    // Keyed (not a single field) because multiple reminders can target the
+    // same session concurrently — a single field would be clobbered.
+    private readonly Dictionary<string, IActorRef> _reminderDeliveryObservers = new(StringComparer.Ordinal);
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
     private static readonly object ReinitializeTimerKey = new();
@@ -156,6 +158,12 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
 
         ReceiveAsync<ReinitializePipeline>(async msg =>
         {
+            _deliveredThisTurn = false;
+            // A reinit aborts any in-flight reminder turn before its
+            // TurnCompleted. Report those as not-delivered now so the
+            // execution actor redelivers immediately instead of stalling
+            // until the backstop timeout.
+            FailPendingReminderDeliveries($"SignalR pipeline reinitialized: {msg.Reason}");
             await _handle.ReinitializeAsync(
                 msg.Reason,
                 () => Timers.StartSingleTimer(
@@ -205,7 +213,13 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
                 AckTarget = ackTarget
             };
 
-            _reminderDeliveryObserver = msg.Source.DeliveryObserver;
+            // Only delivery-gated (DeliveryRequired) reminders carry a
+            // DeliveryObserver. Key it by the per-fire reminder delivery id so a
+            // second concurrent reminder to this session can't overwrite the
+            // first's observer before its turn reaches TurnCompleted.
+            if (msg.Source.DeliveryObserver is { } deliveryObserver
+                && !string.IsNullOrWhiteSpace(msg.Source.ReminderId))
+                _reminderDeliveryObservers[msg.Source.ReminderId] = deliveryObserver;
 
             try
             {
@@ -295,21 +309,37 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
     /// <summary>
     /// Tells the dispatching reminder execution actor (if this turn was a
     /// reminder delivery) whether the assistant reply reached the client,
-    /// then clears the per-turn observer ref.
+    /// then removes that observer.
     /// </summary>
     private void ReportReminderDeliveryResult(TurnCompleted completed, bool delivered)
     {
-        if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
+        if (!string.IsNullOrWhiteSpace(completed.SourceReminderId)
+            && _reminderDeliveryObservers.Remove(completed.SourceReminderId!, out var observer))
         {
-            _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
+            observer.Tell(new ReminderDeliveryResult(
                 completed.SourceReminderId!,
                 _channelType,
                 Delivered: delivered,
                 FailureReason: delivered ? null : "SignalR client did not receive the reply",
                 ObservedAtMs: completed.TimestampMs));
         }
+    }
 
-        _reminderDeliveryObserver = null;
+    /// <summary>
+    /// Tells every in-flight reminder observer that delivery did not happen,
+    /// then clears them. Called when a turn can no longer reach TurnCompleted
+    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
+    /// rather than waiting out its backstop timeout.
+    /// </summary>
+    private void FailPendingReminderDeliveries(string reason)
+    {
+        if (_reminderDeliveryObservers.Count == 0)
+            return;
+
+        foreach (var (key, observer) in _reminderDeliveryObservers)
+            observer.Tell(new ReminderDeliveryResult(key, _channelType, Delivered: false, FailureReason: reason));
+
+        _reminderDeliveryObservers.Clear();
     }
 
     protected override void PostStop()

--- a/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
+++ b/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
@@ -31,6 +31,10 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
     private SignalRConnectionId _currentConnectionId;
     private Actors.Channels.ChannelType _channelType = Actors.Channels.ChannelType.Tui;
     private bool _deliveredThisTurn;
+    // Reply target for the current reminder turn's delivery confirmation.
+    // Captured from DeliverTrustedSessionTurn; told a ReminderDeliveryResult
+    // on TurnCompleted, then cleared.
+    private IActorRef? _reminderDeliveryObserver;
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
     private static readonly object ReinitializeTimerKey = new();
@@ -201,6 +205,8 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
                 AckTarget = ackTarget
             };
 
+            _reminderDeliveryObserver = msg.Source.DeliveryObserver;
+
             try
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -245,8 +251,14 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
         {
             if (_currentConnectionId == default)
             {
-                if (msg.Output is TurnCompleted)
+                // No connected client → nothing was delivered. Report the
+                // outcome (false) so a DeliveryRequired reminder redelivers
+                // rather than waiting out the backstop timeout.
+                if (msg.Output is TurnCompleted noConnTurn)
+                {
+                    ReportReminderDeliveryResult(noConnTurn, delivered: false);
                     _deliveredThisTurn = false;
+                }
                 return;
             }
 
@@ -261,14 +273,7 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
 
             if (msg.Output is TurnCompleted completed)
             {
-                if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _deliveredThisTurn)
-                {
-                    Context.System.EventStream.Publish(new ReminderDeliveryObserved(
-                        completed.SourceReminderId,
-                        _channelType,
-                        completed.TimestampMs));
-                }
-
+                ReportReminderDeliveryResult(completed, delivered: _deliveredThisTurn);
                 _deliveredThisTurn = false;
             }
         }
@@ -277,9 +282,34 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
             _log.Debug(ex,
                 "Failed to deliver output to connection {ConnectionId}", _currentConnectionId.Value);
 
-            if (msg.Output is TurnCompleted)
+            // The hub send threw → the reply did not reach the client. Report
+            // failure so the reminder redelivers instead of stalling.
+            if (msg.Output is TurnCompleted failedTurn)
+            {
+                ReportReminderDeliveryResult(failedTurn, delivered: false);
                 _deliveredThisTurn = false;
+            }
         }
+    }
+
+    /// <summary>
+    /// Tells the dispatching reminder execution actor (if this turn was a
+    /// reminder delivery) whether the assistant reply reached the client,
+    /// then clears the per-turn observer ref.
+    /// </summary>
+    private void ReportReminderDeliveryResult(TurnCompleted completed, bool delivered)
+    {
+        if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && _reminderDeliveryObserver is not null)
+        {
+            _reminderDeliveryObserver.Tell(new ReminderDeliveryResult(
+                completed.SourceReminderId!,
+                _channelType,
+                Delivered: delivered,
+                FailureReason: delivered ? null : "SignalR client did not receive the reply",
+                ObservedAtMs: completed.TimestampMs));
+        }
+
+        _reminderDeliveryObserver = null;
     }
 
     protected override void PostStop()


### PR DESCRIPTION
## Problem

In-session reminders (`delivery_kind=current_session`, `DeliveryRequired=true`) did not reliably confirm delivery, and could silently stop firing.

Two root causes:

1. **Confirmation never reached the execution actor.** `ReminderExecutionActor` awaited the delivery signal *inside* `RunTask`, which suspends the actor mailbox until the task completes — so the actor could never process the `ReminderDeliveryObserved` message it was waiting for. Every `DeliveryRequired` current-session reminder therefore fell through to the 1-hour timeout, reported failure, and auto-disabled after 5 consecutive "failures" regardless of whether the post actually succeeded. Existing tests only passed weakly (assert-at-t0) or via the timeout, so it was never caught.
2. **Discord/Mattermost reported false success.** Both set their per-turn "delivered" flag unconditionally, even when the post threw — so a failed post was reported as a successful delivery (silent loss). Slack and SignalR already gated on real success.

## Approach

Replace the fire-and-forget `EventStream` broadcast (the codebase's only use of it) with a point-to-point `ReminderDeliveryResult` told directly to the dispatching execution actor, carried as a transient, never-persisted `MessageSource.DeliveryObserver` ref. The result reports success **or** failure, so a failed delivery redelivers immediately instead of waiting out the (now backstop-only) timeout. The execution actor waits via actor state + a scheduled backstop message rather than awaiting inside `RunTask`, so the confirmation is actually received.

## What's included

**Core fix**
- Gate Discord/Mattermost delivered flag on real post success (`SafeReplyAsync` returns `Task<bool>`).
- `MessageSource.DeliveryObserver` (ephemeral) + point-to-point `ReminderDeliveryResult`.
- Message-driven wait in `ReminderExecutionActor` (no await-in-`RunTask`).

**Hardening (from a multi-angle review)**
- **Restart loop:** a deferred-queue re-run has a null envelope; the success path called `AckAsync(null)` inside an unguarded `RunTask`, escalating to a supervisor restart + duplicate-post loop. Null-guard the ack and wrap the `RunTask`.
- **Concurrent-reminder clobber:** a single observer field was overwritten when two reminders targeted the same session; key observers by reminder delivery id (`Dictionary`) in all four channels.
- **SignalR result drop:** removed a redundant exact-`ChannelType` guard that failed closed (a cold SignalR actor reports its default `Tui`); the point-to-point ref + unique key already correlate.
- **Pipeline reinit:** reset per-turn delivery flags (Slack leaked a stale flag → false success) and tell in-flight observers `Delivered=false` so they redeliver fast.

**Empty-vs-failed fallback**
- Discord/Mattermost posted "I didn't manage to produce a reply" on a *failed* post (a reply was produced; transport failed) — misleading and doubled up with the redelivered reply. Now suppressed for failed posts (matching Slack's existing behavior); the fallback only fires for genuinely empty turns.

## Testing

- New cross-channel contract tests: delivery success, failed-post reports `Delivered=false`, concurrent same-session reminders each get their own result, and failed posts don't trigger the empty-turn fallback.
- New execution-actor test: explicit delivery failure reports fast (not via timeout).
- Full reminders/channels/sessions and daemon-gateway suites pass; slopwatch clean; copyright headers present.

**Known gap:** SignalR's binding lacks a dedicated contract test (it's not in the shared harness; a faked `IHubContext` fixture is disproportionate). Its change mirrors the three covered channels.