### PR TITLE
fix(tui): synchronize reset-progress ReactiveProperties to stop flaky host crash

### DIFF
--- a/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
@@ -96,15 +96,24 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
     public ReactiveProperty<Phase> CurrentPhase { get; } = new(Phase.Menu);
     public ReactiveProperty<int> SelectedIndex { get; } = new(0);
-    public ReactiveProperty<string> StatusMessage { get; } = new("");
+
+    // Synchronized: also published from the background reset Task — see CurrentProgressStep below.
+    public ReactiveProperty<string> StatusMessage { get; } = new SynchronizedReactiveProperty<string>("");
 
     private ResetScopeKind _scope = ResetScopeKind.SetupOnly;
     public ResetScopeKind Scope => _scope;
 
-    // Progress-screen state
-    public ReactiveProperty<int> CurrentProgressStep { get; } = new(-1);
-    public ReactiveProperty<string> ProgressMessage { get; } = new("");
-    public ReactiveProperty<bool> CanQuitProgress { get; } = new(true);
+    // Progress-screen state. These three (plus StatusMessage above) are published from the
+    // background reset Task (RunResetAsync -> PublishOnLoop), not just the input/loop thread.
+    // R3's ReactiveProperty is not thread-safe — its value-set walks the observer list lock-free
+    // while Subscribe/Dispose mutate that list under a lock, so a background write can corrupt the
+    // list when a subscriber attaches or detaches concurrently. Bound to the Termina loop those
+    // writes marshal onto one thread, but tests (and any unbound use) observe them off-thread.
+    // SynchronizedReactiveProperty serializes set/subscribe/dispose on one monitor; uncontended in
+    // production. The declared type stays ReactiveProperty<T> so the page and all readers are unchanged.
+    public ReactiveProperty<int> CurrentProgressStep { get; } = new SynchronizedReactiveProperty<int>(-1);
+    public ReactiveProperty<string> ProgressMessage { get; } = new SynchronizedReactiveProperty<string>("");
+    public ReactiveProperty<bool> CanQuitProgress { get; } = new SynchronizedReactiveProperty<bool>(true);
     internal Task? ResetTask { get; private set; }
     internal bool IsResetCancellationRequested => _resetCts.IsCancellationRequested;
 


### PR DESCRIPTION
## Summary

Fixes the flaky `InitExistingInstallViewModelTests.ResetFailure_ShowsErrorAndDoesNotNavigate` test-host crash introduced by #1514 ("#1494 stop daemon before reset").

## Root cause

#1494 moved the install reset onto a background `Task.Run` thread that publishes progress by writing four `ReactiveProperty` instances — `StatusMessage`, `CurrentProgressStep`, `ProgressMessage`, `CanQuitProgress`.

- **In production** the view model is bound to the Termina render loop, so `PublishOnLoop` marshals every write onto the single loop thread — single-threaded, safe.
- **In a unit test** the view model is never bound, so `ReactiveViewModel`'s default `InvokeAsync` runs the write **inline on the background thread**, while the test thread concurrently `Subscribe`s/disposes the same property in the `WaitFor*` helpers.

R3's `ReactiveProperty<T>` is **not thread-safe**: its value-set path walks the observer linked list lock-free, while `Subscribe`/`Dispose` mutate that list under `lock(this)`. The two race and can corrupt the list into a cycle → the value-set walk never terminates → the reset `Task` never completes → the xunit host is killed by the watchdog. That matches every symptom: flaky, **Ubuntu-only on a given run, no managed stack trace**, and the same commit observed both green and red. (`ThrowUnobservedTaskExceptions` is off, confirming it's the hang-cycle, not an unobserved fault.)

Diagnosed against the `dotnet-skills:r3-reactive-extensions` concurrency contract: *"`OnNext` must not be called concurrently/re-entrantly from multiple threads … or use `SynchronizedReactiveProperty`."*

## Fix

Make the four properties written from the background thread `SynchronizedReactiveProperty<T>` (R3's built-in lock-based variant — serializes set/subscribe/dispose on one monitor; uncontended in production). The declared type stays `ReactiveProperty<T>`, so `InitExistingInstallPage` and every reader is unchanged. `CurrentPhase`/`SelectedIndex` are input-thread-only and left as plain `ReactiveProperty`.

## Verification

- Builds clean; all 16 `InitExistingInstall` tests pass, including the formerly-flaky `ResetFailure` case across repeated runs.
- Slopwatch: 0 issues; copyright headers present.
- The race only surfaced on specific CI hardware — hundreds of local iterations (incl. heavy contention) didn't reproduce — so CI over time is the real proof. The change is a minimal, root-cause fix that reuses an existing R3 type.
