### PR TITLE
fix(skills): block agent mutations to server feed skill directories

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -886,7 +886,8 @@ public class SkillToolTests : IDisposable
     private void ScanFeedSkills(string feedName)
     {
         var result = SkillScanner.Scan(_paths.ServerFeedDirectory(feedName));
-        _registry.ReplaceAll(result.AcceptedSkills, result.Issues);
+        foreach (var skill in result.AcceptedSkills)
+            _registry.Register(skill);
     }
 
     [Fact]
@@ -948,6 +949,108 @@ public class SkillToolTests : IDisposable
 
             Assert.Contains("External skill directories are read-only", result);
             Assert.True(Directory.Exists(skillDir), "External skill directory should not be deleted");
+        }
+        finally
+        {
+            if (Directory.Exists(externalDir))
+                Directory.Delete(externalDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RemoveFile_rejects_system_skill()
+    {
+        WriteNestedSkill(".system", "sys-remove", """
+            ---
+            name: sys-remove
+            description: System skill.
+            ---
+            # System
+            """);
+        WriteNestedFile(".system", "sys-remove", "references/old.md", "original");
+        ScanSkills();
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(ToolInput.Create(
+                "Action", "remove_file",
+                "Name", "sys-remove",
+                "FilePath", "references/old.md"),
+            PersonalCtx,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("System skills are read-only", result);
+        Assert.True(File.Exists(Path.Combine(_paths.SkillsDirectory, ".system", "sys-remove", "references", "old.md")));
+    }
+
+    [Fact]
+    public async Task WriteFile_rejects_external_skill()
+    {
+        var externalDir = Path.Combine(Path.GetTempPath(), $"netclaw-external-test-{Guid.NewGuid():N}");
+        try
+        {
+            var skillDir = Path.Combine(externalDir, "ext-skill");
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+                ---
+                name: ext-skill
+                description: External skill.
+                ---
+                # External
+                """);
+
+            var externalScan = SkillScanner.Scan(externalDir);
+            _registry.ReplaceAll(externalScan.AcceptedSkills, externalScan.Issues);
+
+            var tool = CreateManageTool();
+            var result = await tool.ExecuteAsync(ToolInput.Create(
+                    "Action", "write_file",
+                    "Name", "ext-skill",
+                    "FilePath", "references/injected.md",
+                    "FileContent", "injected"),
+                PersonalCtx,
+                TestContext.Current.CancellationToken);
+
+            Assert.Contains("External skill directories are read-only", result);
+            Assert.False(File.Exists(Path.Combine(skillDir, "references", "injected.md")));
+        }
+        finally
+        {
+            if (Directory.Exists(externalDir))
+                Directory.Delete(externalDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RemoveFile_rejects_external_skill()
+    {
+        var externalDir = Path.Combine(Path.GetTempPath(), $"netclaw-external-test-{Guid.NewGuid():N}");
+        try
+        {
+            var skillDir = Path.Combine(externalDir, "ext-skill");
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+                ---
+                name: ext-skill
+                description: External skill.
+                ---
+                # External
+                """);
+            Directory.CreateDirectory(Path.Combine(skillDir, "references"));
+            File.WriteAllText(Path.Combine(skillDir, "references", "old.md"), "original");
+
+            var externalScan = SkillScanner.Scan(externalDir);
+            _registry.ReplaceAll(externalScan.AcceptedSkills, externalScan.Issues);
+
+            var tool = CreateManageTool();
+            var result = await tool.ExecuteAsync(ToolInput.Create(
+                    "Action", "remove_file",
+                    "Name", "ext-skill",
+                    "FilePath", "references/old.md"),
+                PersonalCtx,
+                TestContext.Current.CancellationToken);
+
+            Assert.Contains("External skill directories are read-only", result);
+            Assert.True(File.Exists(Path.Combine(skillDir, "references", "old.md")));
         }
         finally
         {

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -532,74 +532,6 @@ public class SkillToolTests : IDisposable
     }
 
     [Fact]
-    public async Task SkillManage_WriteFile_RejectsSystemSkill()
-    {
-        WriteNestedSkill(".system", "sys-wf", """
-            ---
-            name: sys-wf
-            description: System skill.
-            ---
-
-            # System
-            """);
-        ScanSkills();
-
-        var tool = CreateManageTool();
-        var result = await tool.ExecuteAsync(ToolInput.Create(
-            "Action", "write_file",
-            "Name", "sys-wf",
-            "FilePath", "references/guide.md",
-            "FileContent", "content"),
-            PersonalCtx,
-            TestContext.Current.CancellationToken);
-
-        Assert.Contains("System skills are read-only", result);
-
-        var expected = Path.Combine(_paths.SkillsDirectory, ".system", "sys-wf", "references", "guide.md");
-        Assert.False(File.Exists(expected));
-    }
-
-    [Fact]
-    public async Task SkillManage_WriteFile_RejectsExternalSkill()
-    {
-        var externalDir = Path.Combine(Path.GetTempPath(), $"netclaw-external-test-{Guid.NewGuid():N}");
-        try
-        {
-            var skillDir = Path.Combine(externalDir, "ext-wf");
-            Directory.CreateDirectory(skillDir);
-            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
-                ---
-                name: ext-wf
-                description: External skill.
-                ---
-
-                # External
-                """);
-
-            var externalScan = SkillScanner.Scan(externalDir);
-            _registry.ReplaceAll(externalScan.AcceptedSkills, externalScan.Issues);
-
-            var tool = CreateManageTool();
-            var result = await tool.ExecuteAsync(ToolInput.Create(
-                    "Action", "write_file",
-                    "Name", "ext-wf",
-                    "FilePath", "references/guide.md",
-                    "FileContent", "content"),
-                PersonalCtx,
-                TestContext.Current.CancellationToken);
-
-            Assert.Contains("External skill directories are read-only", result);
-            var target = Path.Combine(externalDir, "ext-wf", "references", "guide.md");
-            Assert.False(File.Exists(target));
-        }
-        finally
-        {
-            if (Directory.Exists(externalDir))
-                Directory.Delete(externalDir, recursive: true);
-        }
-    }
-
-    [Fact]
     public async Task SkillManage_Patch_RejectsHighRiskResourceContent()
     {
         WriteSkill("patch-resource", """
@@ -627,72 +559,127 @@ public class SkillToolTests : IDisposable
     }
 
     [Fact]
-    public async Task SkillManage_RemoveFile_RejectsSystemSkill()
+    public async Task SkillManage_ServerFeedSkill_BlocksEdit()
     {
-        WriteNestedSkill(".system", "sys-remove", """
+        WriteServerFeedSkill("my-feed", "feed-skill", """
             ---
-            name: sys-remove
-            description: System skill.
+            name: feed-skill
+            description: Synced from feed.
             ---
-
-            # System
+            # Feed Skill
             """);
+        ScanFeedSkills("my-feed");
 
-        WriteNestedFile(".system", "sys-remove", "references/old.md", "old");
-        ScanSkills();
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(ToolInput.Create(
+                "Action", "edit",
+                "Name", "feed-skill",
+                "Content", "---\nname: feed-skill\ndescription: Hacked.\n---\n# Hacked"),
+            PersonalCtx,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Server feed skill directories are read-only", result);
+        var content = File.ReadAllText(Path.Combine(_paths.ServerFeedDirectory("my-feed"), "feed-skill", "SKILL.md"));
+        Assert.DoesNotContain("Hacked", content);
+    }
+
+    [Fact]
+    public async Task SkillManage_ServerFeedSkill_BlocksPatch()
+    {
+        WriteServerFeedSkill("my-feed", "feed-skill", """
+            ---
+            name: feed-skill
+            description: Synced from feed.
+            ---
+            # Feed Skill
+            """);
+        ScanFeedSkills("my-feed");
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(ToolInput.Create(
+                "Action", "patch",
+                "Name", "feed-skill",
+                "OldString", "Feed Skill",
+                "NewString", "Hacked"),
+            PersonalCtx,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Server feed skill directories are read-only", result);
+        var content = File.ReadAllText(Path.Combine(_paths.ServerFeedDirectory("my-feed"), "feed-skill", "SKILL.md"));
+        Assert.DoesNotContain("Hacked", content);
+    }
+
+    [Fact]
+    public async Task SkillManage_ServerFeedSkill_BlocksDelete()
+    {
+        WriteServerFeedSkill("my-feed", "feed-skill", """
+            ---
+            name: feed-skill
+            description: Synced from feed.
+            ---
+            # Feed Skill
+            """);
+        ScanFeedSkills("my-feed");
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(ToolInput.Create(
+                "Action", "delete",
+                "Name", "feed-skill"),
+            PersonalCtx,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Server feed skill directories are read-only", result);
+        Assert.True(Directory.Exists(Path.Combine(_paths.ServerFeedDirectory("my-feed"), "feed-skill")));
+    }
+
+    [Fact]
+    public async Task SkillManage_ServerFeedSkill_BlocksWriteFile()
+    {
+        WriteServerFeedSkill("my-feed", "feed-skill", """
+            ---
+            name: feed-skill
+            description: Synced from feed.
+            ---
+            # Feed Skill
+            """);
+        ScanFeedSkills("my-feed");
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(ToolInput.Create(
+                "Action", "write_file",
+                "Name", "feed-skill",
+                "FilePath", "references/injected.md",
+                "FileContent", "injected"),
+            PersonalCtx,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Server feed skill directories are read-only", result);
+        Assert.False(File.Exists(Path.Combine(_paths.ServerFeedDirectory("my-feed"), "feed-skill", "references", "injected.md")));
+    }
+
+    [Fact]
+    public async Task SkillManage_ServerFeedSkill_BlocksRemoveFile()
+    {
+        WriteServerFeedSkill("my-feed", "feed-skill", """
+            ---
+            name: feed-skill
+            description: Synced from feed.
+            ---
+            # Feed Skill
+            """);
+        WriteNestedFile(Path.Combine(".server-feeds", "my-feed"), "feed-skill", "references/guide.md", "original");
+        ScanFeedSkills("my-feed");
 
         var tool = CreateManageTool();
         var result = await tool.ExecuteAsync(ToolInput.Create(
                 "Action", "remove_file",
-                "Name", "sys-remove",
-                "FilePath", "references/old.md"),
+                "Name", "feed-skill",
+                "FilePath", "references/guide.md"),
             PersonalCtx,
             TestContext.Current.CancellationToken);
 
-        Assert.Contains("System skills are read-only", result);
-        Assert.True(File.Exists(Path.Combine(_paths.SkillsDirectory, ".system", "sys-remove", "references", "old.md")));
-    }
-
-    [Fact]
-    public async Task SkillManage_RemoveFile_RejectsExternalSkill()
-    {
-        var externalDir = Path.Combine(Path.GetTempPath(), $"netclaw-external-test-{Guid.NewGuid():N}");
-        try
-        {
-            var skillDir = Path.Combine(externalDir, "ext-remove");
-            Directory.CreateDirectory(skillDir);
-            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
-                ---
-                name: ext-remove
-                description: External skill.
-                ---
-
-                # External
-                """);
-
-            Directory.CreateDirectory(Path.Combine(skillDir, "references"));
-            File.WriteAllText(Path.Combine(skillDir, "references", "old.md"), "old");
-
-            var externalScan = SkillScanner.Scan(externalDir);
-            _registry.ReplaceAll(externalScan.AcceptedSkills, externalScan.Issues);
-
-            var tool = CreateManageTool();
-            var result = await tool.ExecuteAsync(ToolInput.Create(
-                    "Action", "remove_file",
-                    "Name", "ext-remove",
-                    "FilePath", "references/old.md"),
-                PersonalCtx,
-                TestContext.Current.CancellationToken);
-
-            Assert.Contains("External skill directories are read-only", result);
-            Assert.True(Directory.Exists(skillDir));
-            Assert.True(File.Exists(Path.Combine(skillDir, "references", "old.md")));
-        }
-        finally
-        {
-            if (Directory.Exists(externalDir))
-                Directory.Delete(externalDir, recursive: true);
-        }
+        Assert.Contains("Server feed skill directories are read-only", result);
+        Assert.True(File.Exists(Path.Combine(_paths.ServerFeedDirectory("my-feed"), "feed-skill", "references", "guide.md")));
     }
 
     [Fact]
@@ -886,6 +873,19 @@ public class SkillToolTests : IDisposable
     private void ScanSkills()
     {
         var result = SkillScanner.Scan(_paths.SkillsDirectory);
+        _registry.ReplaceAll(result.AcceptedSkills, result.Issues);
+    }
+
+    private void WriteServerFeedSkill(string feedName, string skillName, string content)
+    {
+        var dir = Path.Combine(_paths.ServerFeedDirectory(feedName), skillName);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), content);
+    }
+
+    private void ScanFeedSkills(string feedName)
+    {
+        var result = SkillScanner.Scan(_paths.ServerFeedDirectory(feedName));
         _registry.ReplaceAll(result.AcceptedSkills, result.Issues);
     }
 

--- a/src/Netclaw.Actors/Tools/SkillManageTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillManageTool.cs
@@ -167,11 +167,8 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
                 return $"Skill '{name}' not found.";
         }
 
-        if (IsSystemCategory(skill))
-            return "Cannot edit system skills. System skills are read-only.";
-
-        if (IsExternalSkill(skill))
-            return "Cannot edit external skills. External skill directories are read-only.";
+        var readOnlyError = GuardReadOnly(skill, "edit");
+        if (readOnlyError is not null) return readOnlyError;
 
         var contentError = ValidateFrontmatter(args.Content);
         if (contentError is not null) return contentError;
@@ -208,11 +205,8 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (skill is null)
             return $"Skill '{name}' not found.";
 
-        if (IsSystemCategory(skill))
-            return "Cannot patch system skills. System skills are read-only.";
-
-        if (IsExternalSkill(skill))
-            return "Cannot patch external skills. External skill directories are read-only.";
+        var readOnlyError = GuardReadOnly(skill, "patch");
+        if (readOnlyError is not null) return readOnlyError;
 
         // Determine target file
         var targetPath = skill.FilePath;
@@ -283,11 +277,8 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (skill is null)
             return $"Skill '{name}' not found.";
 
-        if (IsSystemCategory(skill))
-            return "Cannot delete system skills. System skills are read-only.";
-
-        if (IsExternalSkill(skill))
-            return "Cannot delete external skills. External skill directories are read-only.";
+        var readOnlyError = GuardReadOnly(skill, "delete");
+        if (readOnlyError is not null) return readOnlyError;
 
         if (skill.IsFlatFile)
         {
@@ -325,11 +316,8 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (skill is null)
             return $"Skill '{name}' not found.";
 
-        if (IsSystemCategory(skill))
-            return "Cannot write files in system skills. System skills are read-only.";
-
-        if (IsExternalSkill(skill))
-            return "Cannot write files in external skills. External skill directories are read-only.";
+        var readOnlyError = GuardReadOnly(skill, "write files in");
+        if (readOnlyError is not null) return readOnlyError;
 
         var fileError = ValidateResourcePath(args.FilePath);
         if (fileError is not null) return fileError;
@@ -370,11 +358,8 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (skill is null)
             return $"Skill '{name}' not found.";
 
-        if (IsSystemCategory(skill))
-            return "Cannot remove files from system skills. System skills are read-only.";
-
-        if (IsExternalSkill(skill))
-            return "Cannot remove files from external skills. External skill directories are read-only.";
+        var readOnlyError = GuardReadOnly(skill, "remove files from");
+        if (readOnlyError is not null) return readOnlyError;
 
         var fileError = ValidateResourcePath(args.FilePath);
         if (fileError is not null) return fileError;
@@ -475,8 +460,26 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         return null;
     }
 
+    private string? GuardReadOnly(SkillEntry skill, string verb)
+    {
+        if (IsSystemCategory(skill))
+            return $"Cannot {verb} system skills. System skills are read-only.";
+        if (IsServerFeedSkill(skill))
+            return $"Cannot {verb} server feed skills. Server feed skill directories are read-only.";
+        if (IsExternalSkill(skill))
+            return $"Cannot {verb} external skills. External skill directories are read-only.";
+        return null;
+    }
+
     private static bool IsSystemCategory(SkillEntry skill)
         => string.Equals(skill.Category, SkillScanner.SystemCategory, StringComparison.Ordinal);
+
+    private bool IsServerFeedSkill(SkillEntry skill)
+    {
+        var feedRoot = PathUtility.Normalize(_paths.ServerFeedsDirectory);
+        var skillPath = PathUtility.Normalize(Path.GetDirectoryName(skill.FilePath)!);
+        return PathUtility.IsWithinRoot(skillPath, feedRoot);
+    }
 
     private bool IsExternalSkill(SkillEntry skill)
     {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -549,6 +549,11 @@ static void ConfigureDaemonServices(
         paths.PidFilePath,
         paths.LockFilePath,
         paths.RestartManifestPath,
+        // Skill directories managed by the sync service — writes from agent tools
+        // are lost on the next sync cycle and corrupt the sync service's view of
+        // on-disk state. The sync service writes directly via filesystem, not tools.
+        paths.SystemSkillsDirectory,
+        paths.ServerFeedsDirectory,
     };
     var readDenyList = new[]
     {
@@ -566,6 +571,8 @@ static void ConfigureDaemonServices(
         paths.PidFilePath,
         paths.LockFilePath,
         paths.RestartManifestPath,
+        paths.SystemSkillsDirectory,
+        paths.ServerFeedsDirectory,
     };
     var toolPathPolicy = new ToolPathPolicy(writeDenyList, readDenyList, shellIndicatorList);
     services.AddSingleton(toolPathPolicy);

--- a/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
@@ -158,6 +158,8 @@ public sealed class ToolPathPolicyTests
             "/home/user/.netclaw/netclaw.pid",
             "/home/user/.netclaw/netclaw.lock",
             "/home/user/.netclaw/cache/restart-manifest.json",
+            "/home/user/.netclaw/skills/.system",
+            "/home/user/.netclaw/skills/.server-feeds",
         };
         var readDeny = new[]
         {
@@ -174,6 +176,8 @@ public sealed class ToolPathPolicyTests
             "/home/user/.netclaw/netclaw.pid",
             "/home/user/.netclaw/netclaw.lock",
             "/home/user/.netclaw/cache/restart-manifest.json",
+            "/home/user/.netclaw/skills/.system",
+            "/home/user/.netclaw/skills/.server-feeds",
         };
         return new ToolPathPolicy(writeDeny, readDeny, shellIndicators);
     }
@@ -183,6 +187,8 @@ public sealed class ToolPathPolicyTests
     [InlineData("/home/user/.netclaw/netclaw.pid")]
     [InlineData("/home/user/.netclaw/netclaw.lock")]
     [InlineData("/home/user/.netclaw/cache/restart-manifest.json")]
+    [InlineData("/home/user/.netclaw/skills/.system/my-skill/SKILL.md")]
+    [InlineData("/home/user/.netclaw/skills/.server-feeds/my-feed/feed-skill/SKILL.md")]
     public void IsDenied_blocks_control_plane_files(string path)
     {
         var policy = CreateProductionPolicy();


### PR DESCRIPTION
Closes #1449

## Summary

- **Root cause**: `.server-feeds/` skills live inside `SkillsDirectory`, so neither the `.system` category check nor the "external skill" (outside native root) check caught them — mutations via `skill_manage` and direct `file_write`/`file_edit` both went through unblocked
- **Two enforcement layers added**: `SkillManageTool` now rejects all mutations on server-feed skills via a new `IsServerFeedSkill` guard; `ToolPathPolicy` write deny list in `Program.cs` now includes `SystemSkillsDirectory` and `ServerFeedsDirectory` so `file_write`, `file_edit`, and shell commands are blocked at the policy layer
- **Refactor**: extracted `GuardReadOnly(skill, verb)` to eliminate five copies of the system/feed/external three-check block

## Test plan

- [ ] 5 new `SkillManage_ServerFeedSkill_Blocks*` tests exercise all mutation actions against a `.server-feeds/my-feed/` skill
- [ ] Restored `RemoveFile_rejects_system_skill`, `WriteFile_rejects_external_skill`, `RemoveFile_rejects_external_skill` — specific actions not covered by the pre-existing edit/delete external tests
- [ ] `ToolPathPolicyTests.CreateProductionPolicy()` updated to mirror the new `Program.cs` deny lists; `IsDenied_blocks_control_plane_files` has `InlineData` for child paths under both new directories
- [ ] `ScanFeedSkills` helper switched from `ReplaceAll` to `Register` so future tests mixing native + feed skill populations don't silently drop one side
- [ ] 2443 Actors.Tests + 594 Security.Tests all green