### PR TITLE
Prune removed skills from server feeds (#1403)

### DIFF
--- a/src/Netclaw.Daemon.Tests/Services/SkillSyncHelpersTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/SkillSyncHelpersTests.cs
@@ -1,0 +1,87 @@
+// -----------------------------------------------------------------------
+// <copyright file="SkillSyncHelpersTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration.Feeds;
+using Netclaw.Daemon.Services;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class SkillSyncHelpersTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+
+    public void Dispose() => _dir.Dispose();
+
+    private string CreateSkillDir(string name)
+    {
+        var dir = Path.Combine(_dir.Path, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), $"---\nname: {name}\n---\n");
+        return dir;
+    }
+
+    [Fact]
+    public void PruneRemovedSkills_drops_stale_dirs_and_state_but_keeps_present_and_bookkeeping()
+    {
+        var feedDir = _dir.Path;
+        CreateSkillDir("skill-a");
+        CreateSkillDir("skill-b");
+        CreateSkillDir("skill-c");
+
+        // Sync-service bookkeeping (dot-prefixed) that must never be pruned.
+        Directory.CreateDirectory(Path.Combine(feedDir, ".staging"));
+        File.WriteAllText(Path.Combine(feedDir, ".sync-state.json"), "{}");
+
+        var syncState = new SkillSyncState();
+        foreach (var name in new[] { "skill-a", "skill-b", "skill-c", "skill-d" })
+            syncState.Skills[name] = new SyncedSkillState { Version = "1.0.0", Sha256 = "abc" };
+
+        // Server index now advertises only skill-a.
+        var changed = SkillSyncHelpers.PruneRemovedSkills(
+            feedDir, new[] { "skill-a" }, syncState, NullLogger.Instance);
+
+        Assert.True(changed);
+
+        // On disk: skill-a kept, removed skills gone.
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-a")));
+        Assert.False(Directory.Exists(Path.Combine(feedDir, "skill-b")));
+        Assert.False(Directory.Exists(Path.Combine(feedDir, "skill-c")));
+
+        // Bookkeeping preserved.
+        Assert.True(Directory.Exists(Path.Combine(feedDir, ".staging")));
+        Assert.True(File.Exists(Path.Combine(feedDir, ".sync-state.json")));
+
+        // State: only skill-a survives (skill-d had no dir but is dropped from state too).
+        Assert.Equal(new[] { "skill-a" }, syncState.Skills.Keys.OrderBy(k => k));
+    }
+
+    [Fact]
+    public void PruneRemovedSkills_is_a_no_op_when_index_covers_everything()
+    {
+        var feedDir = _dir.Path;
+        CreateSkillDir("skill-a");
+        CreateSkillDir("skill-b");
+
+        var syncState = new SkillSyncState
+        {
+            Skills =
+            {
+                ["skill-a"] = new SyncedSkillState { Version = "1", Sha256 = "x" },
+                ["skill-b"] = new SyncedSkillState { Version = "1", Sha256 = "y" },
+            },
+        };
+
+        var changed = SkillSyncHelpers.PruneRemovedSkills(
+            feedDir, new[] { "skill-a", "skill-b" }, syncState, NullLogger.Instance);
+
+        Assert.False(changed);
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-a")));
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-b")));
+        Assert.Equal(2, syncState.Skills.Count);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/SkillSyncHelpersTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/SkillSyncHelpersTests.cs
@@ -25,6 +25,16 @@ public sealed class SkillSyncHelpersTests : IDisposable
         return dir;
     }
 
+    private string CreateNonSkillDir(string name)
+    {
+        var dir = Path.Combine(_dir.Path, name);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static SyncedSkillState State(string version = "1.0.0", string sha = "abc")
+        => new() { Version = version, Sha256 = sha };
+
     [Fact]
     public void PruneRemovedSkills_drops_stale_dirs_and_state_but_keeps_present_and_bookkeeping()
     {
@@ -83,5 +93,54 @@ public sealed class SkillSyncHelpersTests : IDisposable
         Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-a")));
         Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-b")));
         Assert.Equal(2, syncState.Skills.Count);
+    }
+
+    [Fact]
+    public void PruneRemovedSkills_only_deletes_real_skill_directories()
+    {
+        var feedDir = _dir.Path;
+        CreateSkillDir("skill-a");        // live skill, advertised
+        CreateNonSkillDir("not-a-skill"); // no SKILL.md, not in state — must survive
+        CreateNonSkillDir("husk");        // no SKILL.md, tracked in state — dir survives, state pruned
+
+        var syncState = new SkillSyncState
+        {
+            Skills =
+            {
+                ["skill-a"] = State(),
+                ["husk"] = State(),
+            },
+        };
+
+        // Server advertises only skill-a.
+        var changed = SkillSyncHelpers.PruneRemovedSkills(
+            feedDir, new[] { "skill-a" }, syncState, NullLogger.Instance);
+
+        Assert.True(changed); // husk's stale state entry was removed
+
+        // A directory without a SKILL.md is never recursively deleted.
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "not-a-skill")));
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "husk")));
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-a")));
+
+        // State is pruned to what the server still advertises.
+        Assert.Equal(new[] { "skill-a" }, syncState.Skills.Keys.OrderBy(k => k));
+    }
+
+    [Fact]
+    public void PruneRemovedSkills_is_a_no_op_for_an_empty_index()
+    {
+        var feedDir = _dir.Path;
+        CreateSkillDir("skill-a");
+
+        var syncState = new SkillSyncState { Skills = { ["skill-a"] = State() } };
+
+        // An empty server index is not authoritative — prune nothing.
+        var changed = SkillSyncHelpers.PruneRemovedSkills(
+            feedDir, Array.Empty<string>(), syncState, NullLogger.Instance);
+
+        Assert.False(changed);
+        Assert.True(Directory.Exists(Path.Combine(feedDir, "skill-a")));
+        Assert.Single(syncState.Skills);
     }
 }

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -114,7 +114,18 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
             }
         }
 
-        RescanAndUpdateIndex();
+        // Rebuild the registry from disk. Guarded because the scan walks the same
+        // feed tree this service (and others) may be mutating concurrently — a
+        // directory vanishing mid-scan must not tear down the background service.
+        try
+        {
+            RescanAndUpdateIndex();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Skill index rebuild after server feed sync failed — registry left as-is");
+        }
     }
 
     private async Task SyncFeedAsync(SkillFeedSource feed, CancellationToken cancellationToken)

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -264,6 +264,13 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
             }
         }
 
+        // Reverse pass: drop skills the server no longer advertises. This is
+        // only reached with a confirmed, non-empty index (see the early returns
+        // above), so a transient outage or empty response never triggers a prune.
+        var serverSkillNames = index.Skills.Select(e => e.Name).ToList();
+        if (SkillSyncHelpers.PruneRemovedSkills(feedDir, serverSkillNames, syncState, _logger))
+            updated = true;
+
         if (updated)
         {
             syncState.LastSyncUtc = now;

--- a/src/Netclaw.Daemon/Services/SkillSyncHelpers.cs
+++ b/src/Netclaw.Daemon/Services/SkillSyncHelpers.cs
@@ -64,6 +64,83 @@ internal static class SkillSyncHelpers
         File.WriteAllText(path, json);
     }
 
+    /// <summary>
+    /// Removes skills that are no longer present in a server feed's index from
+    /// both the on-disk feed directory and the sync state.
+    /// </summary>
+    /// <remarks>
+    /// Only the server-feed sync path calls this. The system-skill feed
+    /// deliberately keeps removed skills on disk — its CDN manifest is the sole
+    /// source of built-in skills, so a transient empty manifest must never wipe
+    /// them. A private server feed is, by contrast, authoritative for its own
+    /// <c>.server-feeds/{name}/</c> namespace (which nothing else writes to), so
+    /// dropping skills the server no longer advertises is the correct,
+    /// non-destructive behavior.
+    /// <para>
+    /// Callers MUST gate this on a successful, non-empty index fetch. Pruning
+    /// against an empty or failed response would delete every locally synced
+    /// skill on a transient server outage.
+    /// </para>
+    /// </remarks>
+    /// <param name="feedDir">The feed's on-disk root (e.g. <c>.server-feeds/{name}</c>).</param>
+    /// <param name="serverSkillNames">Skill names present in the freshly fetched, non-empty server index.</param>
+    /// <param name="syncState">Sync state to prune in place.</param>
+    /// <param name="logger">Logger for prune diagnostics.</param>
+    /// <returns><c>true</c> if any sync-state entry or on-disk directory was removed.</returns>
+    internal static bool PruneRemovedSkills(
+        string feedDir,
+        IReadOnlyCollection<string> serverSkillNames,
+        SkillSyncState syncState,
+        ILogger logger)
+    {
+        var present = new HashSet<string>(serverSkillNames, StringComparer.Ordinal);
+        var changed = false;
+
+        // 1) Prune stale sync-state entries.
+        var staleStateKeys = syncState.Skills.Keys
+            .Where(name => !present.Contains(name))
+            .ToList();
+        foreach (var name in staleStateKeys)
+        {
+            syncState.Skills.Remove(name);
+            changed = true;
+        }
+
+        // 2) Prune stale on-disk directories. The feed root also holds this
+        //    service's own bookkeeping (.staging from ReplaceSkillDirectoryAsync,
+        //    .sync-state.json) — skip anything dot-prefixed so we only ever touch
+        //    skill directories that the sync service itself created.
+        if (Directory.Exists(feedDir))
+        {
+            foreach (var dir in Directory.GetDirectories(feedDir))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (string.IsNullOrEmpty(dirName) || dirName.StartsWith('.'))
+                    continue;
+
+                if (present.Contains(dirName))
+                    continue;
+
+                try
+                {
+                    Directory.Delete(dir, recursive: true);
+                    logger.LogInformation(
+                        "Pruned removed skill '{SkillName}' from feed directory {FeedDir}",
+                        dirName, feedDir);
+                    changed = true;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to prune removed skill '{SkillName}' from {FeedDir} — leaving in place",
+                        dirName, feedDir);
+                }
+            }
+        }
+
+        return changed;
+    }
+
     internal static async Task ReplaceSkillDirectoryAsync(
         string parentDirectory,
         string skillName,

--- a/src/Netclaw.Daemon/Services/SkillSyncHelpers.cs
+++ b/src/Netclaw.Daemon/Services/SkillSyncHelpers.cs
@@ -15,6 +15,9 @@ internal static class SkillSyncHelpers
 {
     internal static readonly string[] AllowedResourcePrefixes = ["references", "scripts", "assets"];
 
+    // A directory is a skill iff it owns a SKILL.md — the same rule SkillScanner uses.
+    private const string SkillFileName = "SKILL.md";
+
     private static readonly JsonSerializerOptions IndentedJsonOptions = new() { WriteIndented = true };
 
     internal static string ComputeSha256(string content)
@@ -93,10 +96,19 @@ internal static class SkillSyncHelpers
         SkillSyncState syncState,
         ILogger logger)
     {
+        // Never prune against a non-authoritative answer. The caller already
+        // early-returns on an empty index; this makes the destructive operation
+        // safe even if a future caller forgets to.
+        if (serverSkillNames.Count == 0)
+            return false;
+
         var present = new HashSet<string>(serverSkillNames, StringComparer.Ordinal);
         var changed = false;
 
-        // 1) Prune stale sync-state entries.
+        // Drop sync-state entries the server no longer advertises. This is the
+        // load-bearing half: clearing the entry is what lets the forward sync
+        // re-download the skill if it ever reappears — otherwise a same-version
+        // re-add would be skipped while its files are gone.
         var staleStateKeys = syncState.Skills.Keys
             .Where(name => !present.Contains(name))
             .ToList();
@@ -106,19 +118,20 @@ internal static class SkillSyncHelpers
             changed = true;
         }
 
-        // 2) Prune stale on-disk directories. The feed root also holds this
-        //    service's own bookkeeping (.staging from ReplaceSkillDirectoryAsync,
-        //    .sync-state.json) — skip anything dot-prefixed so we only ever touch
-        //    skill directories that the sync service itself created.
+        // Delete on-disk skill directories the server no longer advertises. Only
+        // touch real skill directories (those that own a SKILL.md) so a stray
+        // non-skill directory under the feed root is never recursively deleted;
+        // dot-prefixed bookkeeping (.staging, .sync-state.json) has no root
+        // SKILL.md and is skipped for the same reason.
         if (Directory.Exists(feedDir))
         {
             foreach (var dir in Directory.GetDirectories(feedDir))
             {
                 var dirName = Path.GetFileName(dir);
-                if (string.IsNullOrEmpty(dirName) || dirName.StartsWith('.'))
+                if (string.IsNullOrEmpty(dirName) || dirName.StartsWith('.') || present.Contains(dirName))
                     continue;
 
-                if (present.Contains(dirName))
+                if (!File.Exists(Path.Combine(dir, SkillFileName)))
                     continue;
 
                 try


### PR DESCRIPTION
Closes #1403.

## Problem

`ServerFeedSkillSyncService` only iterated *forward* through a server feed's RFC index — it downloaded/updated skills that exist, but never pruned skills that were deleted or renamed on the server. The stale skill directory persisted on disk, the `SkillSyncState` entry stayed, a rename left both old and new versions registered, and `skill_load` kept working on deleted skills.

## Fix

Add a reverse pass after the forward sync loop (`SkillSyncHelpers.PruneRemovedSkills`) that removes sync-state entries and on-disk skill directories no longer present in the index. The registry self-heals via the existing disk-rebuild (`RescanAndUpdateIndex`).

Pruning runs **per-feed** and only after a **confirmed, non-empty index fetch**, so a transient outage or empty response never wipes locally synced skills.

### Safety hardening (from an adversarial self-review)

- **Empty-index guard inside the helper**, not just the caller — the destructive op is safe by construction.
- **Only directories that own a `SKILL.md` are deleted** (the same rule `SkillScanner` uses), so a stray non-skill directory under the feed root is never recursively deleted. This also neutralizes a scan-vs-prune race: prune no longer deletes the kind of directory `SkillScanner`'s unguarded enumeration would choke on.
- **`RescanAndUpdateIndex` is wrapped** in the same defensive try/catch the per-feed loop uses, so a directory vanishing mid-scan can't tear down the background service.

### Deliberate non-goals

- **No grace period / circuit breaker for partial indexes.** Transient/partial indexes self-heal: prune clears the sync-state entry, so the next full index re-downloads the skill. The only cost is a one-interval gap, automatically recovered.
- **No `skill-server` changes.** `GetRfcIndexAsync` returns a complete snapshot (no pagination), so "absent from the index" reliably means removed. `Netclaw.SkillClient` stays a pure HTTP client.

## Tests

`SkillSyncHelpersTests` covers: stale dirs + state pruned while present skills and `.staging`/`.sync-state.json` bookkeeping are preserved; non-skill directories survive prune (state still cleared); and an empty index is a no-op.

## Validation

- `dotnet test` — 31/31 skill tests pass (incl. 4 new prune tests)
- `dotnet slopwatch analyze` — 0 issues
- `Add-FileHeaders.ps1 -Verify` — all headers present