### PR TITLE
test(sessions): run watchdog tests on Akka TestScheduler to de-flake them

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionStreamingTimeoutTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionStreamingTimeoutTests.cs
@@ -1,9 +1,10 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="LlmSessionStreamingTimeoutTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.AI;
@@ -18,9 +19,20 @@ using static Netclaw.Actors.Sessions.SessionProtocol;
 
 namespace Netclaw.Actors.Tests.Sessions;
 
+/// <summary>
+/// Runs the ActorSystem on <see cref="Akka.TestKit.TestScheduler"/> so the
+/// watchdog's timer fires only on an explicit <c>AdvanceScheduler</c> — no
+/// wall-clock race against threadpool scheduling. The chat client signals when its
+/// streaming method is invoked; that happens strictly after the watchdog is armed,
+/// so the test only advances once the timer exists. The success path advances
+/// nothing, so a healthy stream can never be spuriously timed out under load.
+/// </summary>
 public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : LlmSessionTestBase(output)
 {
+    private static readonly TimeSpan FirstTokenTimeout = TimeSpan.FromSeconds(2);
     private readonly StreamingTimeoutTestChatClient _chatClient = new();
+
+    protected override bool UseTestScheduler => true;
 
     protected override void ConfigureSessionServices(IServiceCollection services)
     {
@@ -32,8 +44,8 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
         });
         services.AddSingleton(new SessionConfig
         {
-            PrefillTimeout = TimeSpan.FromSeconds(2),
-            FirstTokenTimeout = TimeSpan.FromSeconds(2),
+            PrefillTimeout = FirstTokenTimeout,
+            FirstTokenTimeout = FirstTokenTimeout,
             ToolExecutionTimeout = TimeSpan.FromSeconds(10),
             SidecarLlmTimeout = TimeSpan.FromSeconds(10),
             Tuning = new SessionTuning
@@ -67,7 +79,10 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             Content = "hello"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        // FirstTokenTimeout is 2s — should fire within ~3s
+        // The watchdog is armed before the stream is invoked; advance only after.
+        await _chatClient.WaitForStreamInvocationAsync(TestContext.Current.CancellationToken);
+        AdvanceScheduler(FirstTokenTimeout);
+
         var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorCategory.Timeout, error.Category);
         Assert.Contains("timed out", error.Message);
@@ -77,18 +92,24 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
     [Fact]
     public async Task Timeout_resets_on_delta_and_fires_after_silence()
     {
-        // Emit deltas then hang — the unified timeout (2s) resets on each delta,
-        // then fires 2s after the last one
+        // Emit deltas (each resets the liveness budget) then go silent; the timeout
+        // fires one budget after the last delta.
         _chatClient.Mode = StreamMode.EmitThenHang;
 
         var sessionId = new SessionId("streaming-timeout/delta-then-silence");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("delta-silence-sub");
 
+        // Subscribe to streaming deltas so we can observe delta PROCESSING. The
+        // watchdog re-arms on each delta before that delta is emitted, so receiving
+        // the last delta proves the last re-arm has run — only then is it safe to
+        // advance (a delta processed after the advance would re-arm the liveness
+        // timer past it, and the timeout would never fire). ErrorOutput/TurnCompleted
+        // are emitted with no required flag, so they arrive regardless of filter.
         await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
         {
             SessionId = sessionId,
-            Filter = OutputFilter.TextOnly
+            Filter = OutputFilter.TextStreaming
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
 
@@ -98,11 +119,20 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             Content = "hello"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        // Deltas stream, then silence — timeout fires after FirstTokenTimeout (2s) of no activity
-        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(8), cancellationToken: TestContext.Current.CancellationToken);
+        await _chatClient.WaitForStreamInvocationAsync(TestContext.Current.CancellationToken);
+        await subscriber.FishForMessageAsync<object>(
+            m => m is TextDeltaOutput d && d.Delta.Contains("chunk3", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+
+        // The stream is now silent on the virtual clock; advance one budget to fire.
+        AdvanceScheduler(FirstTokenTimeout);
+
+        var error = (ErrorOutput)await subscriber.FishForMessageAsync<object>(
+            m => m is ErrorOutput, TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorCategory.Timeout, error.Category);
         Assert.Contains("timed out", error.Message);
-        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.FishForMessageAsync<object>(
+            m => m is TurnCompleted, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -127,6 +157,8 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             Content = "hello"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
+        // Virtual time never advances, so the watchdog cannot fire — a correct stream
+        // completes regardless of how slowly the box schedules it.
         var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("success", text.Text, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
@@ -136,7 +168,17 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
 
     private sealed class StreamingTimeoutTestChatClient : IChatClient
     {
+        // Unbounded so the producer (chat client) never blocks; SingleReader because
+        // only the test awaits invocations, one turn at a time.
+        private readonly Channel<int> _invocations =
+            Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = true });
+        private int _callCount;
+
         public StreamMode Mode { get; set; } = StreamMode.HangForever;
+
+        /// <summary>Awaits the next streaming invocation. The watchdog is already armed by then.</summary>
+        public async Task WaitForStreamInvocationAsync(CancellationToken cancellationToken)
+            => await _invocations.Reader.ReadAsync(cancellationToken);
 
         public Task<ChatResponse> GetResponseAsync(
             IEnumerable<ChatMessage> messages,
@@ -149,6 +191,8 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             ChatOptions? options = null,
             CancellationToken cancellationToken = default)
         {
+            _invocations.Writer.TryWrite(Interlocked.Increment(ref _callCount));
+
             return Mode switch
             {
                 StreamMode.HangForever => TestStreamingHelpers.NeverCompletesAsync(CancellationToken.None),
@@ -158,7 +202,7 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             };
         }
 
-        private static async IAsyncEnumerable<ChatResponseUpdate> EmitThenHangAsync(
+        private async IAsyncEnumerable<ChatResponseUpdate> EmitThenHangAsync(
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             yield return new ChatResponseUpdate
@@ -180,7 +224,7 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             };
             await Task.Yield();
 
-            // Now hang — stream goes silent
+            // Deltas done; the stream is now silent.
             var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await gate.Task;
             yield break;

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
@@ -29,8 +29,30 @@ public abstract class LlmSessionTestBase : TestKit
     /// </summary>
     protected virtual bool VerifySerialization => false;
 
+    /// <summary>
+    /// Derived watchdog/timer tests override this to run the ActorSystem on
+    /// <see cref="Akka.TestKit.TestScheduler"/>, so scheduled work — including the
+    /// processing watchdog's <c>ITimerScheduler</c> timers — fires only on an
+    /// explicit <see cref="AdvanceScheduler"/>, making timeouts deterministic
+    /// instead of racing the wall clock against threadpool scheduling.
+    /// </summary>
+    protected virtual bool UseTestScheduler => false;
+
+    /// <summary>
+    /// Moves virtual scheduler time forward, synchronously delivering any
+    /// scheduler items (e.g. the processing watchdog timeout) that fall due.
+    /// Only valid when <see cref="UseTestScheduler"/> is true.
+    /// </summary>
+    protected void AdvanceScheduler(TimeSpan offset) =>
+        ((Akka.TestKit.TestScheduler)Sys.Scheduler).Advance(offset);
+
     protected sealed override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
+        if (UseTestScheduler)
+            builder.AddHocon(
+                "akka.scheduler.implementation = \"Akka.TestKit.TestScheduler, Akka.TestKit\"",
+                HoconAddMode.Prepend);
+
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -1,8 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="LlmSessionWatchdogTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Threading.Channels;
 using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.AI;
@@ -16,9 +17,21 @@ using static Netclaw.Actors.Sessions.SessionProtocol;
 
 namespace Netclaw.Actors.Tests.Sessions;
 
+/// <summary>
+/// Runs the ActorSystem on <see cref="Akka.TestKit.TestScheduler"/> so the
+/// processing watchdog's timer fires only on an explicit <c>AdvanceScheduler</c>
+/// instead of racing the wall clock against threadpool scheduling. The chat
+/// client signals each streaming invocation (which happens after the watchdog is
+/// armed), so the test advances virtual time only once the timer exists; a
+/// recovery turn that should succeed never advances, so it cannot be spuriously
+/// timed out under load.
+/// </summary>
 public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessionTestBase(output)
 {
+    private static readonly TimeSpan FirstTokenTimeout = TimeSpan.FromSeconds(1);
     private readonly HangingStreamingChatClient _chatClient = new();
+
+    protected override bool UseTestScheduler => true;
 
     protected override void ConfigureSessionServices(IServiceCollection services)
     {
@@ -30,8 +43,8 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessi
         });
         services.AddSingleton(new SessionConfig
         {
-            PrefillTimeout = TimeSpan.FromSeconds(1),
-            FirstTokenTimeout = TimeSpan.FromSeconds(1),
+            PrefillTimeout = FirstTokenTimeout,
+            FirstTokenTimeout = FirstTokenTimeout,
             ToolExecutionTimeout = TimeSpan.FromSeconds(1),
             SidecarLlmTimeout = TimeSpan.FromSeconds(1),
             Tuning = new SessionTuning
@@ -63,6 +76,9 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessi
             Content = "first"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
+        await _chatClient.WaitForStreamInvocationAsync(TestContext.Current.CancellationToken);
+        AdvanceScheduler(FirstTokenTimeout);
+
         var firstError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("timed out", firstError.Message, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
@@ -72,6 +88,9 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessi
             SessionId = sessionId,
             Content = "second"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        await _chatClient.WaitForStreamInvocationAsync(TestContext.Current.CancellationToken);
+        AdvanceScheduler(FirstTokenTimeout);
 
         var secondError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("timed out", secondError.Message, StringComparison.OrdinalIgnoreCase);
@@ -108,6 +127,11 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessi
             Content = "second"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
+        // Fire only the first turn's watchdog. The buffered second turn succeeds and
+        // is never advanced, so its (correct) recovery cannot be spuriously timed out.
+        await _chatClient.WaitForStreamInvocationAsync(TestContext.Current.CancellationToken);
+        AdvanceScheduler(FirstTokenTimeout);
+
         var firstError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("timed out", firstError.Message, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
@@ -121,10 +145,16 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessi
 
     private sealed class HangingStreamingChatClient : IChatClient
     {
+        private readonly Channel<int> _invocations =
+            Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = true });
         private int _callCount;
 
         public int CallCount => _callCount;
         public bool SucceedAfterFirstTimeout { get; set; }
+
+        /// <summary>Awaits the next streaming invocation. The watchdog is already armed by then.</summary>
+        public async Task WaitForStreamInvocationAsync(CancellationToken cancellationToken)
+            => await _invocations.Reader.ReadAsync(cancellationToken);
 
         public Task<ChatResponse> GetResponseAsync(
             IEnumerable<ChatMessage> messages,
@@ -138,6 +168,7 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessi
             CancellationToken cancellationToken = default)
         {
             var callNumber = Interlocked.Increment(ref _callCount);
+            _invocations.Writer.TryWrite(callNumber);
 
             if (SucceedAfterFirstTimeout && callNumber > 1)
                 return TestStreamingHelpers.ReturnTextAsync($"recovered after timeout on call {callNumber}", cancellationToken);


### PR DESCRIPTION
## Problem

Two `Sessions` integration tests flake **only under local parallel load on high-core machines** — never in CI:

- `LlmSessionStreamingTimeoutTests.Successful_stream_completes_without_timeout`
- `LlmSessionWatchdogTests.Buffered_reprompt_is_replayed_after_failed_turn`

**Root cause:** the processing watchdog arms its timeout on Akka's `ITimerScheduler`, which is backed by the ActorSystem's real-wall-clock `IScheduler`. xUnit runs every test class in parallel, each spinning up its own `IHost` + `ActorSystem`, all sharing one `ThreadPool`. On a many-core box (24 here) the parallel startup burst starves the pool; a healthy stream's success signal lands late and the **real-clock watchdog fires spuriously**, failing the turn. CI runners (2–4 cores) never reproduce it — *more cores = more flaky.* Baselining clean `dev` reproduced the same failures with none of this change present.

## Fix (test-only — no production change)

Run the two affected test classes on **`Akka.TestKit.TestScheduler`** (virtual scheduler) so the watchdog's timer fires only on an explicit `AdvanceScheduler()` instead of on the wall clock. Because `ITimerScheduler` delegates to whatever `IScheduler` the ActorSystem has, swapping in `TestScheduler` makes the watchdog deterministic **without touching the watchdog at all** — it keeps using `ITimerScheduler` with all of its auto-cancel-on-stop and keyed-replace semantics intact.

- `LlmSessionTestBase` gains an opt-in `UseTestScheduler` hook (adds the `akka.scheduler.implementation` HOCON) and an `AdvanceScheduler(offset)` helper. Defaults off, so every other session test is unaffected.
- Mirrors the existing `GatewayLifecycleContractTests` `TestScheduler` setup.

How the tests drive virtual time:
- The fake chat client signals each streaming invocation — which happens *after* the watchdog is armed — so a timeout test advances only once the timer exists; success/recovery turns never advance and so cannot be spuriously timed out under load.
- The delta-reset test waits for the final delta **output** (the watchdog re-arms *before* emitting each delta) before advancing, so a late re-arm can't outrun the advance.
- `ProcessingWatchdogTests` is unchanged (still asserts budgets via a recording `ITimerScheduler`).

## Why test-only, not the production `TimeProvider` rewrite

An earlier revision of this PR moved `ProcessingWatchdog` onto `TimeProvider.CreateTimer`. That worked and was race-reviewed clean, but it rewrote a reliability-critical component — reimplementing by hand what Akka gives for free (auto-cancel-on-stop, keyed replacement, in-mailbox delivery) and adding an off-thread callback. `TestScheduler` achieves the same test determinism with **zero production risk**, so the production change was reverted.

## Verification

- The production `ProcessingWatchdog` / `LlmSessionActor` / `SubAgentActor` are **byte-for-byte identical to `dev`** — the diff is `LlmSessionTestBase` + the two test classes only.
- Full `Netclaw.Actors.Tests` suite green; 20× stress of the two classes: **0/20** failures (previously flaked under load).

## Out of scope

Four other tests (`MaxToolIterationTests.Normal_tool_use_within_limit_works_unchanged`, `ErrorCorrelationTests.Each_error_turn_gets_a_distinct_CorrelationId`, `EmptyResponseEscalationTests.Repeated_thinking_only_responses_fail_turn_after_consecutive_limit`, `LlmSessionIntegrationTests.Ready_session_drains_for_daemon_restart`) are pure ThreadPool-starvation victims hitting TestKit's own real-time `ExpectMsg` budgets; only relieving the starvation (`ThreadPool.SetMinThreads` or a parallelism cap) would cure them. There's also a recurring local `ISessionPipeline` → `ReminderManagerActor` DI-activation error that churns the pool. Both are left for a follow-up.
