### PR TITLE
feat(tui): configure Copilot GitHub Enterprise auth

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
@@ -103,6 +103,33 @@ public sealed class InitWizardPageTests : IDisposable
         Assert.Equal(_registry.KnownTypeKeys[1], vm.ProviderStep.SelectedProviderType);
     }
 
+    [Fact]
+    public async Task GitHubCopilotEnterpriseInputs_AcceptTypedHostAndApiBase()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        input.EnqueueKey(ConsoleKey.DownArrow); // GitHub Copilot
+        input.EnqueueKey(ConsoleKey.Enter);     // provider selection
+        input.EnqueueKey(ConsoleKey.Enter);     // OAuth Device Flow
+        input.EnqueueKey(ConsoleKey.DownArrow); // GitHub Enterprise
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueuePaste("https://ghe.example.com");
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueuePaste("https://api.ghe.example.com/");
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Q, control: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal("github-copilot", vm.ProviderStep.SelectedProviderType);
+        Assert.Equal("https://ghe.example.com", vm.ProviderStep.GitHubCopilotHostInput);
+        Assert.Equal("https://api.ghe.example.com/", vm.ProviderStep.GitHubCopilotApiBaseInput);
+        Assert.NotNull(vm.ProviderStep.VendorOptions);
+        Assert.Equal("https://ghe.example.com", vm.ProviderStep.VendorOptions!["GitHubHost"]);
+        Assert.Equal("https://api.ghe.example.com", vm.ProviderStep.VendorOptions["GitHubApiBase"]);
+    }
+
 
     // ── Config integrity: wizard choices must match written config ──────────
 

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerPageTests.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProviderManagerPageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Cli.Provider;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Netclaw.Providers;
+using Netclaw.Tests.Utilities;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+public sealed class ProviderManagerPageTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+    private readonly FakeProviderProbe _fakeProbe = new();
+    private readonly ProviderDescriptorRegistry _registry = ProviderCommand.CreateDefaultRegistry();
+
+    public ProviderManagerPageTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public async Task GitHubCopilotEnterpriseInputs_AcceptTypedHostAndApiBase()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        input.EnqueueKey(ConsoleKey.DownArrow); // GitHub Copilot
+        input.EnqueueKey(ConsoleKey.Enter);     // type row -> Name your provider
+        input.EnqueueKey(ConsoleKey.Enter);     // accept generated provider name
+        input.EnqueueKey(ConsoleKey.Enter);     // OAuth Device Flow
+        input.EnqueueKey(ConsoleKey.DownArrow); // GitHub Enterprise
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueuePaste("https://ghe.example.com");
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueuePaste("https://api.ghe.example.com/");
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Q, control: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal("github-copilot", vm.NewProviderType);
+        Assert.Equal("https://ghe.example.com", vm.NewGitHubCopilotHost);
+        Assert.Equal("https://api.ghe.example.com/", vm.NewGitHubCopilotApiBase);
+        Assert.NotNull(vm.NewVendorOptions);
+        Assert.Equal("https://ghe.example.com", vm.NewVendorOptions!["GitHubHost"]);
+        Assert.Equal("https://api.ghe.example.com", vm.NewVendorOptions["GitHubApiBase"]);
+    }
+
+    private (VirtualTerminal Terminal, TerminaApplication App, ProviderManagerViewModel Vm)
+        CreateHeadlessApp(out VirtualInputSource input)
+    {
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        ProviderManagerViewModel? capturedVm = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina("/provider", builder =>
+        {
+            builder.RegisterRoute<ProviderManagerPage, ProviderManagerViewModel>(
+                "/provider",
+                _ => new ProviderManagerPage(),
+                _ =>
+                {
+                    capturedVm = new ProviderManagerViewModel(_paths, _registry, _fakeProbe);
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -836,6 +836,147 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public void SelectAuthMethod_GitHubCopilot_ShowsAuthHostChoiceBeforeOAuth()
+    {
+        using var vm = CreateViewModel();
+        vm.NewProviderName = "my-copilot";
+        vm.NewProviderType = "github-copilot";
+
+        vm.SelectAuthMethod(AuthMethod.OAuthDevice);
+
+        Assert.Equal(ProviderManagerState.AddGitHubCopilotAuthHost, vm.CurrentState.Value);
+        Assert.Null(vm.NewVendorOptions);
+    }
+
+    [Fact]
+    public async Task GitHubCopilotPublicHost_PersistsNoVendorOptionsEvenWithAmbientGitHubHost()
+    {
+        var previous = Environment.GetEnvironmentVariable("GH_HOST");
+        try
+        {
+            Environment.SetEnvironmentVariable("GH_HOST", "enterprise.example.com");
+            using var vm = CreateViewModel();
+            vm.NewProviderName = "my-copilot";
+            vm.NewProviderType = "github-copilot";
+            vm.NewAuthMethod = AuthMethod.OAuthDevice;
+
+            vm.SelectGitHubCopilotAuthHost(GitHubCopilotAuthHostMode.GitHubCom);
+            vm.OAuth.Result = new OAuthDeviceFlowResult(
+                new SensitiveString("oauth-access-token"),
+                null,
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                null);
+            vm.SubmitCredentials();
+            await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+            var configProvider = config.RootElement
+                .GetProperty("Providers")
+                .GetProperty("my-copilot");
+            Assert.False(configProvider.TryGetProperty("VendorOptions", out _));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GH_HOST", previous);
+        }
+    }
+
+    [Fact]
+    public async Task GitHubCopilotEnterpriseHostOnly_PersistsDerivedVendorOptions()
+    {
+        using var vm = CreateViewModel();
+        vm.NewProviderName = "copilot-ghe";
+        vm.NewProviderType = "github-copilot";
+        vm.NewAuthMethod = AuthMethod.OAuthDevice;
+
+        Assert.True(vm.TrySetGitHubCopilotEnterpriseHost("ghe.example.com", out var hostError), hostError);
+        Assert.True(vm.TryStartGitHubCopilotEnterpriseOAuth(null, out var apiError), apiError);
+        vm.OAuth.Result = new OAuthDeviceFlowResult(
+            new SensitiveString("oauth-access-token"),
+            null,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            null);
+
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var vendorOptions = config.RootElement
+            .GetProperty("Providers")
+            .GetProperty("copilot-ghe")
+            .GetProperty("VendorOptions");
+
+        Assert.Equal("https://ghe.example.com", vendorOptions.GetProperty("GitHubHost").GetString());
+        Assert.Equal("https://ghe.example.com/api/v3", vendorOptions.GetProperty("GitHubApiBase").GetString());
+    }
+
+    [Fact]
+    public async Task GitHubCopilotEnterpriseExplicitApiBase_PersistsCanonicalVendorOptions()
+    {
+        using var vm = CreateViewModel();
+        vm.NewProviderName = "copilot-ghe";
+        vm.NewProviderType = "github-copilot";
+        vm.NewAuthMethod = AuthMethod.OAuthDevice;
+
+        Assert.True(vm.TrySetGitHubCopilotEnterpriseHost("https://example.ghe.com", out var hostError), hostError);
+        Assert.True(vm.TryStartGitHubCopilotEnterpriseOAuth("https://api.example.ghe.com/", out var apiError), apiError);
+        vm.OAuth.Result = new OAuthDeviceFlowResult(
+            new SensitiveString("oauth-access-token"),
+            null,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            null);
+
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var vendorOptions = config.RootElement
+            .GetProperty("Providers")
+            .GetProperty("copilot-ghe")
+            .GetProperty("VendorOptions");
+
+        Assert.Equal("https://example.ghe.com", vendorOptions.GetProperty("GitHubHost").GetString());
+        Assert.Equal("https://api.example.ghe.com", vendorOptions.GetProperty("GitHubApiBase").GetString());
+    }
+
+    [Fact]
+    public void GitHubCopilotEnterpriseHostChange_ClearsStaleExplicitApiBase()
+    {
+        using var vm = CreateViewModel();
+        vm.NewProviderType = "github-copilot";
+        vm.NewGitHubCopilotHost = "https://old.ghe.example.com";
+        vm.NewGitHubCopilotApiBase = "https://api.old.ghe.example.com";
+        vm.NewVendorOptions = new Dictionary<string, object?>
+        {
+            ["GitHubHost"] = "https://old.ghe.example.com",
+            ["GitHubApiBase"] = "https://api.old.ghe.example.com",
+        };
+
+        Assert.True(vm.SubmitGitHubCopilotEnterpriseHost("https://new.ghe.example.com", out var error), error);
+
+        Assert.Equal(ProviderManagerState.AddGitHubCopilotEnterpriseApiBase, vm.CurrentState.Value);
+        Assert.Equal("https://new.ghe.example.com", vm.NewGitHubCopilotHost);
+        Assert.Null(vm.NewGitHubCopilotApiBase);
+        Assert.Null(vm.NewVendorOptions);
+    }
+
+    [Fact]
+    public void GitHubCopilotEnterpriseInputs_RejectInvalidValuesBeforeVendorOptions()
+    {
+        using var vm = CreateViewModel();
+        vm.NewProviderType = "github-copilot";
+
+        Assert.False(vm.TrySetGitHubCopilotEnterpriseHost("http://ghe.example.com", out var hostError));
+        Assert.Contains("HTTPS", hostError);
+        Assert.Null(vm.NewVendorOptions);
+
+        Assert.True(vm.TrySetGitHubCopilotEnterpriseHost("ghe.example.com", out hostError), hostError);
+        Assert.False(vm.TryStartGitHubCopilotEnterpriseOAuth("http://ghe.example.com/api/v3", out var apiError));
+        Assert.Contains("HTTPS", apiError);
+        Assert.Null(vm.NewVendorOptions);
+    }
+
+    [Fact]
     public async Task SubmitCredentials_OAuthSuccess_PreservesExistingOAuthProviders()
     {
         WriteConfig(new Dictionary<string, object>

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -76,6 +76,21 @@ public sealed class ProviderStepViewModelTests : IDisposable
     }
 
     [Fact]
+    public void TryGoBack_FromGitHubCopilotModelSelection_GoesToAuthHostChoice()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe)
+        {
+            SelectedProviderType = "github-copilot",
+            SelectedAuthMethod = AuthMethod.OAuthDevice,
+        };
+        step.SetSubStep(4);
+
+        Assert.True(step.TryGoBack());
+
+        Assert.Equal(7, step.CurrentSubStep);
+    }
+
+    [Fact]
     public void TryGoBack_FromOAuthDevice_GoesToAuth()
     {
         using var step = new ProviderStepViewModel(_registry, _fakeProbe);
@@ -99,6 +114,27 @@ public sealed class ProviderStepViewModelTests : IDisposable
         step.SetSubStep(4); // model selection
 
         step.OnEnter(_context, NavigationDirection.Back);
+        Assert.Equal(4, step.CurrentSubStep);
+    }
+
+    [Fact]
+    public void OnEnter_Back_AfterGitHubCopilotEnterpriseFlow_ResumesAtModelSelection()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe)
+        {
+            SelectedProviderType = "github-copilot",
+            SelectedAuthMethod = AuthMethod.OAuthDevice,
+        };
+
+        step.SetSubStep(7);
+        step.SetSubStep(8);
+        step.SetSubStep(9);
+        step.SetSubStep(5);
+        step.SetSubStep(3);
+        step.SetSubStep(4);
+
+        step.OnEnter(_context, NavigationDirection.Back);
+
         Assert.Equal(4, step.CurrentSubStep);
     }
 
@@ -226,6 +262,107 @@ public sealed class ProviderStepViewModelTests : IDisposable
         Assert.Equal(ModelDiscoverySource.Live, builder.Model.Provenance);
         Assert.Equal(ModelModality.Text | ModelModality.Image, builder.Model.InputModalities);
         Assert.Equal(ModelModality.Text, builder.Model.OutputModalities);
+    }
+
+    [Fact]
+    public void GitHubCopilotPublicHost_ContributeConfig_EmitsNoVendorOptions()
+    {
+        var previous = Environment.GetEnvironmentVariable("GH_HOST");
+        try
+        {
+            Environment.SetEnvironmentVariable("GH_HOST", "enterprise.example.com");
+            using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+            step.SelectedProviderType = "github-copilot";
+            step.SelectedAuthMethod = AuthMethod.OAuthDevice;
+            step.SelectGitHubCopilotAuthHost(GitHubCopilotAuthHostMode.GitHubCom);
+
+            var builder = new WizardConfigBuilder(_context.Paths);
+            step.ContributeConfig(builder);
+
+            Assert.NotNull(builder.Provider);
+            Assert.Equal("github-copilot", builder.Provider!.TypeKey);
+            Assert.Null(builder.Provider.VendorOptions);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GH_HOST", previous);
+        }
+    }
+
+    [Fact]
+    public void GitHubCopilotEnterpriseHostOnly_ContributeConfig_EmitsDerivedVendorOptions()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+        step.SelectedProviderType = "github-copilot";
+        step.SelectedAuthMethod = AuthMethod.OAuthDevice;
+
+        Assert.True(step.TrySetGitHubCopilotEnterpriseHost("ghe.example.com", out var hostError), hostError);
+        Assert.True(step.TryStartGitHubCopilotEnterpriseOAuth(null, out var apiError), apiError);
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Provider?.VendorOptions);
+        Assert.Equal("https://ghe.example.com", builder.Provider!.VendorOptions!["GitHubHost"]);
+        Assert.Equal("https://ghe.example.com/api/v3", builder.Provider.VendorOptions["GitHubApiBase"]);
+    }
+
+    [Fact]
+    public void GitHubCopilotEnterpriseExplicitApiBase_ContributeConfig_EmitsCanonicalVendorOptions()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+        step.SelectedProviderType = "github-copilot";
+        step.SelectedAuthMethod = AuthMethod.OAuthDevice;
+
+        Assert.True(step.TrySetGitHubCopilotEnterpriseHost("https://example.ghe.com", out var hostError), hostError);
+        Assert.True(step.TryStartGitHubCopilotEnterpriseOAuth("https://api.example.ghe.com/", out var apiError), apiError);
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Provider?.VendorOptions);
+        Assert.Equal("https://example.ghe.com", builder.Provider!.VendorOptions!["GitHubHost"]);
+        Assert.Equal("https://api.example.ghe.com", builder.Provider.VendorOptions["GitHubApiBase"]);
+    }
+
+    [Fact]
+    public void GitHubCopilotEnterpriseHostChange_ClearsStaleExplicitApiBase()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe)
+        {
+            SelectedProviderType = "github-copilot",
+            SelectedAuthMethod = AuthMethod.OAuthDevice,
+            GitHubCopilotHostInput = "https://old.ghe.example.com",
+            GitHubCopilotApiBaseInput = "https://api.old.ghe.example.com",
+            VendorOptions = new Dictionary<string, object?>
+            {
+                ["GitHubHost"] = "https://old.ghe.example.com",
+                ["GitHubApiBase"] = "https://api.old.ghe.example.com",
+            },
+        };
+
+        Assert.True(step.TrySetGitHubCopilotEnterpriseHost("https://new.ghe.example.com", out var error), error);
+
+        Assert.Equal("https://new.ghe.example.com", step.GitHubCopilotHostInput);
+        Assert.Null(step.GitHubCopilotApiBaseInput);
+        Assert.Null(step.VendorOptions);
+    }
+
+    [Fact]
+    public void GitHubCopilotEnterpriseInputs_RejectInvalidValuesBeforeVendorOptions()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+        step.SelectedProviderType = "github-copilot";
+        step.SelectedAuthMethod = AuthMethod.OAuthDevice;
+
+        Assert.False(step.TrySetGitHubCopilotEnterpriseHost("http://ghe.example.com", out var hostError));
+        Assert.Contains("HTTPS", hostError);
+        Assert.Null(step.VendorOptions);
+
+        Assert.True(step.TrySetGitHubCopilotEnterpriseHost("ghe.example.com", out hostError), hostError);
+        Assert.False(step.TryStartGitHubCopilotEnterpriseOAuth("http://ghe.example.com/api/v3", out var apiError));
+        Assert.Contains("HTTPS", apiError);
+        Assert.Null(step.VendorOptions);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/GitHubCopilotSetupFlow.cs
+++ b/src/Netclaw.Cli/Tui/GitHubCopilotSetupFlow.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// <copyright file="GitHubCopilotSetupFlow.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Netclaw.Cli.Json;
+using Netclaw.Configuration;
+using Netclaw.Providers.GitHubCopilot;
+using Netclaw.Providers.OAuth;
+
+namespace Netclaw.Cli.Tui;
+
+public enum GitHubCopilotAuthHostMode
+{
+    GitHubCom,
+    Enterprise
+}
+
+internal static class GitHubCopilotSetupFlow
+{
+    public const string ProviderType = "github-copilot";
+    public const string GitHubComLabel = "GitHub.com";
+    public const string EnterpriseLabel = "GitHub Enterprise";
+
+    public static readonly IReadOnlyList<string> AuthHostLabels = [GitHubComLabel, EnterpriseLabel];
+
+    public static bool IsGitHubCopilot(string? providerType)
+        => string.Equals(providerType, ProviderType, StringComparison.OrdinalIgnoreCase);
+
+    public static GitHubCopilotAuthHostMode ParseAuthHostLabel(string label)
+        => string.Equals(label, EnterpriseLabel, StringComparison.Ordinal)
+            ? GitHubCopilotAuthHostMode.Enterprise
+            : GitHubCopilotAuthHostMode.GitHubCom;
+
+    public static bool TryResolveEnterpriseVendorOptions(
+        string? gitHubHost,
+        string? gitHubApiBase,
+        out IReadOnlyDictionary<string, object?>? vendorOptions,
+        out string error)
+    {
+        vendorOptions = null;
+        error = string.Empty;
+
+        if (!GitHubCopilotAuthResolver.TryResolveSetupOptions(
+                gitHubHost,
+                gitHubApiBase,
+                includeAmbientEnvironment: false,
+                out var setupOptions,
+                out var setupError))
+        {
+            error = setupError ?? "GitHub Copilot Enterprise host settings are invalid.";
+            return false;
+        }
+
+        vendorOptions = GitHubCopilotAuthResolver.ToVendorOptions(setupOptions);
+        return true;
+    }
+
+    public static string GetApiBasePlaceholder(string? gitHubHost)
+    {
+        if (GitHubCopilotAuthResolver.TryResolveSetupOptions(
+                gitHubHost,
+                gitHubApiBase: null,
+                includeAmbientEnvironment: false,
+                out var options,
+                out _))
+        {
+            return options.GitHubApiBase.ToString().TrimEnd('/');
+        }
+
+        return "https://ghe.example.com/api/v3";
+    }
+
+    public static ProviderEntry BuildOAuthEntry(IReadOnlyDictionary<string, object?>? vendorOptions)
+    {
+        var entry = new ProviderEntry
+        {
+            Type = ProviderType,
+            AuthMethod = AuthMethod.OAuthDevice,
+        };
+        entry.SetVendorOptions(ToJsonObject(vendorOptions));
+        return entry;
+    }
+
+    public static JsonObject? ToJsonObject(IReadOnlyDictionary<string, object?>? vendorOptions)
+    {
+        if (vendorOptions is null || vendorOptions.Count == 0)
+            return null;
+
+        return JsonNode.Parse(JsonSerializer.Serialize(vendorOptions, JsonDefaults.ConfigFile))?.AsObject();
+    }
+}

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -33,8 +33,11 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
     private SelectionListNode<string>? _providerList;
     private SelectionListNode<string>? _authList;
+    private SelectionListNode<string>? _githubCopilotAuthHostList;
     private TextInputNode? _apiKeyInput;
     private TextInputNode? _endpointInput;
+    private TextInputNode? _githubCopilotHostInput;
+    private TextInputNode? _githubCopilotApiBaseInput;
     private TextInputNode? _nameInput;
     private TextInputNode? _renameInput;
     private SelectionListNode<string>? _confirmList;
@@ -82,6 +85,9 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                 ProviderManagerState.AddSelectType => BuildAddSelectTypeView(),
                 ProviderManagerState.AddName => BuildAddNameView(),
                 ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
+                ProviderManagerState.AddGitHubCopilotAuthHost => BuildGitHubCopilotAuthHostView(),
+                ProviderManagerState.AddGitHubCopilotEnterpriseHost => BuildGitHubCopilotEnterpriseHostView(),
+                ProviderManagerState.AddGitHubCopilotEnterpriseApiBase => BuildGitHubCopilotEnterpriseApiBaseView(),
                 ProviderManagerState.AddCredentials => BuildCredentialsView(),
                 ProviderManagerState.AddOAuthDeviceFlow => BuildOAuthDeviceFlowView(),
                 ProviderManagerState.AddBrowserOAuthFlow => BuildBrowserOAuthFlowView(),
@@ -139,6 +145,12 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                         " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.AddName =>
                         " [Enter] Continue  [Esc] Cancel  [Ctrl+Q] Quit",
+                    ProviderManagerState.AddGitHubCopilotAuthHost =>
+                        " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit",
+                    ProviderManagerState.AddGitHubCopilotEnterpriseHost =>
+                        " [Enter] Continue  [Esc] Back  [Ctrl+Q] Quit",
+                    ProviderManagerState.AddGitHubCopilotEnterpriseApiBase =>
+                        " [Enter] Continue  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.Details =>
                         " [K] Update key  [N] Rename  [R] Remove  [V] Re-validate  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.RenameProvider =>
@@ -352,6 +364,107 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             .WithChild(new TextNode($"  Authentication for {descriptor.DisplayName}:")
                 .WithForeground(Color.White))
             .WithChild(_authList);
+    }
+
+    private ILayoutNode BuildGitHubCopilotAuthHostView()
+    {
+        _githubCopilotAuthHostList = Layouts.SelectionList(GitHubCopilotSetupFlow.AuthHostLabels.ToList())
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _githubCopilotAuthHostList.OnFocused();
+        _lastFocusedList = _githubCopilotAuthHostList;
+
+        _githubCopilotAuthHostList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                ViewModel.SelectGitHubCopilotAuthHost(
+                    GitHubCopilotSetupFlow.ParseAuthHostLabel(selected[0]));
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  GitHub Copilot authentication host:")
+                .WithForeground(Color.White))
+            .WithChild(new TextNode("  Choose GitHub Enterprise only if your Copilot subscription is tied to GHE.")
+                .WithForeground(Color.Gray))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(_githubCopilotAuthHostList);
+    }
+
+    private ILayoutNode BuildGitHubCopilotEnterpriseHostView()
+    {
+        var children = Layouts.Vertical();
+        children.WithChild(new TextNode("  GitHub Enterprise host")
+            .WithForeground(Color.White).Bold());
+        children.WithChild(new TextNode("").Height(1));
+        children.WithChild(new TextNode("  Enter the GitHub Enterprise web host used for OAuth.")
+            .WithForeground(Color.Gray));
+        children.WithChild(new TextNode("  Example: https://ghe.example.com")
+            .WithForeground(Color.Gray));
+        children.WithChild(new TextNode("").Height(1));
+
+        _githubCopilotHostInput = new TextInputNode()
+            .WithPlaceholder("https://ghe.example.com");
+        if (!string.IsNullOrWhiteSpace(ViewModel.NewGitHubCopilotHost))
+            _githubCopilotHostInput.Text = ViewModel.NewGitHubCopilotHost;
+        _githubCopilotHostInput.OnFocused();
+        _lastFocusedInput = _githubCopilotHostInput;
+
+        _githubCopilotHostInput.Submitted
+            .Subscribe(text =>
+            {
+                if (ViewModel.SubmitGitHubCopilotEnterpriseHost(text, out var error))
+                {
+                    ViewModel.ErrorMessage.Value = "";
+                    return;
+                }
+
+                ViewModel.ErrorMessage.Value = error;
+                ViewModel.RequestRedraw();
+            })
+            .DisposeWith(_stepSubs);
+
+        children.WithChild(NetclawTuiChrome.BuildTextInputPanel(_githubCopilotHostInput, "GitHub host"));
+        return children;
+    }
+
+    private ILayoutNode BuildGitHubCopilotEnterpriseApiBaseView()
+    {
+        var placeholder = GitHubCopilotSetupFlow.GetApiBasePlaceholder(ViewModel.NewGitHubCopilotHost);
+        var children = Layouts.Vertical();
+        children.WithChild(new TextNode("  GitHub Enterprise API base")
+            .WithForeground(Color.White).Bold());
+        children.WithChild(new TextNode("").Height(1));
+        children.WithChild(new TextNode("  Press Enter to use the derived API base, or type an explicit API URL.")
+            .WithForeground(Color.Gray));
+        children.WithChild(new TextNode($"  Derived default: {placeholder}")
+            .WithForeground(Color.Gray));
+        children.WithChild(new TextNode("").Height(1));
+
+        _githubCopilotApiBaseInput = new TextInputNode()
+            .WithPlaceholder(placeholder);
+        if (!string.IsNullOrWhiteSpace(ViewModel.NewGitHubCopilotApiBase))
+            _githubCopilotApiBaseInput.Text = ViewModel.NewGitHubCopilotApiBase;
+        _githubCopilotApiBaseInput.OnFocused();
+        _lastFocusedInput = _githubCopilotApiBaseInput;
+
+        _githubCopilotApiBaseInput.Submitted
+            .Subscribe(text =>
+            {
+                if (!ViewModel.TryStartGitHubCopilotEnterpriseOAuth(text, out var error))
+                {
+                    ViewModel.ErrorMessage.Value = error;
+                    ViewModel.RequestRedraw();
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        children.WithChild(NetclawTuiChrome.BuildTextInputPanel(_githubCopilotApiBaseInput, "GitHub API base"));
+        return children;
     }
 
     private ILayoutNode BuildCredentialsView()

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -30,6 +30,9 @@ public enum ProviderManagerState
     AddSelectType,
     AddName,
     AddSelectAuth,
+    AddGitHubCopilotAuthHost,
+    AddGitHubCopilotEnterpriseHost,
+    AddGitHubCopilotEnterpriseApiBase,
     AddCredentials,
     AddOAuthDeviceFlow,
     AddBrowserOAuthFlow,
@@ -127,6 +130,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public string? NewApiKey { get; set; }
     public string? NewEndpoint { get; set; }
     public IReadOnlyDictionary<string, object?>? NewVendorOptions { get; set; }
+    public GitHubCopilotAuthHostMode NewGitHubCopilotHostMode { get; set; } = GitHubCopilotAuthHostMode.GitHubCom;
+    public string? NewGitHubCopilotHost { get; set; }
+    public string? NewGitHubCopilotApiBase { get; set; }
     private bool _newProviderPersisted;
 
     // ── OAuth flow (shared coordinator) ──
@@ -473,24 +479,14 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
         if (method == AuthMethod.OAuthDevice)
         {
-            if (!TryBuildOAuthFlowEntry(out var oauthEntry, out var error))
+            if (!IsFixFlow && GitHubCopilotSetupFlow.IsGitHubCopilot(NewProviderType))
             {
-                StatusMessage.Value = error;
-                RequestRedraw();
+                CurrentState.Value = ProviderManagerState.AddGitHubCopilotAuthHost;
+                NotifyStateChanged();
                 return;
             }
 
-            CurrentState.Value = ProviderManagerState.AddOAuthDeviceFlow;
-            NotifyStateChanged();
-            ProbeElapsedSeconds.Value = 0;
-            var ct = OAuth.StartDeviceFlow(NewProviderType!, result =>
-            {
-                NewApiKey = result.AccessToken.Value;
-                CurrentState.Value = ProviderManagerState.AddValidating;
-                NotifyStateChanged();
-                StartProbe();
-            }, oauthEntry);
-            _ = RunProbeTimerAsync(ct);
+            StartOAuthDeviceFlow();
             return;
         }
 
@@ -515,11 +511,112 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         NotifyStateChanged();
     }
 
+    public void SelectGitHubCopilotAuthHost(GitHubCopilotAuthHostMode mode)
+    {
+        NewGitHubCopilotHostMode = mode;
+        ErrorMessage.Value = "";
+
+        if (mode == GitHubCopilotAuthHostMode.GitHubCom)
+        {
+            NewGitHubCopilotHost = null;
+            NewGitHubCopilotApiBase = null;
+            NewVendorOptions = null;
+            StartOAuthDeviceFlow();
+            return;
+        }
+
+        CurrentState.Value = ProviderManagerState.AddGitHubCopilotEnterpriseHost;
+        NotifyStateChanged();
+    }
+
+    public bool TrySetGitHubCopilotEnterpriseHost(string? gitHubHost, out string error)
+    {
+        var previousHost = NewGitHubCopilotHost;
+        var trimmedHost = gitHubHost?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedHost))
+        {
+            error = "GitHub Enterprise host is required.";
+            return false;
+        }
+
+        if (!GitHubCopilotSetupFlow.TryResolveEnterpriseVendorOptions(
+                trimmedHost,
+                gitHubApiBase: null,
+                out _,
+                out error))
+        {
+            return false;
+        }
+
+        NewGitHubCopilotHost = trimmedHost;
+        if (!string.Equals(previousHost, trimmedHost, StringComparison.Ordinal))
+        {
+            NewGitHubCopilotApiBase = null;
+            NewVendorOptions = null;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    public bool SubmitGitHubCopilotEnterpriseHost(string? gitHubHost, out string error)
+    {
+        if (!TrySetGitHubCopilotEnterpriseHost(gitHubHost, out error))
+            return false;
+
+        CurrentState.Value = ProviderManagerState.AddGitHubCopilotEnterpriseApiBase;
+        NotifyStateChanged();
+        return true;
+    }
+
+    public bool TryStartGitHubCopilotEnterpriseOAuth(string? gitHubApiBase, out string error)
+    {
+        NewGitHubCopilotApiBase = string.IsNullOrWhiteSpace(gitHubApiBase)
+            ? null
+            : gitHubApiBase.Trim();
+
+        if (!GitHubCopilotSetupFlow.TryResolveEnterpriseVendorOptions(
+                NewGitHubCopilotHost,
+                NewGitHubCopilotApiBase,
+                out var vendorOptions,
+                out error))
+        {
+            return false;
+        }
+
+        NewVendorOptions = vendorOptions;
+        ErrorMessage.Value = "";
+        StartOAuthDeviceFlow();
+        return true;
+    }
+
+    private void StartOAuthDeviceFlow()
+    {
+        if (!TryBuildOAuthFlowEntry(out var oauthEntry, out var error))
+        {
+            ErrorMessage.Value = error;
+            RequestRedraw();
+            return;
+        }
+
+        CurrentState.Value = ProviderManagerState.AddOAuthDeviceFlow;
+        NotifyStateChanged();
+        ProbeElapsedSeconds.Value = 0;
+        var ct = OAuth.StartDeviceFlow(NewProviderType!, result =>
+        {
+            NewApiKey = result.AccessToken.Value;
+            CurrentState.Value = ProviderManagerState.AddValidating;
+            NotifyStateChanged();
+            StartProbe();
+        }, oauthEntry);
+        _ = RunProbeTimerAsync(ct);
+    }
+
     private bool TryBuildOAuthFlowEntry(out ProviderEntry? entry, out string error)
     {
         entry = null;
         error = string.Empty;
-        if (!string.Equals(NewProviderType, "github-copilot", StringComparison.OrdinalIgnoreCase))
+        if (!GitHubCopilotSetupFlow.IsGitHubCopilot(NewProviderType))
             return true;
 
         if (IsFixFlow && DetailProvider?.Entry is { } existing)
@@ -528,24 +625,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             return true;
         }
 
-        if (!GitHubCopilotAuthResolver.TryResolveSetupOptions(
-                gitHubHost: null,
-                gitHubApiBase: null,
-                includeAmbientEnvironment: true,
-                out var setupOptions,
-                out var setupError))
-        {
-            error = setupError ?? "GitHub Copilot enterprise host settings are invalid.";
-            return false;
-        }
-
-        NewVendorOptions = GitHubCopilotAuthResolver.ToVendorOptions(setupOptions);
-        entry = new ProviderEntry
-        {
-            Type = "github-copilot",
-            AuthMethod = AuthMethod.OAuthDevice,
-        };
-        entry.SetVendorOptions(ToJsonObject(NewVendorOptions));
+        entry = GitHubCopilotSetupFlow.BuildOAuthEntry(NewVendorOptions);
         return true;
     }
 
@@ -893,10 +973,24 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             case ProviderManagerState.AddSelectAuth:
                 GoBackToList();
                 break;
+            case ProviderManagerState.AddGitHubCopilotAuthHost:
+                CurrentState.Value = ProviderManagerState.AddSelectAuth;
+                NotifyStateChanged();
+                break;
+            case ProviderManagerState.AddGitHubCopilotEnterpriseHost:
+                CurrentState.Value = ProviderManagerState.AddGitHubCopilotAuthHost;
+                NotifyStateChanged();
+                break;
+            case ProviderManagerState.AddGitHubCopilotEnterpriseApiBase:
+                CurrentState.Value = ProviderManagerState.AddGitHubCopilotEnterpriseHost;
+                NotifyStateChanged();
+                break;
             case ProviderManagerState.AddOAuthDeviceFlow:
             case ProviderManagerState.AddBrowserOAuthFlow:
                 OAuth.Cancel();
-                CurrentState.Value = ProviderManagerState.AddSelectAuth;
+                CurrentState.Value = GitHubCopilotSetupFlow.IsGitHubCopilot(NewProviderType) && !IsFixFlow
+                    ? ProviderManagerState.AddGitHubCopilotAuthHost
+                    : ProviderManagerState.AddSelectAuth;
                 NotifyStateChanged();
                 break;
             case ProviderManagerState.AddCredentials:
@@ -915,7 +1009,10 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 }
                 else
                 {
-                    CurrentState.Value = ProviderManagerState.AddCredentials;
+                    CurrentState.Value = NewAuthMethod == AuthMethod.OAuthDevice
+                                         && GitHubCopilotSetupFlow.IsGitHubCopilot(NewProviderType)
+                        ? ProviderManagerState.AddOAuthDeviceFlow
+                        : ProviderManagerState.AddCredentials;
                 }
                 NotifyStateChanged();
                 break;
@@ -1185,6 +1282,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         NewApiKey = null;
         NewEndpoint = null;
         NewVendorOptions = null;
+        NewGitHubCopilotHostMode = GitHubCopilotAuthHostMode.GitHubCom;
+        NewGitHubCopilotHost = null;
+        NewGitHubCopilotApiBase = null;
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
         IsFixFlow = false;

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepView.cs
@@ -20,7 +20,8 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Termina view for the Provider wizard step.
-/// 7 sub-steps: provider selection → auth → credentials → validation → model → OAuth device → OAuth browser.
+/// Sub-steps: provider selection → auth → credentials → validation → model → OAuth device → OAuth browser,
+/// plus GitHub Copilot host-mode and Enterprise host inputs.
 /// </summary>
 public sealed class ProviderStepView : IWizardStepView
 {
@@ -28,8 +29,11 @@ public sealed class ProviderStepView : IWizardStepView
 
     private SelectionListNode<string>? _providerList;
     private SelectionListNode<string>? _authMethodList;
+    private SelectionListNode<string>? _githubCopilotAuthHostList;
     private TextInputNode? _apiKeyInput;
     private TextInputNode? _endpointInput;
+    private TextInputNode? _githubCopilotHostInput;
+    private TextInputNode? _githubCopilotApiBaseInput;
     private SelectionListNode<string>? _modelList;
     private TextInputNode? _manualModelInput;
     private TextInputNode? _redirectUrlInput;
@@ -60,6 +64,9 @@ public sealed class ProviderStepView : IWizardStepView
             4 => BuildModelSelection(vm, callbacks),
             5 => BuildOAuthDeviceFlow(vm),
             6 => BuildBrowserOAuthFlow(vm, callbacks),
+            7 => BuildGitHubCopilotAuthHost(vm, callbacks),
+            8 => BuildGitHubCopilotEnterpriseHost(vm, callbacks),
+            9 => BuildGitHubCopilotEnterpriseApiBase(vm, callbacks),
             _ => Layouts.Empty()
         };
     }
@@ -133,8 +140,15 @@ public sealed class ProviderStepView : IWizardStepView
                     }
                     else if (method == AuthMethod.OAuthDevice)
                     {
-                        vm.SetSubStep(5);
-                        vm.StartOAuthFlow();
+                        if (GitHubCopilotSetupFlow.IsGitHubCopilot(vm.SelectedProviderType))
+                        {
+                            vm.SetSubStep(7);
+                        }
+                        else
+                        {
+                            vm.SetSubStep(5);
+                            vm.StartOAuthFlow();
+                        }
                     }
                     else
                     {
@@ -148,6 +162,108 @@ public sealed class ProviderStepView : IWizardStepView
         return Layouts.Vertical()
             .WithChild(new TextNode($"  Authentication for {descriptor.DisplayName}:").WithForeground(Color.White))
             .WithChild(_authMethodList);
+    }
+
+    private ILayoutNode BuildGitHubCopilotAuthHost(ProviderStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        _githubCopilotAuthHostList = Layouts.SelectionList(GitHubCopilotSetupFlow.AuthHostLabels.ToList())
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _githubCopilotAuthHostList.OnFocused();
+        _lastFocusedList = _githubCopilotAuthHostList;
+        _lastFocusedInput = null;
+
+        _githubCopilotAuthHostList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                callbacks.ClearStatusMessage();
+                vm.SelectGitHubCopilotAuthHost(GitHubCopilotSetupFlow.ParseAuthHostLabel(selected[0]));
+                callbacks.InvalidateAndRedraw();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  GitHub Copilot authentication host:").WithForeground(Color.White))
+            .WithChild(new TextNode("  Choose GitHub Enterprise only if your Copilot subscription is tied to GHE.")
+                .WithForeground(Color.Gray))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(_githubCopilotAuthHostList);
+    }
+
+    private ILayoutNode BuildGitHubCopilotEnterpriseHost(ProviderStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        _lastFocusedList = null;
+
+        _githubCopilotHostInput = new TextInputNode()
+            .WithPlaceholder("https://ghe.example.com");
+        if (!string.IsNullOrWhiteSpace(vm.GitHubCopilotHostInput))
+            _githubCopilotHostInput.Text = vm.GitHubCopilotHostInput;
+        _githubCopilotHostInput.OnFocused();
+        _lastFocusedInput = _githubCopilotHostInput;
+
+        _githubCopilotHostInput.Submitted
+            .Subscribe(text =>
+            {
+                if (vm.TrySetGitHubCopilotEnterpriseHost(text, out var error))
+                {
+                    callbacks.ClearStatusMessage();
+                    vm.SetSubStep(9);
+                    callbacks.InvalidateAndRedraw();
+                    return;
+                }
+
+                callbacks.ShowValidationError(error);
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  GitHub Enterprise host").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode("  Enter the GitHub Enterprise web host used for OAuth.").WithForeground(Color.Gray))
+            .WithChild(new TextNode("  Example: https://ghe.example.com").WithForeground(Color.Gray))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(WizardStepHelpers.BuildTextInputPanel(_githubCopilotHostInput, "GitHub host"));
+    }
+
+    private ILayoutNode BuildGitHubCopilotEnterpriseApiBase(ProviderStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        _lastFocusedList = null;
+        var placeholder = GitHubCopilotSetupFlow.GetApiBasePlaceholder(vm.GitHubCopilotHostInput);
+
+        _githubCopilotApiBaseInput = new TextInputNode()
+            .WithPlaceholder(placeholder);
+        if (!string.IsNullOrWhiteSpace(vm.GitHubCopilotApiBaseInput))
+            _githubCopilotApiBaseInput.Text = vm.GitHubCopilotApiBaseInput;
+        _githubCopilotApiBaseInput.OnFocused();
+        _lastFocusedInput = _githubCopilotApiBaseInput;
+
+        _githubCopilotApiBaseInput.Submitted
+            .Subscribe(text =>
+            {
+                if (vm.TryStartGitHubCopilotEnterpriseOAuth(text, out var error))
+                {
+                    callbacks.ClearStatusMessage();
+                    callbacks.InvalidateAndRedraw();
+                    return;
+                }
+
+                callbacks.ShowValidationError(error);
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  GitHub Enterprise API base").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode("  Press Enter to use the derived API base, or type an explicit API URL.")
+                .WithForeground(Color.Gray))
+            .WithChild(new TextNode($"  Derived default: {placeholder}")
+                .WithForeground(Color.Gray))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(WizardStepHelpers.BuildTextInputPanel(_githubCopilotApiBaseInput, "GitHub API base"));
     }
 
     private ILayoutNode BuildCredentialInput(ProviderStepViewModel vm, StepViewCallbacks callbacks)
@@ -442,8 +558,11 @@ public sealed class ProviderStepView : IWizardStepView
         _lastFocusedInput = null;
         _providerList = null;
         _authMethodList = null;
+        _githubCopilotAuthHostList = null;
         _apiKeyInput = null;
         _endpointInput = null;
+        _githubCopilotHostInput = null;
+        _githubCopilotApiBaseInput = null;
         _modelList = null;
         _manualModelInput = null;
         _redirectUrlInput = null;

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -15,7 +15,6 @@ using Netclaw.Cli.Tui.Sections;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
 using Netclaw.Providers;
-using Netclaw.Providers.GitHubCopilot;
 using Netclaw.Providers.OAuth;
 using R3;
 
@@ -24,7 +23,8 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// <summary>
 /// Wizard step for selecting and configuring the LLM provider.
 /// Sub-steps: 0=provider selection, 1=auth method, 2=credentials, 3=validation,
-/// 4=model selection, 5=OAuth device flow, 6=OAuth browser flow.
+/// 4=model selection, 5=OAuth device flow, 6=OAuth browser flow,
+/// 7=GitHub Copilot host mode, 8=GitHub Enterprise host, 9=GitHub Enterprise API base.
 /// </summary>
 public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
 {
@@ -64,6 +64,9 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
     public string? ApiKeyInput { get; set; }
     public string? EndpointInput { get; set; }
     public IReadOnlyDictionary<string, object?>? VendorOptions { get; set; }
+    public GitHubCopilotAuthHostMode GitHubCopilotHostMode { get; set; } = GitHubCopilotAuthHostMode.GitHubCom;
+    public string? GitHubCopilotHostInput { get; set; }
+    public string? GitHubCopilotApiBaseInput { get; set; }
     public string? SelectedModelId { get; set; }
     public bool HasStoredCredential { get; private set; }
     public List<DiscoveredModel> DiscoveredModels { get; } = [];
@@ -89,6 +92,9 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         4 => "  Select the model to use for conversations.",
         5 => "  Complete the authorization in your browser.",
         6 => "  Complete the authorization in your browser.",
+        7 => "  Choose whether GitHub Copilot should authenticate through GitHub.com or GitHub Enterprise.",
+        8 => "  Enter the GitHub Enterprise web host used for OAuth.",
+        9 => "  Enter the GitHub Enterprise API base, or leave blank to use the derived default.",
         _ => ""
     };
 
@@ -99,9 +105,11 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
     public void SetSubStep(int step)
     {
         _currentSubStep = step;
-        if (step > _highWaterSubStep)
+        if (IsResumeSubStep(step) && step > _highWaterSubStep)
             _highWaterSubStep = step;
     }
+
+    private static bool IsResumeSubStep(int step) => step is >= 0 and <= 4;
 
     public bool TryAdvance()
     {
@@ -121,14 +129,29 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         {
             case 5: // OAuth device flow → auth selection
                 OAuth.Cancel();
-                _currentSubStep = 1;
+                _currentSubStep = GitHubCopilotSetupFlow.IsGitHubCopilot(SelectedProviderType) ? 7 : 1;
                 return true;
             case 6: // OAuth browser flow → auth selection
                 OAuth.Cancel();
                 _currentSubStep = 1;
                 return true;
+            case 7: // GitHub Copilot host mode → auth selection
+                _currentSubStep = 1;
+                return true;
+            case 8: // GitHub Enterprise host → host mode
+                _currentSubStep = 7;
+                return true;
+            case 9: // GitHub Enterprise API base → GitHub Enterprise host
+                _currentSubStep = 8;
+                return true;
             case 4: // Model selection → credentials
-                _currentSubStep = 2;
+                _currentSubStep = SelectedAuthMethod switch
+                {
+                    AuthMethod.OAuthDevice when GitHubCopilotSetupFlow.IsGitHubCopilot(SelectedProviderType) => 7,
+                    AuthMethod.OAuthDevice => 5,
+                    AuthMethod.OAuthPkce => 6,
+                    _ => 2,
+                };
                 return true;
             case 3: // Validation → back to correct input
                 CancelProbe();
@@ -301,31 +324,82 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         _ = RunProbeTimerAsync(ct);
     }
 
+    public void SelectGitHubCopilotAuthHost(GitHubCopilotAuthHostMode mode)
+    {
+        GitHubCopilotHostMode = mode;
+
+        if (mode == GitHubCopilotAuthHostMode.GitHubCom)
+        {
+            GitHubCopilotHostInput = null;
+            GitHubCopilotApiBaseInput = null;
+            VendorOptions = null;
+            SetSubStep(5);
+            StartOAuthFlow();
+            return;
+        }
+
+        SetSubStep(8);
+    }
+
+    public bool TrySetGitHubCopilotEnterpriseHost(string? gitHubHost, out string error)
+    {
+        var previousHost = GitHubCopilotHostInput;
+        var trimmedHost = gitHubHost?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedHost))
+        {
+            error = "GitHub Enterprise host is required.";
+            return false;
+        }
+
+        if (!GitHubCopilotSetupFlow.TryResolveEnterpriseVendorOptions(
+                trimmedHost,
+                gitHubApiBase: null,
+                out _,
+                out error))
+        {
+            return false;
+        }
+
+        GitHubCopilotHostInput = trimmedHost;
+        if (!string.Equals(previousHost, trimmedHost, StringComparison.Ordinal))
+        {
+            GitHubCopilotApiBaseInput = null;
+            VendorOptions = null;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    public bool TryStartGitHubCopilotEnterpriseOAuth(string? gitHubApiBase, out string error)
+    {
+        GitHubCopilotApiBaseInput = string.IsNullOrWhiteSpace(gitHubApiBase)
+            ? null
+            : gitHubApiBase.Trim();
+
+        if (!GitHubCopilotSetupFlow.TryResolveEnterpriseVendorOptions(
+                GitHubCopilotHostInput,
+                GitHubCopilotApiBaseInput,
+                out var vendorOptions,
+                out error))
+        {
+            return false;
+        }
+
+        VendorOptions = vendorOptions;
+        SetSubStep(5);
+        StartOAuthFlow();
+        return true;
+    }
+
     private bool TryBuildOAuthFlowEntry(out ProviderEntry? entry, out string error)
     {
         entry = null;
         error = string.Empty;
-        if (!string.Equals(SelectedProviderType, "github-copilot", StringComparison.OrdinalIgnoreCase))
+        if (!GitHubCopilotSetupFlow.IsGitHubCopilot(SelectedProviderType))
             return true;
 
-        if (!GitHubCopilotAuthResolver.TryResolveSetupOptions(
-                gitHubHost: null,
-                gitHubApiBase: null,
-                includeAmbientEnvironment: true,
-                out var setupOptions,
-                out var setupError))
-        {
-            error = setupError ?? "GitHub Copilot enterprise host settings are invalid.";
-            return false;
-        }
-
-        VendorOptions = GitHubCopilotAuthResolver.ToVendorOptions(setupOptions);
-        entry = new ProviderEntry
-        {
-            Type = "github-copilot",
-            AuthMethod = AuthMethod.OAuthDevice,
-        };
-        entry.SetVendorOptions(ToJsonObject(VendorOptions));
+        entry = GitHubCopilotSetupFlow.BuildOAuthEntry(VendorOptions);
         return true;
     }
 
@@ -352,6 +426,9 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         ApiKeyInput = null;
         EndpointInput = null;
         VendorOptions = null;
+        GitHubCopilotHostMode = GitHubCopilotAuthHostMode.GitHubCom;
+        GitHubCopilotHostInput = null;
+        GitHubCopilotApiBaseInput = null;
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
         SelectedModelId = null;


### PR DESCRIPTION
## Summary
- Adds a GitHub.com vs GitHub Enterprise host choice for GitHub Copilot OAuth setup in `netclaw provider` and `netclaw init`.
- Validates and canonicalizes Enterprise host/API-base values through a shared setup flow, then persists `VendorOptions` only for Enterprise setups.
- Adds provider-manager and init-wizard typed-input coverage plus view-model regression tests for public, derived, explicit, invalid, stale, and back/resume paths.

## Validation
- `dotnet test "src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj"`
- `./scripts/smoke/run-smoke.sh provider-add`
- `./scripts/smoke/run-smoke.sh init-wizard`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `dotnet slopwatch analyze` (only existing unrelated SW004 warnings)