### PR TITLE
Fix subagent terminal result summaries

### DIFF
--- a/docs/runbooks/memory-health-and-evals.md
+++ b/docs/runbooks/memory-health-and-evals.md
@@ -44,11 +44,15 @@ sqlite3 "$HOME/.netclaw/memory/netclaw-memory.db" \
 Subagent-originated memory candidates are surfaced as session `SubAgentOutput`
 completion events with:
 
+- `outcome` (`completed`, `partial`, `failed`)
+- `outcomeReason` (when the run ended for a machine-readable non-completed reason)
 - `memoryDecision` (`accepted`, `deferred`, `rejected`)
 - `memoryDecisionReason` (when decision is not accepted)
 - `findingsCount`
 
 Only `accepted` findings are enqueued into the memory checkpoint pipeline.
+Partial runs can still produce accepted findings; failed runs are treated as
+operator-visible diagnostics rather than durable-memory evidence by default.
 
 ## Eval Execution
 

--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -93,8 +93,11 @@ first user message is just the raw task, identical to the pre-context protocol.
    lifecycle-managed — stops when the session stops).
 4. The subagent runs an autonomous LLM loop: call tools, process results, repeat.
 5. After at most 30 tool iterations, a final response, or an inactivity timeout,
-   the subagent returns its final text response.
-6. The main agent receives this response as the `spawn_agent` tool result.
+   the subagent returns a terminal run result.
+6. The main agent receives the `spawn_agent` tool result as an explicit text
+   envelope: agent name, run id, outcome (`completed`, `partial`, or `failed`),
+   optional reason, diagnostics pointer, and either a `Summary:` or `Error:`
+   section containing the subagent's final text.
 
 Child creation is marshaled back onto the session actor thread, so supervision
 stays within Akka's actor-thread rules. If the parent tool call is cancelled or
@@ -117,10 +120,16 @@ are suppressed in Slack.
 Completion events are emitted for every finished subagent run, even when the
 subagent returns no structured findings. In that case `FindingsCount` is `0`
 and the memory-decision fields are empty because there was nothing to review.
+The completion event carries the same terminal outcome and reason used by the
+tool-result envelope, so operators can distinguish a useful partial summary from
+a failed run.
 
 Structured findings are conservative, parent-reviewed durable-memory candidates.
 They should be emitted as explicit conclusion envelopes with review metadata,
-not inferred from free-form work logs or tool transcripts.
+not inferred from free-form work logs or tool transcripts. They are not the
+parent-facing `spawn_agent` result; they exist so accepted subagent conclusions
+can enter the memory checkpoint pipeline without asking the parent model to parse
+free-form work logs.
 
 ## Defining subagents
 

--- a/docs/spec/SPEC-016-tool-liveness-and-stall-detection.md
+++ b/docs/spec/SPEC-016-tool-liveness-and-stall-detection.md
@@ -150,8 +150,9 @@ Expected stream shape:
    longer applied to this call.
 4. The child watchdog governs prefill, model deltas, keepalive-only wedges,
    tool-loop progress, approval waits, cancellation, and iteration exhaustion.
-5. The terminal `ToolCompletedUpdate` carries either a successful sub-agent result
-   or a failed sub-agent result produced by the child.
+5. The terminal `ToolCompletedUpdate` carries an explicit sub-agent run envelope
+   produced by the child: run id, outcome, optional reason, diagnostics pointer,
+   and the final summary or error text.
 
 ## Validation Strategy
 
@@ -204,7 +205,7 @@ without the parent killing it, while opaque tools remain bounded.
 ### Diagnostics And Manual Repro
 
 - Logs SHALL correlate parent session id, sub-agent run id, child watchdog
-  reason, and terminal `spawn_agent` result.
+  reason, terminal outcome, and terminal `spawn_agent` result.
 - Manual repro should run parallel `spawn_agent` calls where one child opens a
   quiet window longer than the parent tool timeout. The expected result is no
   parent `produced no activity` failure; either the child completes or the child

--- a/feeds/skills/.system/files/subagent-authoring/SKILL.md
+++ b/feeds/skills/.system/files/subagent-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: subagent-authoring
 description: "How to create and troubleshoot file-defined subagents in ~/.netclaw/agents. Load when the user asks to add, edit, or debug subagent definitions, or when a skill routes via metadata.subagent."
 metadata:
   author: netclaw
-  version: "1.3.1"
+  version: "1.3.2"
 ---
 
 # Subagent Authoring
@@ -135,6 +135,12 @@ Subagents share the same tool-loop budget strategy as parent sessions: budget
 nudges, duplicate-call nudges, and force-no-tools wrap-up. The current
 subagent budget is 30 tool iterations per run, where one LLM response with any
 number of parallel tool calls counts as one iteration.
+
+The parent-facing `spawn_agent` result is an explicit terminal text envelope:
+agent name, run id, outcome (`completed`, `partial`, or `failed`), optional
+reason, diagnostics pointer, and a `Summary:` or `Error:` section. Structured
+findings, when enabled, are a separate parent-reviewed memory-candidate path;
+do not rely on them as the visible result returned to the parent model.
 
 ## Fail-loud loader behavior
 

--- a/src/Netclaw.Actors.Tests/Sessions/TurnStateTrackerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/TurnStateTrackerTests.cs
@@ -138,7 +138,9 @@ public sealed class TurnStateTrackerTests
 
         // The cap-th iteration hits the limit.
         var capped = tracker.RecordToolCompletion(resultCount: 1, maxToolIterationsPerTurn: cap);
-        Assert.IsType<ToolBudgetStatus.Exhausted>(capped);
+        var exhausted = Assert.IsType<ToolBudgetStatus.Exhausted>(capped);
+        Assert.Contains("executive summary", exhausted.NudgeText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Partial or Unknown", exhausted.NudgeText, StringComparison.Ordinal);
         Assert.Equal(cap, tracker.ToolIterationCount);
     }
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
@@ -121,6 +121,9 @@ public class SpawnAgentStreamingTests : TestKit
         // not a "Subagent '...' failed: ..." message from FormatResult.
         Assert.NotNull(result);
         Assert.NotEmpty(result);
+        Assert.Contains("Subagent run finished.", result, StringComparison.Ordinal);
+        Assert.Contains("Outcome: completed", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Summary:", result, StringComparison.Ordinal);
         Assert.DoesNotContain("failed", result, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -207,6 +210,8 @@ public class SpawnAgentStreamingTests : TestKit
 
         var result = await drain.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
         Assert.NotNull(result);
+        Assert.Contains("Subagent run finished.", result, StringComparison.Ordinal);
+        Assert.Contains("Outcome: completed", result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("summary complete", result);
     }
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -68,6 +68,8 @@ public class SubAgentActorTests : TestKit
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
+        Assert.Equal(SubAgentRunOutcome.Completed, result.Outcome);
+        Assert.Null(result.OutcomeReason);
         Assert.Contains("Response #1", result.Output);
         Assert.Equal("test-agent", result.AgentName.Value);
         Assert.Empty(result.Findings);
@@ -1021,6 +1023,8 @@ public class SubAgentActorTests : TestKit
 
         // After the configured tool budget, force a no-tools call which returns text.
         Assert.True(result.Success);
+        Assert.Equal(SubAgentRunOutcome.Partial, result.Outcome);
+        Assert.Equal(SubAgentOutcomeReason.ToolIterationBudgetExhausted, result.OutcomeReason);
         Assert.Equal(4, fakeClient.CallCount);
         Assert.NotNull(fakeClient.LastReceivedMessages);
         Assert.Contains(fakeClient.LastReceivedMessages,
@@ -1270,11 +1274,14 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
-    public async Task Long_text_response_emits_findings_when_enabled()
+    public async Task Long_text_response_emits_untruncated_findings_when_enabled()
     {
+        var longSummary = string.Concat(
+            new string('a', 1900),
+            "\nTAIL_CONCLUSION: preserve this final conclusion and citation.");
         var fakeClient = new FakeChatClient
         {
-            ResponseText = "This is a durable subagent summary with enough detail to be considered a memory candidate for parent-session checkpoint review."
+            ResponseText = longSummary
         };
         var definition = CreateDefinition() with { EmitStructuredFindings = true };
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
@@ -1285,11 +1292,14 @@ public class SubAgentActorTests : TestKit
 
         Assert.True(result.Success);
         Assert.Single(result.Findings);
+        Assert.Equal(longSummary, result.Findings[0].Content);
+        Assert.Contains("TAIL_CONCLUSION", result.Findings[0].Content, StringComparison.Ordinal);
         Assert.Equal(SubAgentFindingShape.Conclusion, result.Findings[0].Shape);
         Assert.Equal("subagent:test-agent", result.Findings[0].Title);
         Assert.Equal(SubAgentFindingDurability.Durable, result.Findings[0].Durability);
         Assert.Equal(SubAgentFindingReusability.Reusable, result.Findings[0].Reusability);
         Assert.Equal(SubAgentFindingRecallMode.Searchable, result.Findings[0].RecallMode);
+        Assert.Contains("subagent_outcome:completed", result.Findings[0].Evidence);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -123,6 +123,8 @@ public sealed record SessionOutputDto
     public string? Phase { get; init; }
     public int? ToolCountSub { get; init; }
     public bool? SubAgentSuccess { get; init; }
+    public string? SubAgentOutcome { get; init; }
+    public string? SubAgentOutcomeReason { get; init; }
     public double? DurationMs { get; init; }
     public string? MemoryDecision { get; init; }
     public string? MemoryDecisionReason { get; init; }

--- a/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Reminders;
 using Netclaw.Media;
+using Netclaw.Tools;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
 namespace Netclaw.Actors.Protocol;
@@ -133,6 +134,12 @@ public static class SessionOutputDtoMapper
             Phase = msg.Phase.ToString().ToLowerInvariant(),
             ToolCountSub = msg.ToolCount,
             SubAgentSuccess = msg.Success,
+            SubAgentOutcome = msg.Phase == SubAgents.SubAgentPhase.Completed
+                ? msg.Outcome.ToString().ToLowerInvariant()
+                : null,
+            SubAgentOutcomeReason = msg.Phase == SubAgents.SubAgentPhase.Completed
+                ? msg.OutcomeReason?.Value
+                : null,
             DurationMs = msg.Duration.TotalMilliseconds,
             MemoryDecision = msg.MemoryDecision,
             MemoryDecisionReason = msg.MemoryDecisionReason,
@@ -294,21 +301,7 @@ public static class SessionOutputDtoMapper
                 FileName = dto.FileName ?? "file",
                 MimeType = new MimeType(dto.MimeType)
             },
-            SessionOutputTypes.SubAgent => new SubAgentOutput
-            {
-                SessionId = sessionId,
-                TimestampMs = dto.TimestampMs,
-                AgentName = new SubAgents.AgentName(dto.AgentName ?? "unknown"),
-                Phase = dto.Phase?.Equals("completed", StringComparison.OrdinalIgnoreCase) == true
-                    ? SubAgents.SubAgentPhase.Completed
-                    : SubAgents.SubAgentPhase.Started,
-                ToolCount = dto.ToolCountSub ?? 0,
-                Success = dto.SubAgentSuccess ?? false,
-                Duration = TimeSpan.FromMilliseconds(dto.DurationMs ?? 0),
-                MemoryDecision = dto.MemoryDecision,
-                MemoryDecisionReason = dto.MemoryDecisionReason,
-                FindingsCount = dto.FindingsCount ?? 0
-            },
+            SessionOutputTypes.SubAgent => MapSubAgentOutput(dto, sessionId),
             SessionOutputTypes.BufferFlush => new BufferFlush
             {
                 SessionId = sessionId,
@@ -362,6 +355,42 @@ public static class SessionOutputDtoMapper
                 TimestampMs = dto.TimestampMs,
                 Message = $"Unknown output type from daemon: {dto.Type}"
             }
+            };
+    }
+
+    private static SubAgentRunOutcome ParseSubAgentOutcome(string? value, bool? success)
+    {
+        if (!string.IsNullOrWhiteSpace(value)
+            && Enum.TryParse<SubAgentRunOutcome>(value, ignoreCase: true, out var parsed))
+            return parsed;
+
+        return success == false ? SubAgentRunOutcome.Failed : SubAgentRunOutcome.Completed;
+    }
+
+    private static SubAgentOutput MapSubAgentOutput(SessionOutputDto dto, SessionId sessionId)
+    {
+        var phase = dto.Phase?.Equals("completed", StringComparison.OrdinalIgnoreCase) == true
+            ? SubAgents.SubAgentPhase.Completed
+            : SubAgents.SubAgentPhase.Started;
+
+        return new SubAgentOutput
+        {
+            SessionId = sessionId,
+            TimestampMs = dto.TimestampMs,
+            AgentName = new SubAgents.AgentName(dto.AgentName ?? "unknown"),
+            Phase = phase,
+            ToolCount = dto.ToolCountSub ?? 0,
+            Success = dto.SubAgentSuccess ?? false,
+            Outcome = phase == SubAgents.SubAgentPhase.Completed
+                ? ParseSubAgentOutcome(dto.SubAgentOutcome, dto.SubAgentSuccess)
+                : SubAgentRunOutcome.Completed,
+            OutcomeReason = phase == SubAgents.SubAgentPhase.Completed && !string.IsNullOrWhiteSpace(dto.SubAgentOutcomeReason)
+                ? new SubAgentOutcomeReason(dto.SubAgentOutcomeReason)
+                : null,
+            Duration = TimeSpan.FromMilliseconds(dto.DurationMs ?? 0),
+            MemoryDecision = dto.MemoryDecision,
+            MemoryDecisionReason = dto.MemoryDecisionReason,
+            FindingsCount = dto.FindingsCount ?? 0
         };
     }
 }

--- a/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
@@ -124,9 +124,9 @@ internal sealed class TurnStateTracker
             return new ToolBudgetStatus.Exhausted(
                 $"You have reached the tool iteration limit for this turn. "
                 + "Do NOT request any more tools. "
-                + "Summarize the work you completed and produce your final response "
-                + "based on the information you have gathered so far. "
-                + "If you could not complete the task, explain what you found and what remains.");
+                + "Produce a concise final executive summary based only on the information gathered so far. "
+                + "Use this format: Summary, Completed, Partial or Unknown, Caveats, Useful Evidence. "
+                + "Clearly state that the result is partial when work remains or evidence is incomplete.");
         }
 
         var budgetThreshold = (int)(maxToolIterationsPerTurn * BudgetNudgeRatio);

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -100,9 +100,11 @@ internal sealed record ToolExecutionBatchCompleted : INoSerializationVerificatio
 
 internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 {
-    public required string RunId { get; init; }
+    public required SubAgentRunId RunId { get; init; }
     public required SubAgents.AgentName AgentName { get; init; }
     public required bool Success { get; init; }
+    public required SubAgentRunOutcome Outcome { get; init; }
+    public SubAgentOutcomeReason? OutcomeReason { get; init; }
     public required TimeSpan Duration { get; init; }
     public int FindingsCount { get; init; }
     public string? MemoryDecision { get; init; }
@@ -111,7 +113,7 @@ internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 
 internal sealed record AcceptedSubAgentFinding : INoSerializationVerificationNeeded
 {
-    public required string RunId { get; init; }
+    public required SubAgentRunId RunId { get; init; }
     public required SubAgents.AgentName AgentName { get; init; }
     public required TimeSpan Duration { get; init; }
     public required SubAgentFindingShape Shape { get; init; }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -811,13 +811,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         foreach (var startedJob in msg.StartedBackgroundJobs)
             TrackStartedBackgroundJob(startedJob);
 
-        var emittedRunIds = new HashSet<string>(StringComparer.Ordinal);
+        var emittedRunIds = new HashSet<SubAgentRunId>();
         foreach (var finding in msg.AcceptedSubAgentFindings)
         {
             if (emittedRunIds.Add(finding.RunId))
             {
                 var runSummary = msg.CompletedSubAgentRuns
-                    .FirstOrDefault(x => string.Equals(x.RunId, finding.RunId, StringComparison.Ordinal));
+                    .FirstOrDefault(x => x.RunId == finding.RunId);
 
                 EmitOutput(new SubAgentOutput
                 {
@@ -826,6 +826,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     AgentName = finding.AgentName,
                     Phase = Netclaw.Actors.SubAgents.SubAgentPhase.Completed,
                     Success = true,
+                    Outcome = runSummary?.Outcome ?? SubAgentRunOutcome.Completed,
+                    OutcomeReason = runSummary?.OutcomeReason,
                     Duration = finding.Duration,
                     MemoryDecision = finding.Decision.ToWireValue(),
                     MemoryDecisionReason = finding.DecisionReason,
@@ -860,6 +862,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 AgentName = run.AgentName,
                 Phase = Netclaw.Actors.SubAgents.SubAgentPhase.Completed,
                 Success = run.Success,
+                Outcome = run.Outcome,
+                OutcomeReason = run.OutcomeReason,
                 Duration = run.Duration,
                 MemoryDecision = run.MemoryDecision,
                 MemoryDecisionReason = run.MemoryDecisionReason,
@@ -4339,13 +4343,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         TrackStartedBackgroundJob(result.StartedBackgroundJob);
 
-        var emittedRunIds = new HashSet<string>(StringComparer.Ordinal);
+        var emittedRunIds = new HashSet<SubAgentRunId>();
         foreach (var finding in result.AcceptedSubAgentFindings)
         {
             if (emittedRunIds.Add(finding.RunId))
             {
                 var runSummary = result.CompletedSubAgentRuns
-                    .FirstOrDefault(x => string.Equals(x.RunId, finding.RunId, StringComparison.Ordinal));
+                    .FirstOrDefault(x => x.RunId == finding.RunId);
 
                 EmitOutput(new SubAgentOutput
                 {
@@ -4354,6 +4358,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     AgentName = finding.AgentName,
                     Phase = Netclaw.Actors.SubAgents.SubAgentPhase.Completed,
                     Success = true,
+                    Outcome = runSummary?.Outcome ?? SubAgentRunOutcome.Completed,
+                    OutcomeReason = runSummary?.OutcomeReason,
                     Duration = finding.Duration,
                     MemoryDecision = finding.Decision.ToWireValue(),
                     MemoryDecisionReason = finding.DecisionReason,
@@ -4388,6 +4394,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 AgentName = run.AgentName,
                 Phase = Netclaw.Actors.SubAgents.SubAgentPhase.Completed,
                 Success = run.Success,
+                Outcome = run.Outcome,
+                OutcomeReason = run.OutcomeReason,
                 Duration = run.Duration,
                 MemoryDecision = run.MemoryDecision,
                 MemoryDecisionReason = run.MemoryDecisionReason,

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -318,6 +318,8 @@ internal static class SessionToolExecutionPipeline
                     RunId = info.RunId,
                     AgentName = new SubAgents.AgentName(info.AgentName),
                     Success = info.Success,
+                    Outcome = info.Outcome ?? (info.Success ? SubAgentRunOutcome.Completed : SubAgentRunOutcome.Failed),
+                    OutcomeReason = info.OutcomeReason,
                     Duration = info.Duration,
                     FindingsCount = info.Findings.Count,
                     MemoryDecision = decision,

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -121,7 +121,7 @@ public sealed class SessionLogActor : ReceiveActor
                 SubAgentOutput sa when sa.Phase == SubAgentPhase.Started =>
                     $"SubAgent started: {sa.AgentName} (tools={sa.ToolCount})",
                 SubAgentOutput sa =>
-                    $"SubAgent completed: {sa.AgentName} (success={sa.Success}, duration={sa.Duration.TotalSeconds:F1}s, findings={sa.FindingsCount}, memory={sa.MemoryDecision ?? "n/a"}{(string.IsNullOrWhiteSpace(sa.MemoryDecisionReason) ? string.Empty : $", reason={sa.MemoryDecisionReason}")})",
+                    $"SubAgent completed: {sa.AgentName} (success={sa.Success}, outcome={sa.Outcome.ToString().ToLowerInvariant()}, reason={sa.OutcomeReason?.Value ?? "-"}, duration={sa.Duration.TotalSeconds:F1}s, findings={sa.FindingsCount}, memory={sa.MemoryDecision ?? "n/a"}{(string.IsNullOrWhiteSpace(sa.MemoryDecisionReason) ? string.Empty : $", memoryReason={sa.MemoryDecisionReason}")})",
                 ErrorOutput error => $"Error [{error.Category}] (ref: {error.CorrelationId:N}): {error.Message}",
                 FileOutput file => $"File: {file.FileName} ({file.MimeType})",
                 _ => null

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -591,7 +591,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         CompactionOutput
             => "[session compacted]",
         SubAgentOutput sa when sa.Phase == SubAgentPhase.Completed
-            => $"[subagent] {sa.AgentName} completed (findings={sa.FindingsCount})",
+            => $"[subagent] {sa.AgentName} {sa.Outcome.ToString().ToLowerInvariant()} (findings={sa.FindingsCount})",
         ErrorOutput error
             => $"[error] {error.Message}",
         _ => null

--- a/src/Netclaw.Actors/Sessions/SessionProtocol.Outputs.cs
+++ b/src/Netclaw.Actors/Sessions/SessionProtocol.Outputs.cs
@@ -256,6 +256,12 @@ public static partial class SessionProtocol
         /// <summary>Whether the subagent completed successfully (on Completed).</summary>
         public bool Success { get; init; }
 
+        /// <summary>Terminal outcome of the subagent run (on Completed).</summary>
+        public SubAgentRunOutcome Outcome { get; init; } = SubAgentRunOutcome.Completed;
+
+        /// <summary>Machine-readable reason when <see cref="Outcome"/> is not completed.</summary>
+        public SubAgentOutcomeReason? OutcomeReason { get; init; }
+
         /// <summary>Wall-clock duration (on Completed).</summary>
         public TimeSpan Duration { get; init; }
 

--- a/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
+++ b/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
@@ -114,7 +115,23 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
     }
 
     private static string FormatResult(string agent, SubAgentResult result)
-        => result.Success ? result.Output : $"Subagent '{agent}' failed: {result.Output}";
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Subagent run finished.");
+        builder.AppendLine($"Agent: {agent}");
+        if (result.RunId is { } runId)
+            builder.AppendLine($"RunId: {runId.Value}");
+        builder.AppendLine($"Outcome: {result.Outcome.ToString().ToLowerInvariant()}");
+        if (result.OutcomeReason is { } reason)
+            builder.AppendLine($"Reason: {reason.Value}");
+        if (result.ScopeId is { } scopeId)
+            builder.AppendLine($"Diagnostics: session log entries include SubSessionId {scopeId.Value}.");
+
+        builder.AppendLine();
+        builder.AppendLine(result.Success ? "Summary:" : "Error:");
+        builder.Append(result.Output);
+        return builder.ToString();
+    }
 
     /// <summary>
     /// Validate the invocation and resolve the requested agent. Returns an error

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -123,6 +123,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private CancellationTokenRegistration _externalCancellationRegistration;
     private ToolExecutionContext _toolExecutionContext = ToolExecutionContext.Empty;
     private bool _malformedFinalOutputRepairAttempted;
+    private SubAgentOutcomeReason? _forcedFinalOutcomeReason;
 
     public SubAgentActor(
         SubAgentDefinition definition,
@@ -196,6 +197,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 Success = false,
                 Output = "Subagent stopped before completion.",
                 AgentName = _definition.Name,
+                Outcome = SubAgentRunOutcome.Failed,
+                OutcomeReason = SubAgentOutcomeReason.ActorStopped,
                 Findings = [],
                 FindingsCount = 0
             });
@@ -231,7 +234,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 Complete(
                     success: false,
                     "Sub-agent spawn failed: no trust audience was provided. A sub-agent "
-                    + "must inherit the spawning session's audience.");
+                    + "must inherit the spawning session's audience.",
+                    SubAgentRunOutcome.Failed,
+                    SubAgentOutcomeReason.MissingAudience);
                 return;
             }
 
@@ -316,7 +321,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     analysis.ToolCalls.Count,
                     _turnState.ToolCallCount,
                     _maxToolIterations);
-                Complete(false, "Subagent exceeded its tool iteration budget and continued requesting tools after tools were disabled.");
+                Complete(
+                    false,
+                    "Subagent exceeded its tool iteration budget and continued requesting tools after tools were disabled.",
+                    SubAgentRunOutcome.Failed,
+                    SubAgentOutcomeReason.ToolIterationBudgetExceededAfterDisable);
                 return;
             }
 
@@ -358,7 +367,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             "SubAgent [{AgentName}] produced repeated {Kind} responses — reporting failure",
                             _definition.Name,
                             analysis.Kind);
-                        Complete(false, fail.ErrorMessage);
+                        Complete(false, fail.ErrorMessage, SubAgentRunOutcome.Failed, SubAgentOutcomeReason.EmptyFinalResponse);
                         return;
                 }
             }
@@ -373,7 +382,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 _log.Warning(
                     "SubAgent [{AgentName}] LLM returned empty text after non-empty analysis — reporting as failure",
                     _definition.Name);
-                Complete(false, "Subagent returned an empty final response.");
+                Complete(false, "Subagent returned an empty final response.", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.EmptyFinalResponse);
                 return;
             }
 
@@ -393,11 +402,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 _log.Warning(
                     "SubAgent [{AgentName}] repeatedly emitted unexecuted tool-call markup as final text; reporting failure",
                     _definition.Name);
-                Complete(false, MalformedFinalOutputMessage);
+                Complete(false, MalformedFinalOutputMessage, SubAgentRunOutcome.Failed, SubAgentOutcomeReason.MalformedFinalOutput);
                 return;
             }
 
-            Complete(true, text);
+            Complete(
+                true,
+                text,
+                _forcedFinalOutcomeReason.HasValue ? SubAgentRunOutcome.Partial : SubAgentRunOutcome.Completed,
+                _forcedFinalOutcomeReason);
         });
 
         Receive<ToolExecutionCompleted>(msg =>
@@ -436,6 +449,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 case ToolBudgetStatus.Exhausted exhausted:
                     _log.Warning("SubAgent [{AgentName}] hit tool iteration limit ({Count}), forcing text response",
                         _definition.Name, _turnState.ToolIterationCount);
+                    _forcedFinalOutcomeReason = SubAgentOutcomeReason.ToolIterationBudgetExhausted;
                     AddSystemNudge(exhausted.NudgeText);
                     FireLlmCall(forceNoTools: true);
                     return;
@@ -459,13 +473,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             _toolExecutionWatchdogState = ToolExecutionWatchdogState.None;
             _log.Error(msg.Cause, "SubAgent [{AgentName}] tool execution failed", _definition.Name);
-            Complete(false, $"Tool execution failed: {msg.Cause.Message}");
+            Complete(false, $"Tool execution failed: {msg.Cause.Message}", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.ToolExecutionFailed);
         });
 
         Receive<LlmCallFailed>(msg =>
         {
             _log.Error(msg.Cause, "SubAgent [{AgentName}] LLM call failed callId={CallId}", _definition.Name, msg.CallId);
-            Complete(false, $"LLM call failed: {msg.Cause.Message}");
+            Complete(false, $"LLM call failed: {msg.Cause.Message}", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.LlmCallFailed);
         });
 
         Receive<SubAgentCancelled>(_ =>
@@ -473,7 +487,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _executionCts?.Cancel();
             _externalCts?.Cancel();
             _log.Warning("SubAgent [{AgentName}] cancelled by parent", _definition.Name);
-            Complete(false, "Subagent cancelled by parent");
+            Complete(false, "Subagent cancelled by parent", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.CancelledByParent);
         });
 
         Receive<ProcessingWatchdogExpired>(msg =>
@@ -498,7 +512,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 _log.Warning(
                     "SubAgent [{AgentName}] timed out: no substantive output for {Budget:F0}s after {Iterations} tool iterations",
                     _definition.Name, noProgress, _turnState.ToolIterationCount);
-                Complete(false, $"Subagent timed out: no substantive output for {noProgress:F0}s.");
+                Complete(false, $"Subagent timed out: no substantive output for {noProgress:F0}s.", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.NoSubstantiveOutputTimeout);
                 return;
             }
 
@@ -530,7 +544,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 "SubAgent [{AgentName}] timed out: no activity for {Budget}s ({Phase}) after {Iterations} tool iterations",
                 _definition.Name, activeBudget.TotalSeconds,
                 _anyContentStreamed ? "inter-delta" : "prefill", _turnState.ToolIterationCount);
-            Complete(false, $"Subagent timed out: no activity for {activeBudget.TotalSeconds:F0}s.");
+            Complete(false, $"Subagent timed out: no activity for {activeBudget.TotalSeconds:F0}s.", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.NoActivityTimeout);
         });
 
         Receive<SubAgentApprovalWaitStarted>(_ =>
@@ -694,7 +708,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     private bool _completed;
 
-    private void Complete(bool success, string output)
+    private void Complete(
+        bool success,
+        string output,
+        SubAgentRunOutcome? outcome = null,
+        SubAgentOutcomeReason? outcomeReason = null)
     {
         // Idempotent guard: a stale ProcessingWatchdogExpired or other handler can
         // land after Complete has already run (Tell from a thread-pool finally
@@ -716,8 +734,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _externalCts = null;
         _pendingApprovalWaits = 0;
 
-        _log.Info("SubAgent [{AgentName}] completed (success={Success}, output={OutputLength} chars, iterations={Iterations})",
-            _definition.Name, success, output.Length, _turnState.ToolIterationCount);
+        var resolvedOutcome = outcome ?? (success ? SubAgentRunOutcome.Completed : SubAgentRunOutcome.Failed);
+
+        _log.Info("SubAgent [{AgentName}] completed (success={Success}, outcome={Outcome}, reason={Reason}, output={OutputLength} chars, iterations={Iterations})",
+            _definition.Name, success, resolvedOutcome, outcomeReason?.Value ?? "-", output.Length, _turnState.ToolIterationCount);
 
         // Log cumulative stats for observability — total LLM calls, tool usage, etc.
         // This gives operators a single summary line for sub-agent duration analysis.
@@ -729,7 +749,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _runStopwatch.Elapsed.TotalSeconds);
 
         var findings = success && _definition.EmitStructuredFindings
-            ? BuildFindings(output, _toolExecutionContext.SessionId)
+            ? BuildFindings(output, _toolExecutionContext.SessionId, resolvedOutcome, outcomeReason)
             : [];
 
         _replyTo.Tell(new SubAgentResult
@@ -737,6 +757,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             Success = success,
             Output = output,
             AgentName = _definition.Name,
+            Outcome = resolvedOutcome,
+            OutcomeReason = outcomeReason,
             Findings = findings,
             FindingsCount = findings.Count
         });
@@ -788,7 +810,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         EmitActivity(phase);
     }
 
-    private List<SubAgentFinding> BuildFindings(string output, string? sessionId)
+    private List<SubAgentFinding> BuildFindings(
+        string output,
+        string? sessionId,
+        SubAgentRunOutcome outcome,
+        SubAgentOutcomeReason? outcomeReason)
     {
         var content = output?.Trim() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(content))
@@ -797,11 +823,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         if (content.Length < 30)
             return [];
 
-        var normalized = content.Length <= 1800
-            ? content
-            : content[..1800];
-
-        var confidence = 0.65;
+        var confidence = outcome == SubAgentRunOutcome.Partial ? 0.6 : 0.65;
         var policy = _policyEvaluator.EvaluateWrite(
             sensitivity: SubAgentFindingSensitivity.Normal.ToWireValue(),
             recallMode: SubAgentFindingRecallMode.Auto.ToWireValue(),
@@ -811,13 +833,17 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         if (!policy.Allowed)
             return [];
 
+        var evidence = new List<string> { $"subagent_outcome:{outcome.ToString().ToLowerInvariant()}" };
+        if (outcomeReason is { } reason)
+            evidence.Add($"subagent_outcome_reason:{reason.Value}");
+
         return
         [
             new SubAgentFinding
             {
                 Shape = SubAgentFindingShape.Conclusion,
                 Title = $"subagent:{_definition.Name}",
-                Content = normalized,
+                Content = content,
                 Kind = "record",
                 Sensitivity = SubAgentFindingSensitivity.Normal,
                 RecallMode = SubAgentFindingRecallMode.Searchable,
@@ -825,7 +851,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 Confidence = confidence,
                 Durability = SubAgentFindingDurability.Durable,
                 Reusability = SubAgentFindingReusability.Reusable,
-                Evidence = []
+                Evidence = evidence
             }
         ];
     }

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -185,6 +185,18 @@ public sealed record SubAgentResult : ISubAgentResponse
     /// <summary>Name of the subagent that produced this result.</summary>
     public required AgentName AgentName { get; init; }
 
+    /// <summary>Terminal outcome of the run, separate from the legacy success flag.</summary>
+    public SubAgentRunOutcome Outcome { get; init; } = SubAgentRunOutcome.Completed;
+
+    /// <summary>Machine-readable reason when <see cref="Outcome"/> is not completed.</summary>
+    public SubAgentOutcomeReason? OutcomeReason { get; init; }
+
+    /// <summary>Spawner-generated run id used to correlate logs and notifications.</summary>
+    public SubAgentRunId? RunId { get; init; }
+
+    /// <summary>Subagent scope id used in structured logs.</summary>
+    public SubAgentScopeId? ScopeId { get; init; }
+
     /// <summary>
     /// Structured findings returned to the owning session for policy and checkpoint review.
     /// </summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -85,7 +85,9 @@ public sealed class SubAgentSpawner
             {
                 Success = false,
                 Output = $"Cannot spawn subagent '{profile.Name}': no session context available.",
-                AgentName = new AgentName(profile.Name)
+                AgentName = new AgentName(profile.Name),
+                Outcome = SubAgentRunOutcome.Failed,
+                OutcomeReason = SubAgentOutcomeReason.SpawnUnavailable
             };
         }
 
@@ -100,7 +102,9 @@ public sealed class SubAgentSpawner
             {
                 Success = false,
                 Output = $"Cannot spawn subagent '{profile.Name}': no tools are available under the parent audience policy.",
-                AgentName = new AgentName(profile.Name)
+                AgentName = new AgentName(profile.Name),
+                Outcome = SubAgentRunOutcome.Failed,
+                OutcomeReason = SubAgentOutcomeReason.NoToolsAvailable
             };
         }
 
@@ -115,7 +119,7 @@ public sealed class SubAgentSpawner
             OperatingRules = ResolveOperatingRules(context)
         };
 
-        var runId = Guid.NewGuid().ToString("N");
+        var runId = SubAgentRunId.New();
 
         // Notify session that subagent is starting
         context.OnSubAgentActivity?.Invoke(new SubAgentNotificationInfo
@@ -134,6 +138,7 @@ public sealed class SubAgentSpawner
         var subAgentScopeId = !string.IsNullOrWhiteSpace(context.SessionId)
             ? $"{context.SessionId}/subagent/{definition.Name}/{runId}"
             : $"subagent/{definition.Name}/{runId}";
+        var scopeId = new SubAgentScopeId(subAgentScopeId);
 
         // Spawn as child of the session actor via the context factory
         var props = SubAgentActor.CreateProps(
@@ -164,7 +169,9 @@ public sealed class SubAgentSpawner
                 RunId = runId,
                 AgentName = definition.Name.Value,
                 IsStarted = false,
-                Success = false
+                Success = false,
+                Outcome = SubAgentRunOutcome.Failed,
+                OutcomeReason = SubAgentOutcomeReason.SpawnError
             });
             activitySink?.TryComplete();
             throw;
@@ -225,6 +232,8 @@ public sealed class SubAgentSpawner
                 AgentName = definition.Name.Value,
                 IsStarted = false,
                 Success = result.Success,
+                Outcome = result.Outcome,
+                OutcomeReason = result.OutcomeReason,
                 Duration = sw.Elapsed,
                 Findings = result.Findings
             });
@@ -233,7 +242,11 @@ public sealed class SubAgentSpawner
                 "SubAgent [{AgentName}] completed (runId={RunId}, success={Success}, duration={Duration}ms)",
                 profile.Name, runId, result.Success, sw.ElapsedMilliseconds);
 
-            return result;
+            return result with
+            {
+                RunId = runId,
+                ScopeId = scopeId
+            };
         }
         catch (Exception ex)
         {
@@ -247,6 +260,8 @@ public sealed class SubAgentSpawner
                 AgentName = definition.Name.Value,
                 IsStarted = false,
                 Success = false,
+                Outcome = SubAgentRunOutcome.Failed,
+                OutcomeReason = SubAgentOutcomeReason.SpawnError,
                 Duration = sw.Elapsed
             });
 
@@ -255,7 +270,11 @@ public sealed class SubAgentSpawner
             {
                 Success = false,
                 Output = $"Subagent error: {ex.Message}",
-                AgentName = new AgentName(profile.Name)
+                AgentName = new AgentName(profile.Name),
+                Outcome = SubAgentRunOutcome.Failed,
+                OutcomeReason = SubAgentOutcomeReason.SpawnError,
+                RunId = runId,
+                ScopeId = scopeId
             };
         }
         finally

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
@@ -6,6 +6,7 @@
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.SubAgents;
 using Netclaw.Cli.Daemon;
+using Netclaw.Tools;
 using Xunit;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
@@ -160,6 +161,8 @@ public sealed class DaemonClientMappingTests
         Assert.Equal("memory-curator", dto.AgentName);
         Assert.Equal("started", dto.Phase);
         Assert.Equal(5, dto.ToolCountSub);
+        Assert.Null(dto.SubAgentOutcome);
+        Assert.Null(dto.SubAgentOutcomeReason);
         Assert.Null(dto.MemoryDecision);
 
         var roundTripped = DaemonClient.FromDto(dto);
@@ -179,6 +182,8 @@ public sealed class DaemonClientMappingTests
             AgentName = new AgentName("memory-retriever"),
             Phase = SubAgentPhase.Completed,
             Success = true,
+            Outcome = SubAgentRunOutcome.Partial,
+            OutcomeReason = SubAgentOutcomeReason.ToolIterationBudgetExhausted,
             Duration = TimeSpan.FromSeconds(12.3)
         };
 
@@ -186,6 +191,8 @@ public sealed class DaemonClientMappingTests
         Assert.Equal("subagent", dto.Type);
         Assert.Equal("completed", dto.Phase);
         Assert.True(dto.SubAgentSuccess);
+        Assert.Equal("partial", dto.SubAgentOutcome);
+        Assert.Equal("tool_iteration_budget_exhausted", dto.SubAgentOutcomeReason);
 
         var enrichedDto = dto with
         {
@@ -199,6 +206,8 @@ public sealed class DaemonClientMappingTests
         Assert.Equal("memory-retriever", result.AgentName.Value);
         Assert.Equal(SubAgentPhase.Completed, result.Phase);
         Assert.True(result.Success);
+        Assert.Equal(SubAgentRunOutcome.Partial, result.Outcome);
+        Assert.Equal(SubAgentOutcomeReason.ToolIterationBudgetExhausted, result.OutcomeReason);
         Assert.Equal(12300, result.Duration.TotalMilliseconds, 1);
         Assert.Equal("accepted", result.MemoryDecision);
         Assert.Equal(2, result.FindingsCount);

--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
@@ -408,7 +408,9 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
 
     private static async Task WaitForProgressAsync(InitExistingInstallViewModel vm, int expectedStep)
     {
-        if (vm.CurrentProgressStep.Value >= expectedStep)
+        bool Matches() => vm.CurrentProgressStep.Value >= expectedStep;
+
+        if (Matches())
             return;
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -418,12 +420,17 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
                 tcs.TrySetResult();
         });
 
+        if (Matches())
+            return;
+
         await tcs.Task.WaitAsync(TestContext.Current.CancellationToken);
     }
 
     private static async Task WaitForProgressMessageAsync(InitExistingInstallViewModel vm, string prefix)
     {
-        if (vm.ProgressMessage.Value.StartsWith(prefix, StringComparison.Ordinal))
+        bool Matches() => vm.ProgressMessage.Value.StartsWith(prefix, StringComparison.Ordinal);
+
+        if (Matches())
             return;
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -433,12 +440,17 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
                 tcs.TrySetResult();
         });
 
+        if (Matches())
+            return;
+
         await tcs.Task.WaitAsync(TestContext.Current.CancellationToken);
     }
 
     private static async Task WaitForStatusMessageAsync(InitExistingInstallViewModel vm, string prefix)
     {
-        if (vm.StatusMessage.Value.StartsWith(prefix, StringComparison.Ordinal))
+        bool Matches() => vm.StatusMessage.Value.StartsWith(prefix, StringComparison.Ordinal);
+
+        if (Matches())
             return;
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -447,6 +459,9 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
             if (message.StartsWith(prefix, StringComparison.Ordinal))
                 tcs.TrySetResult();
         });
+
+        if (Matches())
+            return;
 
         await tcs.Task.WaitAsync(TestContext.Current.CancellationToken);
     }

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -306,10 +306,11 @@ public sealed class HeadlessChannel : IChannel
                 }
                 else
                 {
-                    var status = msg.Success ? "success" : "failed";
+                    var status = msg.Outcome.ToString().ToLowerInvariant();
+                    var reason = msg.OutcomeReason is { } outcomeReason ? $", reason={outcomeReason.Value}" : string.Empty;
                     if (!_jsonOutput)
-                        Console.WriteLine($"[subagent:done] {msg.AgentName} ({status}, {msg.Duration.TotalSeconds:F1}s)");
-                    Log(log, $"SUBAGENT_DONE: name={msg.AgentName} success={msg.Success} duration={msg.Duration.TotalSeconds:F1}s");
+                        Console.WriteLine($"[subagent:done] {msg.AgentName} ({status}, {msg.Duration.TotalSeconds:F1}s{reason})");
+                    Log(log, $"SUBAGENT_DONE: name={msg.AgentName} success={msg.Success} outcome={status}{reason} duration={msg.Duration.TotalSeconds:F1}s");
                 }
                 break;
 

--- a/src/Netclaw.Tools.Abstractions/SubAgentRunMetadata.cs
+++ b/src/Netclaw.Tools.Abstractions/SubAgentRunMetadata.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubAgentRunMetadata.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Tools;
+
+/// <summary>
+/// Terminal outcome of a subagent run. This is distinct from transport success:
+/// a partial run can still return useful text and be eligible for memory review.
+/// </summary>
+public enum SubAgentRunOutcome
+{
+    Completed,
+    Partial,
+    Failed
+}
+
+/// <summary>Spawner-generated subagent run id used to correlate logs and notifications.</summary>
+public readonly record struct SubAgentRunId(string Value)
+{
+    public static SubAgentRunId New() => new(Guid.NewGuid().ToString("N"));
+
+    public static explicit operator SubAgentRunId(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>Subagent execution scope id used in structured logs.</summary>
+public readonly record struct SubAgentScopeId(string Value)
+{
+    public static explicit operator SubAgentScopeId(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>Machine-readable reason for a non-completed subagent outcome.</summary>
+public readonly record struct SubAgentOutcomeReason(string Value)
+{
+    public static readonly SubAgentOutcomeReason MissingAudience = new("missing_audience");
+    public static readonly SubAgentOutcomeReason ToolIterationBudgetExhausted = new("tool_iteration_budget_exhausted");
+    public static readonly SubAgentOutcomeReason ToolIterationBudgetExceededAfterDisable = new("tool_iteration_budget_exceeded_after_disable");
+    public static readonly SubAgentOutcomeReason EmptyFinalResponse = new("empty_final_response");
+    public static readonly SubAgentOutcomeReason MalformedFinalOutput = new("malformed_final_output");
+    public static readonly SubAgentOutcomeReason ToolExecutionFailed = new("tool_execution_failed");
+    public static readonly SubAgentOutcomeReason LlmCallFailed = new("llm_call_failed");
+    public static readonly SubAgentOutcomeReason CancelledByParent = new("cancelled_by_parent");
+    public static readonly SubAgentOutcomeReason NoSubstantiveOutputTimeout = new("no_substantive_output_timeout");
+    public static readonly SubAgentOutcomeReason NoActivityTimeout = new("no_activity_timeout");
+    public static readonly SubAgentOutcomeReason ActorStopped = new("actor_stopped");
+    public static readonly SubAgentOutcomeReason SpawnUnavailable = new("spawn_unavailable");
+    public static readonly SubAgentOutcomeReason NoToolsAvailable = new("no_tools_available");
+    public static readonly SubAgentOutcomeReason SpawnError = new("spawn_error");
+
+    public static explicit operator SubAgentOutcomeReason(string value) => new(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -25,11 +25,13 @@ public sealed record FileAttachmentInfo(string FilePath, string FileName, MimeTy
 /// </summary>
 public sealed record SubAgentNotificationInfo
 {
-    public required string RunId { get; init; }
+    public required SubAgentRunId RunId { get; init; }
     public required string AgentName { get; init; }
     public required bool IsStarted { get; init; }
     public int ToolCount { get; init; }
     public bool Success { get; init; }
+    public SubAgentRunOutcome? Outcome { get; init; }
+    public SubAgentOutcomeReason? OutcomeReason { get; init; }
     public TimeSpan Duration { get; init; }
     public IReadOnlyList<SubAgentFinding> Findings { get; init; } = [];
 }


### PR DESCRIPTION
## Summary

Fixes the loop where the parent model receives a completed `spawn_agent` result as an undifferentiated text blob, misses that the subagent already finished the task, and delegates the same work again.

This change makes every `spawn_agent` completion return a clear terminal envelope with the subagent name, run id, outcome, optional reason, diagnostics pointer, and either a `Summary:` or `Error:` section. A run that exhausts its tool-iteration budget but still returns a useful final answer is now marked `partial` instead of looking like an ordinary success or a hard failure.

Structured findings remain available for the memory pipeline, but they are kept separate from the parent-facing tool result and no longer blind-truncate the subagent's final output.

Fixes #1507.

## Validation

- `dotnet build Netclaw.slnx --no-restore`
- `dotnet test src/Netclaw.Actors.Tests --no-build --filter "FullyQualifiedName~SubAgent|FullyQualifiedName~TurnStateTracker"`
- `dotnet test src/Netclaw.Cli.Tests --filter "FullyQualifiedName~DaemonClientMappingTests"`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- Subagents eval category passed 5/5 against the configured eval provider