### PR TITLE
fix(tui): marshal off-loop Channels label refresh onto the loop (#1426)

### DIFF
--- a/.claude/skills/termina-tui-patterns.md
+++ b/.claude/skills/termina-tui-patterns.md
@@ -25,7 +25,7 @@ reach for `GetResult()`.
 
 ## How Termina actually works (the mental model)
 
-Termina (package `Termina` 0.12.1, which pulls `R3` 1.3.1) runs **one** loop:
+Termina (package `Termina` 0.14.0-beta.1, which pulls `R3` 1.3.1) runs **one** loop:
 `TerminaApplication.RunAsync` does `await foreach` over an **unbounded
 `Channel<object>`**, and after every dequeued event calls `RenderCurrentPage()`.
 That loop is the single-threaded *serializer* — exactly one event is processed
@@ -51,11 +51,19 @@ Three consequences that define every correct pattern:
    a reactive property from a background continuation is therefore an off-loop UI
    mutation unless every subscriber is known to be thread-safe.
 4. **Every background-to-UI handoff needs an explicit publication strategy.** Use
-   one of these, and document which one applies: locked snapshots, immutable
-   replacement values, `Volatile`/`Interlocked` for scalar flags and counters, or
-   a genuine loop-owned action processed by a Termina input/redraw path. Canceling
-   and awaiting a background task prevents stale writers, but it is not a memory
-   barrier for fields concurrently read by render/input.
+   one of these, and document which one applies: a loop marshal (`Post`/`InvokeAsync`,
+   below — preferred when the continuation must *run code* on the loop), locked
+   snapshots, immutable replacement values, or `Volatile`/`Interlocked` for scalar
+   flags and counters. Canceling and awaiting a background task prevents stale
+   writers, but it is not a memory barrier for fields concurrently read by render/input.
+5. **Termina 0.14+ gives you a real loop-marshal primitive.** `ReactiveViewModel`
+   exposes `Post(Action)` and `InvokeAsync(Action, ct)` — they enqueue your action as
+   a `LoopWorkRequested` on the same event channel, so it runs **on the loop thread**,
+   serialized with render and input. `RenderFrameProvider` is the R3 `FrameProvider`
+   bound to the loop (`obs.ObserveOn(RenderFrameProvider)`). This is the blessed way
+   to get an off-loop *result* applied on-loop; you no longer have to hand-roll a
+   publish-cell + drain-at-chokepoint. (Unbound — i.e. a view-model not yet bound to a
+   page, as in unit tests — `Post` is a no-op and `InvokeAsync` runs inline; see below.)
 
 On ARM64 this distinction matters. x64's stronger memory ordering can hide plain
 field races; Apple Silicon will not. A field written by a background continuation
@@ -121,6 +129,51 @@ The rules baked into that shape:
   outside that edge.
 - **Expose the `Task`** (`PendingProbe`) so tests await it deterministically. No
   `Task.Delay`/`Thread.Sleep` in tests (see CLAUDE.md Testing Guidelines).
+
+## Marshal the apply onto the loop (the preferred handoff)
+
+When the continuation needs to **run code** that touches shared view-model state
+(`ReactiveProperty.Value` with UI subscribers, a mutable `Dictionary`, persisted
+config, navigation/focus), don't reconcile in the continuation and don't hand-roll a
+publish-cell + drain. Probe off-loop, then **marshal the apply onto the loop** with
+`InvokeAsync`. `ChannelsConfigViewModel.RefreshChannelLabelsInBackgroundAsync` is the
+reference (issue #1426):
+
+```csharp
+private async Task RunProbeAsync(CancellationToken ct)
+{
+    var pending = await ProbeAsync(ct);                  // pure probe, OFF-loop, no shared writes
+    if (pending is null || ct.IsCancellationRequested) return;
+
+    // Fire-and-forget the marshal — do NOT await it (see below). The apply runs ON the
+    // loop thread, serialized with render/input. The re-check skips a stale apply when a
+    // newer probe / a reset has already cancelled this ct before the loop reaches it.
+    _ = InvokeAsync(() =>
+    {
+        if (ct.IsCancellationRequested) return;
+        ApplyResult(pending);                            // mutate VM state / persist — on the loop
+        NotifyContentChanged();                          // RequestRedraw() inside
+    }, ct);
+}
+```
+
+Two non-obvious rules, both load-bearing:
+
+- **Do NOT `await` the marshal if a save/reset cancel-and-awaits this task.** Awaiting
+  `InvokeAsync` ties this task's completion to a *loop turn* — but a save runs its
+  `CancelAndAwaitLabelRefreshAsync` (which awaits this task) and then writes config
+  fire-and-forget. If the await blocks on the loop, the save is deferred and a fast
+  `Ctrl+Q` quits before its disk write lands — **lost data** (the #1426 follow-up
+  regression). Fire-and-forget the marshal so the tracked task completes as soon as the
+  *probe* unwinds; the apply still runs on the loop, and cancellation neuters a stale one.
+- **`InvokeAsync` is testable without a host.** Unbound (a `new`-ed view-model in a unit
+  test) its default runs the action **inline**, so after `await vm.PendingProbe` the
+  apply has already run — assert directly, no drain seam. `Post` is a *no-op* unbound, so
+  prefer `InvokeAsync` for anything a unit test must observe. The real loop-thread
+  marshaling is covered by the native smoke tapes, not xUnit.
+
+Use the snapshot/lock/atomic patterns below instead when you only need to **publish a
+value** for render to read (no code to run on the loop) — e.g. streaming row snapshots.
 
 ## The save-vs-background-write discipline
 
@@ -241,10 +294,11 @@ checked before further TUI async work is considered safe:
   `_context.StatusMessage`, and `LaunchChat()` are written from async health-check
   continuations and should not synchronously drive Termina invalidation/navigation
   off-loop.
-- `ChannelsConfigViewModel`: `RefreshChannelLabelsAsync` / `ReconcileResolvedChannels`
-  mutate `Step`, `_channelAudiences`, `Status`, `IsSaved`, and persisted config off-loop;
-  page callbacks invalidate nodes inline. Either move reconciliation onto a loop-owned
-  action or protect the shared state with a documented lock/snapshot discipline.
+- `ChannelsConfigViewModel`: **fixed (#1426) — now the reference for the loop marshal.**
+  The background label refresh probes off-loop, then marshals the reconcile (which mutates
+  `Step`, `_channelAudiences`, `Status`, `IsSaved`, and persisted config) onto the loop via
+  fire-and-forget `InvokeAsync`. The inline add path (`RefreshChannelLabelsAsync`) still
+  applies inline because it is awaited inside a serialized config write. Copy this shape.
 - `SkillSourcesConfigViewModel`: `RunProbeAsync` publishes `_pendingRemoteProbeResult`,
   `_pendingRemoteProbeMessage`, `Status`, and `IsSaved` from a background continuation;
   page subscriptions invalidate inline. Dispose cancels but does not drain `_probeTask`.
@@ -295,7 +349,7 @@ backstop, not an event-loop interaction pattern.
 ## Key reference files
 
 - `src/Netclaw.Cli/Tui/Config/SkillSourcesConfigViewModel.cs` — useful probe shape, but audit its off-loop publication before copying
-- `src/Netclaw.Cli/Tui/Config/ChannelsConfigViewModel.cs` — label-refresh/save ordering; do not copy its off-loop mutable-state publication without fixing synchronization
+- `src/Netclaw.Cli/Tui/Config/ChannelsConfigViewModel.cs` — **reference for the loop marshal** (#1426): probe off-loop, fire-and-forget `InvokeAsync` the reconcile onto the loop; label-refresh/save cancel-and-await ordering
 - `src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs` — probe + cosmetic timer (`StartProbe`, `:155-244`)
 - `src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs` — streaming results into a locked list + version-counter redraw
 - `src/Netclaw.Cli/Tui/ChatPage.cs` / `ChatViewModel.cs` / `Daemon/DaemonClient.cs` — live streaming to the front end

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.12.1" />
+    <PackageVersion Include="Termina" Version="0.14.0-beta.1" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigNavigationTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigNavigationTests.cs
@@ -441,6 +441,16 @@ public sealed class ChannelsConfigNavigationTests : IDisposable
         await app.RunAsync(cts.Token);
 
         var channelsVm = Assert.IsType<ChannelsConfigViewModel>(getChannelsVm());
+
+        // The sub-flow's channel-NAME resolution runs as a fire-and-forget background probe that marshals the
+        // reconcile (name -> id on disk) back onto the loop via InvokeAsync. This script quits (Ctrl+Q) right
+        // after the last sub-flow, which can race the loop running that final apply. The real loop has stopped
+        // here, so settle the canonicalization deterministically on this (loop-equivalent) thread the way the
+        // next frame would have — drive the inline resolution path, which probes and applies synchronously.
+        if (channelsVm.PendingLabelRefresh is { } pendingRefresh)
+            await pendingRefresh;
+        await channelsVm.RefreshChannelLabelsAsync(ChannelType.Slack, TestContext.Current.CancellationToken);
+
         var config = ConfigFileHelper.LoadJsonDict(_paths.NetclawConfigPath);
         var secrets = ConfigFileHelper.LoadJsonDict(_paths.SecretsPath);
 

--- a/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigViewModelTests.cs
@@ -396,7 +396,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Enable_slack_then_discord_via_subflow_channel_names_then_escape_preserves_both()
+    public async Task Enable_slack_then_discord_via_subflow_channel_names_then_escape_preserves_both()
     {
         // Variant that mirrors the realistic wizard path: channel names are entered
         // during the adapter sub-flow (Slack sub-step 3 / Discord channel-IDs sub-step),
@@ -435,6 +435,9 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
         slack.ChannelNamesInput = "general";
         for (var i = 0; i < 10 && vm.Step.IsInSubFlow; i++)
             vm.GoNext();
+        // Sub-flow completion starts a background label refresh that canonicalizes "general" -> "C100".
+        // The probe publishes off-loop; drain on the (test = loop) thread, as the page does on render.
+        await SettleBackgroundLabelRefreshAsync(vm);
         vm.GoBack(); // ChannelPermissions -> AdapterMenu
         vm.GoBack(); // AdapterMenu -> Picker
 
@@ -450,6 +453,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
         discord.ChannelIdsInput = "555000111";
         for (var i = 0; i < 10 && vm.Step.IsInSubFlow; i++)
             vm.GoNext();
+        await SettleBackgroundLabelRefreshAsync(vm); // canonicalize the Discord sub-flow channel on the loop thread
         vm.GoBack(); // ChannelPermissions -> AdapterMenu
         vm.GoBack(); // AdapterMenu -> Picker
 
@@ -1237,7 +1241,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Open_management_resolves_persisted_slack_channel_labels()
+    public async Task Open_management_resolves_persisted_slack_channel_labels()
     {
         WriteAllChannelConfig();
         WriteAllChannelSecrets();
@@ -1252,7 +1256,8 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
         using var vm = CreateViewModel(slackProbe: slackProbe);
 
         vm.OpenAdapterManagement(ChannelType.Slack);
-        vm.ActivateManagementMenuItem();
+        vm.ActivateManagementMenuItem(); // starts the background label refresh (probe publishes off-loop)
+        await SettleBackgroundLabelRefreshAsync(vm); // loop thread applies the published result
 
         Assert.Equal(1, slackProbe.ResolveCallCount);
         Assert.Equal(["C01"], slackProbe.LastResolvedNames);
@@ -1370,6 +1375,73 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task Background_label_refresh_probes_off_loop_without_mutating_shared_state_until_marshaled_apply()
+    {
+        // The off-loop label-refresh race (issue #1426): the background refresh used to RECONCILE in its
+        // continuation — mutating _channelAudiences / the Step channel ids / IsSaved / Status / disk — on a
+        // thread-pool thread, concurrently with the loop thread reading that state for render (GetChannelRows /
+        // FormatChannelLabel) and mutating it in the ←/→ audience handler. _channelAudiences is a plain
+        // Dictionary and the audience is a security-relevant ACL trust tier, so the concurrent access was a
+        // torn read / lost update.
+        //
+        // After the fix the background path does ONLY the pure probe off-loop and marshals the reconcile back
+        // onto the loop via InvokeAsync. This test proves the invariant deterministically (no Thread.Sleep /
+        // Task.Delay — a finite probe-entered/release handshake): hold the probe open mid-flight and assert
+        // shared view-model state is UNCHANGED while the continuation is parked off-loop. The stored channel is
+        // a literal name ("netclaw-test") that resolves to "C99", so a reconcile WOULD be observable — it must
+        // not appear until the marshaled apply runs.
+        File.WriteAllText(_paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Slack": {
+                "Enabled": true,
+                "SocketMode": true,
+                "AllowedChannelIds": ["C01", "netclaw-test"],
+                "AllowedUserIds": ["U01"],
+                "AllowDirectMessages": true,
+                "ChannelAudiences": { "C01": "team", "netclaw-test": "public", "dm": "personal" }
+              }
+            }
+            """);
+        WriteChannelSecrets();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var slackProbe = new FakeSlackProbe
+        {
+            ReleaseResolve = gate.Task, // park the probe in flight until we release it
+            NextResolutionResult = new SlackChannelResolutionResult(
+                true,
+                null,
+                [new ResolvedSlackChannel("general", "C01"), new ResolvedSlackChannel("netclaw-test", "C99")],
+                [])
+        };
+        using var vm = CreateViewModel(slackProbe: slackProbe);
+
+        vm.OpenAdapterManagement(ChannelType.Slack);
+        vm.ActivateManagementMenuItem();        // starts the fire-and-forget background refresh
+        await slackProbe.ResolveEntered;        // the probe is now parked off-loop, continuation suspended
+
+        // While the probe continuation is suspended off-loop, NOTHING shared has moved: render reads succeed and
+        // the stored allow-list is still the un-canonicalized name. A regression that reconciled off-loop would
+        // already show "C99" here (or tear the Dictionary GetChannelRows enumerates).
+        var rowsWhileParked = vm.GetChannelRows(includeAddAction: false)
+            .Where(r => !r.IsAction && !r.IsDirectMessage).Select(r => r.Id).ToArray();
+        Assert.Equal(["C01", "netclaw-test"], rowsWhileParked);
+        Assert.Equal(["C01", "netclaw-test"], PersistedChannels(ChannelType.Slack));
+        Assert.False(vm.IsSaved.Value);
+
+        // Release the probe and let the marshaled apply run (InvokeAsync's unbound default applies inline, the
+        // post-frame state the loop reaches in production). Only now does the reconcile land.
+        gate.SetResult();
+        await SettleBackgroundLabelRefreshAsync(vm);
+
+        Assert.Equal(["C01", "C99"], PersistedChannels(ChannelType.Slack));
+        Assert.Equal(
+            ["C01", "C99"],
+            vm.GetChannelRows(includeAddAction: false).Where(r => !r.IsAction && !r.IsDirectMessage).Select(r => r.Id).ToArray());
+    }
+
+    [Fact]
     public async Task ApplyResetConfirmation_surfaces_save_failure_without_crashing_the_loop()
     {
         WriteAllChannelConfig();
@@ -1415,7 +1487,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Open_management_normalizes_resolved_slack_channel_name_to_id_and_persists()
+    public async Task Open_management_normalizes_resolved_slack_channel_name_to_id_and_persists()
     {
         // Bug C: a channel saved as a literal NAME (it did not resolve at first save) stays inert
         // in the runtime ACL, which matches AllowedChannelIds by Slack channel ID. Once the bot can
@@ -1448,6 +1520,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
 
         vm.OpenAdapterManagement(ChannelType.Slack);
         vm.ActivateManagementMenuItem();
+        await SettleBackgroundLabelRefreshAsync(vm); // loop thread applies the published resolution
 
         // The stored name was rewritten to its ID on disk so the runtime ACL can match it.
         var config = ConfigFileHelper.LoadJsonDict(_paths.NetclawConfigPath);
@@ -1464,7 +1537,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Open_management_does_not_rewrite_already_canonical_slack_channels()
+    public async Task Open_management_does_not_rewrite_already_canonical_slack_channels()
     {
         // Guard against spurious writes: opening management when every channel is already stored
         // as its canonical ID must not rewrite the config file at all.
@@ -1487,12 +1560,13 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
 
         vm.OpenAdapterManagement(ChannelType.Slack);
         vm.ActivateManagementMenuItem();
+        await SettleBackgroundLabelRefreshAsync(vm); // reconcile runs but every channel is already canonical
 
         Assert.Equal(configBefore, File.ReadAllText(_paths.NetclawConfigPath));
     }
 
     [Fact]
-    public void Open_management_resolves_persisted_discord_channel_labels()
+    public async Task Open_management_resolves_persisted_discord_channel_labels()
     {
         WriteAllChannelConfig();
         WriteAllChannelSecrets();
@@ -1508,6 +1582,7 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
 
         vm.OpenAdapterManagement(ChannelType.Discord);
         vm.ActivateManagementMenuItem();
+        await SettleBackgroundLabelRefreshAsync(vm); // loop thread applies the published resolution
 
         Assert.Equal(1, discordProbe.ResolveCallCount);
         Assert.Equal(["123456789"], discordProbe.LastResolvedIds);
@@ -1753,6 +1828,17 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
         await vm.RefreshChannelLabelsAsync(type, TestContext.Current.CancellationToken);
     }
 
+    // Awaits the fire-and-forget background label refresh started by OpenAdapterManagement/ManageChannels
+    // (StartChannelLabelResolution). The background path probes off-loop, then marshals the reconcile onto the
+    // Termina loop via InvokeAsync. Unbound to a host (as here), InvokeAsync's default runs that apply inline,
+    // so by the time the tracked task completes the reconcile has run — exactly the post-frame state the loop
+    // reaches in production. Awaiting the task is therefore enough to observe the canonicalized result.
+    private static async Task SettleBackgroundLabelRefreshAsync(ChannelsConfigViewModel vm)
+    {
+        if (vm.PendingLabelRefresh is { } refresh)
+            await refresh;
+    }
+
     // Drives the real picker-driven entry flow for a brand-new adapter: select its
     // row in the picker, toggle it on (which enters the credential/channel sub-flow),
     // stage credentials + channel input on the step VM, step through the sub-flow to
@@ -1788,6 +1874,11 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
 
         Assert.False(vm.Step.IsInSubFlow);
         Assert.Equal(ChannelsConfigScreen.ChannelPermissions, vm.Screen.Value);
+
+        // Sub-flow completion opens the permissions screen and starts a background label refresh for the
+        // names entered in the sub-flow. The probe publishes off-loop; drain it on the (test = loop) thread
+        // to canonicalize those names to ids before adding the next channel — what the page does on render.
+        await SettleBackgroundLabelRefreshAsync(vm);
 
         vm.BeginAddChannel();
         vm.AddChannelInput = channelInput;

--- a/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
@@ -61,6 +61,22 @@ public sealed class FakeSlackProbe : ISlackProbe
     /// </summary>
     public IReadOnlyDictionary<string, string>? ResolveByName { get; set; }
 
+    /// <summary>
+    /// Optional gate for deterministic concurrency tests: when set, <see cref="ResolveChannelNamesAsync"/>
+    /// signals <see cref="ResolveEntered"/> (the probe is now in flight) and then awaits this task before
+    /// returning — letting a test hold the background refresh open while it races loop-thread edits, then
+    /// release it to publish. No <c>Thread.Sleep</c>/<c>Task.Delay</c> in the test: it is a finite handshake.
+    /// </summary>
+    public Task? ReleaseResolve { get; set; }
+
+    private readonly TaskCompletionSource _resolveEntered =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Completes when <see cref="ResolveChannelNamesAsync"/> has started and parked on <see cref="ReleaseResolve"/>.
+    /// </summary>
+    public Task ResolveEntered => _resolveEntered.Task;
+
     public async Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
     {
         ProbeCallCount++;
@@ -78,6 +94,12 @@ public sealed class FakeSlackProbe : ISlackProbe
         LastResolvedNames = channelNames;
         if (ResolutionException is not null)
             throw ResolutionException;
+
+        if (ReleaseResolve is not null)
+        {
+            _resolveEntered.TrySetResult();
+            await ReleaseResolve.WaitAsync(ct);
+        }
 
         if (DelayBeforeResult.HasValue)
             await Task.Delay(DelayBeforeResult.Value, ct);

--- a/src/Netclaw.Cli/Tui/Config/ChannelsConfigViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Config/ChannelsConfigViewModel.cs
@@ -371,35 +371,136 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
         StartChannelLabelResolution(type);
     }
 
+    // The inline, awaited label-resolution path used by ApplyAddChannelAsync (the add flow). It is part of
+    // one linear awaited write that is serialized behind any other config write by EnqueueConfigWriteAsync;
+    // the caller awaits it and then expects the canonical state settled, so the reconcile runs inline here
+    // rather than deferring to a loop-thread drain. (The fire-and-forget BACKGROUND refresh launched by
+    // StartChannelLabelResolution must NOT use this path — its continuation would reconcile off-loop,
+    // concurrently with render and the edit handlers. That path publishes via RefreshChannelLabelsInBackground
+    // and the loop thread drains it.)
     internal async Task RefreshChannelLabelsAsync(ChannelType type, CancellationToken ct = default)
     {
-        if (!Step.IsAdapterEnabled(type))
+        var pending = await ProbeChannelLabelsAsync(type, ct);
+        if (pending is null || ct.IsCancellationRequested)
             return;
+
+        ApplyChannelResolution(pending);
+        NotifyContentChanged();
+    }
+
+    // The fire-and-forget BACKGROUND refresh (StartChannelLabelResolution). It runs the pure async probe
+    // off-loop, then marshals the reconcile back onto the Termina loop thread via InvokeAsync — it must NOT
+    // reconcile, set LastChannelResolution, write config, or set IsSaved/Status off-loop, because render and
+    // the edit handlers touch that same state on the loop thread (and audiences are security-relevant ACL
+    // trust tiers). Tracked so the save/reset guard can cancel-and-await it.
+    private async Task RefreshChannelLabelsInBackgroundAsync(ChannelType type, CancellationToken ct)
+    {
+        var pending = await ProbeChannelLabelsAsync(type, ct);
+        if (pending is null || ct.IsCancellationRequested)
+            return;
+
+        // Marshal the reconcile onto the Termina render loop, but DO NOT await it. The tracked task must
+        // complete as soon as the off-loop probe unwinds: CancelAndAwaitLabelRefreshAsync — which a save/reset
+        // awaits at its top — would otherwise block on a loop turn, deferring the save's OWN disk write behind
+        // this apply and dropping it on a fast quit. InvokeAsync queues the apply on the loop thread (Termina
+        // installs no SynchronizationContext, so reconciling in this continuation would race render/input — the
+        // #1426 race); the re-check makes a superseding refresh or a reset that has already cancelled this ct
+        // skip the now-stale apply when the loop reaches it. Fire-and-forget is exception-safe here: the queued
+        // work only completes-or-cancels (ApplyChannelResolution surfaces its own warnings on the loop — see
+        // ReconcileResolvedChannels), so it never faults an unobserved task. In tests the unbound InvokeAsync
+        // runs the apply inline — the post-frame state the loop reaches in production.
+        _ = InvokeAsync(
+            () =>
+            {
+                if (ct.IsCancellationRequested)
+                    return;
+
+                ApplyChannelResolution(pending);
+                NotifyContentChanged();
+            },
+            ct);
+    }
+
+    // Shared probe step for both label-refresh paths: read the loop-thread channel snapshot synchronously
+    // BEFORE the await, run the probe off-loop, and package the outcome as ONE immutable PendingChannelResolution
+    // (or null when the adapter is disabled / has no channels / lacks credentials). Sets NO shared state.
+    private async Task<PendingChannelResolution?> ProbeChannelLabelsAsync(ChannelType type, CancellationToken ct)
+    {
+        if (!Step.IsAdapterEnabled(type))
+            return null;
 
         var channelIds = GetChannelIds(type);
         if (channelIds.Count == 0)
-            return;
+            return null;
 
         try
         {
-            var resolution = await ResolveChannelReferencesAsync(type, channelIds, ct);
-            if (resolution is null || ct.IsCancellationRequested)
-                return;
+            var probe = await ResolveChannelReferencesAsync(type, channelIds, ct);
+            if (probe is null || ct.IsCancellationRequested)
+                return null;
 
-            ReconcileResolvedChannels(type, channelIds, resolution.Value.Error, resolution.Value.Resolved);
-            NotifyContentChanged();
+            return new PendingChannelResolution(
+                type, channelIds, probe.Value.Result, probe.Value.Error, probe.Value.Resolved.ToArray());
         }
         catch (Exception ex)
         {
-            // A superseded background refresh (a newer resolution started, or the user navigated
-            // away) cancels via ct — that is not a lookup failure, so abandon it quietly rather than
-            // surfacing a warning. Any other failure surfaces the warning status.
+            // A superseded background refresh (a newer resolution started, or the user navigated away)
+            // cancels via ct — not a lookup failure, so abandon it quietly. Any other failure becomes a
+            // warning the loop thread surfaces (Status fan-out invalidates Termina nodes — never set off-loop).
             if (ex is OperationCanceledException && ct.IsCancellationRequested)
-                return;
+                return null;
 
-            Status.Value = new ConfigStatusMessage(
-                $"{GetAdapterDisplayName(type)} channel label lookup failed: {ex.Message}",
-                ConfigStatusTone.Warning);
+            return PendingChannelResolution.Failed(
+                type, $"{GetAdapterDisplayName(type)} channel label lookup failed: {ex.Message}");
+        }
+    }
+
+    // Applies one resolution outcome to shared view-model state. MUST run on the loop thread (the inline add
+    // path awaits it; the background path marshals it there via InvokeAsync). Sets the adapter's
+    // LastChannelResolution snapshot, then reconciles the stored allow-list to canonical ids — or surfaces a
+    // lookup-failure warning.
+    private void ApplyChannelResolution(PendingChannelResolution pending)
+    {
+        if (pending.LookupErrorStatus is { } lookupError)
+        {
+            Status.Value = new ConfigStatusMessage(lookupError, ConfigStatusTone.Warning);
+            return;
+        }
+
+        SetLastChannelResolution(pending.Type, pending.Result);
+        ReconcileResolvedChannels(pending.Type, pending.Stored, pending.Error, pending.Resolved);
+    }
+
+    // Carries one off-loop label-resolution outcome to the loop thread. Immutable: the only fields are the
+    // probed type, the references that were probed, the raw resolution result (for LastChannelResolution),
+    // and the (error, resolved-pair) reconcile inputs. A LookupErrorStatus instead means the probe threw.
+    private sealed record PendingChannelResolution(
+        ChannelType Type,
+        IReadOnlyList<string> Stored,
+        object? Result,
+        string? Error,
+        IReadOnlyList<(string Id, string Name)> Resolved,
+        string? LookupErrorStatus = null)
+    {
+        internal static PendingChannelResolution Failed(ChannelType type, string status)
+            => new(type, [], null, null, [], status);
+    }
+
+    // Applies the raw probe result onto the active adapter's LastChannelResolution (loop-thread only).
+    // The probe returns the platform-specific result object; route it to the matching adapter VM.
+    private void SetLastChannelResolution(ChannelType type, object? result)
+    {
+        switch (type)
+        {
+            case ChannelType.Slack when result is SlackChannelResolutionResult slackResult:
+                Step.GetAdapterViewModel<SlackStepViewModel>(ChannelType.Slack).LastChannelResolution = slackResult;
+                break;
+            case ChannelType.Discord when result is DiscordChannelResolutionResult discordResult:
+                Step.GetAdapterViewModel<DiscordStepViewModel>(ChannelType.Discord).LastChannelResolution = discordResult;
+                break;
+            case ChannelType.Mattermost when result is MattermostChannelResolutionResult mattermostResult:
+                Step.GetAdapterViewModel<MattermostStepViewModel>(ChannelType.Mattermost).LastChannelResolution = mattermostResult;
+                break;
         }
     }
 
@@ -1080,10 +1181,12 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
     }
 
     // The single place that knows each transport's probe shape: probe the live adapter for the given
-    // references and return (probe-error, resolved id/name pairs) — or null when the adapter's credentials
-    // aren't available. Everything downstream (ReconcileResolvedChannels) is transport-agnostic, so
-    // onboarding and the add-channel flow share one resolution path for every channel type.
-    private async Task<(string? Error, IEnumerable<(string Id, string Name)> Resolved)?> ResolveChannelReferencesAsync(
+    // references and return the raw result plus (probe-error, resolved id/name pairs) — or null when the
+    // adapter's credentials aren't available. Reads the credential snapshot synchronously before the await
+    // (loop-thread state), then awaits the probe off-loop. Crucially it does NOT write LastChannelResolution
+    // here: it returns the raw Result, and the loop-thread apply sets it (SetLastChannelResolution) — the inline
+    // add path inline, the background path via InvokeAsync. Downstream (ReconcileResolvedChannels) is transport-agnostic.
+    private async Task<(object Result, string? Error, IEnumerable<(string Id, string Name)> Resolved)?> ResolveChannelReferencesAsync(
         ChannelType type, IReadOnlyList<string> channelIds, CancellationToken ct)
     {
         switch (type)
@@ -1096,8 +1199,7 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
                     return null;
 
                 var result = await _slackProbe.ResolveChannelNamesAsync(botToken, channelIds, ct);
-                slack.LastChannelResolution = result;
-                return (result.ErrorMessage, result.Resolved.Select(static c => (c.Id, c.Name)));
+                return (result, result.ErrorMessage, result.Resolved.Select(static c => (c.Id, c.Name)));
             }
 
             case ChannelType.Discord:
@@ -1108,8 +1210,7 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
                     return null;
 
                 var result = await _discordProbe.ResolveChannelIdsAsync(botToken, channelIds, ct);
-                discord.LastChannelResolution = result;
-                return (result.ErrorMessage, result.Resolved.Select(static c => (c.ChannelId, c.ChannelName)));
+                return (result, result.ErrorMessage, result.Resolved.Select(static c => (c.ChannelId, c.ChannelName)));
             }
 
             case ChannelType.Mattermost:
@@ -1121,8 +1222,7 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
                     return null;
 
                 var result = await _mattermostProbe.ResolveChannelIdsAsync(serverUrl, botToken, channelIds, ct);
-                mattermost.LastChannelResolution = result;
-                return (result.ErrorMessage, result.Resolved.Select(static c => (c.ChannelId, c.ChannelName)));
+                return (result, result.ErrorMessage, result.Resolved.Select(static c => (c.ChannelId, c.ChannelName)));
             }
 
             default:
@@ -1140,8 +1240,9 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
     //     a real channel id (it would be an inert allow-list entry that silently grants nothing). Fail loud.
     // A probe failure (auth/scope/network) produces no id mapping for the typed display names, so by the
     // same rule they are not persisted — only id-shaped references survive it — and the underlying reason
-    // is surfaced. This runs off the loop thread: it only mutates view-model/status state and persists,
-    // then NotifyContentChanged posts the redraw (see the termina-tui-patterns skill); never blocks the loop.
+    // is surfaced. This mutates shared view-model/status state and persists, so it MUST run on the loop
+    // thread (the inline add path awaits it; the background path marshals it there via InvokeAsync).
+    // See .claude/skills/termina-tui-patterns.md ("Marshal the apply onto the loop") for why off-loop is unsafe.
     private void ReconcileResolvedChannels(
         ChannelType type,
         IReadOnlyList<string> stored,
@@ -1339,6 +1440,10 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
         // guard. Awaited (not blocked via .GetResult()) so it never freezes the Termina loop and
         // never deadlocks under a host that installs a SynchronizationContext (e.g. the xunit v3 test
         // runner). Dispatched fire-and-forget via ResetConfirmationFromInputAsync.
+        // Cancelling the refresh also neuters its marshaled apply: the background path queues the reconcile on
+        // the loop via InvokeAsync(..., ct), and that queued work re-checks ct and skips once cancellation
+        // trips. So even though the apply is fire-and-forget (not awaited), no stale reconcile can re-add the
+        // deleted channels on a later frame after this reset deletes the section.
         await CancelAndAwaitLabelRefreshAsync();
 
         var resetType = _activeAdapterType;
@@ -1793,7 +1898,9 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
         _labelResolutionCts?.Cancel();
         _labelResolutionCts?.Dispose();
         _labelResolutionCts = new CancellationTokenSource();
-        _labelRefreshTask = RefreshChannelLabelsAsync(type, _labelResolutionCts.Token);
+        // Fire-and-forget: probe off-loop, then marshal the reconcile onto the loop via InvokeAsync. This
+        // path must NOT reconcile in its continuation (that is the render/edit race this fix closes).
+        _labelRefreshTask = RefreshChannelLabelsInBackgroundAsync(type, _labelResolutionCts.Token);
     }
 
     // Exposes the in-flight background label refresh for tests asserting save/dispose serialization.
@@ -1810,9 +1917,12 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
         if (inFlight is null)
             return;
 
-        // RefreshChannelLabelsAsync catches all of its own exceptions (cancellation is abandoned
-        // quietly, any other failure surfaces a warning status), so awaiting the tracked task here
-        // observes completion without throwing.
+        // The tracked task completes as soon as the off-loop PROBE unwinds — the apply is marshaled onto the
+        // loop fire-and-forget, not awaited here, precisely so this wait can't block on a loop turn and defer
+        // the caller's own disk write. ProbeChannelLabelsAsync catches its own exceptions (returning a
+        // Failed/null result), so awaiting completes without throwing. Cancelling above guarantees any apply the
+        // refresh already queued re-checks ct and skips, so once this returns no resumed probe or stale apply
+        // can clobber the just-reloaded state or write off-loop.
         await inFlight;
 
         _labelRefreshTask = null;


### PR DESCRIPTION
## Summary

The background channel-label refresh in `ChannelsConfigViewModel` reconciled in its probe continuation — mutating `_channelAudiences`, the Step channel IDs, `Status`/`IsSaved`, and the persisted config — on a thread-pool thread, racing the Termina loop thread that reads that state for render and mutates it in the audience/remove handlers. Audiences are security-relevant ACL trust tiers, so the race could tear the `Dictionary` or lose an audience-lowering edit (fail open).

## Fix

- Bump **Termina `0.12.1` → `0.14.0-beta.1`** to use the new `ReactiveViewModel` loop-marshal primitive (`Post`/`InvokeAsync`).
- The background path now runs only the pure probe off-loop and **fire-and-forgets the reconcile onto the loop via `InvokeAsync`**, serialized with render/input. This replaces the hand-rolled publish-cell + drain + page-chokepoint approach.
- The marshal is **fire-and-forget (not awaited)** on purpose: awaiting it would tie the tracked task's completion to a loop turn, so `CancelAndAwaitLabelRefreshAsync` (which `SaveAsync` awaits at its top) would defer the save's own disk write behind a loop turn — a save-then-immediate-quit would drop the write. Cancelling neuters any queued stale apply via the `ct` re-check.
- Updated the `termina-tui-patterns` skill to document the new marshal primitive and mark `ChannelsConfigViewModel` as the reference.

## ⚠️ Dependency note

This introduces a dependency on a **prerelease** Termina (`0.14.0-beta.1`).

## Validation

- `Netclaw.Cli.Tests`: **1096/1096**
- Native smoke: `config-channels` tape (real Termina loop) ✓
- `dotnet slopwatch analyze` (no new violations) + copyright headers ✓
- Canonical Docker build (`scripts/docker/build-image.sh`) + in-container CLI smoke (`test-nonroot-cli.sh`) + interactive `config` smoke (added channel persists with correct canonical ID + audience) ✓
- Manual interactive testing: audience-lowering integrity + save-then-quit durability ✓

## Follow-on

#1418 (retry-with-feedback paradigm) is sequenced to build on this marshal foundation.

Closes #1426
