### PR TITLE
fix(deps): suppress GHSA-2m69-gcr7-jv3q (SQLitePCLRaw CVE-2025-6965) until upstream patches

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,4 +113,14 @@
   <ItemGroup>
     <PackageVersion Include="MessagePack" Version="2.5.301" />
   </ItemGroup>
+  <!-- Transitive audit suppress: Microsoft.Data.Sqlite → SQLitePCLRaw.lib.e_sqlite3 2.1.11
+       is flagged by NuGetAudit (GHSA-2m69-gcr7-jv3q, CVE-2025-6965 — SQLite < 3.50.2
+       memory corruption in aggregate-term handling). No patched version of
+       SQLitePCLRaw.lib.e_sqlite3 is available on NuGet: 3.50.3 was published then unlisted,
+       and 2.1.11 remains the latest stable release. This suppress will be removed once
+       Microsoft ships a Microsoft.Data.Sqlite release that pins a non-vulnerable
+       SQLitePCLRaw.lib.e_sqlite3. Track: https://github.com/dotnet/efcore/issues/38257 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (transitive dep of `Microsoft.Data.Sqlite`) is flagged by NuGetAudit as **high severity** (CVE-2025-6965): SQLite < 3.50.2 has a memory corruption flaw in aggregate-term handling
- No patched version of `SQLitePCLRaw.lib.e_sqlite3` exists: 3.50.3 was published to NuGet then **unlisted**, and 2.1.11 remains the latest stable release
- This is breaking CI on the `osx-arm64` native binary publish job (NU1903 as error)

## Fix

Adds a targeted `NuGetAuditSuppress` for this specific advisory in `Directory.Packages.props`, following the same pattern as the existing MessagePack pin. Includes a comment with:
- The CVE and GHSA IDs
- Why we can't pin to a fixed version
- The upstream tracking issue to remove this once Microsoft ships a fix

**Upstream tracking:** https://github.com/dotnet/efcore/issues/38257

## Test plan

- [ ] `dotnet restore` completes without NU1903 errors
- [ ] CI passes — the osx-arm64 native binary publish job unblocks