### PR TITLE
Prepare release 0.24.0-beta.4 (#1390)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.24.0</VersionPrefix>
-    <VersionSuffix>beta.3</VersionSuffix>
+    <VersionSuffix>beta.4</VersionSuffix>
     <PackageReleaseNotes>Netclaw v0.24.0-beta.3 — Channel infrastructure standardization, Discord/Mattermost gateway self-healing, and install script fix
 
 **Features**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+#### 0.24.0-beta.4 2026-06-11 ####
+
+Netclaw v0.24.0-beta.4 — Reminder delivery fixes and shell approval normalization
+
+**Bug Fixes**
+
+* **In-session reminder delivery now confirms successfully** — fixed current-session reminders that were incorrectly reporting delivery failures. Reminders scheduled with `delivery_kind: current_session` now complete without spurious errors. ([#1387](https://github.com/netclaw-dev/netclaw/pull/1387))
+
+* **Reminder list includes disabled reminders** — the reminder list endpoint now correctly returns disabled reminders alongside active ones, so you can see the full schedule even for paused reminders. ([#1386](https://github.com/netclaw-dev/netclaw/pull/1386))
+
+* **Shell approval no longer matches version/value arguments** — normalized how version and value arguments are processed in shell approval verb chains, preventing false-positive pattern matches on numeric arguments. ([#1388](https://github.com/netclaw-dev/netclaw/pull/1388))
+
+---
+
 #### 0.24.0-beta.3 2026-06-10 ####
 
 Netclaw v0.24.0-beta.3 — Channel infrastructure standardization, Discord/Mattermost gateway self-healing, and install script fix


### PR DESCRIPTION
## Netclaw v0.24.0-beta.4 — Reminder delivery fixes and shell approval normalization

**Bug Fixes**

* **In-session reminder delivery now confirms successfully** — fixed current-session reminders that were incorrectly reporting delivery failures. Reminders scheduled with `delivery_kind: current_session` now complete without spurious errors. ([#1387](https://github.com/netclaw-dev/netclaw/pull/1387))

* **Reminder list includes disabled reminders** — the reminder list endpoint now correctly returns disabled reminders alongside active ones, so you can see the full schedule even for paused reminders. ([#1386](https://github.com/netclaw-dev/netclaw/pull/1386))

* **Shell approval no longer matches version/value arguments** — normalized how version and value arguments are processed in shell approval verb chains, preventing false-positive pattern matches on numeric arguments. ([#1388](https://github.com/netclaw-dev/netclaw/pull/1388))

---

**Commits since beta.3**
- cca0f3a5 chore(openspec): verify and archive shell-approval-value-token-normalization (#1389)
- 5f4a8f9f Fix in-session reminder delivery confirmation (current-session reminders) (#1387)
- 208c2abf Normalize version/value args out of shell approval verb chains (#1388)
- 02c0a70b chore(openspec): sync and archive 7 completed changes (#1380)
- f0b9671f Fix reminder list endpoint to include disabled reminders (#1386)
- f2215205 Fix VersionPrefix for 0.24.0-beta.3 release
