### PR TITLE
Require explicit main model configuration for degraded startup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,12 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreVersion)" />
+    <!-- Transitive security pin: Microsoft.AspNetCore.OpenApi 10.0.9 pulls
+         Microsoft.OpenApi 2.0.0, which trips NU1903 (GHSA-v5pm-xwqc-g5wc,
+         circular schema references can terminate OpenAPI parsing). Keep this on
+         the patched 2.x line until ASP.NET Core ships a non-vulnerable
+         transitive dependency. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -230,12 +230,14 @@ When trust-context policy is configured, diagnostics SHALL surface:
 `netclaw doctor` SHALL include a **Chat Client** check that reports:
 
 - **pass** — a real provider chat client is configured.
-- **warn** — the No-Op chat client will be active (no valid provider
-  configured); the daemon starts in degraded mode and chat turns return a
-  fixed recovery banner. Remediation references `netclaw model` and editing
-  `netclaw.json`.
+- **warn** — the No-Op chat client will be active because no explicit
+  `Models:Main` provider/model is configured, no providers exist, or Main points
+  to an unconfigured provider. Bound defaults do not count as configuration.
+  The daemon starts in degraded mode and chat turns return a fixed recovery
+  banner. Remediation references `netclaw model` and editing `netclaw.json`.
 - **fail** — provider configuration is malformed (declared provider missing
-  required credentials, schema violation, model points to an unconfigured
+  required credentials or `Type`, schema violation, explicit Fallback/Compaction
+  role is incomplete, or explicit Fallback/Compaction points to an unconfigured
   provider); daemon startup will fail until resolved.
 
 ### CLI-005 Session Operations

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -127,7 +127,9 @@ Command ownership stays explicit:
 
 - `netclaw chat` — interactive agent prompt. Pure thin client connecting to the
   daemon over SignalR. Renders `SessionOutput` stream, sends `ChannelInput`.
-  Session entity key: `tui/{uuid}`. See TUI-001 wireframes.
+  Session entity key: `tui/{uuid}`. If `netclaw.json` is absent, the command
+  SHALL fail before contacting the daemon with
+  `daemon not configured - please run netclaw init`. See TUI-001 wireframes.
 
 ### TUI-Interactive Commands (Termina, offline)
 
@@ -147,9 +149,14 @@ Command ownership stays explicit:
 
 ### Diagnostics (Plain CLI, offline)
 
+- `netclaw status` — query daemon runtime health when initialized. If
+  `netclaw.json` is absent, the command SHALL fail before contacting the daemon
+  with `daemon not configured - please run netclaw init`.
 - `netclaw doctor` — validate config files, check daemon reachability, test
   provider connectivity, report system health, and flag unsafe trust-policy
-  combinations such as unrestricted `public` or `team` audience profiles
+  combinations such as unrestricted `public` or `team` audience profiles. If
+  `netclaw.json` is absent, the config-file diagnostic SHALL warn with
+  `daemon not configured - please run netclaw init`.
 
 ### Security and Policy (daemon required)
 

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -227,6 +227,17 @@ When trust-context policy is configured, diagnostics SHALL surface:
 - unsafe unrestricted profile combinations
 - sandbox-shell readiness when `ShellMode` resolves to `SandboxOnly`
 
+`netclaw doctor` SHALL include a **Chat Client** check that reports:
+
+- **pass** — a real provider chat client is configured.
+- **warn** — the No-Op chat client will be active (no valid provider
+  configured); the daemon starts in degraded mode and chat turns return a
+  fixed recovery banner. Remediation references `netclaw model` and editing
+  `netclaw.json`.
+- **fail** — provider configuration is malformed (declared provider missing
+  required credentials, schema violation, model points to an unconfigured
+  provider); daemon startup will fail until resolved.
+
 ### CLI-005 Session Operations
 
 `session inspect` exposes current state, last activity, compaction metadata,

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -241,7 +241,9 @@ When trust-context policy is configured, diagnostics SHALL surface:
   `Models:Main` provider/model is configured, no providers exist, or Main points
   to an unconfigured provider. Bound defaults do not count as configuration.
   The daemon starts in degraded mode and chat turns return a fixed recovery
-  banner. Remediation references `netclaw model` and editing `netclaw.json`.
+  banner. Remediation references `netclaw init` for first-time provider/model
+  setup, `netclaw model` when a provider already exists, and manual
+  `netclaw.json` / `secrets.json` repair.
 - **fail** — provider configuration is malformed (declared provider missing
   required credentials or `Type`, schema violation, explicit Fallback/Compaction
   role is incomplete, or explicit Fallback/Compaction points to an unconfigured

--- a/docs/prd/PRD-005-model-provider-strategy.md
+++ b/docs/prd/PRD-005-model-provider-strategy.md
@@ -135,7 +135,8 @@ succeed in a degraded mode. Bound object defaults such as
 unless `Models:Main:Provider` and `Models:Main:ModelId` are present in config.
 The host registers a No-Op `IChatClient` that returns a fixed banner beginning
 with `"No valid model configuration detected."` and lists the recovery commands
-(`netclaw doctor`, `netclaw model`, edit `netclaw.json`). The No-Op client
+(`netclaw doctor`, `netclaw init` for first-time provider/model setup,
+`netclaw model` when a provider already exists, or manual config repair). The No-Op client
 SHALL NOT contact any external service and SHALL NOT emit tool calls.
 
 Malformed provider configuration (declared provider missing required

--- a/docs/prd/PRD-005-model-provider-strategy.md
+++ b/docs/prd/PRD-005-model-provider-strategy.md
@@ -6,6 +6,7 @@
 - Owner: Netclaw engineering
 - Date: 2026-02-21
 - Revised: 2026-02-21 (MEAI abstraction, primary+fallback model)
+- Revised: 2026-05-27 (No-Op chat client fallback for degraded startup)
 - Depends on: `PRD-001`, `PRD-004`
 
 ## Goal
@@ -124,6 +125,22 @@ The provider abstraction SHALL support tool/function calling through MEAI's
 built-in tool calling API. Tool definitions are registered at session startup
 based on policy grants.
 
+### Degraded startup (No-Op chat client)
+
+If provider/model configuration validation reports **no provider configured**
+(e.g., empty `Providers` section, `Models:Main` references an unconfigured
+provider), daemon startup SHALL succeed in a degraded mode. The host
+registers a No-Op `IChatClient` that returns a fixed banner beginning with
+`"No valid model configuration detected."` and lists the recovery commands
+(`netclaw doctor`, `netclaw model`, edit `netclaw.json`). The No-Op client
+SHALL NOT contact any external service and SHALL NOT emit tool calls.
+
+Malformed provider configuration (declared provider missing required
+credentials, schema violations) remains a **fatal** startup error — only the
+"no provider configured" outcome selects the No-Op fallback. Recovery from
+degraded mode requires a daemon restart; live config swap is out of scope.
+`netclaw doctor` reports the state as a **warn**-level "Chat Client" item.
+
 ## Non-Goals (MVP)
 
 - Automated cross-provider failover logic (beyond primary/fallback)
@@ -140,6 +157,9 @@ based on policy grants.
 5. CI validation pipeline passes with provider mocks/fakes only.
 6. Fallback model activates when primary is unreachable.
 7. Tool calling works through MEAI abstraction.
+8. Daemon starts in degraded mode with No-Op chat client when no provider
+   is configured; doctor reports the state as a warn-level item; chat turns
+   return the fixed recovery banner instead of crashing.
 
 ## Cross-References
 

--- a/docs/prd/PRD-005-model-provider-strategy.md
+++ b/docs/prd/PRD-005-model-provider-strategy.md
@@ -128,18 +128,23 @@ based on policy grants.
 ### Degraded startup (No-Op chat client)
 
 If provider/model configuration validation reports **no provider configured**
-(e.g., empty `Providers` section, `Models:Main` references an unconfigured
-provider), daemon startup SHALL succeed in a degraded mode. The host
-registers a No-Op `IChatClient` that returns a fixed banner beginning with
-`"No valid model configuration detected."` and lists the recovery commands
+(e.g., empty `Providers` section, missing or incomplete `Models:Main`, or
+`Models:Main` references an unconfigured provider), daemon startup SHALL
+succeed in a degraded mode. Bound object defaults such as
+`local-ollama/qwen3:30b` SHALL NOT count as explicit operator configuration
+unless `Models:Main:Provider` and `Models:Main:ModelId` are present in config.
+The host registers a No-Op `IChatClient` that returns a fixed banner beginning
+with `"No valid model configuration detected."` and lists the recovery commands
 (`netclaw doctor`, `netclaw model`, edit `netclaw.json`). The No-Op client
 SHALL NOT contact any external service and SHALL NOT emit tool calls.
 
 Malformed provider configuration (declared provider missing required
-credentials, schema violations) remains a **fatal** startup error — only the
-"no provider configured" outcome selects the No-Op fallback. Recovery from
-degraded mode requires a daemon restart; live config swap is out of scope.
-`netclaw doctor` reports the state as a **warn**-level "Chat Client" item.
+credentials or `Type`, schema violations, or explicit `Fallback` / `Compaction`
+roles that are incomplete or reference unconfigured providers) remains a
+**fatal** startup error — only the "no provider configured" outcome selects the
+No-Op fallback. Recovery from degraded mode requires a daemon restart; live
+config swap is out of scope. `netclaw doctor` reports the state as a
+**warn**-level "Chat Client" item.
 
 ## Non-Goals (MVP)
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.23.0"
+  version: "2.23.1"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.22.0"
+  version: "2.23.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
@@ -14,6 +14,12 @@ When something seems wrong with Netclaw itself:
 3. Check daemon logs at `~/.netclaw/logs/daemon-{yyyy-MM-dd}.log`
 4. Check session logs at `~/.netclaw/logs/sessions/{sanitized-session-id}/session.log`
 
+If `netclaw status` or `netclaw chat` prints `daemon not configured - please run
+netclaw init`, do not troubleshoot daemon reachability or model defaults. The
+install has no `netclaw.json`; run `netclaw init` first. If doctor prints the
+same message in the config-file check, treat it as the same uninitialized-install
+state.
+
 Log split — one stream, partitioned locally by session:
 
 - A log line that carries a session id (an actor's `WithContext("SessionId", …)`,

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -35,12 +35,15 @@ options instead of adding provider-specific properties to `ProviderEntry`.
 
 ### Degraded mode: No-Op chat client
 
-When Netclaw starts without a valid inference provider/model configuration
-(no `Providers` section, no main model, or `Models:Main` points to a provider
-that is not configured), the daemon launches in **degraded mode** with a No-Op
-chat client. Every chat turn returns a fixed configuration banner beginning with
-`"No valid model configuration detected."` and listing recovery steps:
-`netclaw doctor`, `netclaw model`, or edit `netclaw.json`.
+When Netclaw starts without an explicitly configured main model/provider
+(no `Models:Main`, incomplete `Models:Main`, no `Providers`, or `Models:Main`
+points to a provider that is not configured), the daemon launches in
+**degraded mode** with a No-Op chat client. Bound defaults such as
+`local-ollama/qwen3:30b` do not count as operator configuration unless those
+fields are actually present in config. Every chat turn returns a fixed
+configuration banner beginning with `"No valid model configuration detected."`
+and listing recovery steps: `netclaw doctor`, `netclaw model`, or edit
+`netclaw.json`.
 
 If the operator reports seeing that banner, do not troubleshoot model behavior;
 the daemon has no working provider. Direct them through the recovery steps and
@@ -48,8 +51,9 @@ restart the daemon after the provider/model config is fixed. `netclaw doctor`
 reports the state as a warn-level "Chat Client" item.
 
 Malformed provider configuration, such as a declared provider missing required
-credentials or schema-invalid config, is not degraded mode; it fails startup
-loudly.
+credentials, missing provider `Type`, schema-invalid config, or invalid explicit
+`Fallback` / `Compaction` model references, is not degraded mode; it fails
+startup loudly.
 
 For OpenAI ChatGPT subscription auth, Netclaw persists the OAuth access token,
 refresh token, and ChatGPT account ID returned by the OpenAI ID token. The

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -42,8 +42,11 @@ points to a provider that is not configured), the daemon launches in
 `local-ollama/qwen3:30b` do not count as operator configuration unless those
 fields are actually present in config. Every chat turn returns a fixed
 configuration banner beginning with `"No valid model configuration detected."`
-and listing recovery steps: `netclaw doctor`, `netclaw model`, or edit
-`netclaw.json`.
+and listing recovery steps. If no provider is configured, send the operator
+through `netclaw init`; it configures both a provider and main model. If a
+provider already exists but the main model is missing or points to the wrong
+provider name, use `netclaw model`. Manual repair means editing `netclaw.json`
+/ `secrets.json` and restarting the daemon.
 
 If the operator reports seeing that banner, do not troubleshoot model behavior;
 the daemon has no working provider. Direct them through the recovery steps and

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -33,6 +33,24 @@ Provider-specific behavior toggles belong under
 config layer; each provider plugin deserializes and validates its own typed
 options instead of adding provider-specific properties to `ProviderEntry`.
 
+### Degraded mode: No-Op chat client
+
+When Netclaw starts without a valid inference provider/model configuration
+(no `Providers` section, no main model, or `Models:Main` points to a provider
+that is not configured), the daemon launches in **degraded mode** with a No-Op
+chat client. Every chat turn returns a fixed configuration banner beginning with
+`"No valid model configuration detected."` and listing recovery steps:
+`netclaw doctor`, `netclaw model`, or edit `netclaw.json`.
+
+If the operator reports seeing that banner, do not troubleshoot model behavior;
+the daemon has no working provider. Direct them through the recovery steps and
+restart the daemon after the provider/model config is fixed. `netclaw doctor`
+reports the state as a warn-level "Chat Client" item.
+
+Malformed provider configuration, such as a declared provider missing required
+credentials or schema-invalid config, is not degraded mode; it fails startup
+loudly.
+
 For OpenAI ChatGPT subscription auth, Netclaw persists the OAuth access token,
 refresh token, and ChatGPT account ID returned by the OpenAI ID token. The
 account ID is required by the Codex backend. If OpenAI OAuth validation reports

--- a/openspec/changes/add-noop-chat-client-fallback/.openspec.yaml
+++ b/openspec/changes/add-noop-chat-client-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/add-noop-chat-client-fallback/design.md
+++ b/openspec/changes/add-noop-chat-client-fallback/design.md
@@ -203,16 +203,18 @@ client's response is itself the per-turn signal to the user.
   and `netclaw doctor` output. No rollback procedure required beyond
   reverting the daemon binary.
 
-## Open Questions
+## Resolved Decisions (formerly open questions)
 
-- **Should the `IChatClientProvider` expose a `bool IsDegraded` property** so
-  doctor/diagnostics can query it directly without sniffing the concrete
-  implementation? Leaning yes — cleaner than `is NoOpChatClientProvider`
-  checks at call sites. Will resolve during specs/tasks drafting.
-- **Should we emit a metric** for "no-op chat turns served" so operators
-  running with degraded mode in production can alert on it? Probably yes,
-  but small enough to land in this change or a follow-up — flag for tasks.
-- **Exact wording of the configuration banner** — design fixes the structure
-  and required content; final copy can be refined during implementation
-  against the eval suite (identity/skill grounding cases will catch
-  regressions where the banner ends up in places it shouldn't).
+- **`IChatClientProvider.IsDegraded`** — added as a default interface method
+  returning `false`. `NoOpChatClientProvider` overrides to `true`. Existing
+  test doubles and `SingleClientProvider` inherit the default and need no
+  changes.
+- **`chat.noop_responses_total` metric** — **deferred**. The doctor warn
+  item and the per-turn banner are sufficient signals for operator
+  awareness in MVP; a metric is easy to add later if production telemetry
+  reveals operators silently running in degraded mode. Tracked as a
+  follow-up, not blocking this change.
+- **Banner copy** — finalized at implementation time; structure matches
+  this design. See `NoOpChatClient.BuildBanner` for the canonical text.
+  Eval suite is unchanged because the banner only surfaces in degraded
+  mode, which the eval suite does not cover.

--- a/openspec/changes/add-noop-chat-client-fallback/design.md
+++ b/openspec/changes/add-noop-chat-client-fallback/design.md
@@ -1,0 +1,218 @@
+## Context
+
+Netclaw routes all model access through the Microsoft.Extensions.AI
+`IChatClient` abstraction. The current composition root in
+`Netclaw.Daemon.Configuration` builds a `NetclawChatClientProvider` from a
+`ProviderPluginFactory` + `ModelSelection` at host construction time. If
+provider configuration is absent or invalid, factory construction throws and
+the daemon fails to come up. Operators are then left without the surfaces
+(`netclaw doctor`, `netclaw model`, the running daemon's diagnostics) that
+would help them fix the problem.
+
+Onboarding (`netclaw-onboarding`) already differentiates "exposure validation
+failure" from generic readiness timeouts so the wizard can show actionable
+errors — but a missing/invalid inference provider is still treated as a fatal
+startup error rather than a recoverable, surfaced state.
+
+This change introduces a fallback path: a No-Op `IChatClient` is registered
+whenever validation reports "no valid provider configuration." Startup
+succeeds; chat turns return a fixed, instructional message; doctor flags the
+state clearly. The real client comes back on restart once configuration is
+fixed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Daemon SHALL start successfully when no valid provider/model configuration
+  is present.
+- Any actor that requests an `IChatClient` via `IChatClientProvider` SHALL
+  receive a deterministic No-Op client whose responses are a fixed
+  configuration-error message with actionable recovery steps.
+- The No-Op response SHALL reference available provider options when the
+  config layer can enumerate them (cached/known provider list).
+- `netclaw doctor` SHALL report the degraded "no-op chat client active"
+  state distinctly from other failure modes.
+- All downstream code paths (sessions, sub-agents, memory curation, title
+  generation, compaction) keep working against `IChatClient` without
+  special-casing the No-Op variant.
+
+**Non-Goals:**
+
+- **No hot-swap.** Picking up a newly-valid configuration requires a daemon
+  restart. Live swapping the chat client mid-process is out of scope and
+  would interact poorly with in-flight session pipelines and Akka actor
+  lifecycles. Follow-up tracked under `netclaw-config-hot-reload`.
+- **No partial-validity heuristics.** If validation cannot prove the
+  configuration is valid (provider+model present, required credentials
+  present, schema valid), the No-Op client is selected. We do not try to
+  "use the provider but skip the model" or similar half-states.
+- **No tool calls or external I/O from the No-Op client.** It is intentionally
+  inert.
+- **No auto-`doctor --fix` on startup.** Operator runs `netclaw doctor`
+  explicitly.
+
+## Decisions
+
+### Decision 1: A new "no provider configured" validation outcome, distinct from "invalid"
+
+Provider/model configuration validation currently has a binary outcome from
+the daemon's perspective: either the `ProviderPluginFactory` can build clients,
+or startup fails. We introduce a third outcome:
+
+- **valid** — build real clients (today's happy path).
+- **no provider configured** — non-fatal; select No-Op client.
+- **invalid** — fatal; surface validation error (today's failure path
+  preserved for *malformed* config, e.g. schema violations, bad credentials
+  for a configured provider).
+
+**Why split these:** the failure modes have different operator remediation.
+"No provider configured" is the first-run / not-yet-onboarded shape and the
+operator's next step is `netclaw model`. "Invalid" means the operator
+attempted a config and something is malformed — they need the specific
+validation error, not a generic "please configure a model" message. Collapsing
+these would either swallow real configuration bugs behind the No-Op fallback
+or force every first-run user to hit a fatal error before discovering
+`netclaw model`. The split aligns with the
+[fail-loudly principle in CLAUDE.md][rule] — we only fall back when partial
+failure is a normal runtime condition (here: a fresh install without a model).
+
+[rule]: see "No silent fallbacks" under Universal Quality Bar.
+
+**Alternative considered:** always select No-Op when client construction
+throws. Rejected — it would hide misconfiguration bugs (bad URL, wrong
+credentials, schema-rejected fields) behind a generic message and violate the
+no-silent-fallbacks rule.
+
+### Decision 2: Register `NoOpChatClient` as `IChatClient`, behind the same `IChatClientProvider` contract
+
+`NetclawChatClientProvider` is the choke point all actors go through to
+acquire chat clients. We add a sibling provider implementation
+`NoOpChatClientProvider` (or a static factory branch inside the existing
+provider) that returns the same `NoOpChatClient` instance for every
+`ModelRole`. Composition root picks one or the other based on the validation
+outcome above.
+
+**Why at the provider level, not inside the factory:** the factory builds
+clients from `ModelSelection`; selecting "no provider" earlier means we never
+try to build, we never instantiate provider plugins, and we keep
+provider-specific failure paths out of the degraded code path. It also keeps
+the No-Op client transport-agnostic — it does not pretend to be any provider.
+
+**Alternative considered:** make the existing `NetclawChatClientProvider`
+tolerate a null `ModelSelection.Main` and return No-Op internally. Rejected
+because it muddles the contract — callers that successfully constructed the
+provider should be able to assume they have a working client surface.
+Branching at composition keeps each provider implementation honest.
+
+### Decision 3: `NoOpChatClient` returns a single deterministic message
+
+Response contract (same for streaming and non-streaming):
+
+```
+No valid model configuration detected.
+
+Netclaw is running, but no inference provider/model is configured. To get
+chat working:
+
+  1. Run `netclaw doctor` to see what's missing.
+  2. Run `netclaw model` to pick a provider and model interactively.
+  3. Or edit `netclaw.json` directly and restart the daemon.
+
+Available providers: <comma-separated list>     (when discoverable)
+```
+
+The "Available providers" line is appended **only** when the configuration
+layer can enumerate known provider profiles without contacting any
+external service. We do not probe networks from the No-Op client.
+
+For streaming responses, the No-Op client emits the message as a single
+`ChatResponseUpdate` chunk plus a completed signal — no artificial
+token-by-token streaming. The downstream session pipelines do not depend on
+specific chunking behavior.
+
+Tool-calling: the No-Op client SHALL NOT emit tool calls regardless of the
+tools registered on the request. This is enforced unconditionally so the
+secure-by-default tool surface is preserved.
+
+### Decision 4: Doctor surfaces "no-op chat client active" as a distinct health item
+
+`netclaw doctor` SHALL include a check that reports:
+
+- **pass** — a real provider client is active.
+- **warn** — the No-Op client is active because no valid provider
+  configuration was detected. The message includes the next-step commands.
+- **fail** — provider configuration was malformed (delegates to the existing
+  validation-failure message).
+
+This separates "degraded but recoverable" from "broken" in operator
+diagnostics.
+
+### Decision 5: Startup logs the fallback selection once, at WARN
+
+When the No-Op provider is selected, the host SHALL log a single WARN-level
+entry naming the selection reason and pointing at `netclaw doctor`. We
+explicitly do **not** repeat the warning on every chat turn — the No-Op
+client's response is itself the per-turn signal to the user.
+
+## Risks / Trade-offs
+
+- **[Risk] Operators mistake the No-Op message for a model response.**
+  → Mitigation: the message leads with the exact phrase `"No valid model
+  configuration detected."` and `doctor` flags the state. Slack-side
+  presentation is unchanged (no special formatting), but the wording is
+  unambiguous.
+
+- **[Risk] Hiding genuine misconfiguration bugs under the No-Op fallback.**
+  → Mitigation: Decision 1 — only the "no provider configured" outcome
+  selects No-Op. Malformed config still fails startup loudly.
+
+- **[Risk] Tool calls from a session against the No-Op client could leak
+  intent or fire side-effects if the No-Op accidentally returned tool calls.**
+  → Mitigation: Decision 3 — `NoOpChatClient` unconditionally returns no
+  tool calls. Tested.
+
+- **[Risk] Memory/compaction/sub-agent pipelines could persist No-Op
+  responses as if they were real model output, polluting recall later.**
+  → Mitigation: callers receive a normal `ChatResponse`, but the content is
+  deterministic and obviously a configuration banner. Memory curation will
+  see the same banner repeatedly and treat it as low-signal. We do not add
+  a separate "is-noop" flag to `ChatResponse` (would leak the abstraction);
+  callers that genuinely need to know can detect the situation by asking the
+  `IChatClientProvider` whether it is the no-op variant — see open question.
+
+- **[Trade-off] Restart-required to recover.** Operators must restart the
+  daemon after fixing config. Acceptable for MVP given the actor-system
+  lifecycle complexity of hot-swapping `IChatClient` instances; hot-reload
+  belongs to its own change.
+
+- **[Risk] Actors that special-case errors (e.g., `SessionLlmInvoker`'s
+  retry/failover logic) might treat a No-Op response as a successful call
+  and skip onto downstream behavior.** → Mitigation: this is the *intended*
+  behavior — the call did succeed, the model just returned a configuration
+  banner. No retry storm, no failover. Verified explicitly in tests against
+  `ResilientChatClientProviderDecorator` and `FailoverChatClient`.
+
+## Migration Plan
+
+- Pure addition; no existing config schema changes.
+- Existing deployments with valid provider config behave identically (path
+  is unchanged).
+- Deployments that *previously* failed startup due to missing provider
+  config will now come up in degraded mode. Documented in the release notes
+  and `netclaw doctor` output. No rollback procedure required beyond
+  reverting the daemon binary.
+
+## Open Questions
+
+- **Should the `IChatClientProvider` expose a `bool IsDegraded` property** so
+  doctor/diagnostics can query it directly without sniffing the concrete
+  implementation? Leaning yes — cleaner than `is NoOpChatClientProvider`
+  checks at call sites. Will resolve during specs/tasks drafting.
+- **Should we emit a metric** for "no-op chat turns served" so operators
+  running with degraded mode in production can alert on it? Probably yes,
+  but small enough to land in this change or a follow-up — flag for tasks.
+- **Exact wording of the configuration banner** — design fixes the structure
+  and required content; final copy can be refined during implementation
+  against the eval suite (identity/skill grounding cases will catch
+  regressions where the banner ends up in places it shouldn't).

--- a/openspec/changes/add-noop-chat-client-fallback/proposal.md
+++ b/openspec/changes/add-noop-chat-client-fallback/proposal.md
@@ -1,0 +1,79 @@
+## Why
+
+Today, when Netclaw starts without a valid inference provider/model configuration,
+startup can fail outright or the host can land in a degraded state where chat
+turns produce confusing low-level errors. Operators — especially first-run
+operators following PRD-004 onboarding — lose the surface they need to discover
+and fix the problem (`netclaw doctor`, `netclaw model`, `netclaw.json`). We want
+Netclaw to launch successfully even with no valid provider so it can guide the
+operator to a working configuration instead of crashing or silently degrading.
+
+## What Changes
+
+- Add a No-Op `IChatClient` implementation that satisfies the
+  Microsoft.Extensions.AI abstraction without contacting any provider.
+- Provider/model configuration validation gains a "no valid provider configured"
+  outcome that is distinct from "validation failed" — this outcome is
+  **non-fatal** for startup and selects the No-Op client.
+- Chat client selection prefers the configured provider's `IChatClient`; when no
+  valid configuration is detected, it falls back to the No-Op client and logs the
+  reason at startup.
+- The No-Op client's responses contain a single, deterministic message:
+  - leads with `"No valid model configuration detected."`
+  - lists actionable recovery steps: `netclaw doctor`, edit `netclaw.json`,
+    `netclaw model`
+  - if provider discovery data is available (cached provider list, known
+    profiles), references the available provider options in the message
+- Once a valid configuration is in place, a daemon restart replaces the No-Op
+  client with the real configured client. (Hot-swap on config change is
+  out-of-scope for this change; it is handled by [[netclaw-config-hot-reload]]
+  in a follow-up if needed.)
+- `netclaw doctor` diagnostics SHALL clearly indicate when the No-Op client is
+  active so operators immediately understand why chat turns are returning the
+  configuration message.
+
+## Capabilities
+
+### New Capabilities
+
+None. This is a behavior change inside existing capabilities.
+
+### Modified Capabilities
+
+- `netclaw-model-providers`: add a no-op chat-client fallback path and a
+  "no valid configuration" validation outcome that is non-fatal for startup;
+  define the No-Op client's response contract.
+- `netclaw-onboarding`: startup SHALL succeed (in degraded mode) when no valid
+  provider/model configuration is present, instead of failing the daemon. The
+  wizard / doctor surfaces SHALL report the degraded state.
+
+## Impact
+
+- **Code**
+  - `Netclaw.ModelProviders` (or equivalent) — new `NoOpChatClient`,
+    chat-client selection/factory wiring.
+  - Provider/model configuration validation — distinguish "invalid" (fail) vs
+    "no provider configured" (degraded but operational).
+  - Host startup wiring — register the No-Op client when validation returns the
+    degraded outcome instead of throwing.
+  - `netclaw doctor` — surface the degraded/No-Op state.
+- **PRDs**
+  - PRD-005 (model provider strategy): degraded-startup behavior is an
+    addition; PRD update needed to reflect that "no valid provider" is no
+    longer fatal at startup.
+  - PRD-004 (CLI onboarding & config): doctor output surfaces degraded mode.
+- **Operational**
+  - Operators upgrading from a version that failed-fast on missing provider
+    config will now see Netclaw start successfully and respond to chat turns
+    with the configuration message. This is intentional and discoverable
+    via doctor; runbook update required.
+- **Security**
+  - The No-Op client does not contact any external service and has no tool
+    access. It cannot leak data and cannot be used to bypass ACLs (it produces
+    a fixed response and performs no tool calls). Default-deny posture is
+    preserved.
+- **Out of scope**
+  - Hot-swapping the chat client at runtime when configuration changes
+    (restart required to pick up the real provider).
+  - Auto-running `netclaw doctor --fix` on startup when degraded.
+  - Any UI affordance beyond the chat message itself and doctor reporting.

--- a/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-model-providers/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: No-Op chat client fallback when no provider is configured
+
+The system SHALL provide a No-Op `IChatClient` implementation that is selected
+by the chat-client provider when configuration validation reports that no
+valid provider/model is configured. The No-Op client SHALL allow the daemon
+to start successfully in a degraded-but-operational mode rather than failing
+host startup. The No-Op client SHALL NOT contact any external service and
+SHALL NOT emit tool calls regardless of the tools registered on a request.
+
+#### Scenario: Daemon starts with no provider configured
+
+- **GIVEN** `netclaw.json` contains no inference provider/model configuration
+  (fresh install, or provider section absent)
+- **WHEN** the daemon starts
+- **THEN** host startup SHALL succeed
+- **AND** `IChatClientProvider` SHALL resolve to the No-Op client for every
+  `ModelRole` (Main, Fallback, Compaction)
+- **AND** a single WARN-level log entry SHALL record that the No-Op client
+  was selected and reference `netclaw doctor`
+
+#### Scenario: No-Op response contains configuration message and recovery steps
+
+- **GIVEN** the No-Op chat client is active
+- **WHEN** any caller invokes the chat client (streaming or non-streaming)
+- **THEN** the response content SHALL begin with the exact phrase
+  `"No valid model configuration detected."`
+- **AND** the response SHALL include the recovery steps `netclaw doctor`,
+  `netclaw model`, and editing `netclaw.json`
+- **AND** the response SHALL NOT contain any tool calls
+
+#### Scenario: No-Op response references available providers when discoverable
+
+- **GIVEN** the No-Op chat client is active
+- **AND** the configuration layer can enumerate known provider profiles
+  without performing network I/O
+- **WHEN** the No-Op client responds
+- **THEN** the response SHALL include a line listing the available provider
+  options
+- **AND** if no provider profiles can be enumerated, the response SHALL omit
+  that line rather than emit a misleading default
+
+#### Scenario: Streaming response delivers the message as a single chunk
+
+- **GIVEN** the No-Op chat client is active
+- **WHEN** a caller invokes the streaming chat completion API
+- **THEN** the No-Op client SHALL emit the configuration message as a single
+  `ChatResponseUpdate` followed by a completion signal
+- **AND** the No-Op client SHALL NOT simulate token-by-token streaming
+
+### Requirement: Provider validation distinguishes "no provider configured" from "invalid"
+
+Provider/model configuration validation SHALL produce a tri-state outcome
+that the daemon composition root uses to select the chat client:
+**valid**, **no provider configured** (non-fatal, selects No-Op), and
+**invalid** (fatal, fails startup with the validation error). Malformed
+configuration (schema violations, missing required credentials for an
+explicitly configured provider, unparseable values) SHALL continue to fail
+startup with the existing validation error path and SHALL NOT silently fall
+back to the No-Op client.
+
+#### Scenario: Missing provider section selects No-Op
+
+- **GIVEN** the configuration file has no provider/model section
+- **WHEN** validation runs
+- **THEN** validation SHALL return the "no provider configured" outcome
+- **AND** the host SHALL register the No-Op chat client
+
+#### Scenario: Malformed provider configuration still fails startup
+
+- **GIVEN** the configuration file declares a provider but omits a required
+  credential, contains a schema violation, or contains unparseable values
+- **WHEN** validation runs
+- **THEN** validation SHALL return the "invalid" outcome
+- **AND** the host SHALL fail startup with the existing
+  provider-specific validation error
+- **AND** the host SHALL NOT fall back to the No-Op client
+
+#### Scenario: Valid configuration uses real provider client
+
+- **GIVEN** the configuration file declares a valid provider and model with
+  all required fields present
+- **WHEN** validation runs
+- **THEN** validation SHALL return the "valid" outcome
+- **AND** the host SHALL register the real provider's chat client through
+  `NetclawChatClientProvider` (unchanged behavior)
+
+### Requirement: Chat client provider exposes degraded state for diagnostics
+
+The `IChatClientProvider` contract SHALL expose whether it is operating in
+the degraded No-Op mode so that diagnostic surfaces (notably
+`netclaw doctor`) can report the state without inspecting concrete types.
+
+#### Scenario: Doctor reports No-Op client active
+
+- **GIVEN** the No-Op chat client is active
+- **WHEN** `netclaw doctor` runs the chat-client health check
+- **THEN** doctor SHALL report a **warn**-level item indicating that the
+  No-Op client is active because no valid provider configuration was
+  detected
+- **AND** the doctor output SHALL include the recovery commands
+  `netclaw model` and editing `netclaw.json`
+
+#### Scenario: Doctor reports real client active
+
+- **GIVEN** a real provider chat client is active
+- **WHEN** `netclaw doctor` runs the chat-client health check
+- **THEN** doctor SHALL report a **pass**-level item for the chat-client
+  check
+
+#### Scenario: Doctor distinguishes degraded from invalid
+
+- **GIVEN** the daemon failed to start due to invalid provider configuration
+  (and is therefore not running)
+- **WHEN** `netclaw doctor` reports the chat-client check
+- **THEN** doctor SHALL surface the validation **fail**-level item from the
+  invalid-configuration path
+- **AND** the warn-level "No-Op active" item SHALL NOT be reported in that
+  case (the daemon never started)
+
+### Requirement: Recovery requires daemon restart
+
+The system SHALL replace the No-Op chat client with the real configured
+client only on daemon restart. Hot-swapping the active chat client when
+configuration becomes valid mid-process is explicitly out of scope for this
+capability.
+
+#### Scenario: Operator fixes configuration and restarts
+
+- **GIVEN** the daemon is running with the No-Op chat client active
+- **WHEN** the operator edits `netclaw.json` to add a valid provider/model
+- **AND** restarts the daemon
+- **THEN** validation SHALL return "valid"
+- **AND** the daemon SHALL register the real provider's chat client
+
+#### Scenario: Configuration becomes valid without restart
+
+- **GIVEN** the daemon is running with the No-Op chat client active
+- **WHEN** the operator edits `netclaw.json` to add a valid provider/model
+- **AND** does NOT restart the daemon
+- **THEN** the No-Op chat client SHALL remain active
+- **AND** chat turns SHALL continue to return the configuration message
+  until restart

--- a/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-model-providers/spec.md
@@ -98,6 +98,35 @@ back to the No-Op client.
 - **AND** the host SHALL register the real provider's chat client through
   `NetclawChatClientProvider` (unchanged behavior)
 
+### Requirement: Runtime status reports degraded chat client
+
+The daemon's runtime status wire model (`DaemonRuntimeStatus.Model`) SHALL
+include a `Degraded` boolean and a human-readable `DegradedReason` so that
+`netclaw status` and any other consumer can render the No-Op state
+distinctly. When `Degraded` is true, the overall daemon status SHALL be
+reported as `degraded` rather than `healthy`, even if every other
+subsystem is fine.
+
+#### Scenario: Status reports degraded chat client and degraded overall
+
+- **GIVEN** the daemon is running with the No-Op chat client active
+- **WHEN** a client calls the runtime status endpoint
+- **THEN** `Model.Degraded` SHALL be `true`
+- **AND** `Model.DegradedReason` SHALL contain the validation reason
+  (e.g., the configured-but-unknown provider name)
+- **AND** `Overall` SHALL be `degraded`
+
+#### Scenario: `netclaw status` renders degraded model line distinctly
+
+- **GIVEN** the daemon reports `Model.Degraded = true`
+- **WHEN** the operator runs `netclaw status`
+- **THEN** the model line SHALL clearly indicate the degraded state
+  (e.g., `model: (none — No-Op chat client active)`)
+- **AND** the status SHALL NOT display the configured-but-broken
+  `ModelId`/`Provider` as if they were a live model
+- **AND** the output SHALL reference the recovery commands
+  (`netclaw doctor`, `netclaw model`)
+
 ### Requirement: Chat client provider exposes degraded state for diagnostics
 
 The `IChatClientProvider` contract SHALL expose whether it is operating in

--- a/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-model-providers/spec.md
@@ -67,6 +67,18 @@ back to the No-Op client.
 - **THEN** validation SHALL return the "no provider configured" outcome
 - **AND** the host SHALL register the No-Op chat client
 
+#### Scenario: Model references unknown provider selects No-Op
+
+- **GIVEN** the configuration file declares one or more providers
+- **AND** `Models:Main.Provider` references a provider name that is not in
+  the providers dictionary (e.g., typo: `ollama-local1` vs `ollama-local`)
+- **WHEN** validation runs
+- **THEN** validation SHALL return the "no provider configured" outcome
+- **AND** the No-Op banner's "Available providers:" line SHALL list the
+  configured provider names so the operator can spot the typo
+- **AND** the host SHALL NOT throw an unhandled exception from the
+  provider plugin factory
+
 #### Scenario: Malformed provider configuration still fails startup
 
 - **GIVEN** the configuration file declares a provider but omits a required

--- a/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/add-noop-chat-client-fallback/specs/netclaw-onboarding/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Missing provider configuration does not fail daemon startup
+
+The daemon SHALL start successfully in degraded mode when no valid inference
+provider/model configuration is present, serving No-Op chat responses (see
+`netclaw-model-providers`). The onboarding wizard's health-check step SHALL
+treat this degraded state as a **warn**-level health-check item with
+actionable remediation guidance, distinct from a hard startup failure such
+as exposure-mode validation rejection.
+
+#### Scenario: Wizard health-check on fresh install with no provider configured
+
+- **GIVEN** the operator runs `netclaw init` and skips provider configuration,
+  OR the operator runs the daemon without ever completing onboarding
+- **WHEN** the wizard's health-check step starts the daemon
+- **THEN** the daemon SHALL come up successfully
+- **AND** the wizard SHALL show a **warn**-level health-check item indicating
+  no valid provider/model is configured
+- **AND** the warn item SHALL include remediation guidance referencing
+  `netclaw model` and editing `netclaw.json`
+- **AND** the warn item SHALL NOT be presented as a startup failure
+
+#### Scenario: Wizard distinguishes "no provider configured" from exposure-mode failure
+
+- **GIVEN** the daemon starts in degraded mode because no provider is configured
+- **WHEN** the wizard reports health-check results
+- **THEN** the "no provider configured" item SHALL appear as **warn**
+- **AND** the exposure-mode validation item (if present) SHALL be reported
+  independently per the existing `Exposure-mode startup validation failure
+  shown cleanly` scenario
+- **AND** neither item SHALL be collapsed into a generic
+  `Daemon did not become ready` message
+
+#### Scenario: Wizard does not silently mask invalid provider configuration as degraded
+
+- **GIVEN** the operator wrote a provider configuration that is malformed
+  (schema violation, missing required credential for a declared provider,
+  unparseable values)
+- **WHEN** the wizard's health-check step starts the daemon
+- **THEN** the daemon startup SHALL fail with the existing validation error
+- **AND** the wizard SHALL report a **fail**-level item with the validation
+  message
+- **AND** the wizard SHALL NOT report a warn-level "No-Op active" item in
+  place of the validation failure

--- a/openspec/changes/add-noop-chat-client-fallback/tasks.md
+++ b/openspec/changes/add-noop-chat-client-fallback/tasks.md
@@ -1,55 +1,55 @@
 ## 1. Validation outcome plumbing
 
-- [ ] 1.1 Add a tri-state result type to provider/model validation
+- [x] 1.1 Add a tri-state result type to provider/model validation
       (`valid` / `no-provider-configured` / `invalid`) in
       `Netclaw.Daemon/Configuration/ModelSelectionValidator.cs`
       (or sibling), preserving the existing "invalid" path for malformed
       configurations.
-- [ ] 1.2 Update `ProviderPluginFactory` and any callers so that the
+- [x] 1.2 Update `ProviderPluginFactory` and any callers so that the
       "no-provider-configured" outcome short-circuits before any plugin is
       instantiated (no provider plugin loaded, no credentials read).
-- [ ] 1.3 Unit tests for each outcome: missing provider section, missing
+- [x] 1.3 Unit tests for each outcome: missing provider section, missing
       model, missing required credential for a declared provider, schema
       violations, and a fully valid config. Cover both `netclaw.json`-only
       and DI-overridden config flows.
 
 ## 2. No-Op chat client
 
-- [ ] 2.1 Implement `NoOpChatClient : IChatClient` in
+- [x] 2.1 Implement `NoOpChatClient : IChatClient` in
       `Netclaw.Daemon/Configuration/` (or `Netclaw.Configuration/` if the
       type needs to be visible to tests in another assembly). Streaming
       and non-streaming both return the fixed configuration banner.
-- [ ] 2.2 Banner content: leads with the exact phrase
+- [x] 2.2 Banner content: leads with the exact phrase
       `"No valid model configuration detected."`, includes the three
       recovery steps (`netclaw doctor`, `netclaw model`, edit
       `netclaw.json`), and appends an "Available providers: …" line only
       when discoverable provider profiles can be enumerated without
       network I/O.
-- [ ] 2.3 Tool-call suppression: assert `NoOpChatClient` returns zero tool
+- [x] 2.3 Tool-call suppression: assert `NoOpChatClient` returns zero tool
       calls regardless of the tools registered on the request.
-- [ ] 2.4 Streaming path emits the banner as a single `ChatResponseUpdate`
+- [x] 2.4 Streaming path emits the banner as a single `ChatResponseUpdate`
       plus completion signal (no simulated token chunking).
-- [ ] 2.5 Unit tests covering: exact banner text & ordering, recovery-step
+- [x] 2.5 Unit tests covering: exact banner text & ordering, recovery-step
       presence, providers-line included/omitted, zero tool calls,
       streaming single-chunk behavior.
 
 ## 3. Chat-client provider selection
 
-- [ ] 3.1 Implement `NoOpChatClientProvider : IChatClientProvider` that
+- [x] 3.1 Implement `NoOpChatClientProvider : IChatClientProvider` that
       returns the same `NoOpChatClient` instance for every `ModelRole`.
-- [ ] 3.2 Add `IChatClientProvider.IsDegraded` (or equivalent
+- [x] 3.2 Add `IChatClientProvider.IsDegraded` (or equivalent
       surface from Design open question) so doctor and diagnostics can
       query the degraded state without `is`-checking concrete types.
       Default `false` in `NetclawChatClientProvider`, `true` in
       `NoOpChatClientProvider`. Update both implementations.
-- [ ] 3.3 Update composition in
+- [x] 3.3 Update composition in
       `Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs`
       (and any other registration site) to branch on the validation
       outcome from Task 1 and register either provider implementation.
-- [ ] 3.4 Emit a single WARN-level structured log at startup when the
+- [x] 3.4 Emit a single WARN-level structured log at startup when the
       No-Op provider is selected, naming the reason and referencing
       `netclaw doctor`. Do not log per chat turn.
-- [ ] 3.5 Verify decorators (`ResilientChatClientProviderDecorator`,
+- [x] 3.5 Verify decorators (`ResilientChatClientProviderDecorator`,
       `RetryingChatClient`, `LoggingChatClient`,
       `AlertingChatClientDecorator`, `FailoverChatClient`) interact
       correctly with the No-Op client — i.e., they treat a No-Op response
@@ -57,17 +57,17 @@
 
 ## 4. Doctor integration
 
-- [ ] 4.1 Add a chat-client health check in `netclaw doctor` that uses
+- [x] 4.1 Add a chat-client health check in `netclaw doctor` that uses
       `IChatClientProvider.IsDegraded` to report **pass** (real client),
       **warn** (No-Op active), or **fail** (validation rejected config and
       daemon is not running).
-- [ ] 4.2 Warn-level message includes the recovery commands
+- [x] 4.2 Warn-level message includes the recovery commands
       `netclaw model` and editing `netclaw.json`.
-- [ ] 4.3 Integration test for doctor output in each of the three states.
+- [x] 4.3 Integration test for doctor output in each of the three states.
 
 ## 5. Onboarding wizard integration
 
-- [ ] 5.1 In the wizard's health-check step, treat "no provider
+- [x] 5.1 In the wizard's health-check step, treat "no provider
       configured" as a **warn**-level item with remediation guidance —
       distinct from a fail-level startup validation rejection and not
       collapsed into `Daemon did not become ready`.
@@ -77,19 +77,19 @@
 
 ## 6. Optional metric
 
-- [ ] 6.1 Decide whether to emit a `chat.noop_responses_total` counter
+- [x] 6.1 Decide whether to emit a `chat.noop_responses_total` counter
       (Design open question). If yes, add the metric in `NoOpChatClient`
       and expose it through the existing metrics pipeline. If no, document
       the decision in `design.md` (resolve the open question).
 
 ## 7. Spec sync and docs
 
-- [ ] 7.1 PRD-005 (model provider strategy): document that "no valid
+- [x] 7.1 PRD-005 (model provider strategy): document that "no valid
       provider configured" is non-fatal at startup and selects the No-Op
       client. Link to the doctor warn item.
-- [ ] 7.2 PRD-004 (CLI onboarding & config): document the doctor warn
+- [x] 7.2 PRD-004 (CLI onboarding & config): document the doctor warn
       item for the No-Op chat client.
-- [ ] 7.3 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md`
+- [x] 7.3 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md`
       with operator guidance on what the configuration banner means and
       what to do about it; bump `metadata.version`.
 - [ ] 7.4 Update the release-notes / runbook entry covering the behavior
@@ -98,12 +98,12 @@
 
 ## 8. Quality gates
 
-- [ ] 8.1 `dotnet slopwatch analyze` passes with no new violations.
-- [ ] 8.2 `./scripts/Add-FileHeaders.ps1 -Verify` passes for any new
+- [x] 8.1 `dotnet slopwatch analyze` passes with no new violations.
+- [x] 8.2 `./scripts/Add-FileHeaders.ps1 -Verify` passes for any new
       `.cs` files.
 - [ ] 8.3 Eval suite passes (`./evals/run-evals.sh`) — the No-Op banner
       should not appear in any non-degraded eval run; consider adding a
       regression case asserting the real client is selected when config
       is valid.
-- [ ] 8.4 `openspec validate add-noop-chat-client-fallback` passes; run
+- [x] 8.4 `openspec validate add-noop-chat-client-fallback` passes; run
       `/opsx-verify` once implementation lands.

--- a/openspec/changes/add-noop-chat-client-fallback/tasks.md
+++ b/openspec/changes/add-noop-chat-client-fallback/tasks.md
@@ -1,0 +1,109 @@
+## 1. Validation outcome plumbing
+
+- [ ] 1.1 Add a tri-state result type to provider/model validation
+      (`valid` / `no-provider-configured` / `invalid`) in
+      `Netclaw.Daemon/Configuration/ModelSelectionValidator.cs`
+      (or sibling), preserving the existing "invalid" path for malformed
+      configurations.
+- [ ] 1.2 Update `ProviderPluginFactory` and any callers so that the
+      "no-provider-configured" outcome short-circuits before any plugin is
+      instantiated (no provider plugin loaded, no credentials read).
+- [ ] 1.3 Unit tests for each outcome: missing provider section, missing
+      model, missing required credential for a declared provider, schema
+      violations, and a fully valid config. Cover both `netclaw.json`-only
+      and DI-overridden config flows.
+
+## 2. No-Op chat client
+
+- [ ] 2.1 Implement `NoOpChatClient : IChatClient` in
+      `Netclaw.Daemon/Configuration/` (or `Netclaw.Configuration/` if the
+      type needs to be visible to tests in another assembly). Streaming
+      and non-streaming both return the fixed configuration banner.
+- [ ] 2.2 Banner content: leads with the exact phrase
+      `"No valid model configuration detected."`, includes the three
+      recovery steps (`netclaw doctor`, `netclaw model`, edit
+      `netclaw.json`), and appends an "Available providers: …" line only
+      when discoverable provider profiles can be enumerated without
+      network I/O.
+- [ ] 2.3 Tool-call suppression: assert `NoOpChatClient` returns zero tool
+      calls regardless of the tools registered on the request.
+- [ ] 2.4 Streaming path emits the banner as a single `ChatResponseUpdate`
+      plus completion signal (no simulated token chunking).
+- [ ] 2.5 Unit tests covering: exact banner text & ordering, recovery-step
+      presence, providers-line included/omitted, zero tool calls,
+      streaming single-chunk behavior.
+
+## 3. Chat-client provider selection
+
+- [ ] 3.1 Implement `NoOpChatClientProvider : IChatClientProvider` that
+      returns the same `NoOpChatClient` instance for every `ModelRole`.
+- [ ] 3.2 Add `IChatClientProvider.IsDegraded` (or equivalent
+      surface from Design open question) so doctor and diagnostics can
+      query the degraded state without `is`-checking concrete types.
+      Default `false` in `NetclawChatClientProvider`, `true` in
+      `NoOpChatClientProvider`. Update both implementations.
+- [ ] 3.3 Update composition in
+      `Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs`
+      (and any other registration site) to branch on the validation
+      outcome from Task 1 and register either provider implementation.
+- [ ] 3.4 Emit a single WARN-level structured log at startup when the
+      No-Op provider is selected, naming the reason and referencing
+      `netclaw doctor`. Do not log per chat turn.
+- [ ] 3.5 Verify decorators (`ResilientChatClientProviderDecorator`,
+      `RetryingChatClient`, `LoggingChatClient`,
+      `AlertingChatClientDecorator`, `FailoverChatClient`) interact
+      correctly with the No-Op client — i.e., they treat a No-Op response
+      as a successful call (no retry storm, no failover trigger).
+
+## 4. Doctor integration
+
+- [ ] 4.1 Add a chat-client health check in `netclaw doctor` that uses
+      `IChatClientProvider.IsDegraded` to report **pass** (real client),
+      **warn** (No-Op active), or **fail** (validation rejected config and
+      daemon is not running).
+- [ ] 4.2 Warn-level message includes the recovery commands
+      `netclaw model` and editing `netclaw.json`.
+- [ ] 4.3 Integration test for doctor output in each of the three states.
+
+## 5. Onboarding wizard integration
+
+- [ ] 5.1 In the wizard's health-check step, treat "no provider
+      configured" as a **warn**-level item with remediation guidance —
+      distinct from a fail-level startup validation rejection and not
+      collapsed into `Daemon did not become ready`.
+- [ ] 5.2 Wizard test (or smoke tape under `tests/smoke/tapes/`) that
+      simulates running the daemon with no provider configured and
+      asserts the warn-level item appears with the expected message.
+
+## 6. Optional metric
+
+- [ ] 6.1 Decide whether to emit a `chat.noop_responses_total` counter
+      (Design open question). If yes, add the metric in `NoOpChatClient`
+      and expose it through the existing metrics pipeline. If no, document
+      the decision in `design.md` (resolve the open question).
+
+## 7. Spec sync and docs
+
+- [ ] 7.1 PRD-005 (model provider strategy): document that "no valid
+      provider configured" is non-fatal at startup and selects the No-Op
+      client. Link to the doctor warn item.
+- [ ] 7.2 PRD-004 (CLI onboarding & config): document the doctor warn
+      item for the No-Op chat client.
+- [ ] 7.3 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md`
+      with operator guidance on what the configuration banner means and
+      what to do about it; bump `metadata.version`.
+- [ ] 7.4 Update the release-notes / runbook entry covering the behavior
+      change for deployments that previously failed startup on missing
+      provider configuration.
+
+## 8. Quality gates
+
+- [ ] 8.1 `dotnet slopwatch analyze` passes with no new violations.
+- [ ] 8.2 `./scripts/Add-FileHeaders.ps1 -Verify` passes for any new
+      `.cs` files.
+- [ ] 8.3 Eval suite passes (`./evals/run-evals.sh`) — the No-Op banner
+      should not appear in any non-degraded eval run; consider adding a
+      regression case asserting the real client is selected when config
+      is valid.
+- [ ] 8.4 `openspec validate add-noop-chat-client-fallback` passes; run
+      `/opsx-verify` once implementation lands.

--- a/src/Netclaw.Cli.Tests/Cli/CliConfigPreflightTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliConfigPreflightTests.cs
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------
+// <copyright file="CliConfigPreflightTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json.Nodes;
+using Netclaw.Cli;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+public sealed class CliConfigPreflightTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+
+    public CliConfigPreflightTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public void TryWriteMissingConfig_Text_PrintsInitGuidanceAndBlocksCommand()
+    {
+        using var writer = new StringWriter();
+
+        var blocked = CliConfigPreflight.TryWriteMissingConfig(_paths, jsonOutput: false, writer, out var exitCode);
+
+        Assert.True(blocked);
+        Assert.Equal(1, exitCode);
+        Assert.Equal(CliConfigPreflight.MissingConfigMessage, writer.ToString().Trim());
+    }
+
+    [Fact]
+    public void TryWriteMissingConfig_Json_PrintsNotConfiguredPayload()
+    {
+        using var writer = new StringWriter();
+
+        var blocked = CliConfigPreflight.TryWriteMissingConfig(_paths, jsonOutput: true, writer, out var exitCode);
+
+        var json = JsonNode.Parse(writer.ToString())!.AsObject();
+
+        Assert.True(blocked);
+        Assert.Equal(1, exitCode);
+        Assert.Equal("not-configured", json["overall"]!.GetValue<string>());
+        Assert.Equal(CliConfigPreflight.MissingConfigMessage, json["message"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void TryWriteMissingConfig_ConfigExists_AllowsCommand()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, "{}");
+        using var writer = new StringWriter();
+
+        var blocked = CliConfigPreflight.TryWriteMissingConfig(_paths, jsonOutput: false, writer, out var exitCode);
+
+        Assert.False(blocked);
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, writer.ToString());
+    }
+}

--- a/src/Netclaw.Cli.Tests/Cli/CliConfigPreflightTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliConfigPreflightTests.cs
@@ -63,4 +63,24 @@ public sealed class CliConfigPreflightTests : IDisposable
         Assert.Equal(0, exitCode);
         Assert.Equal(string.Empty, writer.ToString());
     }
+
+    [Fact]
+    public void TryWriteMissingChatConfig_HeadlessJson_PrintsJsonPayload()
+    {
+        using var writer = new StringWriter();
+
+        var blocked = CliConfigPreflight.TryWriteMissingChatConfig(
+            _paths,
+            mode: "headless",
+            chatJsonOutput: true,
+            writer,
+            out var exitCode);
+
+        var json = JsonNode.Parse(writer.ToString())!.AsObject();
+
+        Assert.True(blocked);
+        Assert.Equal(1, exitCode);
+        Assert.Equal("not-configured", json["overall"]!.GetValue<string>());
+        Assert.Equal(CliConfigPreflight.MissingConfigMessage, json["message"]!.GetValue<string>());
+    }
 }

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -147,7 +147,7 @@ public sealed class ContextWindowResolutionTests
             daemon);
 
         Assert.True(result.Degraded);
-        Assert.Equal("(no model - run `netclaw model`)", result.ModelId);
+        Assert.Equal("(no model - run `netclaw init`)", result.ModelId);
         Assert.Equal("", result.Provider);
         Assert.Equal(0, result.ContextWindowTokens);
     }

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -129,6 +129,29 @@ public sealed class ContextWindowResolutionTests
     }
 
     [Fact]
+    public async Task ResolveRuntime_DaemonReportsDegraded_ReturnsSentinelModel()
+    {
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(
+            32_768,
+            modelId: "qwen3:30b",
+            provider: "local-ollama",
+            degraded: true)));
+
+        var result = await ContextWindowResolution.ResolveRuntimeAsync(
+            new ModelReference
+            {
+                Provider = "local-ollama",
+                ModelId = "qwen3:30b",
+                ContextWindow = 32_768,
+            },
+            daemon);
+
+        Assert.True(result.Degraded);
+        Assert.Equal("(no model - run `netclaw model`)", result.ModelId);
+        Assert.Equal(0, result.ContextWindowTokens);
+    }
+
+    [Fact]
     public async Task ResolveRuntime_NoConfig_EmptyStatus_Throws()
     {
         var daemon = CreateDaemonApi(_ => new HttpResponseMessage(HttpStatusCode.OK)
@@ -167,7 +190,8 @@ public sealed class ContextWindowResolutionTests
     private static object BuildStatusResponse(
         int contextWindow,
         string modelId = "qwen3:30b",
-        string provider = "openai-compatible") => new
+        string provider = "openai-compatible",
+        bool degraded = false) => new
     {
         Overall = "healthy",
         Build = new { Version = "1.0.0", CommitHash = "abc123", BuildTimestamp = "2026-01-01T00:00:00Z" },
@@ -181,7 +205,8 @@ public sealed class ContextWindowResolutionTests
             Provider = provider,
             ContextWindow = contextWindow,
             InputModalities = "Text",
-            OutputModalities = "Text"
+            OutputModalities = "Text",
+            Degraded = degraded
         }
     };
 

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -132,9 +132,9 @@ public sealed class ContextWindowResolutionTests
     public async Task ResolveRuntime_DaemonReportsDegraded_ReturnsSentinelModel()
     {
         var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(
-            32_768,
-            modelId: "qwen3:30b",
-            provider: "local-ollama",
+            0,
+            modelId: "",
+            provider: "",
             degraded: true)));
 
         var result = await ContextWindowResolution.ResolveRuntimeAsync(
@@ -148,6 +148,7 @@ public sealed class ContextWindowResolutionTests
 
         Assert.True(result.Degraded);
         Assert.Equal("(no model - run `netclaw model`)", result.ModelId);
+        Assert.Equal("", result.Provider);
         Assert.Equal(0, result.ContextWindowTokens);
     }
 

--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -52,6 +52,94 @@ public sealed class ChatClientDoctorCheckTests
     }
 
     [Fact]
+    public async Task ReturnsWarning_WhenProviderExistsButMainModelMissing()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "local-ollama": { "Type": "ollama" }
+              }
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("Models:Main missing", result.Message);
+        Assert.DoesNotContain("Real chat client configured", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsWarning_WhenMainModelSectionHasNoProviderOrModel()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "local-ollama": { "Type": "ollama" }
+              },
+              "Models": {
+                "Main": { }
+              }
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("no model selected", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenReferencedProviderMissingType()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "openrouter": { }
+              },
+              "Models": {
+                "Main": { "Provider": "openrouter", "ModelId": "anthropic/claude-haiku-4" }
+              }
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("missing required Type", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenFallbackReferencesUnknownProvider()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "openrouter": { "Type": "openrouter" }
+              },
+              "Models": {
+                "Main": { "Provider": "openrouter", "ModelId": "anthropic/claude-haiku-4" },
+                "Fallback": { "Provider": "missing", "ModelId": "qwen3:30b" }
+              }
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Fallback", result.Message);
+        Assert.Contains("missing", result.Message);
+    }
+
+    [Fact]
     public async Task ReturnsWarning_WhenModelReferencesUnknownProvider()
     {
         // Regression: a typo in Models:Main.Provider (e.g. operator typed

--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -52,16 +52,22 @@ public sealed class ChatClientDoctorCheckTests
     }
 
     [Fact]
-    public async Task ReturnsError_WhenModelReferencesUnknownProvider()
+    public async Task ReturnsWarning_WhenModelReferencesUnknownProvider()
     {
+        // Regression: a typo in Models:Main.Provider (e.g. operator typed
+        // "ollama-local1" instead of "ollama-local") used to crash the daemon
+        // with an unhandled ProviderPluginFactory exception. We now treat it
+        // as degraded mode — same remediation as genuinely-no-provider —
+        // and surface the typo via the No-Op banner's available-providers
+        // line and this doctor warning.
         var paths = CreatePathsWithConfig("""
             {
               "configVersion": 1,
               "Providers": {
-                "openrouter": { "Type": "openrouter" }
+                "ollama-local": { "Type": "ollama" }
               },
               "Models": {
-                "Main": { "Provider": "anthropic", "ModelId": "claude-4" }
+                "Main": { "Provider": "ollama-local1", "ModelId": "qwen3:30b" }
               }
             }
             """);
@@ -69,9 +75,10 @@ public sealed class ChatClientDoctorCheckTests
         var check = new ChatClientDoctorCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(DoctorSeverity.Error, result.Severity);
-        Assert.Contains("anthropic", result.Message);
-        Assert.DoesNotContain("No-Op", result.Message);
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("No-Op chat client", result.Message);
+        Assert.Contains("ollama-local1", result.Message);
+        Assert.Contains("ollama-local", result.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -28,8 +28,8 @@ public sealed class ChatClientDoctorCheckTests
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Contains("No-Op chat client", result.Message);
-        Assert.Contains("netclaw model", result.Remediation, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("netclaw.json", result.Remediation, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("netclaw init", result.Remediation, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("netclaw provider add", result.Remediation, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -79,6 +79,7 @@ public sealed class ChatClientDoctorCheckTests
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Contains("Models:Main missing", result.Message);
         Assert.DoesNotContain("Real chat client configured", result.Message);
+        Assert.Contains("netclaw model", result.Remediation, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Cli;
 using Netclaw.Cli.Doctor;
 using Netclaw.Configuration;
 using Xunit;
@@ -182,6 +183,7 @@ public sealed class ChatClientDoctorCheckTests
         // Missing config short-circuits via DoctorJsonConfigReader and yields its own
         // warning — the chat-client check is not reached.
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Equal(CliConfigPreflight.MissingConfigMessage, result.Message);
     }
 
     private static NetclawPaths CreatePathsWithConfig(string configJson)

--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChatClientDoctorCheckTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class ChatClientDoctorCheckTests
+{
+    [Fact]
+    public async Task ReturnsWarning_WhenNoProvidersConfigured()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("No-Op chat client", result.Message);
+        Assert.Contains("netclaw model", result.Remediation, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("netclaw.json", result.Remediation, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReturnsPass_WhenProvidersAndModelsAreValid()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "openrouter": { "Type": "openrouter" }
+              },
+              "Models": {
+                "Main": { "Provider": "openrouter", "ModelId": "anthropic/claude-haiku-4" }
+              }
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("openrouter", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenModelReferencesUnknownProvider()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "openrouter": { "Type": "openrouter" }
+              },
+              "Models": {
+                "Main": { "Provider": "anthropic", "ModelId": "claude-4" }
+              }
+            }
+            """);
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("anthropic", result.Message);
+        Assert.DoesNotContain("No-Op", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsWarning_WhenConfigFileMissing()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        var check = new ChatClientDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        // Missing config short-circuits via DoctorJsonConfigReader and yields its own
+        // warning — the chat-client check is not reached.
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+    }
+
+    private static NetclawPaths CreatePathsWithConfig(string configJson)
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+        File.WriteAllText(paths.NetclawConfigPath, configJson);
+        return paths;
+    }
+
+    private static string CreateTempBasePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -5,7 +5,9 @@
 // -----------------------------------------------------------------------
 using Netclaw.Cli;
 using Netclaw.Cli.Doctor;
+using Netclaw.Cli.Provider;
 using Netclaw.Configuration;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Doctor;
@@ -21,7 +23,7 @@ public sealed class ChatClientDoctorCheckTests
             }
             """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
@@ -37,15 +39,22 @@ public sealed class ChatClientDoctorCheckTests
             {
               "configVersion": 1,
               "Providers": {
-                "openrouter": { "Type": "openrouter" }
+                "openrouter": { "Type": "openrouter", "AuthMethod": "ApiKey" }
               },
               "Models": {
                 "Main": { "Provider": "openrouter", "ModelId": "anthropic/claude-haiku-4" }
               }
             }
             """);
+        WriteSecrets(paths, """
+            {
+              "Providers": {
+                "openrouter": { "ApiKey": "sk-test" }
+              }
+            }
+            """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
@@ -64,7 +73,7 @@ public sealed class ChatClientDoctorCheckTests
             }
             """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
@@ -87,7 +96,7 @@ public sealed class ChatClientDoctorCheckTests
             }
             """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
@@ -109,7 +118,7 @@ public sealed class ChatClientDoctorCheckTests
             }
             """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Error, result.Severity);
@@ -132,7 +141,7 @@ public sealed class ChatClientDoctorCheckTests
             }
             """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Error, result.Severity);
@@ -161,7 +170,7 @@ public sealed class ChatClientDoctorCheckTests
             }
             """);
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
@@ -177,13 +186,128 @@ public sealed class ChatClientDoctorCheckTests
         var paths = new NetclawPaths(basePath);
         paths.EnsureDirectoriesExist();
 
-        var check = new ChatClientDoctorCheck(paths);
+        var check = CreateCheck(paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         // Missing config short-circuits via DoctorJsonConfigReader and yields its own
         // warning — the chat-client check is not reached.
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Equal(CliConfigPreflight.MissingConfigMessage, result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenKnownApiKeyProviderHasNoApiKey()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "openrouter": { "Type": "openrouter", "AuthMethod": "ApiKey" }
+              },
+              "Models": {
+                "Main": { "Provider": "openrouter", "ModelId": "anthropic/claude-haiku-4" }
+              }
+            }
+            """);
+
+        var check = CreateCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("requires ApiKey", result.Message);
+        Assert.DoesNotContain("Real chat client configured", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenProviderTypeUnknown()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "custom": { "Type": "not-a-provider" }
+              },
+              "Models": {
+                "Main": { "Provider": "custom", "ModelId": "model-a" }
+              }
+            }
+            """);
+
+        var check = CreateCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("unknown Type", result.Message);
+        Assert.Contains("not-a-provider", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenProviderTypeValueIsNotString()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "openrouter": { "Type": 123 }
+              },
+              "Models": {
+                "Main": { "Provider": "openrouter", "ModelId": "anthropic/claude-haiku-4" }
+              }
+            }
+            """);
+
+        var check = CreateCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Providers.openrouter.Type", result.Message);
+        Assert.Contains("must be a string", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenModelProviderValueIsNotString()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "local-ollama": { "Type": "ollama" }
+              },
+              "Models": {
+                "Main": { "Provider": 123, "ModelId": "qwen3:30b" }
+              }
+            }
+            """);
+
+        var check = CreateCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Models.Main.Provider", result.Message);
+        Assert.Contains("must be a string", result.Message);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenModelIdValueIsNotString()
+    {
+        var paths = CreatePathsWithConfig("""
+            {
+              "configVersion": 1,
+              "Providers": {
+                "local-ollama": { "Type": "ollama" }
+              },
+              "Models": {
+                "Main": { "Provider": "local-ollama", "ModelId": 123 }
+              }
+            }
+            """);
+
+        var check = CreateCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Models.Main.ModelId", result.Message);
+        Assert.Contains("must be a string", result.Message);
     }
 
     private static NetclawPaths CreatePathsWithConfig(string configJson)
@@ -194,6 +318,19 @@ public sealed class ChatClientDoctorCheckTests
         File.WriteAllText(paths.NetclawConfigPath, configJson);
         return paths;
     }
+
+    private static ChatClientDoctorCheck CreateCheck(NetclawPaths paths) => new(
+        paths,
+        BuildConfiguration(paths),
+        ProviderCommand.CreateDefaultRegistry());
+
+    private static IConfigurationRoot BuildConfiguration(NetclawPaths paths) => new ConfigurationBuilder()
+        .AddJsonFile(paths.NetclawConfigPath, optional: true, reloadOnChange: false)
+        .AddJsonFile(paths.SecretsPath, optional: true, reloadOnChange: false)
+        .Build();
+
+    private static void WriteSecrets(NetclawPaths paths, string secretsJson) =>
+        File.WriteAllText(paths.SecretsPath, secretsJson);
 
     private static string CreateTempBasePath()
     {

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Cli;
 using Netclaw.Cli.Doctor;
 using Netclaw.Configuration;
 using Xunit;
@@ -22,7 +23,7 @@ public sealed class ConfigSchemaDoctorCheckTests
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
-        Assert.Contains("not found", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(CliConfigPreflight.MissingConfigMessage, result.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -48,6 +48,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Contains("Context window unavailable", result.Message);
         Assert.Contains("Models:Main missing", result.Message);
+        Assert.Contains("netclaw init", result.Remediation, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("32,768", result.Message);
     }
 
@@ -65,7 +66,24 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Contains("Context window unavailable", result.Message);
+        Assert.Contains("netclaw init", result.Remediation, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("local-ollama", result.Message);
+    }
+
+    [Fact]
+    public async Task MissingModelWithProvider_ReferencesModelCommand()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama")
+        });
+        var check = CreateCheck(CreateOfflineDaemonApi());
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("netclaw model", result.Remediation, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
+using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
 using Netclaw.Configuration;
@@ -33,7 +34,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
-        Assert.Contains("Config file not found", result.Message);
+        Assert.Equal(CliConfigPreflight.MissingConfigMessage, result.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -46,7 +46,26 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
-        Assert.Contains("No Models.Main section", result.Message);
+        Assert.Contains("Context window unavailable", result.Message);
+        Assert.Contains("Models:Main missing", result.Message);
+        Assert.DoesNotContain("32,768", result.Message);
+    }
+
+    [Fact]
+    public async Task MainModelWithoutProvider_ReturnsUnavailableWithoutDefaultProvider()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "qwen3:30b" } }
+        });
+        var check = CreateCheck(CreateOfflineDaemonApi());
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("Context window unavailable", result.Message);
+        Assert.DoesNotContain("local-ollama", result.Message);
     }
 
     [Fact]
@@ -55,6 +74,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "test-model", Provider = "local-ollama", ContextWindow = 131072 } }
         });
         var check = CreateCheck(CreateOfflineDaemonApi());
@@ -71,6 +91,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("openai-codex", "openai"),
             Models = new { Main = new { ModelId = "gpt-5.3-codex", Provider = "openai-codex", ContextWindow = 32768 } }
         });
 
@@ -91,6 +112,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama", ContextWindow = 262144 } }
         });
 
@@ -109,6 +131,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "test-model", Provider = "local-ollama", ContextWindow = -1 } }
         });
         var check = CreateCheck(CreateOfflineDaemonApi());
@@ -124,6 +147,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
         });
 
@@ -143,6 +167,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
         });
 
@@ -163,6 +188,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
         });
 
@@ -184,6 +210,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         WriteConfig(new
         {
             configVersion = 1,
+            Providers = ProviderConfig("local-ollama", "ollama"),
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
         });
 
@@ -211,8 +238,18 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             return Task.FromResult(probeResult);
         }
 
-        return new ContextWindowDoctorCheck(_paths, daemonApi, FakeProbe);
+        return new ContextWindowDoctorCheck(_paths, daemonApi, BuildConfiguration(), FakeProbe);
     }
+
+    private IConfigurationRoot BuildConfiguration() => new ConfigurationBuilder()
+        .AddJsonFile(_paths.NetclawConfigPath, optional: true, reloadOnChange: false)
+        .AddJsonFile(_paths.SecretsPath, optional: true, reloadOnChange: false)
+        .Build();
+
+    private static Dictionary<string, object> ProviderConfig(string name, string type) => new()
+    {
+        [name] = new { Type = type }
+    };
 
     private void WriteConfig(object config)
     {

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -417,7 +417,7 @@ public sealed class ProviderStepViewModelTests : IDisposable
         Assert.True(providerItem.Passed);
         Assert.True(providerItem.IsWarning);
         Assert.Contains("No-Op", providerItem.Label);
-        Assert.Contains("netclaw model", providerItem.Label, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("netclaw init", providerItem.Label, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -448,6 +448,34 @@ public sealed class ProviderStepViewModelTests : IDisposable
         Assert.True(providerItem.Passed);
         Assert.False(providerItem.IsWarning);
         Assert.Contains("LLM provider configured", providerItem.Label);
+
+        var modelItem = items[1];
+        Assert.True(modelItem.Passed);
+        Assert.True(modelItem.IsWarning);
+        Assert.Contains("No model selected", modelItem.Label);
+        Assert.Contains("No-Op", modelItem.Label);
+        Assert.False(runner.AllPassed);
+    }
+
+    [Fact]
+    public async Task ContributeHealthChecks_ProviderAndModelSelected_CountsAsCleanPass()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe)
+        {
+            SelectedProviderType = "ollama",
+            SelectedModelId = "qwen3:30b",
+        };
+
+        var items = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(items, () => { });
+        await step.ContributeHealthChecksAsync(runner, TestContext.Current.CancellationToken);
+
+        Assert.All(items, item =>
+        {
+            Assert.True(item.Passed);
+            Assert.False(item.IsWarning);
+        });
+        Assert.True(runner.AllPassed);
     }
 
     // Reuse the existing FakeProviderProbe from the monolith tests

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -421,6 +421,18 @@ public sealed class ProviderStepViewModelTests : IDisposable
     }
 
     [Fact]
+    public void HealthCheckRunner_WarningItemDoesNotCountAsCleanPass()
+    {
+        var items = new List<HealthCheckItem>
+        {
+            new("No provider configured", Passed: true, IsWarning: true),
+        };
+        var runner = new HealthCheckRunner(items, () => { });
+
+        Assert.False(runner.AllPassed);
+    }
+
+    [Fact]
     public async Task ContributeHealthChecks_ProviderSelected_EmitsPassItem()
     {
         using var step = new ProviderStepViewModel(_registry, _fakeProbe)

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -403,6 +403,41 @@ public sealed class ProviderStepViewModelTests : IDisposable
         Assert.Null(builder.Model);
     }
 
+    [Fact]
+    public async Task ContributeHealthChecks_NoProvider_EmitsWarnItem()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+        // SelectedProviderType deliberately left null.
+
+        var items = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(items, () => { });
+        await step.ContributeHealthChecksAsync(runner, TestContext.Current.CancellationToken);
+
+        var providerItem = items[0];
+        Assert.True(providerItem.Passed);
+        Assert.True(providerItem.IsWarning);
+        Assert.Contains("No-Op", providerItem.Label);
+        Assert.Contains("netclaw model", providerItem.Label, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ContributeHealthChecks_ProviderSelected_EmitsPassItem()
+    {
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe)
+        {
+            SelectedProviderType = "ollama",
+        };
+
+        var items = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(items, () => { });
+        await step.ContributeHealthChecksAsync(runner, TestContext.Current.CancellationToken);
+
+        var providerItem = items[0];
+        Assert.True(providerItem.Passed);
+        Assert.False(providerItem.IsWarning);
+        Assert.Contains("LLM provider configured", providerItem.Label);
+    }
+
     // Reuse the existing FakeProviderProbe from the monolith tests
     private sealed class FakeProviderProbe : IProviderProbe
     {

--- a/src/Netclaw.Cli/CliConfigPreflight.cs
+++ b/src/Netclaw.Cli/CliConfigPreflight.cs
@@ -13,6 +13,26 @@ internal static class CliConfigPreflight
 {
     public const string MissingConfigMessage = "daemon not configured - please run netclaw init";
 
+    public static bool TryWriteMissingChatConfig(
+        NetclawPaths paths,
+        string mode,
+        bool chatJsonOutput,
+        TextWriter writer,
+        out int exitCode)
+    {
+        if (mode is not ("chat" or "headless"))
+        {
+            exitCode = 0;
+            return false;
+        }
+
+        return TryWriteMissingConfig(
+            paths,
+            jsonOutput: mode == "headless" && chatJsonOutput,
+            writer,
+            out exitCode);
+    }
+
     public static bool TryWriteMissingConfig(
         NetclawPaths paths,
         bool jsonOutput,

--- a/src/Netclaw.Cli/CliConfigPreflight.cs
+++ b/src/Netclaw.Cli/CliConfigPreflight.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="CliConfigPreflight.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json.Nodes;
+using Netclaw.Cli.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli;
+
+internal static class CliConfigPreflight
+{
+    public const string MissingConfigMessage = "daemon not configured - please run netclaw init";
+
+    public static bool TryWriteMissingConfig(
+        NetclawPaths paths,
+        bool jsonOutput,
+        TextWriter writer,
+        out int exitCode)
+    {
+        if (File.Exists(paths.NetclawConfigPath))
+        {
+            exitCode = 0;
+            return false;
+        }
+
+        if (jsonOutput)
+        {
+            var node = new JsonObject
+            {
+                ["overall"] = "not-configured",
+                ["message"] = MissingConfigMessage,
+            };
+            writer.WriteLine(node.ToJsonString(JsonDefaults.Indented));
+        }
+        else
+        {
+            writer.WriteLine(MissingConfigMessage);
+        }
+
+        exitCode = 1;
+        return true;
+    }
+}

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -28,7 +28,7 @@ internal static class ContextWindowResolution
         if (status?.Model is { Degraded: true })
         {
             return new ModelRuntimeResolution(
-                "(no model - run `netclaw model`)",
+                "(no model - run `netclaw init`)",
                 string.Empty,
                 0,
                 Degraded: true);

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -25,12 +25,22 @@ internal static class ContextWindowResolution
             return Configured(configuredMain);
         }
 
+        if (status?.Model is { Degraded: true } degradedModel)
+        {
+            return new ModelRuntimeResolution(
+                "(no model - run `netclaw model`)",
+                degradedModel.Provider,
+                0,
+                Degraded: true);
+        }
+
         if (status?.Model is { ContextWindow: > 0 } daemonModel)
         {
             return new ModelRuntimeResolution(
                 daemonModel.ModelId,
                 daemonModel.Provider,
-                daemonModel.ContextWindow);
+                daemonModel.ContextWindow,
+                Degraded: false);
         }
 
         // The daemon was reachable but gave us no usable context window — either an
@@ -49,7 +59,7 @@ internal static class ContextWindowResolution
     }
 
     private static ModelRuntimeResolution Configured(ModelReference configuredMain)
-        => new(configuredMain.ModelId, configuredMain.Provider, configuredMain.ContextWindow!.Value);
+        => new(configuredMain.ModelId, configuredMain.Provider, configuredMain.ContextWindow!.Value, Degraded: false);
 
     private static async Task<DaemonRuntimeStatus.Response?> GetStatusAsync(DaemonApi daemon)
     {
@@ -71,7 +81,8 @@ internal static class ContextWindowResolution
 internal sealed record ModelRuntimeResolution(
     string ModelId,
     string Provider,
-    int ContextWindowTokens);
+    int ContextWindowTokens,
+    bool Degraded);
 
 internal sealed class DaemonUnavailableException : InvalidOperationException
 {

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -25,11 +25,11 @@ internal static class ContextWindowResolution
             return Configured(configuredMain);
         }
 
-        if (status?.Model is { Degraded: true } degradedModel)
+        if (status?.Model is { Degraded: true })
         {
             return new ModelRuntimeResolution(
                 "(no model - run `netclaw model`)",
-                degradedModel.Provider,
+                string.Empty,
                 0,
                 Degraded: true);
         }

--- a/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
@@ -82,7 +82,7 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
                 CheckName,
                 $"No-Op chat client will be active ({validation.Reason}). " +
                 "The daemon will start, but chat turns return a configuration banner instead of model output.",
-                "Run `netclaw model` to pick a provider/model interactively, or edit `netclaw.json` and restart the daemon."),
+                BuildNoProviderRemediation(validation.AvailableProviders)),
 
             ProviderRuntimeStatus.Invalid => DoctorCheckResult.Error(
                 CheckName,
@@ -95,6 +95,15 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
                 $"Unexpected validation status: {validation.Status}",
                 "File a bug — this status is not handled by the doctor check."),
         });
+    }
+
+    private static string BuildNoProviderRemediation(IReadOnlyList<string> availableProviders)
+    {
+        return availableProviders.Count == 0
+            ? "Run `netclaw init` to configure a provider and main model. "
+              + "For manual repair, run `netclaw provider add` first, then `netclaw model set main ...`."
+            : "Run `netclaw model` to pick one of the configured providers and a main model, "
+              + "or run `netclaw init` and choose start over to re-run setup.";
     }
 
     private DoctorCheckResult? ValidateProviderReadiness(

--- a/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
@@ -1,0 +1,95 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChatClientDoctorCheck.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json.Nodes;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+/// <summary>
+/// Reports whether the daemon has a real inference provider configured or is
+/// running with the No-Op chat client fallback. Mirrors
+/// <see cref="ProviderRuntimeValidation"/> so the result lines up with what
+/// the host will actually do at startup.
+/// </summary>
+public sealed class ChatClientDoctorCheck : IDoctorCheck
+{
+    private const string CheckName = "Chat Client";
+    private readonly NetclawPaths _paths;
+
+    public ChatClientDoctorCheck(NetclawPaths paths)
+    {
+        _paths = paths;
+    }
+
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var (root, error) = DoctorJsonConfigReader.TryReadConfig(_paths);
+        if (error is not null)
+            return Task.FromResult(error);
+
+        // No config file at all → treated the same as "no provider configured".
+        var providers = ReadProviders(root);
+        var models = ReadModels(root);
+        var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+
+        return Task.FromResult(validation.Status switch
+        {
+            ProviderRuntimeStatus.Valid => DoctorCheckResult.Pass(
+                CheckName,
+                $"Real chat client configured for provider '{models.Main.Provider}' / model '{models.Main.ModelId}'."),
+
+            ProviderRuntimeStatus.NoProviderConfigured => DoctorCheckResult.Warning(
+                CheckName,
+                $"No-Op chat client will be active ({validation.Reason}). " +
+                "The daemon will start, but chat turns return a configuration banner instead of model output.",
+                "Run `netclaw model` to pick a provider/model interactively, or edit `netclaw.json` and restart the daemon."),
+
+            ProviderRuntimeStatus.Invalid => DoctorCheckResult.Error(
+                CheckName,
+                $"Invalid inference configuration: {validation.Reason}. " +
+                "Daemon startup will fail until this is resolved.",
+                "Fix the model/provider mismatch in `netclaw.json` and restart the daemon."),
+
+            _ => DoctorCheckResult.Error(
+                CheckName,
+                $"Unexpected validation status: {validation.Status}",
+                "File a bug — this status is not handled by the doctor check."),
+        });
+    }
+
+    private static Dictionary<string, ProviderEntry> ReadProviders(JsonObject? root)
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase);
+        if (root?["Providers"] is not JsonObject providersObj)
+            return providers;
+
+        foreach (var (name, value) in providersObj)
+        {
+            // We only need to know which provider keys exist for the validation
+            // outcome — credentials and types are checked elsewhere.
+            providers[name] = new ProviderEntry
+            {
+                Type = (value as JsonObject)?["Type"]?.GetValue<string>() ?? "",
+            };
+        }
+
+        return providers;
+    }
+
+    private static ModelSelection ReadModels(JsonObject? root)
+    {
+        var models = new ModelSelection();
+        if (root?["Models"]?["Main"] is not JsonObject main)
+            return models;
+
+        models.Main = new ModelReference
+        {
+            Provider = main["Provider"]?.GetValue<string>() ?? "",
+            ModelId = main["ModelId"]?.GetValue<string>() ?? "",
+        };
+        return models;
+    }
+}

--- a/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
@@ -33,7 +33,10 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
         // No config file at all → treated the same as "no provider configured".
         var providers = ReadProviders(root);
         var models = ReadModels(root);
-        var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            models,
+            ProviderRuntimeConfiguration.FromJson(root));
 
         return Task.FromResult(validation.Status switch
         {
@@ -82,14 +85,25 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
     private static ModelSelection ReadModels(JsonObject? root)
     {
         var models = new ModelSelection();
-        if (root?["Models"]?["Main"] is not JsonObject main)
+        if (root?["Models"] is not JsonObject modelsObj)
             return models;
 
-        models.Main = new ModelReference
-        {
-            Provider = main["Provider"]?.GetValue<string>() ?? "",
-            ModelId = main["ModelId"]?.GetValue<string>() ?? "",
-        };
+        if (modelsObj["Main"] is JsonObject main)
+            models.Main = ReadModelReference(main);
+
+        if (modelsObj["Fallback"] is JsonObject fallback)
+            models.Fallback = ReadModelReference(fallback);
+
+        if (modelsObj["Compaction"] is JsonObject compaction)
+            models.Compaction = ReadModelReference(compaction);
+
         return models;
     }
+
+    private static ModelReference ReadModelReference(JsonObject model)
+        => new()
+        {
+            Provider = model["Provider"]?.GetValue<string>() ?? "",
+            ModelId = model["ModelId"]?.GetValue<string>() ?? "",
+        };
 }

--- a/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
@@ -4,7 +4,9 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
 using Netclaw.Configuration;
+using Netclaw.Providers;
 
 namespace Netclaw.Cli.Doctor;
 
@@ -18,10 +20,17 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
 {
     private const string CheckName = "Chat Client";
     private readonly NetclawPaths _paths;
+    private readonly IConfiguration _configuration;
+    private readonly ProviderDescriptorRegistry _registry;
 
-    public ChatClientDoctorCheck(NetclawPaths paths)
+    public ChatClientDoctorCheck(
+        NetclawPaths paths,
+        IConfiguration configuration,
+        ProviderDescriptorRegistry registry)
     {
         _paths = paths;
+        _configuration = configuration;
+        _registry = registry;
     }
 
     public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
@@ -30,17 +39,42 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
         if (error is not null)
             return Task.FromResult(error);
 
-        // No config file at all → treated the same as "no provider configured".
-        var providers = ReadProviders(root);
-        var models = ReadModels(root);
-        var validation = ProviderRuntimeValidation.Evaluate(
-            providers,
-            models,
-            ProviderRuntimeConfiguration.FromJson(root));
+        if (TryFindNonStringInferenceValue(root, out var invalidPath))
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                CheckName,
+                $"Invalid inference configuration: {invalidPath} must be a string.",
+                "Fix the provider/model values in `netclaw.json`, then rerun `netclaw doctor`."));
+        }
+
+        ProviderRuntimeValidation validation;
+        Dictionary<string, ProviderEntry> providers;
+        ModelSelection models;
+        ProviderRuntimeConfiguration runtimeConfiguration;
+        try
+        {
+            providers = ProviderConfigurationLoader.Load(_configuration.GetSection("Providers"));
+            models = _configuration.GetSection("Models").Get<ModelSelection>() ?? new ModelSelection();
+            runtimeConfiguration = ProviderRuntimeConfiguration.FromJson(root);
+            validation = ProviderRuntimeValidation.Evaluate(
+                providers,
+                models,
+                runtimeConfiguration);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or FormatException)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                CheckName,
+                $"Invalid inference configuration: {ex.Message}",
+                "Fix the provider/model values in `netclaw.json` and `secrets.json`, then rerun `netclaw doctor`."));
+        }
 
         return Task.FromResult(validation.Status switch
         {
-            ProviderRuntimeStatus.Valid => DoctorCheckResult.Pass(
+            ProviderRuntimeStatus.Valid => ValidateProviderReadiness(
+                providers,
+                models,
+                runtimeConfiguration) ?? DoctorCheckResult.Pass(
                 CheckName,
                 $"Real chat client configured for provider '{models.Main.Provider}' / model '{models.Main.ModelId}'."),
 
@@ -63,47 +97,162 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
         });
     }
 
-    private static Dictionary<string, ProviderEntry> ReadProviders(JsonObject? root)
+    private DoctorCheckResult? ValidateProviderReadiness(
+        IReadOnlyDictionary<string, ProviderEntry> providers,
+        ModelSelection models,
+        ProviderRuntimeConfiguration runtimeConfiguration)
     {
-        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase);
-        if (root?["Providers"] is not JsonObject providersObj)
-            return providers;
-
-        foreach (var (name, value) in providersObj)
+        foreach (var (role, model, configured) in EnumerateConfiguredRoles(models, runtimeConfiguration))
         {
-            // We only need to know which provider keys exist for the validation
-            // outcome — credentials and types are checked elsewhere.
-            providers[name] = new ProviderEntry
+            if (!configured)
+                continue;
+
+            if (!providers.TryGetValue(model.Provider, out var provider))
+                continue;
+
+            if (!_registry.TryGet(provider.Type, out var descriptor))
             {
-                Type = (value as JsonObject)?["Type"]?.GetValue<string>() ?? "",
+                return DoctorCheckResult.Error(
+                    CheckName,
+                    $"Invalid inference configuration: provider '{model.Provider}' referenced by model '{role}' has unknown Type '{provider.Type}'.",
+                    $"Set Providers.{model.Provider}.Type to one of: {string.Join(", ", _registry.KnownTypeKeys)}.");
+            }
+
+            if (MissingCredentialMessage(model.Provider, provider, descriptor) is { } missingCredential)
+            {
+                return DoctorCheckResult.Error(
+                    CheckName,
+                    $"Invalid inference configuration: {missingCredential} Daemon startup will fail until this is resolved.",
+                    $"Run `netclaw provider fix {model.Provider}` or update `secrets.json`, then rerun `netclaw doctor`.");
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<(string Role, ModelReference Model, bool Configured)> EnumerateConfiguredRoles(
+        ModelSelection models,
+        ProviderRuntimeConfiguration runtimeConfiguration)
+    {
+        yield return (nameof(models.Main), models.Main, runtimeConfiguration.Main.RoleConfigured);
+
+        if (models.Fallback is not null)
+            yield return (nameof(models.Fallback), models.Fallback, runtimeConfiguration.Fallback.RoleConfigured);
+
+        if (models.Compaction is not null)
+            yield return (nameof(models.Compaction), models.Compaction, runtimeConfiguration.Compaction.RoleConfigured);
+    }
+
+    private static string? MissingCredentialMessage(
+        string providerName,
+        ProviderEntry provider,
+        IProviderDescriptor descriptor)
+    {
+        var supported = descriptor.Auth.SupportedAuthMethods;
+        if (supported.Contains(AuthMethod.None))
+            return null;
+
+        var hasApiKey = !provider.ApiKey.IsNullOrEmpty();
+        var hasOAuthToken = !provider.OAuthAccessToken.IsNullOrEmpty();
+        var supportsApiKey = supported.Contains(AuthMethod.ApiKey);
+        var supportsOAuth = supported.Any(IsOAuth);
+
+        if (supportsApiKey && supportsOAuth)
+        {
+            return provider.AuthMethod switch
+            {
+                AuthMethod.ApiKey when !hasApiKey =>
+                    $"provider '{providerName}' ({descriptor.TypeKey}) requires ApiKey in secrets.json.",
+                AuthMethod.OAuthDevice or AuthMethod.OAuthPkce when !hasOAuthToken =>
+                    $"provider '{providerName}' ({descriptor.TypeKey}) requires OAuthAccessToken in secrets.json.",
+                AuthMethod.None when !hasApiKey && !hasOAuthToken =>
+                    $"provider '{providerName}' ({descriptor.TypeKey}) requires ApiKey or OAuthAccessToken in secrets.json.",
+                _ => null,
             };
         }
 
-        return providers;
+        if (supportsApiKey && !hasApiKey)
+            return $"provider '{providerName}' ({descriptor.TypeKey}) requires ApiKey in secrets.json.";
+
+        if (supportsOAuth && !hasOAuthToken)
+            return $"provider '{providerName}' ({descriptor.TypeKey}) requires OAuthAccessToken in secrets.json.";
+
+        return null;
     }
 
-    private static ModelSelection ReadModels(JsonObject? root)
+    private static bool IsOAuth(AuthMethod method) => method is AuthMethod.OAuthDevice or AuthMethod.OAuthPkce;
+
+    private static bool TryFindNonStringInferenceValue(JsonObject? root, out string path)
     {
-        var models = new ModelSelection();
-        if (root?["Models"] is not JsonObject modelsObj)
-            return models;
+        if (root?["Providers"] is JsonObject providers)
+        {
+            foreach (var (name, value) in providers)
+            {
+                if (value is JsonObject provider
+                    && TryGetProperty(provider, nameof(ProviderEntry.Type), out var type)
+                    && IsPresentNonString(type))
+                {
+                    path = $"Providers.{name}.Type";
+                    return true;
+                }
+            }
+        }
 
-        if (modelsObj["Main"] is JsonObject main)
-            models.Main = ReadModelReference(main);
+        if (root?["Models"] is JsonObject models)
+        {
+            foreach (var role in new[] { "Main", "Fallback", "Compaction" })
+            {
+                if (models[role] is not JsonObject model)
+                    continue;
 
-        if (modelsObj["Fallback"] is JsonObject fallback)
-            models.Fallback = ReadModelReference(fallback);
+                if (TryGetProperty(model, nameof(ModelReference.Provider), out var provider)
+                    && IsPresentNonString(provider))
+                {
+                    path = $"Models.{role}.Provider";
+                    return true;
+                }
 
-        if (modelsObj["Compaction"] is JsonObject compaction)
-            models.Compaction = ReadModelReference(compaction);
+                if (TryGetProperty(model, nameof(ModelReference.ModelId), out var modelId)
+                    && IsPresentNonString(modelId))
+                {
+                    path = $"Models.{role}.ModelId";
+                    return true;
+                }
+            }
+        }
 
-        return models;
+        path = string.Empty;
+        return false;
     }
 
-    private static ModelReference ReadModelReference(JsonObject model)
-        => new()
+    private static bool TryGetProperty(JsonObject obj, string propertyName, out JsonNode? value)
+    {
+        foreach (var property in obj)
         {
-            Provider = model["Provider"]?.GetValue<string>() ?? "",
-            ModelId = model["ModelId"]?.GetValue<string>() ?? "",
-        };
+            if (string.Equals(property.Key, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool IsPresentNonString(JsonNode? node)
+    {
+        if (node is null)
+            return false;
+
+        try
+        {
+            _ = node.GetValue<string>();
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+    }
 }

--- a/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.Schema;
+using Netclaw.Cli;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -18,8 +19,8 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
         {
             return Task.FromResult(DoctorCheckResult.Warning(
                 "Config Schema",
-                $"Config file not found at {paths.NetclawConfigPath}.",
-                "Run `netclaw init` to scaffold a baseline config."));
+                CliConfigPreflight.MissingConfigMessage,
+                $"Run `netclaw init` to create {paths.NetclawConfigPath}."));
         }
 
         JsonNode? root;

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -52,7 +52,7 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
             return DoctorCheckResult.Warning(
                 "Context Window",
                 $"Context window unavailable because inference configuration is not valid: {runtimeValidation.Reason}.",
-                "Run `netclaw model` to pick a provider/model, or edit `netclaw.json` and rerun `netclaw doctor`.");
+                BuildInferenceRemediation(runtimeValidation.AvailableProviders));
         }
 
         if (main is null)
@@ -60,7 +60,7 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
             return DoctorCheckResult.Warning(
                 "Context Window",
                 "No Models.Main section in config. Context window cannot be resolved until a model is selected.",
-                "Run `netclaw model` to pick a provider/model, or add Models.Main to netclaw.json.");
+                "Run `netclaw init` to configure a provider and main model, or add Models.Main to netclaw.json.");
         }
 
         var contextWindow = main["ContextWindow"];
@@ -141,6 +141,13 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
             // value stands and there is nothing to reconcile against.
             return null;
         }
+    }
+
+    private static string BuildInferenceRemediation(IReadOnlyList<string> availableProviders)
+    {
+        return availableProviders.Count == 0
+            ? "Run `netclaw init` to configure a provider and main model, then rerun `netclaw doctor`."
+            : "Run `netclaw model` to pick one of the configured providers and a main model, then rerun `netclaw doctor`.";
     }
 
     private async Task<DoctorCheckResult> ResolveEffectiveContextWindowAsync(

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
 
@@ -13,20 +14,23 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
 {
     private readonly NetclawPaths _paths;
     private readonly DaemonApi _daemonApi;
+    private readonly IConfiguration _configuration;
     private readonly Func<string, string, CancellationToken, Task<int?>> _probeProvider;
 
-    public ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemonApi)
-        : this(paths, daemonApi, (modelId, provider, ct) => ContextWindowDoctorProbe.ProbeAsync(paths, modelId, provider, ct))
+    public ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemonApi, IConfiguration configuration)
+        : this(paths, daemonApi, configuration, (modelId, provider, ct) => ContextWindowDoctorProbe.ProbeAsync(paths, modelId, provider, ct))
     {
     }
 
     internal ContextWindowDoctorCheck(
         NetclawPaths paths,
         DaemonApi daemonApi,
+        IConfiguration configuration,
         Func<string, string, CancellationToken, Task<int?>> probeProvider)
     {
         _paths = paths;
         _daemonApi = daemonApi;
+        _configuration = configuration;
         _probeProvider = probeProvider;
     }
 
@@ -42,23 +46,32 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
         var models = root["Models"] as JsonObject;
         var main = models?["Main"] as JsonObject;
 
+        var runtimeValidation = ValidateRuntimeConfiguration(root);
+        if (runtimeValidation.Status != ProviderRuntimeStatus.Valid)
+        {
+            return DoctorCheckResult.Warning(
+                "Context Window",
+                $"Context window unavailable because inference configuration is not valid: {runtimeValidation.Reason}.",
+                "Run `netclaw model` to pick a provider/model, or edit `netclaw.json` and rerun `netclaw doctor`.");
+        }
+
         if (main is null)
         {
             return DoctorCheckResult.Warning(
                 "Context Window",
-                "No Models.Main section in config. Using default context window (32,768 tokens).",
-                "Add a Models.Main section with ContextWindow to netclaw.json.");
+                "No Models.Main section in config. Context window cannot be resolved until a model is selected.",
+                "Run `netclaw model` to pick a provider/model, or add Models.Main to netclaw.json.");
         }
 
         var contextWindow = main["ContextWindow"];
         if (contextWindow is null)
         {
-            var modelId = main["ModelId"]?.GetValue<string>() ?? "unknown";
-            var providerName = main["Provider"]?.GetValue<string>() ?? "local-ollama";
+            var modelId = _configuration.GetSection("Models:Main:ModelId").Value ?? "unknown";
+            var providerName = _configuration.GetSection("Models:Main:Provider").Value ?? "unknown";
             return await ResolveEffectiveContextWindowAsync(modelId, providerName, cancellationToken);
         }
 
-        if (contextWindow.GetValue<int>() is var cw and > 0)
+        if (TryGetInt32(contextWindow, out var cw) && cw > 0)
         {
             // Runtime (ContextWindowResolution.ResolveRuntimeAsync) prefers the
             // daemon's live context window over the pinned config when the daemon
@@ -82,6 +95,37 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
             "Context Window",
             "Models.Main.ContextWindow must be a positive integer.",
             "Set Models.Main.ContextWindow to the effective runtime context window size in tokens.");
+    }
+
+    private ProviderRuntimeValidation ValidateRuntimeConfiguration(JsonObject root)
+    {
+        var providers = ProviderConfigurationLoader.Load(_configuration.GetSection("Providers"));
+        var models = _configuration.GetSection("Models")
+            .Get<ModelSelection>() ?? new ModelSelection();
+
+        return ProviderRuntimeValidation.Evaluate(
+            providers,
+            models,
+            ProviderRuntimeConfiguration.FromJson(root));
+    }
+
+    private static bool TryGetInt32(JsonNode node, out int value)
+    {
+        try
+        {
+            value = node.GetValue<int>();
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            value = 0;
+            return false;
+        }
+        catch (FormatException)
+        {
+            value = 0;
+            return false;
+        }
     }
 
     private async Task<int?> TryGetDaemonContextWindowAsync(CancellationToken ct)

--- a/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Nodes;
+using Netclaw.Cli;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -37,8 +38,8 @@ internal static class DoctorJsonConfigReader
         {
             return (null, DoctorCheckResult.Warning(
                 "Config File",
-                $"Config file not found at {paths.NetclawConfigPath}.",
-                "Run `netclaw init` to scaffold a baseline config."));
+                CliConfigPreflight.MissingConfigMessage,
+                $"Run `netclaw init` to create {paths.NetclawConfigPath}."));
         }
 
         try

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Providers;
 
 namespace Netclaw.Cli.Doctor;
 
@@ -11,6 +12,7 @@ public static class DoctorRegistrationExtensions
 {
     public static void AddDoctorChecks(this IServiceCollection services)
     {
+        services.AddProviderDescriptors();
         services.AddSingleton<DoctorRunner>();
         services.AddSingleton<DoctorFixService>();
         services.AddSingleton<IDoctorCheck, ConfigSchemaDoctorCheck>();

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -25,6 +25,7 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<IDoctorCheck, DaemonCrashDoctorCheck>();
         services.AddSingleton<IDoctorCheck, MemoryCheckpointHealthDoctorCheck>();
         services.AddSingleton<IDoctorCheck, McpServersDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, ChatClientDoctorCheck>();
         services.AddSingleton<IDoctorCheck, ContextWindowDoctorCheck>();
         services.AddSingleton<IDoctorCheck, UpdateAvailableDoctorCheck>();
         services.AddSingleton<IDoctorCheck, WebhookFormatDoctorCheck>();

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1018,8 +1018,12 @@ static async Task RunAsync(string[] args)
         }
     }
 
-    if (mode is "chat" or "headless"
-        && CliConfigPreflight.TryWriteMissingConfig(new NetclawPaths(), jsonOutput: false, Console.Out, out var chatExitCode))
+    if (CliConfigPreflight.TryWriteMissingChatConfig(
+            new NetclawPaths(),
+            mode,
+            chatJsonOutput,
+            Console.Out,
+            out var chatExitCode))
     {
         Environment.ExitCode = chatExitCode;
         return;

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1985,13 +1985,16 @@ static ModelCapabilities BuildModelCapabilities(IConfiguration configuration, Da
     var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
     var models = configuration.GetSection("Models")
         .Get<ModelSelection>() ?? new ModelSelection();
-    var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+    var validation = ProviderRuntimeValidation.Evaluate(
+        providers,
+        models,
+        ProviderRuntimeConfiguration.FromConfiguration(configuration));
 
     if (validation.Status != ProviderRuntimeStatus.Valid)
     {
         return new ModelCapabilities
         {
-            ModelId = "(no model — run `netclaw model`)",
+            ModelId = "(no model - run `netclaw model`)",
             ContextWindowTokens = 0,
             CompactionModelId = null,
         };
@@ -2004,6 +2007,6 @@ static ModelCapabilities BuildModelCapabilities(IConfiguration configuration, Da
     {
         ModelId = runtime.ModelId,
         ContextWindowTokens = runtime.ContextWindowTokens,
-        CompactionModelId = models.Compaction?.ModelId,
+        CompactionModelId = runtime.Degraded ? null : models.Compaction?.ModelId,
     };
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1623,9 +1623,19 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
 
     if (status.Model is { } model)
     {
-        Console.WriteLine($"model: {model.DisplayName ?? model.ModelId} (provider: {model.Provider}, context: {model.ContextWindow:N0} tokens)");
-        Console.WriteLine($"  input: {model.InputModalities}");
-        Console.WriteLine($"  output: {model.OutputModalities}");
+        if (model.Degraded)
+        {
+            Console.WriteLine("model: (none — No-Op chat client active)");
+            if (!string.IsNullOrWhiteSpace(model.DegradedReason))
+                Console.WriteLine($"  reason: {model.DegradedReason}");
+            Console.WriteLine("  fix: run `netclaw doctor` for details, then `netclaw model` to configure.");
+        }
+        else
+        {
+            Console.WriteLine($"model: {model.DisplayName ?? model.ModelId} (provider: {model.Provider}, context: {model.ContextWindow:N0} tokens)");
+            Console.WriteLine($"  input: {model.InputModalities}");
+            Console.WriteLine($"  output: {model.OutputModalities}");
+        }
     }
 
     Console.WriteLine("connectors:");

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1646,7 +1646,7 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
             Console.WriteLine("model: (none — No-Op chat client active)");
             if (!string.IsNullOrWhiteSpace(model.DegradedReason))
                 Console.WriteLine($"  reason: {model.DegradedReason}");
-            Console.WriteLine("  fix: run `netclaw doctor` for details, then `netclaw model` to configure.");
+            Console.WriteLine("  fix: run `netclaw doctor` for details; use `netclaw init` if no provider is configured.");
         }
         else
         {
@@ -2012,7 +2012,9 @@ static ModelCapabilities BuildModelCapabilities(IConfiguration configuration, Da
     {
         return new ModelCapabilities
         {
-            ModelId = "(no model - run `netclaw model`)",
+            ModelId = validation.AvailableProviders.Count == 0
+                ? "(no model - run `netclaw init`)"
+                : "(no model - run `netclaw model`)",
             ContextWindowTokens = 0,
             CompactionModelId = null,
         };

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -191,19 +191,7 @@ static async Task RunAsync(string[] args)
                     .AddEnvironmentVariables("NETCLAW_");
                 var initConfig = configBuilder.Build();
 
-                var models = initConfig.GetSection("Models")
-                    .Get<ModelSelection>() ?? new ModelSelection();
-
-                var runtime = ContextWindowResolution.ResolveRuntimeAsync(
-                    models.Main,
-                    sp.GetRequiredService<DaemonApi>()).GetAwaiter().GetResult();
-
-                return new ModelCapabilities
-                {
-                    ModelId = runtime.ModelId,
-                    ContextWindowTokens = runtime.ContextWindowTokens,
-                    CompactionModelId = models.Compaction?.ModelId,
-                };
+                return BuildModelCapabilities(initConfig, sp.GetRequiredService<DaemonApi>());
             });
 
             builder.Services.AddSingleton<InitNavigationState>();
@@ -1963,30 +1951,49 @@ static IConfigurationRoot BuildCliConfig()
 
 static void ConfigureCliChatServices(IServiceCollection services, IConfigurationManager configuration)
 {
-    // Resolve models for session config
-    var models = configuration.GetSection("Models")
-        .Get<ModelSelection>() ?? new ModelSelection();
-
     // Session config: bind operator-facing settings
     var sessionConfig = SessionConfig.BindFromConfiguration(configuration.GetSection("Session"));
     services.AddSingleton(sessionConfig);
-    services.AddSingleton(sp =>
-    {
-        var runtime = ContextWindowResolution.ResolveRuntimeAsync(
-            models.Main,
-            sp.GetRequiredService<DaemonApi>()).GetAwaiter().GetResult();
-
-        return new ModelCapabilities
-        {
-            ModelId = runtime.ModelId,
-            ContextWindowTokens = runtime.ContextWindowTokens,
-            CompactionModelId = models.Compaction?.ModelId,
-        };
-    });
+    services.AddSingleton(sp => BuildModelCapabilities(configuration, sp.GetRequiredService<DaemonApi>()));
 
     // DaemonClient uses the endpoint from DaemonApi. For non-loopback (remote) endpoints,
     // reads DeviceToken from secrets.json and attaches it as a bearer token provider.
     services.AddSingleton(sp => DaemonClientFactory.Create(
         sp.GetRequiredService<DaemonApi>().Endpoint,
         sp.GetRequiredService<NetclawPaths>()));
+}
+
+/// <summary>
+/// Build a <see cref="ModelCapabilities"/> for the CLI's chat surface. When
+/// <see cref="ProviderRuntimeValidation"/> reports the daemon is (or will be)
+/// running in degraded No-Op mode, we substitute a sentinel ModelId so the
+/// chat status bar doesn't display a stale/invalid model name and never
+/// attempt the daemon context-window probe (which would 404 or block).
+/// </summary>
+static ModelCapabilities BuildModelCapabilities(IConfiguration configuration, DaemonApi daemonApi)
+{
+    var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
+    var models = configuration.GetSection("Models")
+        .Get<ModelSelection>() ?? new ModelSelection();
+    var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+
+    if (validation.Status != ProviderRuntimeStatus.Valid)
+    {
+        return new ModelCapabilities
+        {
+            ModelId = "(no model — run `netclaw model`)",
+            ContextWindowTokens = 0,
+            CompactionModelId = null,
+        };
+    }
+
+    var runtime = ContextWindowResolution.ResolveRuntimeAsync(models.Main, daemonApi)
+        .GetAwaiter().GetResult();
+
+    return new ModelCapabilities
+    {
+        ModelId = runtime.ModelId,
+        ContextWindowTokens = runtime.ContextWindowTokens,
+        CompactionModelId = models.Compaction?.ModelId,
+    };
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -327,6 +327,13 @@ static async Task RunAsync(string[] args)
             return;
         }
 
+        var statusPaths = new NetclawPaths();
+        if (CliConfigPreflight.TryWriteMissingConfig(statusPaths, statusAsJson, Console.Out, out var statusExitCode))
+        {
+            Environment.ExitCode = statusExitCode;
+            return;
+        }
+
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
 
@@ -1009,6 +1016,13 @@ static async Task RunAsync(string[] args)
             headlessPrompt = chatPrompt;
             mode = "headless";
         }
+    }
+
+    if (mode is "chat" or "headless"
+        && CliConfigPreflight.TryWriteMissingConfig(new NetclawPaths(), jsonOutput: false, Console.Out, out var chatExitCode))
+    {
+        Environment.ExitCode = chatExitCode;
+        return;
     }
 
     // ── Interactive / headless modes (daemon-backed via SignalR) ──

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -228,7 +228,13 @@ public partial class InitWizardViewModel : ReactiveViewModel
 /// </summary>
 /// <param name="Label">Display text.</param>
 /// <param name="Passed">Null while running, true/false when complete.</param>
-public sealed record HealthCheckItem(string Label, bool? Passed);
+/// <param name="IsWarning">
+/// When <c>true</c> together with <c>Passed=true</c>, the item is rendered as
+/// a degraded/warn state (e.g. No-Op chat client will be active) — the wizard
+/// still treats it as passed so the daemon can start, but the operator sees a
+/// distinct warning indicator.
+/// </param>
+public sealed record HealthCheckItem(string Label, bool? Passed, bool IsWarning = false);
 
 /// <summary>
 /// A channel entry in the Channels wizard step with editable audience.

--- a/src/Netclaw.Cli/Tui/Wizard/HealthCheckRunner.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/HealthCheckRunner.cs
@@ -102,7 +102,7 @@ public sealed class HealthCheckRunner
         get
         {
             lock (Results)
-                return Results.All(h => h.Passed == true);
+                return Results.All(h => h.Passed == true && !h.IsWarning);
         }
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepView.cs
@@ -36,10 +36,11 @@ public sealed class HealthCheckStepView : IWizardStepView
                 continue;
             }
 
-            var (icon, color) = item.Passed.Value switch
+            var (icon, color) = (item.Passed.Value, item.IsWarning) switch
             {
-                true => ("\u2713", Color.Green),
-                false => ("\u2717", Color.Red),
+                (true, true) => ("\u26a0", Color.Yellow),
+                (true, _) => ("\u2713", Color.Green),
+                (false, _) => ("\u2717", Color.Red),
             };
             lines.Add(new TextNode($"  {icon}  {item.Label}").WithForeground(color));
         }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -515,7 +515,7 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         else
         {
             runner.Add(new HealthCheckItem(
-                "No provider configured — No-Op chat client will be active (run `netclaw model` or edit `netclaw.json`)",
+                "No provider configured — No-Op chat client will be active (run `netclaw init` or edit `netclaw.json`)",
                 Passed: true,
                 IsWarning: true));
         }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -502,10 +502,23 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
 
     public Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
     {
-        // Provider check
+        // Provider check. When no provider is selected we emit a warn-level
+        // item rather than a hard failure: the daemon will still start (in
+        // degraded mode with the No-Op chat client) so the operator can fix
+        // the configuration via `netclaw doctor` / `netclaw model`.
         var providerOk = !string.IsNullOrWhiteSpace(SelectedProviderType);
-        var providerLabel = providerOk ? Registry.Get(SelectedProviderType!).DisplayName : "none";
-        runner.Add(new HealthCheckItem($"LLM provider configured ({providerLabel})", providerOk));
+        if (providerOk)
+        {
+            var providerLabel = Registry.Get(SelectedProviderType!).DisplayName;
+            runner.Add(new HealthCheckItem($"LLM provider configured ({providerLabel})", true));
+        }
+        else
+        {
+            runner.Add(new HealthCheckItem(
+                "No provider configured — No-Op chat client will be active (run `netclaw model` or edit `netclaw.json`)",
+                Passed: true,
+                IsWarning: true));
+        }
 
         // Model check
         var modelOk = !string.IsNullOrWhiteSpace(SelectedModelId);

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -525,8 +525,9 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         runner.Add(new HealthCheckItem(
             modelOk
                 ? $"Model selected ({SelectedModelId})"
-                : "Model selected (none — will use provider default)",
-            true)); // not a hard failure
+                : "No model selected — No-Op chat client will be active (run `netclaw model` or pick a model)",
+            Passed: true,
+            IsWarning: !modelOk));
 
         return Task.CompletedTask;
     }

--- a/src/Netclaw.Configuration.Tests/NoOpChatClientProviderTests.cs
+++ b/src/Netclaw.Configuration.Tests/NoOpChatClientProviderTests.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="NoOpChatClientProviderTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class NoOpChatClientProviderTests
+{
+    [Fact]
+    public void IsDegraded_IsTrue()
+    {
+        var provider = new NoOpChatClientProvider();
+        Assert.True(provider.IsDegraded);
+    }
+
+    [Fact]
+    public void DefaultIChatClientProviderIsDegraded_DefaultsToFalse()
+    {
+        // The default interface implementation should leave IsDegraded false
+        // so existing test doubles and SingleClientProvider don't need updating.
+        IChatClientProvider provider = new SingleClientProvider(new NoOpChatClient());
+        Assert.False(provider.IsDegraded);
+    }
+
+    [Fact]
+    public void ReturnsSameClientInstance_ForEveryRole()
+    {
+        var provider = new NoOpChatClientProvider();
+        var main = provider.GetClient(ModelRole.Main);
+        var fallback = provider.GetClient(ModelRole.Fallback);
+        var compaction = provider.GetClient(ModelRole.Compaction);
+
+        Assert.Same(main, fallback);
+        Assert.Same(main, compaction);
+    }
+
+    [Fact]
+    public async Task ProvidedClient_RendersBannerWithAvailableProviders()
+    {
+        var provider = new NoOpChatClientProvider(new[] { "openrouter" });
+        var client = provider.GetClient(ModelRole.Main);
+
+        var response = await client.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "anything") },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Contains("openrouter", response.Text);
+    }
+}

--- a/src/Netclaw.Configuration.Tests/NoOpChatClientTests.cs
+++ b/src/Netclaw.Configuration.Tests/NoOpChatClientTests.cs
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------
+// <copyright file="NoOpChatClientTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class NoOpChatClientTests
+{
+    [Fact]
+    public async Task GetResponseAsync_LeadsWithFixedPhrase()
+    {
+        var client = new NoOpChatClient();
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await client.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "hi") },
+            cancellationToken: ct);
+
+        var text = response.Text;
+        Assert.StartsWith(NoOpChatClient.LeadingPhrase, text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_IncludesAllThreeRecoverySteps()
+    {
+        var client = new NoOpChatClient();
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await client.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "hi") },
+            cancellationToken: ct);
+
+        var text = response.Text;
+        Assert.Contains("netclaw doctor", text);
+        Assert.Contains("netclaw model", text);
+        Assert.Contains("netclaw.json", text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_AppendsAvailableProvidersLine_WhenProvided()
+    {
+        var client = new NoOpChatClient(new[] { "openrouter", "anthropic" });
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await client.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "hi") },
+            cancellationToken: ct);
+
+        Assert.Contains("Available providers:", response.Text);
+        Assert.Contains("openrouter", response.Text);
+        Assert.Contains("anthropic", response.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OmitsAvailableProvidersLine_WhenEmpty()
+    {
+        var client = new NoOpChatClient(Array.Empty<string>());
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await client.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "hi") },
+            cancellationToken: ct);
+
+        Assert.DoesNotContain("Available providers:", response.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ContainsNoToolCalls_EvenWhenToolsRegistered()
+    {
+        var client = new NoOpChatClient();
+        var ct = TestContext.Current.CancellationToken;
+
+        var options = new ChatOptions
+        {
+            Tools = new List<AITool>
+            {
+                AIFunctionFactory.Create(() => "ignored", "noop_tool", "should not be called"),
+            },
+        };
+
+        var response = await client.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "use the tool") },
+            options,
+            cancellationToken: ct);
+
+        var toolCalls = response.Messages
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionCallContent>()
+            .ToList();
+
+        Assert.Empty(toolCalls);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_EmitsSingleChunk()
+    {
+        var client = new NoOpChatClient();
+        var ct = TestContext.Current.CancellationToken;
+
+        var chunks = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+                           new[] { new ChatMessage(ChatRole.User, "hi") },
+                           cancellationToken: ct))
+        {
+            chunks.Add(update);
+        }
+
+        Assert.Single(chunks);
+        Assert.Equal(ChatRole.Assistant, chunks[0].Role);
+        Assert.Contains(NoOpChatClient.LeadingPhrase, chunks[0].Text);
+    }
+}

--- a/src/Netclaw.Configuration.Tests/NoOpChatClientTests.cs
+++ b/src/Netclaw.Configuration.Tests/NoOpChatClientTests.cs
@@ -36,7 +36,7 @@ public sealed class NoOpChatClientTests
 
         var text = response.Text;
         Assert.Contains("netclaw doctor", text);
-        Assert.Contains("netclaw model", text);
+        Assert.Contains("netclaw init", text);
         Assert.Contains("netclaw.json", text);
     }
 
@@ -53,6 +53,7 @@ public sealed class NoOpChatClientTests
         Assert.Contains("Available providers:", response.Text);
         Assert.Contains("openrouter", response.Text);
         Assert.Contains("anthropic", response.Text);
+        Assert.Contains("netclaw model", response.Text);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
+++ b/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProviderRuntimeValidationTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class ProviderRuntimeValidationTests
+{
+    [Fact]
+    public void EmptyProviders_DefaultModelSelection_ReturnsNoProviderConfigured()
+    {
+        // Default ModelSelection.Main has a non-empty default Provider ("local-ollama")
+        // and ModelId ("qwen3:30b"), so the "no providers" branch is what trips here.
+        var validation = ProviderRuntimeValidation.Evaluate(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection());
+
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+        Assert.Empty(validation.AvailableProviders);
+        Assert.Contains("no providers", validation.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EmptyProviders_EmptyModel_ReturnsNoProviderConfigured_WithBothEmptyMessage()
+    {
+        var validation = ProviderRuntimeValidation.Evaluate(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection { Main = new ModelReference { Provider = "", ModelId = "" } });
+
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+        Assert.Contains("no providers or models", validation.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProvidersConfigured_ModelMissing_ReturnsNoProviderConfigured_WithProvidersListed()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+            ["ollama"] = new ProviderEntry { Type = "ollama" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection { Main = new ModelReference { Provider = "", ModelId = "" } });
+
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+        Assert.Equal(2, validation.AvailableProviders.Count);
+        Assert.Contains("openrouter", validation.AvailableProviders);
+    }
+
+    [Fact]
+    public void ProvidersConfigured_ModelPointsToUnknownProvider_ReturnsInvalid()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection { Main = new ModelReference { Provider = "anthropic", ModelId = "claude-4" } });
+
+        Assert.Equal(ProviderRuntimeStatus.Invalid, validation.Status);
+        Assert.Contains("unknown provider", validation.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("anthropic", validation.Reason);
+    }
+
+    [Fact]
+    public void ValidProviderAndModel_ReturnsValid()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection { Main = new ModelReference { Provider = "openrouter", ModelId = "anthropic/claude-haiku-4" } });
+
+        Assert.Equal(ProviderRuntimeStatus.Valid, validation.Status);
+        Assert.Null(validation.Reason);
+        Assert.Single(validation.AvailableProviders);
+    }
+}

--- a/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
+++ b/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
@@ -53,20 +53,28 @@ public sealed class ProviderRuntimeValidationTests
     }
 
     [Fact]
-    public void ProvidersConfigured_ModelPointsToUnknownProvider_ReturnsInvalid()
+    public void ProvidersConfigured_ModelPointsToUnknownProvider_ReturnsNoProviderConfigured()
     {
+        // Regression: operator typo in Models:Main.Provider (e.g. "ollama-local1"
+        // vs configured "ollama-local") used to crash the daemon with a raw
+        // ProviderPluginFactory stack trace. Same operator remediation as
+        // genuinely-no-provider, so select No-Op and surface available providers
+        // in the banner.
         var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
         {
-            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+            ["github-copilot"] = new ProviderEntry { Type = "github-copilot" },
+            ["my-openrouter"] = new ProviderEntry { Type = "openrouter" },
+            ["ollama-local"] = new ProviderEntry { Type = "ollama" },
         };
 
         var validation = ProviderRuntimeValidation.Evaluate(
             providers,
-            new ModelSelection { Main = new ModelReference { Provider = "anthropic", ModelId = "claude-4" } });
+            new ModelSelection { Main = new ModelReference { Provider = "ollama-local1", ModelId = "qwen3:30b" } });
 
-        Assert.Equal(ProviderRuntimeStatus.Invalid, validation.Status);
-        Assert.Contains("unknown provider", validation.Reason, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("anthropic", validation.Reason);
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+        Assert.Contains("ollama-local1", validation.Reason);
+        Assert.Contains("ollama-local", validation.Reason);
+        Assert.Equal(3, validation.AvailableProviders.Count);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
+++ b/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
@@ -10,17 +10,60 @@ namespace Netclaw.Configuration.Tests;
 public sealed class ProviderRuntimeValidationTests
 {
     [Fact]
-    public void EmptyProviders_DefaultModelSelection_ReturnsNoProviderConfigured()
+    public void MainModelAbsent_DefaultModelSelection_ReturnsNoProviderConfigured()
     {
-        // Default ModelSelection.Main has a non-empty default Provider ("local-ollama")
-        // and ModelId ("qwen3:30b"), so the "no providers" branch is what trips here.
+        // Bound defaults are not configuration. A fresh install with no Models:Main
+        // section must be treated as explicitly unconfigured.
         var validation = ProviderRuntimeValidation.Evaluate(
             new Dictionary<string, ProviderEntry>(),
-            new ModelSelection());
+            new ModelSelection(),
+            ProviderRuntimeConfiguration.FromExplicitRoles(
+                new Dictionary<string, ProviderEntry>(), main: false, fallback: false, compaction: false));
 
         Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
         Assert.Empty(validation.AvailableProviders);
-        Assert.Contains("no providers", validation.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Models:Main missing", validation.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProviderExistsButMainModelAbsent_DoesNotTreatDefaultsAsConfigured()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["local-ollama"] = new ProviderEntry { Type = "ollama" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection(),
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: false, fallback: false, compaction: false));
+
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+        Assert.Contains("Models:Main missing", validation.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProviderExistsButMainSectionHasNoProviderOrModel_DoesNotTreatDefaultsAsConfigured()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["local-ollama"] = new ProviderEntry { Type = "ollama" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection(),
+            new ProviderRuntimeConfiguration(
+                Main: new ModelReferenceRuntimeConfiguration(
+                    RoleConfigured: true,
+                    ProviderConfigured: false,
+                    ModelIdConfigured: false),
+                Fallback: ModelReferenceRuntimeConfiguration.FromCompleteRole(false),
+                Compaction: ModelReferenceRuntimeConfiguration.FromCompleteRole(false),
+                ProvidersWithExplicitType: ["local-ollama"]));
+
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+        Assert.Contains("no model selected", validation.Reason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -28,7 +71,9 @@ public sealed class ProviderRuntimeValidationTests
     {
         var validation = ProviderRuntimeValidation.Evaluate(
             new Dictionary<string, ProviderEntry>(),
-            new ModelSelection { Main = new ModelReference { Provider = "", ModelId = "" } });
+            new ModelSelection { Main = new ModelReference { Provider = "", ModelId = "" } },
+            ProviderRuntimeConfiguration.FromExplicitRoles(
+                new Dictionary<string, ProviderEntry>(), main: true, fallback: false, compaction: false));
 
         Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
         Assert.Contains("no providers or models", validation.Reason, StringComparison.OrdinalIgnoreCase);
@@ -45,7 +90,8 @@ public sealed class ProviderRuntimeValidationTests
 
         var validation = ProviderRuntimeValidation.Evaluate(
             providers,
-            new ModelSelection { Main = new ModelReference { Provider = "", ModelId = "" } });
+            new ModelSelection { Main = new ModelReference { Provider = "", ModelId = "" } },
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: true, fallback: false, compaction: false));
 
         Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
         Assert.Equal(2, validation.AvailableProviders.Count);
@@ -69,7 +115,8 @@ public sealed class ProviderRuntimeValidationTests
 
         var validation = ProviderRuntimeValidation.Evaluate(
             providers,
-            new ModelSelection { Main = new ModelReference { Provider = "ollama-local1", ModelId = "qwen3:30b" } });
+            new ModelSelection { Main = new ModelReference { Provider = "ollama-local1", ModelId = "qwen3:30b" } },
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: true, fallback: false, compaction: false));
 
         Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
         Assert.Contains("ollama-local1", validation.Reason);
@@ -87,10 +134,76 @@ public sealed class ProviderRuntimeValidationTests
 
         var validation = ProviderRuntimeValidation.Evaluate(
             providers,
-            new ModelSelection { Main = new ModelReference { Provider = "openrouter", ModelId = "anthropic/claude-haiku-4" } });
+            new ModelSelection { Main = new ModelReference { Provider = "openrouter", ModelId = "anthropic/claude-haiku-4" } },
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: true, fallback: false, compaction: false));
 
         Assert.Equal(ProviderRuntimeStatus.Valid, validation.Status);
         Assert.Null(validation.Reason);
         Assert.Single(validation.AvailableProviders);
+    }
+
+    [Fact]
+    public void ExplicitFallbackWithUnknownProvider_ReturnsInvalid()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection
+            {
+                Main = new ModelReference { Provider = "openrouter", ModelId = "anthropic/claude-haiku-4" },
+                Fallback = new ModelReference { Provider = "missing", ModelId = "qwen3:30b" },
+            },
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: true, fallback: true, compaction: false));
+
+        Assert.Equal(ProviderRuntimeStatus.Invalid, validation.Status);
+        Assert.Contains("Fallback", validation.Reason);
+        Assert.Contains("missing", validation.Reason);
+    }
+
+    [Fact]
+    public void ExplicitCompactionWithIncompleteModel_ReturnsInvalid()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection
+            {
+                Main = new ModelReference { Provider = "openrouter", ModelId = "anthropic/claude-haiku-4" },
+                Compaction = new ModelReference { Provider = "openrouter", ModelId = "" },
+            },
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: true, fallback: false, compaction: true));
+
+        Assert.Equal(ProviderRuntimeStatus.Invalid, validation.Status);
+        Assert.Contains("Compaction", validation.Reason);
+        Assert.Contains("incomplete", validation.Reason);
+    }
+
+    [Fact]
+    public void ReferencedProviderWithoutExplicitType_ReturnsInvalid()
+    {
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["openrouter"] = new ProviderEntry { Type = "openrouter" },
+        };
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            new ModelSelection { Main = new ModelReference { Provider = "openrouter", ModelId = "anthropic/claude-haiku-4" } },
+            new ProviderRuntimeConfiguration(
+                Main: ModelReferenceRuntimeConfiguration.FromCompleteRole(true),
+                Fallback: ModelReferenceRuntimeConfiguration.FromCompleteRole(false),
+                Compaction: ModelReferenceRuntimeConfiguration.FromCompleteRole(false),
+                ProvidersWithExplicitType: []));
+
+        Assert.Equal(ProviderRuntimeStatus.Invalid, validation.Status);
+        Assert.Contains("missing required Type", validation.Reason);
     }
 }

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -96,6 +96,22 @@ public static class DaemonRuntimeStatus
         public required string OutputModalities { get; init; }
 
         public int ContextWindow { get; init; }
+
+        /// <summary>
+        /// True when the daemon is serving the No-Op chat client because no
+        /// valid inference provider/model configuration is present. When
+        /// <c>true</c>, <see cref="ModelId"/> / <see cref="Provider"/> reflect
+        /// the (broken) operator config rather than a live model; clients
+        /// SHOULD render the degraded state instead of those fields.
+        /// </summary>
+        public bool Degraded { get; init; }
+
+        /// <summary>
+        /// Human-readable reason the daemon is in degraded mode (e.g. "no
+        /// providers configured", "model 'Main' references provider 'X' which
+        /// is not configured"). Null when <see cref="Degraded"/> is false.
+        /// </summary>
+        public string? DegradedReason { get; init; }
     }
 
     public sealed class Update : IWireType

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -100,9 +100,9 @@ public static class DaemonRuntimeStatus
         /// <summary>
         /// True when the daemon is serving the No-Op chat client because no
         /// valid inference provider/model configuration is present. When
-        /// <c>true</c>, <see cref="ModelId"/> / <see cref="Provider"/> reflect
-        /// the (broken) operator config rather than a live model; clients
-        /// SHOULD render the degraded state instead of those fields.
+        /// <c>true</c>, <see cref="ModelId"/> / <see cref="Provider"/> are not
+        /// live model identifiers and clients SHOULD render the degraded state
+        /// instead of those fields.
         /// </summary>
         public bool Degraded { get; init; }
 

--- a/src/Netclaw.Configuration/IChatClientProvider.cs
+++ b/src/Netclaw.Configuration/IChatClientProvider.cs
@@ -21,4 +21,13 @@ public interface IChatClientProvider
     /// <see cref="ModelRole.Main"/>.
     /// </summary>
     IChatClient GetClient(ModelRole role);
+
+    /// <summary>
+    /// True when the provider is serving a No-Op fallback because no valid
+    /// inference provider configuration was detected. Diagnostic surfaces
+    /// (notably <c>netclaw doctor</c>) check this so they can report the
+    /// degraded state without inspecting concrete implementation types.
+    /// Real provider implementations leave this as <c>false</c>.
+    /// </summary>
+    bool IsDegraded => false;
 }

--- a/src/Netclaw.Configuration/NoOpChatClient.cs
+++ b/src/Netclaw.Configuration/NoOpChatClient.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------
+// <copyright file="NoOpChatClient.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// <see cref="IChatClient"/> used when no valid inference provider/model
+/// configuration is present. Returns a fixed configuration banner with
+/// recovery instructions and never contacts any external service or
+/// emits tool calls. See <see cref="ProviderRuntimeValidation"/>.
+/// </summary>
+public sealed class NoOpChatClient : IChatClient
+{
+    /// <summary>The exact phrase the banner SHALL begin with — spec-fixed.</summary>
+    public const string LeadingPhrase = "No valid model configuration detected.";
+
+    private readonly string _banner;
+
+    public NoOpChatClient(IReadOnlyList<string>? availableProviders = null)
+    {
+        _banner = BuildBanner(availableProviders);
+    }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var message = new ChatMessage(ChatRole.Assistant, _banner);
+        // No tool calls regardless of options.Tools — secure-by-default.
+        return Task.FromResult(new ChatResponse(message));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Single chunk — no simulated token streaming.
+        yield return new ChatResponseUpdate(ChatRole.Assistant, _banner);
+        await Task.CompletedTask;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        return serviceType.IsInstanceOfType(this) ? this : null;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public static string BuildBanner(IReadOnlyList<string>? availableProviders)
+    {
+        var sb = new StringBuilder();
+        sb.Append(LeadingPhrase).Append('\n').Append('\n');
+        sb.Append("Netclaw is running, but no inference provider/model is configured.\n");
+        sb.Append("To get chat working:\n\n");
+        sb.Append("  1. Run `netclaw doctor` to see what's missing.\n");
+        sb.Append("  2. Run `netclaw model` to pick a provider and model interactively.\n");
+        sb.Append("  3. Or edit `netclaw.json` directly and restart the daemon.");
+
+        if (availableProviders is { Count: > 0 })
+        {
+            sb.Append('\n').Append('\n');
+            sb.Append("Available providers: ").Append(string.Join(", ", availableProviders));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Netclaw.Configuration/NoOpChatClient.cs
+++ b/src/Netclaw.Configuration/NoOpChatClient.cs
@@ -64,8 +64,11 @@ public sealed class NoOpChatClient : IChatClient
         sb.Append("Netclaw is running, but no inference provider/model is configured.\n");
         sb.Append("To get chat working:\n\n");
         sb.Append("  1. Run `netclaw doctor` to see what's missing.\n");
-        sb.Append("  2. Run `netclaw model` to pick a provider and model interactively.\n");
-        sb.Append("  3. Or edit `netclaw.json` directly and restart the daemon.");
+        if (availableProviders is { Count: > 0 })
+            sb.Append("  2. Run `netclaw model` to pick one of the configured providers and a model.\n");
+        else
+            sb.Append("  2. Run `netclaw init` to configure both a provider and model.\n");
+        sb.Append("  3. Or repair `netclaw.json` / `secrets.json` manually and restart the daemon.");
 
         if (availableProviders is { Count: > 0 })
         {

--- a/src/Netclaw.Configuration/NoOpChatClientProvider.cs
+++ b/src/Netclaw.Configuration/NoOpChatClientProvider.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="NoOpChatClientProvider.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// <see cref="IChatClientProvider"/> registered when configuration validation
+/// reports <see cref="ProviderRuntimeStatus.NoProviderConfigured"/>. Returns
+/// the same <see cref="NoOpChatClient"/> instance for every
+/// <see cref="ModelRole"/> and reports <see cref="IsDegraded"/> = true so
+/// doctor and diagnostics can surface the degraded state.
+/// </summary>
+public sealed class NoOpChatClientProvider : IChatClientProvider
+{
+    private readonly NoOpChatClient _client;
+
+    public NoOpChatClientProvider(IReadOnlyList<string>? availableProviders = null)
+    {
+        _client = new NoOpChatClient(availableProviders);
+    }
+
+    public IChatClient GetClient(ModelRole role) => _client;
+
+    public bool IsDegraded => true;
+}

--- a/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
+++ b/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
@@ -64,9 +64,15 @@ public sealed record ProviderRuntimeValidation(
 
         if (!providers.ContainsKey(main.Provider))
         {
+            // Typo / dangling reference: model points at a provider name that
+            // doesn't exist in the providers dict. From the operator's
+            // perspective this is the same remediation as "no provider
+            // configured" (fix the model section), so we select No-Op
+            // instead of failing startup. The available-providers line in
+            // the banner surfaces the mismatch.
             return new(
-                ProviderRuntimeStatus.Invalid,
-                $"model 'Main' references unknown provider '{main.Provider}' (configured: {string.Join(", ", available)})",
+                ProviderRuntimeStatus.NoProviderConfigured,
+                $"model 'Main' references provider '{main.Provider}' which is not configured (available: {string.Join(", ", available)})",
                 available);
         }
 

--- a/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
+++ b/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProviderRuntimeValidation.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Result of evaluating provider+model configuration at host startup.
+/// Tri-state: a valid configuration produces a real chat client; "no provider
+/// configured" produces a No-Op client (degraded but operational); "invalid"
+/// fails startup loudly.
+/// </summary>
+public enum ProviderRuntimeStatus
+{
+    Valid,
+    NoProviderConfigured,
+    Invalid,
+}
+
+/// <summary>
+/// Evaluation outcome for provider+model configuration. The host composition
+/// root branches on <see cref="Status"/> to decide whether to register the
+/// real <see cref="IChatClientProvider"/> or the No-Op fallback.
+/// </summary>
+public sealed record ProviderRuntimeValidation(
+    ProviderRuntimeStatus Status,
+    string? Reason,
+    IReadOnlyList<string> AvailableProviders)
+{
+    public static ProviderRuntimeValidation Evaluate(
+        IReadOnlyDictionary<string, ProviderEntry> providers,
+        ModelSelection models)
+    {
+        var available = providers.Keys.ToList();
+        var main = models.Main;
+        var providersEmpty = providers.Count == 0;
+        var modelMissing = string.IsNullOrWhiteSpace(main.Provider) ||
+                           string.IsNullOrWhiteSpace(main.ModelId);
+
+        if (providersEmpty && modelMissing)
+        {
+            return new(
+                ProviderRuntimeStatus.NoProviderConfigured,
+                "no providers or models configured",
+                available);
+        }
+
+        if (modelMissing)
+        {
+            return new(
+                ProviderRuntimeStatus.NoProviderConfigured,
+                "no model selected (Models:Main missing or incomplete)",
+                available);
+        }
+
+        if (providersEmpty)
+        {
+            return new(
+                ProviderRuntimeStatus.NoProviderConfigured,
+                $"model 'Main' references provider '{main.Provider}' but no providers are configured",
+                available);
+        }
+
+        if (!providers.ContainsKey(main.Provider))
+        {
+            return new(
+                ProviderRuntimeStatus.Invalid,
+                $"model 'Main' references unknown provider '{main.Provider}' (configured: {string.Join(", ", available)})",
+                available);
+        }
+
+        return new(ProviderRuntimeStatus.Valid, null, available);
+    }
+}

--- a/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
+++ b/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
@@ -3,6 +3,9 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
+
 namespace Netclaw.Configuration;
 
 /// <summary>
@@ -30,13 +33,23 @@ public sealed record ProviderRuntimeValidation(
 {
     public static ProviderRuntimeValidation Evaluate(
         IReadOnlyDictionary<string, ProviderEntry> providers,
-        ModelSelection models)
+        ModelSelection models,
+        ProviderRuntimeConfiguration configuration)
     {
         var available = providers.Keys.ToList();
         var main = models.Main;
         var providersEmpty = providers.Count == 0;
-        var modelMissing = string.IsNullOrWhiteSpace(main.Provider) ||
-                           string.IsNullOrWhiteSpace(main.ModelId);
+
+        if (!configuration.Main.RoleConfigured)
+        {
+            return new(
+                ProviderRuntimeStatus.NoProviderConfigured,
+                "no main model configured (Models:Main missing)",
+                available);
+        }
+
+        var modelMissing = ModelReferenceMissing(main) || !configuration.Main.ProviderConfigured ||
+                           !configuration.Main.ModelIdConfigured;
 
         if (providersEmpty && modelMissing)
         {
@@ -54,28 +67,191 @@ public sealed record ProviderRuntimeValidation(
                 available);
         }
 
-        if (providersEmpty)
-        {
-            return new(
-                ProviderRuntimeStatus.NoProviderConfigured,
-                $"model 'Main' references provider '{main.Provider}' but no providers are configured",
-                available);
-        }
+        var invalidMain = ValidateReferencedProvider(
+            nameof(models.Main),
+            main,
+            providers,
+            configuration,
+            missingProviderStatus: ProviderRuntimeStatus.NoProviderConfigured);
+        if (invalidMain is not null)
+            return invalidMain;
 
-        if (!providers.ContainsKey(main.Provider))
-        {
-            // Typo / dangling reference: model points at a provider name that
-            // doesn't exist in the providers dict. From the operator's
-            // perspective this is the same remediation as "no provider
-            // configured" (fix the model section), so we select No-Op
-            // instead of failing startup. The available-providers line in
-            // the banner surfaces the mismatch.
-            return new(
-                ProviderRuntimeStatus.NoProviderConfigured,
-                $"model 'Main' references provider '{main.Provider}' which is not configured (available: {string.Join(", ", available)})",
-                available);
-        }
+        var invalidFallback = ValidateOptionalRole(
+            nameof(models.Fallback),
+            models.Fallback,
+            configuration.Fallback,
+            providers,
+            configuration);
+        if (invalidFallback is not null)
+            return invalidFallback;
+
+        var invalidCompaction = ValidateOptionalRole(
+            nameof(models.Compaction),
+            models.Compaction,
+            configuration.Compaction,
+            providers,
+            configuration);
+        if (invalidCompaction is not null)
+            return invalidCompaction;
 
         return new(ProviderRuntimeStatus.Valid, null, available);
     }
+
+    private static ProviderRuntimeValidation? ValidateOptionalRole(
+        string role,
+        ModelReference? model,
+        ModelReferenceRuntimeConfiguration roleConfiguration,
+        IReadOnlyDictionary<string, ProviderEntry> providers,
+        ProviderRuntimeConfiguration configuration)
+    {
+        if (!roleConfiguration.RoleConfigured)
+            return null;
+
+        if (model is null || ModelReferenceMissing(model) || !roleConfiguration.ProviderConfigured ||
+            !roleConfiguration.ModelIdConfigured)
+        {
+            return new(
+                ProviderRuntimeStatus.Invalid,
+                $"model '{role}' is configured but incomplete (Provider and ModelId are required)",
+                providers.Keys.ToList());
+        }
+
+        return ValidateReferencedProvider(
+            role,
+            model,
+            providers,
+            configuration,
+            missingProviderStatus: ProviderRuntimeStatus.Invalid);
+    }
+
+    private static ProviderRuntimeValidation? ValidateReferencedProvider(
+        string role,
+        ModelReference model,
+        IReadOnlyDictionary<string, ProviderEntry> providers,
+        ProviderRuntimeConfiguration configuration,
+        ProviderRuntimeStatus missingProviderStatus)
+    {
+        var available = providers.Keys.ToList();
+
+        if (providers.Count == 0)
+        {
+            return new(
+                ProviderRuntimeStatus.NoProviderConfigured,
+                $"model '{role}' references provider '{model.Provider}' but no providers are configured",
+                available);
+        }
+
+        if (!providers.TryGetValue(model.Provider, out var provider))
+        {
+            return new(
+                missingProviderStatus,
+                $"model '{role}' references provider '{model.Provider}' which is not configured (available: {string.Join(", ", available)})",
+                available);
+        }
+
+        if (!configuration.HasExplicitProviderType(model.Provider) || string.IsNullOrWhiteSpace(provider.Type))
+        {
+            return new(
+                ProviderRuntimeStatus.Invalid,
+                $"provider '{model.Provider}' referenced by model '{role}' is missing required Type",
+                available);
+        }
+
+        return null;
+    }
+
+    private static bool ModelReferenceMissing(ModelReference model)
+        => string.IsNullOrWhiteSpace(model.Provider) ||
+           string.IsNullOrWhiteSpace(model.ModelId);
+}
+
+/// <summary>
+/// Raw configuration presence data needed before bound defaults are applied.
+/// </summary>
+public sealed record ProviderRuntimeConfiguration(
+    ModelReferenceRuntimeConfiguration Main,
+    ModelReferenceRuntimeConfiguration Fallback,
+    ModelReferenceRuntimeConfiguration Compaction,
+    IReadOnlyCollection<string> ProvidersWithExplicitType)
+{
+    public bool HasExplicitProviderType(string providerName) =>
+        ProvidersWithExplicitType.Contains(providerName, StringComparer.OrdinalIgnoreCase);
+
+    public static ProviderRuntimeConfiguration FromConfiguration(IConfiguration configuration)
+    {
+        var models = configuration.GetSection("Models");
+        var providers = configuration.GetSection("Providers");
+
+        return new ProviderRuntimeConfiguration(
+            Main: ModelReferenceRuntimeConfiguration.FromConfiguration(models.GetSection("Main")),
+            Fallback: ModelReferenceRuntimeConfiguration.FromConfiguration(models.GetSection("Fallback")),
+            Compaction: ModelReferenceRuntimeConfiguration.FromConfiguration(models.GetSection("Compaction")),
+            ProvidersWithExplicitType: providers.GetChildren()
+                .Where(provider => provider.GetSection(nameof(ProviderEntry.Type)).Exists())
+                .Select(provider => provider.Key)
+                .ToList());
+    }
+
+    public static ProviderRuntimeConfiguration FromJson(JsonObject? root)
+    {
+        var models = root?["Models"] as JsonObject;
+        var providers = root?["Providers"] as JsonObject;
+
+        return new ProviderRuntimeConfiguration(
+            Main: ModelReferenceRuntimeConfiguration.FromJson(models?["Main"] as JsonObject),
+            Fallback: ModelReferenceRuntimeConfiguration.FromJson(models?["Fallback"] as JsonObject),
+            Compaction: ModelReferenceRuntimeConfiguration.FromJson(models?["Compaction"] as JsonObject),
+            ProvidersWithExplicitType: providers is null
+                ? []
+                : providers
+                    .Where(provider => provider.Value is JsonObject obj && HasProperty(obj, nameof(ProviderEntry.Type)))
+                    .Select(provider => provider.Key)
+                    .ToList());
+    }
+
+    public static ProviderRuntimeConfiguration FromExplicitRoles(
+        IReadOnlyDictionary<string, ProviderEntry> providers,
+        bool main,
+        bool fallback,
+        bool compaction)
+    {
+        return new ProviderRuntimeConfiguration(
+            ModelReferenceRuntimeConfiguration.FromCompleteRole(main),
+            ModelReferenceRuntimeConfiguration.FromCompleteRole(fallback),
+            ModelReferenceRuntimeConfiguration.FromCompleteRole(compaction),
+            providers
+                .Where(provider => !string.IsNullOrWhiteSpace(provider.Value.Type))
+                .Select(provider => provider.Key)
+                .ToList());
+    }
+
+    internal static bool HasProperty(JsonObject obj, string propertyName) =>
+        obj.Any(property => string.Equals(property.Key, propertyName, StringComparison.OrdinalIgnoreCase));
+}
+
+public sealed record ModelReferenceRuntimeConfiguration(
+    bool RoleConfigured,
+    bool ProviderConfigured,
+    bool ModelIdConfigured)
+{
+    public static ModelReferenceRuntimeConfiguration FromConfiguration(IConfigurationSection section)
+    {
+        return new ModelReferenceRuntimeConfiguration(
+            RoleConfigured: section.Exists(),
+            ProviderConfigured: section.GetSection(nameof(ModelReference.Provider)).Exists(),
+            ModelIdConfigured: section.GetSection(nameof(ModelReference.ModelId)).Exists());
+    }
+
+    public static ModelReferenceRuntimeConfiguration FromJson(JsonObject? obj)
+    {
+        return new ModelReferenceRuntimeConfiguration(
+            RoleConfigured: obj is not null,
+            ProviderConfigured: obj is not null && ProviderRuntimeConfiguration.HasProperty(obj, nameof(ModelReference.Provider)),
+            ModelIdConfigured: obj is not null && ProviderRuntimeConfiguration.HasProperty(obj, nameof(ModelReference.ModelId)));
+    }
+
+    public static ModelReferenceRuntimeConfiguration FromCompleteRole(bool configured) =>
+        configured
+            ? new ModelReferenceRuntimeConfiguration(true, true, true)
+            : new ModelReferenceRuntimeConfiguration(false, false, false);
 }

--- a/src/Netclaw.Daemon.Tests/Configuration/DaemonProviderServiceExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/DaemonProviderServiceExtensionsTests.cs
@@ -1,0 +1,83 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonProviderServiceExtensionsTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Configuration;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class DaemonProviderServiceExtensionsTests
+{
+    [Fact]
+    public void NoProviderConfigured_RegistersNoOpChatClientProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+
+        var providers = new Dictionary<string, ProviderEntry>();
+        var models = new ModelSelection();
+        var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+
+        Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
+
+        services.AddDaemonLlmProviders(providers, models, validation);
+
+        using var sp = services.BuildServiceProvider();
+        var chatProvider = sp.GetRequiredService<IChatClientProvider>();
+
+        Assert.IsType<NoOpChatClientProvider>(chatProvider);
+        Assert.True(chatProvider.IsDegraded);
+    }
+
+    [Fact]
+    public void NoProviderConfigured_DoesNotRegisterRealPluginFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection());
+
+        services.AddDaemonLlmProviders(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection(),
+            validation);
+
+        using var sp = services.BuildServiceProvider();
+
+        // ProviderPluginFactory is only registered on the valid path.
+        Assert.Null(sp.GetService<ProviderPluginFactory>());
+    }
+
+    [Fact]
+    public async Task NoOpProvider_ResponseStartsWithFixedBanner()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection());
+
+        services.AddDaemonLlmProviders(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection(),
+            validation);
+
+        using var sp = services.BuildServiceProvider();
+        var client = sp.GetRequiredService<IChatClientProvider>().GetClient(ModelRole.Main);
+
+        var response = await client.GetResponseAsync(
+            new[] { new Microsoft.Extensions.AI.ChatMessage(Microsoft.Extensions.AI.ChatRole.User, "hi") },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.StartsWith(NoOpChatClient.LeadingPhrase, response.Text);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Configuration/DaemonProviderServiceExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/DaemonProviderServiceExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
+using Netclaw.Providers;
 using Xunit;
 
 namespace Netclaw.Daemon.Tests.Configuration;
@@ -22,7 +23,10 @@ public sealed class DaemonProviderServiceExtensionsTests
 
         var providers = new Dictionary<string, ProviderEntry>();
         var models = new ModelSelection();
-        var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            models,
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: false, fallback: false, compaction: false));
 
         Assert.Equal(ProviderRuntimeStatus.NoProviderConfigured, validation.Status);
 
@@ -43,7 +47,9 @@ public sealed class DaemonProviderServiceExtensionsTests
 
         var validation = ProviderRuntimeValidation.Evaluate(
             new Dictionary<string, ProviderEntry>(),
-            new ModelSelection());
+            new ModelSelection(),
+            ProviderRuntimeConfiguration.FromExplicitRoles(
+                new Dictionary<string, ProviderEntry>(), main: false, fallback: false, compaction: false));
 
         services.AddDaemonLlmProviders(
             new Dictionary<string, ProviderEntry>(),
@@ -54,6 +60,32 @@ public sealed class DaemonProviderServiceExtensionsTests
 
         // ProviderPluginFactory is only registered on the valid path.
         Assert.Null(sp.GetService<ProviderPluginFactory>());
+    }
+
+    [Fact]
+    public void NoProviderConfigured_KeepsProviderDescriptorsAvailableForRecovery()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(new NetclawPaths(Path.Combine(
+            Path.GetTempPath(),
+            $"netclaw-provider-tests-{Guid.NewGuid():N}")));
+
+        var validation = ProviderRuntimeValidation.Evaluate(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection(),
+            ProviderRuntimeConfiguration.FromExplicitRoles(
+                new Dictionary<string, ProviderEntry>(), main: false, fallback: false, compaction: false));
+
+        services.AddDaemonLlmProviders(
+            new Dictionary<string, ProviderEntry>(),
+            new ModelSelection(),
+            validation);
+
+        using var sp = services.BuildServiceProvider();
+
+        var registry = sp.GetRequiredService<ProviderDescriptorRegistry>();
+        Assert.Contains("openrouter", registry.KnownTypeKeys);
     }
 
     [Fact]
@@ -75,7 +107,10 @@ public sealed class DaemonProviderServiceExtensionsTests
         {
             Main = new ModelReference { Provider = "ollama-local1", ModelId = "qwen3:30b" },
         };
-        var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+        var validation = ProviderRuntimeValidation.Evaluate(
+            providers,
+            models,
+            ProviderRuntimeConfiguration.FromExplicitRoles(providers, main: true, fallback: false, compaction: false));
 
         services.AddDaemonLlmProviders(providers, models, validation);
 
@@ -95,7 +130,9 @@ public sealed class DaemonProviderServiceExtensionsTests
 
         var validation = ProviderRuntimeValidation.Evaluate(
             new Dictionary<string, ProviderEntry>(),
-            new ModelSelection());
+            new ModelSelection(),
+            ProviderRuntimeConfiguration.FromExplicitRoles(
+                new Dictionary<string, ProviderEntry>(), main: false, fallback: false, compaction: false));
 
         services.AddDaemonLlmProviders(
             new Dictionary<string, ProviderEntry>(),

--- a/src/Netclaw.Daemon.Tests/Configuration/DaemonProviderServiceExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/DaemonProviderServiceExtensionsTests.cs
@@ -57,6 +57,37 @@ public sealed class DaemonProviderServiceExtensionsTests
     }
 
     [Fact]
+    public void UnknownProviderReference_RegistersNoOpInsteadOfCrashing()
+    {
+        // Regression for the operator typo scenario (Models:Main.Provider
+        // "ollama-local1" vs configured "ollama-local") that previously
+        // crashed the daemon with a raw ProviderPluginFactory stack trace.
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+
+        var providers = new Dictionary<string, ProviderEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["github-copilot"] = new ProviderEntry { Type = "github-copilot" },
+            ["my-openrouter"] = new ProviderEntry { Type = "openrouter" },
+            ["ollama-local"] = new ProviderEntry { Type = "ollama" },
+        };
+        var models = new ModelSelection
+        {
+            Main = new ModelReference { Provider = "ollama-local1", ModelId = "qwen3:30b" },
+        };
+        var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+
+        services.AddDaemonLlmProviders(providers, models, validation);
+
+        using var sp = services.BuildServiceProvider();
+
+        // Must not throw — degraded startup is the contract.
+        var chatProvider = sp.GetRequiredService<IChatClientProvider>();
+        Assert.IsType<NoOpChatClientProvider>(chatProvider);
+        Assert.True(chatProvider.IsDegraded);
+    }
+
+    [Fact]
     public async Task NoOpProvider_ResponseStartsWithFixedBanner()
     {
         var services = new ServiceCollection();

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net;
+using Microsoft.Extensions.AI;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -51,7 +52,9 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         DaemonConfig? daemonConfig = null,
         NetclawPaths? paths = null,
         McpClientManager? mcpClientManager = null,
-        SQLiteMemoryStore? sqliteMemoryStore = null)
+        SQLiteMemoryStore? sqliteMemoryStore = null,
+        IChatClientProvider? chatClientProvider = null,
+        ProviderRuntimeValidation? providerValidation = null)
     {
         return new DaemonRuntimeStatusService(
             new DaemonStartClock(TimeProvider.System),
@@ -63,6 +66,8 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             modelSelection ?? DefaultModelSelection,
             daemonConfig ?? new DaemonConfig(),
             paths ?? CreatePaths(),
+            chatClientProvider ?? new TestChatClientProvider(),
+            providerValidation ?? new ProviderRuntimeValidation(ProviderRuntimeStatus.Valid, null, []),
             mcpClientManager,
             sqliteMemoryStore);
     }
@@ -145,18 +150,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             "model 'Main' references provider 'ollama-local1' which is not configured (available: ollama-local)",
             new[] { "ollama-local" });
 
-        var service = new DaemonRuntimeStatusService(
-            new DaemonStartClock(TimeProvider.System),
-            TimeProvider.System,
-            channels: Array.Empty<IChannel>(),
-            slackOptions: new SlackChannelOptions { Enabled = false },
-            discordOptions: new DiscordChannelOptions { Enabled = false },
-            persistenceOptions: new DaemonPersistenceOptions(),
-            telemetryOptions: Options.Create(new TelemetryOptions()),
-            modelCapabilities: DefaultModelCapabilities,
-            modelSelection: DefaultModelSelection,
-            daemonConfig: new DaemonConfig(),
-            paths: CreatePaths(),
+        var service = CreateService(
             chatClientProvider: noOpProvider,
             providerValidation: validation);
 
@@ -415,5 +409,10 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class TestChatClientProvider : IChatClientProvider
+    {
+        public IChatClient GetClient(ModelRole role) => throw new NotSupportedException();
     }
 }

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -151,6 +151,17 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             new[] { "ollama-local" });
 
         var service = CreateService(
+            modelCapabilities: new ModelCapabilities
+            {
+                ModelId = "qwen3:30b",
+                InputModalities = ModelModality.Text,
+                OutputModalities = ModelModality.Text,
+                ContextWindowTokens = 32_768
+            },
+            modelSelection: new ModelSelection
+            {
+                Main = new ModelReference { Provider = "local-ollama", ModelId = "qwen3:30b" }
+            },
             chatClientProvider: noOpProvider,
             providerValidation: validation);
 
@@ -158,6 +169,10 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
 
         Assert.NotNull(status.Model);
         Assert.True(status.Model.Degraded);
+        Assert.Equal("", status.Model.ModelId);
+        Assert.Equal("", status.Model.Provider);
+        Assert.Equal(0, status.Model.ContextWindow);
+        Assert.Null(status.Model.DisplayName);
         Assert.Contains("ollama-local1", status.Model.DegradedReason);
         Assert.Equal("degraded", status.Overall);
     }

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -137,6 +137,38 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DegradedChatClient_FlagsModelAsDegradedAndOverallAsDegraded()
+    {
+        var noOpProvider = new NoOpChatClientProvider(new[] { "github-copilot", "my-openrouter" });
+        var validation = new ProviderRuntimeValidation(
+            ProviderRuntimeStatus.NoProviderConfigured,
+            "model 'Main' references provider 'ollama-local1' which is not configured (available: ollama-local)",
+            new[] { "ollama-local" });
+
+        var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
+            TimeProvider.System,
+            channels: Array.Empty<IChannel>(),
+            slackOptions: new SlackChannelOptions { Enabled = false },
+            discordOptions: new DiscordChannelOptions { Enabled = false },
+            persistenceOptions: new DaemonPersistenceOptions(),
+            telemetryOptions: Options.Create(new TelemetryOptions()),
+            modelCapabilities: DefaultModelCapabilities,
+            modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig(),
+            paths: CreatePaths(),
+            chatClientProvider: noOpProvider,
+            providerValidation: validation);
+
+        var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(status.Model);
+        Assert.True(status.Model.Degraded);
+        Assert.Contains("ollama-local1", status.Model.DegradedReason);
+        Assert.Equal("degraded", status.Overall);
+    }
+
+    [Fact]
     public async Task IncludesSlackConnectorAsDisabled_WhenNotEnabled()
     {
         var service = CreateService(channelRegistry: CreateRegistry([

--- a/src/Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs
@@ -45,6 +45,20 @@ public static class DaemonProviderServiceExtensions
             return services;
         }
 
+        if (validation.Status == ProviderRuntimeStatus.Invalid)
+        {
+            // Fail loudly with the validation reason rather than letting the
+            // provider plugin factory throw a raw "Provider 'X' not found"
+            // deep in the DI graph. The exception fires when
+            // IChatClientProvider is first resolved so it surfaces during the
+            // host's startup sequence, not at config-binding time.
+            services.AddSingleton<IChatClientProvider>(_ =>
+                throw new InvalidOperationException(
+                    $"Invalid inference configuration: {validation.Reason}. " +
+                    "Fix the issue in `netclaw.json` and restart the daemon. Run `netclaw doctor` for details."));
+            return services;
+        }
+
         // Register plugins and OAuth from Netclaw.Providers
         services.AddLlmProviders();
 

--- a/src/Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="DaemonProviderServiceExtensions.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -19,14 +19,32 @@ public static class DaemonProviderServiceExtensions
 {
     /// <summary>
     /// Registers provider plugins (via Netclaw.Providers) plus the daemon-specific
-    /// plugin factory, retry policy, pipeline composition, and routing.
+    /// plugin factory, retry policy, pipeline composition, and routing. When
+    /// <paramref name="validation"/> reports
+    /// <see cref="ProviderRuntimeStatus.NoProviderConfigured"/>, the No-Op chat
+    /// client provider is registered instead so the host starts in degraded mode.
     /// </summary>
     public static IServiceCollection AddDaemonLlmProviders(
         this IServiceCollection services,
         Dictionary<string, ProviderEntry> providers,
         ModelSelection models,
+        ProviderRuntimeValidation validation,
         RetryPolicy? retryPolicy = null)
     {
+        if (validation.Status == ProviderRuntimeStatus.NoProviderConfigured)
+        {
+            services.AddSingleton<IChatClientProvider>(sp =>
+            {
+                var logger = sp.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("Netclaw.ChatClient");
+                logger.LogWarning(
+                    "No valid inference provider configured ({Reason}). Registering No-Op chat client. Run `netclaw doctor` for details.",
+                    validation.Reason);
+                return new NoOpChatClientProvider(validation.AvailableProviders);
+            });
+            return services;
+        }
+
         // Register plugins and OAuth from Netclaw.Providers
         services.AddLlmProviders();
 

--- a/src/Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonProviderServiceExtensions.cs
@@ -31,6 +31,10 @@ public static class DaemonProviderServiceExtensions
         ProviderRuntimeValidation validation,
         RetryPolicy? retryPolicy = null)
     {
+        // Register descriptors/OAuth endpoints even in degraded mode so operators
+        // can recover through provider/model setup flows without restarting first.
+        services.AddLlmProviders();
+
         if (validation.Status == ProviderRuntimeStatus.NoProviderConfigured)
         {
             services.AddSingleton<IChatClientProvider>(sp =>
@@ -58,9 +62,6 @@ public static class DaemonProviderServiceExtensions
                     "Fix the issue in `netclaw.json` and restart the daemon. Run `netclaw doctor` for details."));
             return services;
         }
-
-        // Register plugins and OAuth from Netclaw.Providers
-        services.AddLlmProviders();
 
         // Raw provider client factory (raw client + vendor options per model)
         services.AddSingleton(sp =>

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -34,7 +34,9 @@ internal sealed class DaemonRuntimeStatusService(
     NetclawPaths paths,
     McpClientManager? mcpClientManager = null,
     SQLiteMemoryStore? sqliteMemoryStore = null,
-    IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null)
+    IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null,
+    IChatClientProvider? chatClientProvider = null,
+    ProviderRuntimeValidation? providerValidation = null)
 {
     public async Task<DaemonRuntimeStatus.Response> GetStatusAsync(CancellationToken cancellationToken = default)
     {
@@ -46,7 +48,8 @@ internal sealed class DaemonRuntimeStatusService(
 
         connectors.AddRange(BuildMcpStatuses());
 
-        var overall = ResolveOverallStatus(connectors);
+        var degraded = chatClientProvider?.IsDegraded ?? false;
+        var overall = ResolveOverallStatus(connectors, degraded);
 
         return new DaemonRuntimeStatus.Response
         {
@@ -76,7 +79,9 @@ internal sealed class DaemonRuntimeStatusService(
                 Provider = modelSelection.Main.Provider,
                 InputModalities = modelCapabilities.InputModalities.ToString(),
                 OutputModalities = modelCapabilities.OutputModalities.ToString(),
-                ContextWindow = modelCapabilities.ContextWindowTokens
+                ContextWindow = modelCapabilities.ContextWindowTokens,
+                Degraded = degraded,
+                DegradedReason = degraded ? providerValidation?.Reason : null,
             },
             Update = BuildUpdateStatus(),
             Memory = await BuildMemoryStatusAsync(cancellationToken),
@@ -324,8 +329,16 @@ internal sealed class DaemonRuntimeStatusService(
         }
     }
 
-    internal static string ResolveOverallStatus(IReadOnlyList<DaemonRuntimeStatus.Connector> connectors)
+    internal static string ResolveOverallStatus(
+        IReadOnlyList<DaemonRuntimeStatus.Connector> connectors,
+        bool chatClientDegraded = false)
     {
+        // A No-Op chat client means the daemon can't actually serve model
+        // responses — surface that at the top level rather than reporting
+        // "healthy" while every chat turn returns the configuration banner.
+        if (chatClientDegraded)
+            return "degraded";
+
         if (connectors.Any(c => c.Enabled && c.Status is "disconnected" or "auth-failed" or "auth-required"))
             return "degraded";
 

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -32,11 +32,11 @@ internal sealed class DaemonRuntimeStatusService(
     ModelSelection modelSelection,
     DaemonConfig daemonConfig,
     NetclawPaths paths,
+    IChatClientProvider chatClientProvider,
+    ProviderRuntimeValidation providerValidation,
     McpClientManager? mcpClientManager = null,
     SQLiteMemoryStore? sqliteMemoryStore = null,
-    IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null,
-    IChatClientProvider? chatClientProvider = null,
-    ProviderRuntimeValidation? providerValidation = null)
+    IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null)
 {
     public async Task<DaemonRuntimeStatus.Response> GetStatusAsync(CancellationToken cancellationToken = default)
     {
@@ -48,7 +48,7 @@ internal sealed class DaemonRuntimeStatusService(
 
         connectors.AddRange(BuildMcpStatuses());
 
-        var degraded = chatClientProvider?.IsDegraded ?? false;
+        var degraded = chatClientProvider.IsDegraded;
         var overall = ResolveOverallStatus(connectors, degraded);
 
         return new DaemonRuntimeStatus.Response

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -74,12 +74,12 @@ internal sealed class DaemonRuntimeStatusService(
             Telemetry = BuildTelemetry(),
             Model = new DaemonRuntimeStatus.Model
             {
-                ModelId = modelCapabilities.ModelId,
-                DisplayName = ModelIdNormalizer.GetDisplayName(modelCapabilities.ModelId),
-                Provider = modelSelection.Main.Provider,
-                InputModalities = modelCapabilities.InputModalities.ToString(),
-                OutputModalities = modelCapabilities.OutputModalities.ToString(),
-                ContextWindow = modelCapabilities.ContextWindowTokens,
+                ModelId = degraded ? string.Empty : modelCapabilities.ModelId,
+                DisplayName = degraded ? null : ModelIdNormalizer.GetDisplayName(modelCapabilities.ModelId),
+                Provider = degraded ? string.Empty : modelSelection.Main.Provider,
+                InputModalities = degraded ? string.Empty : modelCapabilities.InputModalities.ToString(),
+                OutputModalities = degraded ? string.Empty : modelCapabilities.OutputModalities.ToString(),
+                ContextWindow = degraded ? 0 : modelCapabilities.ContextWindowTokens,
                 Degraded = degraded,
                 DegradedReason = degraded ? providerValidation?.Reason : null,
             },

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -362,7 +362,10 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
     var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
     var models = configuration.GetSection("Models")
         .Get<ModelSelection>() ?? new ModelSelection();
-    var validation = ProviderRuntimeValidation.Evaluate(providers, models);
+    var validation = ProviderRuntimeValidation.Evaluate(
+        providers,
+        models,
+        ProviderRuntimeConfiguration.FromConfiguration(configuration));
 
     // The transport RetryingChatClient is the single owner of LLM transient-failure
     // retry, so it uses the configured streaming-retry budget.

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -356,12 +356,13 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
     // TimeProvider (virtualized for testing)
     services.AddSingleton(TimeProvider.System);
 
-    // Providers and model resolution via plugin architecture
+    // Providers and model resolution via plugin architecture.
+    // No silent fallback to local-ollama: an empty Providers section yields
+    // the NoProviderConfigured outcome and the host registers NoOpChatClientProvider.
     var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
-    if (providers.Count == 0)
-        providers = new() { ["local-ollama"] = new ProviderEntry() };
     var models = configuration.GetSection("Models")
         .Get<ModelSelection>() ?? new ModelSelection();
+    var validation = ProviderRuntimeValidation.Evaluate(providers, models);
 
     // The transport RetryingChatClient is the single owner of LLM transient-failure
     // retry, so it uses the configured streaming-retry budget.
@@ -369,7 +370,8 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
         .BindFromConfiguration(configuration.GetSection("Session"))
         .Tuning.StreamingRetryPolicy;
 
-    services.AddDaemonLlmProviders(providers, models, streamingRetryPolicy);
+    services.AddSingleton(validation);
+    services.AddDaemonLlmProviders(providers, models, validation, streamingRetryPolicy);
 
     return paths;
 }
@@ -423,9 +425,10 @@ static void ConfigureDaemonServices(
     // / LoggerFactory needed, and per-resolver Debug output is visible. The
     // factory is invoked eagerly after Build() (see RunDaemonAsync) so timing
     // matches a startup-bound resolution rather than first-session lazy hit.
+    // Capability resolution runs against the loaded providers as-is — if
+    // no providers are configured we never reach a real plugin, the No-Op
+    // client supersedes, and capabilities default to text-only below.
     var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
-    if (providers.Count == 0)
-        providers = new() { ["local-ollama"] = new ProviderEntry() };
     var mainProviderType = providers.TryGetValue(models.Main.Provider, out var mainProvider)
         ? mainProvider.Type
         : null;
@@ -445,9 +448,19 @@ static void ConfigureDaemonServices(
 
     services.AddSingleton<ModelCapabilities>(sp =>
     {
-        var resolver = sp.GetRequiredService<IModelCapabilityResolver>();
         var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("Netclaw.Startup");
 
+        // In degraded mode (No-Op chat client) we never talk to a real model;
+        // skip capability detection (which may do network I/O) and use defaults.
+        var chatProvider = sp.GetRequiredService<IChatClientProvider>();
+        if (chatProvider.IsDegraded)
+        {
+            logger.LogInformation(
+                "No-Op chat client active; skipping model capability detection and using text-only defaults.");
+            return ModelCapabilityResolution.ResolveModelCapabilities(models, detected: null);
+        }
+
+        var resolver = sp.GetRequiredService<IModelCapabilityResolver>();
         var detected = resolver.ResolveAsync(models.Main.ModelId, CancellationToken.None)
             .GetAwaiter().GetResult();
         var resolved = ModelCapabilityResolution.ResolveModelCapabilities(models, detected, logger: logger);

--- a/tests/smoke/tapes/screenshots/wizard-screens.tape
+++ b/tests/smoke/tapes/screenshots/wizard-screens.tape
@@ -56,8 +56,8 @@ Enter
 # Connection probe + model discovery. The "Connected! Found N models"
 # success frame auto-advances; wait directly on the model list header.
 Wait+Screen@45s /Select a model/
-# Models are alphabetical: all-minilm first, qwen2 second.
-Down
+# Embedding-only models are filtered from the chat picker, so qwen2 is the
+# default highlighted model. Accept it directly.
 Enter
 
 # ─── Identity (navigated through, not screenshotted) ─────────────────


### PR DESCRIPTION
## Summary

This PR supersedes #1214 and carries forward its No-Op chat client degraded-startup work on top of the current `dev` branch.

PR #1214 introduced a degraded startup path for missing or typoed provider configuration. During review, we found one remaining gap: bound object defaults such as `local-ollama/qwen3:30b` could still make a fresh or partially configured install look intentionally configured. This replacement PR makes explicit operator configuration the source of truth.

## What changed

- Rebased the PR #1214 work onto current `upstream/dev`.
- Added raw configuration-presence tracking via `ProviderRuntimeConfiguration` so bound defaults do not count as explicit model configuration.
- Treat missing `Models:Main`, incomplete `Models:Main`, no providers, and typoed `Models:Main:Provider` as degraded `NoProviderConfigured` state.
- Preserve fatal startup behavior for malformed explicit config, including missing provider `Type`, incomplete explicit `Fallback` / `Compaction`, and optional roles that reference unknown providers.
- Keep provider descriptors and OAuth setup services registered in degraded mode so operators can recover through `netclaw model` / provider setup flows without a missing service graph.
- Surface degraded model status consistently in daemon status and CLI status-bar model capability resolution.
- Prevent warn-level wizard health checks from counting as a clean pass so setup does not auto-launch chat when the No-Op client is active.
- Updated PRDs and the `netclaw-operations` provider guidance to document the degraded-vs-invalid split.

## Relationship to #1214

This branch is intended to replace #1214 rather than stack on it. It includes the original degraded No-Op client work plus the explicit-model-configuration follow-up fixes and additional regression coverage. #1214 should be closed in favor of this PR.

close #1214

## Validation

- `dotnet test Netclaw.slnx`
- `openspec validate add-noop-chat-client-fallback --strict`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `./scripts/smoke/run-smoke.sh init-wizard`
- `git diff --check upstream/dev..HEAD`
