### PR TITLE
fix(tui): config-screen consistency — Done row, embedded footer, Search spacer

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigViewModelTests.cs
@@ -311,6 +311,28 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
     }
 
     [Fact]
+    public void Adapter_menu_done_row_returns_to_picker()
+    {
+        WriteChannelConfig();
+        WriteChannelSecrets();
+        using var vm = CreateViewModel();
+        vm.OpenAdapterManagement(ChannelType.Slack);
+
+        // The discoverable "Done" row (last management item) backs out to the adapter picker, like Esc.
+        var items = vm.GetManagementMenuItems();
+        var doneIndex = items
+            .Select((item, index) => (item, index))
+            .Single(entry => entry.item.Action == ChannelsManagementAction.Done)
+            .index;
+        Assert.Equal("Done", items[doneIndex].Label);
+
+        vm.MoveManagementMenu(doneIndex);
+        vm.ActivateManagementMenuItem();
+
+        Assert.Equal(ChannelsConfigScreen.Picker, vm.Screen.Value);
+    }
+
+    [Fact]
     public void Esc_from_incomplete_add_channel_draft_writes_nothing()
     {
         WriteAllChannelConfig();

--- a/src/Netclaw.Cli/Tui/Config/ChannelsConfigViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Config/ChannelsConfigViewModel.cs
@@ -515,7 +515,8 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
             new ChannelsManagementMenuItem(ChannelsManagementAction.DirectMessages, "Direct messages", "Enable or disable DM ingress and audience."),
             new ChannelsManagementMenuItem(ChannelsManagementAction.RotateCredentials, "Rotate credentials", "Replace tokens only when explicitly entered."),
             new ChannelsManagementMenuItem(ChannelsManagementAction.ToggleEnabled, enabled ? $"Disable {ActiveAdapterName}" : $"Enable {ActiveAdapterName}", "Preserve saved setup while changing runtime state."),
-            new ChannelsManagementMenuItem(ChannelsManagementAction.ResetConnection, $"Reset {ActiveAdapterName} connection", "Remove saved config and credentials.")
+            new ChannelsManagementMenuItem(ChannelsManagementAction.ResetConnection, $"Reset {ActiveAdapterName} connection", "Remove saved config and credentials."),
+            new ChannelsManagementMenuItem(ChannelsManagementAction.Done, "Done", "Return to Channels.")
         ];
     }
 
@@ -554,6 +555,10 @@ public sealed class ChannelsConfigViewModel : ReactiveViewModel
             case ChannelsManagementAction.ResetConnection:
                 _resetConfirmIndex = 0;
                 Screen.Value = ChannelsConfigScreen.ResetConfirm;
+                break;
+            case ChannelsManagementAction.Done:
+                // Discoverable equivalent of Esc ("[Esc] Channels") — return to the adapter picker.
+                Screen.Value = ChannelsConfigScreen.Picker;
                 break;
         }
 
@@ -1961,7 +1966,8 @@ internal enum ChannelsManagementAction
     DirectMessages,
     RotateCredentials,
     ToggleEnabled,
-    ResetConnection
+    ResetConnection,
+    Done
 }
 
 internal sealed record ChannelsManagementMenuItem(

--- a/src/Netclaw.Cli/Tui/Config/SearchConfigEditorPage.cs
+++ b/src/Netclaw.Cli/Tui/Config/SearchConfigEditorPage.cs
@@ -64,6 +64,11 @@ internal sealed class SearchConfigEditorPage : ReactivePage<SearchConfigEditorVi
         => Layouts.Vertical()
             .WithSpacing(1)
             .WithChild(BuildContent())
+            // Consume the remaining panel height so the status/keybind bars pin to the bottom (matching
+            // every other config page) instead of floating up under short screens like "Validating…". Also
+            // makes the vertical claim full panel height, which the diff renderer needs to overwrite stale
+            // rows left by a taller prior screen.
+            .WithChild(Layouts.Empty().Fill())
             .WithChild(BuildStatusBar())
             .WithChild(BuildKeyBindings());
 

--- a/src/Netclaw.Cli/Tui/ModelManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerPage.cs
@@ -96,7 +96,10 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
                 var text = state switch
                 {
                     ModelManagerState.RoleOverview =>
-                        " [\u2191/\u2193] Navigate  [Enter] Assign  [D] Discover  [C] Clear  [Esc] Quit",
+                        // Embedded in `netclaw config`, Esc backs out to the dashboard; standalone it exits.
+                        ViewModel.IsEmbeddedInConfig
+                            ? " [\u2191/\u2193] Navigate  [Enter] Assign  [D] Discover  [C] Clear  [Esc] Back  [Ctrl+Q] Quit"
+                            : " [\u2191/\u2193] Navigate  [Enter] Assign  [D] Discover  [C] Clear  [Esc] Quit",
                     ModelManagerState.ConfirmAssignment =>
                         " [Enter] Confirm  [Esc] Cancel",
                     _ =>

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -130,7 +130,11 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                     ProviderManagerState.Loading =>
                         " Checking providers...  [Ctrl+Q] Quit",
                     ProviderManagerState.List =>
-                        " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
+                        // Embedded in `netclaw config`, Esc backs out to the dashboard (Navigate("/config"));
+                        // standalone `netclaw provider`, it exits. Match the footer to the real behavior.
+                        ViewModel.IsEmbeddedInConfig
+                            ? " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit"
+                            : " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                     ProviderManagerState.AddSelectType =>
                         " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.AddName =>


### PR DESCRIPTION
## Summary

Three small, independent consistency fixes to the `netclaw config` TUI, surfaced by a UI audit:

1. **Channels adapter menu — "Done" row.** Added a discoverable `Done — Return to Channels.` row to the Slack/Discord/Mattermost management menu, which previously only backed out via `Esc`. Matches the existing pattern on Skill Sources and the channel-permissions screen; routes to the adapter picker — the same place `[Esc] Channels` already goes.
2. **Provider/Model manager footer.** The top-level list footer hard-coded `[Esc] Quit`, but when embedded in `netclaw config` Esc actually navigates back to the dashboard (`Navigate("/config")`). Now conditional on `IsEmbeddedInConfig`: `[Esc] Back` when embedded, `[Esc] Quit` only standalone.
3. **`SearchConfigEditorPage` fill spacer.** Added the `Layouts.Empty().Fill()` spacer that all 8 other config pages already have, so the status/keybind bars pin to the bottom on short screens instead of floating up under the content.

## Validation

- `Netclaw.Cli.Tests`: **1097/1097** (incl. a new test for the adapter-menu Done row)
- `dotnet slopwatch analyze`: no new violations
- copyright headers ✓
- native **`config-channels`** smoke tape ✓ (drives the real adapter menu)

Audit-driven consistency fixes; first batch of a broader config-TUI consistency pass (Done/Back rows on the Security & Access screens to follow).
