### PR TITLE
fix(tui): add Done rows to the Security & Access menu and editors

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Config/ConfigEditorCoverageAuditTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/ConfigEditorCoverageAuditTests.cs
@@ -408,7 +408,11 @@ public sealed class ConfigEditorCoverageAuditTests : IDisposable
             .Select(static item => RouteToEditorId(item.Route!));
 
         using var security = new SecurityAccessViewModel(_paths);
-        var securityEditors = security.Items.Select(SecurityAccessItemToEditorId);
+        var securityEditors = security.Items
+            // "Done" is a navigation row (back to the config dashboard), not a leaf editor — exclude it,
+            // the same way the dashboard's non-routed "Run Full Doctor"/"Quit" rows are excluded above.
+            .Where(static item => item.Label != "Done")
+            .Select(SecurityAccessItemToEditorId);
 
         return rootEditors.Concat(securityEditors).OrderBy(static id => id).ToArray();
     }

--- a/src/Netclaw.Cli.Tests/Tui/Config/SecurityAccessViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/SecurityAccessViewModelTests.cs
@@ -28,8 +28,67 @@ public sealed class SecurityAccessViewModelTests : WizardStepTestBase
             "Security Posture",
             "Enabled Features",
             "Audience Profiles",
-            "Exposure Mode"
+            "Exposure Mode",
+            "Done"
         ], labels);
+    }
+
+    [Fact]
+    public void Done_item_returns_to_the_config_dashboard()
+    {
+        using var vm = new SecurityAccessViewModel(Context.Paths);
+        string? routed = null;
+        vm.RouteRequested = route => routed = route;
+
+        var doneIndex = vm.Items
+            .Select((item, index) => (item, index))
+            .Single(entry => entry.item.Label == "Done")
+            .index;
+        vm.SelectedIndex.Value = doneIndex;
+        vm.ActivateSelected();
+
+        Assert.Equal("/config", routed);
+    }
+
+    [Fact]
+    public void Posture_editor_done_row_backs_out_to_menu()
+    {
+        using var vm = new SecurityAccessViewModel(Context.Paths);
+        vm.OpenPostureEditor();
+        vm.SelectedPostureIndex.Value = vm.PostureOptions.Count; // the appended Done row
+        vm.ApplySelectedPosture();                               // Enter on Done
+        Assert.Equal(SecurityAccessEditorMode.Menu, vm.Mode.Value);
+    }
+
+    [Fact]
+    public void Feature_editor_done_row_backs_out_to_menu()
+    {
+        using var vm = new SecurityAccessViewModel(Context.Paths);
+        vm.OpenFeatureEditor();
+        vm.SelectedFeatureIndex.Value = vm.FeatureNames.Count;   // the appended Done row
+        vm.ToggleSelectedFeature();                              // Space/Enter on Done
+        Assert.Equal(SecurityAccessEditorMode.Menu, vm.Mode.Value);
+    }
+
+    [Fact]
+    public void Audience_list_done_row_backs_out_to_menu()
+    {
+        using var vm = new SecurityAccessViewModel(Context.Paths);
+        vm.OpenAudienceList();
+        vm.SelectedAudienceIndex.Value = vm.AudienceOptions.Count; // the appended Done row
+        vm.OpenSelectedAudienceProfile();                          // Enter on Done
+        Assert.Equal(SecurityAccessEditorMode.Menu, vm.Mode.Value);
+    }
+
+    [Fact]
+    public void Audience_profile_done_row_backs_out_to_audience_list()
+    {
+        using var vm = new SecurityAccessViewModel(Context.Paths);
+        vm.OpenAudienceList();
+        vm.OpenSelectedAudienceProfile();                         // enter the first audience's profile
+        vm.SelectedAudienceRowIndex.Value = vm.ProfileRows.Count; // the appended Done row
+        vm.ActivateSelectedAudienceProfileRow();                  // Space/Enter on Done
+        Assert.Equal(SecurityAccessEditorMode.AudienceList, vm.Mode.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/Config/SecurityAccessPage.cs
+++ b/src/Netclaw.Cli/Tui/Config/SecurityAccessPage.cs
@@ -96,6 +96,11 @@ public sealed class SecurityAccessPage : ReactivePage<SecurityAccessViewModel>
                 active));
         }
 
+        var doneFocused = ViewModel.SelectedPostureIndex.Value == options.Count;
+        layout = layout
+            .WithChild(Layouts.Empty().Height(1))
+            .WithChild(Row($"{FocusPrefix(doneFocused)}Done    Return to Security & Access.", doneFocused));
+
         return layout;
     }
 
@@ -138,6 +143,11 @@ public sealed class SecurityAccessPage : ReactivePage<SecurityAccessViewModel>
                 enabled));
         }
 
+        var doneFocused = ViewModel.SelectedFeatureIndex.Value == names.Count;
+        layout = layout
+            .WithChild(Layouts.Empty().Height(1))
+            .WithChild(Row($"{FocusPrefix(doneFocused)}Done    Return to Security & Access.", doneFocused));
+
         return layout;
     }
 
@@ -161,6 +171,11 @@ public sealed class SecurityAccessPage : ReactivePage<SecurityAccessViewModel>
                 $"{FocusPrefix(focused)}{defaultMarker} {option.Label,-9} {option.Description,-34} {marker}",
                 focused));
         }
+
+        var doneFocused = ViewModel.SelectedAudienceIndex.Value == options.Count;
+        layout = layout
+            .WithChild(Layouts.Empty().Height(1))
+            .WithChild(Row($"{FocusPrefix(doneFocused)}Done    Return to Security & Access.", doneFocused));
 
         return layout;
     }
@@ -206,10 +221,19 @@ public sealed class SecurityAccessPage : ReactivePage<SecurityAccessViewModel>
             layout = layout.WithChild(Row(line, focused, enabled));
         }
 
-        var focusedRow = rows[ViewModel.SelectedAudienceRowIndex.Value];
+        var doneFocused = ViewModel.SelectedAudienceRowIndex.Value == rows.Count;
         layout = layout
             .WithChild(Layouts.Empty().Height(1))
-            .WithChild(Hint($"  {ViewModel.AudienceRowHelp(focusedRow.Kind)}"));
+            .WithChild(Row($"{FocusPrefix(doneFocused)}Done    Return to Audiences.", doneFocused));
+
+        // Per-row help applies only to a real row; the appended Done row (index == rows.Count) has none.
+        if (!doneFocused)
+        {
+            var focusedRow = rows[ViewModel.SelectedAudienceRowIndex.Value];
+            layout = layout
+                .WithChild(Layouts.Empty().Height(1))
+                .WithChild(Hint($"  {ViewModel.AudienceRowHelp(focusedRow.Kind)}"));
+        }
 
         return layout;
     }

--- a/src/Netclaw.Cli/Tui/Config/SecurityAccessViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Config/SecurityAccessViewModel.cs
@@ -157,11 +157,13 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
             SelectedIndex.Value = next;
     }
 
-    public void MovePostureSelection(int delta) => Move(SelectedPostureIndex, delta, Postures.Length);
+    // Each editor appends a "Done" row after its real items (index == item count), so navigation extends one
+    // past the array; activation at that index backs out instead of acting on a row (see the action guards).
+    public void MovePostureSelection(int delta) => Move(SelectedPostureIndex, delta, Postures.Length + 1);
     public void MoveCascadeSelection(int delta) => Move(SelectedCascadeIndex, delta, CascadeOptions.Length);
-    public void MoveFeatureSelection(int delta) => Move(SelectedFeatureIndex, delta, FeatureConfigPaths.Length);
-    public void MoveAudienceSelection(int delta) => Move(SelectedAudienceIndex, delta, Audiences.Length);
-    public void MoveAudienceRow(int delta) => Move(SelectedAudienceRowIndex, delta, AudienceRows.Length);
+    public void MoveFeatureSelection(int delta) => Move(SelectedFeatureIndex, delta, FeatureConfigPaths.Length + 1);
+    public void MoveAudienceSelection(int delta) => Move(SelectedAudienceIndex, delta, Audiences.Length + 1);
+    public void MoveAudienceRow(int delta) => Move(SelectedAudienceRowIndex, delta, AudienceRows.Length + 1);
 
     public void ActivateSelected()
     {
@@ -202,6 +204,10 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
                 return;
             case "Audience Profiles":
                 OpenAudienceList();
+                return;
+            case "Done":
+                // Discoverable equivalent of Esc — back out to the config dashboard.
+                GoBack();
                 return;
         }
 
@@ -256,6 +262,12 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
 
     public void ApplySelectedPosture()
     {
+        if (SelectedPostureIndex.Value >= Postures.Length)
+        {
+            GoBack();
+            return;
+        }
+
         var posture = Postures[SelectedPostureIndex.Value].Value;
         if (posture == CurrentPosture)
         {
@@ -314,6 +326,12 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
 
     public void ToggleSelectedFeature()
     {
+        if (SelectedFeatureIndex.Value >= FeatureConfigPaths.Length)
+        {
+            GoBack();
+            return;
+        }
+
         var index = SelectedFeatureIndex.Value;
         _enabledFeatures[index] = !_enabledFeatures[index];
 
@@ -340,6 +358,12 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
 
     public void OpenSelectedAudienceProfile()
     {
+        if (SelectedAudienceIndex.Value >= Audiences.Length)
+        {
+            GoBack();
+            return;
+        }
+
         SelectedAudienceRowIndex.Value = 0;
         Mode.Value = SecurityAccessEditorMode.AudienceProfile;
         StatusMessage.Value = "";
@@ -386,6 +410,12 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
 
     public void ActivateSelectedAudienceProfileRow()
     {
+        if (SelectedAudienceRowIndex.Value >= AudienceRows.Length)
+        {
+            GoBack();
+            return;
+        }
+
         var row = AudienceRows[SelectedAudienceRowIndex.Value];
         switch (row.Kind)
         {
@@ -423,6 +453,9 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
 
     public void ChangeSelectedAudienceProfileRow(int direction)
     {
+        if (SelectedAudienceRowIndex.Value >= AudienceRows.Length)
+            return; // the Done row has no value to cycle with ←/→
+
         var row = AudienceRows[SelectedAudienceRowIndex.Value];
         switch (row.Kind)
         {
@@ -657,7 +690,8 @@ public sealed class SecurityAccessViewModel : ReactiveViewModel
                 "Deployment trust stance."),
             new("Enabled Features", ReadEnabledFeaturesSummary(config), "Deployment-wide runtime feature gates."),
             new("Audience Profiles", ReadAudienceProfilesSummary(config), "Curated per-audience access rules."),
-            new("Exposure Mode", ReadExposureModeSummary(config), "Daemon reachability and tunnel topology.", "/exposure-mode")
+            new("Exposure Mode", ReadExposureModeSummary(config), "Daemon reachability and tunnel topology.", "/exposure-mode"),
+            new("Done", "", "Return to Settings Areas.")
         ];
     }
 


### PR DESCRIPTION
## Summary

Discoverable "Done" back-out rows across the **Security & Access** surfaces, matching the adapter menu (#1441) and Skill Sources pattern so operators don't have to discover `Esc`.

- **Security & Access menu:** a `Done — Return to Settings Areas.` row backs out to the config dashboard via `GoBack()`. The config-editor coverage audit is updated to treat it as a navigation row, not a leaf editor needing test coverage.
- **The four editor sub-screens** (Posture, Enabled Features, Audience list, Audience profile): a `Done` row is appended after the real items. Each screen's navigation extends one index past its item array, and every per-action method (apply posture, toggle feature, open profile, activate/cycle profile row) guards the Done index to back out via `GoBack()` instead of indexing out of bounds. The audience-profile per-row help is guarded for the Done row too.

## Validation

- `Netclaw.Cli.Tests`: **1102/1102** (5 new routing tests — the menu Done row + one per sub-screen)
- `dotnet slopwatch analyze`: no new violations
- copyright headers ✓
- native smoke: **`config-posture`, `config-features`, `config-audience`** tapes ✓ (the three changed editors)

Second batch of the config-TUI consistency pass (after #1441's adapter-menu Done row + footer/spacer fixes).
