### PR TITLE
fix(mcp): surface MCP tool errors as clean attributed messages, not raw JSON (#1495)

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.20.0"
+  version: "2.21.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/tools.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/tools.md
@@ -92,3 +92,19 @@ Personal audience, press `M` to set a server default (`Approval` is the
 safe choice), `S` to save, then restart the daemon. Repeat for each
 audience you want to tighten. `doctor` stops warning once the default is
 set.
+
+### When an MCP tool fails
+
+A failed MCP tool call returns a plain, attributed error string — not a raw
+JSON blob — so you can act on it directly:
+
+- `Error: MCP tool 'server/tool' reported a failure: <detail>` — the **server**
+  rejected the call (e.g. bad arguments, `old_string not found`). The detail is
+  the server's own message; fix the arguments and retry, or pick a different
+  tool. This is a tool-level error, not a netclaw or "tool not loaded" problem.
+- `Error: MCP tool 'server/tool' failed: <detail>` — the call could not reach
+  the server (transport/connection failure). Check the server's health with
+  `netclaw mcp status`; a reconnect is attempted automatically once.
+
+Both name the server explicitly (`server/tool`), so when two servers expose a
+same-named tool you can tell which one failed.

--- a/src/Netclaw.Actors.Tests/Tools/McpToolResultFormatterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolResultFormatterTests.cs
@@ -40,7 +40,21 @@ public class McpToolResultFormatterTests
     }
 
     [Fact]
-    public void Error_result_without_text_reports_no_detail()
+    public void Error_detail_falls_back_to_structured_content_when_no_text_block()
+    {
+        // The error's actionable detail lives in structuredContent with no text
+        // block — a bare content[].text scan would drop it and report "no detail".
+        var result = Json("""{"content":[],"structuredContent":{"field":"name","reason":"required"},"isError":true}""");
+
+        var message = McpToolResultFormatter.Format(result, "srv/tool");
+
+        Assert.Contains("reported a failure", message);
+        Assert.Contains("required", message);
+        Assert.DoesNotContain("no detail provided", message);
+    }
+
+    [Fact]
+    public void Error_result_without_any_detail_reports_no_detail()
     {
         var result = Json("""{"content":[],"isError":true}""");
 
@@ -50,16 +64,28 @@ public class McpToolResultFormatterTests
     }
 
     [Fact]
-    public void Non_error_json_result_is_passed_through_unchanged()
+    public void Structured_success_surfaces_clean_text_not_the_wrapper()
     {
-        // A structured (non-error) result also arrives as a JsonElement — it must
-        // NOT be reframed as a failure.
-        var result = Json("""{"value":42,"isError":false}""");
+        // Success WITH structuredContent is also serialized to a full
+        // CallToolResult; surface the readable text, not the isError:false wrapper.
+        var result = Json("""{"content":[{"type":"text","text":"42 results found"}],"structuredContent":{"count":42},"isError":false}""");
 
         var message = McpToolResultFormatter.Format(result, "srv/tool");
 
+        Assert.Equal("42 results found", message);
+        Assert.DoesNotContain("isError", message);
         Assert.DoesNotContain("reported a failure", message);
+    }
+
+    [Fact]
+    public void Structured_success_without_text_surfaces_the_structured_content()
+    {
+        var result = Json("""{"content":[],"structuredContent":{"count":42},"isError":false}""");
+
+        var message = McpToolResultFormatter.Format(result, "srv/tool");
+
         Assert.Contains("42", message);
+        Assert.DoesNotContain("reported a failure", message);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/McpToolResultFormatterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolResultFormatterTests.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpToolResultFormatterTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class McpToolResultFormatterTests
+{
+    private static JsonElement Json(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+
+    [Fact]
+    public void Error_result_is_surfaced_as_an_attributed_tool_error()
+    {
+        // What the MCP SDK hands back when a tool sets isError=true: the whole
+        // CallToolResult serialized. Without this formatting the model would see
+        // the raw JSON blob and could not tell it from a netclaw failure (#1495).
+        var result = Json("""{"content":[{"type":"text","text":"old_string not found"}],"isError":true}""");
+
+        var message = McpToolResultFormatter.Format(result, "memorizer/edit");
+
+        Assert.StartsWith("Error: MCP tool 'memorizer/edit' reported a failure:", message);
+        Assert.Contains("old_string not found", message);
+        Assert.DoesNotContain("isError", message);
+    }
+
+    [Fact]
+    public void Error_result_with_multiple_text_blocks_joins_them()
+    {
+        var result = Json("""{"content":[{"type":"text","text":"line one"},{"type":"text","text":"line two"}],"isError":true}""");
+
+        var message = McpToolResultFormatter.Format(result, "srv/tool");
+
+        Assert.Contains("line one", message);
+        Assert.Contains("line two", message);
+    }
+
+    [Fact]
+    public void Error_result_without_text_reports_no_detail()
+    {
+        var result = Json("""{"content":[],"isError":true}""");
+
+        var message = McpToolResultFormatter.Format(result, "srv/tool");
+
+        Assert.Contains("no detail provided", message);
+    }
+
+    [Fact]
+    public void Non_error_json_result_is_passed_through_unchanged()
+    {
+        // A structured (non-error) result also arrives as a JsonElement — it must
+        // NOT be reframed as a failure.
+        var result = Json("""{"value":42,"isError":false}""");
+
+        var message = McpToolResultFormatter.Format(result, "srv/tool");
+
+        Assert.DoesNotContain("reported a failure", message);
+        Assert.Contains("42", message);
+    }
+
+    [Fact]
+    public void Plain_string_result_is_passed_through()
+        => Assert.Equal("Message sent.", McpToolResultFormatter.Format("Message sent.", "srv/tool"));
+
+    [Fact]
+    public void Null_result_is_empty()
+        => Assert.Equal(string.Empty, McpToolResultFormatter.Format(null, "srv/tool"));
+}

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -145,7 +145,7 @@ public sealed class McpToolAdapter : INetclawTool
                 ? new AIFunctionArguments(coerced)
                 : null;
             var result = await func.InvokeAsync(aiArgs, ct);
-            return result?.ToString() ?? "";
+            return McpToolResultFormatter.Format(result, Name);
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Actors/Tools/McpToolResultFormatter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolResultFormatter.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpToolResultFormatter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Renders the object returned by an MCP tool invocation into the string the
+/// model sees.
+/// <para>
+/// The MCP SDK (<c>McpClientTool.InvokeCoreAsync</c>) returns clean
+/// <c>AIContent</c> for a successful, non-structured result — but when the
+/// server sets <c>isError: true</c> it returns the <em>entire</em>
+/// <c>CallToolResult</c> serialized as a <see cref="JsonElement"/>. Passing that
+/// through <c>ToString()</c> hands the model a raw JSON blob
+/// (<c>{"content":[{"type":"text","text":"..."}],"isError":true}</c>), which it
+/// cannot distinguish from a transport failure or a netclaw error — the exact
+/// confusion behind #1495. This extracts the error's text and surfaces it as a
+/// clear, attributed tool-error message instead.
+/// </para>
+/// </summary>
+public static class McpToolResultFormatter
+{
+    public static string Format(object? result, string toolName)
+    {
+        if (result is JsonElement element && IsErrorResult(element))
+        {
+            var detail = ExtractText(element);
+            return string.IsNullOrWhiteSpace(detail)
+                ? $"Error: MCP tool '{toolName}' reported a failure (no detail provided)."
+                : $"Error: MCP tool '{toolName}' reported a failure: {detail}";
+        }
+
+        return result?.ToString() ?? string.Empty;
+    }
+
+    private static bool IsErrorResult(JsonElement element)
+        => element.ValueKind == JsonValueKind.Object
+           && element.TryGetProperty("isError", out var isError)
+           && isError.ValueKind == JsonValueKind.True;
+
+    private static string ExtractText(JsonElement result)
+    {
+        if (!result.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            return string.Empty;
+
+        var parts = new List<string>();
+        foreach (var block in content.EnumerateArray())
+        {
+            if (block.ValueKind == JsonValueKind.Object
+                && block.TryGetProperty("text", out var text)
+                && text.ValueKind == JsonValueKind.String
+                && text.GetString() is { Length: > 0 } s)
+            {
+                parts.Add(s);
+            }
+        }
+
+        return string.Join("\n", parts);
+    }
+}

--- a/src/Netclaw.Actors/Tools/McpToolResultFormatter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolResultFormatter.cs
@@ -12,39 +12,71 @@ namespace Netclaw.Actors.Tools;
 /// model sees.
 /// <para>
 /// The MCP SDK (<c>McpClientTool.InvokeCoreAsync</c>) returns clean
-/// <c>AIContent</c> for a successful, non-structured result — but when the
-/// server sets <c>isError: true</c> it returns the <em>entire</em>
-/// <c>CallToolResult</c> serialized as a <see cref="JsonElement"/>. Passing that
-/// through <c>ToString()</c> hands the model a raw JSON blob
-/// (<c>{"content":[{"type":"text","text":"..."}],"isError":true}</c>), which it
-/// cannot distinguish from a transport failure or a netclaw error — the exact
-/// confusion behind #1495. This extracts the error's text and surfaces it as a
-/// clear, attributed tool-error message instead.
+/// <c>AIContent</c> for a successful, single-content result — but serializes the
+/// <em>entire</em> <c>CallToolResult</c> to a <see cref="JsonElement"/> whenever
+/// it sets <c>isError: true</c> <strong>or</strong> the result carries
+/// <c>structuredContent</c>. Passing that through <c>ToString()</c> hands the
+/// model a raw JSON blob
+/// (<c>{"content":[{"type":"text","text":"..."}],"isError":true}</c>) it cannot
+/// distinguish from a transport failure or a netclaw error — the confusion behind
+/// #1495. This unwraps both shapes: errors become a clear, attributed message,
+/// and structured successes surface their actual content instead of the
+/// <c>isError:false</c> wrapper.
 /// </para>
 /// </summary>
 public static class McpToolResultFormatter
 {
     public static string Format(object? result, string toolName)
     {
-        if (result is JsonElement element && IsErrorResult(element))
+        if (result is JsonElement element && IsCallToolResult(element))
         {
-            var detail = ExtractText(element);
-            return string.IsNullOrWhiteSpace(detail)
-                ? $"Error: MCP tool '{toolName}' reported a failure (no detail provided)."
-                : $"Error: MCP tool '{toolName}' reported a failure: {detail}";
+            var detail = ExtractDetail(element);
+
+            if (IsError(element))
+            {
+                return string.IsNullOrWhiteSpace(detail)
+                    ? $"Error: MCP tool '{toolName}' reported a failure (no detail provided)."
+                    : $"Error: MCP tool '{toolName}' reported a failure: {detail}";
+            }
+
+            // Structured success: surface the clean detail rather than the
+            // {content,structuredContent,isError} wrapper. Fall back to the raw
+            // element only if there is genuinely nothing extractable.
+            return string.IsNullOrWhiteSpace(detail) ? element.GetRawText() : detail;
         }
 
         return result?.ToString() ?? string.Empty;
     }
 
-    private static bool IsErrorResult(JsonElement element)
+    private static bool IsCallToolResult(JsonElement element)
         => element.ValueKind == JsonValueKind.Object
-           && element.TryGetProperty("isError", out var isError)
-           && isError.ValueKind == JsonValueKind.True;
+           && (element.TryGetProperty("content", out _) || element.TryGetProperty("isError", out _));
 
-    private static string ExtractText(JsonElement result)
+    private static bool IsError(JsonElement element)
+        => element.TryGetProperty("isError", out var isError) && isError.ValueKind == JsonValueKind.True;
+
+    /// <summary>
+    /// Prefers the human-readable text blocks, then falls back to
+    /// <c>structuredContent</c> so machine-readable detail (e.g. validation errors
+    /// returned as a JSON object with no text block) is never dropped — which a
+    /// bare <c>content[].text</c> scan would silently do.
+    /// </summary>
+    private static string ExtractDetail(JsonElement element)
     {
-        if (!result.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+        var text = JoinTextContent(element);
+        if (!string.IsNullOrWhiteSpace(text))
+            return text;
+
+        if (element.TryGetProperty("structuredContent", out var structured)
+            && structured.ValueKind is not (JsonValueKind.Undefined or JsonValueKind.Null))
+            return structured.GetRawText();
+
+        return string.Empty;
+    }
+
+    private static string JoinTextContent(JsonElement element)
+    {
+        if (!element.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
             return string.Empty;
 
         var parts = new List<string>();

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -176,7 +176,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
         try
         {
-            return await InvokeFunctionAsync(function, arguments, ct);
+            return await InvokeFunctionAsync(function, toolName.Value, arguments, ct);
         }
         catch (Exception ex)
         {
@@ -190,7 +190,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 || retryFunction is null)
                 throw;
 
-            return await InvokeFunctionAsync(retryFunction, arguments, ct);
+            return await InvokeFunctionAsync(retryFunction, toolName.Value, arguments, ct);
         }
     }
 
@@ -217,7 +217,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                     $"MCP tool '{toolName.Value}' is not available on server '{serverName.Value}'.");
             }
 
-            return await InvokeFunctionAsync(function, arguments, ct);
+            return await InvokeFunctionAsync(function, toolName.Value, arguments, ct);
         }
         finally
         {
@@ -228,6 +228,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
     private static async Task<string> InvokeFunctionAsync(
         AIFunction function,
+        string toolName,
         IDictionary<string, object?>? arguments,
         CancellationToken ct)
     {
@@ -236,7 +237,9 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             : null;
 
         var result = await function.InvokeAsync(aiArgs, ct);
-        return result?.ToString() ?? "";
+        // The SDK returns the whole CallToolResult as raw JSON on isError; surface
+        // a clean, attributed error instead of a blob the model can't classify (#1495).
+        return McpToolResultFormatter.Format(result, toolName);
     }
 
     private bool TryGetSharedFunction(McpServerName serverName, string toolName, out AIFunction? function)

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -176,7 +176,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
         try
         {
-            return await InvokeFunctionAsync(function, toolName.Value, arguments, ct);
+            return await InvokeFunctionAsync(function, $"{serverName.Value}/{toolName.Value}", arguments, ct);
         }
         catch (Exception ex)
         {
@@ -190,7 +190,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 || retryFunction is null)
                 throw;
 
-            return await InvokeFunctionAsync(retryFunction, toolName.Value, arguments, ct);
+            return await InvokeFunctionAsync(retryFunction, $"{serverName.Value}/{toolName.Value}", arguments, ct);
         }
     }
 
@@ -217,7 +217,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                     $"MCP tool '{toolName.Value}' is not available on server '{serverName.Value}'.");
             }
 
-            return await InvokeFunctionAsync(function, toolName.Value, arguments, ct);
+            return await InvokeFunctionAsync(function, $"{serverName.Value}/{toolName.Value}", arguments, ct);
         }
         finally
         {
@@ -226,9 +226,13 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         }
     }
 
+    // qualifiedToolName is the server-qualified "server/tool" name (not the bare
+    // function.Name, which omits the server) so MCP error attribution matches the
+    // bound-tool path (McpToolAdapter.Name) — otherwise the same error renders
+    // differently depending on which invocation path produced it.
     private static async Task<string> InvokeFunctionAsync(
         AIFunction function,
-        string toolName,
+        string qualifiedToolName,
         IDictionary<string, object?>? arguments,
         CancellationToken ct)
     {
@@ -239,7 +243,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         var result = await function.InvokeAsync(aiArgs, ct);
         // The SDK returns the whole CallToolResult as raw JSON on isError; surface
         // a clean, attributed error instead of a blob the model can't classify (#1495).
-        return McpToolResultFormatter.Format(result, toolName);
+        return McpToolResultFormatter.Format(result, qualifiedToolName);
     }
 
     private bool TryGetSharedFunction(McpServerName serverName, string toolName, out AIFunction? function)


### PR DESCRIPTION
## What

Fixes #1495. The issue was filed as *"tool execution should fail explicitly when a tool is not loaded,"* but investigation showed that premise doesn't hold — and pointed at a different, real defect.

## Investigation (why the premise was wrong)

- netclaw only **offers** the model the *loaded* tool set (`FilterExposedTools` → `DiscoveredToolCache`), so the model can't call an unloaded tool in normal operation — there's no "not loaded" gate to add.
- Decompiling the MCP SDK (`ModelContextProtocol.Core` 1.4.0, `McpClientTool.InvokeCoreAsync`) showed the actual mechanism: on a **successful** result it returns clean `AIContent`; but when the server sets **`isError: true`** it falls through and returns the **entire `CallToolResult` serialized as a `JsonElement`**.
- `McpClientManager` then did `result?.ToString()`, handing the model a raw blob:
  ```json
  {"content":[{"type":"text","text":"An error occurred invoking 'edit'"}],"isError":true}
  ```
- That **is** the `"error occurred invoking 'edit'"` the reporter saw — the memorizer server's own error text, buried in a JSON dump. The agent couldn't tell a tool-reported failure from a transport/netclaw error, so it misdiagnosed it as "not loaded."

## Fix

`McpToolResultFormatter`: when an invocation result is an `isError` `JsonElement`, extract the text content and surface it as:

```
Error: MCP tool 'memorizer/edit' reported a failure: <server's error text>
```

Applied at both invocation sites:
- `McpClientManager.InvokeFunctionAsync` (session-scoped / shared invoker path) — now threaded with the tool name.
- `McpToolAdapter.ExecuteViaBoundToolAsync` (bound-tool path).

Unchanged: successful results, **structured (non-error)** results (also arrive as `JsonElement` — must *not* be reframed as failures), and transport exceptions (keep their existing `Error: MCP tool 'X' failed: <ex>` wrapper).

## Tests

`McpToolResultFormatterTests`: error → attributed message (single/multiple/empty text blocks); non-error JSON passthrough; plain-string and null passthrough. Daemon MCP suite (59) green; build + headers + slopwatch clean.

## Note
This reframes the issue from "not loaded gate" to "MCP error surfacing." If you'd prefer #1495 stay scoped to its original title, I can retitle/close and file this under a fresh issue — but the fix here is the concrete, evidence-backed improvement behind the report.