### PR TITLE
fix(subagents): honor approval-pause in every tool-watchdog mode

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/StreamingToolCallTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/StreamingToolCallTests.cs
@@ -236,6 +236,54 @@ public sealed class StreamingToolCallTests
         await Assert.ThrowsAsync<TimeoutException>(() => task);
     }
 
+    /// <summary>
+    /// A human-approval block (<see cref="ToolActivityUpdate.SuspendsInactivityWatchdog"/>)
+    /// must pause the watchdog in EVERY budget mode — a human-in-the-loop wait is not the
+    /// tool running away on its own output, so it must never burn the budget. Regression
+    /// guard: before the fix, the <c>wallClock</c> case ignored the suspend and tripped the
+    /// timeout mid-approval. The pre-fix suspend test only exercised <c>Flat</c>, which is
+    /// exactly why the WallClock regression slipped through.
+    /// </summary>
+    [Theory]
+    [InlineData("flat")]
+    [InlineData("firstItemOnly")]
+    [InlineData("wallClock")]
+    public async Task Explicit_suspend_pauses_watchdog_in_every_mode(string mode)
+    {
+        var budget = mode switch
+        {
+            "flat" => ToolWatchdogBudget.Flat(TimeSpan.FromSeconds(5)),
+            "firstItemOnly" => ToolWatchdogBudget.FirstItemOnly(TimeSpan.FromSeconds(5)),
+            "wallClock" => ToolWatchdogBudget.WallClock(TimeSpan.FromSeconds(5)),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "unknown budget mode")
+        };
+        var time = new FakeTimeProvider();
+        var channel = Channel.CreateUnbounded<ToolCallUpdate>();
+        var activitySeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = StreamingToolWatchdog.ConsumeAsync(
+            channel.Reader.ReadAllAsync(TestContext.Current.CancellationToken),
+            "spawn_agent",
+            budget,
+            time,
+            onActivity: _ => activitySeen.TrySetResult(),
+            TestContext.Current.CancellationToken);
+
+        channel.Writer.TryWrite(new ToolActivityUpdate("awaiting human approval")
+        {
+            SuspendsInactivityWatchdog = true
+        });
+        await activitySeen.Task;
+
+        // A long human-approval wait — far past the budget — must not trip the watchdog.
+        time.Advance(TimeSpan.FromMinutes(5));
+        Assert.False(task.IsCompleted);
+
+        channel.Writer.TryWrite(new ToolCompletedUpdate("done"));
+        channel.Writer.Complete();
+        Assert.Equal("done", await task);
+    }
+
     [Fact]
     public async Task Concurrent_calls_are_bounded_independently()
     {

--- a/src/Netclaw.Actors/Sessions/Pipelines/StreamingToolWatchdog.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/StreamingToolWatchdog.cs
@@ -106,7 +106,14 @@ internal static class StreamingToolWatchdog
                     case ToolCompletedUpdate completed:
                         return completed.Result;
                     case ToolActivityUpdate activity:
-                        if (budget.ResetMode != ToolWatchdogResetMode.WallClock && activity.SuspendsInactivityWatchdog)
+                        // An explicit suspend (a tool blocked on human approval) pauses
+                        // the watchdog in EVERY mode. A human-in-the-loop wait is an
+                        // external block, not the tool running away on its own output, so
+                        // it must never burn the budget — including WallClock. This is
+                        // deliberately NOT mode-gated: ordinary per-item resets stay
+                        // mode-gated in ApplyItemReset (WallClock still ignores those), but
+                        // the explicit approval-pause signal is honored everywhere.
+                        if (activity.SuspendsInactivityWatchdog)
                             Volatile.Write(ref budgetTicks, TimeSpan.Zero.Ticks);
                         onActivity?.Invoke(activity);
                         break;


### PR DESCRIPTION
## What & why

**Step 1 of #1472.** A human-approval block sets `ToolActivityUpdate.SuspendsInactivityWatchdog` to pause the per-tool-call liveness clock. The tool-liveness change gated that suspend behind `ResetMode != WallClock`, so in **WallClock mode (every opaque tool)** the approval-pause was ignored and the wall-clock budget kept ticking through a human approval — killing a healthy tool mid-approval whenever the human took longer than the budget.

This violated the intended contract: *approvals (and any explicit human-block) must never affect the wall clock, in any mode.*

## The fix

`StreamingToolWatchdog.cs` — honor `SuspendsInactivityWatchdog` in **all** modes. The change is surgical: ordinary per-item resets stay mode-gated in `ApplyItemReset` (WallClock still can't be kept alive by its own streamed output); only the explicit human-block signal is now universal.

```diff
- if (budget.ResetMode != ToolWatchdogResetMode.WallClock && activity.SuspendsInactivityWatchdog)
+ if (activity.SuspendsInactivityWatchdog)
      Volatile.Write(ref budgetTicks, TimeSpan.Zero.Ticks);
```

## Test (the part that lets it regress)

The pre-existing suspend test only exercised `Flat` mode — which is exactly why the WallClock regression slipped through. Replaced with a mode-matrix `[Theory]` across `Flat` / `FirstItemOnly` / `WallClock`. Verified as a real guard:

- old guard restored → **`wallClock` FAILS**, `flat`/`firstItemOnly` pass
- fix applied → all three pass

## Scope

Targeted fix only — deliberately small and shippable independent of the larger consolidation. The structural rework (collapse to one actor-owned watchdog, approval-as-state, kill the silent `?? Opaque`, etc.) is tracked as the migration steps in #1472.

Relates to #1467. Part of #1472.
