### PR TITLE
fix(smoke): eliminate mcp-permissions screenshot race with deterministic MCP readiness poll

### DIFF
--- a/scripts/smoke/run-smoke.sh
+++ b/scripts/smoke/run-smoke.sh
@@ -432,26 +432,53 @@ frame_needs_retry() {
 }
 
 # run_shot_tape_with_retry <tape> — run a capture tape, then inspect the frames
-# it emits. If any is a transient blank (SHOT_BLANK_RETRIES), re-run the whole
-# tape so the next attempt captures a settled frame. Bounded so a genuinely
-# broken tape still fails at compare time instead of looping forever.
+# it emits. If any is a transient blank or missing (SHOT_BLANK_RETRIES), re-run
+# the whole tape so the next attempt captures a settled frame. Bounded so a
+# genuinely broken tape still fails at compare time instead of looping forever.
+#
+# Two transient shapes are retried:
+#   * blank / partial frame — VHS sampled between a Termina [2J clear and
+#     repaint (frame_needs_retry).
+#   * missing capture — the tape timed out (e.g. a Wait+Screen anchor fired
+#     too early) before reaching the Screenshot command. frame_needs_retry
+#     returns false for missing files, so we handle this case explicitly.
+#
+# In both cases the tape-level failure added by run_shot_tape to failed[] is
+# rolled back before the retry so that a clean retry does not count as a run
+# failure. If all SHOT_BLANK_RETRIES attempts produce a bad frame, the last
+# tape-level failure is left in place for compare_shot_frame to report on.
 run_shot_tape_with_retry() {
   local tape="$1"
   local frames
   frames="$(shot_tape_frames "$tape")"
   local attempt=1
   while :; do
+    local failed_before=${#failed[@]}
     run_shot_tape "$tape"
     [[ -z "$frames" ]] && return          # no frame map → accept the single run
 
     local bad="" f
     for f in $frames; do
+      # A missing capture means the tape timed out before reaching Screenshot.
+      # Treat it the same as a blank/partial frame: retry if budget remains.
+      if [[ ! -f "/tmp/shot-${f}.png" ]]; then
+        bad="${f} (missing — tape timed out)"
+        break
+      fi
       if frame_needs_retry "$f"; then
         bad="$f"
         break
       fi
     done
-    [[ -z "$bad" ]] && return              # all frames settled → done
+
+    if [[ -z "$bad" ]]; then
+      # All captures present and settled. Remove any tape-level failure that
+      # run_shot_tape added for this attempt — a clean retry is not a failure.
+      if (( ${#failed[@]} > failed_before )); then
+        failed=("${failed[@]:0:$failed_before}")
+      fi
+      return
+    fi
 
     if (( attempt >= SHOT_BLANK_RETRIES )); then
       echo "  WARN: ${tape} produced a transient frame (${bad}) on all ${attempt} attempts;" >&2
@@ -460,6 +487,10 @@ run_shot_tape_with_retry() {
     fi
     echo "  RETRY: ${tape} attempt ${attempt} produced a transient frame (${bad}) —" >&2
     echo "         re-running tape (blank or partial Termina full-refresh capture)." >&2
+    # Roll back the tape-level failure before the next attempt.
+    if (( ${#failed[@]} > failed_before )); then
+      failed=("${failed[@]:0:$failed_before}")
+    fi
     attempt=$((attempt + 1))
     for f in $frames; do rm -f "/tmp/shot-${f}.png"; done   # clear stale captures
   done

--- a/tests/smoke/tapes/screenshots/mcp-permissions.tape
+++ b/tests/smoke/tapes/screenshots/mcp-permissions.tape
@@ -66,27 +66,36 @@ Enter
 # smoke-math should appear as "Connected, 3 tools".
 Wait+Screen@15s /smoke-math/
 Wait+Screen@5s /3 tools/
+# Sleep 3s: let the server-list frame fully settle before capturing. The
+# first match of 'smoke-math'/'3 tools' can be a transient render; the
+# daemon may push a state update (re-index, status refresh) immediately
+# after the initial display. The sleep absorbs that window.
+Sleep 3s
 Screenshot "/tmp/shot-mcp-permissions-server-list.png"
 
 # ─── Navigate into the ToolGrid ──────────────────────────────────────
-# Sleep 2s here is an intentional settle guard: the daemon can push a
-# server-state update (tool re-index, reconnect) immediately after the
-# server-list frame stabilises. Navigating into the tool grid during such
-# an update causes Enter to hit the TUI mid-transition, producing a blank
-# screen rather than the tool grid. The sleep lets any in-flight update
-# complete before Enter is delivered. 2s (was 1s) provides more headroom
-# under CI load where daemon indexing can lag.
-Sleep 2s
+# Re-anchor immediately before Enter: confirm smoke-math is STILL Connected
+# after the settle sleep. If the daemon pushed a state update during the
+# sleep (periodic re-index / reconnect), these waits will hold until the
+# server list is stable again. Without this double-anchor the Enter can
+# land on an empty server list (daemon cleared it mid-transition), causing
+# the TUI to navigate to a blank or non-existent tool grid.
+Wait+Screen@20s /smoke-math/
+Wait+Screen@10s /3 tools/
+# Sleep 5s: extended settle guard (was 2s). Daemon MCP state updates can
+# arrive at any point; 5s provides substantially more headroom under CI
+# load where the re-index cycle can be slow.
+Sleep 5s
 Enter
 
 # ─── Frame 2: ToolGrid ───────────────────────────────────────────────
 # All header rows (Server, Audience, Server enabled, Server default) plus
 # all tool rows (add, echo, record-tasks) must be visible simultaneously.
 # If the #1424 regression reappears, tool rows will overwrite the header.
-# Timeout is 15s to match the server-list anchor; /Server default:/ (with
-# colon) matches the rendered "Server default: [Auto]" line, which is
-# unique to the tool-grid view and absent from the server-list scrollback.
-Wait+Screen@15s /record-tasks/
+# Timeout is 30s (was 15s) to give the tool grid more headroom to load
+# under CI load. /Server default:/ (with colon) matches the rendered
+# "Server default: [Auto]" line, unique to the tool-grid view.
+Wait+Screen@30s /record-tasks/
 Wait+Screen@10s /Server default:/
 # Sleep 500ms: settle guard against a Spectre Console full-refresh repaint
 # racing with VHS Screenshot. The Wait+Screen anchors fire on first match,

--- a/tests/smoke/tapes/screenshots/mcp-permissions.tape
+++ b/tests/smoke/tapes/screenshots/mcp-permissions.tape
@@ -48,8 +48,14 @@ Type "netclaw daemon start"
 Enter
 Wait+Screen@20s /TAPE\$/
 
-# Allow time for the daemon to spawn the stdio MCP process and index tools.
-Sleep 5s
+# Poll until the daemon reports smoke-math as fully connected with 3 tools.
+# Replaces the former fixed Sleep 5s: we wait for the actual CLI signal
+# rather than guessing. `netclaw mcp list` queries the daemon's cached
+# server state; "connected (3 tools)" means the stdio handshake and tool
+# indexing are complete. The Wait+Screen@60s is a safety net for a hard hang.
+Type "until netclaw mcp list 2>/dev/null | grep -q 'connected (3 tools)'; do sleep 2; done"
+Enter
+Wait+Screen@60s /TAPE\$/
 Show
 
 # ─── Launch the TUI ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause**: `mcp-permissions` screenshot tape used a fixed `Sleep 5s` after `netclaw daemon start` before opening the TUI. Under CI load, the stdio MCP spawn + JSON-RPC handshake + tool indexing takes longer, so `Wait+Screen@15s /smoke-math/` timed out and VHS exited before the `Screenshot` commands ran — producing no capture files and an unrecoverable failure.
- **Fix 1 (tape)**: Replace `Sleep 5s` with a CLI polling loop: `until netclaw mcp list 2>/dev/null | grep -q 'connected (3 tools)'; do sleep 2; done`. Waits for the actual daemon signal instead of guessing. A `Wait+Screen@60s` wrapper provides a hard-hang safety net.
- **Fix 2 (harness)**: `run_shot_tape_with_retry` in `run-smoke.sh` had a gap — `frame_needs_retry` returns false for missing files, so a timed-out tape fell through as "all frames settled" with no retry triggered. The retry now also fires on missing captures, and rolls back the tape-level failure from `failed[]` before each retry so a clean re-run does not count as a run failure.

## Test plan

- [ ] Screenshot Regression (Linux) passes on this PR
- [ ] Verify the `mcp-permissions-server-list` and `mcp-permissions-tool-grid` frames both emit and match baseline
- [ ] Verify all other screenshot frames still pass (`help`, `wizard-screens`, `provider-manager`, `config-search`)
- [ ] Confirm no regressions in Native Smoke (Linux / macOS)

Closes #1526