### PR TITLE
Fix flaky actor-startup tests with deterministic readiness barriers (#1409, #1378)

### DIFF
--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -221,7 +221,7 @@ public class BackgroundJobManagerActorTests : TestKit
             SessionId = sessionId,
             Rationale = "dev server",
             Status = BackgroundJobStatus.Running,
-            StartedAtMs = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds(),
+            StartedAtMs = TimeProvider.System.GetUtcNow().AddMinutes(-5).ToUnixTimeMilliseconds(),
             Audience = TrustAudience.Personal,
             Boundary = TrustBoundary.Personal,
             OriginChannelType = ChannelType.Tui
@@ -267,7 +267,7 @@ public class BackgroundJobManagerActorTests : TestKit
             SessionId = new Netclaw.Actors.Protocol.SessionId("test/thread"),
             Rationale = "orphaned test",
             Status = BackgroundJobStatus.Running,
-            StartedAtMs = DateTimeOffset.UtcNow.AddMinutes(-30).ToUnixTimeMilliseconds(),
+            StartedAtMs = TimeProvider.System.GetUtcNow().AddMinutes(-30).ToUnixTimeMilliseconds(),
             Audience = TrustAudience.Personal,
             Boundary = TrustBoundary.Personal,
             OriginChannelType = ChannelType.Tui
@@ -293,6 +293,9 @@ public class BackgroundJobManagerActorTests : TestKit
     [Fact]
     public async Task StartupReconciliation_EmitsAlert_ForLegacyJobMissingTrustFields()
     {
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+
         const string jobId = "legacy-job-alert";
         var filePath = Path.Combine(_dir.Path, "jobs", $"{Uri.EscapeDataString(jobId)}.json");
         File.WriteAllText(filePath, $$"""
@@ -307,7 +310,6 @@ public class BackgroundJobManagerActorTests : TestKit
             }
             """);
 
-        var paths = new NetclawPaths(_dir.Path);
         var store = new BackgroundJobDefinitionStore(paths);
         var sink = new RecordingNotificationSink();
 

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -233,9 +233,14 @@ public class BackgroundJobManagerActorTests : TestKit
 
         // A fresh manager's PreStart reconciliation marks the orphan Lost and
         // must notify the owning session through the gateway.
-        Sys.ActorOf(
+        var manager = Sys.ActorOf(
             Props.Create(() => new BackgroundJobManagerActor(_store, TimeProvider.System)),
             "lost-notify-manager");
+
+        // Readiness barrier: reconciliation runs before this reply.
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
         var delivery = await gatewayProbe.ExpectMsgAsync<DeliverTrustedSessionTurn>(
             TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
@@ -270,18 +275,19 @@ public class BackgroundJobManagerActorTests : TestKit
         _store.Save(orphanDef);
 
         // Create a second manager — its PreStart reconciliation should mark the orphan as Lost
-        Sys.ActorOf(
+        var manager = Sys.ActorOf(
             Props.Create(() => new BackgroundJobManagerActor(_store, TimeProvider.System)),
             "reconcile-test-manager");
 
-        await AwaitAssertAsync(() =>
-        {
-            var reconciled = _store.Get(new BackgroundJobId("orphan-123"));
-            Assert.NotNull(reconciled);
-            Assert.Equal(BackgroundJobStatus.Lost, reconciled!.Status);
-            Assert.NotNull(reconciled.CompletedAtMs);
-            return Task.CompletedTask;
-        }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        // Readiness barrier: reconciliation runs before this reply.
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        var reconciled = _store.Get(new BackgroundJobId("orphan-123"));
+        Assert.NotNull(reconciled);
+        Assert.Equal(BackgroundJobStatus.Lost, reconciled!.Status);
+        Assert.NotNull(reconciled.CompletedAtMs);
     }
 
     [Fact]
@@ -305,17 +311,18 @@ public class BackgroundJobManagerActorTests : TestKit
         var store = new BackgroundJobDefinitionStore(paths);
         var sink = new RecordingNotificationSink();
 
-        Sys.ActorOf(
+        var legacyManager = Sys.ActorOf(
             Props.Create(() => new BackgroundJobManagerActor(store, TimeProvider.System, sink)),
             "legacy-job-alert-manager");
 
-        await AwaitAssertAsync(() =>
-        {
-            Assert.Contains(sink.Alerts, alert =>
-                alert.Category == AlertType.BackgroundJobSchemaDropped
-                && alert.Summary.Contains(jobId, StringComparison.Ordinal));
-            return Task.CompletedTask;
-        }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        // Readiness barrier: startup alert emission runs before this reply.
+        await legacyManager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.Contains(sink.Alerts, alert =>
+            alert.Category == AlertType.BackgroundJobSchemaDropped
+            && alert.Summary.Contains(jobId, StringComparison.Ordinal));
     }
 
     private sealed class RecordingNotificationSink : IOperationalNotificationSink

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -56,7 +56,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     /// messages from the observer to the returned probe. This is needed for
     /// tests that verify idle-triggered distillation (which sends to Context.Parent).
     /// </summary>
-    private (IActorRef Observer, IActorRef ParentActor, Akka.TestKit.TestProbe ParentProbe) CreateObserverWithParentProbe(
+    private async Task<(IActorRef Observer, IActorRef ParentActor, Akka.TestKit.TestProbe ParentProbe)> CreateObserverWithParentProbeAsync(
         string sessionSuffix,
         FakeChatClient? client = null,
         TimeSpan? idleTimeout = null,
@@ -72,15 +72,15 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         var parent = Sys.ActorOf(Props.Create(() => new ForwardingParent(props, probe.Ref)),
             $"parent-wrapper-{sessionSuffix}");
 
-        // Ask the parent for the child ref
-        var observer = parent.Ask<IActorRef>(GetChild.Instance, TimeSpan.FromSeconds(3)).Result;
+        var observer = await parent.Ask<IActorRef>(GetChild.Instance, TimeSpan.FromSeconds(3),
+            TestContext.Current.CancellationToken);
         return (observer, parent, probe);
     }
 
     [Fact]
     public async Task ReceiveTimeout_with_no_new_content_does_not_reply_to_parent()
     {
-        var (observer, _, parentProbe) = CreateObserverWithParentProbe("observer-timeout");
+        var (observer, _, parentProbe) = await CreateObserverWithParentProbeAsync("observer-timeout");
 
         observer.Tell(ReceiveTimeout.Instance, parentProbe.Ref);
 
@@ -104,7 +104,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     public async Task SessionPhaseChanged_Passivating_disables_idle_distillation()
     {
         // Use a very short idle timeout so the test doesn't wait long
-        var (observer, _, parentProbe) = CreateObserverWithParentProbe("passivate-idle",
+        var (observer, _, parentProbe) = await CreateObserverWithParentProbeAsync("passivate-idle",
             idleTimeout: TimeSpan.FromMilliseconds(200));
 
         // Feed content so idle distillation would fire
@@ -124,7 +124,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     [Fact]
     public async Task SessionPhaseChanged_Ready_after_Passivating_re_enables_idle_distillation()
     {
-        var (observer, _, parentProbe) = CreateObserverWithParentProbe("abort-idle",
+        var (observer, _, parentProbe) = await CreateObserverWithParentProbeAsync("abort-idle",
             idleTimeout: TimeSpan.FromMilliseconds(300));
 
         // Feed content
@@ -197,7 +197,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeChatClient { NextResponseGate = gate };
 
-        var (observer, _, parentProbe) = CreateObserverWithParentProbe("mid-distill", client: client,
+        var (observer, _, parentProbe) = await CreateObserverWithParentProbeAsync("mid-distill", client: client,
             idleTimeout: TimeSpan.FromSeconds(30)); // long idle to prevent auto-fire
 
         var passivationProbe = CreateTestProbe("passivation-caller");
@@ -240,7 +240,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeChatClient { NextResponseGate = gate };
 
-        var (observer, _, parentProbe) = CreateObserverWithParentProbe("abort-stash", client: client,
+        var (observer, _, parentProbe) = await CreateObserverWithParentProbeAsync("abort-stash", client: client,
             idleTimeout: TimeSpan.FromSeconds(30));
 
         var passivationProbe = CreateTestProbe("passivation-abort-caller");
@@ -290,7 +290,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     {
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeChatClient { NextResponseGate = gate };
-        var (observer, _, parentProbe) = CreateObserverWithParentProbe("dirty-mid-run", client: client,
+        var (observer, _, parentProbe) = await CreateObserverWithParentProbeAsync("dirty-mid-run", client: client,
             idleTimeout: TimeSpan.FromSeconds(30));
 
         observer.Tell(new SendUserMessage
@@ -325,7 +325,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     {
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeChatClient { NextResponseGate = gate };
-        var (observer, parentActor, parentProbe) = CreateObserverWithParentProbe("same-parent-passivation", client: client,
+        var (observer, parentActor, parentProbe) = await CreateObserverWithParentProbeAsync("same-parent-passivation", client: client,
             idleTimeout: TimeSpan.FromSeconds(30));
 
         observer.Tell(new SendUserMessage

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -61,6 +61,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         Receive<QueryBackgroundJob>(HandleQuery);
         Receive<KillJobsForSession>(HandleKillJobsForSession);
         Receive<Reconcile>(_ => HandleReconcile());
+        Receive<GetBackgroundJobManagerHealth>(_ => HandleGetHealth());
     }
 
     protected override void PreStart()
@@ -272,6 +273,11 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
             Elapsed = elapsed,
             Rationale = def.Rationale
         });
+    }
+
+    private void HandleGetHealth()
+    {
+        Sender.Tell(new BackgroundJobManagerHealthResponse(_activeJobIds.Count, _deferredQueue.Count));
     }
 
     private void HandleReconcile()

--- a/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
@@ -195,6 +195,7 @@ public sealed record BackgroundJobDefinition
 public sealed record GetBackgroundJobManagerHealth : INoSerializationVerificationNeeded
 {
     public static readonly GetBackgroundJobManagerHealth Instance = new();
+    private GetBackgroundJobManagerHealth() { }
 }
 
 /// <summary>Response from <see cref="GetBackgroundJobManagerHealth"/> with current runtime counters.</summary>

--- a/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Netclaw.Configuration;
@@ -189,3 +190,14 @@ public sealed record BackgroundJobDefinition
     public DateTimeOffset? CompletedAt =>
         CompletedAtMs is not null ? DateTimeOffset.FromUnixTimeMilliseconds(CompletedAtMs.Value) : null;
 }
+
+/// <summary>Ping sent to <see cref="BackgroundJobManagerActor"/> to confirm it is ready (PreStart + startup reconciliation complete).</summary>
+public sealed record GetBackgroundJobManagerHealth : INoSerializationVerificationNeeded
+{
+    public static readonly GetBackgroundJobManagerHealth Instance = new();
+}
+
+/// <summary>Response from <see cref="GetBackgroundJobManagerHealth"/> with current runtime counters.</summary>
+public sealed record BackgroundJobManagerHealthResponse(
+    int ActiveJobCount,
+    int QueuedJobCount) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
@@ -50,7 +50,7 @@ public sealed class DailyStatsActorTests : IDisposable
 
         var rows = await actor.Ask<DailyStatsActor.QuerySkillUsageStatsResult>(
             new DailyStatsActor.QuerySkillUsageStats(7),
-            TimeSpan.FromSeconds(3),
+            TimeSpan.FromSeconds(15),
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(3, rows.Rows.Count);
@@ -65,7 +65,7 @@ public sealed class DailyStatsActorTests : IDisposable
 
         var totals = await actor.Ask<DailyStatsActor.ProcessStatsResult>(
             new DailyStatsActor.QueryProcessStats(),
-            TimeSpan.FromSeconds(3),
+            TimeSpan.FromSeconds(15),
             cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(4, totals.SkillsLoadedTotal);
     }


### PR DESCRIPTION
## Summary

Fixes the class of flaky tests described in #1409 where actor startup side effects (reconciliation, schema alerts, lost-job notifications) were awaited on fixed wall-clock budgets instead of deterministic signals. Also closes #1378 (DailyStatsActorTests timeout on Windows CI).

- **`BackgroundJobManagerActor`**: add `GetBackgroundJobManagerHealth` query + handler. Because `PreStart` does `Self.Tell(Reconcile.Instance)`, the mailbox order is always `[Reconcile → HealthAsk]`, so a successful health reply proves reconciliation ran to completion before any assertion fires.
- **Three startup-reconciliation tests** in `BackgroundJobManagerActorTests`: replace `AwaitAssertAsync(5s)` / `ExpectMsgAsync(10s)` polls with a 30s health-Ask barrier then direct assertions.
- **`DailyStatsActorTests`** (#1378): raise both Ask timeouts 3s → 15s. The query handler opens `SqliteConnection` synchronously on the mailbox thread; on Windows CI, cold-file open (Defender scan + NTFS fsync + pool drain) combined with ThreadPool hill-climb can exceed 3s.
- **`SessionMemoryObserverActorTests`**: make `CreateObserverWithParentProbeAsync` truly async (was blocking with `.Result`), thread `CancellationToken` through.

## Code review fixes (3rd commit)

- Replace `DateTimeOffset.UtcNow` with `TimeProvider.System.GetUtcNow()` in two test fixture definitions (CLAUDE.md rule)
- Move `NetclawPaths` + `EnsureDirectoriesExist()` before `File.WriteAllText` in the legacy-alert test — removes implicit dependency on `ConfigureAkka` having already created the `jobs/` directory
- Add `private` constructor to `GetBackgroundJobManagerHealth` to match the singleton enforcement pattern used by `GetActiveEntityIds`

## Test plan

- [ ] All existing `BackgroundJobManagerActorTests` pass (startup-reconciliation tests no longer flake under parallel CI load)
- [ ] `DailyStatsActorTests` passes on Windows CI within the 15s window
- [ ] `SessionMemoryObserverActorTests` passes (async refactor is behaviorally identical)
- [ ] `dotnet slopwatch analyze` — no new violations
- [ ] `Add-FileHeaders.ps1 -Verify` — all headers present

Closes #1409
Closes #1378