### PR TITLE
refactor(skills): decompose netclaw-operations + reconcile identity-vs-memory routing

### DIFF
--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -75,19 +75,29 @@ jobs:
 
       - name: Validate R2 uploads
         run: |
-          # Spot-check: fetch the first skill URL from the manifest and verify it resolves
-          url=$(python3 -c "
+          # Spot-check that uploaded objects resolve: the first skill's SKILL.md AND
+          # the first reference (files[]) entry. Validating a files[] URL is what
+          # confirms multi-file / progressive-disclosure skills publish end-to-end,
+          # not just the top-level SKILL.md.
+          python3 - <<'PY' > urls-to-validate.txt
           import json
           m = json.load(open('feeds/skills/.system/manifest.json'))
-          print(m['skills'][0]['url'])
-          ")
-          echo "Validating R2 URL: $url"
-          status=$(curl -sSL -o /dev/null -w "%{http_code}" "$url")
-          if [ "$status" != "200" ]; then
-            echo "Validation failed: $url returned HTTP $status" >&2
-            exit 1
-          fi
-          echo "R2 validation passed"
+          print('skill', m['skills'][0]['url'])
+          for s in m['skills']:
+              files = s.get('files') or []
+              if files:
+                  print('reference', files[0]['url'])
+                  break
+          PY
+          while read -r kind url; do
+            echo "Validating $kind URL: $url"
+            status=$(curl -sSL -o /dev/null -w "%{http_code}" "$url")
+            if [ "$status" != "200" ]; then
+              echo "Validation failed: $kind $url returned HTTP $status" >&2
+              exit 1
+            fi
+          done < urls-to-validate.txt
+          echo "R2 validation passed (skill + reference file)"
 
       - name: Validate custom-domain manifest propagation
         run: |

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -910,6 +910,17 @@ assert_skill_scheduling_knowledge() {
     stdout_contains 'cron' && daemon_log_skill_loaded 'netclaw-operations'
 }
 
+# Two-hop progressive disclosure: the model must (1) load netclaw-operations, then
+# (2) call skill_read_resource on references/scheduling.md to recover a detail that
+# lives ONLY in the reference file (the auto-disable threshold + alert name), never
+# in the slim SKILL.md index. Catches a model that loads the index but skips the
+# second hop — the failure mode that silently regresses smaller local agents.
+assert_skill_progressive_disclosure() {
+    daemon_log_skill_loaded 'netclaw-operations' \
+        && stdout_tool_called 'skill_read_resource' \
+        && { stdout_contains 'ReminderAutoDisabled' || stdout_contains '5 consecutive'; }
+}
+
 assert_skill_memory_knowledge() {
     stdout_contains 'durable' && stdout_contains 'evidence' && daemon_log_skill_loaded 'netclaw-memory'
 }
@@ -978,8 +989,16 @@ assert_memory_recall_active() {
     daemon_log_contains 'turn_memory_recall.*degraded=False'
 }
 
+# Per the netclaw-agent-memory spec, durable user preferences are memory documents,
+# not identity-file edits. The invariant under test: the preference is routed to
+# memory and NOT written to an identity file (SOUL.md). The eval memory store is
+# shared across runs, so after the first store the model correctly recognizes the
+# fact is already in durable memory rather than re-storing it — both are correct
+# routing. The hard failure we guard against is a SOUL.md (file_edit/file_write) edit.
 assert_memory_identity_preference_routing() {
-    stdout_contains 'SOUL\.md' && (stdout_tool_called 'file_edit' || stdout_tool_called 'file_write')
+    ! stdout_tool_called 'file_edit' \
+        && ! stdout_tool_called 'file_write' \
+        && { stdout_tool_called 'store_memory' || stdout_contains 'memory'; }
 }
 
 assert_memory_explicit_store() {
@@ -1394,6 +1413,9 @@ run_all() {
         "What scheduling formats do Netclaw reminders support?" \
         "Explain the different schedule types I can use with reminders"
 
+    run_case skill_progressive_disclosure "reads reference via skill_read_resource (2nd hop)" \
+        "Exactly how many consecutive reminder execution failures cause Netclaw to auto-disable a reminder, and what is the exact name of the alert it raises when that happens? Be precise."
+
     run_case skill_memory_knowledge "knows memory classes from skill" \
         "What types of memory do you have? Explain the differences and how long each lasts." \
         "How does your memory system work? What are the different memory classes?"
@@ -1479,7 +1501,7 @@ run_all() {
     run_case memory_recall_active "recall active, not degraded" \
         "What do you know about me?"
 
-    run_case memory_identity_preference_routing "personal preference routed to SOUL.md" \
+    run_case memory_identity_preference_routing "durable user preference routed to memory, not SOUL.md" \
         "Please remember this new preference for future conversations: my favorite color is chartreuse. Use whichever persistent storage path Netclaw's identity-vs-memory rules require, then acknowledge once you've saved it."
 
     run_case memory_explicit_store "explicit remember request uses store_memory" \

--- a/feeds/skills/.system/files/netclaw-memory/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-memory/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-memory
 description: "REQUIRED when the user asks what you remember, recall, or know from past conversations, previous sessions, or cross-session memory. Also before using memory tools: find_memories, get_memories, store_memory, update_memory."
 metadata:
   author: netclaw
-  version: "1.4.1"
+  version: "1.5.0"
 ---
 
 # Netclaw Memory
@@ -109,9 +109,13 @@ context.
 
 ## Identity vs Memory
 
-Do not put project facts, research, or tool findings in identity files.
-`SOUL.md` is only for narrow identity/profile updates. Everything else
-goes through the memory pipeline.
+Identity files (`SOUL.md`, `AGENTS.md`, `TOOLING.md`) define **the agent** —
+persona, tone, operating rules, and the foundational user grounding set at init
+(name, timezone). Do **not** put project facts, research, tool findings, or
+**durable facts and preferences about the user** (favorites, family, history,
+working preferences) in identity files — those go through the **memory pipeline**
+(`store_memory`) and are recalled when relevant. A user asking you to "remember" a
+preference is a memory write, not a `SOUL.md` edit.
 
 If unsure, load `netclaw-operations` for the identity-vs-memory triage guide.
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.17.0"
+  version: "2.18.0"
 ---
 
 # Netclaw Operations
@@ -14,301 +14,47 @@ problems, how to update preferences, or how to maintain itself.
 
 ## Route by Intent
 
-| User intent | Section below |
-|-------------|---------------|
-| Schedule reminders, cron jobs | [Scheduling](#scheduling) |
-| Work on a project, switch projects | [Project Directory](#project-directory) |
-| Discover MCP tools | [Tool Discovery](#tool-discovery) |
+Safety-critical and high-frequency guidance (tool arguments, large output,
+approvals, identity-vs-memory routing) is inline below. Everything else lives in
+a reference file — load the one matching the user's intent with
+`skill_read_resource`.
+
+| User intent | Where |
+|-------------|-------|
+| Schedule reminders/cron; run background shell jobs | `skill_read_resource('netclaw-operations', 'references/scheduling.md')` |
+| How tool arguments are validated | [Tool argument validation](#tool-argument-validation) |
+| Handle very large tool output | [Large tool output](#large-tool-output) |
 | Understand approval prompts | [Approval Prompts](#approval-prompts) |
-| Manage skills and sources | [Skill Management](#skill-management) |
-| Something is broken, debug it | [Diagnostics](#diagnostics) |
-| Update preferences, tone, profile | [Identity](#identity) |
-| Pair remote devices, manage access | [Device Pairing](#device-pairing) |
-| Check health, update self | [Self-Maintenance](#self-maintenance) |
-| Run long shell commands in background | [Background Jobs](#background-jobs) |
-| Manage inbound webhooks | [Webhook Management](#webhook-management) |
-| Add or switch LLM provider, OAuth login | [LLM Providers](#llm-providers) |
-| Show / kick the tires on Netclaw end-to-end locally | [Demo AppHost](#demo-apphost) |
-| Search backend errors, configure SearXNG | [Search Providers](#search-providers) |
-| Rotate or repair secrets | [Secret Management](#secret-management) |
+| Update identity / where facts go (identity vs memory) | [Identity](#identity) |
+| Work on a project, switch projects | `skill_read_resource('netclaw-operations', 'references/projects.md')` |
+| Discover MCP / available tools | `skill_read_resource('netclaw-operations', 'references/tools.md')` |
+| Manage skills and sources | `skill_read_resource('netclaw-operations', 'references/skills.md')` |
+| Manage inbound webhooks / attachments | `skill_read_resource('netclaw-operations', 'references/webhooks.md')` |
+| Add/switch LLM or search provider, OAuth login | `skill_read_resource('netclaw-operations', 'references/providers.md')` |
+| Diagnose problems, kill switches, self-update | `skill_read_resource('netclaw-operations', 'references/diagnostics.md')` |
+| Rotate or repair secrets | `skill_read_resource('netclaw-operations', 'references/secrets.md')` |
+| Pair remote devices, manage access | `skill_read_resource('netclaw-operations', 'references/devices.md')` |
+| Kick the tires on Netclaw end-to-end locally | `skill_read_resource('netclaw-operations', 'references/demo-apphost.md')` |
 
 ## Project Directory
 
-Sessions track a **project directory** — the root of the codebase or project
-you are currently working on. When set, the project's identity file (checked in
-order: `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` — first
-match wins) is automatically loaded into the system prompt alongside the global
-SOUL/AGENTS/TOOLING layers.
+`set_working_directory(path)` sets the session's project root (absolute path within
+allowed roots); the project's identity file (`.netclaw/AGENTS.md`, `CLAUDE.md`,
+`AGENTS.md`, or `CONTEXT.md`) then loads into the prompt. Full rules:
+`skill_read_resource('netclaw-operations', 'references/projects.md')`.
 
-Use `set_working_directory` to set or change the project directory:
+## Scheduling & Background Jobs
 
-```
-set_working_directory(path: "/home/user/workspaces/akadonic")
-```
+Reminders: `set_reminder` with schedule type `once` / `interval` / `cron`. Always
+set `delivery_kind` explicitly (`current_session` / `channel` / `none`). A reminder
+that fires unattended cannot answer approval prompts, so pre-approve any shell verbs
+it needs first with `netclaw approvals trust-verb <verb>`. Background shell: set
+`_background: true` on `shell_execute` (max 5 concurrent; cancel servers/watchers
+when done; background jobs are killed when the session passivates).
 
-Rules:
-
-- The path must be an absolute path to an existing directory
-- The path must be within the session's allowed file access roots
-- Profile-managed: granted to Team and Personal audiences by default, not Public
-- Project identity files are re-read from disk on each `SetSystemPrompt()` call,
-  so edits to the project's `AGENTS.md` take effect on the next project switch
-  or daemon restart
-- The project directory persists across crash/restart via `WorkingContext`
-- The `[working-context]` block includes `project_dir:` so you always know which
-  project is active
-
-The project directory is distinct from the session directory
-(`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for
-state isolation (inbox, media). The project directory is mutable and points to
-the project root.
-
-## Scheduling
-
-Scheduling is gated on `Scheduling.Enabled` in `netclaw.json` (default `true`).
-When disabled, reminder tools are hidden, `ReminderManagerActor` skips startup
-reconciliation, and fired reminders are acknowledged but not executed. Public
-audience sessions cannot use scheduling tools regardless of the config flag.
-
-`set_reminder` accepts three schedule types:
-
-| Type | Examples |
-|------|---------|
-| `once` | `"30m"`, `"2h"`, `"2026-03-15T14:30:00Z"` |
-| `interval` | `"30m"`, `"6h"`, `"1d"` |
-| `cron` | `"0 */6 * * *"`, `"0 9 * * MON-FRI"` |
-
-Delivery contract parameters:
-
-- `delivery_kind`: required, one of `current_session`, `channel`, `none`
-- `delivery_transport`: required when `delivery_kind=channel` (e.g. `slack`, `discord`, `mattermost`)
-- `delivery_address`: required when `delivery_kind=channel` (`#channel`, `@user`, or canonical ID)
-- `delivery_required`: optional bool, default `true`; set `false` only for audit/cleanup tasks
-- `delivery_instructions`: optional content guidance only (never routing)
-- `expires_in`: optional recurring-reminder expiry duration (for `interval`/`cron` only), e.g. `"24h"`, `"7d"`
-
-You may also pass the structured form `delivery: { kind, transport?, address? }`
-instead of the three flat delivery fields.
-
-Rules:
-
-- Always choose `delivery_kind` explicitly.
-- Do not try to route via `delivery_instructions`.
-- `current_session` is the session check-back path and should be preferred for
-  conversational follow-ups in Slack/TUI/SignalR sessions.
-- `channel` requires both transport + address and resolves names/handles to
-  canonical IDs at set time; unresolved targets fail loud.
-- `none` runs silently (history still records execution).
-- `expires_in` is not valid for `once` reminders; omit it for one-shot schedules.
-- For recurring reminders that are permanently complete (PR merged, deploy done,
-  incident resolved), call `cancel_reminder` with that reminder's ID so it does
-  not keep firing indefinitely.
-
-`cancel_reminder` **disables** the reminder — it stops future executions but
-preserves the definition file on disk for diagnosis and re-enablement. To
-permanently delete a reminder and its history, use the CLI:
-
-```
-netclaw reminder delete <id>
-```
-
-The `cancel` CLI subcommand mirrors the tool behavior (disable only):
-
-```
-netclaw reminder cancel <id>     # disable, keep definition
-netclaw reminder delete <id>     # permanent delete + history
-```
-
-Reminders that hit 5 consecutive execution failures are auto-disabled with a
-`ReminderAutoDisabled` critical alert. The definition stays on disk so the
-operator can diagnose and re-enable after fixing the root cause.
-
-If `audience` is omitted during conversational scheduling, the reminder inherits
-the audience of the channel/session that created it. A reminder cannot be
-minted with broader audience than the creator currently holds; lowering the
-audience is always allowed.
-
-Other scheduling tools: `list_reminders`, `cancel_reminder`,
-`get_reminder_history`.
-
-### Proactive channel messaging
-
-To start a brand-new conversation on a chat channel — a `delivery_kind=channel`
-reminder firing, or unprompted cross-channel outreach ("let the team know") —
-use the generic proactive-post tool:
-
-- `send_channel_message(channel_key, destination, text)` posts through the
-  selected enabled channel and creates a new conversation thread when that
-  channel supports it.
-- `destination` must be a resolved object with `channel_key`, `kind`, and `id`.
-  Do not pass bare display names like `#general` or `@alice`.
-- `destination.kind="destination"` posts to a channel/destination ID returned by
-  `lookup_channel_destination`.
-- `destination.kind="direct_message"` sends a DM using the stable user ID from
-  `lookup_channel_user`; this is supported only by channels that advertise DM
-  output (Slack, Discord, and Mattermost when enabled in config).
-- Reminder- and webhook-originated turns may only call `send_channel_message`
-  against the delivery target configured on the reminder or webhook route. If a
-  trigger turn has no configured target, Netclaw fails loud instead of choosing a
-  default output channel.
-
-Use the generic lookup tools before sending when you do not already have a
-stable channel/user ID:
-
-- `lookup_channel_user(channel_key, query)` resolves users on enabled channels
-  that support user lookup, currently Slack, Discord, and Mattermost.
-- `lookup_channel_destination(channel_key, query)` resolves destinations on
-  enabled channels that support destination lookup. Slack can resolve channel
-  names and IDs; Discord can resolve channel mentions, stable IDs, and cached
-  text-channel names; Mattermost requires an exact channel ID.
-- **Discovery:** call `lookup_channel_destination` with `query` omitted (or
-  blank) to list every destination the channel can currently deliver to —
-  Slack lists the configured allowlist (the resolved default channel plus
-  `AllowedChannelIds`) with display names resolved from the API and archived
-  channels excluded, Discord lists ACL-allowed guild text channels, and
-  Mattermost lists the configured allowlist. Use this to answer "where can I
-  post?" before sending. Listing is destination-only: user directories are
-  unbounded, so `lookup_channel_user` always requires a query.
-
-Both tools require `channel_key` as the first argument. Use the returned
-`channel_key` and `stable_id` exactly; for destination lookups, use the returned
-`address_kind` (`destination`) as `destination.kind`. For user lookups, set
-`destination.kind` to `direct_message` and pass the returned user `stable_id`.
-If lookup is ambiguous, pick from the returned candidates instead of guessing.
-Do not use channel-specific lookup aliases such as `lookup_slack_user` or
-`lookup_mattermost_user`; lookup is intentionally routed through the generic
-channel tools.
-
-Examples:
-
-```
-send_channel_message(
-  channel_key: "slack",
-  destination: { channel_key: "slack", kind: "destination", id: "C0123ABC" },
-  text: "Deployment finished successfully.")
-
-send_channel_message(
-  channel_key: "mattermost",
-  destination: { channel_key: "mattermost", kind: "direct_message", id: "26characterMattermostUserId" },
-  text: "Your report is ready.")
-
-send_channel_message(
-  channel_key: "discord",
-  destination: { channel_key: "discord", kind: "direct_message", id: "123456789012345678" },
-  text: "Your report is ready.")
-```
-
-### Approval Requirements for Reminders and Webhooks
-
-Reminders and webhooks execute without a human present — they CANNOT prompt for
-tool approval. The cwd at firing time will not match any cwd a user clicked
-"Always here" for during interactive use, so folder-scoped approvals will not
-match.
-
-**Before creating a reminder that uses shell commands**, identify the verbs the
-task will need (e.g. `freshdesk`, `curl`, `git pull`) and pre-approve them as
-global wildcards. Two paths:
-
-1. **Suggest `trust-verb` from the agent.** When you (the agent) are helping the
-   user set up a scheduled task, identify the verbs the task will need and ask
-   the user before pre-approving each one. Example:
-
-   > "This reminder will need to call `freshdesk --since=24h` whenever it
-   > fires. Mind if I pre-approve `freshdesk` as a global verb so the reminder
-   > can run unattended? I'll do this with
-   > `netclaw approvals trust-verb freshdesk`."
-
-   On confirmation, run the trust-verb command via `shell_execute`. The grant
-   becomes a `(verb, null)` entry — auto-approved for any cwd.
-
-2. **Operator runs the CLI directly:** `netclaw approvals trust-verb <verb>`.
-   Same outcome; useful when the user already knows what they want.
-
-If the user has already trusted the verb in a previous session, no action is
-needed — `(verb, null)` grants persist in `tool-approvals.json` across daemon
-restarts.
-
-**Path restrictions:** A trusted verb runs wherever the creating audience's
-file-access policy allows — the same scoping `file_write` uses. A Personal
-reminder/webhook (the default when created from a Personal session) has
-unrestricted filesystem access; a Team or Public one is confined to its session
-directory — and cannot run `shell_execute` at all, since shell is Personal-only.
-Protected paths — `secrets.json`, `.netclaw/keys`, `config/webhooks` — are always
-denied regardless of audience or pre-approval.
-
-**If a reminder fails with `command_not_pre_approved`:** The verb is not in the
-approval store as a global wildcard. Run
-`netclaw approvals trust-verb <verb>` and the next firing succeeds.
-
-**If a reminder fails with `path_outside_trust_zone`:** The command targets a
-path outside the allowed roots. Either move the target into a workspace, or ask
-the user to add the path to trusted roots in config.
-
-## Background Jobs
-
-A background job is a **detached process with no expectation of completion** —
-use it for anything that outlives a single tool call: long builds, test suites,
-dev servers, watchers. Output streams to the job's log file while it runs, and
-you are notified whenever the process terminates, by whatever cause.
-
-To submit: set `_background: true` in the `shell_execute` tool call metadata.
-Approval gates are evaluated before the job starts. The submit result includes
-the output log path.
-
-Lifecycle:
-
-- **No `_timeout_seconds` = no kill timer.** The job runs until it exits, you
-  cancel it, or the session passivates. A positive `_timeout_seconds` arms an
-  explicit kill timer.
-- **Jobs are killed when the session passivates** (conversation idle past the
-  idle timeout). A job killed this way shows as `reaped` in
-  `[active-background-jobs]` on your next turn — its process is gone; resubmit
-  if still needed (its output log remains readable). For work that must survive
-  an idle conversation, use a scheduled task; check-back reminders also keep
-  the session (and its jobs) alive across a long wait.
-- On daemon restart, running jobs are killed and you receive a `lost`
-  notification with the log path — relaunch if still needed.
-- Process exit (success or failure) delivers a result turn with exit code,
-  output tail, and log path — even if the session was passivated mid-flight.
-
-Monitoring a running job (e.g. waiting for a dev server to come up):
-
-- `file_read`/`grep` the output log — it streams live (secret-redacted,
-  rotation-bounded) at `~/.netclaw/jobs/{id}/output.log`.
-- `check_background_job(JobId: "id")` — status, elapsed time, live output tail
-- Probe the service directly (e.g. curl the port) once the log shows it started.
-- `check_background_job(JobId: "id", Cancel: true)` — cancel a running job.
-  **Cancel servers and watchers when you are done validating** — do not leave
-  them holding one of the 5 concurrent job slots.
-
-Rules:
-
-- Only `shell_execute` supports background mode. Other tools ignore `_background`.
-- `_timeout_seconds` alone does NOT trigger background execution.
-- For synchronous calls `_timeout_seconds` is honored as you set it (no ceiling
-  or floor); when omitted, the default tool timeout applies. Background jobs
-  differ: omitted means no timer at all.
-- Synchronous tool timeouts are wall-clock budgets for opaque tools; repeated
-  stdout/progress output does not extend them. `spawn_agent` is self-monitoring:
-  the parent applies NO timeout to it at all — the subagent owns its liveness end
-  to end (its own prefill/no-progress watchdog reports a stall, and it always
-  returns a final result). A spawned subagent is bounded only by its own internal
-  watchdog or by you cancelling the turn (send another message in the thread).
-- **Long-running delegation calls** (e.g. `curl` to a local coding-agent or
-  model server that takes minutes to respond) should run as background jobs.
-- The user must approve the command before it starts running in the background.
-- Maximum 5 concurrent background jobs; overflow queues FIFO.
-- Job definitions persist to `~/.netclaw/jobs/{id}.json`.
-
-`check_background_job` is only available when shell execution is granted (same
-`shell` grant category). It validates that the requesting session matches the
-submitting session's audience and boundary.
-
-After submitting a long finite job, schedule a check-back reminder so you report
-results proactively when it completes.
-
-Active background jobs appear in the `[active-background-jobs]` section of the
-session context on every turn.
+Full detail — delivery contract, proactive channel messaging, approval scoping,
+job lifecycle — is in
+`skill_read_resource('netclaw-operations', 'references/scheduling.md')`.
 
 ## Tool argument validation
 
@@ -353,94 +99,9 @@ re-reading a whole file. Secret-bearing values are redacted from all tool output
 
 ## Tool Discovery
 
-MCP tools are not loaded by default. Use `search_tools` to discover them:
-
-```
-search_tools(query: "servers")                  # list all MCP servers
-search_tools(query: "all", server: "notion")    # browse a server's tools
-search_tools(query: "email")                    # keyword search
-```
-
-After discovery, matched tools become callable for the session.
-
-Sessions receive granted tool categories. `builtin` is always granted.
-Other categories (`web`, `file`, `shell`, `scheduling`) depend on ACL
-config. If a tool is missing, it may not be granted for this session.
-
-Built-in tool grants follow the audience and are monotonic (Public ⊆ Team ⊆
-Personal). **Public** sessions get read-only file tools only — `file_read`,
-`file_list`, `attach_file` — and no outbound web access. **Team** adds
-`file_write`, `file_edit`, `web_search`, `web_fetch`, the scheduling tools,
-`skill_manage`, and `set_working_directory`. **Personal** gets everything.
-`shell_execute` is Personal-only — in a Team or Public session, use `file_list`
-to enumerate a directory instead of `ls`.
-
-Tools belonging to disabled subsystems (see [Feature Kill Switches](#feature-kill-switches))
-are hidden from `search_tools` results for all audiences. Public sessions
-additionally cannot discover or load skills, subagents, memory tools,
-scheduling tools, or the `web_search` / `web_fetch` tools regardless of
-feature flags.
-
-### Adding MCP servers (fail-closed by default)
-
-`netclaw mcp add` writes new MCP servers with **zero granted tools** and
-per-audience approval defaults so freshly added servers are never silently
-exposed:
-
-| Audience | Grants | Approval default |
-|----------|--------|------------------|
-| Personal | `[]` (empty list — all tools denied until the operator opts in) | `Approval` |
-| Team     | `[]` | `Approval` |
-| Public   | `[]` | `Deny` |
-
-After `mcp add`, the operator uses `netclaw mcp permissions` — an
-interactive TUI — to grant specific tools and adjust the per-tool or
-per-server approval mode. Bare `netclaw mcp tools` is a read-only CLI view
-of the same state; both commands surface a discoverability hint toward the
-TUI.
-
-Escape hatch: `netclaw mcp add --grant-all` keeps the legacy "null grants
-= all tools pass" behavior for CI. Even with `--grant-all`, the per-audience
-approval defaults (Personal/Team=Approval, Public=Deny) are still written —
-you cannot turn off the approval prompts at `mcp add` time.
-
-Inside the TUI (`netclaw mcp permissions`):
-
-- `Enter` toggles the highlighted tool's grant
-- `A` toggles all tools on/off for the current audience
-- `E` enables/disables the whole server for the current audience
-- `M` cycles the **server default** approval mode (`Auto → Approval → Deny → Auto`)
-- `P` cycles the **highlighted tool's explicit override** (`inherit → Auto → Approval → Deny → inherit`) — `inherit` removes any explicit override so the tool inherits the server default
-- `S` saves pending changes to `netclaw.json`
-- `←/→` cycles the selected audience
-
-Approval-mode resolution precedence (for MCP tools):
-
-1. Exact `ToolOverrides["{server}/{tool}"]` override
-2. `McpServerDefaults[{server}]` default
-3. Fail-closed fallback (Personal audience, shell/file-edit matcher family)
-4. Audience `DefaultMode`
-
-Newly discovered tools on an existing server automatically inherit the
-server default; you do not need to re-run `permissions` after the server
-learns a new tool.
-
-### Migrating existing MCP servers
-
-Servers added to `netclaw.json` before this behavior shipped stay untouched —
-their tool grants, `ApprovalPolicy.McpServerDefaults`, and `ToolOverrides`
-entries are not rewritten during an upgrade.
-
-`netclaw doctor` will emit a warning for each enabled MCP server that
-Personal can reach (`McpServersMode = All`) but has no
-`ApprovalPolicy.McpServerDefaults[server]` entry and no `notion/*`-style
-`ToolOverrides` entry. The warning points at `netclaw mcp permissions`.
-
-To resolve: run `netclaw mcp permissions`, pick the server, switch to the
-Personal audience, press `M` to set a server default (`Approval` is the
-safe choice), `S` to save, then restart the daemon. Repeat for each
-audience you want to tighten. `doctor` stops warning once the default is
-set.
+Only a core toolset is always loaded. Use `search_tools(query)` to find additional
+or MCP tools by capability before concluding a tool doesn't exist. Full guidance:
+`skill_read_resource('netclaw-operations', 'references/tools.md')`.
 
 ## Approval Prompts
 
@@ -611,401 +272,34 @@ Restart the daemon so in-memory session approvals are cleared too.
 
 ## Skill Management
 
-The `netclaw skill` CLI manages skills and skill sources. All subcommands
-are offline — no daemon required.
+Skills load on demand; manage skills and sources via the skill tools. Full guidance:
+`skill_read_resource('netclaw-operations', 'references/skills.md')`.
 
-| Command | What it does |
-|---------|--------------|
-| `netclaw skill list` | List all discovered skills with source, version, status |
-| `netclaw skill show <name>` | Show skill metadata and full content |
-| `netclaw skill validate <path>` | Validate a SKILL.md file's frontmatter format |
-| `netclaw skill remove <name>` | Remove a native skill (refuses system/external) |
-| `netclaw skill issues` | Show only scanner issues (rejected items with reasons) |
-| `netclaw skill search <query>` | Search skills by name or description |
+## Webhooks & Inbound Attachments
 
-### External skill sources
-
-Register additional skill directories (e.g. `~/.claude/skills/`):
-
-| Command | What it does |
-|---------|--------------|
-| `netclaw skill source list` | Show configured external sources |
-| `netclaw skill source add <name> --well-known claude-code` | Add Claude Code skills |
-| `netclaw skill source add <name> --path /shared/skills` | Add a custom directory |
-| `netclaw skill source remove <name>` | Remove a source |
-| `netclaw skill source enable <name>` | Enable a disabled source |
-| `netclaw skill source disable <name>` | Disable without removing |
-
-The daemon's `SkillDirectoryWatcherService` automatically rescans all skill
-directories (native + external) when files change on disk. No restart needed.
-
-## Webhook Management
-
-Webhooks are gated on `Webhooks.Enabled` in `netclaw.json` (default `true`).
-When disabled, the webhook HTTP endpoint returns 404 for all routes and
-webhook tools are hidden from discovery.
-
-Inbound webhooks use a split config model:
-
-- `~/.netclaw/config/netclaw.json` -> `Webhooks.Enabled` toggles the feature
-- `~/.netclaw/config/webhooks/*.json` -> one route per file; filename is the
-  route name used at `/api/webhooks/{route}`
-
-Use the dedicated tools instead of generic file tools when available:
-
-- `set_webhook`
-- `list_webhooks`
-- `delete_webhook`
-
-When using `set_webhook`, use `delivery_required` (bool, default `true`) to
-control required notification behavior. `notify_policy` is deprecated.
-
-`set_webhook` inherits the audience of the channel/session that created it when
-`audience` is omitted — the same provenance model as reminders. A route cannot be
-minted with a broader audience than the creator holds; downgrading is always
-allowed. A webhook created from a Team channel runs as Team (and therefore cannot
-run `shell_execute`); one created from a Personal CLI session runs as Personal.
-
-Route files are secret-bearing config because they may contain inline
-verification secrets. Treat `config/webhooks` like `secrets.json` and avoid
-broad file reads/writes there unless the user explicitly wants raw config work.
-
-Verification kinds are generic:
-
-- `Hmac`
-- `HeaderSecret`
-
-Route files hot-reload without restarting the daemon. If a route file becomes
-invalid, Netclaw removes that route immediately and emits an operational alert.
-
-**Approval gate:** Webhooks run without a human — they cannot prompt for
-approval. The same rules as reminders apply: shell commands must be pre-approved
-in `tool-approvals.json`, and path arguments are scoped by the route's audience
-the same way `file_write` is. See "Approval Requirements for Reminders and
-Webhooks" in the Scheduling section.
-
-### Webhook observability
-
-`netclaw stats` includes a `webhooks:` section with:
-
-- **Route counts** — `total`, `enabled`, `disabled`, `invalid` (files on disk,
-  classified by parse/validation status plus the per-route `Enabled` flag).
-- **Delivery counters** — `accepted`, `filtered` (event not in allowlist),
-  `duplicate` (delivery id already seen), plus per-rejection counts:
-  `404` (route_not_found), `401` (verification_failed), `413` (body_too_large),
-  `400` (invalid_json), `429` (rate_limited).
-
-Every ingress outcome writes a structured line to `daemon-{date}.log`:
-
-```
-Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp}
-  delivery_id={DeliveryId} event_type={EventType}
-```
-
-Rejection paths only log + increment counters — they do NOT fire outbound
-operational notifications, so bad or adversarial traffic does not spam the
-configured notification target.
-
-## Inbound Attachments
-
-When a user sends a file in Slack, Discord, or Mattermost, Netclaw runs the
-attachment through an ingress pipeline before it reaches the LLM:
-
-1. **Policy gate** — uses declared MIME plus filename extension for a provisional
-   catalog-backed category, then checks audience and per-message file count
-   against `ChannelAttachmentPolicy`
-2. **Size gate** — rejects files above the per-audience byte limit
-3. **Download** — fetches from Slack's private file API with bot-token auth
-4. **Content scan** — runs the configured `IContentScanner` and produces a
-   scanner-verified canonical MIME type
-5. **Inbox write** — saves to `~/.netclaw/sessions/{session-id}/inbox/`
-6. **Announcement line** — appends `[attachment]` text to the user turn
-
-The `[attachment]` line format is:
-```
-[attachment] name="..." mime="..." size=N path="inbox/..." inlined="true|false"
-```
-
-`inlined="true"` means the file bytes were forwarded to the model as
-`DataContent` (currently image files on image-capable models). `inlined="false"`
-means the model only sees the path reference.
-
-Declared transport MIME is metadata, not proof. Attachment announcements,
-inlined `DataContent`, and model-input handoff use the scanner-verified MIME.
-Unknown image/audio/video subtypes do not get privileged categories by prefix;
-they must be explicitly present in the media catalog. OpenAI-compatible
-providers only serialize image `DataContent` through `image_url` and fail loudly
-if non-image bytes reach that boundary.
-
-`file_read` follows the same file taxonomy as chat attachments. It reads
-text-like files directly, including UTF-8, UTF-16/UTF-32 Unicode text, and
-common Windows-1252 text files. For images, it can load the file for visual
-inspection when the active model or delegated sub-agent supports image input.
-For PDFs, audio/video, archives, binary documents, and unknown binaries, it
-returns metadata plus explicit guidance; it does not perform PDF extraction,
-OCR, transcription, keyframe extraction, or raw binary output.
-
-**Historical thread backfill** follows the same download/scan flow for all
-file types (not just images) — PDFs and other documents from prior thread
-messages are included.
-
-**When attachment ingress fails**, Netclaw posts a stable user-facing message
-(e.g. "Couldn't download `file.pdf` — please try again later.") and logs the
-full exception internally. Exception details are **never** forwarded to Slack.
-
-| Symptom | Check |
-|---------|-------|
-| File rejected before download | audience/category policy gate; check `ChannelAttachmentPolicy` config |
-| Download timeout | bot token valid? Slack network reachable? check `daemon-{date}.log` |
-| Content scan rejection | `netclaw status` scanner section; check scan config |
-| Inbox write failure | disk space? permissions on `~/.netclaw/sessions/`? |
+Inbound webhooks are configured per route; route files are secret-bearing and
+protected. Attachment handling is covered alongside. Full setup + rules:
+`skill_read_resource('netclaw-operations', 'references/webhooks.md')`.
 
 ## Secret Management
 
-Secrets live in `~/.netclaw/config/secrets.json`; never print raw values in a
-conversation, issue, PR, or log summary. Use the CLI instead of direct edits:
+Secrets live in `~/.netclaw/config/secrets.json` — **never print raw secret values**
+in chat, issues, PRs, or logs. Set them via CLI (`netclaw secrets set <Path> <value>`),
+never by direct file edit. Protected paths (`secrets.json`, `.netclaw/keys`,
+`config/webhooks`) are always access-denied. Full rotation guidance:
+`skill_read_resource('netclaw-operations', 'references/secrets.md')`.
 
-```bash
-netclaw secrets set Discord:BotToken <replacement>
-netclaw secrets set Slack.BotToken <replacement>
-```
+## LLM & Search Providers
 
-Rules:
+Add or switch model providers (including OAuth login) and configure search backends
+(e.g. SearXNG) via provider config. Full setup:
+`skill_read_resource('netclaw-operations', 'references/providers.md')`.
 
-- `.` and `:` are both accepted as path delimiters; prefer the documented dotted
-  form unless the operator provides a configuration-style colon path.
-- `netclaw secrets add` is an alias for `set` and overwrites the same effective
-  path.
-- Re-running `netclaw init` on an existing install opens an action menu
-  (`Redo identity setup`, `Open configuration editor`, `Start over from
-  scratch`, `Cancel`) rather than re-walking setup. Update individual secrets
-  with `netclaw secrets set` or the relevant `netclaw config` editor.
-- If a channel reports a 401 or invalid-token error, rotate the relevant secret
-  and restart the daemon so the channel reloads config.
+## Diagnostics, Kill Switches & Self-Maintenance
 
-## LLM Providers
-
-Netclaw routes chat completions through configured **provider entries** in
-`secrets.json` / `netclaw.json`. Each entry has a logical name (operator-chosen)
-and a `type` (well-known identifier). Manage them with `netclaw provider`:
-
-| Subcommand | Purpose |
-|------------|---------|
-| `netclaw provider list` | Show configured entries and their types |
-| `netclaw provider add <name> <type> [...flags]` | Add a new entry |
-| `netclaw provider remove <name>` | Delete an entry |
-| `netclaw provider rename <old> <new>` | Rename without re-authenticating |
-| `netclaw provider` (no args) | Interactive TUI for add/edit/delete |
-
-### Supported provider types
-
-| Type | Auth | Notes |
-|------|------|-------|
-| `ollama` | Endpoint only | `--endpoint http://host:11434` |
-| `openai` | API key **or** OAuth (ChatGPT sub) | Codex backend for OAuth path |
-| `openai-compatible` | Endpoint; optional API key | Generic OpenAI-shape proxies, llama.cpp, vLLM. Also DwarfStar (ds4): `--endpoint http://127.0.0.1:8000`, run `ds4-server` separately, model ids `deepseek-v4-flash` / `deepseek-v4-pro`, context window auto-detected |
-| `anthropic` | API key | `sk-ant-...` |
-| `openrouter` | API key | `sk-or-...` |
-| `github-copilot` | OAuth device flow only | Requires active Copilot subscription on the GitHub account |
-| `veniceai` | API key | OpenAI-compatible at `https://api.venice.ai/api/v1`. Suppresses Venice's prepended system prompt by default; opt in via `VendorOptions.IncludeVeniceSystemPrompt = true` |
-
-Provider-specific behavior toggles belong under
-`Providers.<name>.VendorOptions`. Netclaw keeps that bag opaque at the core
-config layer; each provider plugin deserializes and validates its own typed
-options instead of adding provider-specific properties to `ProviderEntry`.
-
-For OpenAI ChatGPT subscription auth, Netclaw persists the OAuth access token,
-refresh token, and ChatGPT account ID returned by the OpenAI ID token. The
-account ID is required by the Codex backend. If OpenAI OAuth validation reports
-that the account ID is missing, re-authenticate the provider with `netclaw
-provider fix <name>` or remove and add it again. API-key OpenAI auth does not
-use the Codex backend or this account-ID metadata.
-
-For `openai` OAuth providers, `netclaw model discover <provider>` queries the
-Codex backend model catalog with the OAuth bearer token and
-`ChatGPT-Account-Id`. This path is fail-closed: if the live catalog is
-unavailable, returns no picker-visible models, or omits context-window or
-input-modality metadata, Netclaw reports the provider error instead of using a
-stale built-in model list. The catalog query's `client_version` tracks the
-official `@openai/codex` release version, not Netclaw's own version, because the
-Codex backend uses that value to gate newer model entries.
-
-When adding an OpenAI provider from the CLI, `netclaw provider add <name>
-openai` defaults to the ChatGPT OAuth device flow. Use `--auth api-key
---api-key <key>` to force platform API-key auth instead.
-
-### Adding GitHub Copilot
-
-GitHub Copilot uses the OAuth device flow only — no API key. The operator
-must have an active personal Copilot subscription. From the CLI:
-
-```bash
-netclaw provider add my-copilot github-copilot --auth oauth-device
-```
-
-The terminal prints a user code and the URL `https://github.com/login/device`.
-The operator opens the URL in a browser, enters the code, and approves the
-Netclaw GitHub App. On success, the long-lived GitHub OAuth token is
-persisted to `secrets.json`. A short-lived (~30 min) Copilot API token is
-minted lazily on each chat request and never written to disk.
-
-If a Copilot probe or chat call returns "GitHub Copilot authorization
-expired", the stored OAuth token has been revoked. The remediation is:
-
-```bash
-netclaw provider remove my-copilot
-netclaw provider add my-copilot github-copilot --auth oauth-device
-```
-
-The token is **not** auto-cleared on 401 — the operator retains visibility
-into the failing credential until they explicitly remove the entry.
-
-## Search Providers
-
-The `web_search` and `web_fetch` tools route through one configured search
-backend, selected by `Search.Backend` in `netclaw.json`:
-
-| Backend | Shape | Notes |
-|---------|-------|-------|
-| `SearXng` | Self-hosted | Operator runs the instance; `Search.SearXngEndpoint` points at it. JSON output must be enabled in the instance's `settings.yml`. Authenticated instances are not supported in current releases. |
-| `Brave`   | Managed | Requires `Search.BraveApiKey` in `secrets.json`. |
-| `DuckDuckGo` | Scraped | No config; least reliable, may hit bot detection. |
-
-When a search tool returns an error mentioning `settings.yml`,
-`search.formats`, or "rate limit exceeded", the operator's SearXNG instance
-is misconfigured or being throttled. Point them at the canonical setup
-guide:
-
-```
-https://netclaw.dev/docs/configuration/search-providers/
-```
-
-That page lists the supported `settings.yml` keys, reverse-proxy header
-requirements (Netclaw's outbound `User-Agent` is `Netclaw/{version}
-(+https://netclaw.dev)` — non-empty UAs must pass), and the limiter
-behavior we honor (HTTP 429 + `Retry-After`).
-
-For Brave, an authentication error surfaces as "API authentication failed"
-— the fix is updating `Search.BraveApiKey` in `secrets.json`.
-
-## Diagnostics
-
-When something seems wrong with Netclaw itself:
-
-1. Run `netclaw doctor` via `shell_execute` — validates config, providers,
-   MCP connections, memory health, and recent daemon crash logs
-2. If doctor reports fixable issues, run `netclaw doctor --fix --dry-run` to
-   preview auto-repairs (schema-driven: stale properties, enum coercion, missing defaults)
-3. Run `netclaw status` via `shell_execute` — live runtime state from daemon
-3. Check daemon logs at `~/.netclaw/logs/daemon-{yyyy-MM-dd}.log`
-4. Check session logs at `~/.netclaw/logs/sessions/{sanitized-session-id}/session.log`
-
-Log split:
-
-- Daemon-global diagnostics stay in the daemon log (rolled daily, capped
-  at 10 MB per file).
-- Session-owned diagnostics and session output audit trails append to
-  `~/.netclaw/logs/sessions/{sanitized-session-id}/session.log` —
-  one file per session, no rotation today (see netclaw-dev/netclaw#919).
-- Session log directories use the sanitized session ID (`/`, `.`, spaces,
-  etc. replaced with `_`). Sub-agent diagnostics roll up into the parent
-  session's `session.log`; you will not find a separate file for a
-  sub-agent run.
-
-What to expect inside `session.log`:
-
-- A single chronological timeline. One actor (`SessionLogActor`) is the
-  only writer per file, so audit lines and diagnostic lines interleave in
-  wall-clock order — useful for reading "what happened, in order" without
-  cross-referencing two files.
-- Two line shapes: session output audit lines (`User:`, `Assistant:`,
-  `Thinking:`, `Tool call:`, `Tool result:`, `Usage:`, `Turn N completed`,
-  etc.) and `Diagnostic:` lines from MEL providers (LLM client, HTTP,
-  retry middleware) emitted under a session diagnostics scope.
-- Best-effort observability. Individual lines may be dropped on transient
-  IO errors and logged at Debug level in the daemon log; this is not a
-  transactional audit trail. Cross-check the daemon log for warnings
-  if a critical line appears missing.
-- Sidecar paths (compaction, title generation, sub-agents, memory
-  distillation) currently bypass the session diagnostics scope, so their
-  internal diagnostics may not appear in `session.log` even though their
-  output audit lines do. Tracked in netclaw-dev/netclaw#920.
-
-| Symptom | Check |
-|---------|-------|
-| No LLM responses | `netclaw doctor`; verify provider credentials |
-| Missing tools | `netclaw mcp list`; check MCP connection state |
-| Memory recall degraded | `netclaw status` memory section |
-| Daemon won't start | crash logs at `~/.netclaw/logs/crash-*.log` |
-| Docker daemon cannot create `/home/netclaw/.netclaw/*` | Official image entrypoint repairs writable bind mounts to UID/GID `1654:1654`; if bypassed or read-only, run `sudo chown -R 1654:1654 <host-data-dir>` or use a Docker named volume |
-| Discord/Slack channel offline | `netclaw status` shows the channel `disconnected` with a reason. Discord may also report `degraded` when Discord.Net says the socket is connected but the gateway is not ready, such as after a resumed session that Netclaw is replacing with a clean reconnect. A misconfigured channel (bad token, missing Discord Message Content intent) degrades only that channel — the daemon keeps running and other channels are unaffected. A transient network failure retries automatically; a config/permission failure stays offline until the operator fixes the config and restarts the daemon. |
-| `command not found` for `netclaw` from shell tool when daemon runs as systemd service | `netclaw doctor` (the **Systemd Unit PATH** check warns when the unit was installed before PATH was baked in) |
-
-If webhook notifications are configured, daemon crash paths emit
-`daemon.crashing` operational alerts with context (PID, reason, and latest known
-session/turn snapshot when available).
-
-Doctor checks include `exposure-mode`, which validates that the `Daemon`
-config section (if present) specifies a supported exposure mode and that
-the corresponding tunnel integration is reachable.
-
-Exposure diagnostics are fail-closed:
-- `reverse-proxy` requires at least one remote authentication path and rejects
-  loopback final hops (`127.0.0.1`, `::1`, `localhost`) because loopback
-  auto-auth is reserved for true local operator traffic.
-- `Daemon.TrustedProxies` entries must be literal IPs or CIDR strings; malformed
-  values fail loudly in schema validation, `netclaw doctor`, and daemon startup.
-- Tunnel-backed modes (`tailscale-serve`, `tailscale-funnel`,
-  `cloudflare-tunnel`) require their local tunnel process by default.
-  `Daemon.SkipTunnelProcessCheck=true` is an explicit opt-in only for sidecar or
-  host-managed tunnel topologies; all other exposure requirements still apply.
-- The `netclaw config` Exposure Mode editor preserves dormant reverse-proxy
-  values in `~/.netclaw/config/editor-state.json` when switching to `local` or a
-  tunnel mode. Runtime-active `Daemon.Host` and `Daemon.TrustedProxies` are
-  removed from `netclaw.json` while inactive so local startup validation remains
-  loopback-only. Treat `editor-state.json` as passive editor state, not daemon
-  configuration.
-
-Network exposure is configured in `netclaw config` → Security & Access →
-Exposure Mode — not in first-run `netclaw init`, which is a minimal bootstrap
-(Provider → Identity → Security Posture → Enabled Features → Health Check).
-The exposure editor offers all five modes — `local`, `reverse-proxy`,
-`tailscale-serve`, `tailscale-funnel`, `cloudflare-tunnel`. Selecting
-`reverse-proxy` collects `Daemon.Host` (must be non-loopback) and
-`Daemon.TrustedProxies` (≥1 entry required, comma-separated). The editor
-refuses to save past the trusted-proxies prompt with an empty list — the same
-minimum the daemon validator enforces at startup — so an operator who does not
-yet know their proxy IP can leave exposure at `local` and set the bind address
-and trusted proxies later once the proxy topology is known.
-
-Config files: `~/.netclaw/config/netclaw.json` (daemon-owned base config,
-including `Daemon.Host`, `Daemon.Port`, `Daemon.ExposureMode`),
-`~/.netclaw/client/config.json` (local CLI endpoint state),
-`~/.netclaw/config/secrets.json` (credentials — never display API keys), and
-`~/.netclaw/config/editor-state.json` (passive config-editor state for dormant
-mode-specific values).
-
-## Feature Kill Switches
-
-Deployment-wide feature flags in `netclaw.json` disable entire subsystems
-for all audiences. Each defaults to `true` (enabled).
-
-| Config path | What it gates |
-|-------------|---------------|
-| `Memory.Enabled` | Recall, extraction, memory tools |
-| `Search.Enabled` | `web_search`, `web_fetch` tools |
-| `SkillSync.Enabled` | `skill_load`, `skill_read_resource`, skill index |
-| `SubAgents.Enabled` | `spawn_agent`, subagent discovery |
-| `Scheduling.Enabled` | Reminder tools, reminder execution, `ReminderManagerActor` startup |
-| `Webhooks.Enabled` | Webhook ingress and webhook tools |
-
-When a subsystem is disabled, its tools are hidden from `search_tools` for
-ALL audiences (not just Public), and direct invocation returns a generic
-denial. Context layers for disabled subsystems return empty content.
-
-The `netclaw init` wizard presents a Feature Selection step for Team and
-Public postures, allowing operators to pre-configure which subsystems are
-active. Personal posture skips this step (all features enabled by default).
+When something is broken, start with `netclaw status`, then `netclaw doctor`. Feature
+kill switches and self-update/health are covered in the reference. Full guidance:
+`skill_read_resource('netclaw-operations', 'references/diagnostics.md')`.
 
 ## Identity
 
@@ -1018,140 +312,35 @@ Your identity is defined by layered files loaded into the session prompt:
 | TOOLING.md | `~/.netclaw/identity/TOOLING.md` (filesystem) | Team/Personal only |
 | Project instructions | `.netclaw/AGENTS.md` etc. in project directory | Team/Personal only |
 
-**AGENTS.md is binary-owned.** The full AGENTS (Team/Personal) contains
-operating rules, autonomy guidance, grounding, search policy, scheduling,
-background shell, subagent delegation, skill reference, identity file paths,
-and memory triage. The Public AGENTS contains only basic operating rules,
-autonomy, grounding, and media attachment guidance — no scheduling, subagent,
-skill, identity-path, memory, search, or background-shell sections.
+**AGENTS.md is binary-owned.** The full AGENTS (Team/Personal) contains operating
+rules, autonomy guidance, grounding, search policy, scheduling, background shell,
+subagent delegation, skill reference, identity file paths, and memory triage. The
+Public AGENTS contains only basic operating rules, autonomy, grounding, and media
+attachment guidance.
 
 SOUL.md and TOOLING.md remain editable on disk:
 - To edit: read the file first with `file_read`, then write with `file_write`.
 - Detail subdirectories: `identity/soul/`, `identity/tooling/`.
 
-**Identity vs memory:** If it should shape every future session → identity
-file. If it should be recalled when relevant → SQLite memory.
+**Identity vs memory — what goes where:**
 
-## Self-Maintenance
+- **Identity files define the agent**: persona, tone, communication style, operating
+  rules, and the foundational user grounding set at init (the user's name, timezone).
+  Edit these only to change *how the agent itself operates*.
+- **Durable facts and preferences about the user** learned or stated over time
+  (favorite things, family, history, working preferences) → **memory**
+  (`store_memory`); they are recalled when relevant. A user asking you to "remember"
+  a preference is a memory write, **not** a SOUL.md edit.
 
-| Action | Command (via `shell_execute`) |
-|--------|-------------------------------|
-| Check for updates | `netclaw update` |
-| Switch update channel (saved) | `netclaw update --channel beta` |
-| Self-diagnose | `netclaw doctor` |
-| Runtime health | `netclaw status` |
-| Memory/token stats | `netclaw stats` |
-| Historical skill usage by method/name | `netclaw stats skills` |
-| List/manage skills | `netclaw skill list` |
-| List past sessions | `netclaw sessions --once` |
-| Inspect reminder history | `netclaw reminder history <id> --last 5` |
-| Permanently delete a reminder | `netclaw reminder delete <id>` |
-
-`netclaw update` preserves daemon ownership. When `netclaw.service` is active or
-enabled as a systemd user service, update restarts it with `systemctl --user`
-instead of launching a detached daemon. If restart fails, inspect
-`systemctl --user status netclaw.service`, then start it manually with
-`systemctl --user start netclaw.service` or fall back to `netclaw daemon start`
-only when no systemd user service owns the daemon.
-
-## Demo AppHost
-
-For "show me Netclaw working end-to-end" or "I want to kick the tires
-without setting up Slack and provider accounts," point the user at the
-self-contained .NET Aspire demo under `samples/Netclaw.Demo.AppHost/`.
-
-```text
-dotnet run --project samples/Netclaw.Demo.AppHost
-```
-
-One command brings up a containerized Mattermost (seeded with admin,
-team, bot, access token, default channel, and a test user), a
-containerized Ollama with `qwen3.5:2b-q4_K_M` pulled and cached, and the
-Netclaw daemon as an Aspire project resource sandboxed via
-`NETCLAW_HOME` so nothing touches a host-installed `~/.netclaw/`.
-Default credentials and the seeded channel name are printed to the
-Aspire dashboard.
-
-Key facts to share with the operator:
-
-- Aspire dashboard at <http://localhost:15294>; Mattermost web UI URL is
-  visible there under the `mattermost` resource's `web` endpoint
-  (port allocated dynamically).
-- Default Mattermost login for the demo's non-admin test user:
-  `testuser` / `TestUser1234!`. Admin is `admin` / `Admin1234!`.
-- The demo launches the `fast` profile by default. It keeps the seeded
-  Mattermost channel on the `public` audience, caps tool loops
-  aggressively, disables Ollama thinking mode, tunes Ollama for
-  single-user local inference, and prewarms the model before the
-  daemon starts.
-- For the heavier tool-rich path, opt into
-  `NETCLAW_DEMO_PROFILE=full dotnet run --project samples/Netclaw.Demo.AppHost`.
-- Daemon binds `127.0.0.1:5299` (not the production default 5199, so
-  it never collides with a host-installed daemon).
-- `fast` is materially quicker on CPU than the old demo path, but GPU is
-  still the best experience; the README documents the
-  `WithGPUSupport(OllamaGpuVendor.Nvidia)` opt-in for snappy demos.
-- Clean reset: `rm -rf samples/Netclaw.Demo.AppHost/.demo-home/` plus
-  `docker volume rm` for the Ollama volume.
-
-The demo is for evaluation, not production. It uses `mattermost-preview`
-(deprecated upstream but self-contained), runs the daemon as a host
-process (containerizing collides with `ExposureMode.Local` + loopback
-auth — see the README's "Why the daemon isn't containerized" section),
-and ships with no custom `netclaw.json` so the default secure posture
-applies.
+When unsure: does it change who the agent *is* or how it operates? → identity file.
+Is it a fact about the user to recall later? → memory.
 
 ## Device Pairing
 
-Remote devices authenticate with the daemon using a two-sided pairing protocol.
+Pair remote devices and manage their access via the pairing flow. Full steps:
+`skill_read_resource('netclaw-operations', 'references/devices.md')`.
 
-### Pairing flow
+## Demo AppHost
 
-**Daemon side** (requires local/SSH access):
-
-```
-shell_execute: netclaw daemon pair
-```
-
-This generates a single-use pairing code (8 chars, 5-minute TTL). The code
-generation endpoint is loopback-only.
-
-If `netclaw daemon pair` fails immediately after an exposure-mode change, run
-`netclaw doctor` and inspect `~/.netclaw/logs/crash-*.log` for the specific
-startup validation failure instead of assuming a generic readiness timeout.
-
-**Client side** (remote device):
-
-```
-shell_execute: netclaw pair https://my-daemon.tail1234.ts.net:5000
-```
-
-The user is prompted for the pairing code. On success, the bearer token is
-saved to `secrets.json` (`DeviceToken` field) and the endpoint is saved to
-`~/.netclaw/client/config.json`.
-
-### Device management
-
-| Action | Command |
-|--------|---------|
-| List paired devices | `netclaw daemon devices` |
-| Revoke a device | `netclaw daemon devices revoke <name>` |
-
-### Security notes
-
-- Codes: single-use, 8 chars from 32-char alphabet (~1.1 trillion
-  combinations), 5-minute TTL
-- Rate limiting: 5 attempts/min/IP; after 10 failures, the IP is blocked for
-  15 minutes
-- When no code is pending, the exchange endpoint returns 404 (invisible to
-  scanners)
-- Tokens are stored as salted SHA-256 hashes on the daemon; the raw token is
-  never persisted server-side
-
-### Config locations
-
-- `~/.netclaw/config/devices.json` — paired device registry (daemon side)
-- `~/.netclaw/config/secrets.json` — `DeviceToken` field (client side, added
-  by `netclaw pair`)
-- `~/.netclaw/config/netclaw.json` — `Daemon` section (`Host`, `Port`,
-  `ExposureMode`)
+To demo or kick the tires on Netclaw end-to-end locally:
+`skill_read_resource('netclaw-operations', 'references/demo-apphost.md')`.

--- a/feeds/skills/.system/files/netclaw-operations/references/demo-apphost.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/demo-apphost.md
@@ -1,0 +1,50 @@
+# Demo AppHost
+
+
+## Demo AppHost
+
+
+For "show me Netclaw working end-to-end" or "I want to kick the tires
+without setting up Slack and provider accounts," point the user at the
+self-contained .NET Aspire demo under `samples/Netclaw.Demo.AppHost/`.
+
+```text
+dotnet run --project samples/Netclaw.Demo.AppHost
+```
+
+One command brings up a containerized Mattermost (seeded with admin,
+team, bot, access token, default channel, and a test user), a
+containerized Ollama with `qwen3.5:2b-q4_K_M` pulled and cached, and the
+Netclaw daemon as an Aspire project resource sandboxed via
+`NETCLAW_HOME` so nothing touches a host-installed `~/.netclaw/`.
+Default credentials and the seeded channel name are printed to the
+Aspire dashboard.
+
+Key facts to share with the operator:
+
+- Aspire dashboard at <http://localhost:15294>; Mattermost web UI URL is
+  visible there under the `mattermost` resource's `web` endpoint
+  (port allocated dynamically).
+- Default Mattermost login for the demo's non-admin test user:
+  `testuser` / `TestUser1234!`. Admin is `admin` / `Admin1234!`.
+- The demo launches the `fast` profile by default. It keeps the seeded
+  Mattermost channel on the `public` audience, caps tool loops
+  aggressively, disables Ollama thinking mode, tunes Ollama for
+  single-user local inference, and prewarms the model before the
+  daemon starts.
+- For the heavier tool-rich path, opt into
+  `NETCLAW_DEMO_PROFILE=full dotnet run --project samples/Netclaw.Demo.AppHost`.
+- Daemon binds `127.0.0.1:5299` (not the production default 5199, so
+  it never collides with a host-installed daemon).
+- `fast` is materially quicker on CPU than the old demo path, but GPU is
+  still the best experience; the README documents the
+  `WithGPUSupport(OllamaGpuVendor.Nvidia)` opt-in for snappy demos.
+- Clean reset: `rm -rf samples/Netclaw.Demo.AppHost/.demo-home/` plus
+  `docker volume rm` for the Ollama volume.
+
+The demo is for evaluation, not production. It uses `mattermost-preview`
+(deprecated upstream but self-contained), runs the daemon as a host
+process (containerizing collides with `ExposureMode.Local` + loopback
+auth — see the README's "Why the daemon isn't containerized" section),
+and ships with no custom `netclaw.json` so the default secure posture
+applies.

--- a/feeds/skills/.system/files/netclaw-operations/references/devices.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/devices.md
@@ -1,0 +1,58 @@
+# Device Pairing
+
+
+## Device Pairing
+
+
+Remote devices authenticate with the daemon using a two-sided pairing protocol.
+
+### Pairing flow
+
+**Daemon side** (requires local/SSH access):
+
+```
+shell_execute: netclaw daemon pair
+```
+
+This generates a single-use pairing code (8 chars, 5-minute TTL). The code
+generation endpoint is loopback-only.
+
+If `netclaw daemon pair` fails immediately after an exposure-mode change, run
+`netclaw doctor` and inspect `~/.netclaw/logs/crash-*.log` for the specific
+startup validation failure instead of assuming a generic readiness timeout.
+
+**Client side** (remote device):
+
+```
+shell_execute: netclaw pair https://my-daemon.tail1234.ts.net:5000
+```
+
+The user is prompted for the pairing code. On success, the bearer token is
+saved to `secrets.json` (`DeviceToken` field) and the endpoint is saved to
+`~/.netclaw/client/config.json`.
+
+### Device management
+
+| Action | Command |
+|--------|---------|
+| List paired devices | `netclaw daemon devices` |
+| Revoke a device | `netclaw daemon devices revoke <name>` |
+
+### Security notes
+
+- Codes: single-use, 8 chars from 32-char alphabet (~1.1 trillion
+  combinations), 5-minute TTL
+- Rate limiting: 5 attempts/min/IP; after 10 failures, the IP is blocked for
+  15 minutes
+- When no code is pending, the exchange endpoint returns 404 (invisible to
+  scanners)
+- Tokens are stored as salted SHA-256 hashes on the daemon; the raw token is
+  never persisted server-side
+
+### Config locations
+
+- `~/.netclaw/config/devices.json` — paired device registry (daemon side)
+- `~/.netclaw/config/secrets.json` — `DeviceToken` field (client side, added
+  by `netclaw pair`)
+- `~/.netclaw/config/netclaw.json` — `Daemon` section (`Host`, `Port`,
+  `ExposureMode`)

--- a/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
@@ -1,0 +1,146 @@
+# Diagnostics, Kill Switches & Self-Maintenance
+
+
+## Diagnostics
+
+
+When something seems wrong with Netclaw itself:
+
+1. Run `netclaw doctor` via `shell_execute` — validates config, providers,
+   MCP connections, memory health, and recent daemon crash logs
+2. If doctor reports fixable issues, run `netclaw doctor --fix --dry-run` to
+   preview auto-repairs (schema-driven: stale properties, enum coercion, missing defaults)
+3. Run `netclaw status` via `shell_execute` — live runtime state from daemon
+3. Check daemon logs at `~/.netclaw/logs/daemon-{yyyy-MM-dd}.log`
+4. Check session logs at `~/.netclaw/logs/sessions/{sanitized-session-id}/session.log`
+
+Log split:
+
+- Daemon-global diagnostics stay in the daemon log (rolled daily, capped
+  at 10 MB per file).
+- Session-owned diagnostics and session output audit trails append to
+  `~/.netclaw/logs/sessions/{sanitized-session-id}/session.log` —
+  one file per session, no rotation today (see netclaw-dev/netclaw#919).
+- Session log directories use the sanitized session ID (`/`, `.`, spaces,
+  etc. replaced with `_`). Sub-agent diagnostics roll up into the parent
+  session's `session.log`; you will not find a separate file for a
+  sub-agent run.
+
+What to expect inside `session.log`:
+
+- A single chronological timeline. One actor (`SessionLogActor`) is the
+  only writer per file, so audit lines and diagnostic lines interleave in
+  wall-clock order — useful for reading "what happened, in order" without
+  cross-referencing two files.
+- Two line shapes: session output audit lines (`User:`, `Assistant:`,
+  `Thinking:`, `Tool call:`, `Tool result:`, `Usage:`, `Turn N completed`,
+  etc.) and `Diagnostic:` lines from MEL providers (LLM client, HTTP,
+  retry middleware) emitted under a session diagnostics scope.
+- Best-effort observability. Individual lines may be dropped on transient
+  IO errors and logged at Debug level in the daemon log; this is not a
+  transactional audit trail. Cross-check the daemon log for warnings
+  if a critical line appears missing.
+- Sidecar paths (compaction, title generation, sub-agents, memory
+  distillation) currently bypass the session diagnostics scope, so their
+  internal diagnostics may not appear in `session.log` even though their
+  output audit lines do. Tracked in netclaw-dev/netclaw#920.
+
+| Symptom | Check |
+|---------|-------|
+| No LLM responses | `netclaw doctor`; verify provider credentials |
+| Missing tools | `netclaw mcp list`; check MCP connection state |
+| Memory recall degraded | `netclaw status` memory section |
+| Daemon won't start | crash logs at `~/.netclaw/logs/crash-*.log` |
+| Docker daemon cannot create `/home/netclaw/.netclaw/*` | Official image entrypoint repairs writable bind mounts to UID/GID `1654:1654`; if bypassed or read-only, run `sudo chown -R 1654:1654 <host-data-dir>` or use a Docker named volume |
+| Discord/Slack channel offline | `netclaw status` shows the channel `disconnected` with a reason. Discord may also report `degraded` when Discord.Net says the socket is connected but the gateway is not ready, such as after a resumed session that Netclaw is replacing with a clean reconnect. A misconfigured channel (bad token, missing Discord Message Content intent) degrades only that channel — the daemon keeps running and other channels are unaffected. A transient network failure retries automatically; a config/permission failure stays offline until the operator fixes the config and restarts the daemon. |
+| `command not found` for `netclaw` from shell tool when daemon runs as systemd service | `netclaw doctor` (the **Systemd Unit PATH** check warns when the unit was installed before PATH was baked in) |
+
+If webhook notifications are configured, daemon crash paths emit
+`daemon.crashing` operational alerts with context (PID, reason, and latest known
+session/turn snapshot when available).
+
+Doctor checks include `exposure-mode`, which validates that the `Daemon`
+config section (if present) specifies a supported exposure mode and that
+the corresponding tunnel integration is reachable.
+
+Exposure diagnostics are fail-closed:
+- `reverse-proxy` requires at least one remote authentication path and rejects
+  loopback final hops (`127.0.0.1`, `::1`, `localhost`) because loopback
+  auto-auth is reserved for true local operator traffic.
+- `Daemon.TrustedProxies` entries must be literal IPs or CIDR strings; malformed
+  values fail loudly in schema validation, `netclaw doctor`, and daemon startup.
+- Tunnel-backed modes (`tailscale-serve`, `tailscale-funnel`,
+  `cloudflare-tunnel`) require their local tunnel process by default.
+  `Daemon.SkipTunnelProcessCheck=true` is an explicit opt-in only for sidecar or
+  host-managed tunnel topologies; all other exposure requirements still apply.
+- The `netclaw config` Exposure Mode editor preserves dormant reverse-proxy
+  values in `~/.netclaw/config/editor-state.json` when switching to `local` or a
+  tunnel mode. Runtime-active `Daemon.Host` and `Daemon.TrustedProxies` are
+  removed from `netclaw.json` while inactive so local startup validation remains
+  loopback-only. Treat `editor-state.json` as passive editor state, not daemon
+  configuration.
+
+Network exposure is configured in `netclaw config` → Security & Access →
+Exposure Mode — not in first-run `netclaw init`, which is a minimal bootstrap
+(Provider → Identity → Security Posture → Enabled Features → Health Check).
+The exposure editor offers all five modes — `local`, `reverse-proxy`,
+`tailscale-serve`, `tailscale-funnel`, `cloudflare-tunnel`. Selecting
+`reverse-proxy` collects `Daemon.Host` (must be non-loopback) and
+`Daemon.TrustedProxies` (≥1 entry required, comma-separated). The editor
+refuses to save past the trusted-proxies prompt with an empty list — the same
+minimum the daemon validator enforces at startup — so an operator who does not
+yet know their proxy IP can leave exposure at `local` and set the bind address
+and trusted proxies later once the proxy topology is known.
+
+Config files: `~/.netclaw/config/netclaw.json` (daemon-owned base config,
+including `Daemon.Host`, `Daemon.Port`, `Daemon.ExposureMode`),
+`~/.netclaw/client/config.json` (local CLI endpoint state),
+`~/.netclaw/config/secrets.json` (credentials — never display API keys), and
+`~/.netclaw/config/editor-state.json` (passive config-editor state for dormant
+mode-specific values).
+
+## Feature Kill Switches
+
+
+Deployment-wide feature flags in `netclaw.json` disable entire subsystems
+for all audiences. Each defaults to `true` (enabled).
+
+| Config path | What it gates |
+|-------------|---------------|
+| `Memory.Enabled` | Recall, extraction, memory tools |
+| `Search.Enabled` | `web_search`, `web_fetch` tools |
+| `SkillSync.Enabled` | `skill_load`, `skill_read_resource`, skill index |
+| `SubAgents.Enabled` | `spawn_agent`, subagent discovery |
+| `Scheduling.Enabled` | Reminder tools, reminder execution, `ReminderManagerActor` startup |
+| `Webhooks.Enabled` | Webhook ingress and webhook tools |
+
+When a subsystem is disabled, its tools are hidden from `search_tools` for
+ALL audiences (not just Public), and direct invocation returns a generic
+denial. Context layers for disabled subsystems return empty content.
+
+The `netclaw init` wizard presents a Feature Selection step for Team and
+Public postures, allowing operators to pre-configure which subsystems are
+active. Personal posture skips this step (all features enabled by default).
+
+## Self-Maintenance
+
+
+| Action | Command (via `shell_execute`) |
+|--------|-------------------------------|
+| Check for updates | `netclaw update` |
+| Switch update channel (saved) | `netclaw update --channel beta` |
+| Self-diagnose | `netclaw doctor` |
+| Runtime health | `netclaw status` |
+| Memory/token stats | `netclaw stats` |
+| Historical skill usage by method/name | `netclaw stats skills` |
+| List/manage skills | `netclaw skill list` |
+| List past sessions | `netclaw sessions --once` |
+| Inspect reminder history | `netclaw reminder history <id> --last 5` |
+| Permanently delete a reminder | `netclaw reminder delete <id>` |
+
+`netclaw update` preserves daemon ownership. When `netclaw.service` is active or
+enabled as a systemd user service, update restarts it with `systemctl --user`
+instead of launching a detached daemon. If restart fails, inspect
+`systemctl --user status netclaw.service`, then start it manually with
+`systemctl --user start netclaw.service` or fall back to `netclaw daemon start`
+only when no systemd user service owns the daemon.

--- a/feeds/skills/.system/files/netclaw-operations/references/projects.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/projects.md
@@ -1,0 +1,34 @@
+# Project Directory
+
+
+## Project Directory
+
+
+Sessions track a **project directory** — the root of the codebase or project
+you are currently working on. When set, the project's identity file (checked in
+order: `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` — first
+match wins) is automatically loaded into the system prompt alongside the global
+SOUL/AGENTS/TOOLING layers.
+
+Use `set_working_directory` to set or change the project directory:
+
+```
+set_working_directory(path: "/home/user/workspaces/akadonic")
+```
+
+Rules:
+
+- The path must be an absolute path to an existing directory
+- The path must be within the session's allowed file access roots
+- Profile-managed: granted to Team and Personal audiences by default, not Public
+- Project identity files are re-read from disk on each `SetSystemPrompt()` call,
+  so edits to the project's `AGENTS.md` take effect on the next project switch
+  or daemon restart
+- The project directory persists across crash/restart via `WorkingContext`
+- The `[working-context]` block includes `project_dir:` so you always know which
+  project is active
+
+The project directory is distinct from the session directory
+(`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for
+state isolation (inbox, media). The project directory is mutable and points to
+the project root.

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -1,0 +1,109 @@
+# LLM & Search Providers
+
+
+## LLM Providers
+
+
+Netclaw routes chat completions through configured **provider entries** in
+`secrets.json` / `netclaw.json`. Each entry has a logical name (operator-chosen)
+and a `type` (well-known identifier). Manage them with `netclaw provider`:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `netclaw provider list` | Show configured entries and their types |
+| `netclaw provider add <name> <type> [...flags]` | Add a new entry |
+| `netclaw provider remove <name>` | Delete an entry |
+| `netclaw provider rename <old> <new>` | Rename without re-authenticating |
+| `netclaw provider` (no args) | Interactive TUI for add/edit/delete |
+
+### Supported provider types
+
+| Type | Auth | Notes |
+|------|------|-------|
+| `ollama` | Endpoint only | `--endpoint http://host:11434` |
+| `openai` | API key **or** OAuth (ChatGPT sub) | Codex backend for OAuth path |
+| `openai-compatible` | Endpoint; optional API key | Generic OpenAI-shape proxies, llama.cpp, vLLM. Also DwarfStar (ds4): `--endpoint http://127.0.0.1:8000`, run `ds4-server` separately, model ids `deepseek-v4-flash` / `deepseek-v4-pro`, context window auto-detected |
+| `anthropic` | API key | `sk-ant-...` |
+| `openrouter` | API key | `sk-or-...` |
+| `github-copilot` | OAuth device flow only | Requires active Copilot subscription on the GitHub account |
+| `veniceai` | API key | OpenAI-compatible at `https://api.venice.ai/api/v1`. Suppresses Venice's prepended system prompt by default; opt in via `VendorOptions.IncludeVeniceSystemPrompt = true` |
+
+Provider-specific behavior toggles belong under
+`Providers.<name>.VendorOptions`. Netclaw keeps that bag opaque at the core
+config layer; each provider plugin deserializes and validates its own typed
+options instead of adding provider-specific properties to `ProviderEntry`.
+
+For OpenAI ChatGPT subscription auth, Netclaw persists the OAuth access token,
+refresh token, and ChatGPT account ID returned by the OpenAI ID token. The
+account ID is required by the Codex backend. If OpenAI OAuth validation reports
+that the account ID is missing, re-authenticate the provider with `netclaw
+provider fix <name>` or remove and add it again. API-key OpenAI auth does not
+use the Codex backend or this account-ID metadata.
+
+For `openai` OAuth providers, `netclaw model discover <provider>` queries the
+Codex backend model catalog with the OAuth bearer token and
+`ChatGPT-Account-Id`. This path is fail-closed: if the live catalog is
+unavailable, returns no picker-visible models, or omits context-window or
+input-modality metadata, Netclaw reports the provider error instead of using a
+stale built-in model list. The catalog query's `client_version` tracks the
+official `@openai/codex` release version, not Netclaw's own version, because the
+Codex backend uses that value to gate newer model entries.
+
+When adding an OpenAI provider from the CLI, `netclaw provider add <name>
+openai` defaults to the ChatGPT OAuth device flow. Use `--auth api-key
+--api-key <key>` to force platform API-key auth instead.
+
+### Adding GitHub Copilot
+
+GitHub Copilot uses the OAuth device flow only — no API key. The operator
+must have an active personal Copilot subscription. From the CLI:
+
+```bash
+netclaw provider add my-copilot github-copilot --auth oauth-device
+```
+
+The terminal prints a user code and the URL `https://github.com/login/device`.
+The operator opens the URL in a browser, enters the code, and approves the
+Netclaw GitHub App. On success, the long-lived GitHub OAuth token is
+persisted to `secrets.json`. A short-lived (~30 min) Copilot API token is
+minted lazily on each chat request and never written to disk.
+
+If a Copilot probe or chat call returns "GitHub Copilot authorization
+expired", the stored OAuth token has been revoked. The remediation is:
+
+```bash
+netclaw provider remove my-copilot
+netclaw provider add my-copilot github-copilot --auth oauth-device
+```
+
+The token is **not** auto-cleared on 401 — the operator retains visibility
+into the failing credential until they explicitly remove the entry.
+
+## Search Providers
+
+
+The `web_search` and `web_fetch` tools route through one configured search
+backend, selected by `Search.Backend` in `netclaw.json`:
+
+| Backend | Shape | Notes |
+|---------|-------|-------|
+| `SearXng` | Self-hosted | Operator runs the instance; `Search.SearXngEndpoint` points at it. JSON output must be enabled in the instance's `settings.yml`. Authenticated instances are not supported in current releases. |
+| `Brave`   | Managed | Requires `Search.BraveApiKey` in `secrets.json`. |
+| `DuckDuckGo` | Scraped | No config; least reliable, may hit bot detection. |
+
+When a search tool returns an error mentioning `settings.yml`,
+`search.formats`, or "rate limit exceeded", the operator's SearXNG instance
+is misconfigured or being throttled. Point them at the canonical setup
+guide:
+
+```
+https://netclaw.dev/docs/configuration/search-providers/
+```
+
+That page lists the supported `settings.yml` keys, reverse-proxy header
+requirements (Netclaw's outbound `User-Agent` is `Netclaw/{version}
+(+https://netclaw.dev)` — non-empty UAs must pass), and the limiter
+behavior we honor (HTTP 429 + `Retry-After`).
+
+For Brave, an authentication error surfaces as "API authentication failed"
+— the fix is updating `Search.BraveApiKey` in `secrets.json`.

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -1,0 +1,247 @@
+# Scheduling & Background Jobs
+
+Scheduling is gated on `Scheduling.Enabled` in `netclaw.json` (default `true`).
+When disabled, reminder tools are hidden, `ReminderManagerActor` skips startup
+reconciliation, and fired reminders are acknowledged but not executed. Public
+audience sessions cannot use scheduling tools regardless of the config flag.
+
+`set_reminder` accepts three schedule types:
+
+| Type | Examples |
+|------|---------|
+| `once` | `"30m"`, `"2h"`, `"2026-03-15T14:30:00Z"` |
+| `interval` | `"30m"`, `"6h"`, `"1d"` |
+| `cron` | `"0 */6 * * *"`, `"0 9 * * MON-FRI"` |
+
+Delivery contract parameters:
+
+- `delivery_kind`: required, one of `current_session`, `channel`, `none`
+- `delivery_transport`: required when `delivery_kind=channel` (e.g. `slack`, `discord`, `mattermost`)
+- `delivery_address`: required when `delivery_kind=channel` (`#channel`, `@user`, or canonical ID)
+- `delivery_required`: optional bool, default `true`; set `false` only for audit/cleanup tasks
+- `delivery_instructions`: optional content guidance only (never routing)
+- `expires_in`: optional recurring-reminder expiry duration (for `interval`/`cron` only), e.g. `"24h"`, `"7d"`
+
+You may also pass the structured form `delivery: { kind, transport?, address? }`
+instead of the three flat delivery fields.
+
+Rules:
+
+- Always choose `delivery_kind` explicitly.
+- Do not try to route via `delivery_instructions`.
+- `current_session` is the session check-back path and should be preferred for
+  conversational follow-ups in Slack/TUI/SignalR sessions.
+- `channel` requires both transport + address and resolves names/handles to
+  canonical IDs at set time; unresolved targets fail loud.
+- `none` runs silently (history still records execution).
+- `expires_in` is not valid for `once` reminders; omit it for one-shot schedules.
+- For recurring reminders that are permanently complete (PR merged, deploy done,
+  incident resolved), call `cancel_reminder` with that reminder's ID so it does
+  not keep firing indefinitely.
+
+`cancel_reminder` **disables** the reminder — it stops future executions but
+preserves the definition file on disk for diagnosis and re-enablement. To
+permanently delete a reminder and its history, use the CLI:
+
+```
+netclaw reminder delete <id>
+```
+
+The `cancel` CLI subcommand mirrors the tool behavior (disable only):
+
+```
+netclaw reminder cancel <id>     # disable, keep definition
+netclaw reminder delete <id>     # permanent delete + history
+```
+
+Reminders that hit 5 consecutive execution failures are auto-disabled with a
+`ReminderAutoDisabled` critical alert. The definition stays on disk so the
+operator can diagnose and re-enable after fixing the root cause.
+
+If `audience` is omitted during conversational scheduling, the reminder inherits
+the audience of the channel/session that created it. A reminder cannot be
+minted with broader audience than the creator currently holds; lowering the
+audience is always allowed.
+
+Other scheduling tools: `list_reminders`, `cancel_reminder`,
+`get_reminder_history`.
+
+## Proactive channel messaging
+
+To start a brand-new conversation on a chat channel — a `delivery_kind=channel`
+reminder firing, or unprompted cross-channel outreach ("let the team know") —
+use the generic proactive-post tool:
+
+- `send_channel_message(channel_key, destination, text)` posts through the
+  selected enabled channel and creates a new conversation thread when that
+  channel supports it.
+- `destination` must be a resolved object with `channel_key`, `kind`, and `id`.
+  Do not pass bare display names like `#general` or `@alice`.
+- `destination.kind="destination"` posts to a channel/destination ID returned by
+  `lookup_channel_destination`.
+- `destination.kind="direct_message"` sends a DM using the stable user ID from
+  `lookup_channel_user`; this is supported only by channels that advertise DM
+  output (Slack, Discord, and Mattermost when enabled in config).
+- Reminder- and webhook-originated turns may only call `send_channel_message`
+  against the delivery target configured on the reminder or webhook route. If a
+  trigger turn has no configured target, Netclaw fails loud instead of choosing a
+  default output channel.
+
+Use the generic lookup tools before sending when you do not already have a
+stable channel/user ID:
+
+- `lookup_channel_user(channel_key, query)` resolves users on enabled channels
+  that support user lookup, currently Slack, Discord, and Mattermost.
+- `lookup_channel_destination(channel_key, query)` resolves destinations on
+  enabled channels that support destination lookup. Slack can resolve channel
+  names and IDs; Discord can resolve channel mentions, stable IDs, and cached
+  text-channel names; Mattermost requires an exact channel ID.
+- **Discovery:** call `lookup_channel_destination` with `query` omitted (or
+  blank) to list every destination the channel can currently deliver to —
+  Slack lists the configured allowlist (the resolved default channel plus
+  `AllowedChannelIds`) with display names resolved from the API and archived
+  channels excluded, Discord lists ACL-allowed guild text channels, and
+  Mattermost lists the configured allowlist. Use this to answer "where can I
+  post?" before sending. Listing is destination-only: user directories are
+  unbounded, so `lookup_channel_user` always requires a query.
+
+Both tools require `channel_key` as the first argument. Use the returned
+`channel_key` and `stable_id` exactly; for destination lookups, use the returned
+`address_kind` (`destination`) as `destination.kind`. For user lookups, set
+`destination.kind` to `direct_message` and pass the returned user `stable_id`.
+If lookup is ambiguous, pick from the returned candidates instead of guessing.
+Do not use channel-specific lookup aliases such as `lookup_slack_user` or
+`lookup_mattermost_user`; lookup is intentionally routed through the generic
+channel tools.
+
+Examples:
+
+```
+send_channel_message(
+  channel_key: "slack",
+  destination: { channel_key: "slack", kind: "destination", id: "C0123ABC" },
+  text: "Deployment finished successfully.")
+
+send_channel_message(
+  channel_key: "mattermost",
+  destination: { channel_key: "mattermost", kind: "direct_message", id: "26characterMattermostUserId" },
+  text: "Your report is ready.")
+
+send_channel_message(
+  channel_key: "discord",
+  destination: { channel_key: "discord", kind: "direct_message", id: "123456789012345678" },
+  text: "Your report is ready.")
+```
+
+## Approval Requirements for Reminders and Webhooks
+
+Reminders and webhooks execute without a human present — they CANNOT prompt for
+tool approval. The cwd at firing time will not match any cwd a user clicked
+"Always here" for during interactive use, so folder-scoped approvals will not
+match.
+
+**Before creating a reminder that uses shell commands**, identify the verbs the
+task will need (e.g. `freshdesk`, `curl`, `git pull`) and pre-approve them as
+global wildcards. Two paths:
+
+1. **Suggest `trust-verb` from the agent.** When you (the agent) are helping the
+   user set up a scheduled task, identify the verbs the task will need and ask
+   the user before pre-approving each one. Example:
+
+   > "This reminder will need to call `freshdesk --since=24h` whenever it
+   > fires. Mind if I pre-approve `freshdesk` as a global verb so the reminder
+   > can run unattended? I'll do this with
+   > `netclaw approvals trust-verb freshdesk`."
+
+   On confirmation, run the trust-verb command via `shell_execute`. The grant
+   becomes a `(verb, null)` entry — auto-approved for any cwd.
+
+2. **Operator runs the CLI directly:** `netclaw approvals trust-verb <verb>`.
+   Same outcome; useful when the user already knows what they want.
+
+If the user has already trusted the verb in a previous session, no action is
+needed — `(verb, null)` grants persist in `tool-approvals.json` across daemon
+restarts.
+
+**Path restrictions:** A trusted verb runs wherever the creating audience's
+file-access policy allows — the same scoping `file_write` uses. A Personal
+reminder/webhook (the default when created from a Personal session) has
+unrestricted filesystem access; a Team or Public one is confined to its session
+directory — and cannot run `shell_execute` at all, since shell is Personal-only.
+Protected paths — `secrets.json`, `.netclaw/keys`, `config/webhooks` — are always
+denied regardless of audience or pre-approval.
+
+**If a reminder fails with `command_not_pre_approved`:** The verb is not in the
+approval store as a global wildcard. Run
+`netclaw approvals trust-verb <verb>` and the next firing succeeds.
+
+**If a reminder fails with `path_outside_trust_zone`:** The command targets a
+path outside the allowed roots. Either move the target into a workspace, or ask
+the user to add the path to trusted roots in config.
+
+## Background Jobs
+
+
+A background job is a **detached process with no expectation of completion** —
+use it for anything that outlives a single tool call: long builds, test suites,
+dev servers, watchers. Output streams to the job's log file while it runs, and
+you are notified whenever the process terminates, by whatever cause.
+
+To submit: set `_background: true` in the `shell_execute` tool call metadata.
+Approval gates are evaluated before the job starts. The submit result includes
+the output log path.
+
+Lifecycle:
+
+- **No `_timeout_seconds` = no kill timer.** The job runs until it exits, you
+  cancel it, or the session passivates. A positive `_timeout_seconds` arms an
+  explicit kill timer.
+- **Jobs are killed when the session passivates** (conversation idle past the
+  idle timeout). A job killed this way shows as `reaped` in
+  `[active-background-jobs]` on your next turn — its process is gone; resubmit
+  if still needed (its output log remains readable). For work that must survive
+  an idle conversation, use a scheduled task; check-back reminders also keep
+  the session (and its jobs) alive across a long wait.
+- On daemon restart, running jobs are killed and you receive a `lost`
+  notification with the log path — relaunch if still needed.
+- Process exit (success or failure) delivers a result turn with exit code,
+  output tail, and log path — even if the session was passivated mid-flight.
+
+Monitoring a running job (e.g. waiting for a dev server to come up):
+
+- `file_read`/`grep` the output log — it streams live (secret-redacted,
+  rotation-bounded) at `~/.netclaw/jobs/{id}/output.log`.
+- `check_background_job(JobId: "id")` — status, elapsed time, live output tail
+- Probe the service directly (e.g. curl the port) once the log shows it started.
+- `check_background_job(JobId: "id", Cancel: true)` — cancel a running job.
+  **Cancel servers and watchers when you are done validating** — do not leave
+  them holding one of the 5 concurrent job slots.
+
+Rules:
+
+- Only `shell_execute` supports background mode. Other tools ignore `_background`.
+- `_timeout_seconds` alone does NOT trigger background execution.
+- For synchronous calls `_timeout_seconds` is honored as you set it (no ceiling
+  or floor); when omitted, the default tool timeout applies. Background jobs
+  differ: omitted means no timer at all.
+- Synchronous tool timeouts are wall-clock budgets for opaque tools; repeated
+  stdout/progress output does not extend them. `spawn_agent` is self-monitoring:
+  the parent applies NO timeout to it at all — the subagent owns its liveness end
+  to end (its own prefill/no-progress watchdog reports a stall, and it always
+  returns a final result). A spawned subagent is bounded only by its own internal
+  watchdog or by you cancelling the turn (send another message in the thread).
+- **Long-running delegation calls** (e.g. `curl` to a local coding-agent or
+  model server that takes minutes to respond) should run as background jobs.
+- The user must approve the command before it starts running in the background.
+- Maximum 5 concurrent background jobs; overflow queues FIFO.
+- Job definitions persist to `~/.netclaw/jobs/{id}.json`.
+
+`check_background_job` is only available when shell execution is granted (same
+`shell` grant category). It validates that the requesting session matches the
+submitting session's audience and boundary.
+
+After submitting a long finite job, schedule a check-back reminder so you report
+results proactively when it completes.
+
+Active background jobs appear in the `[active-background-jobs]` section of the
+session context on every turn.

--- a/feeds/skills/.system/files/netclaw-operations/references/secrets.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/secrets.md
@@ -1,0 +1,26 @@
+# Secret Management
+
+
+## Secret Management
+
+
+Secrets live in `~/.netclaw/config/secrets.json`; never print raw values in a
+conversation, issue, PR, or log summary. Use the CLI instead of direct edits:
+
+```bash
+netclaw secrets set Discord:BotToken <replacement>
+netclaw secrets set Slack.BotToken <replacement>
+```
+
+Rules:
+
+- `.` and `:` are both accepted as path delimiters; prefer the documented dotted
+  form unless the operator provides a configuration-style colon path.
+- `netclaw secrets add` is an alias for `set` and overwrites the same effective
+  path.
+- Re-running `netclaw init` on an existing install opens an action menu
+  (`Redo identity setup`, `Open configuration editor`, `Start over from
+  scratch`, `Cancel`) rather than re-walking setup. Update individual secrets
+  with `netclaw secrets set` or the relevant `netclaw config` editor.
+- If a channel reports a 401 or invalid-token error, rotate the relevant secret
+  and restart the daemon so the channel reloads config.

--- a/feeds/skills/.system/files/netclaw-operations/references/skills.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/skills.md
@@ -1,0 +1,33 @@
+# Skill Management
+
+
+## Skill Management
+
+
+The `netclaw skill` CLI manages skills and skill sources. All subcommands
+are offline — no daemon required.
+
+| Command | What it does |
+|---------|--------------|
+| `netclaw skill list` | List all discovered skills with source, version, status |
+| `netclaw skill show <name>` | Show skill metadata and full content |
+| `netclaw skill validate <path>` | Validate a SKILL.md file's frontmatter format |
+| `netclaw skill remove <name>` | Remove a native skill (refuses system/external) |
+| `netclaw skill issues` | Show only scanner issues (rejected items with reasons) |
+| `netclaw skill search <query>` | Search skills by name or description |
+
+### External skill sources
+
+Register additional skill directories (e.g. `~/.claude/skills/`):
+
+| Command | What it does |
+|---------|--------------|
+| `netclaw skill source list` | Show configured external sources |
+| `netclaw skill source add <name> --well-known claude-code` | Add Claude Code skills |
+| `netclaw skill source add <name> --path /shared/skills` | Add a custom directory |
+| `netclaw skill source remove <name>` | Remove a source |
+| `netclaw skill source enable <name>` | Enable a disabled source |
+| `netclaw skill source disable <name>` | Disable without removing |
+
+The daemon's `SkillDirectoryWatcherService` automatically rescans all skill
+directories (native + external) when files change on disk. No restart needed.

--- a/feeds/skills/.system/files/netclaw-operations/references/tools.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/tools.md
@@ -1,0 +1,94 @@
+# Tool Discovery
+
+
+## Tool Discovery
+
+
+MCP tools are not loaded by default. Use `search_tools` to discover them:
+
+```
+search_tools(query: "servers")                  # list all MCP servers
+search_tools(query: "all", server: "notion")    # browse a server's tools
+search_tools(query: "email")                    # keyword search
+```
+
+After discovery, matched tools become callable for the session.
+
+Sessions receive granted tool categories. `builtin` is always granted.
+Other categories (`web`, `file`, `shell`, `scheduling`) depend on ACL
+config. If a tool is missing, it may not be granted for this session.
+
+Built-in tool grants follow the audience and are monotonic (Public ⊆ Team ⊆
+Personal). **Public** sessions get read-only file tools only — `file_read`,
+`file_list`, `attach_file` — and no outbound web access. **Team** adds
+`file_write`, `file_edit`, `web_search`, `web_fetch`, the scheduling tools,
+`skill_manage`, and `set_working_directory`. **Personal** gets everything.
+`shell_execute` is Personal-only — in a Team or Public session, use `file_list`
+to enumerate a directory instead of `ls`.
+
+Tools belonging to disabled subsystems (see [Feature Kill Switches](#feature-kill-switches))
+are hidden from `search_tools` results for all audiences. Public sessions
+additionally cannot discover or load skills, subagents, memory tools,
+scheduling tools, or the `web_search` / `web_fetch` tools regardless of
+feature flags.
+
+### Adding MCP servers (fail-closed by default)
+
+`netclaw mcp add` writes new MCP servers with **zero granted tools** and
+per-audience approval defaults so freshly added servers are never silently
+exposed:
+
+| Audience | Grants | Approval default |
+|----------|--------|------------------|
+| Personal | `[]` (empty list — all tools denied until the operator opts in) | `Approval` |
+| Team     | `[]` | `Approval` |
+| Public   | `[]` | `Deny` |
+
+After `mcp add`, the operator uses `netclaw mcp permissions` — an
+interactive TUI — to grant specific tools and adjust the per-tool or
+per-server approval mode. Bare `netclaw mcp tools` is a read-only CLI view
+of the same state; both commands surface a discoverability hint toward the
+TUI.
+
+Escape hatch: `netclaw mcp add --grant-all` keeps the legacy "null grants
+= all tools pass" behavior for CI. Even with `--grant-all`, the per-audience
+approval defaults (Personal/Team=Approval, Public=Deny) are still written —
+you cannot turn off the approval prompts at `mcp add` time.
+
+Inside the TUI (`netclaw mcp permissions`):
+
+- `Enter` toggles the highlighted tool's grant
+- `A` toggles all tools on/off for the current audience
+- `E` enables/disables the whole server for the current audience
+- `M` cycles the **server default** approval mode (`Auto → Approval → Deny → Auto`)
+- `P` cycles the **highlighted tool's explicit override** (`inherit → Auto → Approval → Deny → inherit`) — `inherit` removes any explicit override so the tool inherits the server default
+- `S` saves pending changes to `netclaw.json`
+- `←/→` cycles the selected audience
+
+Approval-mode resolution precedence (for MCP tools):
+
+1. Exact `ToolOverrides["{server}/{tool}"]` override
+2. `McpServerDefaults[{server}]` default
+3. Fail-closed fallback (Personal audience, shell/file-edit matcher family)
+4. Audience `DefaultMode`
+
+Newly discovered tools on an existing server automatically inherit the
+server default; you do not need to re-run `permissions` after the server
+learns a new tool.
+
+### Migrating existing MCP servers
+
+Servers added to `netclaw.json` before this behavior shipped stay untouched —
+their tool grants, `ApprovalPolicy.McpServerDefaults`, and `ToolOverrides`
+entries are not rewritten during an upgrade.
+
+`netclaw doctor` will emit a warning for each enabled MCP server that
+Personal can reach (`McpServersMode = All`) but has no
+`ApprovalPolicy.McpServerDefaults[server]` entry and no `notion/*`-style
+`ToolOverrides` entry. The warning points at `netclaw mcp permissions`.
+
+To resolve: run `netclaw mcp permissions`, pick the server, switch to the
+Personal audience, press `M` to set a server default (`Approval` is the
+safe choice), `S` to save, then restart the daemon. Repeat for each
+audience you want to tighten. `doctor` stops warning once the default is
+set.

--- a/feeds/skills/.system/files/netclaw-operations/references/webhooks.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/webhooks.md
@@ -1,0 +1,125 @@
+# Webhooks & Inbound Attachments
+
+
+## Webhook Management
+
+
+Webhooks are gated on `Webhooks.Enabled` in `netclaw.json` (default `true`).
+When disabled, the webhook HTTP endpoint returns 404 for all routes and
+webhook tools are hidden from discovery.
+
+Inbound webhooks use a split config model:
+
+- `~/.netclaw/config/netclaw.json` -> `Webhooks.Enabled` toggles the feature
+- `~/.netclaw/config/webhooks/*.json` -> one route per file; filename is the
+  route name used at `/api/webhooks/{route}`
+
+Use the dedicated tools instead of generic file tools when available:
+
+- `set_webhook`
+- `list_webhooks`
+- `delete_webhook`
+
+When using `set_webhook`, use `delivery_required` (bool, default `true`) to
+control required notification behavior. `notify_policy` is deprecated.
+
+`set_webhook` inherits the audience of the channel/session that created it when
+`audience` is omitted — the same provenance model as reminders. A route cannot be
+minted with a broader audience than the creator holds; downgrading is always
+allowed. A webhook created from a Team channel runs as Team (and therefore cannot
+run `shell_execute`); one created from a Personal CLI session runs as Personal.
+
+Route files are secret-bearing config because they may contain inline
+verification secrets. Treat `config/webhooks` like `secrets.json` and avoid
+broad file reads/writes there unless the user explicitly wants raw config work.
+
+Verification kinds are generic:
+
+- `Hmac`
+- `HeaderSecret`
+
+Route files hot-reload without restarting the daemon. If a route file becomes
+invalid, Netclaw removes that route immediately and emits an operational alert.
+
+**Approval gate:** Webhooks run without a human — they cannot prompt for
+approval. The same rules as reminders apply: shell commands must be pre-approved
+in `tool-approvals.json`, and path arguments are scoped by the route's audience
+the same way `file_write` is. See "Approval Requirements for Reminders and
+Webhooks" in the Scheduling section.
+
+### Webhook observability
+
+`netclaw stats` includes a `webhooks:` section with:
+
+- **Route counts** — `total`, `enabled`, `disabled`, `invalid` (files on disk,
+  classified by parse/validation status plus the per-route `Enabled` flag).
+- **Delivery counters** — `accepted`, `filtered` (event not in allowlist),
+  `duplicate` (delivery id already seen), plus per-rejection counts:
+  `404` (route_not_found), `401` (verification_failed), `413` (body_too_large),
+  `400` (invalid_json), `429` (rate_limited).
+
+Every ingress outcome writes a structured line to `daemon-{date}.log`:
+
+```
+Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp}
+  delivery_id={DeliveryId} event_type={EventType}
+```
+
+Rejection paths only log + increment counters — they do NOT fire outbound
+operational notifications, so bad or adversarial traffic does not spam the
+configured notification target.
+
+## Inbound Attachments
+
+
+When a user sends a file in Slack, Discord, or Mattermost, Netclaw runs the
+attachment through an ingress pipeline before it reaches the LLM:
+
+1. **Policy gate** — uses declared MIME plus filename extension for a provisional
+   catalog-backed category, then checks audience and per-message file count
+   against `ChannelAttachmentPolicy`
+2. **Size gate** — rejects files above the per-audience byte limit
+3. **Download** — fetches from Slack's private file API with bot-token auth
+4. **Content scan** — runs the configured `IContentScanner` and produces a
+   scanner-verified canonical MIME type
+5. **Inbox write** — saves to `~/.netclaw/sessions/{session-id}/inbox/`
+6. **Announcement line** — appends `[attachment]` text to the user turn
+
+The `[attachment]` line format is:
+```
+[attachment] name="..." mime="..." size=N path="inbox/..." inlined="true|false"
+```
+
+`inlined="true"` means the file bytes were forwarded to the model as
+`DataContent` (currently image files on image-capable models). `inlined="false"`
+means the model only sees the path reference.
+
+Declared transport MIME is metadata, not proof. Attachment announcements,
+inlined `DataContent`, and model-input handoff use the scanner-verified MIME.
+Unknown image/audio/video subtypes do not get privileged categories by prefix;
+they must be explicitly present in the media catalog. OpenAI-compatible
+providers only serialize image `DataContent` through `image_url` and fail loudly
+if non-image bytes reach that boundary.
+
+`file_read` follows the same file taxonomy as chat attachments. It reads
+text-like files directly, including UTF-8, UTF-16/UTF-32 Unicode text, and
+common Windows-1252 text files. For images, it can load the file for visual
+inspection when the active model or delegated sub-agent supports image input.
+For PDFs, audio/video, archives, binary documents, and unknown binaries, it
+returns metadata plus explicit guidance; it does not perform PDF extraction,
+OCR, transcription, keyframe extraction, or raw binary output.
+
+**Historical thread backfill** follows the same download/scan flow for all
+file types (not just images) — PDFs and other documents from prior thread
+messages are included.
+
+**When attachment ingress fails**, Netclaw posts a stable user-facing message
+(e.g. "Couldn't download `file.pdf` — please try again later.") and logs the
+full exception internally. Exception details are **never** forwarded to Slack.
+
+| Symptom | Check |
+|---------|-------|
+| File rejected before download | audience/category policy gate; check `ChannelAttachmentPolicy` config |
+| Download timeout | bot token valid? Slack network reachable? check `daemon-{date}.log` |
+| Content scan rejection | `netclaw status` scanner section; check scan config |
+| Inbox write failure | disk space? permissions on `~/.netclaw/sessions/`? |

--- a/feeds/skills/.system/files/skill-authoring/SKILL.md
+++ b/feeds/skills/.system/files/skill-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: skill-authoring
 description: "How to create, edit, and manage Netclaw skills. Read this when you need to synthesize a new skill from a session, understand the skill file format, or use the skill_manage tool."
 metadata:
   author: netclaw
-  version: "1.7.0"
+  version: "1.7.1"
 ---
 
 # Skill Authoring
@@ -34,7 +34,7 @@ Create a skill when you notice a **repeating pattern** (done 2+ times):
 
 Do **not** create a skill for:
 - One-time facts or observations (use `store_memory` instead)
-- Personal preferences or profile data (use identity files: SOUL.md, AGENTS.md)
+- Durable user facts or preferences (use `store_memory`, not identity files)
 - Tool availability information (already in the tool index)
 
 ## Skill File Format

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -234,7 +234,7 @@ Identity configuration lives in `{{IDENTITY_DIR}}/`:
 
 | File | Purpose |
 |------|---------|
-| `{{SOUL_PATH}}` | Personality, tone, user profile |
+| `{{SOUL_PATH}}` | Agent personality & tone; foundational user grounding (name, timezone) |
 | `{{AGENTS_PATH}}` | Operating rules, meta-guidance (this file) |
 | `{{TOOLING_PATH}}` | Host environment capabilities |
 
@@ -246,9 +246,10 @@ Keep top-level files concise. For depth, create detail files in matching subdire
 
 | Information Type | Destination |
 |-----------------|-------------|
-| Personal facts (name, family, preferences) | `SOUL.md` |
-| Operating rules, workflow preferences | `AGENTS.md` |
+| Agent personality & tone; user's name/timezone (set at init) | `SOUL.md` |
+| Agent operating rules & conventions | `AGENTS.md` |
 | Environment capabilities, tool configs | `TOOLING.md` |
+| Durable facts & preferences about the user (favorites, family, history, working preferences) | Memory tools (`store_memory`, `find_memories`) |
 | World knowledge, project details, solutions | Memory tools (`store_memory`, `find_memories`) |
 | Procedures, reusable workflows | Skill files in `{{SKILLS_DIR}}/` |
 


### PR DESCRIPTION
## Summary

Decomposes the 1,148-line `netclaw-operations` skill into a **hybrid** progressive-disclosure layout (a variant of #1115) and reconciles the identity-vs-memory routing rule to `openspec/specs/netclaw-agent-memory`.

## Part 1 — Decompose `netclaw-operations` (#1115)

`SKILL.md` drops **1,148 → 346 lines**. Safety-critical / high-frequency guidance stays **inline** (tool-argument validation, large-output handling, the full approval-prompts section, identity routing); the long-tail manuals move into `references/*.md`, surfaced on demand via `skill_read_resource`.

**Why hybrid, not the full split #1115 sketched:** I gated the decomposition on whether the local-tier model (`Qwen3.6-35B-A3B`) reliably does the `skill_load → skill_read_resource` two-hop. It does **~80% of runs** (3/5 clean, 1/5 after thrashing, 1/5 bypassed to a web fetch of the source). For long-tail detail that's fine; for distilled guidance with no external fallback a missed hop = lost guidance — so the high-value content stays inline.

Mechanism verified end-to-end (no runtime/feed changes needed):
- Skill auto-activation keys off the frontmatter `description` (unchanged) — the split does **not** affect activation (`SkillRegistry.GenerateIndex/Search`).
- `references/*.md` are auto-discovered (`SkillScanner.EnumerateResources`) and surfaced by `skill_load`; `skill_read_resource` reads them (scoped to `references/`/`scripts/`/`assets/`).

## Part 2 — Reconcile identity-vs-memory routing

Per `openspec/specs/netclaw-agent-memory`, durable user facts & preferences are **memory documents** (`store_memory`); identity files (`SOUL.md`/`AGENTS.md`) define **the agent**. The binary `AGENTS.md` memory-triage table, `skill-authoring`, and `netclaw-operations` had all routed user "preferences" → `SOUL.md`, contradicting the spec and `netclaw-memory`. The model correctly used `store_memory` and *failed* the old eval. Aligned all four sources.

## Part 3 — Evals

- **Added `skill_progressive_disclosure`** — verifies the `skill_read_resource` second hop via a reference-only detail (the reminder auto-disable threshold/alert name).
- **Repurposed `memory_identity_preference_routing`** to assert the spec-correct invariant: routed to memory, **never** an identity-file edit. **5/5** on the local-tier model.

Version bumps: `netclaw-operations` 2.17.0, `netclaw-memory` 1.5.0, `skill-authoring` 1.7.1. (2.17.0 rather than 2.16.0 because #1481 independently took 2.16.0 on `dev`; this PR is rebased past it and folds its sub-agent-liveness wording into `references/scheduling.md`.)

## Verification

Full rebuild + 55-case eval suite vs `Qwen3.6-35B-A3B` (spark1): tool-calling **8/8**, identity **4/4**, grounding **3/3**, multi-turn **7/7** — no regressions from the split or the always-loaded `AGENTS.md` change. `memory_identity_preference_routing` **5/5** (refined assertion). Remaining suite movement is small-sample model nondeterminism in untouched categories. `skill_progressive_disclosure` lands ~70–80% — the intended ongoing signal for the two-hop read (and the reason for the hybrid layout).

## CI

This is the first multi-file skill, so I hardened `publish_skills.yml`: the post-upload validation previously only spot-checked the first skill's `SKILL.md` URL. It now also fetches a `files[]` (reference) URL from the generated manifest and asserts HTTP 200 — self-verifying that progressive-disclosure reference files actually publish to R2 end-to-end, not just the top-level `SKILL.md`.

Verified the full publish chain on this branch: `generate-skill-manifest.sh` emits `netclaw-operations` v2.17.0 with all 10 `references/*.md` in `files[]` (each with `path`/`sha256`/`sizeBytes`/`url`) and an upload-list entry per file; `publish_skills.yml` uploads every upload-list entry to R2; the consumer (`SkillFeedManifest` / `SystemSkillSyncService`) reads `files[]` with matching field names and downloads + sha256-verifies each reference atomically.

Closes #1115.
