### PR TITLE
Fix scheduler race in BackgroundJobManagerActor startup reconciliation

### DIFF
--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -39,7 +39,6 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     private readonly TimeProvider _timeProvider;
     private readonly IOperationalNotificationSink _notificationSink;
     private readonly ILoggingAdapter _log;
-    private bool _startupSchemaAlertsEmitted;
 
     private readonly HashSet<string> _activeJobIds = [];
     private readonly Queue<string> _deferredQueue = new();
@@ -60,14 +59,17 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         Receive<CancelBackgroundJob>(HandleCancel);
         Receive<QueryBackgroundJob>(HandleQuery);
         Receive<KillJobsForSession>(HandleKillJobsForSession);
-        Receive<Reconcile>(_ => HandleReconcile());
         Receive<GetBackgroundJobManagerHealth>(_ => HandleGetHealth());
     }
 
     protected override void PreStart()
     {
         _log.Info("BackgroundJobManagerActor started");
-        Self.Tell(Reconcile.Instance);
+        // Run synchronously in PreStart so reconciliation completes before any
+        // user message is dispatched. A Self.Tell approach races on slow schedulers
+        // (macOS CI): ActorOf returns before PreStart executes, allowing external
+        // messages to queue ahead of the Reconcile message.
+        HandleReconcile();
     }
 
     private async Task HandleStartAsync(StartBackgroundJob cmd)
@@ -283,11 +285,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     private void HandleReconcile()
     {
         var persisted = _store.List();
-        if (!_startupSchemaAlertsEmitted)
-        {
-            EmitRejectedLegacyDefinitionAlerts();
-            _startupSchemaAlertsEmitted = true;
-        }
+        EmitRejectedLegacyDefinitionAlerts();
 
         var reconciled = 0;
 
@@ -497,8 +495,4 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
                output + filePath;
     }
 
-    private sealed record Reconcile : INoSerializationVerificationNeeded
-    {
-        public static readonly Reconcile Instance = new();
-    }
 }


### PR DESCRIPTION
## Summary

- `Self.Tell(Reconcile.Instance)` in `PreStart` raced on slow schedulers (macOS CI): `ActorOf` returns the `ActorRef` before `PreStart` executes, so external messages could arrive in the user mailbox ahead of the `Reconcile` message
- Fixed by calling `HandleReconcile()` synchronously in `PreStart` — Akka.NET guarantees `PreStart` completes before any user message is dispatched, eliminating the race entirely
- Removed the now-dead `Reconcile` record, its `Receive<>` handler, and `_startupSchemaAlertsEmitted` guard

## Root cause

Four tests failed exclusively on `macos-26` (job [81675499970](https://github.com/netclaw-dev/netclaw/actions/runs/27622636612/job/81675499970)):

| Test | Symptom |
|------|---------|
| `StartupReconciliation_MarksOrphanedJobsAsLost` | Health barrier resolved before reconciliation ran; store still showed `Running` |
| `StartupReconciliation_EmitsAlert_ForLegacyJobMissingTrustFields` | Alert sink was empty when checked; emit happened during actor teardown |
| `BackgroundJob_WithMissingWorkingDirectory_FailsWithHelpfulError` | Freshly-started job reconciled as `Lost` before the execution actor ran |
| `CancelRunningJob_ViaCheckBackgroundJobTool` | Same race; delivered "was lost" instead of "cancelled" |

The macOS CI workers have a different thread scheduler that delays actor dispatch enough for the test body to enqueue messages before `PreStart` executes.

## Test plan

- [x] All four previously-failing tests now pass locally
- [x] Full `Netclaw.Actors.Tests` suite passes (2196 tests)
- [x] `dotnet slopwatch analyze` — no new violations
- [x] Copyright headers verified