### PR TITLE
fix(tools): allow autonomous sessions to write the workspace directory (#1493)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,19 @@ manifest or installer feed.
   to the primitive defeats the purpose. Use `.Value` for explicit access and
   explicit casts where truly needed. If a value object can silently become a
   string, it provides no more safety than a raw string.
+- **Optional/nullable parameters are rare by default — make dependencies
+  required.** A constructor or method parameter should be optional (nullable or
+  defaulted) only when its absence is a genuine, intended runtime state the
+  callee handles explicitly (a real feature toggle: "no search backend
+  configured" → no web-search tool). NEVER add an optional parameter for
+  backward/source compatibility or to avoid updating call sites — update the
+  call sites instead. This is acute for security-relevant dependencies (path
+  roots, deny-list / access / command policies): a nullable security dependency
+  consumed with `?.` (`_policy?.IsDenied(p) == true`, `if (_policy is not null)`)
+  means a null silently **disables the check** — exactly how trust-zone and
+  privilege-escalation bugs hide. Require it so the type system guarantees it is
+  always present; if it is unconditionally constructed in production, there is no
+  justification for letting it be null.
 - **Comments: skip noise, keep signal.** Don't narrate what code does when
   identifiers already say it (`// increment counter`). Do write comments
   that help a human reviewer scanning in isolation: security gate

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.18.0"
+  version: "2.19.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -164,12 +164,19 @@ needed — `(verb, null)` grants persist in `tool-approvals.json` across daemon
 restarts.
 
 **Path restrictions:** A trusted verb runs wherever the creating audience's
-file-access policy allows — the same scoping `file_write` uses. A Personal
-reminder/webhook (the default when created from a Personal session) has
-unrestricted filesystem access; a Team or Public one is confined to its session
-directory — and cannot run `shell_execute` at all, since shell is Personal-only.
-Protected paths — `secrets.json`, `.netclaw/keys`, `config/webhooks` — are always
-denied regardless of audience or pre-approval.
+file-access policy allows — the same scoping `file_write` uses. Reminders and
+webhooks run autonomously (no live human approver), so even a Personal one is
+confined to an *autonomous zone* rather than the blanket access an interactive
+Personal session gets. Inside that zone it can **read** its session directory,
+the current project, and the shared read roots (skills, identity, workspaces),
+and can **write** to its session directory, the current project, and the
+**workspaces** directory — the designated working area for persisted state, so a
+reminder can keep a dedup/state file there across runs. It cannot write outside
+those — notably not to the system-managed skills or identity trees. A Team or
+Public reminder/webhook is confined to its session directory and cannot run
+`shell_execute` at all, since shell is Personal-only. Protected paths —
+`secrets.json`, `.netclaw/keys`, `config/webhooks` — are always denied regardless
+of audience or pre-approval.
 
 **If a reminder fails with `command_not_pre_approved`:** The verb is not in the
 approval store as a global wildcard. Run

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -14,7 +14,7 @@ namespace Netclaw.Actors.Tests.Tools;
 public class AttachFileToolTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
-    private readonly AttachFileTool _tool = new(new ToolConfig());
+    private readonly AttachFileTool _tool = new(new ToolConfig(), new NetclawPaths());
 
     public void Dispose()
     {

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -111,18 +111,46 @@ public sealed class AutonomousZoneClampTests : IDisposable
     }
 
     [Fact]
-    public void Autonomous_personal_can_read_but_not_write_outside_current_project()
+    public void Autonomous_personal_can_write_workspaces_but_not_identity_or_skills()
     {
-        // Reads reach the non-sensitive global read roots (incl. workspaces), so an
-        // autonomous session can read across the project tree; writes stay confined
-        // to its session + current project, not the whole workspace tree.
+        // The workspace is the operator's designated writable working area, so an
+        // autonomous session may persist cross-run state there (e.g. a dedup file).
+        // Skills and identity are system-managed: readable via the global read
+        // roots, but never writable by an autonomous session — it must not be able
+        // to rewrite its own identity or skills.
         var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
         var ctx = Ctx(TrustAudience.Personal, autonomous: true);
 
-        var sibling = Path.Combine(_paths.WorkspacesDirectory, "other-project", "RELEASE_NOTES.md");
+        var workspaceFile = Path.Combine(_paths.WorkspacesDirectory, "gotowebinar-last-run.json");
+        var identityFile = Path.Combine(_paths.IdentityDirectory, "SOUL.md");
+        var skillFile = Path.Combine(_paths.SkillsDirectory, "netclaw-operations", "SKILL.md");
 
-        Assert.True(policy.TryResolveReadPath(sibling, ctx, out _, out var e), e);
-        Assert.False(policy.TryResolveWritePath(sibling, ctx, out _, out _));
+        // Reads reach all three global read roots.
+        Assert.True(policy.TryResolveReadPath(workspaceFile, ctx, out _, out var er1), er1);
+        Assert.True(policy.TryResolveReadPath(identityFile, ctx, out _, out var er2), er2);
+
+        // Writes reach the workspace but NOT the system-managed identity/skills trees.
+        Assert.True(policy.TryResolveWritePath(workspaceFile, ctx, out _, out var ew1), ew1);
+        Assert.False(policy.TryResolveWritePath(identityFile, ctx, out _, out _));
+        Assert.False(policy.TryResolveWritePath(skillFile, ctx, out _, out _));
+    }
+
+    [Fact]
+    public void Autonomous_personal_can_write_under_configured_custom_workspaces_dir()
+    {
+        // Cross-boundary contract: the daemon passes Workspaces:Directory into
+        // NetclawPaths(workspacesDirectory:), and the autonomous write zone must
+        // honor that configured location — not a hardcoded default — so persisted
+        // state lands where the operator pointed it.
+        var customWorkspaces = Path.Combine(_dir.Path, "custom-ws");
+        Directory.CreateDirectory(customWorkspaces);
+        var paths = new NetclawPaths(_dir.Path, customWorkspaces);
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), paths);
+        var ctx = Ctx(TrustAudience.Personal, autonomous: true);
+
+        var stateFile = Path.Combine(customWorkspaces, "state.json");
+
+        Assert.True(policy.TryResolveWritePath(stateFile, ctx, out _, out var e), e);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -33,7 +33,7 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(baseConfig);
+        registry.WithFirstPartyTools(baseConfig, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
         _executor = new DispatchingToolExecutor(
             registry,
             new ToolAccessPolicy(
@@ -55,7 +55,7 @@ public class DispatchingToolExecutorTests
         restrictedConfig.AudienceProfiles.Team.AllowedTools = ["file_read", "file_list", "file_write", "file_edit", "attach_file", "shell_execute"];
         restrictedConfig.AudienceProfiles.Public.AllowedTools = ["file_read", "file_list", "attach_file"];
         var restrictedRegistry = new ToolRegistry();
-        restrictedRegistry.WithFirstPartyTools(restrictedConfig);
+        restrictedRegistry.WithFirstPartyTools(restrictedConfig, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
         _restrictedExecutor = new DispatchingToolExecutor(
             restrictedRegistry,
             new ToolAccessPolicy(
@@ -329,7 +329,7 @@ public class DispatchingToolExecutorTests
         config.AudienceProfiles.Personal.AllowedTools = ["file_read", "file_write", "attach_file"];
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var executor = new DispatchingToolExecutor(
             registry,
@@ -364,7 +364,7 @@ public class DispatchingToolExecutorTests
         config.AudienceProfiles.Personal.AllowedTools.Add("shell_execute");
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var executor = new DispatchingToolExecutor(
             registry,
@@ -532,7 +532,7 @@ public class DispatchingToolExecutorTests
         var registry = new ToolRegistry();
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-webhook-tools-{Guid.NewGuid():N}"));
         paths.EnsureDirectoriesExist();
-        registry.WithFirstPartyTools(config, toolAccessPolicy: policy, paths: paths, webhookRouteStore: new WebhookRouteStore(paths));
+        registry.WithFirstPartyTools(config, paths: paths, pathPolicy: new ToolPathPolicy([]), shellCommandPolicy: new ShellCommandPolicy(), toolAccessPolicy: policy, webhookRouteStore: new WebhookRouteStore(paths));
 
         var teamContext = new Netclaw.Tools.ToolExecutionContext("slack/thread-1", Path.GetTempPath())
         {
@@ -571,7 +571,7 @@ public class DispatchingToolExecutorTests
         var registry = new ToolRegistry();
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-public-tools-{Guid.NewGuid():N}"));
         paths.EnsureDirectoriesExist();
-        registry.WithFirstPartyTools(config, toolAccessPolicy: policy, paths: paths, webhookRouteStore: new WebhookRouteStore(paths));
+        registry.WithFirstPartyTools(config, paths: paths, pathPolicy: new ToolPathPolicy([]), shellCommandPolicy: new ShellCommandPolicy(), toolAccessPolicy: policy, webhookRouteStore: new WebhookRouteStore(paths));
 
         var publicContext = new Netclaw.Tools.ToolExecutionContext("slack/thread-1", Path.GetTempPath())
         {
@@ -636,7 +636,7 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var system = ActorSystem.Create($"tool-approval-{Guid.NewGuid():N}");
         try
@@ -706,7 +706,7 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var executor = new DispatchingToolExecutor(
             registry,
@@ -762,7 +762,7 @@ public class DispatchingToolExecutorTests
             };
 
             var registry = new ToolRegistry();
-            registry.WithFirstPartyTools(config);
+            registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
             var executor = new DispatchingToolExecutor(
                 registry,
@@ -832,7 +832,7 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var system = ActorSystem.Create($"tool-approval-filtered-once-{Guid.NewGuid():N}");
         try
@@ -909,7 +909,7 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var tempFile = Path.GetTempFileName();
         var system = ActorSystem.Create($"tool-approval-audit-{Guid.NewGuid():N}");
@@ -970,7 +970,7 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
         var system = ActorSystem.Create($"tool-approval-session-{Guid.NewGuid():N}");
         try

--- a/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
@@ -15,7 +15,7 @@ namespace Netclaw.Actors.Tests.Tools;
 public class FileEditToolTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
-    private readonly FileEditTool _tool = new(new ToolConfig());
+    private readonly FileEditTool _tool = new(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
     private readonly string _sessionDir;
 
     public FileEditToolTests()
@@ -120,7 +120,7 @@ public class FileEditToolTests : IDisposable
         var filePath = Path.Combine(_dir.Path, "secrets.json");
         await File.WriteAllTextAsync(filePath, "secret data", TestContext.Current.CancellationToken);
         var policy = new ToolPathPolicy([filePath]);
-        var tool = new FileEditTool(new ToolConfig(), policy);
+        var tool = new FileEditTool(new ToolConfig(), new NetclawPaths(), policy);
 
         var result = await tool.ExecuteAsync(ToolInput.Create("Path", filePath, "OldString", "secret", "NewString", "public"), CreatePersonalContext(), CancellationToken.None);
 

--- a/src/Netclaw.Actors.Tests/Tools/FileListToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileListToolTests.cs
@@ -15,7 +15,7 @@ namespace Netclaw.Actors.Tests.Tools;
 public sealed class FileListToolTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
-    private readonly FileListTool _tool = new(new ToolConfig());
+    private readonly FileListTool _tool = new(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
     private readonly string _sessionDir;
 
     public FileListToolTests()
@@ -73,7 +73,7 @@ public sealed class FileListToolTests : IDisposable
     {
         var paths = new NetclawPaths(_dir.Path);
         Directory.CreateDirectory(Path.Combine(paths.WorkspacesDirectory, "project-a"));
-        var tool = new FileListTool(new ToolConfig(), paths);
+        var tool = new FileListTool(new ToolConfig(), paths, new ToolPathPolicy([]));
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Path", paths.WorkspacesDirectory), CreateTeamContext(), CancellationToken.None);
@@ -111,7 +111,7 @@ public sealed class FileListToolTests : IDisposable
         Directory.CreateDirectory(protectedDir);
 
         var policy = new ToolPathPolicy([protectedDir]);
-        var tool = new FileListTool(new ToolConfig(), pathPolicy: policy);
+        var tool = new FileListTool(new ToolConfig(), new NetclawPaths(), policy);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Path", protectedDir),
@@ -134,7 +134,7 @@ public sealed class FileListToolTests : IDisposable
         await File.WriteAllTextAsync(visibleFile, "visible", TestContext.Current.CancellationToken);
 
         var policy = new ToolPathPolicy([protectedDir], [protectedFile, protectedDir], [protectedDir]);
-        var tool = new FileListTool(new ToolConfig(), pathPolicy: policy);
+        var tool = new FileListTool(new ToolConfig(), new NetclawPaths(), policy);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Path", _sessionDir),

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -18,7 +18,7 @@ namespace Netclaw.Actors.Tests.Tools;
 public class FileReadToolTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
-    private readonly FileReadTool _tool = new(new ToolConfig());
+    private readonly FileReadTool _tool = new(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
     private readonly string _sessionDir;
 
     public FileReadToolTests()
@@ -221,7 +221,7 @@ public class FileReadToolTests : IDisposable
     [Fact]
     public async Task Large_file_is_truncated_with_continuation_hint()
     {
-        var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 100 });
+        var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 100 }, new NetclawPaths(), new ToolPathPolicy([]));
         var filePath = Path.Combine(_dir.Path, "large.txt");
         await File.WriteAllTextAsync(filePath, new string('x', 500), TestContext.Current.CancellationToken);
 
@@ -239,7 +239,7 @@ public class FileReadToolTests : IDisposable
     [Fact]
     public async Task Paginated_read_truncated_by_char_limit_includes_continuation_hint()
     {
-        var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 50 });
+        var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 50 }, new NetclawPaths(), new ToolPathPolicy([]));
         var filePath = Path.Combine(_dir.Path, "paged.txt");
         var lines = Enumerable.Range(1, 20).Select(i => $"Line {i:D2} content here");
         await File.WriteAllLinesAsync(filePath, lines, TestContext.Current.CancellationToken);
@@ -275,7 +275,7 @@ public class FileReadToolTests : IDisposable
         await File.WriteAllTextAsync(filePath, """{"secret": "value"}""", TestContext.Current.CancellationToken);
 
         var policy = new ToolPathPolicy([filePath]);
-        var tool = new FileReadTool(new ToolConfig(), policy);
+        var tool = new FileReadTool(new ToolConfig(), new NetclawPaths(), policy);
         var args = ToolInput.Create("Path", filePath);
 
         var result = await tool.ExecuteAsync(args, CreatePersonalContext(), CancellationToken.None);
@@ -320,7 +320,7 @@ public class FileReadToolTests : IDisposable
         await File.WriteAllTextAsync(skillFile, "# Test Skill", TestContext.Current.CancellationToken);
 
         var paths = new NetclawPaths(_dir.Path);
-        var tool = new FileReadTool(new ToolConfig(), paths: paths);
+        var tool = new FileReadTool(new ToolConfig(), paths, new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Path", skillFile);
         var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
@@ -341,7 +341,7 @@ public class FileReadToolTests : IDisposable
         var scan = SkillScanner.Scan(paths.SkillsDirectory);
         registry.ReplaceAll(scan.AcceptedSkills, scan.Issues);
 
-        var tool = new FileReadTool(new ToolConfig(), paths: paths, skillRegistry: registry, sessionMetrics: metrics);
+        var tool = new FileReadTool(new ToolConfig(), paths, new ToolPathPolicy([]), skillRegistry: registry, sessionMetrics: metrics);
 
         await tool.ExecuteAsync(ToolInput.Create("Path", skillFile), CreateTeamContext(), CancellationToken.None);
 
@@ -359,7 +359,7 @@ public class FileReadToolTests : IDisposable
         var filePath = Path.Combine(_sessionDir, "notes.txt");
         await File.WriteAllTextAsync(filePath, "notes", TestContext.Current.CancellationToken);
 
-        var tool = new FileReadTool(new ToolConfig(), paths: paths, skillRegistry: registry, sessionMetrics: metrics);
+        var tool = new FileReadTool(new ToolConfig(), paths, new ToolPathPolicy([]), skillRegistry: registry, sessionMetrics: metrics);
 
         await tool.ExecuteAsync(ToolInput.Create("Path", filePath), CreatePersonalContext(), CancellationToken.None);
 
@@ -375,7 +375,7 @@ public class FileReadToolTests : IDisposable
         await File.WriteAllTextAsync(soulFile, "# Soul", TestContext.Current.CancellationToken);
 
         var paths = new NetclawPaths(_dir.Path);
-        var tool = new FileReadTool(new ToolConfig(), paths: paths);
+        var tool = new FileReadTool(new ToolConfig(), paths, new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Path", soulFile);
         var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
@@ -391,7 +391,7 @@ public class FileReadToolTests : IDisposable
         await File.WriteAllTextAsync(secretFile, "secret data", TestContext.Current.CancellationToken);
 
         var paths = new NetclawPaths(_dir.Path);
-        var tool = new FileReadTool(new ToolConfig(), paths: paths);
+        var tool = new FileReadTool(new ToolConfig(), paths, new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Path", secretFile);
         var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
@@ -410,7 +410,7 @@ public class FileReadToolTests : IDisposable
         await File.WriteAllTextAsync(skillFile, "# Test Skill", TestContext.Current.CancellationToken);
 
         // No paths injected — no global read roots
-        var tool = new FileReadTool(new ToolConfig());
+        var tool = new FileReadTool(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Path", skillFile);
         var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
@@ -434,7 +434,7 @@ public class FileReadToolTests : IDisposable
             }
         };
         var paths = new NetclawPaths(_dir.Path);
-        var tool = new FileReadTool(config, paths: paths);
+        var tool = new FileReadTool(config, paths, new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Path", dataFile);
         var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
@@ -458,7 +458,7 @@ public class FileReadToolTests : IDisposable
             }
         };
         // No NetclawPaths injected — literal paths should still resolve
-        var tool = new FileReadTool(config);
+        var tool = new FileReadTool(config, new NetclawPaths(), new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Path", dataFile);
         var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);

--- a/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
@@ -15,7 +15,7 @@ namespace Netclaw.Actors.Tests.Tools;
 public class FileWriteToolTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
-    private readonly FileWriteTool _tool = new(new ToolConfig());
+    private readonly FileWriteTool _tool = new(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
     private readonly string _sessionDir;
 
     public FileWriteToolTests()
@@ -100,7 +100,7 @@ public class FileWriteToolTests : IDisposable
     {
         var filePath = Path.Combine(_dir.Path, "secrets.json");
         var policy = new ToolPathPolicy([filePath]);
-        var tool = new FileWriteTool(new ToolConfig(), policy);
+        var tool = new FileWriteTool(new ToolConfig(), new NetclawPaths(), policy);
 
         var args = ToolInput.Create("Path", filePath, "Content", "malicious content");
 

--- a/src/Netclaw.Actors.Tests/Tools/GeneratedToolSchemaMetaTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/GeneratedToolSchemaMetaTests.cs
@@ -16,7 +16,7 @@ public class GeneratedToolSchemaMetaTests
     [Fact]
     public void Generated_schema_includes_rationale_as_required_string()
     {
-        var tool = new FileReadTool(new ToolConfig());
+        var tool = new FileReadTool(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]));
         var schema = tool.ParameterSchema;
         var props = schema.GetProperty("properties");
 
@@ -31,7 +31,7 @@ public class GeneratedToolSchemaMetaTests
     [Fact]
     public void Generated_schema_includes_timeout_seconds_as_optional_integer()
     {
-        var tool = new FileReadTool(new ToolConfig());
+        var tool = new FileReadTool(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]));
         var schema = tool.ParameterSchema;
         var props = schema.GetProperty("properties");
 
@@ -46,7 +46,7 @@ public class GeneratedToolSchemaMetaTests
     [Fact]
     public void Generated_schema_includes_background_as_optional_boolean()
     {
-        var tool = new FileReadTool(new ToolConfig());
+        var tool = new FileReadTool(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]));
         var schema = tool.ParameterSchema;
         var props = schema.GetProperty("properties");
 
@@ -61,7 +61,7 @@ public class GeneratedToolSchemaMetaTests
     [Fact]
     public void Generated_ParseArguments_ignores_meta_fields()
     {
-        var tool = new FileReadTool(new ToolConfig());
+        var tool = new FileReadTool(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]));
         var args = ToolInput.Create("Path", "/tmp/test.txt", "_rationale", "reading config file", "_timeout_seconds", 30, "_background", false);
 
         // ParseArguments should succeed and ignore meta fields

--- a/src/Netclaw.Actors.Tests/Tools/GeneratedToolStrictBindingTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/GeneratedToolStrictBindingTests.cs
@@ -19,7 +19,7 @@ namespace Netclaw.Actors.Tests.Tools;
 /// </summary>
 public class GeneratedToolStrictBindingTests
 {
-    private static FileReadTool NewFileReadTool() => new(new ToolConfig());
+    private static FileReadTool NewFileReadTool() => new(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]));
 
     private static ToolExecutionContext PersonalContext()
         => new("signalr/thread-1", Path.GetTempPath())

--- a/src/Netclaw.Actors.Tests/Tools/MessyCommandOneTimeApprovalTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/MessyCommandOneTimeApprovalTests.cs
@@ -67,7 +67,7 @@ public sealed class MessyCommandOneTimeApprovalTests : TestKit
             sp.GetRequiredService<EffectivePolicyDefaults>()));
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(toolConfig);
+        registry.WithFirstPartyTools(toolConfig, new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]), new Netclaw.Security.ShellCommandPolicy());
         services.AddSingleton(registry);
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/MetaFieldResolutionTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/MetaFieldResolutionTests.cs
@@ -62,7 +62,7 @@ public class MetaFieldResolutionTests
     public void No_first_party_tool_parameter_collides_with_a_meta_field()
     {
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(new ToolConfig());
+        registry.WithFirstPartyTools(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]), new Netclaw.Security.ShellCommandPolicy());
 
         var collisions = new List<string>();
         foreach (var registration in registry.GetAllRegistrations())

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolStreamingTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolStreamingTests.cs
@@ -14,7 +14,7 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public class ShellToolStreamingTests
 {
-    private readonly ShellTool _tool = new(new ToolConfig());
+    private readonly ShellTool _tool = new(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
     private static async Task<(List<ToolActivityUpdate> Activities, ToolCompletedUpdate? Completion)>
         CollectStreamAsync(ShellTool tool, IDictionary<string, object?> args,
@@ -109,7 +109,7 @@ public class ShellToolStreamingTests
     [Fact]
     public async Task Output_clamping_preserved_in_completion_result()
     {
-        var tool = new ShellTool(new ToolConfig { MaxOutputChars = 100 });
+        var tool = new ShellTool(new ToolConfig { MaxOutputChars = 100 }, new ToolPathPolicy([]), new ShellCommandPolicy());
         // Generate output much larger than the 100-char budget
         var cmd = OperatingSystem.IsWindows()
             ? "for /L %i in (1,1,10000) do @echo %i"
@@ -137,7 +137,7 @@ public class ShellToolStreamingTests
     public async Task Hard_deny_yields_immediate_error_completion()
     {
         var policy = new ShellCommandPolicy(["kill"], []);
-        var tool = new ShellTool(new ToolConfig(), commandPolicy: policy);
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), policy);
         var args = ToolInput.Create("Command", "kill -9 1");
         var (activities, completion) = await CollectStreamAsync(tool, args, ct: TestContext.Current.CancellationToken);
 

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -14,7 +14,7 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public class ShellToolTests
 {
-    private readonly ShellTool _tool = new(new ToolConfig());
+    private readonly ShellTool _tool = new(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
     [Fact]
     public async Task Execute_echo_returns_output()
@@ -48,7 +48,7 @@ public class ShellToolTests
     [Fact]
     public async Task Timeout_kills_long_running_process()
     {
-        var tool = new ShellTool(new ToolConfig());
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
         var args = ToolInput.Create("Command", "sleep 100");
         var context = new ToolExecutionContext("test/thread", Path.GetTempPath())
         {
@@ -64,7 +64,7 @@ public class ShellToolTests
     [Fact]
     public async Task Requested_timeout_overrides_default_timeout()
     {
-        var tool = new ShellTool(new ToolConfig());
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
         var args = ToolInput.Create("Command", "sleep 1");
         var context = new ToolExecutionContext("test/thread", Path.GetTempPath())
         {
@@ -87,7 +87,7 @@ public class ShellToolTests
         // exception. On Unix the command also spawns a background child that
         // inherits stdout/stderr; if the tree kill regresses, that child keeps
         // the pipe write-ends open and the test never completes.
-        var tool = new ShellTool(new ToolConfig());
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
         var command = OperatingSystem.IsWindows()
             ? "ping 127.0.0.1 -n 120 > nul"
             : "sleep 120 & wait";
@@ -111,7 +111,7 @@ public class ShellToolTests
         // inline-budget bound + spill happen centrally in DispatchingToolExecutor
         // (covered by DispatchingToolExecutorTests). `echo` is a builtin on both
         // bash and cmd.exe; a long literal is deterministic on stdout.
-        var tool = new ShellTool(new ToolConfig());
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
         var args = ToolInput.Create("Command", $"echo {new string('x', 200)}");
 
         var result = await tool.ExecuteAsync(args, CancellationToken.None);
@@ -378,7 +378,7 @@ public class ShellToolTests
     {
         var secretsPath = "/home/user/.netclaw/config/secrets.json";
         var policy = new ToolPathPolicy([secretsPath]);
-        var tool = new ShellTool(new ToolConfig(), policy);
+        var tool = new ShellTool(new ToolConfig(), policy, new ShellCommandPolicy());
 
         var args = ToolInput.Create("Command", $"cat {secretsPath}");
 
@@ -394,7 +394,7 @@ public class ShellToolTests
     {
         var secretsPath = "/home/user/.netclaw/config/secrets.json";
         var policy = new ToolPathPolicy([secretsPath]);
-        var tool = new ShellTool(new ToolConfig(), policy);
+        var tool = new ShellTool(new ToolConfig(), policy, new ShellCommandPolicy());
 
         var args = ToolInput.Create("Command", "cat ~/.netclaw/config/*.json");
 
@@ -408,7 +408,7 @@ public class ShellToolTests
     public async Task Hard_deny_blocks_daemon_stop()
     {
         var commandPolicy = new ShellCommandPolicy();
-        var tool = new ShellTool(new ToolConfig(), commandPolicy: commandPolicy);
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), commandPolicy);
 
         var args = ToolInput.Create("Command", "netclaw daemon stop");
         var result = await tool.ExecuteAsync(args, CancellationToken.None);
@@ -420,7 +420,7 @@ public class ShellToolTests
     public async Task Hard_deny_blocks_kill_command()
     {
         var commandPolicy = new ShellCommandPolicy();
-        var tool = new ShellTool(new ToolConfig(), commandPolicy: commandPolicy);
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), commandPolicy);
 
         var args = ToolInput.Create("Command", "kill -9 12345");
         var result = await tool.ExecuteAsync(args, CancellationToken.None);

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -42,7 +42,7 @@ public sealed class ToolApprovalGateTests
     private static INetclawTool ShellTool()
     {
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
-        return new ShellTool(config);
+        return new ShellTool(config, new ToolPathPolicy([]), new ShellCommandPolicy());
     }
 
     [Fact]
@@ -182,8 +182,8 @@ public sealed class ToolApprovalGateTests
             fileApprovalMatcher: new FilePathApprovalMatcher(ControlPlaneRoot));
     }
 
-    private static INetclawTool FileWriteToolInstance() => new FileWriteTool();
-    private static INetclawTool FileEditToolInstance() => new FileEditTool();
+    private static INetclawTool FileWriteToolInstance() => new FileWriteTool(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
+    private static INetclawTool FileEditToolInstance() => new FileEditTool(new ToolConfig(), new NetclawPaths(), new ToolPathPolicy([]));
 
     [Fact]
     public void file_write_to_netclaw_json_requires_approval_under_fail_closed_default()
@@ -742,7 +742,7 @@ public sealed class ToolApprovalGateTests
         };
 
         // Real policy — Personal profile resolves WriteFiles.Mode == All.
-        var trustZone = new ShellTrustZonePolicy(config);
+        var trustZone = new ShellTrustZonePolicy(config, new NetclawPaths());
         var policy = new ToolAccessPolicy(
             config,
             new EffectivePolicyDefaults(

--- a/src/Netclaw.Actors.Tests/Tools/ToolArgumentValidatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolArgumentValidatorTests.cs
@@ -35,7 +35,7 @@ public class ToolArgumentValidatorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
         _executor = new DispatchingToolExecutor(
             registry,
             new ToolAccessPolicy(

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
@@ -293,7 +293,7 @@ public class ToolRegistryTests
         // must not mangle them in either direction.
         var config = new ToolConfig();
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config);
+        registry.WithFirstPartyTools(config, new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]), new Netclaw.Security.ShellCommandPolicy());
 
         Assert.Equal("shell_execute", registry.ToCanonicalName("shell_execute"));
         Assert.Equal("shell_execute", registry.ToLlmFacingName("shell_execute"));

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -28,12 +28,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         [property: Description("Absolute path to the file to attach")] string Path,
         [property: Description("Optional display name for the file")] string? DisplayName = null);
 
-    public AttachFileTool()
-        : this(new ToolConfig())
-    {
-    }
-
-    public AttachFileTool(ToolConfig config, NetclawPaths? paths = null)
+    public AttachFileTool(ToolConfig config, NetclawPaths paths)
     {
         _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
     }

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -33,9 +33,9 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
     {
     }
 
-    public AttachFileTool(ToolConfig config)
+    public AttachFileTool(ToolConfig config, NetclawPaths? paths = null)
     {
-        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+        _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -35,16 +35,16 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
         [property: Description("Replace all occurrences instead of just the first (default: false)")] bool? ReplaceAll = null,
         [property: Description("Full content to write to the file, creating parent directories if needed. Mutually exclusive with OldString/NewString.")] string? Content = null);
 
-    public FileEditTool(ToolPathPolicy? pathPolicy = null)
+    public FileEditTool(ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
     {
         _pathPolicy = pathPolicy;
-        _fileAccessPolicy = new ScopedFileAccessPolicy(new ToolConfig());
+        _fileAccessPolicy = new ScopedFileAccessPolicy(new ToolConfig(), paths);
     }
 
-    public FileEditTool(ToolConfig config, ToolPathPolicy? pathPolicy = null)
+    public FileEditTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
     {
         _pathPolicy = pathPolicy;
-        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+        _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -25,7 +25,7 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
 {
     public const string ToolName = "file_edit";
 
-    private readonly ToolPathPolicy? _pathPolicy;
+    private readonly ToolPathPolicy _pathPolicy;
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
 
     public record Params(
@@ -35,13 +35,7 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
         [property: Description("Replace all occurrences instead of just the first (default: false)")] bool? ReplaceAll = null,
         [property: Description("Full content to write to the file, creating parent directories if needed. Mutually exclusive with OldString/NewString.")] string? Content = null);
 
-    public FileEditTool(ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
-    {
-        _pathPolicy = pathPolicy;
-        _fileAccessPolicy = new ScopedFileAccessPolicy(new ToolConfig(), paths);
-    }
-
-    public FileEditTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
+    public FileEditTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)
     {
         _pathPolicy = pathPolicy;
         _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
@@ -83,7 +77,7 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
         if (!_fileAccessPolicy.TryResolveWritePath(path, context, out var authorizedPath, out var accessError))
             return accessError;
 
-        if (_pathPolicy?.IsDenied(authorizedPath) == true)
+        if (_pathPolicy.IsDenied(authorizedPath))
             return FileToolErrors.ControlPlaneWriteDenied(authorizedPath);
 
         try
@@ -115,7 +109,7 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
         if (!_fileAccessPolicy.TryResolveWritePath(path, context, out var authorizedPath, out var accessError))
             return accessError;
 
-        if (_pathPolicy?.IsDenied(authorizedPath) == true)
+        if (_pathPolicy.IsDenied(authorizedPath))
             return FileToolErrors.ControlPlaneWriteDenied(authorizedPath);
 
         if (!File.Exists(authorizedPath))

--- a/src/Netclaw.Actors/Tools/FileListTool.cs
+++ b/src/Netclaw.Actors/Tools/FileListTool.cs
@@ -27,12 +27,12 @@ public sealed partial class FileListTool : NetclawTool<FileListTool.Params>
     private const int MaxEntries = 1000;
 
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
-    private readonly ToolPathPolicy? _pathPolicy;
+    private readonly ToolPathPolicy _pathPolicy;
 
     public record Params(
         [property: Description("Absolute path to the directory to list")] string Path);
 
-    public FileListTool(ToolConfig config, NetclawPaths? paths = null, ToolPathPolicy? pathPolicy = null)
+    public FileListTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)
     {
         _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
         _pathPolicy = pathPolicy;
@@ -52,7 +52,7 @@ public sealed partial class FileListTool : NetclawTool<FileListTool.Params>
         if (!_fileAccessPolicy.TryResolveReadPath(args.Path, context, out var authorizedPath, out var accessError))
             return Task.FromResult(accessError);
 
-        if (_pathPolicy?.IsReadDenied(authorizedPath) == true)
+        if (_pathPolicy.IsReadDenied(authorizedPath))
             return Task.FromResult(FileToolErrors.CredentialReadDenied(authorizedPath));
 
         if (!Directory.Exists(authorizedPath))

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -36,7 +36,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     public override bool SuppressOutputRedaction => true;
 
     private readonly ToolConfig _config;
-    private readonly ToolPathPolicy? _pathPolicy;
+    private readonly ToolPathPolicy _pathPolicy;
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
     private readonly SkillRegistry? _skillRegistry;
     private readonly ISessionMetrics? _sessionMetrics;
@@ -49,8 +49,8 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
     public FileReadTool(
         ToolConfig config,
-        ToolPathPolicy? pathPolicy = null,
-        NetclawPaths? paths = null,
+        NetclawPaths paths,
+        ToolPathPolicy pathPolicy,
         SkillRegistry? skillRegistry = null,
         ISessionMetrics? sessionMetrics = null,
         ILogger<FileReadTool>? logger = null)
@@ -74,7 +74,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         if (!_fileAccessPolicy.TryResolveReadPath(args.Path, context, out var authorizedPath, out var accessError))
             return accessError;
 
-        if (_pathPolicy?.IsReadDenied(authorizedPath) == true)
+        if (_pathPolicy.IsReadDenied(authorizedPath))
             return FileToolErrors.CredentialReadDenied(authorizedPath);
 
         if (!File.Exists(authorizedPath))

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -29,14 +29,14 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
         [property: Description("Absolute path to the file to write")] string Path,
         [property: Description("Content to write to the file")] string Content);
 
-    public FileWriteTool(ToolPathPolicy? pathPolicy = null)
+    public FileWriteTool(ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
     {
-        _editTool = new FileEditTool(pathPolicy);
+        _editTool = new FileEditTool(pathPolicy, paths);
     }
 
-    public FileWriteTool(ToolConfig config, ToolPathPolicy? pathPolicy = null)
+    public FileWriteTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
     {
-        _editTool = new FileEditTool(config, pathPolicy);
+        _editTool = new FileEditTool(config, pathPolicy, paths);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -29,14 +29,9 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
         [property: Description("Absolute path to the file to write")] string Path,
         [property: Description("Content to write to the file")] string Content);
 
-    public FileWriteTool(ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
+    public FileWriteTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)
     {
-        _editTool = new FileEditTool(pathPolicy, paths);
-    }
-
-    public FileWriteTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
-    {
-        _editTool = new FileEditTool(config, pathPolicy, paths);
+        _editTool = new FileEditTool(config, paths, pathPolicy);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -13,6 +13,7 @@ internal sealed class ScopedFileAccessPolicy
 {
     private readonly ToolAudienceProfileResolver _profileResolver;
     private readonly Lazy<IReadOnlyList<string>> _cachedGlobalReadRoots;
+    private readonly Lazy<string?> _cachedWorkspacesRoot;
 
     public ScopedFileAccessPolicy(ToolConfig toolConfig, NetclawPaths? paths = null)
     {
@@ -22,6 +23,11 @@ internal sealed class ScopedFileAccessPolicy
                 .Select(PathUtility.Normalize)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray());
+        _cachedWorkspacesRoot = new Lazy<string?>(() =>
+        {
+            var workspaces = _profileResolver.ResolveWorkspacesDirectory();
+            return string.IsNullOrWhiteSpace(workspaces) ? null : PathUtility.Normalize(workspaces);
+        });
     }
 
     public bool TryResolveReadPath(string rawPath, ToolExecutionContext context, out string fullPath, out string error)
@@ -191,12 +197,16 @@ internal sealed class ScopedFileAccessPolicy
     /// <summary>
     /// Resolves the autonomous filesystem zone from the data already on the
     /// execution context: the per-session directory and the current project
-    /// directory. Write/attach access is confined to those; read access additionally
-    /// includes the non-sensitive global read roots (skills, identity, workspaces)
-    /// that interactive non-Public audiences already receive, so an autonomous
-    /// session can still read across the project tree but only write within its
-    /// session or current project. No additional plumbing — both fields and the
-    /// cached read roots already exist on this policy.
+    /// directory, always present for both reads and writes. Read access
+    /// additionally includes the non-sensitive global read roots (skills,
+    /// identity, workspaces). Write/attach access additionally includes the
+    /// configured <em>workspaces</em> directory only — the operator's designated
+    /// writable working area — but NOT skills/identity, which are system-managed
+    /// (an autonomous session must never rewrite its own identity or skills).
+    /// Plain file writes are not gated by the interactive approval system, so
+    /// confining them to session+project blocked legitimate cross-run state in
+    /// the workspace without a security benefit. No additional plumbing — the
+    /// cached read roots and workspaces root already exist on this policy.
     /// </summary>
     private IReadOnlyList<string> ResolveAutonomousZone(ToolExecutionContext context, AccessKind accessKind)
     {
@@ -210,6 +220,8 @@ internal sealed class ScopedFileAccessPolicy
 
         if (accessKind == AccessKind.Read)
             roots.AddRange(_cachedGlobalReadRoots.Value);
+        else if (_cachedWorkspacesRoot.Value is { } workspacesRoot)
+            roots.Add(workspacesRoot);
 
         return roots
             .Select(PathUtility.Normalize)

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -15,7 +15,10 @@ internal sealed class ScopedFileAccessPolicy
     private readonly Lazy<IReadOnlyList<string>> _cachedGlobalReadRoots;
     private readonly Lazy<string?> _cachedWorkspacesRoot;
 
-    public ScopedFileAccessPolicy(ToolConfig toolConfig, NetclawPaths? paths = null)
+    // paths is required (not nullable): the workspaces/global-read roots are
+    // sourced from it, and a null would silently drop them — the exact silent
+    // fallback that let autonomous workspace access break unnoticed (#1493).
+    public ScopedFileAccessPolicy(ToolConfig toolConfig, NetclawPaths paths)
     {
         _profileResolver = new ToolAudienceProfileResolver(toolConfig, paths);
         _cachedGlobalReadRoots = new Lazy<IReadOnlyList<string>>(() =>

--- a/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
@@ -36,9 +36,9 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
         [property: Description("Absolute path to the project root directory.")]
         string Path);
 
-    public SetWorkingDirectoryTool(ToolConfig config)
+    public SetWorkingDirectoryTool(ToolConfig config, NetclawPaths? paths = null)
     {
-        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+        _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
     }
 
     protected override Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
@@ -36,7 +36,7 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
         [property: Description("Absolute path to the project root directory.")]
         string Path);
 
-    public SetWorkingDirectoryTool(ToolConfig config, NetclawPaths? paths = null)
+    public SetWorkingDirectoryTool(ToolConfig config, NetclawPaths paths)
     {
         _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
     }

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -41,14 +41,14 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
     public override int InlineOutputBudgetChars => 2000;
 
     private readonly ToolConfig _config;
-    private readonly ToolPathPolicy? _pathPolicy;
-    private readonly ShellCommandPolicy? _commandPolicy;
+    private readonly ToolPathPolicy _pathPolicy;
+    private readonly ShellCommandPolicy _commandPolicy;
 
     public record Params(
         [property: Description("The shell command to execute")] string Command,
         [property: Description("Working directory to run the command in (optional)")] string? WorkingDirectory = null);
 
-    public ShellTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, ShellCommandPolicy? commandPolicy = null)
+    public ShellTool(ToolConfig config, ToolPathPolicy pathPolicy, ShellCommandPolicy commandPolicy)
     {
         _config = config;
         _pathPolicy = pathPolicy;
@@ -63,14 +63,11 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         if (string.IsNullOrWhiteSpace(args.Command))
             return "Error: 'command' parameter is required.";
 
-        if (_commandPolicy is not null)
-        {
-            var commandDecision = _commandPolicy.Evaluate(args.Command);
-            if (!commandDecision.Allowed)
-                return $"Error: Command blocked by hard deny policy: {commandDecision.DenyReason}";
-        }
+        var commandDecision = _commandPolicy.Evaluate(args.Command);
+        if (!commandDecision.Allowed)
+            return $"Error: Command blocked by hard deny policy: {commandDecision.DenyReason}";
 
-        if (_pathPolicy?.CommandReferencesDeniedPath(args.Command, args.WorkingDirectory) == true)
+        if (_pathPolicy.CommandReferencesDeniedPath(args.Command, args.WorkingDirectory))
             return "Error: Command references a protected file path. Access denied by security policy.";
 
         var isWindows = OperatingSystem.IsWindows();
@@ -296,18 +293,15 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
                 return;
             }
 
-            if (_commandPolicy is not null)
+            var commandDecision = _commandPolicy.Evaluate(args.Command);
+            if (!commandDecision.Allowed)
             {
-                var commandDecision = _commandPolicy.Evaluate(args.Command);
-                if (!commandDecision.Allowed)
-                {
-                    output.TryWrite(new ToolCompletedUpdate(
-                        $"Error: Command blocked by hard deny policy: {commandDecision.DenyReason}"));
-                    return;
-                }
+                output.TryWrite(new ToolCompletedUpdate(
+                    $"Error: Command blocked by hard deny policy: {commandDecision.DenyReason}"));
+                return;
             }
 
-            if (_pathPolicy?.CommandReferencesDeniedPath(args.Command, args.WorkingDirectory) == true)
+            if (_pathPolicy.CommandReferencesDeniedPath(args.Command, args.WorkingDirectory))
             {
                 output.TryWrite(new ToolCompletedUpdate(
                     "Error: Command references a protected file path. Access denied by security policy."));

--- a/src/Netclaw.Actors/Tools/ShellTrustZonePolicy.cs
+++ b/src/Netclaw.Actors/Tools/ShellTrustZonePolicy.cs
@@ -19,7 +19,7 @@ public sealed class ShellTrustZonePolicy : IShellTrustZonePolicy
 {
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
 
-    public ShellTrustZonePolicy(ToolConfig toolConfig, NetclawPaths? paths = null)
+    public ShellTrustZonePolicy(ToolConfig toolConfig, NetclawPaths paths)
     {
         _fileAccessPolicy = new ScopedFileAccessPolicy(toolConfig, paths);
     }

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -65,6 +65,14 @@ internal sealed class ToolAudienceProfileResolver
         return roots;
     }
 
+    /// <summary>
+    /// Resolves the operator-configured workspaces directory — the designated
+    /// writable working area shared across sessions. Returns null when
+    /// <see cref="_paths"/> is unavailable (e.g. a policy constructed without
+    /// paths), so callers fail closed rather than inventing a default root.
+    /// </summary>
+    public string? ResolveWorkspacesDirectory() => _paths?.WorkspacesDirectory;
+
     public bool IsToolAllowed(ToolName toolName, ToolExecutionContext? context)
     {
         if (!IsProfileManagedTool(toolName))

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -38,9 +38,9 @@ public static class ToolRegistrationExtensions
         registry.Register(new ShellTool(config, pathPolicy, shellCommandPolicy));
         registry.Register(new FileReadTool(config, pathPolicy, paths));
         registry.Register(new FileListTool(config, paths, pathPolicy));
-        registry.Register(new FileWriteTool(config, pathPolicy));
-        registry.Register(new FileEditTool(config, pathPolicy));
-        registry.Register(new AttachFileTool(config));
+        registry.Register(new FileWriteTool(config, pathPolicy, paths));
+        registry.Register(new FileEditTool(config, pathPolicy, paths));
+        registry.Register(new AttachFileTool(config, paths));
         if (webhookRouteStore is not null)
         {
             registry.Register(new SetWebhookTool(webhookRouteStore));
@@ -50,7 +50,7 @@ public static class ToolRegistrationExtensions
         if (searchBackend is not null)
             registry.Register(new WebSearchTool(searchBackend));
         registry.Register(new WebFetchTool(config));
-        registry.Register(new SetWorkingDirectoryTool(config));
+        registry.Register(new SetWorkingDirectoryTool(config, paths));
 
         // Register search_tools and load_tool meta-tools (always loaded, "builtin" grant)
         registry.Register(new SearchToolsTool(registry, toolAccessPolicy));

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -28,18 +28,18 @@ public static class ToolRegistrationExtensions
     public static ToolRegistry WithFirstPartyTools(
         this ToolRegistry registry,
         ToolConfig config,
+        NetclawPaths paths,
+        ToolPathPolicy pathPolicy,
+        ShellCommandPolicy shellCommandPolicy,
         ISearchBackend? searchBackend = null,
-        ToolPathPolicy? pathPolicy = null,
-        ShellCommandPolicy? shellCommandPolicy = null,
         ToolAccessPolicy? toolAccessPolicy = null,
-        NetclawPaths? paths = null,
         WebhookRouteStore? webhookRouteStore = null)
     {
         registry.Register(new ShellTool(config, pathPolicy, shellCommandPolicy));
-        registry.Register(new FileReadTool(config, pathPolicy, paths));
+        registry.Register(new FileReadTool(config, paths, pathPolicy));
         registry.Register(new FileListTool(config, paths, pathPolicy));
-        registry.Register(new FileWriteTool(config, pathPolicy, paths));
-        registry.Register(new FileEditTool(config, pathPolicy, paths));
+        registry.Register(new FileWriteTool(config, paths, pathPolicy));
+        registry.Register(new FileEditTool(config, paths, pathPolicy));
         registry.Register(new AttachFileTool(config, paths));
         if (webhookRouteStore is not null)
         {

--- a/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
+++ b/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
@@ -30,7 +30,7 @@ internal static class SkillToolRegistration
         var skillIndexLayer = services.GetRequiredService<SkillIndexContextLayer>();
         var paths = services.GetRequiredService<NetclawPaths>();
         var toolConfig = services.GetRequiredService<ToolConfig>();
-        var pathPolicy = services.GetService<ToolPathPolicy>();
+        var pathPolicy = services.GetRequiredService<ToolPathPolicy>();
         var scanner = services.GetRequiredService<ISkillContentScanner>();
         var externalSources = services.GetRequiredService<IReadOnlyList<ResolvedExternalSource>>();
         var metrics = services.GetService<ISessionMetrics>();
@@ -40,7 +40,7 @@ internal static class SkillToolRegistration
         var skillSyncConfig = services.GetService<SkillSyncConfig>();
         var loggerFactory = services.GetRequiredService<ILoggerFactory>();
 
-        registry.Replace(new FileReadTool(toolConfig, pathPolicy, paths, skillRegistry, metrics,
+        registry.Replace(new FileReadTool(toolConfig, paths, pathPolicy, skillRegistry, metrics,
             loggerFactory.CreateLogger<FileReadTool>()));
 
         registry.WithSkillTools(

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -649,7 +649,7 @@ static void ConfigureDaemonServices(
     services.AddSingleton<IToolApprovalService, AkkaToolApprovalService>();
 
     var toolRegistry = new ToolRegistry();
-    toolRegistry.WithFirstPartyTools(toolConfig, searchBackend, toolPathPolicy, shellCommandPolicy, toolAccessPolicy, paths,
+    toolRegistry.WithFirstPartyTools(toolConfig, paths, toolPathPolicy, shellCommandPolicy, searchBackend, toolAccessPolicy,
         webhooksConfig.Enabled ? webhookRouteStore : null);
 
     // Skills system: seed built-in skills to .system/, register sync service


### PR DESCRIPTION
## What

Fixes #1493. Autonomous (non-interactive) reminder/webhook sessions could not write files under `{workspaces_dir}` — the operator's designated writable working area — even though the workspace exists to be written to. An autonomous reminder that tried to persist a dedup/state file there hit:

> Error: autonomous session may only access files inside its session directory, project directory, or configured autonomous roots.

…then degraded and stalled (a root trigger for the #1492 duplicate-guard hang).

## Root cause (two compounding issues)

1. **By design (over-restriction).** `ScopedFileAccessPolicy.ResolveAutonomousZone` included the global read roots for **reads** but excluded them for **writes/attach** (introduced in #1250). So autonomous writes were confined to session + project only.
2. **Plumbing gap.** `FileWriteTool` / `FileEditTool` / `AttachFileTool` / `SetWorkingDirectoryTool` constructed `ScopedFileAccessPolicy` **without** `NetclawPaths`, leaving the global-roots cache empty — so even read-eligible operations on those tools couldn't resolve `{workspaces_dir}`.

## Fix

- The autonomous **write/attach** zone now additionally includes the configured **workspaces** directory only — **not** the system-managed skills/identity trees, which stay read-only (an autonomous session must never rewrite its own identity or skills).
- `NetclawPaths` is threaded into the four write-side tools (mirroring `FileReadTool`/`FileListTool`), so `{workspaces_dir}` resolves.

The workspaces root is sourced from `NetclawPaths.WorkspacesDirectory`, which the daemon builds from the `Workspaces:Directory` config (`Program.cs:351`) — verified, so writes land where the operator pointed them.

## Tests

- `AutonomousZoneClampTests`: replaced the old "can read but not write workspace" assertion with `Autonomous_personal_can_write_workspaces_but_not_identity_or_skills` (workspace writable; identity/skills denied) and added `Autonomous_personal_can_write_under_configured_custom_workspaces_dir` (cross-boundary contract — honors the configured override).
- Full `Netclaw.Actors.Tests` suite green (2479 passed).
- `dotnet slopwatch analyze`: clean (the 3 warnings are pre-existing, in files this PR doesn't touch); copyright headers verified.

## Skill

Updated `netclaw-operations` (scheduling reference) to describe the autonomous zone accurately, including the now-writable workspace; bumped `metadata.version` 2.18.0 → 2.19.0.

## Gates not run locally

The behavioral eval suite (`./evals/run-evals.sh`) requires a live model endpoint not configured in this environment — should be run in CI / before merge given the skill-content edit.