### PR TITLE
refactor(sessions): extract CurrentTurnScope + drop dead _approvalTurnState (superseded by #1508)

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/CurrentTurnScopeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CurrentTurnScopeTests.cs
@@ -1,0 +1,100 @@
+// -----------------------------------------------------------------------
+// <copyright file="CurrentTurnScopeTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions.Handlers;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Characterization tests for the turn correlation-identity derivation that
+/// <see cref="CurrentTurnScope"/> took over from the actor's former
+/// <c>BindTurnTelemetry</c> overloads. The fallback chain (source turn id →
+/// source message id → generated id) is the only real logic in the scope; these
+/// lock it before the actor's ~40 read sites are rewired onto the container.
+/// </summary>
+public sealed class CurrentTurnScopeTests
+{
+    private static MessageSource Source(string? messageId, TurnId? turnId, ChannelType channelType = ChannelType.Slack)
+        => new()
+        {
+            ChannelType = channelType,
+            SenderId = new SenderId("U123"),
+            MessageId = messageId,
+            TurnId = turnId,
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            Principal = PrincipalClassification.TrustedInternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community)
+        };
+
+    [Fact]
+    public void Bind_from_source_uses_the_source_turn_id_when_present()
+    {
+        var scope = new CurrentTurnScope();
+
+        scope.Bind(Source(messageId: "msg-1", turnId: new TurnId("turn-1"), channelType: ChannelType.Discord));
+
+        Assert.Equal("turn-1", scope.TurnId?.Value);
+        Assert.Equal("msg-1", scope.MessageId);
+        Assert.Equal(ChannelType.Discord, scope.ChannelType);
+    }
+
+    [Fact]
+    public void Bind_from_source_falls_back_to_message_id_when_no_turn_id()
+    {
+        var scope = new CurrentTurnScope();
+
+        scope.Bind(Source(messageId: "msg-2", turnId: null));
+
+        Assert.Equal("msg-2", scope.TurnId?.Value);
+        Assert.Equal("msg-2", scope.MessageId);
+    }
+
+    [Fact]
+    public void Bind_from_source_generates_a_turn_id_when_neither_is_present()
+    {
+        var scope = new CurrentTurnScope();
+
+        scope.Bind(Source(messageId: null, turnId: null));
+
+        Assert.False(string.IsNullOrWhiteSpace(scope.TurnId?.Value));
+        Assert.Null(scope.MessageId);
+    }
+
+    [Fact]
+    public void Bind_from_null_source_still_yields_a_generated_turn_id()
+    {
+        var scope = new CurrentTurnScope();
+
+        scope.Bind((MessageSource?)null);
+
+        Assert.False(string.IsNullOrWhiteSpace(scope.TurnId?.Value));
+        Assert.Null(scope.MessageId);
+        Assert.Null(scope.ChannelType);
+    }
+
+    [Fact]
+    public void Bind_from_turn_context_takes_id_and_channel_and_clears_message_id()
+    {
+        var scope = new CurrentTurnScope();
+        // A prior source bind leaves a message id behind; the context re-bind must clear it.
+        scope.Bind(Source(messageId: "stale", turnId: new TurnId("old")));
+
+        var context = TurnContext.FromMessageSource(
+            new SessionId("C1/1"),
+            new TurnId("turn-ctx"),
+            Source(messageId: "ignored", turnId: new TurnId("ignored"), channelType: ChannelType.Mattermost));
+
+        scope.Bind(context);
+
+        Assert.Equal("turn-ctx", scope.TurnId?.Value);
+        Assert.Equal(ChannelType.Mattermost, scope.ChannelType);
+        Assert.Null(scope.MessageId);
+    }
+}

--- a/src/Netclaw.Actors/Sessions/Handlers/CurrentTurnScope.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/CurrentTurnScope.cs
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------
+// <copyright file="CurrentTurnScope.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Channels;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Sessions.Handlers;
+
+/// <summary>
+/// Owns the transient "what turn is active and where did it come from" state:
+/// the inbound source, the derived turn/trust context, the turn's recalled
+/// memories, and the diagnostic correlation identity (turn/message/channel).
+/// Populated at turn start and re-bound on approval re-drive; the actor reads
+/// these to build persisted event records, authorize tool exposure, and enrich
+/// turn-scoped logs.
+///
+/// The correlation identity (<see cref="TurnId"/>/<see cref="MessageId"/>/
+/// <see cref="ChannelType"/>) is mutated only through <see cref="Bind(MessageSource?)"/>
+/// and <see cref="Bind(TurnContext)"/> so the three stay in lockstep. The
+/// remaining fields are overwritten each turn; only <see cref="TurnContext"/>
+/// is explicitly cleared at a turn boundary (the actor nulls it directly).
+/// </summary>
+internal sealed class CurrentTurnScope
+{
+    /// <summary>Provenance of the active turn (channel, sender, reminder/job id).</summary>
+    public MessageSource? Source { get; set; }
+
+    /// <summary>Trust/boundary/audience context derived from <see cref="Source"/>.</summary>
+    public TurnContext? TurnContext { get; set; }
+
+    /// <summary>Effective trust context used to authorize approvals and tool exposure.</summary>
+    public EffectiveTrustContext? TrustContext { get; set; }
+
+    /// <summary>Memories recalled for this turn, reused across the tool loop.</summary>
+    public AutomaticRecallResult? Recall { get; set; }
+
+    /// <summary>Correlation turn id for telemetry/logging (ephemeral).</summary>
+    public Protocol.TurnId? TurnId { get; private set; }
+
+    /// <summary>Inbound message id for crash-context breadcrumbs (ephemeral).</summary>
+    public string? MessageId { get; private set; }
+
+    /// <summary>Channel type of the active turn (ephemeral).</summary>
+    public Channels.ChannelType? ChannelType { get; private set; }
+
+    /// <summary>
+    /// Establishes the diagnostic correlation identity for a turn from its
+    /// inbound source, generating a turn id when the source carries none.
+    /// </summary>
+    public void Bind(MessageSource? source)
+    {
+        MessageId = source?.MessageId;
+        TurnId = source?.TurnId ?? new Protocol.TurnId(MessageId ?? IdGen.ShortId());
+        ChannelType = source?.ChannelType;
+    }
+
+    /// <summary>
+    /// Re-binds correlation identity from a recovered or parked turn context.
+    /// No inbound message id is available on this path.
+    /// </summary>
+    public void Bind(TurnContext context)
+    {
+        MessageId = null;
+        TurnId = context.TurnId;
+        ChannelType = context.ChannelType;
+    }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -85,8 +85,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Media loaded by tools for model-visible inspection during a streamed tool
     // batch; drained into a system nudge when the batch completes.
     private readonly ModelInputMediaBuffer _mediaBuffer = new();
-    private MessageSource? _currentTurnSource;
-    private TurnContext? _currentTurnContext;
+    // "What turn is active and where did it come from": source, derived
+    // turn/trust context, recalled memories, and diagnostic correlation identity.
+    private readonly CurrentTurnScope _turn = new();
     private bool _processingStateActive;
     private readonly ToolRegistry? _fullRegistry;
     private readonly ToolAccessPolicy? _toolAccessPolicy;
@@ -153,13 +154,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // (the generous prefill budget before the first token vs the tighter inter-delta
     // budget after).
     private bool _anyContentStreamed;
-
-    // Per-turn diagnostic correlation (ephemeral)
-    private Protocol.TurnId? _activeTurnId;
-    private string? _activeMessageId;
-    private Channels.ChannelType? _activeChannelType;
-    private AutomaticRecallResult? _activeRecall;
-    private EffectiveTrustContext? _currentTrustContext;
 
     // Startup context layers: injected on first LLM call, re-injected after compaction
     private bool _startupContextInjected;
@@ -837,7 +831,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             EnqueueCheckpointFireAndForget(new MemoryCheckpointRequest(
                 SessionId: _sessionId,
-                TurnId: _activeTurnId,
+                TurnId: _turn.TurnId,
                 TriggerType: Memory.CheckpointTriggerType.SubagentFindings,
                 Priority: 80,
                 Payload: SessionMemoryCheckpointFactory.ForSubAgentFinding(
@@ -1023,7 +1017,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (msg.Proposals.Count > 0 && _curationActor is not null
             && CurrentTurnAudience() != TrustAudience.Public && _memoryConfig.Enabled)
         {
-            if (ShouldSkipMemoryCurationForThirdPartyAdoptedContext(_currentTurnContext, _currentTurnSource))
+            if (ShouldSkipMemoryCurationForThirdPartyAdoptedContext(_turn.TurnContext, _turn.Source))
             {
                 TurnLog().Info("memory_curation_skipped third-party adopted-context present; waiting for explicit elevation");
                 if (stopAfterAcceptedProposalPersistence)
@@ -1235,7 +1229,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             EnqueueCheckpointFireAndForget(new MemoryCheckpointRequest(
                 SessionId: _sessionId,
-                TurnId: _activeTurnId,
+                TurnId: _turn.TurnId,
                 TriggerType: Memory.CheckpointTriggerType.CompactionBoundary,
                 Priority: 90,
                 Payload: SessionMemoryCheckpointFactory.ForCompactionBoundary(
@@ -1992,7 +1986,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _activeToolExecutionCts = new CancellationTokenSource();
         var toolExecutionCt = _activeToolExecutionCts.Token;
 
-        _ = SessionToolExecutionPipeline.ExecuteToolsAsync(executor, toolCalls, sessionId, _currentTurnSource, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput, spawnChildActor,
+        _ = SessionToolExecutionPipeline.ExecuteToolsAsync(executor, toolCalls, sessionId, _turn.Source, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput, spawnChildActor,
             approvalChannel: _approvalChannel,
             emitApprovalRequest: request => self.Tell(request),
             approvalTimeout: Timeout.InfiniteTimeSpan,
@@ -2003,7 +1997,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             modelInputModalities: _model.InputModalities,
             oneTimeApprovalPreSeed: oneTimeApprovalPreSeed,
             decisionOverride: decisionOverride,
-            turnContext: _currentTurnContext,
+            turnContext: _turn.TurnContext,
             ct: toolExecutionCt);
     }
 
@@ -2036,8 +2030,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             },
             AssistantReply = reply,
             RecordedAtMs = NowMs(),
-            SourceReminderId = _currentTurnSource?.ReminderId,
-            SourceBackgroundJobId = _currentTurnSource?.BackgroundJobId
+            SourceReminderId = _turn.Source?.ReminderId,
+            SourceBackgroundJobId = _turn.Source?.BackgroundJobId
         };
 
         Persist(turnEvent, evt =>
@@ -2061,11 +2055,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitResponseOutputs(lastMessage, usage, includeText: true, includeThinking: true);
             MaybeSnapshot();
             MaybeGenerateTitle();
-            _activeRecall = recallResult;
+            _turn.Recall = recallResult;
 
             EnqueueCheckpointFireAndForget(new MemoryCheckpointRequest(
                 SessionId: _sessionId,
-                TurnId: _activeTurnId,
+                TurnId: _turn.TurnId,
                 TriggerType: Memory.CheckpointTriggerType.TurnComplete,
                 Priority: 40,
                 Payload: SessionMemoryCheckpointFactory.ForTurnComplete(
@@ -2241,13 +2235,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private void ContinueIncomingUserMessage(SendUserMessage cmd)
     {
         _deliveryRetry.Clear();
-        _currentTurnSource = cmd.Source;
+        _turn.Source = cmd.Source;
         BindTurnTelemetry(cmd.Source);
-        _currentTurnContext = TurnContext.FromMessageSource(
+        _turn.TurnContext = TurnContext.FromMessageSource(
             _sessionId,
-            _activeTurnId ?? new Protocol.TurnId(IdGen.ShortId()),
+            _turn.TurnId ?? new Protocol.TurnId(IdGen.ShortId()),
             cmd.Source);
-        _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(_currentTurnContext);
+        _turn.TrustContext = _trustContextDeriver?.DeriveFromTurnContext(_turn.TurnContext);
         PersistAdoptedContextIfNeeded(cmd.Source);
 
         // Sessions created from Slack/Discord start without transport-derived
@@ -2634,10 +2628,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 recallQuery,
                 _state,
                 _sessionId,
-                _currentTurnSource,
+                _turn.Source,
                 _memoryRecallCoordinator,
                 _memoryConfig.Enabled,
-                turnContext: _currentTurnContext);
+                turnContext: _turn.TurnContext);
             recallSw.Stop();
 
             resolved = _recallManager.ApplyProgressiveRecall(resolved, _log);
@@ -2681,7 +2675,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // (llama.cpp, vLLM, OpenAI, Ollama, ...) extend the cache prefix
             // through this content on every subsequent turn instead of
             // re-tokenizing it from scratch.
-            _activeRecall = _recallManager.TurnRecallCache;
+            _turn.Recall = _recallManager.TurnRecallCache;
             var volatileBlock = SessionMessageAssembler.BuildVolatileContextBlock(new ContextAssemblyInput(
                 State: _state,
                 ContextLayers: _contextLayers,
@@ -2692,7 +2686,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId: _sessionId,
                 SessionsBasePath: _sessionsBasePath,
                 FileReadGranted: HasFileReadGranted(),
-                ActiveRecall: _activeRecall,
+                ActiveRecall: _turn.Recall,
                 Audience: CurrentTurnAudience(),
                 SkillHint: BuildSkillHint()));
             if (!string.IsNullOrEmpty(volatileBlock))
@@ -2701,7 +2695,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
         }
 
-        _activeRecall = _recallManager.TurnRecallCache;
+        _turn.Recall = _recallManager.TurnRecallCache;
 
         // Build the full message list via the cache-stable assembler.
         // Static content (persisted prompt, OnceAtStart layers, [session],
@@ -2724,7 +2718,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             SessionId: _sessionId,
             SessionsBasePath: _sessionsBasePath,
             FileReadGranted: HasFileReadGranted(),
-            ActiveRecall: _activeRecall,
+            ActiveRecall: _turn.Recall,
             Audience: CurrentTurnAudience(),
             SkillHint: skillHint,
             // Canonical names live in history (post-PR follow-up); the
@@ -2758,16 +2752,16 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
 
     private TrustAudience CurrentTurnAudience()
-        => _currentTurnContext?.Audience
-           ?? _currentTurnSource?.Audience
+        => _turn.TurnContext?.Audience
+           ?? _turn.Source?.Audience
            ?? SecurityPolicyDefaults.ResolveAudienceFromSessionId(_sessionId.Value);
 
     private string CurrentMemoryAudience()
-        => (_currentTurnContext?.Audience ?? _currentTurnSource?.Audience ?? TrustAudience.Public).ToWireValue();
+        => (_turn.TurnContext?.Audience ?? _turn.Source?.Audience ?? TrustAudience.Public).ToWireValue();
 
     private string CurrentMemoryBoundary()
-        => _currentTurnContext?.Boundary.Value
-           ?? _currentTurnSource?.Boundary.Value
+        => _turn.TurnContext?.Boundary.Value
+           ?? _turn.Source?.Boundary.Value
            ?? SecurityPolicyDefaults.ResolveBoundaryFromSessionId(_sessionId.Value, CurrentTurnAudience()).Value;
 
     private IReadOnlyList<AITool> ResolveExposedToolsForCurrentTurn()
@@ -2776,7 +2770,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (_toolAccessPolicy is null || _fullRegistry is null || availableTools.Count == 0)
             return availableTools;
 
-        return _toolAccessPolicy.FilterExposedTools(availableTools, _fullRegistry, _currentTrustContext);
+        return _toolAccessPolicy.FilterExposedTools(availableTools, _fullRegistry, _turn.TrustContext);
     }
 
     /// <summary>
@@ -2793,7 +2787,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         var registration = _fullRegistry.GetRegistrationByToolName(SetWorkingDirectoryTool.ToolName);
         return registration is not null
-               && _toolAccessPolicy.IsToolExposed(registration, _currentTrustContext);
+               && _toolAccessPolicy.IsToolExposed(registration, _turn.TrustContext);
     }
 
 
@@ -2838,7 +2832,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     SessionId = _sessionId,
                     TurnNumber = new TurnNumber(_state.TurnCount),
                     Outcome = TurnOutcome.Skipped,
-                    SourceReminderId = _currentTurnSource?.ReminderId
+                    SourceReminderId = _turn.Source?.ReminderId
                 });
                 TryReplyAck();
                 return true;
@@ -2864,7 +2858,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             SessionId = _sessionId,
             TurnNumber = new TurnNumber(_state.TurnCount),
             Outcome = TurnOutcome.Skipped,
-            SourceReminderId = _currentTurnSource?.ReminderId
+            SourceReminderId = _turn.Source?.ReminderId
         });
         TryReplyAck();
         return true;
@@ -2891,7 +2885,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
-                SourceReminderId = _currentTurnSource?.ReminderId
+                SourceReminderId = _turn.Source?.ReminderId
             });
             TryReplyAck();
             return true;
@@ -2928,7 +2922,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
-                SourceReminderId = _currentTurnSource?.ReminderId
+                SourceReminderId = _turn.Source?.ReminderId
             });
             TryReplyAck();
             return true;
@@ -2948,7 +2942,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
-                SourceReminderId = _currentTurnSource?.ReminderId
+                SourceReminderId = _turn.Source?.ReminderId
             });
             TryReplyAck();
             return true;
@@ -2965,7 +2959,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
-                SourceReminderId = _currentTurnSource?.ReminderId
+                SourceReminderId = _turn.Source?.ReminderId
             });
             TryReplyAck();
             return true;
@@ -2990,7 +2984,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
-                SourceReminderId = _currentTurnSource?.ReminderId
+                SourceReminderId = _turn.Source?.ReminderId
             });
             TryReplyAck();
             return true;
@@ -3023,10 +3017,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var context = new ToolExecutionContext(_sessionId.Value, GetSessionDirectory())
             {
                 // No active turn context/source carries no trust context — fall closed.
-                Audience = _currentTurnContext?.Audience ?? _currentTurnSource?.Audience ?? TrustAudience.Public,
-                Boundary = _currentTurnContext?.Boundary ?? _currentTurnSource?.Boundary,
-                ChannelType = _currentTurnContext?.ChannelType?.ToWireValue()
-                              ?? (_currentTurnSource is null ? null : _currentTurnSource.ChannelType.ToWireValue()),
+                Audience = _turn.TurnContext?.Audience ?? _turn.Source?.Audience ?? TrustAudience.Public,
+                Boundary = _turn.TurnContext?.Boundary ?? _turn.Source?.Boundary,
+                ChannelType = _turn.TurnContext?.ChannelType?.ToWireValue()
+                              ?? (_turn.Source is null ? null : _turn.Source.ChannelType.ToWireValue()),
                 ProjectDirectory = _state.WorkingContext.ProjectDirectory,
                 SupportsInteractiveApproval = false,
             };
@@ -3091,8 +3085,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 Content = msg.Result.Output
             },
             RecordedAtMs = NowMs(),
-            SourceReminderId = _currentTurnSource?.ReminderId,
-            SourceBackgroundJobId = _currentTurnSource?.BackgroundJobId
+            SourceReminderId = _turn.Source?.ReminderId,
+            SourceBackgroundJobId = _turn.Source?.BackgroundJobId
         };
 
         Persist(turnEvent, evt =>
@@ -3123,7 +3117,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Completed,
-                SourceReminderId = _currentTurnSource?.ReminderId
+                SourceReminderId = _turn.Source?.ReminderId
             });
 
             MaybeSnapshot();
@@ -3181,7 +3175,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var registration = _fullRegistry.GetRegistrationByToolName(toolName);
         if (registration is null) return false;
 
-        if (_toolAccessPolicy is not null && !_toolAccessPolicy.IsToolExposed(registration, _currentTrustContext))
+        if (_toolAccessPolicy is not null && !_toolAccessPolicy.IsToolExposed(registration, _turn.TrustContext))
             return false;
 
         var tool = registration.Tool;
@@ -3277,11 +3271,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ToolName = msg.ToolName.Value,
             Patterns = msg.Patterns,
             CandidateVerbs = msg.CandidateVerbs,
-            Audience = _currentTurnContext?.Audience ?? CurrentTurnAudience(),
-            Boundary = _currentTurnContext?.Boundary ?? _currentTurnSource?.Boundary,
-            ChannelType = _currentTurnContext?.ChannelType?.ToWireValue() ?? _currentTurnSource?.ChannelType.ToWireValue(),
-            SupportsInteractiveApproval = _currentTurnContext?.SupportsInteractiveApproval
-                                          ?? _currentTurnSource?.ChannelType.SupportsInteractiveApproval(),
+            Audience = _turn.TurnContext?.Audience ?? CurrentTurnAudience(),
+            Boundary = _turn.TurnContext?.Boundary ?? _turn.Source?.Boundary,
+            ChannelType = _turn.TurnContext?.ChannelType?.ToWireValue() ?? _turn.Source?.ChannelType.ToWireValue(),
+            SupportsInteractiveApproval = _turn.TurnContext?.SupportsInteractiveApproval
+                                          ?? _turn.Source?.ChannelType.SupportsInteractiveApproval(),
             RequesterSenderId = msg.RequesterSenderId,
             RequesterPrincipal = msg.RequesterPrincipal,
             HasThirdPartyAdoptedContext = msg.HasThirdPartyAdoptedContext,
@@ -3289,7 +3283,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             Cwd = msg.Cwd,
             OptionKeys = msg.Options.Select(o => o.Key.Value).ToArray(),
             Candidates = msg.Candidates,
-            TurnContext = _currentTurnContext?.ToRecord(),
+            TurnContext = _turn.TurnContext?.ToRecord(),
             RequestedAtMs = NowMs()
         };
 
@@ -3341,7 +3335,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Restore the parked turn context so a later re-drive authorizes the
         // approval at the audience/boundary the request was originally made under.
         if (persistApprovalState && turnContext is not null)
-            _currentTurnContext = turnContext;
+            _turn.TurnContext = turnContext;
         else if (persistApprovalState && restoreFailure is not null)
             _log.Warning(
                 "Approval request {CallId} could not restore turn context: {Reason}",
@@ -3349,7 +3343,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 restoreFailure);
     }
 
-    private void ClearCurrentTurnContext() => _currentTurnContext = null;
+    private void ClearCurrentTurnContext() => _turn.TurnContext = null;
 
     private void ApplyToolApprovalResolved(ToolApprovalResolved evt)
     {
@@ -3464,7 +3458,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             SessionId = _sessionId,
             TurnNumber = new TurnNumber(_state.TurnCount),
-            SourceReminderId = _currentTurnSource?.ReminderId
+            SourceReminderId = _turn.Source?.ReminderId
         });
     }
 
@@ -4063,7 +4057,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// assistant message in history whose tool calls have no later tool result,
     /// transitions to <see cref="SessionPhase.Processing"/>, and dispatches it
     /// under the parked turn's persisted trust context. After cold recovery
-    /// <see cref="_currentTurnSource"/> is null, so the persisted trust fields
+    /// <see cref="CurrentTurnScope.Source"/> is null, so the persisted trust fields
     /// are what keep the re-driven call faithful to the original turn.
     /// </summary>
     private bool RedriveToolBatchForApproval(
@@ -4115,8 +4109,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return false;
         }
 
-        _currentTurnContext = turnContext;
-        _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(turnContext);
+        _turn.TurnContext = turnContext;
+        _turn.TrustContext = _trustContextDeriver?.DeriveFromTurnContext(turnContext);
         BindTurnTelemetry(turnContext);
 
         TransitionTo(SessionPhase.Processing);
@@ -4163,8 +4157,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void FailCurrentTurn(string errorMessage, Exception cause, ErrorCategory category = ErrorCategory.Unknown)
     {
-        _inFlightDedup.CompleteReminder(_currentTurnSource?.ReminderId);
-        _inFlightDedup.CompleteBackgroundJob(_currentTurnSource?.BackgroundJobId);
+        _inFlightDedup.CompleteReminder(_turn.Source?.ReminderId);
+        _inFlightDedup.CompleteBackgroundJob(_turn.Source?.BackgroundJobId);
         CancelAndDisposeToolExecutionCts();
         _deliveryRetry.Clear();
         _pendingToolInteractions.Clear();
@@ -4193,7 +4187,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             SessionId = _sessionId,
             TurnNumber = new TurnNumber(_state.TurnCount),
             Outcome = TurnOutcome.Failed,
-            SourceReminderId = _currentTurnSource?.ReminderId
+            SourceReminderId = _turn.Source?.ReminderId
         });
 
         DrainBufferedMessagesOrBecomeReady();
@@ -4327,7 +4321,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             EnqueueCheckpointFireAndForget(new MemoryCheckpointRequest(
                 SessionId: _sessionId,
-                TurnId: _activeTurnId,
+                TurnId: _turn.TurnId,
                 TriggerType: Memory.CheckpointTriggerType.SubagentFindings,
                 Priority: 80,
                 Payload: SessionMemoryCheckpointFactory.ForSubAgentFinding(
@@ -4567,45 +4561,38 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void BindTurnTelemetry(MessageSource? source)
     {
-        var sourceMessageId = source?.MessageId;
-        _activeMessageId = sourceMessageId;
-        _activeTurnId = source?.TurnId
-            ?? new Protocol.TurnId(sourceMessageId ?? IdGen.ShortId());
-        _activeChannelType = source?.ChannelType;
-
-        CrashContextSnapshot.Update(
-            _sessionId.Value,
-            _activeTurnId?.Value,
-            _activeMessageId,
-            _activeChannelType?.ToWireValue(),
-            _timeProvider.GetUtcNow());
+        _turn.Bind(source);
+        PublishCrashContext();
     }
 
     private void BindTurnTelemetry(TurnContext context)
     {
-        _activeMessageId = null;
-        _activeTurnId = context.TurnId;
-        _activeChannelType = context.ChannelType;
-
-        CrashContextSnapshot.Update(
-            _sessionId.Value,
-            _activeTurnId?.Value,
-            _activeMessageId,
-            _activeChannelType?.ToWireValue(),
-            _timeProvider.GetUtcNow());
+        _turn.Bind(context);
+        PublishCrashContext();
     }
+
+    // Process-wide best-effort breadcrumb so crash handlers can name the
+    // in-flight turn. Uses actor-owned session id and clock, so it stays here
+    // rather than on the scope.
+    private void PublishCrashContext()
+        => CrashContextSnapshot.Update(
+            _sessionId.Value,
+            _turn.TurnId?.Value,
+            _turn.MessageId,
+            _turn.ChannelType?.ToWireValue(),
+            _timeProvider.GetUtcNow());
 
     private ILoggingAdapter TurnLog()
     {
         var log = _log;
 
-        if (_activeTurnId is { Value: { Length: > 0 } turnIdValue })
+        if (_turn.TurnId is { Value: { Length: > 0 } turnIdValue })
             log = log.WithContext("TurnId", turnIdValue);
 
-        if (!string.IsNullOrWhiteSpace(_activeMessageId))
-            log = log.WithContext("MessageId", _activeMessageId);
+        if (!string.IsNullOrWhiteSpace(_turn.MessageId))
+            log = log.WithContext("MessageId", _turn.MessageId);
 
-        if (_activeChannelType is { } act)
+        if (_turn.ChannelType is { } act)
             log = log.WithContext("ChannelType", act.ToWireValue());
 
         return log;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -88,7 +88,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private MessageSource? _currentTurnSource;
     private TurnContext? _currentTurnContext;
     private bool _processingStateActive;
-    private ApprovalTurnState _approvalTurnState = ApprovalTurnState.None;
     private readonly ToolRegistry? _fullRegistry;
     private readonly ToolAccessPolicy? _toolAccessPolicy;
     private readonly TrustContextDeriver? _trustContextDeriver;
@@ -263,7 +262,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ApplyTurnRecorded(evt);
             _pendingToolInteractions.Clear();
             _resolvedToolApprovals.Clear();
-            ClearApprovalTurnState();
+            ClearCurrentTurnContext();
             ClearActiveToolBatchTracking();
         });
         Recover<SessionTitleSet>(evt => _state = _state.Apply(evt));
@@ -273,7 +272,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _state = _state.Apply(evt);
             _pendingToolInteractions.Clear();
             _resolvedToolApprovals.Clear();
-            ClearApprovalTurnState();
+            ClearCurrentTurnContext();
             ClearActiveToolBatchTracking();
         });
         Recover<ToolBatchStarted>(ApplyToolBatchStarted);
@@ -990,7 +989,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _resolvedToolApprovals.Clear();
         TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
             _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolIterationsPerTurn, msg.ToolResults.Count);
-        MarkApprovalRunningAfterRedrive();
         FireLlmCall();
     }
 
@@ -1376,7 +1374,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
         else
         {
-            ClearApprovalTurnState();
+            ClearCurrentTurnContext();
             TransitionTo(SessionPhase.Ready);
         }
 
@@ -2118,7 +2116,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        ClearApprovalTurnState();
+        ClearCurrentTurnContext();
         TransitionTo(SessionPhase.Ready);
     }
 
@@ -2206,8 +2204,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // API, which would otherwise wedge every subsequent turn.
         if (_pendingToolInteractions.Count > 0)
         {
-            if (_approvalTurnState is WaitingApprovalTurn waiting)
-                _approvalTurnState = new AbandoningApprovalTurn(waiting.Context, "superseded_by_new_message");
             var abandoned = BuildToolBatchAbandonedEvent();
             Persist(abandoned, evt =>
             {
@@ -2251,7 +2247,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _sessionId,
             _activeTurnId ?? new Protocol.TurnId(IdGen.ShortId()),
             cmd.Source);
-        _approvalTurnState = new RunningApprovalTurn(_currentTurnContext);
         _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(_currentTurnContext);
         PersistAdoptedContextIfNeeded(cmd.Source);
 
@@ -3343,8 +3338,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             evt.Candidates);
         _resolvedToolApprovals.Remove(evt.CallId);
 
+        // Restore the parked turn context so a later re-drive authorizes the
+        // approval at the audience/boundary the request was originally made under.
         if (persistApprovalState && turnContext is not null)
-            RecordWaitingApprovalState(turnContext, evt.CallId, recovered: _phase.Current == SessionPhase.Recovering);
+            _currentTurnContext = turnContext;
         else if (persistApprovalState && restoreFailure is not null)
             _log.Warning(
                 "Approval request {CallId} could not restore turn context: {Reason}",
@@ -3352,37 +3349,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 restoreFailure);
     }
 
-    private void RecordWaitingApprovalState(TurnContext context, string callId, bool recovered)
-    {
-        var pendingCallIds = _approvalTurnState is WaitingApprovalTurn waiting
-            ? new HashSet<string>(waiting.PendingCallIds, StringComparer.Ordinal)
-            : new HashSet<string>(StringComparer.Ordinal);
-        pendingCallIds.Add(callId);
-
-        _currentTurnContext = context;
-        _approvalTurnState = new WaitingApprovalTurn(context, pendingCallIds, recovered);
-    }
-
-    private void MarkApprovalRedrive(PendingToolInteraction pending, string callId)
-    {
-        if (pending.TurnContext is null)
-            return;
-
-        _currentTurnContext = pending.TurnContext;
-        _approvalTurnState = new RedrivingApprovalTurn(pending.TurnContext, callId);
-    }
-
-    private void MarkApprovalRunningAfterRedrive()
-    {
-        if (_approvalTurnState is RedrivingApprovalTurn redriving)
-            _approvalTurnState = new RunningApprovalTurn(redriving.Context);
-    }
-
-    private void ClearApprovalTurnState()
-    {
-        _approvalTurnState = ApprovalTurnState.None;
-        _currentTurnContext = null;
-    }
+    private void ClearCurrentTurnContext() => _currentTurnContext = null;
 
     private void ApplyToolApprovalResolved(ToolApprovalResolved evt)
     {
@@ -3391,12 +3358,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             : ApprovalDecision.Denied;
 
         if (_pendingToolInteractions.Remove(evt.CallId, out var pending))
-        {
             _resolvedToolApprovals[evt.CallId] = new ResolvedToolApproval(pending, decision);
-
-            if (_pendingToolInteractions.Count == 0 && pending.TurnContext is not null)
-                _approvalTurnState = new RunningApprovalTurn(pending.TurnContext);
-        }
     }
 
     private void ApplyToolBatchAbandoned(ToolBatchAbandoned evt)
@@ -3410,7 +3372,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             });
         _pendingToolInteractions.Clear();
         _resolvedToolApprovals.Clear();
-        ClearApprovalTurnState();
+        ClearCurrentTurnContext();
         ClearActiveToolBatchTracking();
     }
 
@@ -4156,7 +4118,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _currentTurnContext = turnContext;
         _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(turnContext);
         BindTurnTelemetry(turnContext);
-        MarkApprovalRedrive(pending, callId);
 
         TransitionTo(SessionPhase.Processing);
         DispatchToolBatch(
@@ -4208,7 +4169,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _deliveryRetry.Clear();
         _pendingToolInteractions.Clear();
         _resolvedToolApprovals.Clear();
-        ClearApprovalTurnState();
+        ClearCurrentTurnContext();
         _state = _state.AddErrorReply(errorMessage);
 
         var correlationId = Guid.NewGuid();
@@ -4531,7 +4492,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         ClearActiveToolBatchTracking();
         TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
             _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolIterationsPerTurn, resultCount);
-        MarkApprovalRunningAfterRedrive();
         FireLlmCall();
     }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2237,9 +2237,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _deliveryRetry.Clear();
         _turn.Source = cmd.Source;
         BindTurnTelemetry(cmd.Source);
+        // _turn.TurnId is non-null after Bind (it generates one from the message id
+        // or IdGen when the source carries none), so reuse it rather than forking a
+        // second id-generation path here.
         _turn.TurnContext = TurnContext.FromMessageSource(
             _sessionId,
-            _turn.TurnId ?? new Protocol.TurnId(IdGen.ShortId()),
+            _turn.TurnId!.Value,
             cmd.Source);
         _turn.TrustContext = _trustContextDeriver?.DeriveFromTurnContext(_turn.TurnContext);
         PersistAdoptedContextIfNeeded(cmd.Source);

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -48,24 +48,6 @@ internal sealed record ToolInteractionRequestDispatch(
     SessionProtocol.ToolInteractionRequest Request,
     bool PersistApprovalState) : INoSerializationVerificationNeeded;
 
-internal abstract record ApprovalTurnState : INoSerializationVerificationNeeded
-{
-    public static ApprovalTurnState None { get; } = new NoActiveApprovalTurn();
-}
-
-internal sealed record NoActiveApprovalTurn : ApprovalTurnState;
-
-internal sealed record RunningApprovalTurn(TurnContext Context) : ApprovalTurnState;
-
-internal sealed record WaitingApprovalTurn(
-    TurnContext Context,
-    ISet<string> PendingCallIds,
-    bool Recovered) : ApprovalTurnState;
-
-internal sealed record RedrivingApprovalTurn(TurnContext Context, string CallId) : ApprovalTurnState;
-
-internal sealed record AbandoningApprovalTurn(TurnContext Context, string Reason) : ApprovalTurnState;
-
 internal sealed record ApprovalRedrivePlan(
     IReadOnlyDictionary<string, IReadOnlyList<string>>? OneTimeApprovalPreSeed,
     IReadOnlyDictionary<string, ApprovalDecision>? DecisionOverride);


### PR DESCRIPTION
Continues the `LlmSessionActor` decomposition started in #1496 (transient-state handlers, steps 1–4). This is **step 5** plus an enabling cleanup. Two commits of substance, no wire/behavior change — every touched field is transient (rebuilt on recovery), and no persisted event/snapshot shape changes.

## 1. Remove the dead `_approvalTurnState` breadcrumb

`_approvalTurnState` and its five-subtype `ApprovalTurnState` hierarchy were **write-only**: a full-repo grep confirmed no subtype payload was ever read to make a decision, and no test referenced it. Every reference was a self-referential read (used only to build the next breadcrumb value) or a pure write; its only *live* side effect was a `_currentTurnContext` write piggybacked inside the mutators.

Removed the field and the hierarchy, **preserving every `_currentTurnContext` write** (load-bearing, especially the recovery-time restore in `ApplyToolApprovalRequested`). `ClearApprovalTurnState` became `ClearCurrentTurnContext`. Removing the breadcrumb also exposed two genuinely dead calls: `MarkApprovalRedrive` only re-set `_currentTurnContext` one line after it was already set, and `MarkApprovalRunningAfterRedrive` was a no-op on the normal tool-completion path.

## 2. Extract `CurrentTurnScope` (step 5)

Grouped the seven ambient "what turn is active and where did it come from" fields — `_currentTurnSource`, `_currentTurnContext`, `_currentTrustContext`, `_activeRecall`, `_activeTurnId`, `_activeMessageId`, `_activeChannelType` (~40 read sites) — into one transient handler, `Sessions/Handlers/CurrentTurnScope`, mirroring the step 1–4 container pattern (`DiscoveredToolCache`, `TurnStateTracker`).

- The correlation identity (`TurnId`/`MessageId`/`ChannelType`) is mutated **only** via `Bind(MessageSource?)` / `Bind(TurnContext)`, which absorb the former `BindTurnTelemetry` derivation (including the source-turn-id → message-id → generated-id fallback) and keep the three in lockstep.
- The actor keeps the `CrashContextSnapshot` breadcrumb (it uses the actor-owned session id + clock) and the read-only audience/boundary precedence projections + trust derivation, reading `_turn.*` at the call site.
- **Reset semantics preserved exactly**: only `TurnContext` is nulled at a turn boundary (the others are overwritten each turn) — no blanket `Clear()` that would change behavior.

Net: the actor loses **8 instance fields** (the 7 above + `_approvalTurnState`). Adds `CurrentTurnScopeTests` characterizing the turn-id derivation fallback that `BindTurnTelemetry` previously had no direct coverage for.

A follow-up commit reuses `_turn.TurnId` directly in `ContinueIncomingUserMessage` instead of re-generating it via a now-dead `?? new TurnId(IdGen.ShortId())` fallback (surfaced by review — the extraction is what makes the duplicate path obvious).

## Verification

- Full `Netclaw.Actors.Tests` Sessions suite green (incl. `ApprovalRehydrationTests` ×19, the primary net for the preserved `_currentTurnContext` writes, and `CompactionIntegrationTests`).
- `dotnet slopwatch analyze`: no new violations. Copyright headers present.
- Not triggered (confirmed): OpenSpec, eval suite, system-skills sync, config-schema, smoke tapes — pure transient-state refactor.
