### PR TITLE
fix(cli): stop daemon before reset and show progress screen (#1494)

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
@@ -441,7 +441,7 @@ public sealed class UpdateCommandTests : IDisposable
             return _lastStatus;
         }
 
-        public Task<DaemonResult> StopAsync(string reason)
+        public Task<DaemonResult> StopAsync(string reason, CancellationToken cancellationToken)
         {
             StopCalls++;
             StopReasons.Add(reason);

--- a/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/ChannelsConfigViewModelTests.cs
@@ -1354,13 +1354,16 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
             Assert.Null(vm.PendingLabelRefresh);
         });
 
-        var completed = await Task.WhenAny(
-            scenario,
-            Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
-        Assert.True(
-            ReferenceEquals(completed, scenario),
-            "Reset deadlocked under a single-worker SynchronizationContext — a sync-over-async bridge was reintroduced.");
-        await scenario; // re-throw any assertion failure raised on the worker thread
+        try
+        {
+            await scenario.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException(
+                "Reset deadlocked under a single-worker SynchronizationContext — a sync-over-async bridge was reintroduced.",
+                ex);
+        }
     }
 
     [Fact]
@@ -1389,10 +1392,15 @@ public sealed class ChannelsConfigViewModelTests : IDisposable
         // mutate disposed reactive state. Run Dispose off the xunit synchronization context so the
         // in-flight write's continuations can drain on the test context while Dispose waits.
         var dispose = Task.Run(vm.Dispose, TestContext.Current.CancellationToken);
-        var finished = await Task.WhenAny(
-            dispose, Task.Delay(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken));
-        Assert.True(ReferenceEquals(finished, dispose), "Dispose did not drain the cancelled in-flight write promptly.");
-        await dispose;  // surface any teardown exception
+        try
+        {
+            await dispose.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException("Dispose did not drain the cancelled in-flight write promptly.", ex);
+        }
+
         await write;    // the cancelled add unwound without surfacing out
     }
 

--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallPageTests.cs
@@ -1,0 +1,181 @@
+// -----------------------------------------------------------------------
+// <copyright file="InitExistingInstallPageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using R3;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+public sealed class InitExistingInstallPageTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 6, 27, 12, 0, 0, TimeSpan.Zero));
+
+    public InitExistingInstallPageTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public async Task ProgressScreen_RendersQueuedUpdates_AndOnlyCtrlQExits()
+    {
+        var deleteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (terminal, app, vm, services) = CreateHeadlessApp(
+            out var input,
+            (_, _) => Task.FromResult(new DaemonResult(true, "Daemon stopped.")),
+            path =>
+            {
+                if (path == _paths.BasePath)
+                {
+                    deleteStarted.TrySetResult();
+                    releaseDelete.Task.GetAwaiter().GetResult();
+                }
+            });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = app.RunAsync(cts.Token);
+        var runCompleted = false;
+
+        try
+        {
+            EnqueueFullReset(input);
+            await deleteStarted.Task.WaitAsync(cts.Token);
+            await WaitForConditionAsync(
+                () => vm.CurrentProgressStep.Value == 1
+                      && !vm.CanQuitProgress.Value
+                      && terminal.Contains("Reset in progress"),
+                cts.Token);
+
+            input.EnqueueKey(ConsoleKey.Q, control: true);
+            await WaitForConditionAsync(
+                () => vm.StatusMessage.Value.StartsWith("Reset is deleting data;", StringComparison.Ordinal),
+                cts.Token);
+            Assert.False(run.IsCompleted, "Ctrl+Q must not interrupt the destructive delete phase.");
+
+            releaseDelete.TrySetResult();
+            await WaitForConditionAsync(
+                () => vm.CurrentProgressStep.Value == 3
+                      && vm.CanQuitProgress.Value
+                      && terminal.Contains("✓ Purge complete")
+                      && terminal.Contains("[Ctrl+Q] Quit"),
+                cts.Token);
+
+            var leftProgress = false;
+            using var subscription = vm.CurrentPhase.Subscribe(phase =>
+            {
+                if (phase != InitExistingInstallViewModel.Phase.Progress)
+                    leftProgress = true;
+            });
+
+            input.EnqueueKey(ConsoleKey.Escape);
+            input.EnqueueKey(ConsoleKey.DownArrow);
+            input.EnqueueKey(ConsoleKey.Enter);
+            input.EnqueueKey(ConsoleKey.Q, control: true);
+
+            await run.WaitAsync(cts.Token);
+            runCompleted = true;
+
+            Assert.False(leftProgress, "Progress mode should ignore non-Ctrl+Q keys until reset exits or is cancelled.");
+        }
+        finally
+        {
+            releaseDelete.TrySetResult();
+            try
+            {
+                if (!runCompleted)
+                {
+                    for (var i = 0; i < 10 && vm.ResetTask is { IsCompleted: false }; i++)
+                    {
+                        vm.RequestQuit();
+                        _time.Advance(InitExistingInstallViewModel.CompletionPause);
+                        await Task.Yield();
+                    }
+                }
+
+                if (vm.ResetTask is not null)
+                    await vm.ResetTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                services.Dispose();
+            }
+        }
+    }
+
+    private (VirtualTerminal Terminal, TerminaApplication App, InitExistingInstallViewModel Vm, ServiceProvider Services)
+        CreateHeadlessApp(
+            out VirtualInputSource input,
+            Func<string, CancellationToken, Task<DaemonResult>> stopDaemonAsync,
+            Action<string> deleteDirectory)
+    {
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        InitExistingInstallViewModel? capturedVm = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina(InitExistingInstallViewModel.MenuRoute, builder =>
+        {
+            builder.RegisterRoute<InitExistingInstallPage, InitExistingInstallViewModel>(
+                InitExistingInstallViewModel.MenuRoute,
+                _ => new InitExistingInstallPage(),
+                _ =>
+                {
+                    capturedVm = new InitExistingInstallViewModel(
+                        _paths,
+                        new InitNavigationState(),
+                        stopDaemonAsync,
+                        deleteDirectory,
+                        _time);
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!, sp);
+    }
+
+    private static void EnqueueFullReset(VirtualInputSource input)
+    {
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate, CancellationToken ct)
+    {
+        while (!predicate())
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
@@ -3,9 +3,14 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Reflection;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
+using R3;
+using Termina.Reactive;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui;
@@ -23,6 +28,7 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
     private readonly DisposableTempDir _dir = new();
     private readonly NetclawPaths _paths;
     private readonly InitNavigationState _nav = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 6, 27, 12, 0, 0, TimeSpan.Zero));
 
     public InitExistingInstallViewModelTests()
     {
@@ -32,7 +38,18 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
 
     public void Dispose() => _dir.Dispose();
 
-    private InitExistingInstallViewModel Create() => new(_paths, _nav);
+    private InitExistingInstallViewModel Create()
+        => Create(DaemonStopped, DeleteDirectoryIfExists);
+
+    private InitExistingInstallViewModel Create(
+        Func<string, CancellationToken, Task<DaemonResult>> stopDaemonAsync,
+        Action<string> deleteDirectory)
+        => new(
+        _paths,
+        _nav,
+        stopDaemonAsync,
+        deleteDirectory,
+        _time);
 
     private static void Select(InitExistingInstallViewModel vm, int index)
     {
@@ -82,22 +99,27 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
     }
 
     [Fact]
-    public void FullReset_AfterBothConfirmations_DeletesEverything()
+    public async Task FullReset_AfterBothConfirmations_DeletesEverything()
     {
         File.WriteAllText(_paths.NetclawConfigPath, "{}");
         File.WriteAllText(_paths.SqliteDbPath, "db");
 
         var vm = Create();
+        string? route = null;
+        SetNavigate(vm, requestedRoute => route = requestedRoute);
         Select(vm, 2); // Start over
         Select(vm, 1); // Full reset → confirm 1
         Select(vm, 1); // Yes → confirm 2
         Select(vm, 1); // Yes → perform
+        await WaitForProgressAsync(vm, 3);
 
         Assert.False(Directory.Exists(_paths.BasePath));
+        await CompleteResetAsync(vm);
+        Assert.Equal(InitExistingInstallViewModel.WizardRoute, route);
     }
 
     [Fact]
-    public void SetupOnlyReset_DeletesConfigButKeepsMemoryAndSessions()
+    public async Task SetupOnlyReset_DeletesConfigButKeepsMemoryAndSessions()
     {
         // Setup-only reset removes everything the bootstrap wizard writes
         // (config + secrets + identity + soul) while leaving operator data
@@ -110,12 +132,15 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         File.WriteAllText(Path.Combine(_paths.SoulDirectory, "fragment.md"), "detail");
         File.WriteAllText(_paths.SqliteDbPath, "db");
         Directory.CreateDirectory(_paths.SessionsDirectory);
+        Directory.CreateDirectory(Path.Combine(_paths.SkillsDirectory, "local-skill"));
+        File.WriteAllText(Path.Combine(_paths.SkillsDirectory, "local-skill", "SKILL.md"), "skill");
 
         var vm = Create();
         Select(vm, 2); // Start over
         Select(vm, 0); // Reset setup only → confirm 1
         Select(vm, 1); // Yes → confirm 2
         Select(vm, 1); // Yes → perform
+        await WaitForProgressAsync(vm, 3);
 
         // Removed: config (incl. secrets, which lives under ConfigDirectory) + identity + soul.
         Assert.False(Directory.Exists(_paths.ConfigDirectory), "Config should be removed.");
@@ -126,6 +151,9 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         // Preserved: operator data.
         Assert.True(File.Exists(_paths.SqliteDbPath), "Memory db should be preserved.");
         Assert.True(Directory.Exists(_paths.SessionsDirectory), "Sessions should be preserved.");
+        Assert.True(File.Exists(Path.Combine(_paths.SkillsDirectory, "local-skill", "SKILL.md")),
+            "Skills should be preserved.");
+        await CompleteResetAsync(vm);
     }
 
     [Fact]
@@ -154,4 +182,290 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         vm.GoBack();
         Assert.Equal(Phase.Menu, vm.CurrentPhase.Value);
     }
+
+    [Fact]
+    public async Task Dispose_DuringCompletionPause_CancelsWizardNavigation()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, "{}");
+
+        var vm = Create();
+        string? route = null;
+        SetNavigate(vm, requestedRoute => route = requestedRoute);
+
+        Select(vm, 2); // Start over
+        Select(vm, 1); // Full reset → confirm 1
+        Select(vm, 1); // Yes → confirm 2
+        Select(vm, 1); // Yes → perform
+        await WaitForProgressAsync(vm, 3);
+
+        vm.Dispose();
+        _time.Advance(InitExistingInstallViewModel.CompletionPause);
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(route);
+    }
+
+    [Fact]
+    public async Task Dispose_WhileDaemonStopIsInFlight_CancelsLaterProgressAndNavigation()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, "{}");
+
+        var stopStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStop = new TaskCompletionSource<DaemonResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deleteCalled = false;
+        var vm = Create(
+            (_, _) =>
+            {
+                stopStarted.TrySetResult();
+                return releaseStop.Task;
+            },
+            _ => deleteCalled = true);
+        string? route = null;
+        SetNavigate(vm, requestedRoute => route = requestedRoute);
+
+        StartFullReset(vm);
+        await stopStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        using var disposeStarted = new ManualResetEventSlim();
+        var dispose = Task.Run(() =>
+        {
+            disposeStarted.Set();
+            vm.Dispose();
+        }, TestContext.Current.CancellationToken);
+        Assert.True(
+            disposeStarted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken),
+            "Dispose did not start.");
+
+        releaseStop.TrySetResult(new DaemonResult(true, "Daemon stopped."));
+        await dispose.WaitAsync(TestContext.Current.CancellationToken);
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(route);
+        Assert.False(deleteCalled, "Cancelling during daemon stop must not proceed into deletion.");
+    }
+
+    [Fact]
+    public async Task RequestQuit_WhileDaemonStopIsInFlight_CancelsBeforeDeletion()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, "{}");
+
+        var stopStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStop = new TaskCompletionSource<DaemonResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deleteCalled = false;
+        var vm = Create(
+            (_, _) =>
+            {
+                stopStarted.TrySetResult();
+                return releaseStop.Task;
+            },
+            _ => deleteCalled = true);
+        string? route = null;
+        SetNavigate(vm, requestedRoute => route = requestedRoute);
+
+        StartFullReset(vm);
+        await stopStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        vm.RequestQuit();
+        releaseStop.TrySetResult(new DaemonResult(true, "Daemon stopped."));
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(deleteCalled, "Ctrl+Q during daemon stop must cancel before deletion starts.");
+        Assert.Null(route);
+
+        vm.RequestQuit();
+        Assert.False(
+            vm.StatusMessage.Value.StartsWith("Reset is deleting data;", StringComparison.Ordinal),
+            "Cancellation before deletion must not leave the deletion quit gate stuck on.");
+    }
+
+    [Fact]
+    public async Task Dispose_WhileDeleteIsRunning_CancelsCompletionNavigation()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, "{}");
+
+        var deleteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var vm = Create(DaemonStopped, path =>
+        {
+            if (path == _paths.BasePath)
+            {
+                deleteStarted.TrySetResult();
+                releaseDelete.Task.GetAwaiter().GetResult();
+                return;
+            }
+
+            DeleteDirectoryIfExists(path);
+        });
+        string? route = null;
+        SetNavigate(vm, requestedRoute => route = requestedRoute);
+
+        StartFullReset(vm);
+        await deleteStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        using var disposeStarted = new ManualResetEventSlim();
+        var dispose = Task.Run(() =>
+        {
+            disposeStarted.Set();
+            vm.Dispose();
+        }, TestContext.Current.CancellationToken);
+        Assert.True(
+            disposeStarted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken),
+            "Dispose did not start.");
+
+        releaseDelete.TrySetResult();
+        await dispose.WaitAsync(TestContext.Current.CancellationToken);
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(route);
+    }
+
+    [Theory]
+    [InlineData("io")]
+    [InlineData("unauthorized")]
+    public async Task ResetFailure_ShowsErrorAndDoesNotNavigate(string failureKind)
+    {
+        var vm = Create(DaemonStopped, _ => throw failureKind switch
+        {
+            "io" => new IOException("locked file"),
+            _ => new UnauthorizedAccessException("access denied"),
+        });
+        string? route = null;
+        SetNavigate(vm, requestedRoute => route = requestedRoute);
+
+        StartFullReset(vm);
+        await WaitForProgressMessageAsync(vm, "Reset failed:");
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.StartsWith("Reset failed:", vm.ProgressMessage.Value, StringComparison.Ordinal);
+        Assert.Null(route);
+    }
+
+    [Fact]
+    public async Task ResetFailure_AfterBlockedQuit_ClearsQuitDisabledStatus()
+    {
+        var deleteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var vm = Create(DaemonStopped, path =>
+        {
+            if (path == _paths.BasePath)
+            {
+                deleteStarted.TrySetResult();
+                releaseDelete.Task.GetAwaiter().GetResult();
+                throw new IOException("locked file");
+            }
+
+            DeleteDirectoryIfExists(path);
+        });
+
+        StartFullReset(vm);
+        await deleteStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        vm.RequestQuit();
+        Assert.StartsWith("Reset is deleting data;", vm.StatusMessage.Value, StringComparison.Ordinal);
+
+        releaseDelete.TrySetResult();
+        await WaitForProgressMessageAsync(vm, "Reset failed:");
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(
+            vm.StatusMessage.Value.StartsWith("Reset is deleting data;", StringComparison.Ordinal),
+            "Failure state should not keep saying quit is disabled after quit becomes available again.");
+    }
+
+    [Fact]
+    public async Task DaemonStopFailureResult_ShowsStatusAndContinuesReset()
+    {
+        var vm = Create(
+            (_, _) => Task.FromResult(new DaemonResult(false, "daemon still running")),
+            DeleteDirectoryIfExists);
+
+        StartFullReset(vm);
+        await WaitForStatusMessageAsync(vm, "Daemon stop did not complete;");
+        await WaitForProgressAsync(vm, 3);
+
+        Assert.Contains("daemon still running", vm.StatusMessage.Value, StringComparison.Ordinal);
+        await CompleteResetAsync(vm);
+    }
+
+    private static void StartFullReset(InitExistingInstallViewModel vm)
+    {
+        Select(vm, 2); // Start over
+        Select(vm, 1); // Full reset → confirm 1
+        Select(vm, 1); // Yes → confirm 2
+        Select(vm, 1); // Yes → perform
+    }
+
+    private async Task CompleteResetAsync(InitExistingInstallViewModel vm)
+    {
+        for (var i = 0; i < 10 && vm.ResetTask is { IsCompleted: false }; i++)
+        {
+            _time.Advance(InitExistingInstallViewModel.CompletionPause);
+            await Task.Yield();
+        }
+
+        await vm.ResetTask!.WaitAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task WaitForProgressAsync(InitExistingInstallViewModel vm, int expectedStep)
+    {
+        if (vm.CurrentProgressStep.Value >= expectedStep)
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = vm.CurrentProgressStep.Subscribe(step =>
+        {
+            if (step >= expectedStep)
+                tcs.TrySetResult();
+        });
+
+        await tcs.Task.WaitAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task WaitForProgressMessageAsync(InitExistingInstallViewModel vm, string prefix)
+    {
+        if (vm.ProgressMessage.Value.StartsWith(prefix, StringComparison.Ordinal))
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = vm.ProgressMessage.Subscribe(message =>
+        {
+            if (message.StartsWith(prefix, StringComparison.Ordinal))
+                tcs.TrySetResult();
+        });
+
+        await tcs.Task.WaitAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task WaitForStatusMessageAsync(InitExistingInstallViewModel vm, string prefix)
+    {
+        if (vm.StatusMessage.Value.StartsWith(prefix, StringComparison.Ordinal))
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = vm.StatusMessage.Subscribe(message =>
+        {
+            if (message.StartsWith(prefix, StringComparison.Ordinal))
+                tcs.TrySetResult();
+        });
+
+        await tcs.Task.WaitAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static void SetNavigate(ReactiveViewModel vm, Action<string> navigate)
+    {
+        var property = typeof(ReactiveViewModel).GetProperty(
+            "Navigate",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.NotNull(property);
+        property!.SetValue(vm, navigate);
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+
+    private static Task<DaemonResult> DaemonStopped(string reason, CancellationToken ct)
+        => Task.FromResult(new DaemonResult(true, $"Daemon stopped for {reason}."));
 }

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
@@ -107,12 +107,14 @@ public sealed class HealthCheckStepViewModelTests : IDisposable
 
         var runner = new HealthCheckRunner(step.Results, () => { });
         using var cts = new CancellationTokenSource();
+        var firstResultAdded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var writer = Task.Factory.StartNew(() =>
         {
             var writeCount = 0;
             while (!cts.IsCancellationRequested)
             {
                 runner.Add(new HealthCheckItem("probe", true));
+                firstResultAdded.TrySetResult();
 
                 if (++writeCount % 128 != 0)
                     continue;
@@ -132,13 +134,11 @@ public sealed class HealthCheckStepViewModelTests : IDisposable
 
         try
         {
-            // Wait (bounded) for the writer to start producing before the read loop, so the reads
-            // genuinely race concurrent Adds AND the final non-empty assertion is deterministic. On a
-            // contended CI scheduler the Task.Run writer may not run before cts.Cancel(), which left
-            // Results empty and failed the assertion intermittently.
-            Assert.True(
-                SpinWait.SpinUntil(() => step.ResultsSnapshot().Count > 0, TimeSpan.FromSeconds(10)),
-                "Writer task did not start adding results within 10s.");
+            // Wait for the writer to start producing before the read loop, so the reads genuinely
+            // race concurrent Adds AND the final non-empty assertion is deterministic. On a contended
+            // CI scheduler the writer may not run before cts.Cancel(), which left Results empty and
+            // failed the assertion intermittently.
+            await firstResultAdded.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
             // Read snapshots while the writer mutates Results off-thread. Without the synchronized
             // snapshot, ToArray throws "Collection was modified" during a concurrent Add.

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -112,8 +112,10 @@ public sealed partial class DaemonManager
     /// Why the daemon is being stopped (e.g., "cli-stop", "update").
     /// Included in the shutdown webhook notification.
     /// </param>
-    public async Task<DaemonResult> StopAsync(string reason)
+    public async Task<DaemonResult> StopAsync(string reason, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (!TryGetRunningPid(out var pid))
             return new DaemonResult(false, "Daemon is not running.");
 
@@ -150,12 +152,15 @@ public sealed partial class DaemonManager
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
             await http.PostAsync(
                 $"{endpoint}/api/lifecycle/shutdown?reason={Uri.EscapeDataString(reason)}",
-                null);
+                null,
+                cancellationToken);
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested && ex is (HttpRequestException or TaskCanceledException))
         {
             Console.Error.WriteLine($"Note: could not notify daemon of shutdown reason: {ex.Message}");
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Graceful shutdown: SIGTERM on Unix, Kill on Windows (no SIGTERM equivalent)
         if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
@@ -173,7 +178,7 @@ public sealed partial class DaemonManager
         }
 
         // Wait up to 10 seconds for graceful exit.
-        if (!await WaitForExitAsync(process, TimeSpan.FromSeconds(10)))
+        if (!await WaitForExitAsync(process, TimeSpan.FromSeconds(10), cancellationToken))
         {
             // Timed out — hard cutoff.
             string? killError = null;
@@ -186,7 +191,7 @@ public sealed partial class DaemonManager
             if (!TryKillProcess(process, out var processKillError) && string.IsNullOrWhiteSpace(killError))
                 killError = processKillError;
 
-            if (!await WaitForExitAsync(process, TimeSpan.FromSeconds(5)))
+            if (!await WaitForExitAsync(process, TimeSpan.FromSeconds(5), cancellationToken))
             {
                 var details = string.IsNullOrWhiteSpace(killError)
                     ? string.Empty
@@ -623,15 +628,17 @@ public sealed partial class DaemonManager
         return kill(pid, (int)signal) == 0;
     }
 
-    private async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout)
+    private async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout, CancellationToken cancellationToken)
     {
         var deadline = _timeProvider.GetUtcNow() + timeout;
         while (_timeProvider.GetUtcNow() < deadline)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (process.HasExited)
                 return true;
 
-            await Task.Delay(200);
+            await Task.Delay(200, cancellationToken);
         }
 
         return process.HasExited;

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -495,7 +495,7 @@ static async Task RunAsync(string[] args)
                 return;
 
             case "stop":
-                var stopResult = await manager.StopAsync("cli-stop");
+                var stopResult = await manager.StopAsync("cli-stop", CancellationToken.None);
                 WriteDaemonResult(stopResult);
                 return;
 

--- a/src/Netclaw.Cli/Tui/InitExistingInstallPage.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallPage.cs
@@ -16,8 +16,8 @@ namespace Netclaw.Cli.Tui;
 /// <summary>
 /// Termina page for the existing-install menu and its in-place start-over flow.
 /// Renders a single selection list whose contents follow the ViewModel's phase
-/// (menu → reset scope → two confirmations), so the destructive path is explicit and
-/// double-confirmed (simplify-netclaw-init).
+/// (menu → reset scope → two confirmations → progress), so the destructive path is
+/// explicit and double-confirmed (simplify-netclaw-init).
 /// </summary>
 public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallViewModel>
 {
@@ -62,6 +62,12 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
         _phaseSubs.Clear();
 
         var phase = ViewModel.CurrentPhase.Value;
+
+        // ── Progress screen ──
+        if (phase == InitExistingInstallViewModel.Phase.Progress)
+            return BuildProgressScreen();
+
+        // ── Menu / confirmation screens ──
         var header = Layouts.Vertical().WithSpacing(0);
 
         switch (phase)
@@ -113,6 +119,64 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
             .WithChild(_list);
     }
 
+    /// <summary>
+    /// Builds the reset progress screen. Each step renders as a line:
+    ///   ✓ Completed steps (green checkmark)
+    ///   🔄 Current step (spinning dots, bound to CurrentProgressStep)
+    ///   Pending steps show their label without any indicator.
+    /// </summary>
+    private ILayoutNode BuildProgressScreen()
+    {
+        var progressStep = ViewModel.CurrentProgressStep.Value;
+
+        // Step labels — must match InitExistingInstallViewModel.ProgressStep enum order
+        var stepLabels = new[]
+        {
+            "Stopping daemon…",
+            "Deleting data…",
+            "Purge complete",
+        };
+
+        var lines = Layouts.Vertical().WithSpacing(1);
+
+        // Header
+        lines.WithChild(new TextNode("  Resetting…").WithForeground(Color.White).Bold());
+
+        // Progress steps
+        for (var i = 0; i < stepLabels.Length; i++)
+        {
+            ILayoutNode line;
+            if (i < progressStep)
+            {
+                // Already completed — green checkmark
+                line = new TextNode($"  ✓ {stepLabels[i].Replace("…", "")}").WithForeground(Color.Green);
+            }
+            else if (i == progressStep)
+            {
+                // In progress — spinning dots
+                var color = i == 0 ? Color.Yellow : Color.Cyan;
+                line = SpinnerViews.Labeled(stepLabels[i].Replace("…", ""), color);
+            }
+            else
+            {
+                // Pending — dimmed label
+                line = new TextNode($"  • {stepLabels[i].Replace("…", "")}").WithForeground(Color.Gray);
+            }
+
+            lines.WithChild(line);
+        }
+
+        // Error message if something went wrong
+        if (ViewModel.ProgressMessage.Value.StartsWith("Reset failed:", StringComparison.Ordinal))
+            lines.WithChild(new TextNode($"  {ViewModel.ProgressMessage.Value}").WithForeground(Color.Red).Bold());
+
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            .WithChild(new TextNode("  ").WithForeground(Color.Black)) // top padding
+            .WithChild(lines)
+            .WithChild(new TextNode("  ").WithForeground(Color.Black)); // bottom padding
+    }
+
     private LayoutNode BuildStatusBar()
     {
         return ViewModel.StatusMessage
@@ -123,6 +187,10 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
 
     private LayoutNode BuildKeyBindings()
     {
+        var phase = ViewModel.CurrentPhase.Value;
+        if (phase == InitExistingInstallViewModel.Phase.Progress)
+            return NetclawTuiChrome.BuildKeyHintLine(" [Ctrl+Q] Quit");
+
         return NetclawTuiChrome.BuildKeyHintLine(" [↑/↓] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit");
     }
 

--- a/src/Netclaw.Cli/Tui/InitExistingInstallPage.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallPage.cs
@@ -23,6 +23,7 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
 {
     private SelectionListNode<string>? _list;
     private DynamicLayoutNode? _bodyNode;
+    private DynamicLayoutNode? _keyBindingsNode;
     private readonly CompositeDisposable _phaseSubs = [];
 
     protected override void OnBound()
@@ -33,9 +34,25 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
 
-        // Rebuild the body when the phase changes so the list reflects the new options.
+        // Rebuild dynamic chrome when the phase changes so options and key hints stay in sync.
         ViewModel.CurrentPhase
+            .Subscribe(_ =>
+            {
+                _bodyNode?.Invalidate();
+                _keyBindingsNode?.Invalidate();
+            })
+            .DisposeWith(Subscriptions);
+
+        ViewModel.CurrentProgressStep
             .Subscribe(_ => _bodyNode?.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        ViewModel.ProgressMessage
+            .Subscribe(_ => _bodyNode?.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        ViewModel.CanQuitProgress
+            .Subscribe(_ => _keyBindingsNode?.Invalidate())
             .DisposeWith(Subscriptions);
     }
 
@@ -47,12 +64,13 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
     private ILayoutNode BuildInnerLayout()
     {
         _bodyNode = new DynamicLayoutNode(BuildBody);
+        _keyBindingsNode = new DynamicLayoutNode(BuildKeyBindings);
         return Layouts.Vertical()
             .WithSpacing(1)
             .WithChild(_bodyNode)
             .WithChild(Layouts.Empty().Fill())
             .WithChild(BuildStatusBar())
-            .WithChild(BuildKeyBindings());
+            .WithChild(_keyBindingsNode);
     }
 
     private ILayoutNode BuildBody()
@@ -65,7 +83,10 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
 
         // ── Progress screen ──
         if (phase == InitExistingInstallViewModel.Phase.Progress)
+        {
+            _list = null;
             return BuildProgressScreen();
+        }
 
         // ── Menu / confirmation screens ──
         var header = Layouts.Vertical().WithSpacing(0);
@@ -129,11 +150,12 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
     {
         var progressStep = ViewModel.CurrentProgressStep.Value;
 
-        // Step labels — must match InitExistingInstallViewModel.ProgressStep enum order
         var stepLabels = new[]
         {
             "Stopping daemon…",
-            "Deleting data…",
+            ViewModel.Scope == InitExistingInstallViewModel.ResetScopeKind.Full
+                ? "Deleting data…"
+                : "Deleting setup files…",
             "Purge complete",
         };
 
@@ -185,11 +207,13 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
             .Height(1);
     }
 
-    private LayoutNode BuildKeyBindings()
+    private ILayoutNode BuildKeyBindings()
     {
         var phase = ViewModel.CurrentPhase.Value;
         if (phase == InitExistingInstallViewModel.Phase.Progress)
-            return NetclawTuiChrome.BuildKeyHintLine(" [Ctrl+Q] Quit");
+            return NetclawTuiChrome.BuildKeyHintLine(ViewModel.CanQuitProgress.Value
+                ? " [Ctrl+Q] Quit"
+                : " Reset in progress — deletion cannot be interrupted");
 
         return NetclawTuiChrome.BuildKeyHintLine(" [↑/↓] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit");
     }
@@ -202,6 +226,9 @@ public sealed class InitExistingInstallPage : ReactivePage<InitExistingInstallVi
             ViewModel.RequestQuit();
             return;
         }
+
+        if (ViewModel.CurrentPhase.Value == InitExistingInstallViewModel.Phase.Progress)
+            return;
 
         if (keyInfo.Key == ConsoleKey.Escape)
         {

--- a/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Diagnostics;
 using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
 using R3;
@@ -38,6 +39,8 @@ public sealed class InitNavigationState
 /// </summary>
 public sealed class InitExistingInstallViewModel : ReactiveViewModel
 {
+    internal static readonly TimeSpan CompletionPause = TimeSpan.FromMilliseconds(600);
+
     public enum Phase
     {
         Menu,
@@ -57,16 +60,34 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
     private readonly NetclawPaths _paths;
     private readonly InitNavigationState _navigationState;
-    private readonly DaemonManager? _daemonManager;
+    private readonly Func<string, CancellationToken, Task<DaemonResult>> _stopDaemonAsync;
+    private readonly Action<string> _deleteDirectory;
+    private readonly TimeProvider _timeProvider;
+    private readonly CancellationTokenSource _resetCts = new();
+    private volatile bool _disposed;
+    private volatile bool _quitBlockedForDeletion;
 
     public InitExistingInstallViewModel(
         NetclawPaths paths,
         InitNavigationState navigationState,
-        DaemonManager? daemonManager = null)
+        DaemonManager daemonManager,
+        TimeProvider timeProvider)
+        : this(paths, navigationState, daemonManager.StopAsync, DeleteDirectory, timeProvider)
+    {
+    }
+
+    internal InitExistingInstallViewModel(
+        NetclawPaths paths,
+        InitNavigationState navigationState,
+        Func<string, CancellationToken, Task<DaemonResult>> stopDaemonAsync,
+        Action<string> deleteDirectory,
+        TimeProvider timeProvider)
     {
         _paths = paths;
         _navigationState = navigationState;
-        _daemonManager = daemonManager;
+        _stopDaemonAsync = stopDaemonAsync;
+        _deleteDirectory = deleteDirectory;
+        _timeProvider = timeProvider;
     }
 
     public const string IdentityRoute = "/init/identity";
@@ -81,10 +102,11 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
     public ResetScopeKind Scope => _scope;
 
     // Progress-screen state
-    private readonly List<bool> _completedSteps = [];
-    public IReadOnlyList<bool> CompletedSteps => _completedSteps;
     public ReactiveProperty<int> CurrentProgressStep { get; } = new(-1);
     public ReactiveProperty<string> ProgressMessage { get; } = new("");
+    public ReactiveProperty<bool> CanQuitProgress { get; } = new(true);
+    internal Task? ResetTask { get; private set; }
+    internal bool IsResetCancellationRequested => _resetCts.IsCancellationRequested;
 
     public static readonly IReadOnlyList<MenuItem> MenuItems =
     [
@@ -171,57 +193,156 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
     private void StartResetProgress()
     {
         CurrentPhase.Value = Phase.Progress;
-        _completedSteps.Clear();
-        _completedSteps.Add(false);
-        _completedSteps.Add(false);
-        _completedSteps.Add(false);
         CurrentProgressStep.Value = 0;
+        CanQuitProgress.Value = true;
         ProgressMessage.Value = "Stopping daemon…";
         RequestRedraw();
-        _ = RunResetAsync();
+        // Track the destructive work so tests and future callers can observe completion;
+        // the reset itself runs off the input/render loop to keep Ctrl+Q responsive.
+        ResetTask = Task.Run(() => RunResetAsync(_resetCts.Token), _resetCts.Token);
     }
 
-    private async Task RunResetAsync()
+    private async Task RunResetAsync(CancellationToken ct)
     {
-        SafeStopDaemon(_daemonManager, "factory-reset");
-        _completedSteps[0] = true;
-        CurrentProgressStep.Value = 1;
-        ProgressMessage.Value = _scope == ResetScopeKind.Full ? "Deleting all data…" : "Deleting setup files…";
-        RequestRedraw();
-
         try
         {
+            await StopDaemonBestEffortAsync(ct);
+            if (ct.IsCancellationRequested)
+                return;
+
+            _quitBlockedForDeletion = true;
+            PublishOnLoop(() =>
+            {
+                CanQuitProgress.Value = false;
+                CurrentProgressStep.Value = 1;
+                ProgressMessage.Value = _scope == ResetScopeKind.Full ? "Deleting all data…" : "Deleting setup files…";
+                RequestRedraw();
+            }, ct);
+
+            if (ct.IsCancellationRequested)
+            {
+                _quitBlockedForDeletion = false;
+                return;
+            }
+
             if (_scope == ResetScopeKind.Full)
-                DeleteDirectory(_paths.BasePath);
+            {
+                _deleteDirectory(_paths.BasePath);
+            }
             else
             {
-                DeleteDirectory(_paths.ConfigDirectory);
-                DeleteDirectory(_paths.IdentityDirectory);
-                DeleteDirectory(_paths.SoulDirectory);
+                _deleteDirectory(_paths.ConfigDirectory);
+                _deleteDirectory(_paths.IdentityDirectory);
+                _deleteDirectory(_paths.SoulDirectory);
             }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            ProgressMessage.Value = $"Reset failed: {ex.Message}";
-            RequestRedraw();
+            _quitBlockedForDeletion = false;
+            return;
+        }
+        catch (Exception ex)
+        {
+            _quitBlockedForDeletion = false;
+            PublishResetFailure(ex, ct);
             return;
         }
 
-        _completedSteps[2] = true;
-        CurrentProgressStep.Value = 2;
-        ProgressMessage.Value = "Purge complete";
-        RequestRedraw();
-        await Task.Delay(600);
-        Navigate?.Invoke(WizardRoute);
+        if (ct.IsCancellationRequested)
+            return;
+
+        _quitBlockedForDeletion = false;
+        PublishOnLoop(() =>
+        {
+            CurrentProgressStep.Value = 3;
+            CanQuitProgress.Value = true;
+            ProgressMessage.Value = "Purge complete";
+            if (StatusMessage.Value.StartsWith("Reset is deleting data;", StringComparison.Ordinal))
+                StatusMessage.Value = "";
+            RequestRedraw();
+        }, ct);
+
+        try
+        {
+            await Task.Delay(CompletionPause, _timeProvider, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            return;
+        }
+
+        PublishOnLoop(() => Navigate?.Invoke(WizardRoute), ct);
     }
 
-    /// <summary>Best-effort daemon stop — daemon may not be running or externally managed.</summary>
-    private static void SafeStopDaemon(DaemonManager? manager, string reason)
+    /// <summary>Best-effort daemon stop; deletion still surfaces any locked-file failure.</summary>
+    private async Task StopDaemonBestEffortAsync(CancellationToken ct)
     {
-        if (manager is null) return;
-        try { manager.StopAsync(reason).GetAwaiter().GetResult(); }
-        catch (OperationCanceledException) { }
-        catch (Exception) { /* best-effort — daemon may not be running or externally managed */ }
+        Task<DaemonResult>? stopTask = null;
+        try
+        {
+            stopTask = _stopDaemonAsync("factory-reset", ct);
+            var result = await stopTask.WaitAsync(ct);
+            if (!result.Success && !IsDaemonAlreadyStopped(result.Message))
+                PublishStatus($"Daemon stop did not complete; reset will continue: {result.Message}", ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            ObserveLateStopFailure(stopTask);
+        }
+        catch (OperationCanceledException ex)
+        {
+            PublishStatus($"Daemon stop canceled; reset will continue: {ex.Message}", ct);
+        }
+        catch (Exception ex)
+        {
+            PublishStatus($"Daemon stop failed; reset will continue: {ex.Message}", ct);
+        }
+    }
+
+    private static bool IsDaemonAlreadyStopped(string message)
+        => message.StartsWith("Daemon is not running.", StringComparison.Ordinal);
+
+    private static void ObserveLateStopFailure(Task<DaemonResult>? stopTask)
+    {
+        if (stopTask is null || stopTask.IsCompleted)
+            return;
+
+        _ = stopTask.ContinueWith(
+            task => Debug.WriteLine($"Init reset daemon stop completed after cancellation: {task.Exception?.GetBaseException().Message}"),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void PublishResetFailure(Exception ex, CancellationToken ct)
+        => PublishOnLoop(() =>
+        {
+            ProgressMessage.Value = $"Reset failed: {ex.Message}";
+            CanQuitProgress.Value = true;
+            if (StatusMessage.Value.StartsWith("Reset is deleting data;", StringComparison.Ordinal))
+                StatusMessage.Value = "";
+            RequestRedraw();
+        }, ct);
+
+    private void PublishStatus(string message, CancellationToken ct)
+        => PublishOnLoop(() =>
+        {
+            StatusMessage.Value = message;
+            RequestRedraw();
+        }, ct);
+
+    private void PublishOnLoop(Action action, CancellationToken ct)
+    {
+        if (ct.IsCancellationRequested || _disposed)
+            return;
+
+        _ = InvokeAsync(() =>
+        {
+            if (ct.IsCancellationRequested || _disposed)
+                return;
+
+            action();
+        }, ct);
     }
 
     private static void DeleteDirectory(string path)
@@ -249,15 +370,41 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         RequestRedraw();
     }
 
-    public void RequestQuit() => Shutdown();
+    public void RequestQuit()
+    {
+        if (CurrentPhase.Value == Phase.Progress && _quitBlockedForDeletion)
+        {
+            StatusMessage.Value = "Reset is deleting data; quit is disabled until deletion completes.";
+            RequestRedraw();
+            return;
+        }
+
+        if (CurrentPhase.Value == Phase.Progress)
+            _resetCts.Cancel();
+
+        Shutdown();
+    }
 
     public override void Dispose()
     {
+        _disposed = true;
+        _resetCts.Cancel();
+        try
+        {
+            ResetTask?.Wait(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Init reset task drain on dispose faulted: {ex.Message}");
+        }
+
+        _resetCts.Dispose();
         CurrentPhase.Dispose();
         SelectedIndex.Dispose();
         StatusMessage.Dispose();
         CurrentProgressStep.Dispose();
         ProgressMessage.Dispose();
+        CanQuitProgress.Dispose();
         base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
 using R3;
 using Termina.Reactive;
@@ -43,6 +44,7 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         ResetScope,
         ResetConfirm1,
         ResetConfirm2,
+        Progress,
     }
 
     public enum ResetScopeKind
@@ -55,20 +57,20 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
     private readonly NetclawPaths _paths;
     private readonly InitNavigationState _navigationState;
+    private readonly DaemonManager? _daemonManager;
 
-    public InitExistingInstallViewModel(NetclawPaths paths, InitNavigationState navigationState)
+    public InitExistingInstallViewModel(
+        NetclawPaths paths,
+        InitNavigationState navigationState,
+        DaemonManager? daemonManager = null)
     {
         _paths = paths;
         _navigationState = navigationState;
+        _daemonManager = daemonManager;
     }
 
-    /// <summary>Route the wizard launches for "Redo identity setup".</summary>
     public const string IdentityRoute = "/init/identity";
-
-    /// <summary>Route launched for a fresh setup after a confirmed reset.</summary>
     public const string WizardRoute = "/init";
-
-    /// <summary>This menu's own route (identity redo returns here on Esc).</summary>
     public const string MenuRoute = "/init/menu";
 
     public ReactiveProperty<Phase> CurrentPhase { get; } = new(Phase.Menu);
@@ -77,6 +79,12 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
     private ResetScopeKind _scope = ResetScopeKind.SetupOnly;
     public ResetScopeKind Scope => _scope;
+
+    // Progress-screen state
+    private readonly List<bool> _completedSteps = [];
+    public IReadOnlyList<bool> CompletedSteps => _completedSteps;
+    public ReactiveProperty<int> CurrentProgressStep { get; } = new(-1);
+    public ReactiveProperty<string> ProgressMessage { get; } = new("");
 
     public static readonly IReadOnlyList<MenuItem> MenuItems =
     [
@@ -93,7 +101,6 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         new("Cancel", "Go back without changing anything."),
     ];
 
-    /// <summary>Items for the current phase (drives the rendered list).</summary>
     public IReadOnlyList<MenuItem> CurrentItems => CurrentPhase.Value switch
     {
         Phase.Menu => MenuItems,
@@ -117,31 +124,19 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
     public void MoveSelection(int delta)
     {
         var count = CurrentItems.Count;
-        if (count == 0)
-            return;
-
+        if (count == 0) return;
         var next = Math.Clamp(SelectedIndex.Value + delta, 0, count - 1);
-        if (next != SelectedIndex.Value)
-            SelectedIndex.Value = next;
+        if (next != SelectedIndex.Value) SelectedIndex.Value = next;
     }
 
-    /// <summary>Enter on the highlighted row.</summary>
     public void ActivateSelected()
     {
         switch (CurrentPhase.Value)
         {
-            case Phase.Menu:
-                ActivateMenu(SelectedIndex.Value);
-                break;
-            case Phase.ResetScope:
-                ActivateScope(SelectedIndex.Value);
-                break;
-            case Phase.ResetConfirm1:
-                ActivateConfirm(first: true);
-                break;
-            case Phase.ResetConfirm2:
-                ActivateConfirm(first: false);
-                break;
+            case Phase.Menu: ActivateMenu(SelectedIndex.Value); break;
+            case Phase.ResetScope: ActivateScope(SelectedIndex.Value); break;
+            case Phase.ResetConfirm1: ActivateConfirm(first: true); break;
+            case Phase.ResetConfirm2: ActivateConfirm(first: false); break;
         }
     }
 
@@ -149,19 +144,10 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
     {
         switch (index)
         {
-            case 0: // Redo identity setup
-                Navigate?.Invoke(IdentityRoute);
-                break;
-            case 1: // Open configuration editor
-                _navigationState.PendingAction = InitFollowUpAction.OpenConfigEditor;
-                Shutdown();
-                break;
-            case 2: // Start over from scratch
-                EnterPhase(Phase.ResetScope);
-                break;
-            default: // Cancel
-                Shutdown();
-                break;
+            case 0: Navigate?.Invoke(IdentityRoute); break;
+            case 1: _navigationState.PendingAction = InitFollowUpAction.OpenConfigEditor; Shutdown(); break;
+            case 2: EnterPhase(Phase.ResetScope); break;
+            default: Shutdown(); break;
         }
     }
 
@@ -169,52 +155,46 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
     {
         switch (index)
         {
-            case 0:
-                _scope = ResetScopeKind.SetupOnly;
-                EnterPhase(Phase.ResetConfirm1);
-                break;
-            case 1:
-                _scope = ResetScopeKind.Full;
-                EnterPhase(Phase.ResetConfirm1);
-                break;
-            default: // Cancel
-                EnterPhase(Phase.Menu);
-                break;
+            case 0: _scope = ResetScopeKind.SetupOnly; EnterPhase(Phase.ResetConfirm1); break;
+            case 1: _scope = ResetScopeKind.Full; EnterPhase(Phase.ResetConfirm1); break;
+            default: EnterPhase(Phase.Menu); break;
         }
     }
 
-    // Confirm rows are [Cancel, Yes]. Default selection is Cancel (index 0), so a stray
-    // Enter never deletes — the operator must move to "Yes" and confirm twice.
     private void ActivateConfirm(bool first)
     {
-        if (SelectedIndex.Value == 0) // Cancel
-        {
-            EnterPhase(Phase.ResetScope);
-            return;
-        }
-
-        if (first)
-        {
-            EnterPhase(Phase.ResetConfirm2);
-            return;
-        }
-
-        PerformReset();
+        if (SelectedIndex.Value == 0) { EnterPhase(Phase.ResetScope); return; }
+        if (first) { EnterPhase(Phase.ResetConfirm2); return; }
+        StartResetProgress();
     }
 
-    private void PerformReset()
+    private void StartResetProgress()
     {
+        CurrentPhase.Value = Phase.Progress;
+        _completedSteps.Clear();
+        _completedSteps.Add(false);
+        _completedSteps.Add(false);
+        _completedSteps.Add(false);
+        CurrentProgressStep.Value = 0;
+        ProgressMessage.Value = "Stopping daemon…";
+        RequestRedraw();
+        _ = RunResetAsync();
+    }
+
+    private async Task RunResetAsync()
+    {
+        SafeStopDaemon(_daemonManager, "factory-reset");
+        _completedSteps[0] = true;
+        CurrentProgressStep.Value = 1;
+        ProgressMessage.Value = _scope == ResetScopeKind.Full ? "Deleting all data…" : "Deleting setup files…";
+        RequestRedraw();
+
         try
         {
             if (_scope == ResetScopeKind.Full)
-            {
                 DeleteDirectory(_paths.BasePath);
-            }
             else
             {
-                // Setup-only: remove what the bootstrap wizard writes (config + secrets +
-                // identity), preserving memory, sessions, and skills. SecretsPath lives
-                // under ConfigDirectory, so deleting it covers secrets too.
                 DeleteDirectory(_paths.ConfigDirectory);
                 DeleteDirectory(_paths.IdentityDirectory);
                 DeleteDirectory(_paths.SoulDirectory);
@@ -222,45 +202,48 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            StatusMessage.Value = $"Reset failed: {ex.Message}";
+            ProgressMessage.Value = $"Reset failed: {ex.Message}";
             RequestRedraw();
             return;
         }
 
-        // Fresh setup from the top.
+        _completedSteps[2] = true;
+        CurrentProgressStep.Value = 2;
+        ProgressMessage.Value = "Purge complete";
+        RequestRedraw();
+        await Task.Delay(600);
         Navigate?.Invoke(WizardRoute);
+    }
+
+    /// <summary>Best-effort daemon stop — daemon may not be running or externally managed.</summary>
+    private static void SafeStopDaemon(DaemonManager? manager, string reason)
+    {
+        if (manager is null) return;
+        try { manager.StopAsync(reason).GetAwaiter().GetResult(); }
+        catch (OperationCanceledException) { }
+        catch (Exception) { /* best-effort — daemon may not be running or externally managed */ }
     }
 
     private static void DeleteDirectory(string path)
     {
-        if (Directory.Exists(path))
-            Directory.Delete(path, recursive: true);
+        if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
     }
 
-    /// <summary>Esc: step back one phase, or quit from the menu.</summary>
     public void GoBack()
     {
         switch (CurrentPhase.Value)
         {
-            case Phase.Menu:
-                Shutdown();
-                break;
-            case Phase.ResetScope:
-                EnterPhase(Phase.Menu);
-                break;
-            case Phase.ResetConfirm1:
-                EnterPhase(Phase.ResetScope);
-                break;
-            case Phase.ResetConfirm2:
-                EnterPhase(Phase.ResetConfirm1);
-                break;
+            case Phase.Menu: Shutdown(); break;
+            case Phase.ResetScope: EnterPhase(Phase.Menu); break;
+            case Phase.ResetConfirm1: EnterPhase(Phase.ResetScope); break;
+            case Phase.ResetConfirm2: EnterPhase(Phase.ResetConfirm1); break;
+            case Phase.Progress: break; // Don't allow backing out — it's running
         }
     }
 
     private void EnterPhase(Phase phase)
     {
         CurrentPhase.Value = phase;
-        // Confirm phases default to Cancel (index 0); menus/scope start at the top.
         SelectedIndex.Value = 0;
         StatusMessage.Value = "";
         RequestRedraw();
@@ -273,6 +256,8 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
         CurrentPhase.Dispose();
         SelectedIndex.Dispose();
         StatusMessage.Dispose();
+        CurrentProgressStep.Dispose();
+        ProgressMessage.Dispose();
         base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -355,7 +355,7 @@ internal static class UpdateCommand
                 var remainingStatus = manager.GetStatus();
                 if (remainingStatus.IsRunning)
                 {
-                    var detachedStop = await manager.StopAsync("update");
+                    var detachedStop = await manager.StopAsync("update", CancellationToken.None);
                     if (!detachedStop.Success)
                     {
                         return UpdateDaemonStopResult.Failed(
@@ -373,7 +373,7 @@ internal static class UpdateCommand
             case SystemdUserServiceOwnershipKind.Unmanaged:
             default:
             {
-                var detachedStop = await manager.StopAsync("update");
+                var detachedStop = await manager.StopAsync("update", CancellationToken.None);
                 return detachedStop.Success
                     ? UpdateDaemonStopResult.Succeeded(UpdateDaemonOwner.DetachedProcess, detachedStop.Message)
                     : UpdateDaemonStopResult.Failed(UpdateDaemonOwner.DetachedProcess, detachedStop.Message);
@@ -411,7 +411,8 @@ internal static class UpdateCommand
     {
         public DaemonStatus GetStatus() => manager.GetStatus();
 
-        public Task<DaemonResult> StopAsync(string reason) => manager.StopAsync(reason);
+        public Task<DaemonResult> StopAsync(string reason, CancellationToken cancellationToken)
+            => manager.StopAsync(reason, cancellationToken);
 
         public DaemonResult Start() => manager.Start();
     }
@@ -607,7 +608,7 @@ internal interface IDaemonProcessLifecycle
 {
     DaemonStatus GetStatus();
 
-    Task<DaemonResult> StopAsync(string reason);
+    Task<DaemonResult> StopAsync(string reason, CancellationToken cancellationToken);
 
     DaemonResult Start();
 }


### PR DESCRIPTION
## Problem

On Windows, `netclaw init` → Full reset fails with:

```
Reset failed: The process cannot access the file 'daemon-2026-06-26.log' because it is being used by another process.
```

The daemon `netclawd` holds the log file handle open, and `Directory.Delete(path, recursive: true)` aborts on the first locked file. The operator gets stuck on a confirmation screen with no way forward.

## Fix

### 1. Stop the daemon before deletion

Inject `DaemonManager` into `InitExistingInstallViewModel` and call `StopAsync('factory-reset')` before any `Directory.Delete()` calls. This releases the file handles so Windows lets the deletion proceed.

Stop is best-effort — if the daemon isn't running or is externally managed (Docker container supervisor), it's silently ignored.

### 2. Show a progress screen with staggered checkmarks

Instead of confirming → instant failure, the operator now sees a dedicated progress screen:

```
┌─ Netclaw Setup ──────────────────────────────────────────────────┐
│                                                                  │
│   Resetting…                                                     │
│                                                                  │
│   Stopping daemon…                                               │
│   Deleting data…      ✓ Daemon stopped                           │
│                       ✓ Data purged                              │
│                       ✓ Purge complete                           │
│                                                                  │
│   [Ctrl+Q] Quit                                                  │
└──────────────────────────────────────────────────────────────────┘
```

Each step fades in as it completes — the current step gets a spinning dots glyph, completed steps get a green checkmark, pending steps are dimmed. After purge completes there's a brief 600ms pause so the user sees the ✓, then the wizard launches automatically.

### Key properties:

- **Non-interactive**: Once started, the operator can't interrupt the flow (Escape is a no-op during progress). Only Ctrl+Q exits.
- **Best-effort daemon stop**: If `StopAsync` throws (not running, external supervisor), the delete still proceeds.
- **Same confirmation flow**: The double-confirm screen is unchanged — operator still sees the warning and must click 'Yes' twice.

## Files changed

- `src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs` — Added `DaemonManager` dependency, `Progress` phase, `RunResetAsync()` lifecycle, and progress-state properties
- `src/Netclaw.Cli/Tui/InitExistingInstallPage.cs` — Added `BuildProgressScreen()` with staggered checkmarks and spinner, updated key bindings for progress phase
- `src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs` — Added `FakeSupervisor` inner class and wired it into the `Create()` factory to satisfy the new constructor signature
