### PR TITLE
fix(reminders): release the duplicate-execution guard when a Mode A reminder session wedges (#1492)

### DIFF
--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -240,6 +240,44 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
         Assert.True(pipeline.CapturedOptions!.Filter.HasFlag(OutputFilter.ToolCalls));
     }
 
+    [Fact]
+    public async Task Mode_A_wedged_session_is_failed_by_stall_backstop_releasing_the_guard()
+    {
+        // #1492 regression: a Channel-delivery (Mode A) reminder whose session
+        // wedges — stops producing output without ever emitting TurnCompleted or
+        // Error — used to hold the duplicate-execution guard forever (the actor
+        // had no execution ceiling). The stall backstop must conclude it as a
+        // failure so the parent clears _activeExecutions and the next fire runs.
+        var originalTimeout = ReminderExecutionActor.ExecutionStallTimeout;
+        ReminderExecutionActor.ExecutionStallTimeout = TimeSpan.FromMilliseconds(250);
+        try
+        {
+            // Emits one non-terminal output, then goes silent forever — no
+            // TurnCompleted/Error ever arrives.
+            var pipeline = new ScriptedSessionPipeline(sessionId =>
+            [
+                new TextOutput("Working on it...") { SessionId = sessionId }
+            ]);
+
+            var definition = CreateDefinition("mode-a-stall");
+            var probe = CreateTestProbe();
+            Sys.ActorOf(
+                Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore)),
+                "exec-mode-a-stall");
+
+            var completed = await probe.ExpectMsgAsync<ReminderExecutionCompleted>(
+                TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+            Assert.False(completed.Success);
+            Assert.Equal("mode-a-stall", completed.Id.Value);
+            Assert.Contains("stalled", completed.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            ReminderExecutionActor.ExecutionStallTimeout = originalTimeout;
+        }
+    }
+
     private static ReminderDefinition CreateDefinition(string id)
     {
         var now = TimeProvider.System.GetUtcNow();

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -37,6 +37,20 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     /// </summary>
     internal static TimeSpan DeliveryObservedTimeout = TimeSpan.FromHours(1);
 
+    /// <summary>
+    /// Backstop inactivity ceiling for the Mode A (Channel / own-pipeline) path.
+    /// The actor runs its own session pipeline and concludes when it emits
+    /// <c>TurnCompleted</c>/<c>Error</c>; if the session wedges and stops
+    /// producing output without ever reaching a terminal signal, nothing else
+    /// stops this actor, so it would hold the duplicate-execution guard forever
+    /// (see #1492). A <see cref="ReceiveTimeout"/> reset by every session output
+    /// fires after this much silence and concludes the run as failed, releasing
+    /// the guard so the next fire can run. Reset by real output, so it never
+    /// preempts a live turn. Mode B (CurrentSession) does NOT arm this — its wait
+    /// is bounded separately by <see cref="DeliveryObservedTimeout"/>.
+    /// </summary>
+    internal static TimeSpan ExecutionStallTimeout = TimeSpan.FromMinutes(20);
+
     private readonly Guid _executionId;
     private readonly ReminderDefinition _definition;
     private readonly ReminderHistoryStore _historyStore;
@@ -100,6 +114,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         Receive<ExecutionStarted>(_ => { });
         Receive<ReminderDeliveryResult>(HandleDeliveryResult);
         Receive<DeliveryBackstopTimeout>(HandleDeliveryBackstopTimeout);
+        Receive<ReceiveTimeout>(_ => HandleExecutionStall());
     }
 
     protected override void PreStart()
@@ -166,6 +181,13 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             });
 
             inputQueue.Complete();
+
+            // Arm the Mode A stall backstop: the pipeline now streams output to
+            // this actor, each ExecutionOutput resets the ReceiveTimeout, and a
+            // terminal TurnCompleted/Error stops us first. If the session wedges
+            // and goes silent without a terminal signal, this fires and releases
+            // the duplicate-execution guard instead of hanging forever (#1492).
+            Context.SetReceiveTimeout(ExecutionStallTimeout);
         }
         catch (Exception ex)
         {
@@ -541,12 +563,27 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         }
     }
 
+    private void HandleExecutionStall()
+    {
+        if (_completed)
+            return;
+
+        var elapsed = _timeProvider.GetUtcNow() - _dispatchedAt;
+        _log.Warning(
+            "ReminderExecution Stalled: execution_id={0} reminder_id={1} title={2} no session output for {3} (elapsed={4}); concluding as failed to release the execution guard.",
+            _executionId, _definition.Id, _definition.Title, ExecutionStallTimeout, elapsed);
+        ReportAndStop(false, $"Reminder execution stalled: no session output for {ExecutionStallTimeout}.");
+    }
+
     private void ReportAndStop(bool success, string? errorMessage = null)
     {
         if (_completed)
             return;
 
         _completed = true;
+
+        // Disarm the Mode A stall backstop so it cannot fire during the drain.
+        Context.SetReceiveTimeout(null);
 
         var durationMs = (long)(_timeProvider.GetUtcNow() - _dispatchedAt).TotalMilliseconds;
         _pendingHistory = new HistoryRecord(


### PR DESCRIPTION
## What

Fixes #1492. A single stuck reminder execution silently blocked **all** future fires of that reminder — 49 `reminder_skipped_duplicate_execution` events in one day in the reported incident, never recovering.

## Root cause (confirmed Mode A)

The `gotowebinar` reminder used **Channel delivery** (`send_channel_message`) — "Mode A". On that path `ReminderExecutionActor` runs its *own* session pipeline and concludes only when the pipeline emits `TurnCompleted`/`Error`. It had **no execution-level ceiling** (unlike `WebhookExecutionActor`, which sets a `ReceiveTimeout` at line 50). When the session wedged — degraded, stopped calling tools, went silent without ever reaching a terminal signal (the issue notes it was spawning code-analyst sub-agents) — the actor waited **forever**.

`ReminderManagerActor` clears `_activeExecutions` only on `ReminderExecutionCompleted`, so the duplicate-execution guard was held indefinitely and every later fire was skipped.

Existing tests already bracket this: Mode A *completes promptly* on a no-notification turn (`Execution_fails_when_required_policy_and_no_notification_sent`), and Mode B is bounded by the 1-hour `DeliveryObservedTimeout` (`CurrentSession_delivery_required_fails_when_delivery_is_not_observed`). The gap was a Mode A turn that never reaches a terminal signal at all.

## Fix

Arm an inactivity `ReceiveTimeout` (`ExecutionStallTimeout`, default **20m** — a static field mirroring `DeliveryObservedTimeout` so tests can shrink it; no new config/schema knob) on the Mode A path once the pipeline is initialized:

- Every session output **resets** it, so it never preempts a live turn.
- A terminal `TurnCompleted`/`Error` stops the actor first and disarms it.
- If the session goes silent for the window, the actor concludes the run as **failed**, releasing the guard so the next fire runs.

Mode B (CurrentSession) is unchanged — it does **not** arm this backstop (already bounded by `DeliveryObservedTimeout`). `WebhookExecutionActor` already had the equivalent ceiling, so this just brings reminders to parity.

## Test

New regression `Mode_A_wedged_session_is_failed_by_stall_backstop_releasing_the_guard`: drives a Mode A reminder whose pipeline emits one non-terminal output then goes silent, shrinks the timeout, and asserts `ReminderExecutionCompleted(success: false)` arrives via the backstop. Full `Netclaw.Actors.Tests` green (2480); slopwatch + headers pass.

## Follow-up

#1494 makes this failure operator-visible (posts a notice to the destination channel) — without that, a stalled reminder now *recovers* but the operator still isn't told it failed. A manager-side `Terminated` watch (defense-in-depth for a child that crashes without reporting) is a possible separate hardening; not needed for this fix since the actor concludes via `ReportAndStop`.