### PR TITLE
perf: optimize `LlmSessionActor` storage to only retain most recent snapshot + last N messages in journal.

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2506,6 +2506,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<SaveSnapshotSuccess>(msg =>
         {
             _log.Info("Snapshot saved (seqNr={SequenceNr})", msg.Metadata.SequenceNr);
+
+            DeleteMessages(msg.Metadata.SequenceNr); // delete all messages in journal up until snapshot was taken
+            DeleteSnapshots(new SnapshotSelectionCriteria(msg.Metadata.SequenceNr-1)); // delete all old snapshots
         });
 
         Command<SaveSnapshotFailure>(msg =>


### PR DESCRIPTION
A basic Akka.Persistence performance optimization I noticed while using Netclaw's code during one of our live Akka.NET trainings https://petabridge.com/training