### PR TITLE
chore(deps): upgrade Termina to 0.15.0-beta1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.14.0" />
+    <PackageVersion Include="Termina" Version="0.15.0-beta1" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>


### PR DESCRIPTION
## What's Changing

Upgrades the **Termina** TUI library from `0.14.0` to `0.15.0-beta1`.

### Key changes in Termina 0.15.0-beta1

- **New KeyMap system** — complete keyboard shortcut framework (46 commits total)
- **Bug fixes**: CJK and Unicode display width handling (#321)
- **Dependency updates**:
  - `dotnet-sdk` 10.0.201 → 10.0.301
  - `Microsoft.Extensions.TimeProvider.Testing` 10.6.0 → 10.7.0
  - `dotnet-sdk` from 5.2.0 → 5.3.0
  - `Microsoft.NET.Test.Sdk` 18.6.0 → 18.7.0

### Verification

- ✅ **Build**: Clean build — 0 warnings, 0 errors
- ✅ **Tests**: All 5,374 tests passed (0 failures)
  - Netclaw.Actors.Tests: 2,382 passed
  - Netclaw.Cli.Tests: 1,126 passed
  - Netclaw.Daemon.Tests: 742 passed
  - Netclaw.Configuration.Tests: 431 passed
  - Netclaw.Security.Tests: 578 passed
  - Netclaw.Media.Tests: 65 passed
  - Netclaw.Search.Tests: 45 passed
  - Netclaw.MemoryRetrievalPoC.Tests: 5 passed