### PR TITLE
test(cli): bind fake hubs to port 0 to fix flaky EADDRINUSE race

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -24,8 +24,8 @@ public sealed class DaemonClientReconnectIntegrationTests
     [Fact]
     public async Task EnsureSession_reattaches_same_session_after_transport_disconnect()
     {
-        var port = GetFreeTcpPort();
-        using var host = await StartFakeHubAsync(port);
+        using var host = await StartFakeHubAsync();
+        var port = TestNetworkHelpers.GetBoundPort(host);
 
         await using var client = new DaemonClient(
             $"http://127.0.0.1:{port}",
@@ -84,8 +84,8 @@ public sealed class DaemonClientReconnectIntegrationTests
     [Fact]
     public async Task EnsureSession_recreates_session_after_server_restart()
     {
-        var port = GetFreeTcpPort();
-        var host1 = await StartFakeHubAsync(port);
+        var host1 = await StartFakeHubAsync();
+        var port = TestNetworkHelpers.GetBoundPort(host1);
 
         // Fast reconnect delays keep the post-restart reconnect tight on the happy
         // path. Short ServerTimeout (2s) bounds how long the client can spend
@@ -179,7 +179,11 @@ public sealed class DaemonClientReconnectIntegrationTests
         return await task.WaitAsync(timeout, TestContext.Current.CancellationToken);
     }
 
-    private static async Task<IHost> StartFakeHubAsync(int port, FakeHubState? state = null)
+    // port: 0 (default) lets Kestrel bind a free ephemeral port and hold it for the
+    // host's lifetime; callers read the actual port back via TestNetworkHelpers
+    // .GetBoundPort. A non-zero port is passed only to rebind a replacement host to a
+    // prior host's now-released port (the server-restart scenario).
+    private static async Task<IHost> StartFakeHubAsync(int port = 0, FakeHubState? state = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseKestrel();
@@ -208,8 +212,6 @@ public sealed class DaemonClientReconnectIntegrationTests
         await app.StartAsync();
         return app;
     }
-
-    private static int GetFreeTcpPort() => TestNetworkHelpers.GetFreeTcpPort();
 
     private sealed class FakeHubState
     {

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
@@ -22,8 +22,8 @@ public sealed class DaemonClientSessionTests
     [Fact]
     public async Task ResumeSessionAsync_reattaches_to_existing_session_via_EnsureSession()
     {
-        var port = GetFreeTcpPort();
-        using var host = await StartFakeHubAsync(port);
+        using var host = await StartFakeHubAsync();
+        var port = TestNetworkHelpers.GetBoundPort(host);
 
         await using var client = new DaemonClient($"http://127.0.0.1:{port}");
 
@@ -56,8 +56,8 @@ public sealed class DaemonClientSessionTests
     [Fact]
     public async Task RespondToInteractionAsync_invokes_hub_method()
     {
-        var port = GetFreeTcpPort();
-        using var host = await StartFakeHubAsync(port);
+        using var host = await StartFakeHubAsync();
+        var port = TestNetworkHelpers.GetBoundPort(host);
         var state = host.Services.GetRequiredService<FakeSessionState>();
 
         await using var client = new DaemonClient($"http://127.0.0.1:{port}");
@@ -71,8 +71,8 @@ public sealed class DaemonClientSessionTests
     [Fact]
     public async Task RespondToInteractionAsync_supports_session_scope()
     {
-        var port = GetFreeTcpPort();
-        using var host = await StartFakeHubAsync(port);
+        using var host = await StartFakeHubAsync();
+        var port = TestNetworkHelpers.GetBoundPort(host);
         var state = host.Services.GetRequiredService<FakeSessionState>();
 
         await using var client = new DaemonClient($"http://127.0.0.1:{port}");
@@ -83,7 +83,9 @@ public sealed class DaemonClientSessionTests
         Assert.Equal(("call-2", ApprovalOptionKeys.ApproveSession), state.LastInteractionResponse);
     }
 
-    private static async Task<IHost> StartFakeHubAsync(int port)
+    // port: 0 (default) lets Kestrel bind a free ephemeral port and hold it for the
+    // host's lifetime; callers read the actual port back via TestNetworkHelpers.GetBoundPort.
+    private static async Task<IHost> StartFakeHubAsync(int port = 0)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseKestrel();
@@ -100,8 +102,6 @@ public sealed class DaemonClientSessionTests
         await app.StartAsync();
         return app;
     }
-
-    private static int GetFreeTcpPort() => TestNetworkHelpers.GetFreeTcpPort();
 
     private sealed class FakeSessionState
     {

--- a/src/Netclaw.Cli.Tests/Cli/TestNetworkHelpers.cs
+++ b/src/Netclaw.Cli.Tests/Cli/TestNetworkHelpers.cs
@@ -1,21 +1,38 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="TestNetworkHelpers.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Net;
-using System.Net.Sockets;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Netclaw.Cli.Tests.Cli;
 
 internal static class TestNetworkHelpers
 {
-    public static int GetFreeTcpPort()
+    /// <summary>
+    /// Reads the port a started host actually bound to. Pair this with Kestrel bound
+    /// to <c>http://127.0.0.1:0</c> so the OS assigns a free port and the host holds
+    /// it for its whole lifetime.
+    ///
+    /// This deliberately replaces the old "open a listener on port 0, read the port,
+    /// close the listener, hand back the bare number" helper. That pattern is a
+    /// time-of-check/time-of-use race: the port is released before the caller binds
+    /// Kestrel to it, so under parallel tests another binder can grab the same
+    /// ephemeral port in the gap and the loser fails with EADDRINUSE
+    /// ("address already in use"). Binding :0 and reading the assigned port back
+    /// closes that window entirely — the port is never selected-but-unbound.
+    /// </summary>
+    public static int GetBoundPort(IHost host)
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
+        var addresses = host.Services.GetRequiredService<IServer>()
+                            .Features.Get<IServerAddressesFeature>()
+                        ?? throw new InvalidOperationException(
+                            "Host exposes no IServerAddressesFeature; call GetBoundPort only after StartAsync.");
+
+        return new Uri(addresses.Addresses.Single()).Port;
     }
 }


### PR DESCRIPTION
## Problem

`DaemonClientReconnectIntegrationTests.EnsureSession_recreates_session_after_server_restart` (and its siblings) intermittently fail on Linux CI with:

```
System.IO.IOException : Failed to bind to address http://127.0.0.1:46367: address already in use.
```

Root cause is `TestNetworkHelpers.GetFreeTcpPort()` — the classic ask-the-OS-for-a-free-port-then-let-it-go antipattern:

```csharp
listener.Start();                                   // OS assigns ephemeral port P
port = ((IPEndPoint)listener.LocalEndpoint).Port;   // observe P
listener.Stop();                                    // RELEASE P
return port;                                         // ...gap... Kestrel binds P later
```

The port is released **before** Kestrel binds it. Under xUnit's default parallelism (two test classes here bind real ports), another binder can grab the same ephemeral port in the gap, and the loser throws `EADDRINUSE`. Linux exposes it because it recycles ephemeral ports fast and binds quickly, widening the window; macOS/Windows usually skate past it (survivorship, not correctness).

## Fix

Bind Kestrel to `127.0.0.1:0` and read the actually-assigned port back from `IServerAddressesFeature` after `StartAsync()`, so the host holds the port from the instant it is chosen — there is no selected-but-unbound window, on any OS.

- Delete `GetFreeTcpPort`; replace with `TestNetworkHelpers.GetBoundPort(IHost)`.
- Fix every call site in `DaemonClientReconnectIntegrationTests` (2) and `DaemonClientSessionTests` (3).
- The server-restart test still rebinds `host2` to `host1`'s released port — that reuse is single-threaded within the test and listener sockets don't enter `TIME_WAIT`, so it is deterministic and not the race.

## Validation

- 5/5 affected tests pass locally; full `Netclaw.Cli.Tests` builds clean.
- No new slopwatch violations; copyright headers verified.

Diagnosed via `/analyze-racy-test` (akka-net-specialist ruled out actor involvement; dotnet-concurrency-specialist localized the TOCTOU and recommended this fix).
