### PR TITLE
Fix: Remove PanelNode workaround in McpToolPermissionsPage (#1427)

### DIFF
--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="McpToolPermissionsPageTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -303,10 +303,9 @@ public sealed class McpToolPermissionsPageTests : IDisposable
     [Fact]
     public async Task ToolGrid_ManyTools_HeaderRowsNotOverwrittenByScrollContent()
     {
-        // Regression test for issue #1424: ScrollableContainerNode.Render ignores
-        // bounds.Y and writes at context (0,0). With enough tools the scroll container
-        // overwrites the server-info and audience rows. The fix wraps the container in
-        // a borderless PanelNode so it receives a properly-offset render context.
+        // Regression test for issue #1424: ScrollableContainerNode.Render now correctly
+        // respects bounds, so it no longer overwrites header rows when many tools are
+        // displayed. The PanelNode workaround was removed in issue #1427.
         var (terminal, app, vm) = CreateHeadlessApp(out var input);
 
         // 15 tools: on a 40-row terminal the tool list starts at row ~10 without the

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -177,15 +177,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             .WithAutoScroll(AutoScrollPolicy.None)
             .WithContent(_toolRowsNode);
         _toolScrollNode.Fill();
-        // ScrollableContainerNode.Render ignores bounds.Y and writes relative to the
-        // context's (0,0). Hosting it inside a borderless PanelNode ensures the
-        // PanelNode calls context.CreateSubContext(bounds) first, so the scroll
-        // container receives a context already offset to its actual screen position.
-        layout = layout.WithChild(
-            new PanelNode()
-                .WithBorder(BorderStyle.None)
-                .WithContent(_toolScrollNode)
-                .Fill());
+        layout = layout.WithChild(_toolScrollNode.Fill());
 
         return layout;
     }


### PR DESCRIPTION
## Fixes #1427

### Summary

Removes the  workaround in  that was originally added to fix issue #1424.

### Changes

- ****: Removed the borderless  wrapper around  in the tool grid layout. The workaround is no longer needed.
- ****: Updated the regression test comment to reflect that the PanelNode workaround was removed, and reference issue #1427.

### Testing

- Existing headless terminal tests in  verify correct rendering without the workaround.
- Manual TUI testing recommended to verify scroll positioning on screens with many tools.