### PR TITLE
Bump Termina to 0.15.0 stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.15.0-beta1" />
+    <PackageVersion Include="Termina" Version="0.15.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>


### PR DESCRIPTION
Upgrade Termina from `0.15.0-beta1` to `0.15.0` stable release.

**Changes:**
- Updated `Directory.Packages.props` to use Termina 0.15.0
- Build verified — 0 warnings, 0 errors