### PR TITLE
fix: pin Microsoft.OpenApi to 2.7.5 to avoid CVE-2026-49451

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,8 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreVersion)" />
+    <!-- Pin to patched version to avoid CVE-2026-49451 (stack overflow on circular schema refs) -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />


### PR DESCRIPTION
## Problem

The `linux-x64` publish job was failing during restore with:

```
error NU1903: Package 'Microsoft.OpenApi' 2.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-v5pm-xwqc-g5wc
```

`Microsoft.OpenApi` 2.0.0 is pulled in transitively by `Microsoft.AspNetCore.OpenApi` 10.0.9. The vulnerable version is affected by **CVE-2026-49451** — a stack overflow (DoS) when parsing OpenAPI documents with circular schema references.

## Fix

Add a central package version pin for `Microsoft.OpenApi` at **2.7.5** (the first patched version in the 2.x line). Since `CentralPackageTransitivePinningEnabled` is already `true` in `Directory.Packages.props`, this forces the transitive dependency to the safe version without changing any direct references.

## Testing

CI should pass — this is a pure dependency pin with no code changes.