### PR TITLE
fix(tui): auto-advance the add-skill-server flow on a successful probe

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Config/SkillSourcesConfigViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/SkillSourcesConfigViewModelTests.cs
@@ -340,6 +340,7 @@ public sealed class SkillSourcesConfigViewModelTests : IDisposable
 
         vm.ActivateSelected();              // phase 2: save anyway -> name review
         Assert.Equal(SkillSourcesScreen.AddRemoteName, vm.Screen.Value);
+        Assert.False(vm.AddRemoteNameTitleIsSuccess); // a save-anyway failure must not render success-green
         ReplaceDraft(vm, "custom-feed");
         vm.ActivateSelected();
 
@@ -363,6 +364,7 @@ public sealed class SkillSourcesConfigViewModelTests : IDisposable
         // the way the init wizard shows "Found N skills". The fake probe reports "reachable"; the real probe
         // formats the advertised count into this same message.
         Assert.Contains("reachable", vm.AddRemoteNameTitle, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.AddRemoteNameTitleIsSuccess); // drives the success-green header on the name screen
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Config/SkillSourcesConfigViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/SkillSourcesConfigViewModelTests.cs
@@ -227,8 +227,7 @@ public sealed class SkillSourcesConfigViewModelTests : IDisposable
         vm.ActivateSelected(); // RequiresAuth -> token field
         vm.AppendText("secret-token");
         vm.ActivateSelected();
-        await vm.PendingProbe!;
-        vm.ActivateSelected(); // success -> name review
+        await vm.PendingProbe!; // success auto-advances to name review (no second Enter)
         ReplaceDraft(vm, "custom-feed");
 
         // Make the DataProtection keys directory unusable (a file, not a directory) so the commit's
@@ -347,6 +346,23 @@ public sealed class SkillSourcesConfigViewModelTests : IDisposable
         var feed = SingleFeedSection();
         Assert.Equal("https://skills.example.test", feed["Url"]);
         Assert.Null(feed["ApiKey"]);
+    }
+
+    [Fact]
+    public async Task Reachable_skill_server_auto_advances_to_name_without_a_second_enter()
+    {
+        using var vm = new SkillSourcesConfigViewModel(_paths, new FakeSkillFeedProbe(true, skillCount: 53));
+
+        BeginAddRemoteServer(vm);
+        vm.AppendText("https://skills.example.test");
+        vm.ActivateSelected();   // single Enter kicks off the probe
+        await vm.PendingProbe!;  // a reachable feed advances on its own — no second Enter
+
+        Assert.Equal(SkillSourcesScreen.AddRemoteName, vm.Screen.Value);
+        // The probe's reachable confirmation is carried onto the name screen (not lost to the auto-advance),
+        // the way the init wizard shows "Found N skills". The fake probe reports "reachable"; the real probe
+        // formats the advertised count into this same message.
+        Assert.Contains("reachable", vm.AddRemoteNameTitle, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -728,10 +744,10 @@ public sealed class SkillSourcesConfigViewModelTests : IDisposable
         Assert.Equal(SkillSourcesScreen.AddRemoteUrl, vm.Screen.Value);
     }
 
-    // Drives the probe-driven add flow for an auth-gated server. The reachability probe now runs
-    // OFF the loop, so each probe is two-phase: the first ActivateSelected kicks it off (await
-    // PendingProbe), the second ActivateSelected acts on the completed result (reveal token / advance
-    // to name). The vm must be constructed with a requiresAuth FakeSkillFeedProbe.
+    // Drives the probe-driven add flow for an auth-gated server. The reachability probe runs OFF the loop.
+    // A FAILURE (401) is two-phase: the first ActivateSelected kicks off the probe (await PendingProbe), the
+    // second acts on the result (reveal the token field). A SUCCESS auto-advances to the name step on its own
+    // — no second keypress — so after the token re-probe we only await. Construct vm with a requiresAuth probe.
     private static async Task AddRemoteServer(SkillSourcesConfigViewModel vm, string url, string token, string name)
     {
         BeginAddRemoteServer(vm);
@@ -741,9 +757,8 @@ public sealed class SkillSourcesConfigViewModelTests : IDisposable
         vm.ActivateSelected();              // phase 2: RequiresAuth -> reveal token field
         Assert.Equal(SkillSourcesScreen.AddRemoteToken, vm.Screen.Value);
         vm.AppendText(token);
-        vm.ActivateSelected();              // phase 1: re-probe with token -> success
+        vm.ActivateSelected();              // re-probe with token -> success auto-advances to name review
         await vm.PendingProbe!;
-        vm.ActivateSelected();              // phase 2: success -> advance to name review
         Assert.Equal(SkillSourcesScreen.AddRemoteName, vm.Screen.Value);
         ReplaceDraft(vm, name);
         vm.ActivateSelected();

--- a/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigPage.cs
+++ b/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigPage.cs
@@ -106,7 +106,7 @@ internal sealed class SkillSourcesConfigPage : ReactivePage<SkillSourcesConfigVi
                     "Blank tokens are not saved. Existing tokens are removed only through Remove token.",
                     isPassword: true),
                 SkillSourcesScreen.AddRemoteName => BuildTextDraft(
-                    "Review remote skill server source.",
+                    ViewModel.AddRemoteNameTitle,
                     "Source name",
                     "Enter adds the source and autosaves."),
                 SkillSourcesScreen.RenameSource => BuildTextDraft(

--- a/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigPage.cs
+++ b/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigPage.cs
@@ -108,7 +108,8 @@ internal sealed class SkillSourcesConfigPage : ReactivePage<SkillSourcesConfigVi
                 SkillSourcesScreen.AddRemoteName => BuildTextDraft(
                     ViewModel.AddRemoteNameTitle,
                     "Source name",
-                    "Enter adds the source and autosaves."),
+                    "Enter adds the source and autosaves.",
+                    titleColor: ViewModel.AddRemoteNameTitleIsSuccess ? Color.Green : null),
                 SkillSourcesScreen.RenameSource => BuildTextDraft(
                     "Rename this skill source.",
                     "Source name",
@@ -209,13 +210,14 @@ internal sealed class SkillSourcesConfigPage : ReactivePage<SkillSourcesConfigVi
         string hint,
         string? calloutTitle = null,
         IReadOnlyList<string>? calloutLines = null,
-        bool isPassword = false)
+        bool isPassword = false,
+        Color? titleColor = null)
     {
         var input = EnsureTextInput(isPassword);
         input.OnFocused();
 
         var layout = Layouts.Vertical()
-            .WithChild(Header($"  {title}"))
+            .WithChild(Header($"  {title}", titleColor))
             .WithChild(Layouts.Empty().Height(1))
             .WithChild(NetclawTuiChrome.BuildTextInputPanel(input, fieldLabel))
             .WithChild(Layouts.Empty().Height(1))
@@ -677,7 +679,7 @@ internal sealed class SkillSourcesConfigPage : ReactivePage<SkillSourcesConfigVi
         _textInputScreen = null;
     }
 
-    private static TextNode Header(string text) => new TextNode(text).WithForeground(Color.White).Bold();
+    private static TextNode Header(string text, Color? color = null) => new TextNode(text).WithForeground(color ?? Color.White).Bold();
     private static TextNode Hint(string text) => new TextNode(text).WithForeground(Color.Gray);
     private static TextNode Text(string text, Color color) => new TextNode(text).WithForeground(color);
 

--- a/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigViewModel.cs
@@ -650,6 +650,14 @@ internal sealed class SkillSourcesConfigViewModel : ReactiveViewModel
     // (no Task.Delay) instead of racing the thread-pool continuation.
     internal Task? PendingProbe => _probeTask;
 
+    // Title for the name-review step. Auto-advance drops the operator here without a confirming keypress, so
+    // carry the probe's result line (e.g. "Skill feed reachable — 53 skills advertised.") onto this screen —
+    // the way the init wizard shows "Found N skills" — instead of letting that confirmation vanish.
+    internal string AddRemoteNameTitle =>
+        string.IsNullOrWhiteSpace(_pendingRemoteProbeMessage)
+            ? "Review remote skill server source."
+            : _pendingRemoteProbeMessage!;
+
     // Kicks off a reachability probe OFF the single-threaded TUI loop so a slow/unreachable feed
     // never freezes input. The synchronous setup (status + redraw) runs on the loop thread; the
     // continuation in RunProbeAsync resumes on the thread pool (no SyncContext here) and may ONLY
@@ -1275,7 +1283,8 @@ internal sealed class SkillSourcesConfigViewModel : ReactiveViewModel
             return;
         }
 
-        // Phase 1: a new URL/token — kick off the off-loop probe. The continuation is status-only.
+        // Phase 1: a new URL/token — kick off the off-loop probe. The continuation is status-only EXCEPT it
+        // marshals the success advance onto the loop thread (navigation is never safe off-loop).
         _lastProbeFingerprint = fingerprint;
         _pendingRemoteProbeResult = null;
         StartBackgroundProbe(
@@ -1287,14 +1296,47 @@ internal sealed class SkillSourcesConfigViewModel : ReactiveViewModel
             {
                 _pendingRemoteProbeResult = r;
                 _pendingRemoteProbeMessage = r.Message;
+
+                if (r.Success)
+                {
+                    // A reachable feed needs no decision, so advance straight to the name step like the init
+                    // wizard rather than making the operator press Enter again. Navigation must run on the
+                    // loop thread; marshal it there via InvokeAsync (this continuation runs off-loop). The
+                    // marshaled AutoAdvanceAfterProbeSuccess re-checks that nothing changed in flight, and the
+                    // ct skips the advance if a newer probe or a dispose has superseded this one. In tests the
+                    // unbound InvokeAsync runs inline, so the advance lands within the awaited probe task.
+                    SetStatus(r.Message, ConfigStatusTone.Success);
+                    var ct = _probeCts?.Token ?? CancellationToken.None;
+                    _ = InvokeAsync(() => AutoAdvanceAfterProbeSuccess(fingerprint), ct);
+                    return;
+                }
+
+                // Failures still pause for a deliberate keypress: a 401 needs the operator to add a bearer
+                // token, and an unreachable feed needs an explicit "save anyway" decision.
                 SetStatus(
-                    r.Success
-                        ? $"{r.Message} Press Enter to continue."
-                        : r.RequiresAuth && _pendingRemoteAuthMode != SkillSourceAuthMode.BearerToken
-                            ? $"{r.Message} Press Enter to add a bearer token."
-                            : $"{r.Message} Press Enter to save anyway.",
-                    r.Success ? ConfigStatusTone.Success : ConfigStatusTone.Warning);
+                    r.RequiresAuth && _pendingRemoteAuthMode != SkillSourceAuthMode.BearerToken
+                        ? $"{r.Message} Press Enter to add a bearer token."
+                        : $"{r.Message} Press Enter to save anyway.",
+                    ConfigStatusTone.Warning);
             });
+    }
+
+    // Loop-thread continuation of a successful add-server probe: advance to the name step. Re-checks that the
+    // operator did not edit the URL/token or leave the URL screen while the probe was in flight, so a stale
+    // marshaled call can never hijack navigation. The phase-2 success branch above is the fallback for the
+    // rare race where the operator presses Enter before this marshaled advance reaches the loop.
+    private void AutoAdvanceAfterProbeSuccess(string fingerprint)
+    {
+        // A probe is launched from either the URL screen or (after a 401) the token screen; advance only if
+        // still on one of those — if the operator backed out of the add flow, the marshaled call is stale.
+        if (Screen.Value is not (SkillSourcesScreen.AddRemoteUrl or SkillSourcesScreen.AddRemoteToken)
+            || _lastProbeFingerprint != fingerprint
+            || _pendingRemoteProbeResult is not { Success: true }
+            || _pendingRemoteUrl is null)
+            return;
+
+        _pendingRemoteProbeResult = null;
+        ShowTextScreen(SkillSourcesScreen.AddRemoteName, MakeUniqueName(SuggestNameFromUrl(_pendingRemoteUrl)));
     }
 
     private void SaveNewRemoteSource()

--- a/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Config/SkillSourcesConfigViewModel.cs
@@ -254,6 +254,7 @@ internal sealed class SkillSourcesConfigViewModel : ReactiveViewModel
     private SkillSourceAuthMode _pendingRemoteAuthMode;
     private string? _pendingRemoteApiKey;
     private string? _pendingRemoteProbeMessage;
+    private bool _pendingRemoteProbeMessageIsSuccess;
     private int _pendingRemoteTimeoutSeconds = DefaultFeedTimeoutSeconds;
     private SkillSourceDetailAction? _editingAction;
     private SkillSourcesScreen? _validationEditScreen;
@@ -657,6 +658,11 @@ internal sealed class SkillSourcesConfigViewModel : ReactiveViewModel
         string.IsNullOrWhiteSpace(_pendingRemoteProbeMessage)
             ? "Review remote skill server source."
             : _pendingRemoteProbeMessage!;
+
+    // True only when the carried title is a reachable confirmation (so the page renders it success-green).
+    // A save-anyway failure also lands here carrying its message, but must NOT read as success.
+    internal bool AddRemoteNameTitleIsSuccess =>
+        !string.IsNullOrWhiteSpace(_pendingRemoteProbeMessage) && _pendingRemoteProbeMessageIsSuccess;
 
     // Kicks off a reachability probe OFF the single-threaded TUI loop so a slow/unreachable feed
     // never freezes input. The synchronous setup (status + redraw) runs on the loop thread; the
@@ -1296,6 +1302,7 @@ internal sealed class SkillSourcesConfigViewModel : ReactiveViewModel
             {
                 _pendingRemoteProbeResult = r;
                 _pendingRemoteProbeMessage = r.Message;
+                _pendingRemoteProbeMessageIsSuccess = r.Success;
 
                 if (r.Success)
                 {


### PR DESCRIPTION
## Summary

Adding a remote skill server made the operator press **Enter twice** on success: once to run the reachability probe, then again to dismiss *"…Press Enter to continue."* The original init wizard didn't — a reachable feed went straight to the name step (it showed "✓ Connected… Found N skills" above the name field). This restores that behavior in the config editor.

- **On a successful probe, auto-advance** to the name step. Navigation is never safe from the off-loop probe continuation, so the advance is marshaled onto the loop thread via `InvokeAsync` (the #1426 primitive). A guarded continuation re-checks that the operator didn't edit the URL/token or leave the add flow while the probe was in flight before navigating.
- **Failures keep their deliberate keypress:** a 401 still pauses to let the operator add a bearer token, and an unreachable feed still requires an explicit "save anyway" — those are real decisions, not a reachable happy path.
- **The reachable confirmation is carried onto the name screen** (e.g. "Skill feed reachable — 53 skills advertised."), the way the wizard shows "Found N skills", so it isn't lost to the auto-advance.

Follow-up to #1452 (advertised skill count), addressing UX feedback that the success path shouldn't require a confirming keypress.

## Validation

- `Netclaw.Cli.Tests`: **1114/1114**, including a new test that a reachable server auto-advances with a *single* Enter, and coverage that the `auth → token → success` path also auto-advances. The existing unreachable test proves a failure still does **not** auto-advance.
- `dotnet slopwatch analyze`: no new violations · copyright headers ✓
- Visually verified against the real `ghcr.io/netclaw-dev/skillserver` (a netclaw image built from this branch).

## Smoke note

No native smoke tape: the add-skill-server prompt flow has no Skill Sources tape (none exists, and standing up a skill server inside a tape is net-new harness work). The flow is covered by the ViewModel tests above and verified end-to-end against the real skillserver image.
