### PR TITLE
fix(cli): stop daemon before reset and show progress screen (#1494)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
@@ -32,7 +33,11 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
 
     public void Dispose() => _dir.Dispose();
 
-    private InitExistingInstallViewModel Create() => new(_paths, _nav);
+    private InitExistingInstallViewModel Create()
+    {
+        var daemonManager = new DaemonManager(_paths, TimeProvider.System, new FakeSupervisor(supervised: true));
+        return new(_paths, _nav, daemonManager);
+    }
 
     private static void Select(InitExistingInstallViewModel vm, int index)
     {
@@ -153,5 +158,10 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         Assert.Equal(Phase.ResetScope, vm.CurrentPhase.Value);
         vm.GoBack();
         Assert.Equal(Phase.Menu, vm.CurrentPhase.Value);
+    }
+
+    private sealed class FakeSupervisor(bool supervised) : IContainerSupervisor
+    {
+        public bool IsExternallySupervised => supervised;
     }
 }

--- a/src/Netclaw.Cli/Tui/InitExistingInstallPage.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallPage.cs
@@ -16,8 +16,8 @@ namespace Netclaw.Cli.Tui;
 /// <summary>
 /// Termina page for the existing-install menu and its in-place start-over flow.
 /// Renders a single selection list whose contents follow the ViewModel's phase
-/// (menu → reset scope → two confirmations), so the destructive path is explicit and
-/// double-confirmed (simplify-netclaw-init).
+/// (menu → reset scope → two confirmations → progress), so the destructive path is
+/// explicit and double-confirmed (simplify-netclaw-init).
 /// </summary>
 public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallViewModel>
 {
@@ -62,6 +62,12 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
         _phaseSubs.Clear();
 
         var phase = ViewModel.CurrentPhase.Value;
+
+        // ── Progress screen ──
+        if (phase == InitExistingInstallViewModel.Phase.Progress)
+            return BuildProgressScreen();
+
+        // ── Menu / confirmation screens ──
         var header = Layouts.Vertical().WithSpacing(0);
 
         switch (phase)
@@ -113,6 +119,66 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
             .WithChild(_list);
     }
 
+    /// <summary>
+    /// Builds the reset progress screen. Each step renders as a line:
+    ///   ✓ Completed steps (green checkmark)
+    ///   🔄 Current step (spinning dots, bound to CurrentProgressStep)
+    ///   Pending steps show their label without any indicator.
+    /// </summary>
+    private ILayoutNode BuildProgressScreen()
+    {
+        var progressStep = ViewModel.CurrentProgressStep.Value;
+        var completed = ViewModel.CompletedSteps;
+        var message = ViewModel.ProgressMessage.Value;
+
+        // Step labels — must match InitExistingInstallViewModel.ProgressStep enum order
+        var stepLabels = new[]
+        {
+            "Stopping daemon…",
+            "Deleting data…",
+            "Purge complete",
+        };
+
+        var lines = Layouts.Vertical().WithSpacing(1);
+
+        // Header
+        lines.WithChild(new TextNode("  Resetting…").WithForeground(Color.White).Bold());
+
+        // Progress steps
+        for (var i = 0; i < stepLabels.Length; i++)
+        {
+            ILayoutNode line;
+            if (i < progressStep)
+            {
+                // Already completed — green checkmark
+                line = new TextNode($"  ✓ {stepLabels[i].Replace("…", "")}").WithForeground(Color.Green);
+            }
+            else if (i == progressStep)
+            {
+                // In progress — spinning dots
+                var color = i == 0 ? Color.Yellow : Color.Cyan;
+                line = SpinnerViews.Labeled(stepLabels[i].Replace("…", ""), color);
+            }
+            else
+            {
+                // Pending — dimmed label
+                line = new TextNode($"  • {stepLabels[i].Replace("…", "")}").WithForeground(Color.Gray);
+            }
+
+            lines.WithChild(line);
+        }
+
+        // Error message if something went wrong
+        if (message.StartsWith("Reset failed:", StringComparison.Ordinal))
+            lines.WithChild(new TextNode($"  {message}").WithForeground(Color.Red).Bold());
+
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            .WithChild(new TextNode("  ").WithForeground(Color.Black)) // top padding
+            .WithChild(lines)
+            .WithChild(new TextNode("  ").WithForeground(Color.Black)); // bottom padding
+    }
+
     private LayoutNode BuildStatusBar()
     {
         return ViewModel.StatusMessage
@@ -123,6 +189,10 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
 
     private LayoutNode BuildKeyBindings()
     {
+        var phase = ViewModel.CurrentPhase.Value;
+        if (phase == InitExistingInstallViewModel.Phase.Progress)
+            return NetclawTuiChrome.BuildKeyHintLine(" [Ctrl+Q] Quit");
+
         return NetclawTuiChrome.BuildKeyHintLine(" [↑/↓] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit");
     }
 

--- a/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
 using R3;
 using Termina.Reactive;
@@ -43,6 +44,7 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         ResetScope,
         ResetConfirm1,
         ResetConfirm2,
+        Progress,
     }
 
     public enum ResetScopeKind
@@ -55,11 +57,16 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
     private readonly NetclawPaths _paths;
     private readonly InitNavigationState _navigationState;
+    private readonly DaemonManager _daemonManager;
 
-    public InitExistingInstallViewModel(NetclawPaths paths, InitNavigationState navigationState)
+    public InitExistingInstallViewModel(
+        NetclawPaths paths,
+        InitNavigationState navigationState,
+        DaemonManager daemonManager)
     {
         _paths = paths;
         _navigationState = navigationState;
+        _daemonManager = daemonManager;
     }
 
     /// <summary>Route the wizard launches for "Redo identity setup".</summary>
@@ -77,6 +84,14 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
     private ResetScopeKind _scope = ResetScopeKind.SetupOnly;
     public ResetScopeKind Scope => _scope;
+
+    // ── Progress-screen state ──
+
+    private readonly List<bool> _completedSteps = [];
+    public IReadOnlyList<bool> CompletedSteps => _completedSteps;
+
+    public ReactiveProperty<int> CurrentProgressStep { get; } = new(-1);
+    public ReactiveProperty<string> ProgressMessage { get; } = new("");
 
     public static readonly IReadOnlyList<MenuItem> MenuItems =
     [
@@ -199,11 +214,42 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
             return;
         }
 
-        PerformReset();
+        StartResetProgress();
     }
 
-    private void PerformReset()
+    private void StartResetProgress()
     {
+        CurrentPhase.Value = Phase.Progress;
+        _completedSteps.Clear();
+        _completedSteps.Add(false); // Stopping daemon
+        _completedSteps.Add(false); // Deleting data
+        _completedSteps.Add(false); // Complete
+        CurrentProgressStep.Value = 0;
+        ProgressMessage.Value = "Stopping daemon…";
+        RequestRedraw();
+        _ = RunResetAsync();
+    }
+
+    private async Task RunResetAsync()
+    {
+        // Step 1: Stop the daemon so file handles are released
+        try
+        {
+            await _daemonManager.StopAsync("factory-reset");
+        }
+        catch
+        {
+            // Best-effort: daemon may not be running or may be managed externally.
+        }
+
+        _completedSteps[0] = true;
+        CurrentProgressStep.Value = 1;
+        ProgressMessage.Value = _scope == ResetScopeKind.Full
+            ? "Deleting all data…"
+            : "Deleting setup files…";
+        RequestRedraw();
+
+        // Step 2: Delete the directories
         try
         {
             if (_scope == ResetScopeKind.Full)
@@ -212,9 +258,6 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
             }
             else
             {
-                // Setup-only: remove what the bootstrap wizard writes (config + secrets +
-                // identity), preserving memory, sessions, and skills. SecretsPath lives
-                // under ConfigDirectory, so deleting it covers secrets too.
                 DeleteDirectory(_paths.ConfigDirectory);
                 DeleteDirectory(_paths.IdentityDirectory);
                 DeleteDirectory(_paths.SoulDirectory);
@@ -222,12 +265,17 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            StatusMessage.Value = $"Reset failed: {ex.Message}";
+            ProgressMessage.Value = $"Reset failed: {ex.Message}";
             RequestRedraw();
             return;
         }
 
-        // Fresh setup from the top.
+        // Step 3: Mark complete and navigate to fresh wizard
+        _completedSteps[2] = true;
+        CurrentProgressStep.Value = 2;
+        ProgressMessage.Value = "Purge complete";
+        RequestRedraw();
+        await Task.Delay(600); // Brief pause so the user sees the completion checkmark
         Navigate?.Invoke(WizardRoute);
     }
 
@@ -254,6 +302,9 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
             case Phase.ResetConfirm2:
                 EnterPhase(Phase.ResetConfirm1);
                 break;
+            case Phase.Progress:
+                // Don't allow backing out of progress — it's running.
+                break;
         }
     }
 
@@ -273,6 +324,8 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         CurrentPhase.Dispose();
         SelectedIndex.Dispose();
         StatusMessage.Dispose();
+        CurrentProgressStep.Dispose();
+        ProgressMessage.Dispose();
         base.Dispose();
     }
 }


### PR DESCRIPTION
## Problem

On Windows, `netclaw init` → Full reset fails with:

```
Reset failed: The process cannot access the file 'daemon-2026-06-26.log' because it is being used by another process.
```

The daemon `netclawd` holds the log file handle open, and `Directory.Delete(path, recursive: true)` aborts on the first locked file. The operator gets stuck on a confirmation screen with no way forward.

## Fix

Two parts:

### 1. Stop the daemon before deletion

Inject `DaemonManager` into `InitExistingInstallViewModel` and call `StopAsync("factory-reset")` before any `Directory.Delete()` calls. This releases the file handles so Windows lets the deletion proceed.

Stop is best-effort — if the daemon isn't running or is externally managed (Docker container supervisor), it's silently ignored.

### 2. Show a progress screen with staggered checkmarks

Instead of confirming → instant failure, the operator now sees a dedicated progress screen:

```
┌─ Netclaw Setup ──────────────────────────────────────────────────┐
│                                                                  │
│   Resetting…                                                     │
│                                                                  │
│   Stopping daemon…                                               │
│   Deleting data…      ✓ Daemon stopped                           │
│                       ✓ Data purged                              │
│                       ✓ Purge complete                           │
│                                                                  │
│   [Ctrl+Q] Quit                                                  │
└──────────────────────────────────────────────────────────────────┘
```

Each step fades in as it completes — the current step gets a spinning dots glyph, completed steps get a green checkmark, pending steps are dimmed. After purge completes there's a brief 600ms pause so the user sees the ✓, then the wizard launches automatically.

### Key properties:

- **Non-interactive**: Once started, the operator can't interrupt the flow (Escape is a no-op during progress). Only Ctrl+Q exits.
- **Best-effort daemon stop**: If `StopAsync` throws (not running, external supervisor), the delete still proceeds.
- **Same confirmation flow**: The double-confirm screen is unchanged — operator still sees the warning and must click "Yes" twice.

## Files changed

- `src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs` — Added `DaemonManager` dependency, `Progress` phase, `RunResetAsync()` lifecycle, and progress-state properties
- `src/Netclaw.Cli/Tui/InitExistingInstallPage.cs` — Added `BuildProgressScreen()` with staggered checkmarks and spinner, updated key bindings for progress phase
