### PR TITLE
test(evals): fix memory recall/checkpoint assertions after log-stream partition (#1472)

### DIFF
--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -986,7 +986,11 @@ assert_skill_no_activation_general_code() {
 
 # Category 3: Memory Pipeline
 assert_memory_recall_active() {
-    daemon_log_contains 'turn_memory_recall.*degraded=False'
+    # The structured turn_memory_recall event (TurnLog/Akka) no longer lands in the file logs
+    # after the log-stream partition (#1472). Assert on the MEL recall-pipeline signals that do:
+    # a completed retrieval (memory_retrieval_final) with no degrade warning.
+    daemon_log_contains 'memory_retrieval_final' \
+        && ! daemon_log_contains 'memory_recall_degraded'
 }
 
 # Per the netclaw-agent-memory spec, durable user preferences are memory documents,
@@ -1006,7 +1010,11 @@ assert_memory_explicit_store() {
 }
 
 assert_memory_checkpoint_enqueue() {
-    daemon_log_contains 'turn_memory_checkpoint_enqueued' \
+    # turn_memory_checkpoint_enqueued (TurnLog/Akka) no longer lands in the file logs after the
+    # log-stream partition (#1472). A turn-complete checkpoint that was enqueued is proven by the
+    # curation worker processing it (MEL, in daemon.log) — whether the fact is later kept or
+    # dropped. Combined with no explicit memory tool call, this verifies automatic enqueue.
+    daemon_log_contains 'Memory checkpoint curation completed.*trigger=turn-complete' \
         && ! stdout_tool_called 'store_memory' \
         && ! stdout_tool_called 'update_memory'
 }


### PR DESCRIPTION
## Problem

The log-stream partition (#1472) moved `TurnLog()` output off the sparse daemon log. Two Memory Pipeline eval assertions grep `daemon.log` for `TurnLog`/Akka events:

- `assert_memory_recall_active` → `turn_memory_recall … degraded=False`
- `assert_memory_checkpoint_enqueue` → `turn_memory_checkpoint_enqueued`

Those events no longer land in `daemon.log` — and they aren't in the per-session audit log either (`logs/signalr-<id>.log` is a *curated* stream: `PROMPT`/`TOOL_CALL`/`USAGE`/`TURN_COMPLETED`, not raw structured lines). So both assertions could never match again and failed **0/5 for correct behavior**, making the Memory Pipeline category read RED regardless of the daemon's actual behavior.

This was surfaced while validating an unrelated memory-id PR against a live vLLM target — the two cases failed while the behavior was demonstrably healthy in the logs.

## Fix

Repoint both assertions to the **MEL memory-pipeline signals that still land in `daemon.log`** — the same logger family `assert_memory_recall_filters` already relies on:

- **`memory_recall_active`**: `memory_retrieval_final` present **and** `memory_recall_degraded` absent → recall completed, not degraded.
- **`memory_checkpoint_enqueue`**: `Memory checkpoint curation completed … trigger=turn-complete` (the turn-complete checkpoint was enqueued and processed, whether the fact is later kept or dropped) **and** no explicit `store_memory`/`update_memory` call.

No production code changes — harness only.

## Validation

Live run against Spark1 (`openai-compatible`, `Qwen3.6-35B-A3B-FP8`), Memory Pipeline category:

| Case | Before | After |
|------|--------|-------|
| `memory_recall_active` | 0/5 | **5/5** |
| `memory_checkpoint_enqueue` | 0/5 | **5/5** |
| `memory_recall_filters` | 5/5 | 5/5 |
| `memory_identity_preference_routing` | 5/5 | 5/5 |
| `memory_explicit_store` | 5/5 | 5/5 |

Category **5/5 GREEN**.

## Follow-up (not in this PR)

`assert_subagent*` still greps `daemon.log` for the `SubAgentActor` completion line (`SubAgent [...] completed (success=...)`). Its routing wasn't confirmed here (the Subagents category wasn't run), so I left it untouched rather than guess — worth verifying separately whether it's also affected by #1472.