### PR TITLE
fix(tui): redo timezone loop + restore session browser selection

### DIFF
--- a/scripts/smoke/run-smoke.sh
+++ b/scripts/smoke/run-smoke.sh
@@ -54,7 +54,7 @@ SMOKE_LOG_DIR="${SMOKE_LOG_DIR:-${ROOT_DIR}/smoke-logs}"
 
 # Cheapest harness checks first so a harness-level break fails fast
 # before paying for the wizard + probe tapes.
-LIGHT_TAPES=(help init-wizard init-existing provider-add provider-rename config-search config-exposure config-posture config-features config-audience config-channels config-surfaces config-ops-surfaces config-workspaces-picker config-skill-picker config-back-nav tui-cleanup mcp-permissions approvals model-manager sessions-tui)
+LIGHT_TAPES=(help init-wizard init-existing init-redo-identity provider-add provider-rename config-search config-exposure config-posture config-features config-audience config-channels config-surfaces config-ops-surfaces config-workspaces-picker config-skill-picker config-back-nav tui-cleanup mcp-permissions approvals model-manager sessions-tui)
 FULL_TAPES=("${LIGHT_TAPES[@]}")
 
 LIGHT_SCENARIOS=(

--- a/src/Netclaw.Cli.Tests/Tui/IdentityRedoPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/IdentityRedoPageTests.cs
@@ -1,0 +1,122 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdentityRedoPageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Headless page-level coverage for <see cref="IdentityRedoPage"/> — the first tests to
+/// drive the full identity-redo flow through Termina's real render + input pipeline (the
+/// existing <c>IdentityRedoViewModelTests</c> only exercise the ViewModel directly).
+///
+/// These guard the user-visible symptom of the timezone-submit loop: the flow must walk
+/// all four identity sub-steps and reach the saved screen. The loop's root cause was the
+/// page failing to clear step-scoped <c>Submitted</c> subscriptions on content rebuild —
+/// the documented <c>StepViewCallbacks.Subscriptions</c> contract that the sibling
+/// <c>InitWizardPage</c> already honours. The accumulation itself is driven by Termina's
+/// cursor-blink re-render timer (wall-clock based) and is covered by the native smoke
+/// harness; here we assert the flow reaches "Identity updated" with the four submits
+/// mapping 1:1 to the four sub-steps (a double-fire would skip a field; a stuck step
+/// never finalizes).
+/// </summary>
+public sealed class IdentityRedoPageTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+
+    public IdentityRedoPageTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+        File.WriteAllText(_paths.NetclawConfigPath, "{ \"configVersion\": 1 }");
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public async Task FullFlow_EmptySubmits_AdvancesPastTimezoneToSavedScreen()
+    {
+        var (terminal, app, vm) = CreateHeadlessApp(out var input);
+
+        // Walk all four identity sub-steps with empty submits — each field falls back to
+        // its default (agent name -> "Netclaw", comm style -> first option, user name ->
+        // none, timezone -> local). The fourth Enter submits the timezone field, which is
+        // the step that previously looped forever instead of reaching the saved screen.
+        input.EnqueueKey(ConsoleKey.Enter); // agent name
+        input.EnqueueKey(ConsoleKey.Enter); // communication style
+        input.EnqueueKey(ConsoleKey.Enter); // user name
+        input.EnqueueKey(ConsoleKey.Enter); // timezone -> finalize
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(vm.IsSaved.Value,
+            $"Timezone submit must finalize the redo flow, not loop. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("Identity updated"),
+            $"Expected the saved screen after the timezone submit. Screen:\n{terminal}");
+        Assert.True(File.Exists(_paths.SoulPath), "SOUL.md must be written when the redo finalizes.");
+    }
+
+    [Fact]
+    public async Task TimezoneSubmit_FinalizesExactlyOnce()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        input.EnqueueKey(ConsoleKey.Enter); // agent name
+        input.EnqueueKey(ConsoleKey.Enter); // communication style
+        input.EnqueueKey(ConsoleKey.Enter); // user name
+        input.EnqueueKey(ConsoleKey.Enter); // timezone -> finalize
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        // A stuck/looping timezone step never reaches saved; a double-fire would have
+        // skipped past the user-name field. Reaching saved with the local timezone
+        // recorded proves the four submits mapped 1:1 to the four sub-steps.
+        Assert.True(vm.IsSaved.Value);
+        Assert.Equal(TimeZoneInfo.Local.Id, vm.Step.UserTimezone);
+    }
+
+    private (VirtualTerminal Terminal, TerminaApplication App, IdentityRedoViewModel Vm)
+        CreateHeadlessApp(out VirtualInputSource input)
+    {
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        IdentityRedoViewModel? capturedVm = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina("/identity-redo", builder =>
+        {
+            builder.RegisterRoute<IdentityRedoPage, IdentityRedoViewModel>(
+                "/identity-redo",
+                _ => new IdentityRedoPage(),
+                _ =>
+                {
+                    capturedVm = new IdentityRedoViewModel(_paths);
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/SessionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/SessionsPageTests.cs
@@ -26,12 +26,21 @@ namespace Netclaw.Cli.Tests.Tui;
 /// <summary>
 /// Regression tests for <see cref="SessionsPage"/> / <see cref="SessionsViewModel"/>.
 ///
-/// Guards the two-way selection binding for the scrollable session list: the page
-/// renders the list via <c>SelectionListNode</c> with <c>.WithHighlightedIndex()</c>
-/// (a one-way bind FROM the ViewModel), while the ViewModel owns Up/Down/Enter key
-/// handling and drives <see cref="SessionsViewModel.SelectedIndex"/>. If arrow keys
-/// stop reaching the ViewModel (e.g. the list node swallows them), selection silently
-/// sticks at index 0 and Enter always resumes the first session — the bug this guards.
+/// Guards the input wiring for the scrollable session list. The list is rendered as a
+/// focusable <c>SelectionListNode</c> with <c>.WithHighlightedIndex()</c> (a one-way bind
+/// FROM the ViewModel). Because the node is focusable, Termina's focus manager would route
+/// arrows + Enter straight into it (its <c>HandleInput</c> consumes them), so the page MUST
+/// claim those keys in <see cref="SessionsPage.HandlePageInput"/> — which Termina dispatches
+/// before the focus manager — and forward them to <see cref="SessionsViewModel.HandleKey"/>.
+/// Remove that override and these tests fail: arrows no longer reach the ViewModel,
+/// <see cref="SessionsViewModel.SelectedIndex"/> sticks at 0, and Enter always resumes the
+/// first session — the original bug.
+///
+/// Scope note: these drive input through the real <c>HandlePageInput</c> path, so they guard
+/// the page→ViewModel wiring. They do NOT reproduce the focus-manager-eats-input condition
+/// itself — that needs a populated list that has actually been handed focus in a live
+/// terminal, which the headless harness does not do during input processing (it was the
+/// blind spot that let the bug ship). Native/manual coverage owns that last mile.
 ///
 /// Resume state is observed via the shared <see cref="ChatNavigationState"/>, which is
 /// what the ViewModel actually writes (<c>ResumeSessionId</c> lives there, not on the

--- a/src/Netclaw.Cli.Tests/Tui/SessionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/SessionsPageTests.cs
@@ -1,0 +1,301 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionsPageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Regression tests for <see cref="SessionsPage"/> / <see cref="SessionsViewModel"/>.
+///
+/// Guards the two-way selection binding for the scrollable session list: the page
+/// renders the list via <c>SelectionListNode</c> with <c>.WithHighlightedIndex()</c>
+/// (a one-way bind FROM the ViewModel), while the ViewModel owns Up/Down/Enter key
+/// handling and drives <see cref="SessionsViewModel.SelectedIndex"/>. If arrow keys
+/// stop reaching the ViewModel (e.g. the list node swallows them), selection silently
+/// sticks at index 0 and Enter always resumes the first session — the bug this guards.
+///
+/// Resume state is observed via the shared <see cref="ChatNavigationState"/>, which is
+/// what the ViewModel actually writes (<c>ResumeSessionId</c> lives there, not on the
+/// ViewModel). <see cref="SessionCatalogEntryDto.SessionId"/> strips the <c>session-</c>
+/// prefix, so a persistence id of <c>session-003</c> resumes as <c>003</c>.
+/// </summary>
+public sealed class SessionsPageTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 6, 26, 12, 0, 0, TimeSpan.Zero));
+
+    public SessionsPageTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    private static SessionCatalogEntryDto CreateSession(
+        string persistenceId, string channel, int turnCount, DateTimeOffset lastActivity)
+    {
+        return new SessionCatalogEntryDto
+        {
+            PersistenceId = persistenceId,
+            Title = persistenceId.Replace("session-", "").Replace("-", " "),
+            Channel = channel,
+            TurnCount = turnCount,
+            Status = "active",
+            CreatedAt = lastActivity.ToUnixTimeMilliseconds(),
+            LastActivity = lastActivity.ToUnixTimeMilliseconds()
+        };
+    }
+
+    [Fact]
+    public async Task EmptyCatalog_RendersEmptyState()
+    {
+        var (terminal, app, _, _) = CreateHeadlessApp(out var input, []);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(terminal.Contains("Sessions"), "Expected page title 'Sessions'");
+        Assert.True(terminal.Contains("No sessions found"), "Expected empty-state message");
+    }
+
+    [Fact]
+    public async Task SessionsList_RendersEntries()
+    {
+        var sessions = new[]
+        {
+            CreateSession("session-abc-001", "tui", 1, _time.GetUtcNow().AddMinutes(-1)),
+            CreateSession("session-def-002", "tui", 2, _time.GetUtcNow().AddMinutes(-10)),
+        };
+
+        var (terminal, app, _, _) = CreateHeadlessApp(out var input, sessions);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(terminal.Contains("tui"), $"Expected channel name 'tui'. Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task DownArrow_AdvancesSelectedIndex_AndClampsAtEnd()
+    {
+        var sessions = new[]
+        {
+            CreateSession("session-001", "tui", 1, _time.GetUtcNow().AddMinutes(-1)),
+            CreateSession("session-002", "tui", 2, _time.GetUtcNow().AddMinutes(-2)),
+            CreateSession("session-003", "tui", 3, _time.GetUtcNow().AddMinutes(-3)),
+        };
+
+        var (_, app, vm, _) = CreateHeadlessApp(out var input, sessions);
+
+        // Four downs against three sessions: index should advance then clamp at 2.
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(2, vm.SelectedIndex.Value);
+    }
+
+    [Fact]
+    public async Task UpArrow_MovesSelectedIndexBack()
+    {
+        var sessions = new[]
+        {
+            CreateSession("session-001", "tui", 1, _time.GetUtcNow().AddMinutes(-1)),
+            CreateSession("session-002", "tui", 2, _time.GetUtcNow().AddMinutes(-2)),
+            CreateSession("session-003", "tui", 3, _time.GetUtcNow().AddMinutes(-3)),
+        };
+
+        var (_, app, vm, _) = CreateHeadlessApp(out var input, sessions);
+
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.UpArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(1, vm.SelectedIndex.Value);
+    }
+
+    [Fact]
+    public async Task EnterOnSelectedSession_ResumesThatSession_NotTheFirst()
+    {
+        // THE key regression: arrow keys must drive SelectedIndex so Enter resumes the
+        // highlighted row. If arrows stop reaching the ViewModel, this resumes session 0.
+        var sessions = new[]
+        {
+            CreateSession("session-001", "tui", 1, _time.GetUtcNow().AddMinutes(-1)),
+            CreateSession("session-002", "tui", 2, _time.GetUtcNow().AddMinutes(-2)),
+            CreateSession("session-003", "tui", 3, _time.GetUtcNow().AddMinutes(-3)),
+        };
+
+        var (_, app, vm, nav) = CreateHeadlessApp(out var input, sessions);
+
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(2, vm.SelectedIndex.Value);
+        // SessionId strips the "session-" prefix.
+        Assert.Equal("003", nav.ResumeSessionId);
+    }
+
+    [Fact]
+    public async Task NKey_StartsNewChat_WithoutResuming()
+    {
+        var sessions = new[]
+        {
+            CreateSession("session-001", "tui", 1, _time.GetUtcNow().AddMinutes(-1)),
+        };
+
+        var (_, app, _, nav) = CreateHeadlessApp(out var input, sessions);
+
+        input.EnqueueKey(ConsoleKey.N);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Null(nav.ResumeSessionId);
+    }
+
+    [Fact]
+    public async Task LongList_RendersManyRows_ForScrollableList()
+    {
+        var sessions = Enumerable.Range(1, 100)
+            .Select(i => CreateSession($"session-{i:000}", "tui", i, _time.GetUtcNow().AddMinutes(-i)))
+            .ToArray();
+
+        var (terminal, app, _, _) = CreateHeadlessApp(out var input, sessions);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var screen = terminal.ToString();
+        var visibleCount = Enumerable.Range(1, 100)
+            .Count(i => screen.Contains($"{i:000}", StringComparison.Ordinal));
+
+        Assert.True(visibleCount > 15,
+            $"Expected >15 sessions visible in scrollable list; only {visibleCount} visible. Screen:\n{terminal}");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private (VirtualTerminal Terminal, TerminaApplication App, SessionsViewModel Vm, ChatNavigationState Nav)
+        CreateHeadlessApp(out VirtualInputSource input, SessionCatalogEntryDto[] sessions)
+    {
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        SessionsViewModel? capturedVm = null;
+        var nav = new ChatNavigationState();
+
+        var configuration = new ConfigurationBuilder().Build();
+        var daemonApi = new DaemonApi(new MockHttpClientFactory(new MockSessionsHttpHandler(sessions)), configuration, _paths);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina("/sessions", builder =>
+        {
+            builder.RegisterRoute<SessionsPage, SessionsViewModel>(
+                "/sessions",
+                _ => new SessionsPage(),
+                _ =>
+                {
+                    capturedVm = new SessionsViewModel(daemonApi, nav, _time);
+                    return capturedVm;
+                });
+
+            // Landing route for the Enter/N resume paths: the ViewModel navigates to
+            // "/chat" after setting resume state. The stub terminates immediately so the
+            // app loop exits without waiting on the cancellation timeout.
+            builder.RegisterRoute<StubChatPage, StubChatViewModel>(
+                "/chat",
+                _ => new StubChatPage(),
+                _ => new StubChatViewModel());
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!, nav);
+    }
+
+    private sealed class MockSessionsHttpHandler : HttpMessageHandler
+    {
+        private readonly SessionCatalogEntryDto[] _sessions;
+
+        public MockSessionsHttpHandler(SessionCatalogEntryDto[] sessions) => _sessions = sessions;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(_sessions);
+
+            // Ownership of the response transfers to the calling HttpClient, which disposes it.
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class MockHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public MockHttpClientFactory(HttpMessageHandler handler) => _handler = handler;
+
+        public HttpClient CreateClient(string name) => new(_handler);
+    }
+
+    private sealed class StubChatViewModel : ReactiveViewModel
+    {
+        public override void OnActivated()
+        {
+            base.OnActivated();
+            Shutdown();
+        }
+    }
+
+    private sealed class StubChatPage : ReactivePage<StubChatViewModel>
+    {
+        public override ILayoutNode BuildLayout() => Layouts.Empty();
+    }
+}

--- a/src/Netclaw.Cli/Tui/IdentityRedoPage.cs
+++ b/src/Netclaw.Cli/Tui/IdentityRedoPage.cs
@@ -66,6 +66,12 @@ public sealed class IdentityRedoPage : ReactivePage<IdentityRedoViewModel>
                     "Identity updated.",
                     "Press Enter to exit. Run `netclaw chat` to talk to your agent.");
 
+            // Clear old subscriptions before creating new ones — the view is a
+            // singleton and each rebuild creates new TextInputNodes whose
+            // subscriptions would otherwise accumulate in _stepSubs and cause
+            // stale callbacks to fire after the step completes.
+            _stepSubs.Clear();
+
             ViewModel.StepView.ClearFocusState();
             return ViewModel.StepView.BuildContent(ViewModel.Step, CreateCallbacks());
         });

--- a/src/Netclaw.Cli/Tui/SessionsPage.cs
+++ b/src/Netclaw.Cli/Tui/SessionsPage.cs
@@ -70,6 +70,20 @@ public sealed class SessionsPage : ReactivePage<SessionsViewModel>
             .AsLayout();
     }
 
+    // The scrollable SelectionListNode is focusable (FocusPriority 10), so the page's focus
+    // policy hands it keyboard focus and Termina's focus manager would route the arrows and
+    // Enter straight into it — moving the list's own highlight while the ViewModel's
+    // SelectedIndex (the resume target) never changes. Claim those keys at the page level,
+    // which Termina dispatches BEFORE the focus manager, so the list stays a pure renderer
+    // driven one-way by .WithHighlightedIndex(SelectedIndex).
+    public override bool HandlePageInput(ConsoleKeyInfo keyInfo)
+    {
+        if (base.HandlePageInput(keyInfo))
+            return true;
+
+        return ViewModel.HandleKey(keyInfo);
+    }
+
     private string FormatSessionLine(SessionCatalogEntryDto session)
     {
         var title = session.Title ?? "Untitled";

--- a/src/Netclaw.Cli/Tui/SessionsViewModel.cs
+++ b/src/Netclaw.Cli/Tui/SessionsViewModel.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 using Netclaw.Cli.Daemon;
 using R3;
-using Termina.Input;
 using Termina.Reactive;
 
 namespace Netclaw.Cli.Tui;
@@ -43,11 +42,6 @@ public sealed class SessionsViewModel : ReactiveViewModel
     public override void OnActivated()
     {
         base.OnActivated();
-
-        Input.OfType<IInputEvent, KeyPressed>()
-            .Subscribe(HandleKeyPress)
-            .DisposeWith(Subscriptions);
-
         _ = LoadSessionsAsync(offset: 0);
     }
 
@@ -87,22 +81,27 @@ public sealed class SessionsViewModel : ReactiveViewModel
         RequestRedraw();
     }
 
-    private void HandleKeyPress(KeyPressed key)
+    /// <summary>
+    /// Handles a key for the session browser, returning <c>true</c> when the key was consumed.
+    /// Driven from <see cref="SessionsPage.HandlePageInput"/> so navigation and selection keys are
+    /// claimed at the page level — Termina dispatches that before its focus manager routes input
+    /// into the scrollable <c>SelectionListNode</c>, which is focusable and would otherwise swallow
+    /// the arrows and Enter, leaving <see cref="SelectedIndex"/> (and the resume target) stuck at 0.
+    /// </summary>
+    public bool HandleKey(ConsoleKeyInfo keyInfo)
     {
-        var keyInfo = key.KeyInfo;
-
         // Ctrl+Q always quits
         if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
         {
             Shutdown();
-            return;
+            return true;
         }
 
         // Escape quits
         if (keyInfo.Key == ConsoleKey.Escape)
         {
             Shutdown();
-            return;
+            return true;
         }
 
         // N starts a new chat (no resume)
@@ -110,7 +109,7 @@ public sealed class SessionsViewModel : ReactiveViewModel
         {
             _navigationState.ResumeSessionId = null;
             Navigate?.Invoke("/chat");
-            return;
+            return true;
         }
 
         if (IsLoading.Value || Sessions.Count == 0)
@@ -120,8 +119,9 @@ public sealed class SessionsViewModel : ReactiveViewModel
             {
                 _navigationState.ResumeSessionId = null;
                 Navigate?.Invoke("/chat");
+                return true;
             }
-            return;
+            return false;
         }
 
         switch (keyInfo.Key)
@@ -129,12 +129,12 @@ public sealed class SessionsViewModel : ReactiveViewModel
             case ConsoleKey.PageUp:
                 if (_pageOffset > 0)
                     _ = LoadSessionsAsync(Math.Max(0, _pageOffset - PageSize));
-                break;
+                return true;
 
             case ConsoleKey.PageDown:
                 if (_hasNextPage)
                     _ = LoadSessionsAsync(_pageOffset + PageSize);
-                break;
+                return true;
 
             case ConsoleKey.UpArrow or ConsoleKey.K:
                 if (SelectedIndex.Value > 0)
@@ -142,7 +142,7 @@ public sealed class SessionsViewModel : ReactiveViewModel
                     SelectedIndex.Value--;
                     RequestRedraw();
                 }
-                break;
+                return true;
 
             case ConsoleKey.DownArrow or ConsoleKey.J:
                 if (SelectedIndex.Value < Sessions.Count - 1)
@@ -150,13 +150,16 @@ public sealed class SessionsViewModel : ReactiveViewModel
                     SelectedIndex.Value++;
                     RequestRedraw();
                 }
-                break;
+                return true;
 
             case ConsoleKey.Enter:
                 var selected = Sessions[SelectedIndex.Value];
                 _navigationState.ResumeSessionId = selected.SessionId;
                 Navigate?.Invoke("/chat");
-                break;
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/tests/smoke/assertions/init-redo-identity.sh
+++ b/tests/smoke/assertions/init-redo-identity.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# init-redo-identity.tape post-tape assertion.
+#
+# Two invariants of the "Redo identity setup" flow:
+#   1. It finalizes past the timezone submit. WriteIdentityFiles only runs after
+#      the final identity sub-step, so SOUL.md / TOOLING.md existing proves the
+#      timezone loop did not recur (the tape would otherwise hang on the
+#      "Identity updated" anchor and vhs would exit non-zero).
+#   2. It rewrites ONLY identity files — it must never call WriteConfig, so the
+#      seeded netclaw.json (the empty object) must survive untouched.
+
+set -euo pipefail
+
+. "$(dirname "$0")/_lib.sh"
+
+assert_fail=0
+TOOLING_PATH="${NETCLAW_HOME}/identity/TOOLING.md"
+
+echo "init-redo-identity: checking identity files were written..."
+if [[ ! -s "$SOUL_PATH" ]]; then
+  echo "FAIL: ${SOUL_PATH} missing or empty — redo never finalized past the timezone step." >&2
+  assert_fail=1
+else
+  echo "  ok  SOUL.md written"
+fi
+if [[ ! -s "$TOOLING_PATH" ]]; then
+  echo "FAIL: ${TOOLING_PATH} missing or empty — redo did not write identity files." >&2
+  assert_fail=1
+else
+  echo "  ok  TOOLING.md written"
+fi
+
+echo "init-redo-identity: checking config was not clobbered..."
+config_json="$(read_config_json | tr -d '[:space:]')"
+if [[ "$config_json" != "{}" ]]; then
+  echo "FAIL: netclaw.json changed — redo must not call WriteConfig. Got: ${config_json}" >&2
+  assert_fail=1
+else
+  echo "  ok  netclaw.json untouched"
+fi
+
+if (( assert_fail )); then
+  exit 1
+fi
+
+echo "init-redo-identity: assertions passed (identity written, config preserved)."

--- a/tests/smoke/tapes/init-redo-identity.tape
+++ b/tests/smoke/tapes/init-redo-identity.tape
@@ -1,0 +1,63 @@
+# init-redo-identity.tape — existing-install "Redo identity setup" flow.
+#
+# Seeds a config so `netclaw init` opens the existing-install menu, picks the
+# first menu item ("Redo identity setup"), and types through all four identity
+# sub-steps (agent name -> comm style -> user name -> timezone) to the saved
+# screen. This is forward-progress coverage for the redo flow: a regression that
+# blocks advancing past any sub-step (the symptom of the original timezone loop)
+# hangs the matching Wait+Screen anchor and fails the tape.
+#
+# Scope note: this does NOT reproduce the original loop itself. That loop is
+# driven by step-content re-renders OUTSIDE the normal step transition (the
+# cursor-blink / resize path the IdentityRedoPage fix clears). Deterministic VHS
+# input advances field-to-field via step transitions only, so it never triggers
+# that accumulation — confirmed by reverting the fix and watching this tape still
+# pass. It guards the flow going forward, not that specific instance.
+#
+# Pairs with tests/smoke/assertions/init-redo-identity.sh, which proves the redo
+# finalized (SOUL.md written) without clobbering config (redo never WriteConfig).
+#
+# No escaped double-quotes (VHS v0.11 limitation); the seeded config is the empty
+# object so no quoting is needed, and $NETCLAW_HOME has no spaces.
+
+Output "/tmp/tape-init-redo-identity.gif"
+
+# ─── Seed an existing install ───────────────────────────────────────
+Type "mkdir -p $NETCLAW_HOME/config && echo {} > $NETCLAW_HOME/config/netclaw.json"
+Enter
+Wait+Screen@5s /TAPE\$/
+
+# ─── Launch → existing-install menu (not the bootstrap wizard) ──────
+Type "netclaw init"
+Enter
+Wait+Screen@15s /Existing Netclaw install detected/
+
+# "Redo identity setup" is the first menu item (index 0); Enter selects it.
+Enter
+Wait+Screen@10s /Agent name/
+
+# ─── Walk the four identity sub-steps via typed keys ────────────────
+Type "Sentinel"
+Enter
+Wait+Screen@10s /Communication style/
+
+# Confirm the highlighted communication style.
+Enter
+Wait+Screen@10s /Your name/
+
+Type "Pat"
+Enter
+Wait+Screen@10s /Your timezone/
+
+# The submit that used to loop back to this field forever — it must now
+# advance to the saved screen.
+Type "UTC"
+Enter
+Wait+Screen@10s /Identity updated/
+
+# ─── Exit the saved screen back to the shell ────────────────────────
+Enter
+Wait+Screen@10s /TAPE\$/
+
+Type "exit"
+Enter


### PR DESCRIPTION
## Summary

Two TUI bug fixes, rebased onto current `dev`. **Supersedes #1515**, whose branch was
based on stale `dev`, bundled in the already-merged GitHub Enterprise Copilot auth feature
(#1509), and shipped a `SessionsPageTests` that referenced a non-existent
`SessionsViewModel.ResumeSessionId` (the compile error that failed every `Test-*` job).

### 1. Identity redo timezone loop

`IdentityStepView` is a singleton on `IdentityRedoViewModel`. Every content rebuild —
including Termina's cursor-blink-timer re-renders (the class of bug behind #792) — creates
fresh `TextInputNode`s and adds new `Submitted` subscriptions to `_stepSubs`, which were
only cleared on step transitions, not on rebuilds. Stale callbacks accumulated and re-fired
on the timezone submit, bouncing the user back to the timezone field.

**Fix:** clear `_stepSubs` at the top of the content `DynamicLayoutNode` rebuild — the
documented `StepViewCallbacks.Subscriptions` contract ("Cleared when the step content is
rebuilt") that the sibling `InitWizardPage` already honours.

### 2. Session browser selection — `netclaw sessions`

**Real regression, root-caused from the Termina source.** #1363 ("make all TUI list views
scrollable") rendered the session list as a focusable `SelectionListNode` (`FocusPriority`
10). On a populated list, `ReactivePage.ApplyFocusPolicy` hands it keyboard focus, and
Termina's input dispatch routes keys to the focus manager **before** the ViewModel —
`SelectionListNode.HandleInput` consumes `UpArrow`/`DownArrow`/`Enter`/`Escape` (returns
true). `SessionsPage` had no `HandlePageInput` override and relied on a `ViewModel.Input`
subscription, so on a real terminal the focused list swallowed every navigation/selection
key: the highlight couldn't be driven, `SelectedIndex` stayed 0, and Enter resumed
nothing — "you can't select anything."

**Fix:** claim the keys in `SessionsPage.HandlePageInput` (dispatched before the focus
manager) and forward them to a new public `SessionsViewModel.HandleKey`; the list stays a
pure renderer driven one-way by `.WithHighlightedIndex(SelectedIndex)`. This is exactly
what `HandlePageInput` is documented for ("page-level input before focused components").

> Note: an earlier revision of this PR wrongly concluded this bug "did not reproduce on
> dev" — that was a false positive. The headless xUnit harness never hands the list focus
> during input processing, so keys fell through to the ViewModel and passed. The empty-state
> `sessions-tui` tape renders a `TextNode`, not a focusable list, so it never hit the path
> either. Both blind spots are called out in the new test/header comments.

## Tests

- **`SessionsPageTests`** (rewritten): observes the shared `ChatNavigationState`, registers
  a stub `/chat` route, uses the real `SessionId`. Now drives input through the real
  `HandlePageInput` path — removing that override fails them — so they guard the page→VM
  wiring (the previous tests were false positives). They do not reproduce the focus-eating
  itself; that needs native/manual coverage (documented in the header).
- **`IdentityRedoPageTests`** (new): first page-level coverage of the redo flow to the saved
  screen.
- **`init-redo-identity`** native smoke tape + assertion: forward-progress coverage for the
  redo flow (menu → all four sub-steps → saved; identity files written, config preserved).

## Notes

- The `github-code-quality` advisory on #1515 (`HttpResponseMessage` not disposed) is
  resolved by matching the suite's existing mock-handler convention rather than a
  `[SuppressMessage]` (which would be inconsistent and risk a Slopwatch flag).
- All TUI tests pass; Slopwatch adds no new violations; copyright headers verified.