### PR TITLE
Terminate approval patterns at multi-line args and summarize them in display text

### DIFF
--- a/openspec/specs/tool-approval-gates/spec.md
+++ b/openspec/specs/tool-approval-gates/spec.md
@@ -123,6 +123,20 @@ tokens (`aws s3 ls`) SHALL NOT be removed. Trimming SHALL apply
 identically on the gate (candidate) path and the persisted/display
 pattern path so the two normalize to the same verb chain.
 
+A multi-line argument — one containing an embedded line break (LF or
+CR), which can only arise inside quoting — SHALL also terminate pattern
+extraction, excluding the argument and everything after it (issue
+#1402). Multi-line quoted strings are call-specific content (message
+bodies, inline scripts) that varies between invocations of the same
+verb chain, and an embedded line break corrupts the stored pattern's
+display and the approval store's formatting; a lone CR additionally
+permits cursor-repositioning spoofing in terminal-rendered prompts. A
+preceding flag (e.g. `--message`) SHALL be retained in the pattern — it
+carries invocation intent. The same termination rule SHALL apply to
+redirect targets: a quoted redirect target carrying an embedded line
+break (e.g. `>> "$LOGDIR⏎file"`) terminates the redirect walk so the
+break never reaches the stored pattern.
+
 For shell approval units, `&&`, `||`, and `;` SHALL split into separate
 units, while `|` SHALL remain inside the current unit. For `bash -c` or
 `sh -c` wrappers, the inner command SHALL be extracted and scanned
@@ -191,6 +205,17 @@ chain. Compound commands SHALL produce N entries from one user click on
 - **AND** a standing `git tag` grant auto-approves both forms
 - **AND** the lowercase-leading form is handled by trimming the trailing
   value token the greedy walk folded into the chain
+
+#### Scenario: Multi-line quoted argument terminates the pattern
+
+- **GIVEN** the command `freshdesk ticket reply --message "Hi,⏎Thanks."`
+  where the quoted argument spans two lines
+- **WHEN** the pattern is extracted
+- **THEN** the pattern is `freshdesk ticket reply --message`
+- **AND** the multi-line body and everything after it are excluded
+  because multi-line arguments are call-specific content
+- **AND** the flag `--message` is retained because flags carry
+  invocation intent
 
 #### Scenario: Digit-bearing ref folded into the chain is trimmed
 
@@ -808,6 +833,25 @@ Single-verb commands MAY collapse the list into the header
 (`Approve <verb> in <cwd> ?`). The body SHALL NOT render separate
 "Patterns" or "Directory Roots" sections.
 
+The display text for a shell command SHALL be single-line. A command
+containing embedded line breaks (LF or CR) SHALL be reconstructed from
+its parse tree: statement separators render as explicit operators (`;`,
+`&&`, `||`, `|`) and each multi-line argument or redirect target is
+replaced with a `(N lines, M chars)` size summary instead of its
+verbatim content (issue #1402) — channel renderers embed the display
+text in single-line code fences, and dumping a multi-line quoted blob
+verbatim corrupts the prompt layout. When the parser cannot decompose
+the command, line breaks SHALL be flattened to spaces.
+
+Commands containing heredocs or subshell groupings SHALL NOT be
+display-reconstructed: the parser drops heredoc bodies from the tree
+(only the `<<EOF` marker survives as a redirect target), so a
+reconstruction would silently omit executable content the approver must
+see — and subshell grouping does not survive the flat clause list, so a
+reconstruction would misstate which statements a pipe or `&&` guard
+applies to. Both fall back to the flattened raw command — ugly but
+fully disclosed.
+
 Button semantics:
 
 - `Once` SHALL run the command this one time and persist nothing.
@@ -865,6 +909,16 @@ Button semantics:
 - **THEN** the current call is refused
 - **AND** `tool-approvals.json` is NOT modified
 - **AND** a later `git push` call still prompts
+
+#### Scenario: Multi-line quoted argument summarized in display text
+
+- **GIVEN** the agent invokes `shell_execute` with command
+  `freshdesk ticket reply 605 --message "Hi,⏎We've rolled out a fix. Please verify."`
+  where the quoted argument spans two lines
+- **WHEN** the approval prompt is rendered
+- **THEN** the display text reads
+  `freshdesk ticket reply 605 --message (2 lines, 42 chars)`
+- **AND** the display text contains no newline characters
 
 ### Requirement: Resolution message single-line format
 

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -275,6 +275,144 @@ public sealed class ShellApprovalMatcherTests
         Assert.Equal("git push origin main", display);
     }
 
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_multiline_quoted_arg_terminates_pattern_at_flag()
+    {
+        // Issue #1402: the multi-line message body is call-specific content,
+        // not approvable intent — the stored pattern stops at the flag so a
+        // later invocation with a different body still matches.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("freshdesk ticket reply --message \"Hi,\nWe've rolled out a fix. Please verify.\""));
+
+        Assert.Single(patterns);
+        Assert.Equal("freshdesk ticket reply --message", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_multiline_quoted_arg_after_digit_id_terminates_at_id()
+    {
+        // The digit-bearing 605 terminates the walk before --message is
+        // reached (IsCallSpecificValueToken), so the multi-line blob never
+        // enters the pattern — pins issue #1402's exact command shape.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("freshdesk ticket reply 605 --message \"Hi,\nWe've rolled out a fix. Please verify.\""));
+
+        Assert.Single(patterns);
+        Assert.Equal("freshdesk ticket reply", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_summarizes_multiline_quoted_arg()
+    {
+        // Issue #1402: channel renderers embed DisplayText in single-line
+        // code fences — the multi-line body renders as a size summary.
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("freshdesk ticket reply 605 --message \"Hi,\nWe've rolled out a fix. Please verify.\""));
+
+        Assert.DoesNotContain('\n', display);
+        Assert.Equal("freshdesk ticket reply 605 --message (2 lines, 42 chars)", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_renders_newline_separated_statements_with_explicit_separator()
+    {
+        // Bare-newline statement separators render as "; " so the one-line
+        // display doesn't visually merge two statements into one command.
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("git fetch\ngit status"));
+
+        Assert.Equal("git fetch; git status", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_heredoc_falls_back_to_flattened_raw_command()
+    {
+        // The parser drops heredoc bodies from the tree (only the <<EOF
+        // marker survives as a redirect target), so a tree reconstruction
+        // would hide the executable payload from the approver. Heredoc
+        // commands fall back to the flattened raw command instead.
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("bash <<EOF\nrm -rf /tmp/x\nEOF"));
+
+        Assert.DoesNotContain('\n', display);
+        Assert.Equal("bash <<EOF rm -rf /tmp/x EOF", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_redirect_target_with_line_break_terminates_pattern()
+    {
+        // A quoted redirect target carrying an embedded newline must not
+        // reach the stored pattern — quote-aware normalization would
+        // otherwise preserve the break verbatim (`echo hi >> $LOGDIR\nfile`).
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("echo hi >> \"$LOGDIR\nfile\""));
+
+        Assert.Single(patterns);
+        Assert.DoesNotContain('\n', patterns[0]);
+        Assert.Equal("echo hi", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_carriage_return_arg_terminates_pattern_at_flag()
+    {
+        // A lone CR (no LF) is a line break too: in a terminal-rendered
+        // prompt it returns the cursor to column 0, so it must terminate
+        // the pattern walk exactly like LF.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("freshdesk ticket reply --message \"Hi,\rEvil\""));
+
+        Assert.Single(patterns);
+        Assert.DoesNotContain('\r', patterns[0]);
+        Assert.Equal("freshdesk ticket reply --message", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_carriage_return_arg_is_summarized()
+    {
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("freshdesk ticket reply --message \"Hi,\rEvil\""));
+
+        Assert.DoesNotContain('\r', display);
+        Assert.DoesNotContain('\n', display);
+        Assert.Equal("freshdesk ticket reply --message (2 lines, 8 chars)", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_summarizes_multiline_redirect_target()
+    {
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("echo hi >> \"$LOGDIR\nfile\""));
+
+        Assert.DoesNotContain('\n', display);
+        Assert.Equal("echo hi >> (2 lines, 12 chars)", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_subshell_falls_back_to_flattened_raw_command()
+    {
+        // Subshell grouping doesn't survive the parser's flat clause list —
+        // a reconstruction would misstate which statements the pipe applies
+        // to. The fallback keeps the parens the user typed.
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("(git fetch\ngit status) | tee log"));
+
+        Assert.DoesNotContain('\n', display);
+        Assert.Equal("(git fetch git status) | tee log", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_subshell_with_multiline_arg_stays_single_line()
+    {
+        // Regression guard: the clause after a closed subshell carries
+        // CompoundOperator.None, which previously threw inside the display
+        // walk and silently fell back to the unsummarized raw command.
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("(echo hi)\nfreshdesk ticket reply --message \"Hi,\nbody\""));
+
+        Assert.DoesNotContain('\n', display);
+        Assert.Equal("(echo hi) freshdesk ticket reply --message \"Hi, body\"", display);
+    }
+
     [Fact]
     public void IsMessy_true_for_bash_control_flow()
     {

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -195,22 +195,31 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         return candidates;
     }
 
-    private static IReadOnlyList<ApprovalCandidate> ExtractCandidatesViaBashParser(string command)
+    /// <summary>
+    /// Parses <paramref name="command"/>, returning null when the parser
+    /// rejects it (unparseable, no clauses) or throws — a parser exception
+    /// must never take down the approval flow. Callers treat null as
+    /// "cannot decompose" and apply their own fail-safe: an empty
+    /// pattern/candidate list (messy semantics — Once/Deny prompt only) or
+    /// the flattened raw command for display.
+    /// </summary>
+    private static ShellSyntaxTree.ParsedCommand? TryParseCommand(string command)
     {
-        ShellSyntaxTree.ParsedCommand result;
         try
         {
-            result = Parser.Parse(command);
+            var result = Parser.Parse(command);
+            return result.IsUnparseable || result.Clauses.Count == 0 ? null : result;
         }
         catch
         {
-            // Defensive: an unhandled parser exception shouldn't take down
-            // the approval flow. Fail-empty so the matcher treats this as
-            // a messy command (Once+Deny prompt only).
-            return [];
+            return null;
         }
+    }
 
-        if (result.IsUnparseable || result.Clauses.Count == 0)
+    private static IReadOnlyList<ApprovalCandidate> ExtractCandidatesViaBashParser(string command)
+    {
+        var result = TryParseCommand(command);
+        if (result is null)
             return [];
 
         // Group consecutive Pipe clauses into a single approval unit so
@@ -327,12 +336,12 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (ShellTokenizer.IsMessyCompoundCommand(command))
             return [];
 
+        var result = TryParseCommand(command);
+        if (result is null)
+            return [];
+
         try
         {
-            var result = Parser.Parse(command);
-            if (result.IsUnparseable || result.Clauses.Count == 0)
-                return [];
-
             var units = new List<string>();
             var current = new StringBuilder();
 
@@ -361,10 +370,10 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         }
         catch
         {
-            // Defensive: a parser exception — or an unmapped redirect/clause
-            // shape from a future ShellSyntaxTree release — must not take
-            // down the approval prompt. Fail-empty so the matcher treats the
-            // command as messy (Once/Deny prompt only).
+            // Defensive: an unmapped redirect/clause shape from a future
+            // ShellSyntaxTree release must not take down the approval
+            // prompt. Fail-empty so the matcher treats the command as messy
+            // (Once/Deny prompt only).
             return [];
         }
     }
@@ -403,6 +412,14 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (IsCallSpecificValueToken(arg.Raw))
                 break;
 
+            // Issue #1402: a multi-line quoted string (a message body, an
+            // inline script) is call-specific content that varies between
+            // invocations — and an embedded line break corrupts the stored
+            // pattern's display. Like the digit rule above, hitting one
+            // terminates the walk.
+            if (ContainsLineBreak(arg.Raw))
+                break;
+
             if (sb.Length > 0)
                 sb.Append(' ');
             sb.Append(arg.Raw);
@@ -416,6 +433,13 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (string.IsNullOrEmpty(redirect.Target))
                 continue;
 
+            // Issue #1402: a quoted redirect target can carry an embedded
+            // line break too (`> "$LOGDIR\nfile"`), and quote-aware path
+            // normalization preserves it — same termination rule as args so
+            // the break never reaches the stored pattern.
+            if (ContainsLineBreak(redirect.Target))
+                break;
+
             if (sb.Length > 0)
                 sb.Append(' ');
             sb.Append(RedirectToken(redirect.Direction));
@@ -425,6 +449,17 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// True when <paramref name="value"/> contains an embedded line break.
+    /// Checks CR as well as LF: a lone carriage return corrupts a stored
+    /// pattern just like a newline, and in a terminal-rendered prompt it
+    /// returns the cursor to column 0 so attacker-influenced content (e.g.
+    /// quoted ticket text flowing into a tool argument) could visually
+    /// overwrite the rendered command at the moment of approval.
+    /// </summary>
+    private static bool ContainsLineBreak(string value)
+        => value.AsSpan().IndexOfAny('\r', '\n') >= 0;
 
     /// <summary>
     /// True when <paramref name="token"/> is a call-specific value that varies
@@ -535,7 +570,143 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         => ShellTokenizer.IsMessyCompoundCommand(GetCommand(arguments));
 
     public string FormatForDisplay(ToolName toolName, IDictionary<string, object?>? arguments)
-        => GetCommand(arguments) ?? "(empty command)";
+    {
+        var command = GetCommand(arguments);
+        if (string.IsNullOrWhiteSpace(command))
+            return "(empty command)";
+
+        // Fast path: a command with no embedded line break renders verbatim.
+        if (!ContainsLineBreak(command))
+            return command;
+
+        // Issue #1402: channel renderers embed DisplayText in single-line
+        // code fences, so a multi-line quoted string (a message body, an
+        // inline script) dumped verbatim corrupts the approval prompt. On
+        // POSIX, rebuild a one-line view from the parse tree with multi-line
+        // args summarized by size; Windows flattens — ShellSyntaxTree is
+        // bash-only. The trailing ReplaceLineEndings catches line breaks the
+        // reconstruction can leak and collapses CRLF to a single space.
+        var display = OperatingSystem.IsWindows()
+            ? command
+            : BuildSanitizedDisplayViaParser(command);
+
+        return display.ReplaceLineEndings(" ");
+    }
+
+    /// <summary>
+    /// Rebuilds a one-line display string for a multi-line command from its
+    /// parse tree: statement separators render as explicit operators and any
+    /// multi-line argument is replaced with a <c>(N lines, M chars)</c>
+    /// summary — the operator approving the command needs its shape, not the
+    /// full content (issue #1402). Returns the raw command (for the caller
+    /// to flatten) when the parser cannot decompose it, when the command
+    /// contains a heredoc — the parser drops heredoc bodies entirely (only
+    /// the <c>&lt;&lt;EOF</c> marker survives as a redirect target), so a
+    /// tree reconstruction would silently omit executable content the
+    /// approver must see — or when it contains a subshell, whose grouping
+    /// does not survive the flat clause list, so a reconstruction would
+    /// misstate which statements a pipe or <c>&amp;&amp;</c> guard applies
+    /// to. The flattened raw command is ugly but fully disclosed.
+    /// </summary>
+    private static string BuildSanitizedDisplayViaParser(string command)
+    {
+        var result = TryParseCommand(command);
+        if (result is null)
+            return command;
+
+        if (result.Clauses.Any(c => c.IsSubshell || c.Redirects.Any(IsHeredocRedirect)))
+            return command;
+
+        try
+        {
+            var sb = new StringBuilder();
+            var first = true;
+
+            foreach (var clause in result.Clauses)
+            {
+                if (!first)
+                    sb.Append(ClauseOperatorText(clause.Operator));
+                first = false;
+
+                sb.Append(clause.Verb.Joined);
+
+                foreach (var arg in clause.Args)
+                {
+                    if (arg.IsCwdAttribution || string.IsNullOrEmpty(arg.Raw))
+                        continue;
+
+                    sb.Append(' ');
+                    sb.Append(ContainsLineBreak(arg.Raw)
+                        ? SummarizeMultilineArg(arg.Raw)
+                        : arg.Raw);
+                }
+
+                foreach (var redirect in clause.Redirects)
+                {
+                    if (string.IsNullOrEmpty(redirect.Target))
+                        continue;
+
+                    sb.Append(' ');
+                    sb.Append(RedirectToken(redirect.Direction));
+                    sb.Append(' ');
+                    sb.Append(ContainsLineBreak(redirect.Target)
+                        ? SummarizeMultilineArg(redirect.Target)
+                        : redirect.Target);
+                }
+            }
+
+            return sb.ToString();
+        }
+        catch
+        {
+            // Defensive: display formatting must never take down the
+            // approval prompt — the caller flattens the raw command's
+            // line breaks instead.
+            return command;
+        }
+    }
+
+    /// <summary>
+    /// True when a parsed redirect is a heredoc marker (<c>&lt;&lt;EOF</c>,
+    /// <c>&lt;&lt;-EOF</c>). The parser keeps only the marker as the redirect
+    /// target and drops the body from the tree, so heredoc-bearing commands
+    /// must not be display-reconstructed — see
+    /// <see cref="BuildSanitizedDisplayViaParser"/>.
+    /// </summary>
+    private static bool IsHeredocRedirect(ShellSyntaxTree.Redirect redirect)
+        => redirect.Target?.StartsWith("<<", StringComparison.Ordinal) == true;
+
+    /// <summary>
+    /// Size summary shown in place of a multi-line argument. Outer quotes
+    /// are excluded from the character count — the operator cares about the
+    /// content's size, not the shell syntax around it. Line endings are
+    /// normalized first so CRLF and lone CR count the same as LF.
+    /// </summary>
+    private static string SummarizeMultilineArg(string raw)
+    {
+        var content = raw.Length >= 2 && (raw[0] == '"' || raw[0] == '\'') && raw[^1] == raw[0]
+            ? raw[1..^1]
+            : raw;
+
+        var normalized = content.ReplaceLineEndings("\n");
+        var lines = normalized.Count(c => c == '\n') + 1;
+        return $"({lines} lines, {normalized.Length} chars)";
+    }
+
+    private static string ClauseOperatorText(ShellSyntaxTree.CompoundOperator op) => op switch
+    {
+        ShellSyntaxTree.CompoundOperator.AndIf => " && ",
+        ShellSyntaxTree.CompoundOperator.OrIf => " || ",
+        ShellSyntaxTree.CompoundOperator.Sequence => "; ",
+        ShellSyntaxTree.CompoundOperator.Pipe => " | ",
+        // None is not just the leading-clause marker: the parser emits it on
+        // the clause following a closed subshell, so it is reachable on
+        // non-first clauses. Render it as a plain statement separator.
+        ShellSyntaxTree.CompoundOperator.None => "; ",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(op), op,
+            "Unknown ShellSyntaxTree compound operator — a package upgrade needs a matcher update."),
+    };
 
     private static string? GetCommand(IDictionary<string, object?>? arguments)
         => ToolArgumentHelper.GetString(arguments, "Command");


### PR DESCRIPTION
Fixes #1402

## Problem

Multi-line quoted strings (message bodies, inline scripts) broke the shell approval flow at two layers:

1. **Stored patterns** — `ReconstructClauseText` appended `arg.Raw` verbatim, so `freshdesk ticket reply --message "Hi,\n..."` persisted the full multi-line blob as the approval pattern. Every unique body became a new pattern, defeating pattern-based auto-approval and bloating the store.
2. **Display text** — `FormatForDisplay` returned the raw command including embedded newlines, which Slack/Discord/Mattermost dump into single-line code fences, corrupting the prompt layout.

Note: for #1402's exact command the stored pattern was already clean — the digit-bearing `605` terminates the walk before `--message`. The pattern bug only manifests when no digit-bearing token precedes the quoted arg.

## Changes

All in `ShellApprovalMatcher` (`src/Netclaw.Security/IToolApprovalMatcher.cs`); no channel renderer changes needed since `FormatForDisplay` feeds all three plus the TUI.

**Pattern path:**
- A line-break-bearing arg is now a termination condition, same mechanism as the digit-bearing value rule — the pattern stops at the preceding flag (`freshdesk ticket reply --message`).
- The same rule guards redirect targets, whose quoted form survives normalization (`>> "$LOGDIR\nfile"` previously persisted a newline-bearing pattern).

**Display path:**
- Multi-line commands are rebuilt from the parse tree: statement separators render as explicit operators, multi-line args/redirect targets become `(N lines, M chars)` size summaries.
- **Heredocs and subshells skip reconstruction** and fall back to the flattened raw command — the parser drops heredoc bodies from the tree (a rebuild would hide the executable payload from the approver), and subshell grouping doesn't survive the flat clause list (a rebuild would misstate pipe/`&&` scope).
- `CompoundOperator.None` on a non-first clause (emitted after a closed subshell) renders as a statement separator instead of throwing into the method's own catch.
- Windows and parser-failure paths flatten line breaks — ShellSyntaxTree is bash-only.

**Robustness:**
- Line-break detection covers lone CR as well as LF (`ContainsLineBreak`): a bare carriage return corrupts patterns identically and enables cursor-repositioning spoofing in terminal-rendered prompts.
- Parse-or-fail-safe handling centralized in `TryParseCommand`.

## Example

Command:
```
freshdesk ticket reply 605 --message "Hi,
We've rolled out a fix. Please verify."
```

| Surface | Before | After |
|---|---|---|
| Display text | full multi-line blob | `freshdesk ticket reply 605 --message (2 lines, 42 chars)` |
| Stored pattern (no ID variant) | full blob inline | `freshdesk ticket reply --message` |

## Testing

- 11 new tests in `ShellApprovalMatcherTests` covering pattern termination (flag/digit-ID/redirect/CR variants), display summarization, heredoc and subshell fallbacks, and statement-separator rendering — 592/592 passing
- Edge shapes verified empirically against ShellSyntaxTree 0.1.5 (heredoc redirect targets, subshell clause flags, None-operator placement)
- `dotnet slopwatch analyze` clean, copyright headers verified

## Spec

`openspec/specs/tool-approval-gates/spec.md` amended in the same PR: line-break termination rule (LF or CR, args and redirect targets), single-line display reconstruction requirement, heredoc/subshell fallback rule, plus scenarios for each.

## Deferred

Single-line quoted free-text args still inflate patterns (same class, no line break) — filed as #1406 since the fix changes grant semantics for things like `git commit -m "fix"` and deserves its own design discussion.