### PR TITLE
Release: v0.24.2-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,28 +8,37 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.24.1</VersionPrefix>
-    <VersionSuffix>
-    </VersionSuffix>
-    <PackageReleaseNotes>Netclaw v0.24.1 — TUI reliability improvements, remote skill server awareness, spawn_agent liveness fixes, and SQLitePCLRaw CVE mitigation
+    <VersionPrefix>0.24.2</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
+    <PackageReleaseNotes>Netclaw v0.24.2-beta.1 — Schema-aware meta argument coercion, reliability fixes, and performance improvements
 
 **Features**
 
-* **Show advertised skill count for remote skill servers** — the TUI now displays the number of skills advertised by each remote skill server, giving users visibility into available capabilities. ([#1452](https://github.com/netclaw-dev/netclaw/pull/1452))
+* **Schema-aware meta argument coercion** — ChatGPT-trained models (Qwen3.6, etc.) were being hard-rejected for using non-canonical meta argument names (`TimeoutSeconds` vs `_timeout_seconds`). This adds schema-aware near-miss resolution that coercively maps model-supplied key variants to canonical names when no real tool parameter shadows them. Fixes "tool was NOT executed" errors that pushed models off tools and into sandbox-style output. ([#1470](https://github.com/netclaw-dev/netclaw/pull/1470))
+
+* **Preserve per-call meta hints across tool-batch re-drive** — Tool calls awaiting approval that passivate and cold-recover were losing meta hints (`_timeout_seconds`, `_rationale`, `_background`), silently falling back to defaults. Fixes a pre-existing bug where the re-drive path never reinjected persisted MetaJson. Long-running tools approved after session recovery now respect the original timeout.
 
 **Bug Fixes**
 
-* **SQLitePCLRaw CVE suppression** — suppressed GHSA-2m69-gcr7-jv3q (SQLitePCLRaw CVE-2025-6965) until upstream patches the vulnerability. ([#1444](https://github.com/netclaw-dev/netclaw/pull/1444))
+* **Subagents: honor approval-pause in every tool-watchdog mode** — In WallClock mode (applied to every opaque tool), the human-approval pause was ignored: the wall-clock budget kept ticking through a human approval, killing healthy tools mid-wait when humans took longer than the budget. Prevents premature tool termination during human-in-the-loop approvals. ([#1473](https://github.com/netclaw-dev/netclaw/pull/1473))
 
-* **Auto-start init health checks** — the TUI now automatically starts health checks during the init wizard, ensuring servers are ready before proceeding. ([#1454](https://github.com/netclaw-dev/netclaw/pull/1454))
+* **Skills: block agent mutations to server-feed skill directories** — Agents could freely edit/delete/write files into `.server-feeds/` skill directories via both `skill_manage` and direct file-write tools. Changes were silently overwritten on the next sync cycle. Two enforcement layers added: `skill_manage` guard + `ToolPathPolicy` write-deny for server-feed paths. Prevents wasted agent effort and misleading session state from server-feed mutations. ([#1466](https://github.com/netclaw-dev/netclaw/pull/1466))
 
-* **Config-screen consistency** — the TUI config screen now consistently shows Done rows, an embedded footer, and proper Search spacer styling. ([#1441](https://github.com/netclaw-dev/netclaw/pull/1441))
+* **Subagents: record spawn lifecycle in the session transcript** — Sub-agent actor logs went through Akka's async logger bridge and were lost because `SessionDiagnosticsContext.AsyncLocal` was gone. Spawns that failed early (guard rejection, watchdog kill, child-actor failure) left the session transcript completely silent. Parent-side breadcrumbs now log spawn lifecycle under the parent session scope. ([#1468](https://github.com/netclaw-dev/netclaw/pull/1468))
 
-* **Auto-advance add-skill-server flow** — the skill server add flow now automatically advances on a successful probe, reducing manual steps. ([#1458](https://github.com/netclaw-dev/netclaw/pull/1458))
+* **Providers: refresh inference OAuth tokens** — OpenAI Copilot and other inference providers with OAuth tokens now refresh tokens at runtime rather than relying on stale tokens. Includes Copilot probe-time token refresh. Prevents authentication failures during long-running sessions when tokens expire. ([#1465](https://github.com/netclaw-dev/netclaw/pull/1465))
 
-* **spawn_agent liveness respect** — spawn_agent now properly respects self-monitoring liveness checks, ensuring child agents are health-checked correctly after startup. ([#1453](https://github.com/netclaw-dev/netclaw/pull/1453))
+**Performance**
 
-* **Security &amp; Access menu Done rows** — added Done rows to the Security &amp; Access menu and editors for consistent UI feedback. ([#1448](https://github.com/netclaw-dev/netclaw/pull/1448))</PackageReleaseNotes>
+* **Optimize `LlmSessionActor` storage** — Only retain the most recent snapshot + last N messages in the journal, instead of storing full history. Reduces memory consumption for long sessions with many messages. ([#1464](https://github.com/netclaw-dev/netclaw/pull/1464))
+
+**Dependency Updates**
+
+* **Bump MessagePack from 2.5.301 to 3.1.7** — Major version bump with serialization improvements. Please test your workflows after upgrading. ([#1420](https://github.com/netclaw-dev/netclaw/pull/1420))
+
+* **Bump Anthropic SDK** — 12.29.1 → 12.30.0 (semver-minor). ([#1460](https://github.com/netclaw-dev/netclaw/pull/1460))
+
+* **Bump Aspire.Hosting.Testing** — 13.4.4 → 13.4.6 (semver-patch). ([#1462](https://github.com/netclaw-dev/netclaw/pull/1462))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>


### PR DESCRIPTION
## Release: v0.24.2-beta.1

### Features

* **Schema-aware meta argument coercion** (#1470) — ChatGPT-trained models (Qwen3.6, etc.) were being hard-rejected for using non-canonical meta argument names. Adds schema-aware near-miss resolution that coercively maps model-supplied key variants to canonical names.
* **Preserve per-call meta hints across tool-batch re-drive** — Tool calls awaiting approval that passivate and cold-recover were losing meta hints.

### Bug Fixes

* **Subagents: honor approval-pause in every tool-watchdog mode** (#1473) — Prevents premature tool termination during human-in-the-loop approvals.
* **Skills: block agent mutations to server-feed skill directories** (#1466) — Prevents wasted agent effort from server-feed mutation overwrites.
* **Subagents: record spawn lifecycle in the session transcript** (#1468) — Sub-agent failures now visible in session.log.
* **Providers: refresh inference OAuth tokens** (#1465) — Prevents auth failures during long-running sessions.

### Performance

* **Optimize `LlmSessionActor` storage** (#1464) — Reduces memory consumption for long sessions.

### Dependency Updates

* **Bump MessagePack from 2.5.301 to 3.1.7** (#1420) — Major version bump.
* **Bump Anthropic SDK** (#1460) — 12.29.1 → 12.30.0.
* **Bump Aspire.Hosting.Testing** (#1462) — 13.4.4 → 13.4.6.