### PR TITLE
feat(reminders): operator visibility into reminder failures and skips (#1494)

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.19.0"
+  version: "2.20.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -58,6 +58,28 @@ Reminders that hit 5 consecutive execution failures are auto-disabled with a
 `ReminderAutoDisabled` critical alert. The definition stays on disk so the
 operator can diagnose and re-enable after fixing the root cause.
 
+**Failure visibility.** When a reminder execution fails for any reason — including
+the 20-minute stall backstop that recovers a wedged run — the failure is posted
+as a plain-language notice to the reminder's **destination channel** (for
+`channel`-delivery reminders), so the operator sees it where they expect that
+reminder's output. This is bounded by the auto-disable threshold (at most a few
+notices plus the disabled notice), not the unbounded skip stream.
+
+A *skipped* fire (one that arrives while the prior execution is still running) is
+**not** posted to the channel — it would be too noisy — but it is counted and
+surfaced by the status command:
+
+```
+netclaw reminder status <id>
+```
+
+`status` shows, per reminder: whether it's enabled, whether an execution is in
+flight right now, when it next fires, the consecutive-failure count, the
+skipped-fire count (since daemon start), and recent run history. Reach for it
+when a reminder seems to have silently stopped doing its job — a high skip count
+means a prior run is wedged (it should self-recover within ~20 minutes), and a
+rising failure count points at a misconfigured or broken reminder.
+
 If `audience` is omitted during conversational scheduling, the reminder inherits
 the audience of the channel/session that created it. A reminder cannot be
 minted with broader audience than the creator currently holds; lowering the

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -73,7 +73,8 @@ public class ReminderManagerActorTests : TestKit
                     TimeProvider.System,
                     definitionStore,
                     historyStore,
-                    _notificationSink)),
+                    _notificationSink,
+                    NullReminderChannelNotifier.Instance)),
                 "reminder-manager-test");
 
             registry.Register<ReminderManagerActorKey>(reminderManager);
@@ -172,6 +173,44 @@ public class ReminderManagerActorTests : TestKit
         Assert.Equal(0, health.ScheduledCount);
         Assert.Equal(0, health.ActiveExecutions);
         Assert.Equal(0, health.FailedCount);
+    }
+
+    [Fact]
+    public async Task Status_query_returns_per_reminder_health()
+    {
+        var manager = await GetManagerAsync();
+
+        var definition = CreateDefinition("test-status", "Check status");
+        var authorization = new ReminderAudienceAuthorizationContext(TrustAudience.Team, "test");
+        await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(definition, Authorization: authorization), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var status = await manager.Ask<ReminderStatusResponse>(
+            new GetReminderStatusQuery(definition.Id), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(status.Found);
+        Assert.True(status.Enabled);
+        Assert.False(status.Executing);
+        Assert.Equal(0, status.ConsecutiveFailures);
+        Assert.Equal(0, status.SkippedDuplicates);
+        Assert.NotNull(status.NextFire);
+        Assert.Empty(status.RecentHistory);
+    }
+
+    [Fact]
+    public async Task Status_query_for_unknown_reminder_returns_not_found()
+    {
+        var manager = await GetManagerAsync();
+
+        var status = await manager.Ask<ReminderStatusResponse>(
+            new GetReminderStatusQuery(new ReminderId("does-not-exist")),
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.False(status.Found);
+        Assert.False(status.Enabled);
+        Assert.Equal(0, status.ConsecutiveFailures);
+        Assert.Equal(0, status.SkippedDuplicates);
+        Assert.Empty(status.RecentHistory);
     }
 
     [Fact]
@@ -411,7 +450,8 @@ public class ReminderManagerActorTests : TestKit
                 TimeProvider.System,
                 store,
                 new ReminderHistoryStore(paths),
-                sink)),
+                sink,
+                NullReminderChannelNotifier.Instance)),
             "legacy-reminder-alert-manager");
 
         // The legacy-schema alert is emitted synchronously inside PreStart, and

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
@@ -63,6 +63,7 @@ public abstract class LlmSessionTestBase : TestKit
         services.AddSingleton<ReminderDefinitionStore>();
         services.AddSingleton<ReminderHistoryStore>();
         services.AddSingleton<IOperationalNotificationSink>(NullNotificationSink.Instance);
+        services.AddSingleton<IReminderChannelNotifier>(NullReminderChannelNotifier.Instance);
         ConfigureSessionServices(services);
         services.AddLlmSessionCompositeRecords();
     }

--- a/src/Netclaw.Actors/Reminders/IReminderChannelNotifier.cs
+++ b/src/Netclaw.Actors/Reminders/IReminderChannelNotifier.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="IReminderChannelNotifier.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// Posts an operator-facing notice to a reminder's destination channel when an
+/// execution fails. Implemented in the daemon over the channel outbound
+/// registry so the actor layer stays transport-agnostic (the manager hands over
+/// an already-resolved <see cref="ChannelDeliveryTargetInfo"/> and plain text).
+/// Fire-and-forget (<c>void</c>) — the manager must never block on channel
+/// delivery, mirroring <see cref="Configuration.IOperationalNotificationSink"/>.
+/// </summary>
+public interface IReminderChannelNotifier
+{
+    /// <summary>
+    /// Posts <paramref name="text"/> to <paramref name="target"/>. Must be
+    /// thread-safe and must not throw — delivery failures are the
+    /// implementation's problem to log, never the caller's to handle.
+    /// </summary>
+    void NotifyFailure(ChannelDeliveryTargetInfo target, string text);
+}
+
+/// <summary>
+/// No-op notifier for environments with no channel outbound path (e.g. tests, or
+/// a daemon with no channels configured). A real Null Object — explicit, not a
+/// silent fallback: callers still get a non-null required dependency.
+/// </summary>
+public sealed class NullReminderChannelNotifier : IReminderChannelNotifier
+{
+    public static readonly NullReminderChannelNotifier Instance = new();
+
+    private NullReminderChannelNotifier()
+    {
+    }
+
+    public void NotifyFailure(ChannelDeliveryTargetInfo target, string text)
+    {
+        // Intentionally does nothing.
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -487,7 +487,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             "Transport and address may be missing or invalid.");
     }
 
-    private static ChannelDeliveryTargetInfo? ResolveChannelDeliveryTarget(ReminderDefinition definition)
+    internal static ChannelDeliveryTargetInfo? ResolveChannelDeliveryTarget(ReminderDefinition definition)
     {
         if (definition.Delivery.Target is not null)
             return definition.Delivery.Target;

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -37,6 +37,9 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     /// </summary>
     internal const int FailurePauseThreshold = 5;
 
+    /// <summary>Recent run records returned by the per-reminder status query.</summary>
+    internal const int RecentHistoryCount = 5;
+
     private readonly ISessionPipeline _pipeline;
     private readonly EffectivePolicyDefaults _defaults;
     private readonly SchedulingConfig _schedulingConfig;
@@ -704,13 +707,17 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                 }));
 
             // Surface the failure where the operator expects this reminder's
-            // output: its destination channel. Bounded by the auto-disable
-            // threshold below, so a permanently-broken reminder posts at most
-            // FailurePauseThreshold notices plus the disabled notice — not the
-            // unbounded skip stream that #1494 also makes visible via status.
-            PostFailureNoticeToChannel(
-                definition,
-                $"Reminder \"{title}\" failed: {completed.ErrorMessage ?? "unknown error"}");
+            // output: its destination channel. Only below the threshold — on the
+            // threshold-hitting failure the disabled notice below already carries
+            // the last error, so posting both would double the noise on the most
+            // important event. Bounded overall by the threshold, never the
+            // unbounded skip stream that #1494 makes visible via status instead.
+            if (count < FailurePauseThreshold)
+            {
+                PostFailureNoticeToChannel(
+                    definition,
+                    $"Reminder \"{title}\" failed: {completed.ErrorMessage ?? "unknown error"}");
+            }
 
             if (count >= FailurePauseThreshold)
             {
@@ -1054,33 +1061,40 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             var definition = _definitionStore.Get(query.Id);
             if (definition is null)
             {
-                replyTo.Tell(NotFoundStatus(query.Id));
+                replyTo.Tell(new ReminderStatusResponse(
+                    query.Id, Found: false, Enabled: false, Executing: false,
+                    NextFire: null, ConsecutiveFailures: 0, SkippedDuplicates: 0,
+                    RecentHistory: []));
                 return;
             }
 
-            var schedules = await ListScheduledRemindersAsync();
-            var history = await _historyStore.ReadAsync(query.Id, 10);
+            // Two independent backend reads — run them concurrently so the
+            // query's latency is max(schedule, history) instead of their sum.
+            // Neither touches actor state until both complete.
+            var schedulesTask = ListScheduledRemindersAsync();
+            var historyTask = _historyStore.ReadAsync(query.Id, RecentHistoryCount);
+            await Task.WhenAll(schedulesTask, historyTask);
 
             replyTo.Tell(new ReminderStatusResponse(
                 query.Id,
                 Found: true,
                 Enabled: definition.Enabled,
                 Executing: _activeExecutions.IsExecuting(query.Id),
-                NextFire: schedules.GetValueOrDefault(query.Id.Value),
+                NextFire: schedulesTask.Result.GetValueOrDefault(query.Id.Value),
                 ConsecutiveFailures: _failureCounts.GetValueOrDefault(query.Id),
                 SkippedDuplicates: _skipCounts.GetValueOrDefault(query.Id),
-                RecentHistory: history));
+                RecentHistory: historyTask.Result));
         }
         catch (Exception ex)
         {
+            // The definition existed, so this is a transient read failure — NOT a
+            // missing reminder. Faulting the Ask surfaces a real error (the
+            // endpoint maps it to 5xx); replying not-found here would tell the
+            // operator a wedged reminder was deleted, the silent fallback this
+            // very feature exists to expose.
             _log.Error(ex, "Error getting status for reminder '{0}'", query.Id.Value);
-            replyTo.Tell(NotFoundStatus(query.Id));
+            replyTo.Tell(new Status.Failure(ex));
         }
-
-        static ReminderStatusResponse NotFoundStatus(ReminderId id) => new(
-            id, Found: false, Enabled: false, Executing: false,
-            NextFire: null, ConsecutiveFailures: 0, SkippedDuplicates: 0,
-            RecentHistory: []);
     }
 
     private sealed record ScheduleAttempt(bool IsSuccess, DateTimeOffset? NextFire, string? ErrorMessage) : INoSerializationVerificationNeeded

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -44,6 +44,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     private readonly ReminderDefinitionStore _definitionStore;
     private readonly ReminderHistoryStore _historyStore;
     private readonly IOperationalNotificationSink _notificationSink;
+    private readonly IReminderChannelNotifier _channelNotifier;
     private readonly ILoggingAdapter _log;
 
     private IReminderClient? _client;
@@ -51,6 +52,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     private readonly ActiveExecutionTracker _activeExecutions = new();
     private readonly Queue<ReminderId> _deferredQueue = new();
     private readonly Dictionary<ReminderId, int> _failureCounts = [];
+    private readonly Dictionary<ReminderId, int> _skipCounts = [];
 
     public ReminderManagerActor(
         ISessionPipeline pipeline,
@@ -59,7 +61,8 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         TimeProvider timeProvider,
         ReminderDefinitionStore definitionStore,
         ReminderHistoryStore historyStore,
-        IOperationalNotificationSink notificationSink)
+        IOperationalNotificationSink notificationSink,
+        IReminderChannelNotifier channelNotifier)
     {
         _pipeline = pipeline;
         _defaults = defaults;
@@ -68,6 +71,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         _definitionStore = definitionStore;
         _historyStore = historyStore;
         _notificationSink = notificationSink;
+        _channelNotifier = channelNotifier;
         _log = Context.GetLogger();
 
         ReceiveAsync<SaveReminderCommand>(HandleSaveAsync);
@@ -83,6 +87,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
         ReceiveAsync<ReconcileReminders>(_ => HandleReconcileAsync());
         Receive<GetReminderHealthQuery>(_ => HandleGetHealth());
+        ReceiveAsync<GetReminderStatusQuery>(HandleGetStatusAsync);
     }
 
     protected override void PreStart()
@@ -417,6 +422,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         await CancelScheduleOnlyAsync(id);
 
         _failureCounts.Remove(id);
+        _skipCounts.Remove(id);
         RemoveFromDeferredQueue(id);
 
         _log.Info("Disabled reminder '{0}'", id.Value);
@@ -433,6 +439,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         _definitionStore.Delete(id);
         await CancelScheduleOnlyAsync(id);
         _failureCounts.Remove(id);
+        _skipCounts.Remove(id);
         RemoveFromDeferredQueue(id);
 
         try
@@ -576,8 +583,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
         if (_activeExecutions.IsExecuting(reminderId))
         {
-            _log.Warning("reminder_skipped_duplicate_execution reminder_id={0} title={1}",
-                reminderId.Value, definition.Title);
+            RecordSkippedDuplicate(reminderId, definition.Title, "scheduled");
             await _client!.AckAsync(envelope);
             return;
         }
@@ -621,6 +627,44 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         }
     }
 
+    /// <summary>
+    /// Records a skipped fire (a fire that arrived while a prior execution of the
+    /// same reminder was still running). Counted in-memory since daemon start and
+    /// surfaced by <c>netclaw reminder status</c> so the silent-skip pattern from
+    /// #1492/#1494 (49 skips in a day, unnoticed) is now visible to operators.
+    /// </summary>
+    private void RecordSkippedDuplicate(ReminderId reminderId, string title, string source)
+    {
+        var count = _skipCounts.GetValueOrDefault(reminderId) + 1;
+        _skipCounts[reminderId] = count;
+        _log.Warning(
+            "reminder_skipped_duplicate_execution reminder_id={0} title={1} source={2} skip_count={3}",
+            reminderId.Value, title, source, count);
+    }
+
+    /// <summary>
+    /// Posts an operator-facing failure notice to a reminder's destination
+    /// channel. Only Channel-delivery reminders have such a channel; CurrentSession
+    /// and None failures are surfaced via the operational alert sink instead. The
+    /// notifier is fire-and-forget — never blocks or throws into the manager.
+    /// </summary>
+    private void PostFailureNoticeToChannel(ReminderDefinition? definition, string text)
+    {
+        if (definition is not { Delivery.Kind: DeliveryKind.Channel })
+            return;
+
+        var target = ReminderExecutionActor.ResolveChannelDeliveryTarget(definition);
+        if (target is null)
+        {
+            _log.Warning(
+                "Reminder '{0}' failed but its channel delivery target could not be resolved; no channel notice posted.",
+                definition.Id.Value);
+            return;
+        }
+
+        _channelNotifier.NotifyFailure(target, text);
+    }
+
     private async Task HandleExecutionCompletedAsync(ReminderExecutionCompleted completed)
     {
         if (!_activeExecutions.Remove(completed.Id))
@@ -659,6 +703,15 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                     ["error"] = completed.ErrorMessage ?? "unknown",
                 }));
 
+            // Surface the failure where the operator expects this reminder's
+            // output: its destination channel. Bounded by the auto-disable
+            // threshold below, so a permanently-broken reminder posts at most
+            // FailurePauseThreshold notices plus the disabled notice — not the
+            // unbounded skip stream that #1494 also makes visible via status.
+            PostFailureNoticeToChannel(
+                definition,
+                $"Reminder \"{title}\" failed: {completed.ErrorMessage ?? "unknown error"}");
+
             if (count >= FailurePauseThreshold)
             {
                 _log.Warning("Reminder '{0}' hit failure threshold ({1}), disabling",
@@ -678,6 +731,11 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                         ["title"] = title,
                         ["failureCount"] = count.ToString(),
                     }));
+
+                PostFailureNoticeToChannel(
+                    definition,
+                    $"Reminder \"{title}\" was automatically disabled after {count} consecutive failures. " +
+                    $"Last error: {completed.ErrorMessage ?? "unknown error"}");
 
                 await DisableReminderInternalAsync(completed.Id);
                 _failureCounts.Remove(completed.Id);
@@ -806,8 +864,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
             if (_activeExecutions.IsExecuting(nextId))
             {
-                _log.Warning("reminder_skipped_duplicate_execution reminder_id={0} title={1} source=deferred_queue",
-                    nextId.Value, definition.Title);
+                RecordSkippedDuplicate(nextId, definition.Title, "deferred_queue");
                 continue;
             }
 
@@ -987,6 +1044,43 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             scheduledCount,
             _activeExecutions.Count,
             _failureCounts.Count));
+    }
+
+    private async Task HandleGetStatusAsync(GetReminderStatusQuery query)
+    {
+        var replyTo = Sender;
+        try
+        {
+            var definition = _definitionStore.Get(query.Id);
+            if (definition is null)
+            {
+                replyTo.Tell(NotFoundStatus(query.Id));
+                return;
+            }
+
+            var schedules = await ListScheduledRemindersAsync();
+            var history = await _historyStore.ReadAsync(query.Id, 10);
+
+            replyTo.Tell(new ReminderStatusResponse(
+                query.Id,
+                Found: true,
+                Enabled: definition.Enabled,
+                Executing: _activeExecutions.IsExecuting(query.Id),
+                NextFire: schedules.GetValueOrDefault(query.Id.Value),
+                ConsecutiveFailures: _failureCounts.GetValueOrDefault(query.Id),
+                SkippedDuplicates: _skipCounts.GetValueOrDefault(query.Id),
+                RecentHistory: history));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error getting status for reminder '{0}'", query.Id.Value);
+            replyTo.Tell(NotFoundStatus(query.Id));
+        }
+
+        static ReminderStatusResponse NotFoundStatus(ReminderId id) => new(
+            id, Found: false, Enabled: false, Executing: false,
+            NextFire: null, ConsecutiveFailures: 0, SkippedDuplicates: 0,
+            RecentHistory: []);
     }
 
     private sealed record ScheduleAttempt(bool IsSuccess, DateTimeOffset? NextFire, string? ErrorMessage) : INoSerializationVerificationNeeded

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -404,6 +404,30 @@ public sealed record ReminderHealthResponse(
     int ActiveExecutions,
     int FailedCount) : IReminderResponse, INoSerializationVerificationNeeded;
 
+/// <summary>
+/// Query sent to <see cref="ReminderManagerActor"/> for the per-reminder
+/// operational status surfaced by <c>netclaw reminder status &lt;id&gt;</c>.
+/// </summary>
+public sealed record GetReminderStatusQuery(ReminderId Id) : IReminderQuery, INoSerializationVerificationNeeded;
+
+/// <summary>
+/// Response to <see cref="GetReminderStatusQuery"/>: per-reminder health for an
+/// operator — whether the reminder exists/is enabled, whether an execution is in
+/// flight right now, when it next fires, the consecutive-failure and
+/// skipped-duplicate counts (in-memory since daemon start), and recent run
+/// history. Lets <c>netclaw reminder status</c> answer "is this reminder healthy
+/// or is it silently failing/skipping?" — the gap that hid #1492.
+/// </summary>
+public sealed record ReminderStatusResponse(
+    ReminderId Id,
+    bool Found,
+    bool Enabled,
+    bool Executing,
+    DateTimeOffset? NextFire,
+    int ConsecutiveFailures,
+    int SkippedDuplicates,
+    IReadOnlyList<HistoryRecord> RecentHistory) : IReminderResponse, INoSerializationVerificationNeeded;
+
 }
 
 public sealed record ReminderInfo(

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -179,6 +179,13 @@ public sealed class DaemonApi
         return await client.GetAsync($"{_endpoint}/api/reminders/{id}/history?last={last}", cts.Token);
     }
 
+    public async Task<HttpResponseMessage> GetReminderStatusAsync(string id, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = CreateHttpClient();
+        return await client.GetAsync($"{_endpoint}/api/reminders/{id}/status", cts.Token);
+    }
+
     public async Task<HttpResponseMessage> EnableReminderAsync(string id, CancellationToken ct = default)
     {
         using var cts = CreateTimeoutCts(DefaultTimeout, ct);

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -59,6 +59,7 @@ internal static class ReminderCommand
             "import" => await RunImportAsync(daemonApi, args),
             "show" => await RunShowAsync(daemonApi, args),
             "history" => await RunHistoryAsync(daemonApi, args),
+            "status" => await RunStatusAsync(daemonApi, args),
             _ => WriteHelp()
         };
     }
@@ -552,6 +553,83 @@ internal static class ReminderCommand
         }
     }
 
+    private static async Task<int> RunStatusAsync(DaemonApi api, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder status <id>");
+            return 1;
+        }
+
+        var id = args[2];
+
+        try
+        {
+            using var response = await api.GetReminderStatusAsync(id);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                Console.Error.WriteLine($"[FAIL] Reminder '{id}' not found.");
+                return 1;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"[FAIL] daemon returned {(int)response.StatusCode}");
+                return 1;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var status = JsonSerializer.Deserialize<ReminderStatusView>(json, JsonOptions);
+            if (status is null)
+            {
+                Console.Error.WriteLine("[FAIL] could not parse status response.");
+                return 1;
+            }
+
+            Console.WriteLine($"Reminder:            {status.Id}");
+            Console.WriteLine($"Enabled:             {status.Enabled}");
+            Console.WriteLine($"Executing now:       {status.Executing}");
+            Console.WriteLine($"Next fire:           {status.NextFire ?? "—"}");
+            Console.WriteLine($"Consecutive fails:   {status.ConsecutiveFailures}");
+            Console.WriteLine($"Skipped (duplicate): {status.SkippedDuplicates}");
+
+            var history = status.RecentHistory ?? [];
+            if (history.Length == 0)
+            {
+                Console.WriteLine("Recent history:      none");
+            }
+            else
+            {
+                Console.WriteLine("Recent history:");
+                foreach (var r in history.Take(5))
+                {
+                    var outcome = r.Success ? "ok" : "failed";
+                    var err = string.IsNullOrEmpty(r.ErrorMessage) ? "" : $" — {r.ErrorMessage}";
+                    Console.WriteLine($"  {r.FiredAt:u}  {outcome}{err}");
+                }
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            Console.Error.WriteLine("       fix: run `netclaw daemon start` and retry.");
+            return 1;
+        }
+    }
+
+    /// <summary>CLI-side projection of the daemon's reminder status JSON.</summary>
+    private sealed record ReminderStatusView(
+        string Id,
+        bool Enabled,
+        bool Executing,
+        string? NextFire,
+        int ConsecutiveFailures,
+        int SkippedDuplicates,
+        HistoryRecord[]? RecentHistory);
+
     private static int WriteHelp()
     {
         Console.WriteLine("Usage: netclaw reminder <subcommand>");
@@ -567,6 +645,7 @@ internal static class ReminderCommand
         Console.WriteLine("  validate <file>                               Validate reminder file");
         Console.WriteLine("  show <id>                                     Show reminder details");
         Console.WriteLine("  history <id> [--last N]                       Show recent execution history (default: 20)");
+        Console.WriteLine("  status <id>                                   Show operational status: failures, skipped fires, in-flight");
         Console.WriteLine();
         Console.WriteLine("Create options:");
         Console.WriteLine("  --name <title>           Human-readable title (defaults to <id>)");

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -590,7 +590,7 @@ internal static class ReminderCommand
             Console.WriteLine($"Reminder:            {status.Id}");
             Console.WriteLine($"Enabled:             {status.Enabled}");
             Console.WriteLine($"Executing now:       {status.Executing}");
-            Console.WriteLine($"Next fire:           {status.NextFire ?? "—"}");
+            Console.WriteLine($"Next fire:           {status.NextFire ?? "not scheduled"}");
             Console.WriteLine($"Consecutive fails:   {status.ConsecutiveFailures}");
             Console.WriteLine($"Skipped (duplicate): {status.SkippedDuplicates}");
 
@@ -601,8 +601,10 @@ internal static class ReminderCommand
             }
             else
             {
-                Console.WriteLine("Recent history:");
-                foreach (var r in history.Take(5))
+                Console.WriteLine("Recent history (newest first):");
+                // History arrives oldest-first; reverse so the most recent runs
+                // (the ones an operator diagnosing a failure cares about) lead.
+                foreach (var r in history.Reverse())
                 {
                     var outcome = r.Success ? "ok" : "failed";
                     var err = string.IsNullOrEmpty(r.ErrorMessage) ? "" : $" — {r.ErrorMessage}";

--- a/src/Netclaw.Daemon.Tests/Reminders/ReminderChannelFailureNotifierTests.cs
+++ b/src/Netclaw.Daemon.Tests/Reminders/ReminderChannelFailureNotifierTests.cs
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------
+// <copyright file="ReminderChannelFailureNotifierTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Channels;
+using Netclaw.Daemon.Reminders;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Reminders;
+
+public class ReminderChannelFailureNotifierTests
+{
+    [Fact]
+    public async Task NotifyFailure_posts_text_to_the_resolved_destination_channel()
+    {
+        var key = ChannelDescriptorKey.Create("slack");
+        var client = new CapturingOutboundClient(key);
+        var notifier = new ReminderChannelFailureNotifier(
+            new StubChannelRegistry(client),
+            NullLogger<ReminderChannelFailureNotifier>.Instance);
+
+        var target = new ChannelDeliveryTargetInfo("slack", "destination", "C12345");
+        notifier.NotifyFailure(target, "Reminder \"gotowebinar\" failed: stalled");
+
+        // Fire-and-forget — await the capture (a real signal, not a sleep).
+        var request = await client.Captured.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal(ChannelAddressKind.Destination, request.AddressKind);
+        Assert.Equal("C12345", request.TargetId);
+        Assert.Contains("failed", request.Text);
+    }
+
+    [Fact]
+    public async Task NotifyFailure_maps_direct_message_kind()
+    {
+        var key = ChannelDescriptorKey.Create("slack");
+        var client = new CapturingOutboundClient(key);
+        var notifier = new ReminderChannelFailureNotifier(
+            new StubChannelRegistry(client),
+            NullLogger<ReminderChannelFailureNotifier>.Instance);
+
+        var target = new ChannelDeliveryTargetInfo("slack", "direct_message", "U999");
+        notifier.NotifyFailure(target, "Reminder failed");
+
+        var request = await client.Captured.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal(ChannelAddressKind.DirectMessage, request.AddressKind);
+        Assert.Equal("U999", request.TargetId);
+    }
+
+    private sealed class CapturingOutboundClient(ChannelDescriptorKey key) : IChannelOutboundClient
+    {
+        private readonly TaskCompletionSource<ChannelSendRequest> _captured =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ChannelDescriptorKey Key { get; } = key;
+
+        public Task<ChannelSendRequest> Captured => _captured.Task;
+
+        public Task<string> SendMessageAsync(ChannelSendRequest request, CancellationToken ct = default)
+        {
+            _captured.TrySetResult(request);
+            return Task.FromResult("ok");
+        }
+    }
+
+    /// <summary>Minimal registry that only resolves the outbound client under test.</summary>
+    private sealed class StubChannelRegistry(IChannelOutboundClient client) : IChannelRegistry
+    {
+        public IChannelOutboundClient GetOutboundClient(ChannelDescriptorKey key) => client;
+
+        public IReadOnlyCollection<ChannelDescriptor> ListChannels() => throw new NotImplementedException();
+        public ChannelDescriptor GetChannel(ChannelDescriptorKey key) => throw new NotImplementedException();
+        public ValueTask<ChannelRuntimeSnapshot> GetSnapshotAsync(ChannelDescriptorKey key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public IChannelAddressResolver GetResolver(ChannelDescriptorKey key, ChannelAddressKind addressKind) => throw new NotImplementedException();
+        public IChannelOutputRenderer GetOutputRenderer(ChannelDescriptorKey key) => throw new NotImplementedException();
+        public ValueTask<ChannelAddressResolutionResult> ResolveAddressAsync(ChannelAddressResolutionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<ChannelAddressResolutionResult> ListDestinationsAsync(ChannelDescriptorKey key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<ChannelOutputRenderResult> RenderOutputAsync(ChannelOutputRenderRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -751,6 +751,13 @@ static void ConfigureDaemonServices(
         services.AddSingleton<IOperationalNotificationSink>(NullNotificationSink.Instance);
     }
 
+    // Posts reminder failure notices to the reminder's destination channel.
+    // IChannelRegistry is always registered (AddChannelRegistry below), so the
+    // real notifier is always available; it no-ops gracefully for reminders whose
+    // channel has no outbound client.
+    services.AddSingleton<Netclaw.Actors.Reminders.IReminderChannelNotifier,
+        Netclaw.Daemon.Reminders.ReminderChannelFailureNotifier>();
+
     // Daemon lifecycle notifier (startup/shutdown webhooks + logging)
     services.AddSingleton<DaemonLifecycleNotifier>();
 

--- a/src/Netclaw.Daemon/Reminders/ReminderChannelFailureNotifier.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderChannelFailureNotifier.cs
@@ -1,0 +1,79 @@
+// -----------------------------------------------------------------------
+// <copyright file="ReminderChannelFailureNotifier.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Reminders;
+using Netclaw.Channels;
+using Netclaw.Tools;
+
+namespace Netclaw.Daemon.Reminders;
+
+/// <summary>
+/// Daemon-side <see cref="IReminderChannelNotifier"/>: posts a reminder's failure
+/// notice to its destination channel via the channel outbound registry, so the
+/// operator sees the failure where they expect that reminder's output. Lives in
+/// the daemon (not the actor) because <see cref="IChannelRegistry"/> is a channel
+/// concern; the actor layer stays transport-agnostic. Fire-and-forget — never
+/// blocks or throws into the reminder manager; delivery failures are logged.
+/// </summary>
+internal sealed class ReminderChannelFailureNotifier : IReminderChannelNotifier
+{
+    private readonly IChannelRegistry _registry;
+    private readonly ILogger<ReminderChannelFailureNotifier> _logger;
+
+    public ReminderChannelFailureNotifier(
+        IChannelRegistry registry,
+        ILogger<ReminderChannelFailureNotifier> logger)
+    {
+        _registry = registry;
+        _logger = logger;
+    }
+
+    public void NotifyFailure(ChannelDeliveryTargetInfo target, string text)
+        => _ = PostAsync(target, text);
+
+    private async Task PostAsync(ChannelDeliveryTargetInfo target, string text)
+    {
+        try
+        {
+            if (!ChannelAddressKindWire.TryParse(target.DestinationKind, out var addressKind))
+            {
+                _logger.LogWarning(
+                    "Reminder failure notice not posted: unrecognized destination kind '{DestinationKind}' for channel '{ChannelKey}'.",
+                    target.DestinationKind, target.ChannelKey);
+                return;
+            }
+
+            IChannelOutboundClient outbound;
+            try
+            {
+                outbound = _registry.GetOutboundClient(ChannelDescriptorKey.Create(target.ChannelKey));
+            }
+            catch (InvalidOperationException)
+            {
+                _logger.LogWarning(
+                    "Reminder failure notice not posted: channel '{ChannelKey}' has no registered outbound client.",
+                    target.ChannelKey);
+                return;
+            }
+
+            // Outbound clients return an "Error: ..." string for expected send
+            // failures rather than throwing, so inspect the result.
+            var result = await outbound.SendMessageAsync(
+                new ChannelSendRequest(addressKind, target.DestinationId, text));
+
+            if (result.StartsWith("Error:", StringComparison.Ordinal))
+                _logger.LogWarning(
+                    "Reminder failure notice to channel '{ChannelKey}' was rejected: {Result}",
+                    target.ChannelKey, result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to post reminder failure notice to channel '{ChannelKey}'.",
+                target.ChannelKey);
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
@@ -323,7 +323,9 @@ public static class ReminderEndpointRouteBuilderExtensions
                 Id: status.Id.Value,
                 Enabled: status.Enabled,
                 Executing: status.Executing,
-                NextFire: SetReminderTool.FormatTimestamp(status.NextFire),
+                // Pass null through (FormatTimestamp renders null as the literal
+                // "unknown"); the CLI shows "not scheduled" for an absent next fire.
+                NextFire: status.NextFire is null ? null : SetReminderTool.FormatTimestamp(status.NextFire),
                 ConsecutiveFailures: status.ConsecutiveFailures,
                 SkippedDuplicates: status.SkippedDuplicates,
                 RecentHistory: status.RecentHistory));

--- a/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
@@ -307,6 +307,30 @@ public static class ReminderEndpointRouteBuilderExtensions
         .WithName("GetReminderHistory")
         .WithSummary("Get recent fire history for a reminder.");
 
+        reminders.MapGet("/{id}/status", async ValueTask<Results<Ok<ReminderStatusDto>, NotFound<ReminderErrorResponse>>> (
+            string id,
+            IRequiredActor<ReminderManagerActorKey> actor,
+            CancellationToken ct) =>
+        {
+            var manager = await actor.GetAsync(ct);
+            var status = await manager.Ask<ReminderStatusResponse>(
+                new GetReminderStatusQuery(new ReminderId(id)), TimeSpan.FromSeconds(10), ct);
+
+            if (!status.Found)
+                return TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
+
+            return TypedResults.Ok(new ReminderStatusDto(
+                Id: status.Id.Value,
+                Enabled: status.Enabled,
+                Executing: status.Executing,
+                NextFire: SetReminderTool.FormatTimestamp(status.NextFire),
+                ConsecutiveFailures: status.ConsecutiveFailures,
+                SkippedDuplicates: status.SkippedDuplicates,
+                RecentHistory: status.RecentHistory));
+        })
+        .WithName("GetReminderStatus")
+        .WithSummary("Get per-reminder operational status: in-flight, consecutive failures, skipped fires, recent history.");
+
         return app;
     }
 
@@ -380,6 +404,16 @@ internal sealed record ReminderDetailDto(
     bool DeliveryRequired,
     string? DeliveryInstructions,
     string? Audience);
+
+/// <summary>Per-reminder operational status projection (see <c>GET /{id}/status</c>).</summary>
+internal sealed record ReminderStatusDto(
+    string Id,
+    bool Enabled,
+    bool Executing,
+    string? NextFire,
+    int ConsecutiveFailures,
+    int SkippedDuplicates,
+    IReadOnlyList<HistoryRecord> RecentHistory);
 
 /// <summary>Acknowledgement carrying a human-readable message.</summary>
 internal sealed record ReminderMessageResponse(string Message);


### PR DESCRIPTION
## What

Fixes #1494. Reminder failures were invisible to operators — only a buried daemon log line — so the gotowebinar reminder silently skipped **49 fires in a day** before anyone noticed. This surfaces failures where operators actually look, and adds a status command.

## Changes

### 1. Failure → destination channel (your primary ask)
When a `channel`-delivery reminder execution fails **for any reason** — including the #1500 stall backstop recovering a wedged run, or hitting the auto-disable threshold — a plain-language notice is posted to the reminder's **own destination channel**, where the operator expects that reminder's output.

- New `IReminderChannelNotifier` seam: interface in `Netclaw.Actors` (transport-agnostic — the manager hands over an already-resolved `ChannelDeliveryTargetInfo`), implemented in `Netclaw.Daemon` over `IChannelRegistry`. Keeps the actor boundary transport-agnostic per the constitution.
- **Bounded, not spammy:** at most a few notices plus the disabled notice (auto-disable threshold). **Skips are not posted** (they can be many) — only counted.
- `NullReminderChannelNotifier` Null Object for tests / no-channel daemons — a *required* dependency (per the new "no optional/nullable deps" rule from #1498), not a nullable one.

### 2. Skipped-duplicate visibility
The two skip sites (scheduled fire + deferred-queue dequeue) now increment an in-memory per-reminder counter instead of only logging — so the silent-skip pattern is finally countable.

### 3. `netclaw reminder status <id>`
New CLI subcommand + `GET /api/reminders/{id}/status` REST endpoint, backed by a new `GetReminderStatusQuery` the manager answers from **live** state: enabled, in-flight right now, next fire, consecutive failures, skipped-fire count (since daemon start), and recent run history. The at-a-glance "is this reminder healthy or silently failing?" view the incident lacked.

## How it fits with #1500

#1500 makes a wedged reminder *recover* (fail after ~20 min instead of forever). #1494 makes that recovery *visible*: the failure posts to the channel, and the skips that piled up in between are countable via `status`. Together they close the incident.

## Layering

`ReminderManagerActor` (in `Netclaw.Actors`) resolves the channel target via `ReminderExecutionActor.ResolveChannelDeliveryTarget` (same assembly) and hands it to the notifier; the daemon-side notifier owns the actual channel post. The actor never references channel/transport types.

## Tests

- `ReminderChannelFailureNotifierTests`: posts the correct `ChannelSendRequest` for both `destination` and `direct_message` kinds (real fire-and-forget awaited via a capture signal, no sleeps).
- `ReminderManagerActorTests`: status query returns per-reminder health; unknown reminder → not-found.
- Full `Netclaw.Actors.Tests` (2482) and `Netclaw.Daemon.Tests` (754) green. Slopwatch clean (3 pre-existing warnings, unrelated files); headers verified.

## Docs

Updates the `netclaw-operations` skill (scheduling reference) with the failure-to-channel behavior and the `reminder status` command; bumps `metadata.version` 2.19.0 → 2.20.0.

## Gate not run locally
The behavioral eval suite (skill-content edit) needs a live model endpoint not configured here — should run in CI / before merge.