### PR TITLE
fix(update): preserve systemd daemon ownership

### DIFF
--- a/docs/runbooks/daemon-upgrade.md
+++ b/docs/runbooks/daemon-upgrade.md
@@ -29,6 +29,11 @@ data.
 
 ## Direct Host Upgrade
 
+`netclaw update` preserves the existing lifecycle owner: a daemon managed by an
+active or enabled systemd user unit is stopped and restarted with
+`systemctl --user`, while a directly-started daemon uses `netclaw daemon` process
+control.
+
 1. Stop daemon:
    - `netclaw daemon stop`
    - or `systemctl --user stop netclaw`

--- a/docs/spec/SPEC-011-daemon-architecture.md
+++ b/docs/spec/SPEC-011-daemon-architecture.md
@@ -199,6 +199,11 @@ the actor system cleanly.
 `netclaw daemon status` checks the PID file and verifies the process is alive.
 Reports: running/stopped, PID, uptime, port, number of active sessions.
 
+`netclaw update` preserves the daemon's lifecycle owner. If the Linux systemd
+user unit is active or enabled, update stops and starts `netclaw.service` via
+`systemctl --user` instead of spawning a detached daemon. If no systemd user
+unit owns the daemon, update uses the direct detached process lifecycle.
+
 ### Crash interception and evidence
 
 The daemon installs process-level exception handlers at startup for:

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.15.0"
+  version: "2.15.1"
 ---
 
 # Netclaw Operations
@@ -1044,6 +1044,13 @@ file. If it should be recalled when relevant → SQLite memory.
 | List past sessions | `netclaw sessions --once` |
 | Inspect reminder history | `netclaw reminder history <id> --last 5` |
 | Permanently delete a reminder | `netclaw reminder delete <id>` |
+
+`netclaw update` preserves daemon ownership. When `netclaw.service` is active or
+enabled as a systemd user service, update restarts it with `systemctl --user`
+instead of launching a detached daemon. If restart fails, inspect
+`systemctl --user status netclaw.service`, then start it manually with
+`systemctl --user start netclaw.service` or fall back to `netclaw daemon start`
+only when no systemd user service owns the daemon.
 
 ## Demo AppHost
 

--- a/src/Netclaw.Cli.Tests/Cli/SystemdUserServiceTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/SystemdUserServiceTests.cs
@@ -1,0 +1,127 @@
+// -----------------------------------------------------------------------
+// <copyright file="SystemdUserServiceTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Daemon;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+public sealed class SystemdUserServiceTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+
+    [Fact]
+    public async Task GetOwnershipAsync_ReturnsUnmanaged_WhenUnitFileMissing()
+    {
+        var runner = new FakeSystemCommandRunner();
+        var service = new SystemdUserService(
+            Path.Combine(_dir.Path, "missing.service"),
+            runner,
+            enabledOnThisPlatform: true);
+
+        var ownership = await service.GetOwnershipAsync();
+
+        Assert.Equal(SystemdUserServiceOwnershipKind.Unmanaged, ownership.Kind);
+        Assert.Empty(runner.Commands);
+    }
+
+    [Fact]
+    public async Task GetOwnershipAsync_ReturnsManaged_WhenUnitIsActive()
+    {
+        var unitPath = WriteUnit();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        var service = new SystemdUserService(unitPath, runner, enabledOnThisPlatform: true);
+
+        var ownership = await service.GetOwnershipAsync();
+
+        Assert.Equal(SystemdUserServiceOwnershipKind.Managed, ownership.Kind);
+        Assert.Equal([("systemctl", "--user is-active --quiet netclaw.service")], runner.Commands);
+    }
+
+    [Fact]
+    public async Task GetOwnershipAsync_ReturnsManaged_WhenUnitIsEnabledButInactive()
+    {
+        var unitPath = WriteUnit();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(3, string.Empty));
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        var service = new SystemdUserService(unitPath, runner, enabledOnThisPlatform: true);
+
+        var ownership = await service.GetOwnershipAsync();
+
+        Assert.Equal(SystemdUserServiceOwnershipKind.Managed, ownership.Kind);
+        Assert.Equal(
+            [
+                ("systemctl", "--user is-active --quiet netclaw.service"),
+                ("systemctl", "--user is-enabled --quiet netclaw.service")
+            ],
+            runner.Commands);
+    }
+
+    [Fact]
+    public async Task GetOwnershipAsync_ReturnsUnknown_WhenSystemctlStateCheckErrors()
+    {
+        var unitPath = WriteUnit();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(1, "Failed to connect to bus"));
+        runner.Enqueue(new SystemCommandResult(1, string.Empty));
+        var service = new SystemdUserService(unitPath, runner, enabledOnThisPlatform: true);
+
+        var ownership = await service.GetOwnershipAsync();
+
+        Assert.Equal(SystemdUserServiceOwnershipKind.Unknown, ownership.Kind);
+        Assert.Contains("Could not determine", ownership.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartAndStop_RunSystemctlUserCommands()
+    {
+        var unitPath = WriteUnit();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        var service = new SystemdUserService(unitPath, runner, enabledOnThisPlatform: true);
+
+        var stop = await service.StopAsync();
+        var start = await service.StartAsync();
+
+        Assert.True(stop.Success);
+        Assert.True(start.Success);
+        Assert.Equal(
+            [
+                ("systemctl", "--user stop netclaw.service"),
+                ("systemctl", "--user start netclaw.service")
+            ],
+            runner.Commands);
+    }
+
+    private string WriteUnit()
+    {
+        var unitPath = Path.Combine(_dir.Path, "netclaw.service");
+        File.WriteAllText(unitPath, "[Service]\nExecStart=/opt/netclaw/netclawd\n");
+        return unitPath;
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    private sealed class FakeSystemCommandRunner : ISystemCommandRunner
+    {
+        private readonly Queue<SystemCommandResult> _results = [];
+
+        public List<(string Command, string Arguments)> Commands { get; } = [];
+
+        public void Enqueue(SystemCommandResult result) => _results.Enqueue(result);
+
+        public Task<SystemCommandResult> RunAsync(string command, string arguments)
+        {
+            Commands.Add((command, arguments));
+            return Task.FromResult(_results.Count == 0
+                ? new SystemCommandResult(1, string.Empty)
+                : _results.Dequeue());
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
@@ -6,6 +6,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Update;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Feeds;
@@ -48,9 +49,149 @@ public sealed class UpdateCommandTests : IDisposable
     {
         MinisignVerifier.TestPublicKeyOverride = null;
         UpdateCommand.TestHttpMessageHandlerFactory = null;
+        UpdateCommand.TestDaemonProcessManagerFactory = null;
+        UpdateCommand.TestSystemdUserServiceFactory = null;
         UpdateCheckService.ResetCache();
         _testSigningKey.Dispose();
         _dir.Dispose();
+    }
+
+    [Fact]
+    public async Task StopDaemonForUpdateAsync_UsesSystemd_WhenServiceOwnsLifecycle()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        manager.EnqueueStatus(NotRunning());
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StopDaemonForUpdateAsync(manager, systemd, Running());
+
+        Assert.True(result.Success);
+        Assert.Equal(UpdateDaemonOwner.SystemdUserService, result.Owner);
+        Assert.Equal(
+            [
+                ("systemctl", "--user is-active --quiet netclaw.service"),
+                ("systemctl", "--user stop netclaw.service")
+            ],
+            runner.Commands);
+        Assert.Equal(0, manager.StopCalls);
+        Assert.Equal(0, manager.StartCalls);
+    }
+
+    [Fact]
+    public async Task StopDaemonForUpdateAsync_StopsDetachedDaemon_WhenSystemdStopLeavesDaemonRunning()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        manager.EnqueueStatus(Running());
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StopDaemonForUpdateAsync(manager, systemd, Running());
+
+        Assert.True(result.Success);
+        Assert.Equal(UpdateDaemonOwner.SystemdUserService, result.Owner);
+        Assert.Equal(
+            [
+                ("systemctl", "--user is-active --quiet netclaw.service"),
+                ("systemctl", "--user stop netclaw.service")
+            ],
+            runner.Commands);
+        Assert.Equal(1, manager.StopCalls);
+        Assert.Equal("update", manager.StopReasons.Single());
+    }
+
+    [Fact]
+    public async Task StopDaemonForUpdateAsync_Fails_WhenSystemdOwnershipIsUnknown()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(1, "Failed to connect to bus"));
+        runner.Enqueue(new SystemCommandResult(1, string.Empty));
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StopDaemonForUpdateAsync(manager, systemd, Running());
+
+        Assert.False(result.Success);
+        Assert.Equal(UpdateDaemonOwner.None, result.Owner);
+        Assert.Contains("Could not determine", result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(("systemctl", "--user stop netclaw.service"), runner.Commands);
+        Assert.Equal(0, manager.StopCalls);
+    }
+
+    [Fact]
+    public async Task StopDaemonForUpdateAsync_UsesDetachedLifecycle_WhenSystemdDoesNotOwnDaemon()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(3, string.Empty));
+        runner.Enqueue(new SystemCommandResult(1, string.Empty));
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StopDaemonForUpdateAsync(manager, systemd, Running());
+
+        Assert.True(result.Success);
+        Assert.Equal(UpdateDaemonOwner.DetachedProcess, result.Owner);
+        Assert.DoesNotContain(("systemctl", "--user stop netclaw.service"), runner.Commands);
+        Assert.Equal(1, manager.StopCalls);
+        Assert.Equal("update", manager.StopReasons.Single());
+    }
+
+    [Fact]
+    public async Task StartDaemonAfterUpdateAsync_UsesSystemd_ForSystemdOwnedDaemon()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(0, string.Empty));
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StartDaemonAfterUpdateAsync(
+            UpdateDaemonOwner.SystemdUserService,
+            manager,
+            systemd);
+
+        Assert.True(result.Success);
+        Assert.Equal([("systemctl", "--user start netclaw.service")], runner.Commands);
+        Assert.Equal(0, manager.StartCalls);
+    }
+
+    [Fact]
+    public async Task StartDaemonAfterUpdateAsync_PropagatesSystemdStartFailure()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        var runner = new FakeSystemCommandRunner();
+        runner.Enqueue(new SystemCommandResult(1, "unit failed"));
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StartDaemonAfterUpdateAsync(
+            UpdateDaemonOwner.SystemdUserService,
+            manager,
+            systemd);
+
+        Assert.False(result.Success);
+        Assert.Contains("unit failed", result.Message, StringComparison.Ordinal);
+        Assert.Equal([("systemctl", "--user start netclaw.service")], runner.Commands);
+        Assert.Equal(0, manager.StartCalls);
+    }
+
+    [Fact]
+    public async Task StartDaemonAfterUpdateAsync_UsesDetachedLifecycle_ForDetachedDaemon()
+    {
+        var manager = new FakeDaemonUpdateProcessManager();
+        var runner = new FakeSystemCommandRunner();
+        var systemd = CreateSystemdService(runner);
+
+        var result = await UpdateCommand.StartDaemonAfterUpdateAsync(
+            UpdateDaemonOwner.DetachedProcess,
+            manager,
+            systemd);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, manager.StartCalls);
+        Assert.Empty(runner.Commands);
     }
 
     [Fact]
@@ -262,6 +403,73 @@ public sealed class UpdateCommandTests : IDisposable
                 }
             ]
         };
+    }
+
+    private static DaemonStatus Running() => new(true, 123, "Daemon running.");
+
+    private static DaemonStatus NotRunning() => new(false, null, "Daemon is not running.");
+
+    private SystemdUserService CreateSystemdService(FakeSystemCommandRunner runner)
+    {
+        var unitPath = Path.Combine(_dir.Path, "netclaw.service");
+        File.WriteAllText(unitPath, "[Service]\nExecStart=/opt/netclaw/netclawd\n");
+        return new SystemdUserService(unitPath, runner, enabledOnThisPlatform: true);
+    }
+
+    private sealed class FakeDaemonUpdateProcessManager : IDaemonProcessLifecycle
+    {
+        private readonly Queue<DaemonStatus> _statuses = [];
+        private DaemonStatus _lastStatus = NotRunning();
+
+        public int StopCalls { get; private set; }
+
+        public int StartCalls { get; private set; }
+
+        public List<string> StopReasons { get; } = [];
+
+        public DaemonResult StopResult { get; set; } = new(true, "detached stopped");
+
+        public DaemonResult StartResult { get; set; } = new(true, "detached started");
+
+        public void EnqueueStatus(DaemonStatus status) => _statuses.Enqueue(status);
+
+        public DaemonStatus GetStatus()
+        {
+            if (_statuses.TryDequeue(out var status))
+                _lastStatus = status;
+
+            return _lastStatus;
+        }
+
+        public Task<DaemonResult> StopAsync(string reason)
+        {
+            StopCalls++;
+            StopReasons.Add(reason);
+            return Task.FromResult(StopResult);
+        }
+
+        public DaemonResult Start()
+        {
+            StartCalls++;
+            return StartResult;
+        }
+    }
+
+    private sealed class FakeSystemCommandRunner : ISystemCommandRunner
+    {
+        private readonly Queue<SystemCommandResult> _results = [];
+
+        public List<(string Command, string Arguments)> Commands { get; } = [];
+
+        public void Enqueue(SystemCommandResult result) => _results.Enqueue(result);
+
+        public Task<SystemCommandResult> RunAsync(string command, string arguments)
+        {
+            Commands.Add((command, arguments));
+            return Task.FromResult(_results.Count == 0
+                ? new SystemCommandResult(1, string.Empty)
+                : _results.Dequeue());
+        }
     }
 
 }

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -602,30 +602,10 @@ public sealed partial class DaemonManager
 
     private static async Task<DaemonResult> RunCommandAsync(string command, string arguments)
     {
-        try
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = command,
-                Arguments = arguments,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            };
-
-            using var proc = Process.Start(psi)!;
-            var stderr = await proc.StandardError.ReadToEndAsync();
-            await proc.WaitForExitAsync();
-
-            return proc.ExitCode == 0
-                ? new DaemonResult(true, "OK")
-                : new DaemonResult(false, stderr.Trim());
-        }
-        catch (Exception ex)
-        {
-            return new DaemonResult(false, ex.Message);
-        }
+        var result = await ProcessSystemCommandRunner.Instance.RunAsync(command, arguments);
+        return result.Success
+            ? new DaemonResult(true, "OK")
+            : new DaemonResult(false, result.Message);
     }
 
     // POSIX signals via P/Invoke

--- a/src/Netclaw.Cli/Daemon/SystemdUserService.cs
+++ b/src/Netclaw.Cli/Daemon/SystemdUserService.cs
@@ -1,0 +1,142 @@
+// -----------------------------------------------------------------------
+// <copyright file="SystemdUserService.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Diagnostics;
+
+namespace Netclaw.Cli.Daemon;
+
+internal enum SystemdUserServiceOwnershipKind
+{
+    Unmanaged,
+    Managed,
+    Unknown
+}
+
+internal sealed record SystemdUserServiceOwnership(
+    SystemdUserServiceOwnershipKind Kind,
+    string Message)
+{
+    public static SystemdUserServiceOwnership Managed(string message) =>
+        new(SystemdUserServiceOwnershipKind.Managed, message);
+
+    public static SystemdUserServiceOwnership Unmanaged(string message) =>
+        new(SystemdUserServiceOwnershipKind.Unmanaged, message);
+
+    public static SystemdUserServiceOwnership Unknown(string message) =>
+        new(SystemdUserServiceOwnershipKind.Unknown, message);
+}
+
+internal sealed class SystemdUserService(
+    string? unitFilePath = null,
+    ISystemCommandRunner? commandRunner = null,
+    bool? enabledOnThisPlatform = null)
+{
+    private const string ServiceName = "netclaw.service";
+
+    private readonly string _unitFilePath = unitFilePath ?? DaemonManager.SystemdUserUnitFilePath;
+    private readonly ISystemCommandRunner _commandRunner = commandRunner ?? ProcessSystemCommandRunner.Instance;
+    private readonly bool _enabledOnThisPlatform = enabledOnThisPlatform ?? OperatingSystem.IsLinux();
+
+    public async Task<SystemdUserServiceOwnership> GetOwnershipAsync()
+    {
+        if (!_enabledOnThisPlatform)
+            return SystemdUserServiceOwnership.Unmanaged("systemd user services are Linux-only.");
+
+        if (!File.Exists(_unitFilePath))
+            return SystemdUserServiceOwnership.Unmanaged("No netclaw systemd user service is installed.");
+
+        var active = await _commandRunner.RunAsync("systemctl", $"--user is-active --quiet {ServiceName}");
+        if (active.Success)
+            return SystemdUserServiceOwnership.Managed("netclaw.service is active.");
+
+        var enabled = await _commandRunner.RunAsync("systemctl", $"--user is-enabled --quiet {ServiceName}");
+        if (enabled.Success)
+            return SystemdUserServiceOwnership.Managed("netclaw.service is enabled.");
+
+        if (active.ExecutionError is not null || enabled.ExecutionError is not null)
+        {
+            return SystemdUserServiceOwnership.Unknown(
+                $"Could not execute systemctl: {active.ExecutionError ?? enabled.ExecutionError}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(active.StandardError) || !string.IsNullOrWhiteSpace(enabled.StandardError))
+        {
+            return SystemdUserServiceOwnership.Unknown(
+                $"Could not determine netclaw.service state: {active.Message}; {enabled.Message}");
+        }
+
+        return SystemdUserServiceOwnership.Unmanaged(
+            "netclaw.service is installed but neither active nor enabled.");
+    }
+
+    public async Task<DaemonResult> StopAsync()
+    {
+        var result = await _commandRunner.RunAsync("systemctl", $"--user stop {ServiceName}");
+        return ToDaemonResult(result, "Stopped systemd user service.");
+    }
+
+    public async Task<DaemonResult> StartAsync()
+    {
+        var result = await _commandRunner.RunAsync("systemctl", $"--user start {ServiceName}");
+        return ToDaemonResult(result, "Started systemd user service.");
+    }
+
+    private static DaemonResult ToDaemonResult(SystemCommandResult result, string successMessage) =>
+        result.Success
+            ? new DaemonResult(true, successMessage)
+            : new DaemonResult(false, result.Message);
+}
+
+internal interface ISystemCommandRunner
+{
+    Task<SystemCommandResult> RunAsync(string command, string arguments);
+}
+
+internal sealed record SystemCommandResult(
+    int ExitCode,
+    string StandardError,
+    string? ExecutionError = null)
+{
+    public bool Success => ExecutionError is null && ExitCode == 0;
+
+    public string Message => ExecutionError
+        ?? (string.IsNullOrWhiteSpace(StandardError)
+            ? $"Command exited with code {ExitCode}."
+            : StandardError.Trim());
+}
+
+internal sealed class ProcessSystemCommandRunner : ISystemCommandRunner
+{
+    public static ProcessSystemCommandRunner Instance { get; } = new();
+
+    public async Task<SystemCommandResult> RunAsync(string command, string arguments)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = command,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var proc = Process.Start(psi);
+            if (proc is null)
+                return new SystemCommandResult(-1, string.Empty, $"Failed to start command '{command}'.");
+
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            await proc.WaitForExitAsync();
+
+            return new SystemCommandResult(proc.ExitCode, stderr);
+        }
+        catch (Exception ex)
+        {
+            return new SystemCommandResult(-1, string.Empty, ex.Message);
+        }
+    }
+}

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -18,6 +18,8 @@ namespace Netclaw.Cli.Update;
 internal static class UpdateCommand
 {
     internal static Func<HttpMessageHandler>? TestHttpMessageHandlerFactory { get; set; }
+    internal static Func<NetclawPaths, IDaemonProcessLifecycle>? TestDaemonProcessManagerFactory { get; set; }
+    internal static Func<SystemdUserService>? TestSystemdUserServiceFactory { get; set; }
 
     internal static bool ShouldRunStartupUpdateCheck(string mode, string[] args)
     {
@@ -225,18 +227,21 @@ internal static class UpdateCommand
             }
 
             // Check if daemon is running (we'll need to restart it)
-            var manager = new DaemonManager(paths, TimeProvider.System);
+            var manager = CreateDaemonProcessManager(paths);
+            var systemdService = CreateSystemdUserService();
             var daemonStatus = manager.GetStatus();
-            var daemonWasRunning = daemonStatus.IsRunning;
+            var stopResult = UpdateDaemonStopResult.Succeeded(
+                UpdateDaemonOwner.None,
+                daemonStatus.Message);
 
-            if (daemonWasRunning)
+            if (daemonStatus.IsRunning)
             {
                 Console.Write("Stopping daemon...");
-                var stopResult = await manager.StopAsync("update");
+                stopResult = await StopDaemonForUpdateAsync(manager, systemdService, daemonStatus);
                 if (!stopResult.Success)
                 {
                     Console.WriteLine($" failed: {stopResult.Message}");
-                    Console.WriteLine("Update aborted. Stop the daemon manually and retry with --force.");
+                    Console.WriteLine("Update aborted. Stop the daemon manually, fix service state, and retry.");
                     return 1;
                 }
                 Console.WriteLine(" done.");
@@ -280,11 +285,18 @@ internal static class UpdateCommand
             Console.WriteLine(" done.");
 
             // Restart daemon if it was running
-            if (daemonWasRunning)
+            if (stopResult.ShouldRestart)
             {
                 Console.Write("Restarting daemon...");
-                var startResult = manager.Start();
-                Console.WriteLine(startResult.Success ? " done." : $" {startResult.Message}");
+                var startResult = await StartDaemonAfterUpdateAsync(stopResult.Owner, manager, systemdService);
+                if (!startResult.Success)
+                {
+                    Console.WriteLine($" failed: {startResult.Message}");
+                    Console.WriteLine("Update installed, but daemon restart failed. Start the daemon manually and check `netclaw status`.");
+                    return 1;
+                }
+
+                Console.WriteLine(" done.");
             }
 
             // Clean up backup files
@@ -307,6 +319,101 @@ internal static class UpdateCommand
             try { Directory.Delete(tempDir, recursive: true); }
             catch (Exception ex) { Console.Error.WriteLine($"warn: temp cleanup failed: {ex.Message}"); }
         }
+    }
+
+    internal static async Task<UpdateDaemonStopResult> StopDaemonForUpdateAsync(
+        IDaemonProcessLifecycle manager,
+        SystemdUserService systemdService,
+        DaemonStatus? daemonStatus = null)
+    {
+        daemonStatus ??= manager.GetStatus();
+        if (!daemonStatus.IsRunning)
+        {
+            return UpdateDaemonStopResult.Succeeded(
+                UpdateDaemonOwner.None,
+                daemonStatus.Message);
+        }
+
+        var systemdOwnership = await systemdService.GetOwnershipAsync();
+        switch (systemdOwnership.Kind)
+        {
+            case SystemdUserServiceOwnershipKind.Unknown:
+                return UpdateDaemonStopResult.Failed(
+                    UpdateDaemonOwner.None,
+                    $"Could not determine whether systemd owns the daemon lifecycle: {systemdOwnership.Message}");
+
+            case SystemdUserServiceOwnershipKind.Managed:
+            {
+                var systemdStop = await systemdService.StopAsync();
+                if (!systemdStop.Success)
+                {
+                    return UpdateDaemonStopResult.Failed(
+                        UpdateDaemonOwner.SystemdUserService,
+                        $"systemd stop failed: {systemdStop.Message}");
+                }
+
+                var remainingStatus = manager.GetStatus();
+                if (remainingStatus.IsRunning)
+                {
+                    var detachedStop = await manager.StopAsync("update");
+                    if (!detachedStop.Success)
+                    {
+                        return UpdateDaemonStopResult.Failed(
+                            UpdateDaemonOwner.SystemdUserService,
+                            "systemd service stopped, but a detached daemon is still running and "
+                            + $"could not be stopped: {detachedStop.Message}");
+                    }
+                }
+
+                return UpdateDaemonStopResult.Succeeded(
+                    UpdateDaemonOwner.SystemdUserService,
+                    systemdStop.Message);
+            }
+
+            case SystemdUserServiceOwnershipKind.Unmanaged:
+            default:
+            {
+                var detachedStop = await manager.StopAsync("update");
+                return detachedStop.Success
+                    ? UpdateDaemonStopResult.Succeeded(UpdateDaemonOwner.DetachedProcess, detachedStop.Message)
+                    : UpdateDaemonStopResult.Failed(UpdateDaemonOwner.DetachedProcess, detachedStop.Message);
+            }
+        }
+    }
+
+    internal static async Task<DaemonResult> StartDaemonAfterUpdateAsync(
+        UpdateDaemonOwner owner,
+        IDaemonProcessLifecycle manager,
+        SystemdUserService systemdService)
+    {
+        return owner switch
+        {
+            UpdateDaemonOwner.None => new DaemonResult(true, "Daemon was not running."),
+            UpdateDaemonOwner.SystemdUserService => await systemdService.StartAsync(),
+            UpdateDaemonOwner.DetachedProcess => manager.Start(),
+            _ => new DaemonResult(false, $"Unknown daemon lifecycle owner: {owner}.")
+        };
+    }
+
+    private static IDaemonProcessLifecycle CreateDaemonProcessManager(NetclawPaths paths)
+    {
+        return TestDaemonProcessManagerFactory?.Invoke(paths)
+            ?? new DaemonProcessLifecycle(new DaemonManager(paths, TimeProvider.System));
+    }
+
+    private static SystemdUserService CreateSystemdUserService()
+    {
+        return TestSystemdUserServiceFactory?.Invoke()
+            ?? new SystemdUserService();
+    }
+
+    private sealed class DaemonProcessLifecycle(DaemonManager manager) : IDaemonProcessLifecycle
+    {
+        public DaemonStatus GetStatus() => manager.GetStatus();
+
+        public Task<DaemonResult> StopAsync(string reason) => manager.StopAsync(reason);
+
+        public DaemonResult Start() => manager.Start();
     }
 
     private static async Task<bool> DownloadAndVerifyAsync(
@@ -494,4 +601,34 @@ internal static class UpdateCommand
         if (notice is not null)
             Console.Error.WriteLine(notice);
     }
+}
+
+internal interface IDaemonProcessLifecycle
+{
+    DaemonStatus GetStatus();
+
+    Task<DaemonResult> StopAsync(string reason);
+
+    DaemonResult Start();
+}
+
+internal enum UpdateDaemonOwner
+{
+    None,
+    DetachedProcess,
+    SystemdUserService
+}
+
+internal sealed record UpdateDaemonStopResult(
+    bool Success,
+    UpdateDaemonOwner Owner,
+    string Message)
+{
+    public bool ShouldRestart => Success && Owner is not UpdateDaemonOwner.None;
+
+    public static UpdateDaemonStopResult Succeeded(UpdateDaemonOwner owner, string message) =>
+        new(true, owner, message);
+
+    public static UpdateDaemonStopResult Failed(UpdateDaemonOwner owner, string message) =>
+        new(false, owner, message);
 }


### PR DESCRIPTION
## Summary
- preserve systemd user-service ownership during `netclaw update`
- stop/start active or enabled `netclaw.service` via `systemctl --user` instead of detached `Process.Start`
- keep detached daemon behavior when no systemd user unit owns lifecycle
- add focused tests plus daemon lifecycle docs and operations skill guidance

Closes #1469

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~UpdateCommandTests|FullyQualifiedName~SystemdUserServiceTests"`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check upstream/dev`
- focused eval rerun: `skill_activation_scheduling` 5/5 on isolated port 5400