### PR TITLE
chore: remove JsonSchema.Net from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
       patterns:
         - "Akka.*"
         - "Aaron.Akka.*"
+  ignore:
+    - dependency-name: "JsonSchema.Net"
+      # Moved to commercial license (v8+), keeping v7.x — no further updates desired


### PR DESCRIPTION
## Summary

Removes `JsonSchema.Net` from dependabot update tracking. The library moved to a commercial license (v8+), and we want to keep using the last free version (v7.x) without receiving update PRs.

## Changes

- Added `ignore` entry for `JsonSchema.Net` in `.github/dependabot.yml`

## Context

JsonSchema.Net v8+ requires a commercial license. See: https://github.com/json-schema-org/JsonSchema.Net