### PR TITLE
Normalize version/value args out of shell approval verb chains

### DIFF
--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "createdAt": "2026-05-12T17:20:55.7365203+00:00",
-  "updatedAt": "2026-05-12T17:20:55.74213+00:00",
+  "updatedAt": "2026-06-10T19:44:08.3092383+00:00",
   "description": "Initial baseline created by 'slopwatch init' on 2026-05-12 17:20:55 UTC",
   "entries": [
     {
@@ -146,7 +146,7 @@
       "lineNumber": 30,
       "codeSnippet": "Fact(SkipUnless = nameof(IsPosix), Skip = \"POSIX-only — matcher routes through BashParser on POSIX\")",
       "message": "Test method 'ExtractPatterns_multiline_command_splits_one_unit_per_statement' is disabled: POSIX-only — matcher routes through BashParser on POSIX",
-      "baselinedAt": "2026-05-16T00:00:00.0000000+00:00"
+      "baselinedAt": "2026-05-16T00:00:00+00:00"
     },
     {
       "hash": "a016290b3480868d",
@@ -155,7 +155,25 @@
       "lineNumber": 68,
       "codeSnippet": "Fact(SkipUnless = nameof(IsPosix), Skip = \"POSIX-only path semantics\")",
       "message": "Test method 'ExtractCandidates_multiline_surfaces_each_verb' is disabled: POSIX-only path semantics",
-      "baselinedAt": "2026-05-16T00:00:00.0000000+00:00"
+      "baselinedAt": "2026-05-16T00:00:00+00:00"
+    },
+    {
+      "hash": "da8ee1bcfe9df24e",
+      "ruleId": "SW001",
+      "filePath": "src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs",
+      "lineNumber": 111,
+      "codeSnippet": "Theory(SkipUnless = nameof(IsPosix), Skip = \"POSIX-only — matcher routes through BashParser on POSIX\")",
+      "message": "Test method 'ExtractCandidateVerbs_strips_trailing_version_token' is disabled: POSIX-only — matcher routes through BashParser on POSIX",
+      "baselinedAt": "2026-06-10T19:44:08.3078562+00:00"
+    },
+    {
+      "hash": "5d2151723744bf3e",
+      "ruleId": "SW001",
+      "filePath": "src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs",
+      "lineNumber": 136,
+      "codeSnippet": "Fact(SkipUnless = nameof(IsPosix), Skip = \"POSIX-only — matcher routes through BashParser on POSIX\")",
+      "message": "Test method 'IsApproved_git_tag_grant_matches_both_version_forms' is disabled: POSIX-only — matcher routes through BashParser on POSIX",
+      "baselinedAt": "2026-06-10T19:44:08.3092375+00:00"
     }
   ]
 }

--- a/openspec/changes/shell-approval-value-token-normalization/.openspec.yaml
+++ b/openspec/changes/shell-approval-value-token-normalization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/shell-approval-value-token-normalization/design.md
+++ b/openspec/changes/shell-approval-value-token-normalization/design.md
@@ -1,0 +1,116 @@
+# Design: Shell Approval Value-Token Normalization
+
+## Context
+
+ShellSyntaxTree's greedy verb walk (parser SPEC §6.1) extends through every
+verb-like token — lowercase-leading, `[a-z0-9._-]` body — and its own SPEC
+§6.1.1 declares `Clause.Verb` "a convenience hint, not a security contract."
+A lowercase-leading value like `v0.4.2` is verb-like by shape and folds into
+the chain (`git tag v0.4.2`); a digit-leading `0.4.2` stops the walk and lands
+in Args. Netclaw's `ShellApprovalMatcher` compared the full chain for exact
+equality against persisted `ApprovalEntry` records, so the two forms of the
+same intent gated differently: `git tag 0.4.2` auto-approved under a standing
+`git tag` grant; `git tag v0.4.2` re-prompted.
+
+The fix is implemented on the PR branch (PR #1388); this document records the
+decisions for the spec delta.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One stable verb chain per intent, regardless of how the parser splits value
+  tokens between Verb and Args.
+- Gate (candidate) path and persisted/display pattern path normalize
+  identically.
+- Zero per-CLI knowledge; bounded, auditable classification.
+
+**Non-Goals**
+
+- Positional/prefix grant matching (see Decision 1 alternatives).
+- Windows legacy tokenizer parity (follow-up).
+- Approval store migration.
+
+## Decisions
+
+### Decision 1: Morphological classification, one rule
+
+A token is a call-specific value iff it is **not a flag, not path-shaped, and
+contains a digit** (`IsCallSpecificValueToken`). This replaces the prior
+composition of two shape predicates (bare-integer #1331 + a dotted-version
+shape) and deletes both.
+
+**Alternatives considered:**
+
+- **Shape taxonomy (bare integers + version shapes + …)** — rejected: accretes
+  a special case per value family (SHAs, IPs, dates, calver…) while still
+  mis-drawing boundaries (`git checkout v2` kept but `v2.0` stripped;
+  alpha-leading SHAs never normalized, so a `git show` grant could not cover
+  the dominant SHA use-case).
+- **Positional/prefix matching (grant tokens are a prefix of the command
+  tokens)** — rejected: deciding where verbs end and arguments begin
+  positionally requires per-CLI verb-depth knowledge — effectively a global
+  classification system of shell commands — and changing read semantics
+  retroactively rescopes every grant already persisted in deployed
+  `tool-approvals.json` files with no schema change to gate a migration on.
+  Morphology identifies likely arguments inside an arbitrary, compounded verb
+  chain with no CLI knowledge at all.
+
+### Decision 2: Trailing-only trim with a one-token floor
+
+`TrimTrailingValueTokens` strips value tokens only from the end of the parsed
+chain and always retains the command word. Mid-chain digit-bearing tokens
+(`aws s3 ls`) and heads (`python3`) are never touched. This bounds the
+worst-case mis-classification to the chain tail, where the token is most
+likely an operand.
+
+### Decision 3: Flag and path exemptions
+
+Flags (`-3`, `--max-count=10`) carry invocation intent, not values; path-shaped
+tokens must survive into `ExtractFirstPathArgument`/directory scoping and the
+display pattern. Both are excluded from value classification. All-alpha
+operands are deliberately unclassified: no shape rule distinguishes `dev`
+(branch) from `worktree` (subcommand), and mis-stripping a subcommand silently
+widens a grant — the unrecoverable failure direction.
+
+### Decision 4: Apply at both extraction sites, POSIX path only
+
+The trim runs in `ExtractCandidatesViaBashParser` (gate candidates) and
+`ReconstructClauseText` (persisted/display patterns) so store and gate stay in
+lockstep. The Windows legacy tokenizer path is untouched; tests are
+POSIX-gated. Cross-OS grant portability for folded value tokens is a known
+limitation tracked as a follow-up.
+
+## Actor Boundaries and Persistence
+
+None changed. The matcher is pure in-process logic inside `Netclaw.Security`;
+`ApprovalEntry` schema, `tool-approvals.json` format, approval actors, and
+session persistence are untouched. Matching remains exact verb equality —
+normalization only changes the strings being compared, and the approval prompt
+displays the normalized pattern, so displayed scope equals stored scope.
+
+## Failure Modes and Recovery
+
+- **Parser failure / messy command** → unchanged: fail-empty, gate offers
+  Once/Deny only.
+- **Under-classification** (all-alpha value, e.g. SHA `abcdef`) → re-prompt;
+  recoverable.
+- **Over-classification** (digit-bearing true subcommand at chain tail, e.g.
+  bare `aws s3` with only flags after) → candidate collapses to the parent
+  verb; the prompt displays the collapsed pattern, so any resulting grant is
+  exactly what the operator saw and confirmed.
+- **Stale digit-bearing entries** (`git show aa211dcb` persisted pre-change) →
+  go dead and re-prompt once; recoverable, no migration needed.
+
+## Risks / Trade-offs
+
+- [Digit-bearing operands truncate display patterns mid-arg-list
+  (`docker run --name test123 --port=8080` → `docker run --name`)] → the full
+  command text is still shown in the prompt header (`FormatForDisplay`); the
+  pattern is the grant key, not the audit record.
+- [Windows path divergence] → disclosed; follow-up to port the trim to the
+  legacy tokenizer.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/shell-approval-value-token-normalization/proposal.md
+++ b/openspec/changes/shell-approval-value-token-normalization/proposal.md
@@ -1,0 +1,88 @@
+# Proposal: Shell Approval Value-Token Normalization
+
+## Why
+
+The shell approval gate treated semantically-identical commands differently based
+on the leading character of a value argument: `git tag 0.4.2` auto-approved under
+a standing `git tag` grant while `git tag v0.4.2` re-prompted, because
+ShellSyntaxTree's greedy verb walk folds lowercase-leading value tokens
+(`v0.4.2`, `aa211dcb`, `feature2`) into the verb chain that the matcher compares
+for exact equality. The fix is implemented (PR #1388); this change records the
+matching spec delta so `tool-approval-gates` describes actual behavior.
+
+## What Changes
+
+- Generalize the bare-integer exclusion (issue #1331) in the "Shell command
+  pattern matching" requirement to a single morphological rule: a token is a
+  call-specific value iff it is **not a flag, not path-shaped, and contains a
+  digit**. Versions, SHAs, IPs, ports, ticket IDs, and digit-bearing refs all
+  normalize uniformly; no taxonomy of value shapes.
+- Trailing value tokens that greedy extraction folded into the verb chain are
+  trimmed (trailing-only, retaining at least the command word) on **both** the
+  gate (candidate) path and the persisted/display pattern path, so the two
+  normalize identically.
+- Behavior change to an existing scenario: digit-bearing operands now terminate
+  the pattern (e.g. `docker run --name test123 --port=8080` persists
+  `docker run --name`, not the full token list). The prior "Non-bare numeric
+  tokens are preserved" scenario is replaced.
+- All-alpha operands (branch names, remote names, package names) remain
+  unclassified by design — no shape rule distinguishes them from subcommands.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `tool-approval-gates` — "Shell command pattern matching" requirement: value
+  classification generalized from bare integers to digit-bearing tokens;
+  trailing verb-chain trim added; one scenario replaced, scenarios added.
+
+## Scope
+
+**In scope (MVP):**
+
+- Spec delta documenting the implemented POSIX (BashParser) extraction behavior.
+
+**Out of scope:**
+
+- Positional/prefix-based grant matching (rejected: requires per-CLI verb-depth
+  knowledge — a global classification system of shell commands — and would
+  retroactively rescope grants already persisted in deployed
+  `tool-approvals.json` files).
+- Windows legacy tokenizer path (`ShellTokenizer.ExtractVerbChain` /
+  `TraverseApprovalUnits`) — retains prior behavior; follow-up candidate.
+- Approval store migration or re-keying of existing entries.
+
+## Security and Operational Impact
+
+- **Grant generalization is bounded.** Trimming is trailing-only with a
+  one-token floor, so mid-chain tokens (`aws s3 ls`) and command heads
+  (`python3`) are never stripped. Flags and path-shaped tokens are exempt, so
+  digit-bearing paths still reach directory scoping.
+- **No silent scope change for stored grants.** Matching remains exact verb
+  equality against `ApprovalEntry` records; the change only normalizes what the
+  candidate/pattern strings contain. Approval prompts display the normalized
+  pattern, so what the operator sees remains what is stored.
+- **Recoverable failure direction.** A value token the rule fails to classify
+  (all-alpha SHA, e.g. `abcdef`) re-prompts (false negative, recoverable) rather
+  than silently auto-granting.
+- **Operationally inert.** No config, schema, persistence, or actor topology
+  changes; no migration required. Existing stored entries keep matching
+  (digit-bearing legacy entries such as `git show aa211dcb` go dead and simply
+  re-prompt once).
+
+## Impact
+
+- Code (already merged to PR branch): `src/Netclaw.Security/IToolApprovalMatcher.cs`
+  (`ShellApprovalMatcher.ExtractCandidatesViaBashParser`,
+  `ReconstructClauseText`, `IsCallSpecificValueToken`,
+  `TrimTrailingValueTokens`; `IsVersionShapedToken` and `IsBareIntegerToken`
+  deleted).
+- Tests: `src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs` (parity,
+  persist-path, boundary table).
+- Specs: `openspec/specs/tool-approval-gates/spec.md` (this delta).
+- PRD traceability: PRD-002 Gateway Security Envelope (SEC-006 Pairing and
+  Approval Surfaces — approval prompt/grant surface behavior).

--- a/openspec/changes/shell-approval-value-token-normalization/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/shell-approval-value-token-normalization/specs/tool-approval-gates/spec.md
@@ -1,0 +1,160 @@
+# Delta: tool-approval-gates — shell approval value-token normalization
+
+## MODIFIED Requirements
+
+### Requirement: Shell command pattern matching
+
+The system SHALL extract verb-chain prefix patterns from shell commands
+using tokenization. The verb chain SHALL consist of non-flag tokens from
+the start of the command until the first flag (`-`), path, URL, or
+call-specific value argument. A token SHALL be classified as a
+call-specific value iff it is not a flag, not path-shaped, and contains
+a digit — one morphological rule, not a taxonomy of value shapes.
+Extraction is greedy: bare-word operands that are neither flags, paths,
+URLs, nor digit-bearing values (all-alpha subcommands, remote names,
+branch names, refs) SHALL remain in the verb chain — the extractor SHALL
+NOT attempt to distinguish all-alpha subcommands from positional
+operands.
+
+> **Why digit-bearing tokens are excluded:** Tokens containing digits
+> (`123`, `8080`, `0.4.2`, `v0.4.2`, `aa211dcb`, `feature2`) are
+> overwhelmingly call-specific values — ticket IDs, ports, timeouts,
+> versions, SHAs, refs — that vary between invocations of the same verb
+> chain. Baking them into the pattern produces overly-specific approval
+> entries that do not generalize: `git tag v0.4.2` vs `git tag v0.5.0`
+> would create two unrelated entries, forcing separate approval for each
+> release. This generalizes the earlier bare-integer rule (issue #1331).
+> All-alpha operands are intentionally NOT classified: no shape rule can
+> distinguish a branch name (`dev`) from a subcommand (`worktree`), and
+> mis-stripping a subcommand would silently widen a grant. Flags are
+> exempt (`-3`, `--max-count=10` carry invocation intent); path-shaped
+> tokens are exempt so digit-bearing paths still reach directory scoping.
+
+Where greedy extraction has folded a trailing value token into the verb
+chain (e.g. `git tag v0.4.2`, where `v0.4.2` is lowercase-leading and
+therefore verb-like to the parser), the system SHALL trim trailing
+call-specific value tokens from the chain, always retaining at least the
+command word. Trimming SHALL be trailing-only: mid-chain digit-bearing
+tokens (`aws s3 ls`) SHALL NOT be removed. Trimming SHALL apply
+identically on the gate (candidate) path and the persisted/display
+pattern path so the two normalize to the same verb chain.
+
+For shell approval units, `&&`, `||`, and `;` SHALL split into separate
+units, while `|` SHALL remain inside the current unit. For `bash -c` or
+`sh -c` wrappers, the inner command SHALL be extracted and scanned
+recursively.
+
+When `ShellTokenizer.SplitCompoundCommand` detects bash control-flow
+tokens or unbalanced quotes/brackets, it SHALL return an empty
+verb-chain list. The approval gate SHALL then offer only `Once` and
+`Deny`. See the "Pattern extraction refuses bash control-flow"
+requirement for details.
+
+The matcher SHALL operate on `ApprovalEntry` records keyed by
+`(verb, directory)`. The "is this string a verb chain or a directory
+root?" inspection logic of v1 SHALL NOT be present in the v2 matcher.
+
+Approval persistence SHALL store one `ApprovalEntry` per extracted verb
+chain. Compound commands SHALL produce N entries from one user click on
+`Always here` or `Always anywhere`.
+
+#### Scenario: Verb chain extracted from simple command
+
+- **GIVEN** the command `git push origin main`
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `git push origin main`
+- **AND** the all-alpha operands `origin` and `main` remain in the verb
+  chain because greedy extraction does not strip positional operands
+
+#### Scenario: Verb chain strips bare integer positional argument
+
+- **GIVEN** the command `freshdesk ticket get 123`
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `freshdesk ticket get`
+- **AND** the digit-bearing token `123` is excluded because it is
+  call-specific
+
+#### Scenario: Verb chain generalizes across different integer values
+
+- **GIVEN** commands `nc host 8080` and `nc host 9090`
+- **WHEN** patterns are extracted for both
+- **THEN** both produce the same pattern `nc host`
+- **AND** approval granted for one integer value covers all values of the same verb chain
+
+#### Scenario: Verb chain terminates at value token (not just skips it)
+
+- **GIVEN** the command `timeout 30 curl http://example.com`
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `timeout`
+- **AND** everything after the value token (including wrapped subcommands like `curl`) is dropped from the pattern
+
+#### Scenario: Digit-bearing operand terminates the pattern
+
+- **GIVEN** the command `docker run --name test123 --port=8080`
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `docker run --name`
+- **AND** the digit-bearing operand `test123` and everything after it are
+  excluded because digit-bearing non-flag, non-path tokens are
+  call-specific values
+- **AND** the flag `--name` is retained because flags are exempt from
+  value classification
+
+#### Scenario: Version arguments normalize to one verb chain regardless of prefix
+
+- **GIVEN** commands `git tag v0.4.2` and `git tag 0.4.2`
+- **WHEN** candidate verbs and patterns are extracted for both
+- **THEN** both produce the verb chain `git tag`
+- **AND** a standing `git tag` grant auto-approves both forms
+- **AND** the lowercase-leading form is handled by trimming the trailing
+  value token the greedy walk folded into the chain
+
+#### Scenario: Digit-bearing ref folded into the chain is trimmed
+
+- **GIVEN** the command `git show aa211dcb`
+- **WHEN** the candidate verb is extracted
+- **THEN** the verb chain is `git show`
+- **AND** the alpha-leading SHA normalizes the same way as a
+  digit-leading SHA (`git show 1234abcd`)
+
+#### Scenario: Trailing-only trim never removes mid-chain tokens
+
+- **GIVEN** the command `aws s3 ls`
+- **WHEN** the candidate verb is extracted
+- **THEN** the verb chain is `aws s3 ls`
+- **AND** the mid-chain digit-bearing token `s3` is untouched because
+  only trailing value tokens are trimmed
+
+#### Scenario: Verb chain stops at flag
+
+- **GIVEN** the command `ls -la /tmp`
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `ls`
+- **AND** the flag and path are not part of the persisted verb chain
+
+#### Scenario: Multi-level verb chain
+
+- **GIVEN** the command `docker compose up -d`
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `docker compose up`
+
+#### Scenario: Control operators create separate approval units
+
+- **GIVEN** the command `git add . && git commit -m "fix" && git push`
+- **WHEN** approval is checked
+- **THEN** `git add`, `git commit`, and `git push` are checked as
+  separate approval units against the v2 matcher
+
+#### Scenario: Compound segments batched in one prompt
+
+- **GIVEN** none of `git add`, `git commit`, `git push` are approved
+- **WHEN** the command `git add . && git commit -m "fix" && git push`
+  is checked
+- **THEN** a single approval prompt lists all three verbs as bullets
+- **AND** one click on `Always here` persists three `(verb, cwd)` entries
+
+#### Scenario: bash -c inner command scanned recursively
+
+- **GIVEN** the command `bash -c "git push --force"`
+- **WHEN** approval and hard deny are checked
+- **THEN** the inner command `git push --force` is extracted and scanned
+- **AND** verb chain `git push` is checked through the v2 matcher

--- a/openspec/changes/shell-approval-value-token-normalization/tasks.md
+++ b/openspec/changes/shell-approval-value-token-normalization/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Shell Approval Value-Token Normalization
+
+Implementation landed on branch `fix/shell-approval-version-arg-normalization`
+(PR #1388, commits `5e28920c` + `2755035f`) before this change was opened;
+tasks below are checked where the work is already done and verified.
+
+## 1. Core Implementation
+
+- [x] 1.1 Add `IsCallSpecificValueToken` (not a flag, not path-shaped, contains
+  a digit) to `ShellApprovalMatcher`, replacing and deleting
+  `IsBareIntegerToken` and the version-shape predicate
+- [x] 1.2 Add `TrimTrailingValueTokens` (trailing-only, one-token floor) and
+  apply it in `ExtractCandidatesViaBashParser` (gate candidates)
+- [x] 1.3 Apply the same trim and value-termination in `ReconstructClauseText`
+  (persisted/display patterns) so both paths normalize identically
+
+## 2. Tests
+
+- [x] 2.1 Parity tests: `git tag v0.4.2` / `git tag 0.4.2` produce identical
+  candidate verbs and patterns; standing `git tag` grant approves both
+- [x] 2.2 Boundary table: trailing-only (mid-chain `aws s3 ls` untouched),
+  all-alpha operands preserved (`git push origin main`), SHAs and range refs
+  trimmed, flags retained before a value (`docker run --name test123`)
+- [x] 2.3 Full `Netclaw.Security.Tests` (580) and actor approval/dispatch
+  suites (311) pass; Slopwatch clean on changed files
+
+## 3. Spec Sync and Closeout
+
+- [x] 3.1 Create delta spec for `tool-approval-gates` "Shell command pattern
+  matching" (this change)
+- [x] 3.2 Sync delta to `openspec/specs/tool-approval-gates/spec.md`
+  (`/opsx-sync`) and commit on the PR branch
+- [ ] 3.3 Verify implementation matches artifacts (`/opsx-verify`)
+- [ ] 3.4 Archive the change after PR #1388 merges (`/opsx-archive`)

--- a/openspec/specs/tool-approval-gates/spec.md
+++ b/openspec/specs/tool-approval-gates/spec.md
@@ -90,19 +90,38 @@ SHALL be able to add or remove patterns via configuration.
 
 The system SHALL extract verb-chain prefix patterns from shell commands
 using tokenization. The verb chain SHALL consist of non-flag tokens from
-the start of the command until the first flag (`-`), path, URL, or bare
-integer argument. Extraction is greedy: bare-word operands that are
-neither flags, paths, URLs, nor integers (subcommands, remote names,
+the start of the command until the first flag (`-`), path, URL, or
+call-specific value argument. A token SHALL be classified as a
+call-specific value iff it is not a flag, not path-shaped, and contains
+a digit — one morphological rule, not a taxonomy of value shapes.
+Extraction is greedy: bare-word operands that are neither flags, paths,
+URLs, nor digit-bearing values (all-alpha subcommands, remote names,
 branch names, refs) SHALL remain in the verb chain — the extractor SHALL
-NOT attempt to distinguish subcommands from positional operands.
+NOT attempt to distinguish all-alpha subcommands from positional
+operands.
 
-> **Why integers are excluded:** Bare integers (pure digit sequences like
-> `123`, `8080`, `30`) are never CLI subcommands. They represent
-> call-specific values — ticket IDs, port numbers, timeouts — that vary
-> between invocations of the same verb chain. Baking them into the pattern
-> produces overly-specific approval entries that do not generalize:
-> `freshdesk ticket get 123` vs `freshdesk ticket get 456` would create
-> two unrelated entries, forcing separate approval for each unique value.
+> **Why digit-bearing tokens are excluded:** Tokens containing digits
+> (`123`, `8080`, `0.4.2`, `v0.4.2`, `aa211dcb`, `feature2`) are
+> overwhelmingly call-specific values — ticket IDs, ports, timeouts,
+> versions, SHAs, refs — that vary between invocations of the same verb
+> chain. Baking them into the pattern produces overly-specific approval
+> entries that do not generalize: `git tag v0.4.2` vs `git tag v0.5.0`
+> would create two unrelated entries, forcing separate approval for each
+> release. This generalizes the earlier bare-integer rule (issue #1331).
+> All-alpha operands are intentionally NOT classified: no shape rule can
+> distinguish a branch name (`dev`) from a subcommand (`worktree`), and
+> mis-stripping a subcommand would silently widen a grant. Flags are
+> exempt (`-3`, `--max-count=10` carry invocation intent); path-shaped
+> tokens are exempt so digit-bearing paths still reach directory scoping.
+
+Where greedy extraction has folded a trailing value token into the verb
+chain (e.g. `git tag v0.4.2`, where `v0.4.2` is lowercase-leading and
+therefore verb-like to the parser), the system SHALL trim trailing
+call-specific value tokens from the chain, always retaining at least the
+command word. Trimming SHALL be trailing-only: mid-chain digit-bearing
+tokens (`aws s3 ls`) SHALL NOT be removed. Trimming SHALL apply
+identically on the gate (candidate) path and the persisted/display
+pattern path so the two normalize to the same verb chain.
 
 For shell approval units, `&&`, `||`, and `;` SHALL split into separate
 units, while `|` SHALL remain inside the current unit. For `bash -c` or
@@ -128,7 +147,7 @@ chain. Compound commands SHALL produce N entries from one user click on
 - **GIVEN** the command `git push origin main`
 - **WHEN** the pattern is extracted
 - **THEN** the pattern is `git push origin main`
-- **AND** the bare-word operands `origin` and `main` remain in the verb
+- **AND** the all-alpha operands `origin` and `main` remain in the verb
   chain because greedy extraction does not strip positional operands
 
 #### Scenario: Verb chain strips bare integer positional argument
@@ -136,7 +155,8 @@ chain. Compound commands SHALL produce N entries from one user click on
 - **GIVEN** the command `freshdesk ticket get 123`
 - **WHEN** the pattern is extracted
 - **THEN** the pattern is `freshdesk ticket get`
-- **AND** the bare integer `123` is excluded because it is call-specific
+- **AND** the digit-bearing token `123` is excluded because it is
+  call-specific
 
 #### Scenario: Verb chain generalizes across different integer values
 
@@ -145,19 +165,48 @@ chain. Compound commands SHALL produce N entries from one user click on
 - **THEN** both produce the same pattern `nc host`
 - **AND** approval granted for one integer value covers all values of the same verb chain
 
-#### Scenario: Verb chain terminates at integer (not just skips it)
+#### Scenario: Verb chain terminates at value token (not just skips it)
 
 - **GIVEN** the command `timeout 30 curl http://example.com`
 - **WHEN** the pattern is extracted
 - **THEN** the pattern is `timeout`
-- **AND** everything after the integer (including wrapped subcommands like `curl`) is dropped from the pattern
+- **AND** everything after the value token (including wrapped subcommands like `curl`) is dropped from the pattern
 
-#### Scenario: Non-bare numeric tokens are preserved
+#### Scenario: Digit-bearing operand terminates the pattern
 
-- **GIVEN** the command `docker run --name test123 --port=8080 -e VAR=1e5`
+- **GIVEN** the command `docker run --name test123 --port=8080`
 - **WHEN** the pattern is extracted
-- **THEN** the pattern includes `test123`, `--port=8080`, and `VAR=1e5`
-- **AND** only pure digit-only tokens are treated as integers
+- **THEN** the pattern is `docker run --name`
+- **AND** the digit-bearing operand `test123` and everything after it are
+  excluded because digit-bearing non-flag, non-path tokens are
+  call-specific values
+- **AND** the flag `--name` is retained because flags are exempt from
+  value classification
+
+#### Scenario: Version arguments normalize to one verb chain regardless of prefix
+
+- **GIVEN** commands `git tag v0.4.2` and `git tag 0.4.2`
+- **WHEN** candidate verbs and patterns are extracted for both
+- **THEN** both produce the verb chain `git tag`
+- **AND** a standing `git tag` grant auto-approves both forms
+- **AND** the lowercase-leading form is handled by trimming the trailing
+  value token the greedy walk folded into the chain
+
+#### Scenario: Digit-bearing ref folded into the chain is trimmed
+
+- **GIVEN** the command `git show aa211dcb`
+- **WHEN** the candidate verb is extracted
+- **THEN** the verb chain is `git show`
+- **AND** the alpha-leading SHA normalizes the same way as a
+  digit-leading SHA (`git show 1234abcd`)
+
+#### Scenario: Trailing-only trim never removes mid-chain tokens
+
+- **GIVEN** the command `aws s3 ls`
+- **WHEN** the candidate verb is extracted
+- **THEN** the verb chain is `aws s3 ls`
+- **AND** the mid-chain digit-bearing token `s3` is untouched because
+  only trailing value tokens are trimmed
 
 #### Scenario: Verb chain stops at flag
 

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -30,7 +30,7 @@ public sealed class ShellApprovalMatcherTests
     /// matcher falls through to the legacy <c>ShellTokenizer</c> path
     /// on Windows (ShellSyntaxTree is bash-only), so tests that pin
     /// BashParser cwd attribution / <c>arg.Resolved</c> canonicalization
-    /// don't apply. Marking them <c>[Fact(SkipUnless = nameof(IsPosix))]</c>
+    /// don't apply. Marking them <c>[Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]</c>
     /// produces a proper "Skipped" entry in the test log on Windows
     /// runners instead of hiding the gap behind an early-return.
     /// </summary>
@@ -97,6 +97,80 @@ public sealed class ShellApprovalMatcherTests
             Args("cat /home/user/.netclaw/logs/crash.log"));
         Assert.Single(verbs);
         Assert.Equal("cat", verbs[0]);
+    }
+
+    // ---- Call-specific value normalization (version / tag-name args) ----
+    // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds a lowercase-leading
+    // version like `v0.4.2` into the verb chain (`git tag v0.4.2`) but stops at
+    // a digit-leading `0.4.2` (verb stays `git tag`). Both are call-specific
+    // values, so the matcher normalizes them off the chain on the gate path
+    // (ExtractCandidateVerbs / IsApproved) AND the persisted-pattern path
+    // (ExtractPatterns), so the same intent yields one stable verb. Regression
+    // for the v0.4.2-vs-0.4.2 approval divergence.
+
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    [InlineData("git tag v0.4.2")]
+    [InlineData("git tag 0.4.2")]
+    [InlineData("git tag 1.0.0-beta.3")]
+    [InlineData("git tag v2.0")]
+    public void ExtractCandidateVerbs_strips_trailing_version_token(string command)
+    {
+        var verbs = _matcher.ExtractCandidateVerbs(new ToolName("shell_execute"), Args(command));
+        Assert.Single(verbs);
+        Assert.Equal("git tag", verbs[0]);
+    }
+
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    [InlineData("git tag v0.4.2")]
+    [InlineData("git tag 0.4.2")]
+    public void ExtractPatterns_strips_trailing_version_token(string command)
+    {
+        // The persisted grant (ExtractPatterns) must normalize to the same
+        // `git tag` the gate compares, so a freshly-granted version generalizes
+        // across versions instead of pinning to the one that was approved.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"), Args(command));
+        Assert.Single(patterns);
+        Assert.Equal("git tag", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void IsApproved_git_tag_grant_matches_both_version_forms()
+    {
+        // The exact production scenario: a standing `git tag` (anywhere) grant
+        // auto-approved `git tag 0.4.2` but `git tag v0.4.2` re-prompted,
+        // because the `v`-prefixed version folded into the verb chain.
+        var approved = new[] { Verb("git tag") };
+
+        Assert.True(_matcher.IsApproved(
+            new ToolName("shell_execute"), Args("git tag v0.4.2"), approved, cwd: "/repo"));
+        Assert.True(_matcher.IsApproved(
+            new ToolName("shell_execute"), Args("git tag 0.4.2"), approved, cwd: "/repo"));
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void IsApproved_tag_then_push_compound_matches_standing_grants()
+    {
+        // Full session command: `git tag <v> && git push origin <v>` under
+        // standing `git tag` + `git push origin` grants.
+        var approved = new[] { Verb("git tag"), Verb("git push origin") };
+
+        Assert.True(_matcher.IsApproved(
+            new ToolName("shell_execute"),
+            Args("git tag v0.4.2 && git push origin v0.4.2"),
+            approved,
+            cwd: "/repo"));
+    }
+
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    [InlineData("git checkout v2", "git checkout v2")]            // no dot -> not a version value
+    [InlineData("git show 1234abcd", "git show")]                 // digit-leading hex SHA is an arg
+    [InlineData("git show aa211dcb", "git show aa211dcb")]        // alpha-leading SHA stays (not version-shaped)
+    [InlineData("git push origin main", "git push origin main")]  // branch name preserved
+    public void ExtractCandidateVerbs_preserves_non_version_tokens(string command, string expected)
+    {
+        var verbs = _matcher.ExtractCandidateVerbs(new ToolName("shell_execute"), Args(command));
+        Assert.Single(verbs);
+        Assert.Equal(expected, verbs[0]);
     }
 
     [Fact]
@@ -309,7 +383,7 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     /// matcher falls through to the legacy <c>ShellTokenizer</c> path
     /// on Windows (ShellSyntaxTree is bash-only), so tests that pin
     /// BashParser cwd attribution / <c>arg.Resolved</c> canonicalization
-    /// don't apply. Marking them <c>[Fact(SkipUnless = nameof(IsPosix))]</c>
+    /// don't apply. Marking them <c>[Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]</c>
     /// produces a proper "Skipped" entry in the test log on Windows
     /// runners instead of hiding the gap behind an early-return.
     /// </summary>

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -99,11 +99,12 @@ public sealed class ShellApprovalMatcherTests
         Assert.Equal("cat", verbs[0]);
     }
 
-    // ---- Call-specific value normalization (version / tag-name args) ----
-    // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds a lowercase-leading
-    // version like `v0.4.2` into the verb chain (`git tag v0.4.2`) but stops at
-    // a digit-leading `0.4.2` (verb stays `git tag`). Both are call-specific
-    // values, so the matcher normalizes them off the chain on the gate path
+    // ---- Call-specific value normalization (digit-bearing tokens) ----
+    // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds lowercase-leading
+    // value tokens into the verb chain (`git tag v0.4.2`, `git show aa211dcb`)
+    // but stops at digit-leading ones (`0.4.2` lands in Args, verb stays
+    // `git tag`). Both are call-specific values, so the matcher trims trailing
+    // digit-bearing non-flag, non-path tokens off the chain on the gate path
     // (ExtractCandidateVerbs / IsApproved) AND the persisted-pattern path
     // (ExtractPatterns), so the same intent yields one stable verb. Regression
     // for the v0.4.2-vs-0.4.2 approval divergence.
@@ -113,7 +114,7 @@ public sealed class ShellApprovalMatcherTests
     [InlineData("git tag 0.4.2")]
     [InlineData("git tag 1.0.0-beta.3")]
     [InlineData("git tag v2.0")]
-    public void ExtractCandidateVerbs_strips_trailing_version_token(string command)
+    public void ExtractCandidateVerbs_strips_trailing_value_token(string command)
     {
         var verbs = _matcher.ExtractCandidateVerbs(new ToolName("shell_execute"), Args(command));
         Assert.Single(verbs);
@@ -123,7 +124,7 @@ public sealed class ShellApprovalMatcherTests
     [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
     [InlineData("git tag v0.4.2")]
     [InlineData("git tag 0.4.2")]
-    public void ExtractPatterns_strips_trailing_version_token(string command)
+    public void ExtractPatterns_strips_trailing_value_token(string command)
     {
         // The persisted grant (ExtractPatterns) must normalize to the same
         // `git tag` the gate compares, so a freshly-granted version generalizes
@@ -162,11 +163,13 @@ public sealed class ShellApprovalMatcherTests
     }
 
     [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
-    [InlineData("git checkout v2", "git checkout v2")]            // no dot -> not a version value
-    [InlineData("git show 1234abcd", "git show")]                 // digit-leading hex SHA is an arg
-    [InlineData("git show aa211dcb", "git show aa211dcb")]        // alpha-leading SHA stays (not version-shaped)
-    [InlineData("git push origin main", "git push origin main")]  // branch name preserved
-    public void ExtractCandidateVerbs_preserves_non_version_tokens(string command, string expected)
+    [InlineData("git checkout v2", "git checkout")]               // digit-bearing ref is a value
+    [InlineData("git show 1234abcd", "git show")]                 // digit-leading SHA lands in Args
+    [InlineData("git show aa211dcb", "git show")]                 // alpha-leading SHA folds into chain, then trims
+    [InlineData("git log v0.4.1..dev", "git log")]                // range ref is a value
+    [InlineData("git push origin main", "git push origin main")]  // all-alpha operands are unclassifiable by shape -> preserved
+    [InlineData("aws s3 ls", "aws s3 ls")]                        // mid-chain digit token is not trailing -> untouched
+    public void ExtractCandidateVerbs_trims_digit_bearing_tokens_trailing_only(string command, string expected)
     {
         var verbs = _matcher.ExtractCandidateVerbs(new ToolName("shell_execute"), Args(command));
         Assert.Single(verbs);

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -135,6 +135,18 @@ public sealed class ShellApprovalMatcherTests
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_digit_bearing_operand_terminates_pattern()
+    {
+        // Digit-bearing operands (`test123`) are call-specific values and
+        // terminate the pattern; flags before the value are retained.
+        var patterns = _matcher.ExtractPatterns(
+            new ToolName("shell_execute"),
+            Args("docker run --name test123 --port=8080"));
+        Assert.Single(patterns);
+        Assert.Equal("docker run --name", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
     public void IsApproved_git_tag_grant_matches_both_version_forms()
     {
         // The exact production scenario: a standing `git tag` (anywhere) grant

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -232,7 +232,17 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (!ReferenceEquals(clause, groupHead))
                 continue;  // pipe-tail clauses fold into the group head
 
-            var verb = ShellTokenizer.ApplyVerbShortCircuit(clause.Verb.Joined);
+            // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds a
+            // lowercase-leading version token such as `v0.4.2` into the verb
+            // chain (`git tag v0.4.2`), while a digit-leading `0.4.2` stops the
+            // walk and lands in Args (verb stays `git tag`). Both are
+            // call-specific values, not approvable intent, so strip them off
+            // the chain before gating — otherwise `git tag v0.4.2` would miss a
+            // `git tag` grant that `git tag 0.4.2` matches. Mirrors the #1331
+            // arg-stripping in ReconstructClauseText so the gate candidate and
+            // the persisted pattern normalize identically.
+            var verb = ShellTokenizer.ApplyVerbShortCircuit(
+                string.Join(" ", TrimTrailingValueTokens(clause.Verb.Tokens)));
             if (string.IsNullOrEmpty(verb))
                 continue;
 
@@ -374,17 +384,22 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     /// </summary>
     private static string ReconstructClauseText(ShellSyntaxTree.Clause clause)
     {
-        var sb = new StringBuilder(clause.Verb.Joined);
+        // Strip the trailing call-specific value tokens the greedy verb walk
+        // folded into the chain (see TrimTrailingValueTokens) so the persisted
+        // pattern matches the gate candidate for `git tag v0.4.2`.
+        var sb = new StringBuilder(string.Join(" ", TrimTrailingValueTokens(clause.Verb.Tokens)));
 
         foreach (var arg in clause.Args)
         {
             if (arg.IsCwdAttribution || string.IsNullOrEmpty(arg.Raw))
                 continue;
 
-            // Issue #1331: bare integer args are a termination condition.
-            // Once we hit an integer, subsequent args (wrapped subcommands
-            // like `curl` after `timeout 30`) are outside the approval intent.
-            if (IsBareIntegerToken(arg.Raw))
+            // Issue #1331 (extended): call-specific value args — bare integers
+            // and version-shaped tokens like `0.4.2` — are a termination
+            // condition. Once we hit one, subsequent args (wrapped subcommands
+            // like `curl` after `timeout 30`, or trailing flags after a
+            // version) are outside the approval intent.
+            if (IsCallSpecificValueToken(arg.Raw))
                 break;
 
             if (sb.Length > 0)
@@ -435,6 +450,68 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="token"/> is a call-specific value that varies
+    /// between invocations of the same verb chain — a bare integer (issue
+    /// #1331: ticket IDs, ports, timeouts) or a version-shaped token
+    /// (<c>v0.4.2</c>, <c>0.4.2</c>, <c>1.0-rc1</c>). These are operands, not
+    /// approvable intent, so they are normalized out of the verb chain on both
+    /// the gate path and the persisted-pattern path.
+    /// </summary>
+    private static bool IsCallSpecificValueToken(string token)
+        => IsBareIntegerToken(token) || IsVersionShapedToken(token);
+
+    /// <summary>
+    /// True when <paramref name="token"/> looks like a dotted version: an
+    /// optional leading <c>v</c>/<c>V</c>, then a digit, then a run of
+    /// alphanumerics, dots, dashes, and pluses containing at least one dot. So
+    /// <c>v0.4.2</c>, <c>2.0.0-beta.3</c>, and <c>1.0+build</c> match, but
+    /// subcommand words (<c>version</c>), branch-like single tokens
+    /// (<c>v2</c>), and hex SHAs (<c>1234abcd</c>) do not. The dot requirement
+    /// keeps the predicate from swallowing single-token subcommands; bare
+    /// integers are handled separately by <see cref="IsBareIntegerToken"/>.
+    /// </summary>
+    private static bool IsVersionShapedToken(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            return false;
+
+        var i = token[0] is 'v' or 'V' ? 1 : 0;
+        if (i >= token.Length || !char.IsAsciiDigit(token[i]))
+            return false;
+
+        var hasDot = false;
+        for (; i < token.Length; i++)
+        {
+            var c = token[i];
+            if (c == '.')
+            {
+                hasDot = true;
+                continue;
+            }
+
+            if (!(char.IsAsciiLetterOrDigit(c) || c is '-' or '+'))
+                return false;
+        }
+
+        return hasDot;
+    }
+
+    /// <summary>
+    /// Drops trailing call-specific value tokens from a parsed verb chain,
+    /// always retaining at least the command word. See
+    /// <see cref="IsCallSpecificValueToken"/> for why <c>git tag v0.4.2</c> and
+    /// <c>git tag 0.4.2</c> must both normalize to <c>git tag</c>.
+    /// </summary>
+    private static IReadOnlyList<string> TrimTrailingValueTokens(IReadOnlyList<string> verbTokens)
+    {
+        var end = verbTokens.Count;
+        while (end > 1 && IsCallSpecificValueToken(verbTokens[end - 1]))
+            end--;
+
+        return end == verbTokens.Count ? verbTokens : verbTokens.Take(end).ToList();
     }
 
     private static string RedirectToken(ShellSyntaxTree.RedirectDirection direction) => direction switch

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -232,15 +232,16 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (!ReferenceEquals(clause, groupHead))
                 continue;  // pipe-tail clauses fold into the group head
 
-            // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds a
-            // lowercase-leading version token such as `v0.4.2` into the verb
-            // chain (`git tag v0.4.2`), while a digit-leading `0.4.2` stops the
-            // walk and lands in Args (verb stays `git tag`). Both are
-            // call-specific values, not approvable intent, so strip them off
-            // the chain before gating — otherwise `git tag v0.4.2` would miss a
-            // `git tag` grant that `git tag 0.4.2` matches. Mirrors the #1331
-            // arg-stripping in ReconstructClauseText so the gate candidate and
-            // the persisted pattern normalize identically.
+            // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds
+            // lowercase-leading value tokens into the verb chain (`git tag
+            // v0.4.2`, `git show aa211dcb`, `git checkout feature2`), while
+            // digit-leading ones (`0.4.2`) stop the walk and land in Args
+            // (verb stays `git tag`). Both are call-specific values, not
+            // approvable intent, so strip them off the chain before gating —
+            // otherwise `git tag v0.4.2` would miss a `git tag` grant that
+            // `git tag 0.4.2` matches. Mirrors the value-termination in
+            // ReconstructClauseText so the gate candidate and the persisted
+            // pattern normalize identically.
             var verb = ShellTokenizer.ApplyVerbShortCircuit(
                 string.Join(" ", TrimTrailingValueTokens(clause.Verb.Tokens)));
             if (string.IsNullOrEmpty(verb))
@@ -372,12 +373,12 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     /// Rebuilds one clause's user-facing text from its parsed parts: verb
     /// chain, positional/flag args, and redirects. Synthetic cd-attribution
     /// args are dropped — they carry an inherited cwd, not a token the user
-    /// typed. Bare integer arguments (issue #1331) are also excluded since
-    /// they represent call-specific values (ticket IDs, port numbers,
-    /// timeouts) that vary between invocations of the same verb chain.
-    /// Once a bare integer is encountered, the greedy walk terminates —
-    /// subsequent args (wrapped subcommands like <c>curl</c> after
-    /// <c>timeout 30</c>) are outside the approval intent.
+    /// typed. Call-specific value arguments (issue #1331, generalized to
+    /// digit-bearing tokens — see <see cref="IsCallSpecificValueToken"/>)
+    /// are also excluded since they vary between invocations of the same
+    /// verb chain. Once a value token is encountered, the greedy walk
+    /// terminates — subsequent args (wrapped subcommands like <c>curl</c>
+    /// after <c>timeout 30</c>) are outside the approval intent.
     /// The result is fed back through
     /// <see cref="ShellTokenizer.NormalizeApprovalUnit"/> for path
     /// normalization, so this only needs to emit a clean token sequence.
@@ -394,8 +395,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (arg.IsCwdAttribution || string.IsNullOrEmpty(arg.Raw))
                 continue;
 
-            // Issue #1331 (extended): call-specific value args — bare integers
-            // and version-shaped tokens like `0.4.2` — are a termination
+            // Issue #1331 (generalized): call-specific value args —
+            // digit-bearing non-flag, non-path tokens — are a termination
             // condition. Once we hit one, subsequent args (wrapped subcommands
             // like `curl` after `timeout 30`, or trailing flags after a
             // version) are outside the approval intent.
@@ -426,77 +427,35 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     }
 
     /// <summary>
-    /// True when <paramref name="token"/> is a bare integer (sequence of
-    /// digits with an optional leading minus for negative numbers). Excludes
-    /// flag-form tokens (those starting with <c>-</c>) — e.g. <c>-c</c>,
-    /// <c>--version</c> are never treated as integers. Negative flags like
-    /// <c>-3</c> start with <c>-</c> so the flag check short-circuits first.
-    /// </summary>
-    private static bool IsBareIntegerToken(string token)
-    {
-        // Negative flags like `-3` start with `-` — not a bare integer.
-        if (token.Length == 0 || token[0] == '-')
-            return false;
-
-        var length = token.Length;
-        // Must be at least one digit.
-        if (!char.IsDigit(token[0]))
-            return false;
-
-        for (var i = 1; i < length; i++)
-        {
-            if (!char.IsDigit(token[i]))
-                return false;
-        }
-
-        return true;
-    }
-
-    /// <summary>
     /// True when <paramref name="token"/> is a call-specific value that varies
-    /// between invocations of the same verb chain — a bare integer (issue
-    /// #1331: ticket IDs, ports, timeouts) or a version-shaped token
-    /// (<c>v0.4.2</c>, <c>0.4.2</c>, <c>1.0-rc1</c>). These are operands, not
-    /// approvable intent, so they are normalized out of the verb chain on both
-    /// the gate path and the persisted-pattern path.
+    /// between invocations of the same verb chain. The classification is
+    /// morphological — one rule, not a taxonomy of value shapes: any non-flag,
+    /// non-path token containing a digit is a value. That covers versions
+    /// (<c>v0.4.2</c>, <c>0.4.2</c>), SHAs (<c>aa211dcb</c>), IPs, ports,
+    /// ticket IDs, and digit-bearing refs (<c>feature2</c>) — generalizing
+    /// issue #1331's bare-integer rule. Flags are exempt (<c>-3</c>,
+    /// <c>--max-count=10</c> carry invocation intent, not values);
+    /// path-shaped tokens are exempt so digit-bearing paths
+    /// (<c>/tmp/build2</c>) still reach directory scoping and the display
+    /// pattern. All-alpha operands (branch names, package names) are
+    /// intentionally NOT classified — no shape rule can tell them apart from
+    /// subcommands, and mis-stripping a subcommand silently widens a grant.
     /// </summary>
     private static bool IsCallSpecificValueToken(string token)
-        => IsBareIntegerToken(token) || IsVersionShapedToken(token);
-
-    /// <summary>
-    /// True when <paramref name="token"/> looks like a dotted version: an
-    /// optional leading <c>v</c>/<c>V</c>, then a digit, then a run of
-    /// alphanumerics, dots, dashes, and pluses containing at least one dot. So
-    /// <c>v0.4.2</c>, <c>2.0.0-beta.3</c>, and <c>1.0+build</c> match, but
-    /// subcommand words (<c>version</c>), branch-like single tokens
-    /// (<c>v2</c>), and hex SHAs (<c>1234abcd</c>) do not. The dot requirement
-    /// keeps the predicate from swallowing single-token subcommands; bare
-    /// integers are handled separately by <see cref="IsBareIntegerToken"/>.
-    /// </summary>
-    private static bool IsVersionShapedToken(string token)
     {
-        if (string.IsNullOrEmpty(token))
+        if (string.IsNullOrEmpty(token) || token[0] == '-')
             return false;
 
-        var i = token[0] is 'v' or 'V' ? 1 : 0;
-        if (i >= token.Length || !char.IsAsciiDigit(token[i]))
+        if (ShellTokenizer.IsPathToken(token))
             return false;
 
-        var hasDot = false;
-        for (; i < token.Length; i++)
+        foreach (var c in token)
         {
-            var c = token[i];
-            if (c == '.')
-            {
-                hasDot = true;
-                continue;
-            }
-
-            if (!(char.IsAsciiLetterOrDigit(c) || c is '-' or '+'))
-                return false;
+            if (char.IsAsciiDigit(c))
+                return true;
         }
 
-        return hasDot;
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes an approval-gate inconsistency where semantically-identical shell commands were gated differently based on the leading character of a version argument.

ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds a lowercase-leading version like `v0.4.2` into the verb chain (`git tag v0.4.2`), but a digit-leading `0.4.2` stops the walk and lands in Args (verb stays `git tag`). Because `ShellApprovalMatcher` compared the full verb chain for exact equality against persisted grants, `git tag 0.4.2` matched a standing `git tag` grant and ran instantly while `git tag v0.4.2` missed it and re-prompted.

This extends the issue #1331 call-specific-value rule (bare integers) to version-shaped tokens, applied on **both** the gate path (`ExtractCandidatesViaBashParser`) and the persisted/display path (`ReconstructClauseText`) so they normalize identically. `git tag v0.4.2` and `git tag 0.4.2` now both normalize to `git tag`.

## Verification
- Build clean; 578 `Netclaw.Security.Tests` + 311 actor approval/dispatch tests pass.
- 12 new `ShellApprovalMatcherTests` cases (parity, persist-path, IsApproved scenarios, conservatism boundary).
- File headers present; Slopwatch clean for changed files (5 new POSIX-only tests baselined per repo convention).

## Draft — open review items
A high-effort review surfaced follow-ups to triage before marking ready:
1. **Spec not updated** — `openspec/specs/tool-approval-gates/spec.md` ("Shell command pattern matching") still lists only flag/path/URL/bare-integer as stop conditions; needs a version-token delta.
2. **Predicate over-matches non-versions** — `IsVersionShapedToken` matches IPv4/dates (`8.8.8.8`, `2024.06.01`); for network commands the destination operand gets normalized away.
3. **`break` drops trailing flags** — `git tag 0.4.2 --sign` persists `git tag` (order-dependent); consider `continue` vs `break`.
4. Cleanup: dedupe the trim+join across the two call sites; char-class inconsistency (`IsDigit` vs `IsAsciiDigit`).
5. POSIX-only fix; Windows legacy path unchanged (disclosed scope boundary).