### PR TITLE
fix(provider): route GitHub Copilot chat to the token's endpoints.api host (GHE data residency)

### DIFF
--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/ProviderOAuthRefreshingProbeTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/ProviderOAuthRefreshingProbeTests.cs
@@ -117,12 +117,16 @@ public sealed class ProviderOAuthRefreshingProbeTests
                     refresh_token = "refresh-ghe-new",
                     expires_in = 3600,
                 }),
+                // A GHE data-residency token exchange reports the tenant Copilot
+                // host in endpoints.api; the probe must follow it there, not the
+                // public api.githubcopilot.com (issue #1550).
                 "https://ghe.example.com/api/v3/copilot_internal/v2/token" => FakeHttpMessageHandler.JsonResponse(new
                 {
                     token = "copilot-ghe",
                     expires_at = now.AddMinutes(30).ToUnixTimeSeconds(),
+                    endpoints = new { api = "https://api.ghe.example.com" },
                 }),
-                "https://api.githubcopilot.com/models" => new HttpResponseMessage(HttpStatusCode.OK)
+                "https://api.ghe.example.com/models" => new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(
                         """
@@ -155,7 +159,7 @@ public sealed class ProviderOAuthRefreshingProbeTests
         Assert.Equal([
             "https://ghe.example.com/login/oauth/access_token",
             "https://ghe.example.com/api/v3/copilot_internal/v2/token",
-            "https://api.githubcopilot.com/models",
+            "https://api.ghe.example.com/models",
         ], requestUris);
     }
 

--- a/src/Netclaw.Configuration/IProviderProbe.cs
+++ b/src/Netclaw.Configuration/IProviderProbe.cs
@@ -12,7 +12,20 @@ namespace Netclaw.Configuration;
 public sealed record ProviderProbeResult(
     bool Success,
     string? ErrorMessage,
-    IReadOnlyList<DiscoveredModel> Models);
+    IReadOnlyList<DiscoveredModel> Models)
+{
+    /// <summary>
+    /// When <see cref="Success"/> is false, indicates the failure is a
+    /// reachable-server retryable condition (response/request timeout, 5xx, or
+    /// rate limiting) where a retry may succeed. A connection failure (unreachable
+    /// host) and auth/other 4xx errors are NOT transient — they signal a
+    /// configuration problem that needs operator action. Providers use this to
+    /// decide whether a failed model listing may be masked by a curated fallback
+    /// list or must surface as a hard failure. Defaults to false so an
+    /// unclassified failure is never silently masked.
+    /// </summary>
+    public bool Transient { get; init; }
+}
 
 /// <summary>
 /// Probes a provider's model listing API to validate credentials

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotRequestPolicyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotRequestPolicyTests.cs
@@ -25,16 +25,23 @@ public sealed class CopilotRequestPolicyTests
             OAuthAccessToken = new SensitiveString(token),
         };
 
-    private static CopilotTokenExchanger ExchangerReturning(string copilotToken)
+    private static CopilotTokenExchanger ExchangerReturning(string copilotToken, string? apiBase = null)
     {
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(
-                JsonSerializer.Serialize(new
-                {
-                    token = copilotToken,
-                    expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
-                }),
+                JsonSerializer.Serialize(apiBase is null
+                    ? new
+                    {
+                        token = copilotToken,
+                        expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                    }
+                    : (object)new
+                    {
+                        token = copilotToken,
+                        expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                        endpoints = new { api = apiBase },
+                    }),
                 Encoding.UTF8,
                 "application/json"),
         });
@@ -45,7 +52,8 @@ public sealed class CopilotRequestPolicyTests
     public async Task ProcessAsync_AppliesThreeCopilotHeaders()
     {
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-bearer"), OAuthEntry(), new ApiKeyCredential("placeholder"));
+            ExchangerReturning("copilot-bearer"), OAuthEntry(), new ApiKeyCredential("placeholder"),
+            followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();
@@ -84,7 +92,7 @@ public sealed class CopilotRequestPolicyTests
         // end-to-end in GitHubCopilotProviderPluginTests).
         var credential = new ApiKeyCredential("placeholder");
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-real"), OAuthEntry(), credential);
+            ExchangerReturning("copilot-real"), OAuthEntry(), credential, followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();
@@ -100,13 +108,106 @@ public sealed class CopilotRequestPolicyTests
     }
 
     [Fact]
+    public async Task ProcessAsync_RoutesRequestToTokenApiHost()
+    {
+        // GHE data residency: the token is valid only at the tenant host reported
+        // in endpoints.api. The SDK client is configured with the public host, so
+        // the policy must rewrite the outgoing request's authority — otherwise the
+        // tenant token hits api.githubcopilot.com and Copilot returns HTTP 400
+        // (issue #1550). The path and query are SDK-built and must be preserved.
+        var policy = new CopilotRequestPolicy(
+            ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com"),
+            OAuthEntry(), new ApiKeyCredential("placeholder"), followTokenHost: true);
+
+        var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
+        using var message = clientPipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://api.githubcopilot.com/chat/completions?api-version=2024");
+
+        IReadOnlyList<PipelinePolicy> pipeline = [policy, new TerminalCapturingPolicy(() => { })];
+
+        await policy.ProcessAsync(message, pipeline, 0);
+
+        Assert.Equal("api.tenant.ghe.com", message.Request.Uri!.Host);
+        Assert.Equal("/chat/completions", message.Request.Uri.AbsolutePath);
+        Assert.Equal("?api-version=2024", message.Request.Uri.Query);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ApiBaseWithPath_PrependsBasePath()
+    {
+        // Defensive/consistency: if endpoints.api ever carries a base path, chat
+        // must land on base-path + /chat/completions — matching what the /models
+        // probe builds against the same base — not silently drop the prefix.
+        var policy = new CopilotRequestPolicy(
+            ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com/v1"),
+            OAuthEntry(), new ApiKeyCredential("placeholder"), followTokenHost: true);
+
+        var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
+        using var message = clientPipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://api.githubcopilot.com/chat/completions");
+
+        IReadOnlyList<PipelinePolicy> pipeline = [policy, new TerminalCapturingPolicy(() => { })];
+
+        await policy.ProcessAsync(message, pipeline, 0);
+
+        Assert.Equal("api.tenant.ghe.com", message.Request.Uri!.Host);
+        Assert.Equal("/v1/chat/completions", message.Request.Uri.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoApiBase_LeavesRequestHostUnchanged()
+    {
+        // Standard github.com flow: the exchange reports no endpoints.api, so the
+        // request must stay on the host the SDK client was configured with.
+        var policy = new CopilotRequestPolicy(
+            ExchangerReturning("copilot-standard"), OAuthEntry(), new ApiKeyCredential("placeholder"),
+            followTokenHost: true);
+
+        var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
+        using var message = clientPipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://api.githubcopilot.com/chat/completions");
+
+        IReadOnlyList<PipelinePolicy> pipeline = [policy, new TerminalCapturingPolicy(() => { })];
+
+        await policy.ProcessAsync(message, pipeline, 0);
+
+        Assert.Equal("https://api.githubcopilot.com/chat/completions", message.Request.Uri!.ToString());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CustomEndpointOverride_DoesNotFollowTokenHost()
+    {
+        // The operator deliberately pointed the entry at a proxy (followTokenHost
+        // is false). Even when the token reports an endpoints.api, we must not
+        // silently reroute their traffic away from the configured host.
+        var policy = new CopilotRequestPolicy(
+            ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com"),
+            OAuthEntry(), new ApiKeyCredential("placeholder"), followTokenHost: false);
+
+        var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
+        using var message = clientPipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://copilot-proxy.example.com/chat/completions");
+
+        IReadOnlyList<PipelinePolicy> pipeline = [policy, new TerminalCapturingPolicy(() => { })];
+
+        await policy.ProcessAsync(message, pipeline, 0);
+
+        Assert.Equal("copilot-proxy.example.com", message.Request.Uri!.Host);
+    }
+
+    [Fact]
     public void Process_Synchronous_ThrowsNotSupported()
     {
         // The sync pipeline path would require blocking on async token exchange.
         // The OpenAI SDK uses the async pipeline for chat completions; the sync
         // overload is only hit by misconfigured callers and we fail loudly.
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-bearer"), OAuthEntry(), new ApiKeyCredential("placeholder"));
+            ExchangerReturning("copilot-bearer"), OAuthEntry(), new ApiKeyCredential("placeholder"),
+            followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotRequestPolicyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotRequestPolicyTests.cs
@@ -52,8 +52,8 @@ public sealed class CopilotRequestPolicyTests
     public async Task ProcessAsync_AppliesThreeCopilotHeaders()
     {
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-bearer", apiBase: null), OAuthEntry(), new ApiKeyCredential("placeholder"),
-            followTokenHost: true);
+            ExchangerReturning("copilot-bearer", apiBase: "https://api.githubcopilot.com"),
+            OAuthEntry(), new ApiKeyCredential("placeholder"), followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();
@@ -92,7 +92,8 @@ public sealed class CopilotRequestPolicyTests
         // end-to-end in GitHubCopilotProviderPluginTests).
         var credential = new ApiKeyCredential("placeholder");
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-real", apiBase: null), OAuthEntry(), credential, followTokenHost: true);
+            ExchangerReturning("copilot-real", apiBase: "https://api.githubcopilot.com"),
+            OAuthEntry(), credential, followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();
@@ -157,10 +158,12 @@ public sealed class CopilotRequestPolicyTests
     }
 
     [Fact]
-    public async Task ProcessAsync_NoApiBase_LeavesRequestHostUnchanged()
+    public async Task ProcessAsync_NoApiHostWhileFollowingToken_ThrowsInsteadOfGuessing()
     {
-        // Standard github.com flow: the exchange reports no endpoints.api, so the
-        // request must stay on the host the SDK client was configured with.
+        // We are meant to follow the token's host but the exchange reported no
+        // endpoints.api. The old code silently kept the configured public host —
+        // exactly how a GHE token reached the wrong host in issue #1550. Refuse to
+        // guess: fail loudly rather than send the token somewhere it may not be valid.
         var policy = new CopilotRequestPolicy(
             ExchangerReturning("copilot-standard", apiBase: null), OAuthEntry(), new ApiKeyCredential("placeholder"),
             followTokenHost: true);
@@ -170,11 +173,14 @@ public sealed class CopilotRequestPolicyTests
         message.Request.Method = "POST";
         message.Request.Uri = new Uri("https://api.githubcopilot.com/chat/completions");
 
-        IReadOnlyList<PipelinePolicy> pipeline = [policy, new TerminalCapturingPolicy(() => { })];
+        var terminalReached = false;
+        IReadOnlyList<PipelinePolicy> pipeline = [policy, new TerminalCapturingPolicy(() => terminalReached = true)];
 
-        await policy.ProcessAsync(message, pipeline, 0);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await policy.ProcessAsync(message, pipeline, 0));
 
-        Assert.Equal("https://api.githubcopilot.com/chat/completions", message.Request.Uri!.ToString());
+        Assert.Contains("endpoints.api", ex.Message);
+        Assert.False(terminalReached, "the request must not be sent when no host is known");
     }
 
     [Fact]
@@ -206,8 +212,8 @@ public sealed class CopilotRequestPolicyTests
         // The OpenAI SDK uses the async pipeline for chat completions; the sync
         // overload is only hit by misconfigured callers and we fail loudly.
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-bearer", apiBase: null), OAuthEntry(), new ApiKeyCredential("placeholder"),
-            followTokenHost: true);
+            ExchangerReturning("copilot-bearer", apiBase: "https://api.githubcopilot.com"),
+            OAuthEntry(), new ApiKeyCredential("placeholder"), followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotRequestPolicyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotRequestPolicyTests.cs
@@ -25,7 +25,7 @@ public sealed class CopilotRequestPolicyTests
             OAuthAccessToken = new SensitiveString(token),
         };
 
-    private static CopilotTokenExchanger ExchangerReturning(string copilotToken, string? apiBase = null)
+    private static CopilotTokenExchanger ExchangerReturning(string copilotToken, string? apiBase)
     {
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -52,7 +52,7 @@ public sealed class CopilotRequestPolicyTests
     public async Task ProcessAsync_AppliesThreeCopilotHeaders()
     {
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-bearer"), OAuthEntry(), new ApiKeyCredential("placeholder"),
+            ExchangerReturning("copilot-bearer", apiBase: null), OAuthEntry(), new ApiKeyCredential("placeholder"),
             followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
@@ -92,7 +92,7 @@ public sealed class CopilotRequestPolicyTests
         // end-to-end in GitHubCopilotProviderPluginTests).
         var credential = new ApiKeyCredential("placeholder");
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-real"), OAuthEntry(), credential, followTokenHost: true);
+            ExchangerReturning("copilot-real", apiBase: null), OAuthEntry(), credential, followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
         using var message = clientPipeline.CreateMessage();
@@ -162,7 +162,7 @@ public sealed class CopilotRequestPolicyTests
         // Standard github.com flow: the exchange reports no endpoints.api, so the
         // request must stay on the host the SDK client was configured with.
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-standard"), OAuthEntry(), new ApiKeyCredential("placeholder"),
+            ExchangerReturning("copilot-standard", apiBase: null), OAuthEntry(), new ApiKeyCredential("placeholder"),
             followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());
@@ -206,7 +206,7 @@ public sealed class CopilotRequestPolicyTests
         // The OpenAI SDK uses the async pipeline for chat completions; the sync
         // overload is only hit by misconfigured callers and we fail loudly.
         var policy = new CopilotRequestPolicy(
-            ExchangerReturning("copilot-bearer"), OAuthEntry(), new ApiKeyCredential("placeholder"),
+            ExchangerReturning("copilot-bearer", apiBase: null), OAuthEntry(), new ApiKeyCredential("placeholder"),
             followTokenHost: true);
 
         var clientPipeline = ClientPipeline.Create(new ClientPipelineOptions());

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotTokenExchangerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/CopilotTokenExchangerTests.cs
@@ -50,11 +50,13 @@ public sealed class CopilotTokenExchangerTests
             OAuthTokenExpiry = now.AddMinutes(-1),
         };
 
-    private static HttpResponseMessage TokenResponse(string token, long expiresAt) =>
+    private static HttpResponseMessage TokenResponse(string token, long expiresAt, string? apiBase = null) =>
         new(HttpStatusCode.OK)
         {
             Content = new StringContent(
-                JsonSerializer.Serialize(new { token, expires_at = expiresAt }),
+                JsonSerializer.Serialize(apiBase is null
+                    ? new { token, expires_at = expiresAt }
+                    : (object)new { token, expires_at = expiresAt, endpoints = new { api = apiBase } }),
                 Encoding.UTF8,
                 "application/json"),
         };
@@ -74,8 +76,76 @@ public sealed class CopilotTokenExchangerTests
         var token = await exchanger.GetTokenAsync(EntryWithOAuth("oauth-1"),
             TestContext.Current.CancellationToken);
 
-        Assert.Equal("copilot-token-1", token);
+        Assert.Equal("copilot-token-1", token.Token.Value);
         Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task GetToken_ParsesEndpointsApiFromResponse()
+    {
+        // GHE data residency mints a token that is only valid at the tenant host
+        // reported in endpoints.api. Callers route chat/completions there instead
+        // of the public api.githubcopilot.com (issue #1550).
+        var handler = new FakeHttpMessageHandler(_ =>
+            TokenResponse("copilot-ghe",
+                DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                apiBase: "https://api.tenant.ghe.com"));
+        var exchanger = new CopilotTokenExchanger(new HttpClient(handler));
+
+        var token = await exchanger.GetTokenAsync(EntryWithOAuth("oauth-1"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("copilot-ghe", token.Token.Value);
+        Assert.Equal(new Uri("https://api.tenant.ghe.com"), token.ApiBase);
+    }
+
+    [Fact]
+    public async Task GetToken_NoEndpoints_ApiBaseNull()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            TokenResponse("copilot-standard",
+                DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()));
+        var exchanger = new CopilotTokenExchanger(new HttpClient(handler));
+
+        var token = await exchanger.GetTokenAsync(EntryWithOAuth("oauth-1"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("copilot-standard", token.Token.Value);
+        Assert.Null(token.ApiBase);
+    }
+
+    [Fact]
+    public async Task GetToken_ToString_DoesNotLeakBearer()
+    {
+        // The bearer is a live ~30-min credential: the CopilotToken record must
+        // not print it if the object is ever logged or interpolated.
+        var handler = new FakeHttpMessageHandler(_ =>
+            TokenResponse("super-secret-bearer",
+                DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()));
+        var exchanger = new CopilotTokenExchanger(new HttpClient(handler));
+
+        var token = await exchanger.GetTokenAsync(EntryWithOAuth("oauth-1"),
+            TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("super-secret-bearer", token.ToString());
+        Assert.Equal("super-secret-bearer", token.Token.Value);
+    }
+
+    [Fact]
+    public async Task GetToken_NonHttpsEndpointsApi_Ignored()
+    {
+        // A malformed / plaintext endpoints.api must never redirect authenticated
+        // traffic off HTTPS; the caller keeps its configured endpoint instead.
+        var handler = new FakeHttpMessageHandler(_ =>
+            TokenResponse("copilot-1",
+                DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                apiBase: "http://api.tenant.ghe.com"));
+        var exchanger = new CopilotTokenExchanger(new HttpClient(handler));
+
+        var token = await exchanger.GetTokenAsync(EntryWithOAuth("oauth-1"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(token.ApiBase);
     }
 
     [Fact]
@@ -114,7 +184,7 @@ public sealed class CopilotTokenExchangerTests
             PublicOAuth,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal("copilot-token", token);
+        Assert.Equal("copilot-token", token.Token.Value);
         Assert.Equal("oauth-new", entry.OAuthAccessToken!.Value);
         Assert.Equal("refresh-new", entry.OAuthRefreshToken!.Value);
         Assert.Equal(now.AddHours(1), entry.OAuthTokenExpiry);
@@ -193,7 +263,7 @@ public sealed class CopilotTokenExchangerTests
         time.Advance(TimeSpan.FromMinutes(advanceMinutes));
         var token = await exchanger.GetTokenAsync(entry, TestContext.Current.CancellationToken);
 
-        Assert.Equal(expectedToken, token);
+        Assert.Equal(expectedToken, token.Token.Value);
         Assert.Equal(expectedCalls, callCount);
     }
 
@@ -329,7 +399,7 @@ public sealed class CopilotTokenExchangerTests
 
         var token = await exchanger.GetTokenAsync(entry, TestContext.Current.CancellationToken);
 
-        Assert.Equal("copilot-ghe", token);
+        Assert.Equal("copilot-ghe", token.Token.Value);
         Assert.Equal("https://ghe.example.com/api/v3/copilot_internal/v2/token",
             captured!.RequestUri!.ToString());
         Assert.Equal("Bearer gho_ghe", captured.Headers.Authorization!.ToString());

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotDescriptorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotDescriptorTests.cs
@@ -103,6 +103,134 @@ public sealed class GitHubCopilotDescriptorTests
     }
 
     [Fact]
+    public async Task Probe_AuthError_SurfacesFailureInsteadOfCuratedFallback()
+    {
+        // A 401 on /models means the token/tenant is wrong — a real
+        // misconfiguration that must surface at `provider add`, not be masked by
+        // the curated list only to fail on the first chat (issue #1550).
+        var handler = new FakeHttpMessageHandler(request =>
+            request.RequestUri!.ToString() switch
+            {
+                TokenExchangeUrl => TokenOk(),
+                ModelsUrl => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            });
+
+        var httpClient = new HttpClient(handler);
+        var descriptor = new GitHubCopilotDescriptor(httpClient,
+            new CopilotTokenExchanger(httpClient));
+
+        var result = await descriptor.ProbeAsync(OAuthEntry(),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.DoesNotContain("curated fallback", result.ErrorMessage ?? string.Empty);
+        Assert.Empty(result.Models);
+    }
+
+    [Fact]
+    public async Task Probe_ConnectionFailureToTokenHost_SurfacesFailure()
+    {
+        // An unreachable tenant host (endpoints.api) must surface at setup, not be
+        // masked by the curated fallback — otherwise the provider reports healthy
+        // and only fails on the first chat, the exact symptom of issue #1550.
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            if (request.RequestUri!.ToString() == TokenExchangeUrl)
+                return Json(new
+                {
+                    token = "copilot-api-token",
+                    expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                    endpoints = new { api = "https://api.unreachable.ghe.com" },
+                });
+
+            throw new HttpRequestException("No such host is known.");
+        });
+
+        var httpClient = new HttpClient(handler);
+        var descriptor = new GitHubCopilotDescriptor(httpClient,
+            new CopilotTokenExchanger(httpClient));
+
+        var result = await descriptor.ProbeAsync(OAuthEntry(),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.DoesNotContain("curated fallback", result.ErrorMessage ?? string.Empty);
+        Assert.Empty(result.Models);
+    }
+
+    [Fact]
+    public async Task Probe_ProbesModelsAtTokenApiHost()
+    {
+        // GHE data residency: /models must be probed at the tenant host reported
+        // in endpoints.api, not the public api.githubcopilot.com (issue #1550).
+        string? probedModelsUrl = null;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url == TokenExchangeUrl)
+                return Json(new
+                {
+                    token = "copilot-api-token",
+                    expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                    endpoints = new { api = "https://api.tenant.ghe.com" },
+                });
+
+            probedModelsUrl = url;
+            return Json(new
+            {
+                data = new[] { new { id = "gpt-4o", capabilities = new { type = "chat" } } },
+            });
+        });
+
+        var httpClient = new HttpClient(handler);
+        var descriptor = new GitHubCopilotDescriptor(httpClient,
+            new CopilotTokenExchanger(httpClient));
+
+        var result = await descriptor.ProbeAsync(OAuthEntry(),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://api.tenant.ghe.com/models", probedModelsUrl);
+    }
+
+    [Fact]
+    public async Task Probe_CustomEndpointOverride_ProbesConfiguredHostNotTokenApi()
+    {
+        // A deliberate proxy override must win over the token's endpoints.api on
+        // the probe path too, matching the chat path.
+        string? probedModelsUrl = null;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url == TokenExchangeUrl)
+                return Json(new
+                {
+                    token = "copilot-api-token",
+                    expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                    endpoints = new { api = "https://api.tenant.ghe.com" },
+                });
+
+            probedModelsUrl = url;
+            return Json(new
+            {
+                data = new[] { new { id = "gpt-4o", capabilities = new { type = "chat" } } },
+            });
+        });
+
+        var httpClient = new HttpClient(handler);
+        var descriptor = new GitHubCopilotDescriptor(httpClient,
+            new CopilotTokenExchanger(httpClient));
+        var entry = OAuthEntry();
+        entry.Endpoint = "https://copilot-proxy.example.com";
+
+        var result = await descriptor.ProbeAsync(entry, TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://copilot-proxy.example.com/models", probedModelsUrl);
+    }
+
+    [Fact]
     public async Task Probe_FallsBackToCuratedListWhenModelsReturnsEmpty()
     {
         var handler = new FakeHttpMessageHandler(request =>

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotDescriptorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotDescriptorTests.cs
@@ -35,10 +35,14 @@ public sealed class GitHubCopilotDescriptorTests
                 "application/json"),
         };
 
+    // A realistic token exchange response: GitHub always reports the API host in
+    // endpoints.api. For a standard account that host is api.githubcopilot.com,
+    // which keeps ModelsUrl below correct.
     private static HttpResponseMessage TokenOk() => Json(new
     {
         token = "copilot-api-token",
         expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+        endpoints = new { api = "https://api.githubcopilot.com" },
     });
 
     [Fact]
@@ -125,6 +129,38 @@ public sealed class GitHubCopilotDescriptorTests
 
         Assert.False(result.Success);
         Assert.DoesNotContain("curated fallback", result.ErrorMessage ?? string.Empty);
+        Assert.Empty(result.Models);
+    }
+
+    [Fact]
+    public async Task Probe_NoApiHostWhileFollowingToken_SurfacesFailure()
+    {
+        // The exchange succeeds but reports no endpoints.api. We must not silently
+        // probe the public default (issue #1550) — surface the anomaly. The
+        // /models handler returns success on purpose: if the code wrongly fell
+        // back to api.githubcopilot.com the probe would pass, so asserting failure
+        // proves we did not guess a host.
+        var handler = new FakeHttpMessageHandler(request =>
+            request.RequestUri!.ToString() == TokenExchangeUrl
+                ? Json(new
+                {
+                    token = "copilot-api-token",
+                    expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                })
+                : Json(new
+                {
+                    data = new[] { new { id = "gpt-4o", capabilities = new { type = "chat" } } },
+                }));
+
+        var httpClient = new HttpClient(handler);
+        var descriptor = new GitHubCopilotDescriptor(httpClient,
+            new CopilotTokenExchanger(httpClient));
+
+        var result = await descriptor.ProbeAsync(OAuthEntry(),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Contains("endpoints.api", result.ErrorMessage);
         Assert.Empty(result.Models);
     }
 

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
@@ -17,16 +17,23 @@ namespace Netclaw.Daemon.Tests.Providers.GitHubCopilot;
 
 public sealed class GitHubCopilotProviderPluginTests
 {
-    private static CopilotTokenExchanger ExchangerReturning(string copilotToken)
+    private static CopilotTokenExchanger ExchangerReturning(string copilotToken, string? apiBase = null)
     {
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(
-                JsonSerializer.Serialize(new
-                {
-                    token = copilotToken,
-                    expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
-                }),
+                JsonSerializer.Serialize(apiBase is null
+                    ? new
+                    {
+                        token = copilotToken,
+                        expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                    }
+                    : (object)new
+                    {
+                        token = copilotToken,
+                        expires_at = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds(),
+                        endpoints = new { api = apiBase },
+                    }),
                 Encoding.UTF8,
                 "application/json"),
         });
@@ -132,6 +139,91 @@ public sealed class GitHubCopilotProviderPluginTests
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("Bearer copilot-real", sentAuthorization);
+    }
+
+    [Fact]
+    public async Task CreateChatClient_RoutesChatToTokenApiHost()
+    {
+        // End-to-end proof for issue #1550: the entry is configured with the
+        // public endpoint (the default), but the GHE token reports a tenant host
+        // in endpoints.api. The fully-assembled request that reaches the wire
+        // must target the tenant host, not api.githubcopilot.com — otherwise
+        // Copilot rejects the tenant token with HTTP 400.
+        Uri? sentUri = null;
+        var captureHandler = new FakeHttpMessageHandler(req =>
+        {
+            sentUri = req.RequestUri;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    MinimalChatCompletionJson, Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var exchanger = ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com");
+        var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
+        var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
+        {
+            TransportOverride = new HttpClientPipelineTransport(new HttpClient(captureHandler)),
+        };
+
+        var entry = new ProviderEntry
+        {
+            Type = "github-copilot",
+            AuthMethod = AuthMethod.OAuthDevice,
+            OAuthAccessToken = new SensitiveString("oauth-1"),
+        };
+        var client = plugin.CreateChatClient(
+            entry, new ModelReference { Provider = "my-copilot", ModelId = "gpt-4o" });
+
+        await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(sentUri);
+        Assert.Equal("api.tenant.ghe.com", sentUri!.Host);
+        Assert.Equal("/chat/completions", sentUri.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CreateChatClient_CustomEndpoint_KeepsOperatorHostOverToken()
+    {
+        // A deliberate proxy override must win over the token's endpoints.api so
+        // the operator's traffic is never silently rerouted off their proxy.
+        Uri? sentUri = null;
+        var captureHandler = new FakeHttpMessageHandler(req =>
+        {
+            sentUri = req.RequestUri;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    MinimalChatCompletionJson, Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var exchanger = ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com");
+        var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
+        var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
+        {
+            TransportOverride = new HttpClientPipelineTransport(new HttpClient(captureHandler)),
+        };
+
+        var entry = new ProviderEntry
+        {
+            Type = "github-copilot",
+            AuthMethod = AuthMethod.OAuthDevice,
+            OAuthAccessToken = new SensitiveString("oauth-1"),
+            Endpoint = "https://copilot-proxy.example.com",
+        };
+        var client = plugin.CreateChatClient(
+            entry, new ModelReference { Provider = "my-copilot", ModelId = "gpt-4o" });
+
+        await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(sentUri);
+        Assert.Equal("copilot-proxy.example.com", sentUri!.Host);
     }
 
     private const string MinimalChatCompletionJson =

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
@@ -118,7 +118,7 @@ public sealed class GitHubCopilotProviderPluginTests
             };
         });
 
-        var exchanger = ExchangerReturning("copilot-real", apiBase: null);
+        var exchanger = ExchangerReturning("copilot-real", apiBase: "https://api.githubcopilot.com");
         var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
         var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
         {

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
@@ -17,7 +17,7 @@ namespace Netclaw.Daemon.Tests.Providers.GitHubCopilot;
 
 public sealed class GitHubCopilotProviderPluginTests
 {
-    private static CopilotTokenExchanger ExchangerReturning(string copilotToken, string? apiBase = null)
+    private static CopilotTokenExchanger ExchangerReturning(string copilotToken, string? apiBase)
     {
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -40,7 +40,7 @@ public sealed class GitHubCopilotProviderPluginTests
         return new CopilotTokenExchanger(new HttpClient(handler));
     }
 
-    private static CopilotTokenExchanger NewExchanger() => ExchangerReturning("copilot-token");
+    private static CopilotTokenExchanger NewExchanger() => ExchangerReturning("copilot-token", apiBase: null);
 
     private static GitHubCopilotProviderPlugin NewPlugin()
     {
@@ -118,7 +118,7 @@ public sealed class GitHubCopilotProviderPluginTests
             };
         });
 
-        var exchanger = ExchangerReturning("copilot-real");
+        var exchanger = ExchangerReturning("copilot-real", apiBase: null);
         var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
         var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
         {

--- a/src/Netclaw.Providers/GitHubCopilot/CopilotRequestPolicy.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/CopilotRequestPolicy.cs
@@ -89,7 +89,22 @@ internal sealed class CopilotRequestPolicy(
     // never silently reroute their traffic to the token's host.
     private void RouteToCopilotApiHost(PipelineMessage message, Uri? apiBase)
     {
-        if (!followTokenHost || apiBase is null || message.Request.Uri is not { } current)
+        // Operator pinned a custom endpoint — use it verbatim, ignore the token's host.
+        if (!followTokenHost)
+            return;
+
+        // We are meant to follow the token's host but the exchange reported none
+        // (missing or non-HTTPS endpoints.api). Do NOT guess a host — sending an
+        // auth token to a host it may not be valid at is exactly issue #1550. Fail
+        // loudly rather than silently fall back to the configured default.
+        if (apiBase is null)
+            throw new InvalidOperationException(
+                "GitHub Copilot token exchange did not return a usable API host "
+                + "(endpoints.api). Refusing to route chat/completions to a guessed "
+                + "host — re-authenticate the provider, or set an explicit endpoint "
+                + "to override the Copilot API host.");
+
+        if (message.Request.Uri is not { } current)
             return;
 
         var basePath = apiBase.AbsolutePath.TrimEnd('/');

--- a/src/Netclaw.Providers/GitHubCopilot/CopilotRequestPolicy.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/CopilotRequestPolicy.cs
@@ -10,11 +10,11 @@ using Netclaw.Configuration;
 namespace Netclaw.Providers.GitHubCopilot;
 
 /// <summary>
-/// Pipeline policy for <c>api.githubcopilot.com</c>. On every outbound
-/// request it resolves a fresh Copilot API token via
-/// <see cref="CopilotTokenExchanger"/> (cached, with a 2-minute refresh
-/// buffer) and adds the three custom headers the Copilot API rejects
-/// requests without.
+/// Pipeline policy for the Copilot chat API. On every outbound request it
+/// resolves a fresh Copilot API token via <see cref="CopilotTokenExchanger"/>
+/// (cached, with a 2-minute refresh buffer), routes the request to the host the
+/// token is valid at (the exchange's <c>endpoints.api</c>), and adds the three
+/// custom headers the Copilot API rejects requests without.
 /// </summary>
 /// <remarks>
 /// The Authorization header is NOT set here. The OpenAI SDK's own
@@ -36,6 +36,7 @@ internal sealed class CopilotRequestPolicy(
     CopilotTokenExchanger exchanger,
     ProviderEntry entry,
     ApiKeyCredential credential,
+    bool followTokenHost,
     string? providerName = null,
     OAuthAuth? oauth = null)
     : PipelinePolicy
@@ -65,9 +66,40 @@ internal sealed class CopilotRequestPolicy(
 
         // Refresh the credential the SDK's auth policy reads downstream, so it
         // emits "Authorization: Bearer {token}" with our short-lived token.
-        credential.Update(token);
+        credential.Update(token.Token.Value);
+        RouteToCopilotApiHost(message, token.ApiBase);
         ApplyCopilotHeaders(message);
         await ProcessNextAsync(message, pipeline, currentIndex);
+    }
+
+    // The chat host must follow the token, not the statically-configured provider
+    // endpoint. The token exchange reports (in endpoints.api) the host its token
+    // is valid at; for GitHub Enterprise Cloud data residency that's a
+    // tenant-specific api.<subdomain>.ghe.com, and a token minted there is
+    // rejected with HTTP 400 at the public api.githubcopilot.com the OpenAI SDK
+    // client is otherwise configured with (issue #1550). We rebase onto the
+    // token's origin AND any base path it carries, then re-append the SDK-built
+    // path and query (/chat/completions?api-version=...). endpoints.api is a bare
+    // origin today, so the base path is normally empty — but prepending it keeps
+    // this consistent with the probe (which appends /models to the same base),
+    // so both paths agree if GitHub ever returns a path-bearing endpoints.api.
+    //
+    // followTokenHost is false when the operator deliberately pointed the entry
+    // at a custom host (e.g. a corporate proxy); we respect that override and
+    // never silently reroute their traffic to the token's host.
+    private void RouteToCopilotApiHost(PipelineMessage message, Uri? apiBase)
+    {
+        if (!followTokenHost || apiBase is null || message.Request.Uri is not { } current)
+            return;
+
+        var basePath = apiBase.AbsolutePath.TrimEnd('/');
+        message.Request.Uri = new UriBuilder(current)
+        {
+            Scheme = apiBase.Scheme,
+            Host = apiBase.Host,
+            Port = apiBase.IsDefaultPort ? -1 : apiBase.Port,
+            Path = basePath + current.AbsolutePath,
+        }.Uri;
     }
 
     private static void ApplyCopilotHeaders(PipelineMessage message)

--- a/src/Netclaw.Providers/GitHubCopilot/CopilotTokenExchanger.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/CopilotTokenExchanger.cs
@@ -17,6 +17,17 @@ using Netclaw.Providers.OAuth;
 namespace Netclaw.Providers.GitHubCopilot;
 
 /// <summary>
+/// A short-lived Copilot API bearer token together with the chat/completions
+/// host it is valid at, as reported by the token exchange in its
+/// <c>endpoints.api</c> field. <see cref="ApiBase"/> is null when the exchange
+/// response did not include a usable HTTPS host, in which case callers keep
+/// their configured provider endpoint. The bearer is a live ~30-minute
+/// credential, so it is a <see cref="SensitiveString"/> — the record's default
+/// <c>ToString</c> redacts it, and access requires an explicit <c>.Value</c>.
+/// </summary>
+public sealed record CopilotToken(SensitiveString Token, Uri? ApiBase);
+
+/// <summary>
 /// Exchanges a long-lived GitHub OAuth token for a short-lived (~30 min)
 /// Copilot API token, caching the result per OAuth-token identity. The cache
 /// key is a SHA-256 hash of the OAuth token so multiple Copilot accounts can
@@ -55,7 +66,7 @@ public sealed class CopilotTokenExchanger(
     /// <exception cref="CopilotAuthExpiredException">
     /// The GitHub OAuth token was rejected (HTTP 401).
     /// </exception>
-    public async Task<string> GetTokenAsync(
+    public async Task<CopilotToken> GetTokenAsync(
         ProviderEntry entry, CancellationToken ct = default)
     {
         var oauthToken = entry.OAuthAccessToken.RequireValid(
@@ -69,7 +80,7 @@ public sealed class CopilotTokenExchanger(
     /// GitHub OAuth credential when its configured expiry is inside the refresh
     /// buffer.
     /// </summary>
-    public async Task<string> GetTokenAsync(
+    public async Task<CopilotToken> GetTokenAsync(
         string providerName,
         ProviderEntry entry,
         OAuthAuth oauth,
@@ -87,12 +98,12 @@ public sealed class CopilotTokenExchanger(
         return await GetTokenAsync(oauthToken, GitHubCopilotAuthResolver.Resolve(entry).CopilotTokenExchangeEndpoint, ct);
     }
 
-    private async Task<string> GetTokenAsync(SensitiveString oauthToken, Uri tokenEndpoint, CancellationToken ct)
+    private async Task<CopilotToken> GetTokenAsync(SensitiveString oauthToken, Uri tokenEndpoint, CancellationToken ct)
     {
         var slot = slots.GetOrAdd(HashKey(oauthToken.Value, tokenEndpoint), _ => new CacheSlot());
 
         if (IsFresh(slot.Token))
-            return slot.Token!.Token;
+            return slot.Token!.ToCopilotToken();
 
         await slot.Lock.WaitAsync(ct);
         try
@@ -100,11 +111,11 @@ public sealed class CopilotTokenExchanger(
             // Re-check under the lock — a previous caller may have refreshed
             // while we were waiting.
             if (IsFresh(slot.Token))
-                return slot.Token!.Token;
+                return slot.Token!.ToCopilotToken();
 
             var fresh = await ExchangeAsync(oauthToken.Value, tokenEndpoint, ct);
             slot.Token = fresh;
-            return fresh.Token;
+            return fresh.ToCopilotToken();
         }
         finally
         {
@@ -188,8 +199,25 @@ public sealed class CopilotTokenExchanger(
 
         return new CachedToken(
             parsed.Token,
-            DateTimeOffset.FromUnixTimeSeconds(parsed.ExpiresAt));
+            DateTimeOffset.FromUnixTimeSeconds(parsed.ExpiresAt),
+            ResolveApiBase(parsed.Endpoints?.Api));
     }
+
+    // The token response reports, in endpoints.api, the Copilot API host its
+    // short-lived token is actually valid at: api.githubcopilot.com for
+    // standard/individual accounts, api.business|enterprise.githubcopilot.com
+    // for orgs, and a tenant-specific api.<subdomain>.ghe.com for GitHub
+    // Enterprise Cloud data residency. The chat/completions request MUST target
+    // this host — a data-residency token sent to the public host is rejected
+    // with HTTP 400 (issue #1550). Require an absolute HTTPS URI so a malformed
+    // field can never redirect authenticated traffic to a plaintext or
+    // attacker-shaped host; null lets the caller keep its configured endpoint.
+    private static Uri? ResolveApiBase(string? api) =>
+        !string.IsNullOrWhiteSpace(api)
+        && Uri.TryCreate(api, UriKind.Absolute, out var uri)
+        && uri.Scheme == Uri.UriSchemeHttps
+            ? uri
+            : null;
 
     private static string Truncate(string body) =>
         body.Length > 512 ? body[..512] + "…" : body;
@@ -200,7 +228,10 @@ public sealed class CopilotTokenExchanger(
         return Convert.ToHexString(bytes);
     }
 
-    private sealed record CachedToken(string Token, DateTimeOffset ExpiresAt);
+    private sealed record CachedToken(string Token, DateTimeOffset ExpiresAt, Uri? ApiBase)
+    {
+        public CopilotToken ToCopilotToken() => new(new SensitiveString(Token), ApiBase);
+    }
 
     // Volatile so the lock-free fast-path read in GetTokenAsync sees the
     // store from a previous caller's refresh without acquiring the lock.
@@ -219,5 +250,9 @@ public sealed class CopilotTokenExchanger(
 
     private sealed record TokenResponse(
         [property: JsonPropertyName("token")] string Token,
-        [property: JsonPropertyName("expires_at")] long ExpiresAt);
+        [property: JsonPropertyName("expires_at")] long ExpiresAt,
+        [property: JsonPropertyName("endpoints")] TokenEndpoints? Endpoints);
+
+    private sealed record TokenEndpoints(
+        [property: JsonPropertyName("api")] string? Api);
 }

--- a/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotDescriptor.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotDescriptor.cs
@@ -19,10 +19,26 @@ public sealed class GitHubCopilotDescriptor(
     HttpClient httpClient, CopilotTokenExchanger tokenExchanger) : IProviderDescriptor
 {
 
+    // The public Copilot API host. Standard/individual tokens are valid here;
+    // org and GHE-data-residency tokens are valid only at the host reported in
+    // the token exchange's endpoints.api (see CopilotTokenExchanger).
+    internal const string PublicApiEndpoint = "https://api.githubcopilot.com";
+
     public string TypeKey => "github-copilot";
     public string DisplayName => "GitHub Copilot";
-    public string DefaultEndpoint => "https://api.githubcopilot.com";
+    public string DefaultEndpoint => PublicApiEndpoint;
     public string ModelListingPath => "/models";
+
+    /// <summary>
+    /// True when the operator deliberately redirected Copilot traffic to a custom
+    /// host (e.g. a corporate proxy) rather than leaving it on the public API
+    /// host. A deliberate override is always respected; otherwise the chat and
+    /// probe host follows the token's <c>endpoints.api</c>, which GHE data
+    /// residency requires (issue #1550).
+    /// </summary>
+    internal static bool HasCustomEndpointOverride(string? entryEndpoint) =>
+        !string.IsNullOrWhiteSpace(entryEndpoint)
+        && !string.Equals(entryEndpoint.TrimEnd('/'), PublicApiEndpoint, StringComparison.OrdinalIgnoreCase);
 
     public IProviderAuth Auth { get; } = CreateOAuthAuth(new GitHubCopilotAuthOptions());
 
@@ -77,10 +93,10 @@ public sealed class GitHubCopilotDescriptor(
                 []);
         }
 
-        string copilotToken;
+        CopilotToken copilot;
         try
         {
-            copilotToken = await tokenExchanger.GetTokenAsync(entry, ct);
+            copilot = await tokenExchanger.GetTokenAsync(entry, ct);
         }
         catch (CopilotAuthExpiredException)
         {
@@ -103,22 +119,39 @@ public sealed class GitHubCopilotDescriptor(
                 []);
         }
 
+        // Probe /models at the host the token is valid at (endpoints.api). For
+        // GHE data residency this is the tenant host, not api.githubcopilot.com;
+        // probing the wrong host is what let a broken GHE provider report healthy
+        // at setup (issue #1550). A deliberate custom endpoint override wins; a
+        // null endpoints.api (standard github.com flow) falls back to the
+        // configured/default endpoint.
+        var probeEndpoint = HasCustomEndpointOverride(entry.Endpoint)
+            ? entry.Endpoint
+            : copilot.ApiBase?.ToString() ?? entry.Endpoint;
+
         var modelsResult = await ProbeHelpers.ExecuteProbeAsync(
             httpClient,
             "GitHub Copilot",
             DefaultEndpoint,
             ModelListingPath,
-            entry.Endpoint,
-            ApplyCopilotRequestHeaders(copilotToken),
+            probeEndpoint,
+            ApplyCopilotRequestHeaders(copilot.Token.Value),
             ParseCopilotModels,
             ct);
 
         if (!modelsResult.Success)
         {
-            return new ProviderProbeResult(true,
-                $"GitHub Copilot /models unreachable ({modelsResult.ErrorMessage}); "
-                + "using curated fallback list.",
-                CuratedModels);
+            // A transient /models hiccup (timeout, 5xx, rate limit) shouldn't
+            // leave the model picker empty, so fall back to the curated list. But
+            // auth/client errors (revoked token, wrong tenant, bad request) are
+            // real misconfigurations: surface them here so the operator fixes
+            // setup instead of hitting the failure on the first chat (issue #1550).
+            return modelsResult.Transient
+                ? new ProviderProbeResult(true,
+                    $"GitHub Copilot /models unreachable ({modelsResult.ErrorMessage}); "
+                    + "using curated fallback list.",
+                    CuratedModels)
+                : modelsResult;
         }
 
         return modelsResult;

--- a/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotDescriptor.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotDescriptor.cs
@@ -122,12 +122,27 @@ public sealed class GitHubCopilotDescriptor(
         // Probe /models at the host the token is valid at (endpoints.api). For
         // GHE data residency this is the tenant host, not api.githubcopilot.com;
         // probing the wrong host is what let a broken GHE provider report healthy
-        // at setup (issue #1550). A deliberate custom endpoint override wins; a
-        // null endpoints.api (standard github.com flow) falls back to the
-        // configured/default endpoint.
-        var probeEndpoint = HasCustomEndpointOverride(entry.Endpoint)
-            ? entry.Endpoint
-            : copilot.ApiBase?.ToString() ?? entry.Endpoint;
+        // at setup (issue #1550). A deliberate custom endpoint override wins. If
+        // we are meant to follow the token's host but the exchange reported none,
+        // surface that — never silently probe a guessed default host.
+        string probeEndpoint;
+        if (HasCustomEndpointOverride(entry.Endpoint))
+        {
+            probeEndpoint = entry.Endpoint!;
+        }
+        else if (copilot.ApiBase is { } apiBase)
+        {
+            probeEndpoint = apiBase.ToString();
+        }
+        else
+        {
+            return new ProviderProbeResult(false,
+                "GitHub Copilot token exchange did not return an API host "
+                + "(endpoints.api); cannot determine where to reach the Copilot API. "
+                + "Re-authenticate the provider, or set an explicit endpoint to "
+                + "override the host.",
+                []);
+        }
 
         var modelsResult = await ProbeHelpers.ExecuteProbeAsync(
             httpClient,

--- a/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotProviderPlugin.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotProviderPlugin.cs
@@ -12,10 +12,11 @@ using OpenAI;
 namespace Netclaw.Providers.GitHubCopilot;
 
 /// <summary>
-/// Daemon-side plugin for GitHub Copilot. Routes chat completions through
-/// the OpenAI SDK pointed at <c>api.githubcopilot.com/chat/completions</c>
-/// with <see cref="CopilotRequestPolicy"/> handling token refresh and the
-/// three Copilot-specific headers.
+/// Daemon-side plugin for GitHub Copilot. Routes chat completions through the
+/// OpenAI SDK, with <see cref="CopilotRequestPolicy"/> handling token refresh,
+/// the three Copilot-specific headers, and directing the request to the host the
+/// token is valid at (<c>endpoints.api</c> — the public host for standard
+/// accounts, a tenant host for GHE data residency).
 /// </summary>
 public sealed class GitHubCopilotProviderPlugin(
     GitHubCopilotDescriptor descriptor,
@@ -51,8 +52,13 @@ public sealed class GitHubCopilotProviderPlugin(
         // first request goes out.
         var credential = new ApiKeyCredential("placeholder");
         var oauth = GitHubCopilotDescriptor.CreateOAuthAuth(entry);
+
+        // When the operator left the endpoint on the public default, let the chat
+        // host follow the token's endpoints.api (required for GHE data residency,
+        // issue #1550). A deliberate custom endpoint (e.g. a proxy) is respected.
+        var followTokenHost = !GitHubCopilotDescriptor.HasCustomEndpointOverride(entry.Endpoint);
         options.AddPolicy(
-            new CopilotRequestPolicy(tokenExchanger, entry, credential, model.Provider, oauth),
+            new CopilotRequestPolicy(tokenExchanger, entry, credential, followTokenHost, model.Provider, oauth),
             PipelinePosition.PerCall);
 
         var client = new OpenAIClient(credential, options);

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -128,10 +128,11 @@ internal static class ProbeHelpers
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
+            // Timeout, not caller cancellation: the endpoint may just be slow.
             return new ProviderProbeResult(false,
                 $"No response from {baseUrl} after {(int)effectiveTimeout.TotalSeconds}s. "
                 + "The server may be slow, loading a model, or unreachable — "
-                + "confirm it is up, then try again.", []);
+                + "confirm it is up, then try again.", []) { Transient = true };
         }
         catch (OperationCanceledException)
         {
@@ -139,6 +140,10 @@ internal static class ProbeHelpers
         }
         catch (HttpRequestException ex)
         {
+            // A connection failure (DNS, refused, TLS) means the endpoint is
+            // unreachable — a configuration problem a retry won't fix, and one a
+            // provider must not mask (issue #1550: an unreachable GHE tenant host
+            // must surface at setup, not report healthy and fail on first use).
             return new ProviderProbeResult(false, $"Connection failed: {ex.Message}", []);
         }
     }
@@ -171,7 +176,15 @@ internal static class ProbeHelpers
                 $"{providerName} returned HTTP {(int)statusCode}."
         };
 
-        return new ProviderProbeResult(false, message, []);
+        // Request-timeout, 5xx, and rate limiting are worth a retry; auth and
+        // other 4xx errors (incl. 404 "not found" at the token's own API host)
+        // signal a real misconfiguration the operator has to fix.
+        var transient = statusCode is HttpStatusCode.RequestTimeout
+            or HttpStatusCode.TooManyRequests
+            or HttpStatusCode.InternalServerError or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable or HttpStatusCode.GatewayTimeout;
+
+        return new ProviderProbeResult(false, message, []) { Transient = transient };
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1550.

## Root cause

GitHub Enterprise Cloud **data residency** mints Copilot tokens that are scoped to the enterprise's region and are only valid at a **tenant-specific host** (`api.<subdomain>.ghe.com`). GitHub reports that host in the `endpoints.api` field of the `/copilot_internal/v2/token` response — and every real Copilot client (litellm, the VS Code extension) uses it as the chat base URL.

Netclaw ignored `endpoints.api` and sent `chat/completions` to the hardcoded public `api.githubcopilot.com`. A GHE-scoped token at the public host is rejected with **HTTP 400** — exactly the split in the issue: the token exchange (against the correct tenant host) returned 200, then the chat call (against the wrong public host) returned 400.

Secondary problem: the setup probe hit the same wrong host, failed, and was silently masked by the curated fallback model list — so `provider add` reported **healthy** for a provider that couldn't chat.

## What changed

- **`CopilotTokenExchanger`** parses `endpoints.api` and returns it alongside the bearer as a new `CopilotToken`. The bearer is now a `SensitiveString` (redacted `ToString`), and a non-HTTPS `endpoints.api` is ignored so authenticated traffic can never be redirected off HTTPS.
- **`CopilotRequestPolicy`** rebases the outgoing chat request onto that host (origin + any base path), preserving the SDK-built `/chat/completions` path and query. This is the actual 400 fix.
- **`GitHubCopilotProviderPlugin`** wires the routing decision through.
- **`GitHubCopilotDescriptor`** probes `/models` at the token's host and no longer masks auth/connection failures behind the curated fallback — a broken GHE provider now surfaces at `provider add` instead of on the first chat.
- **`ProbeHelpers` / `ProviderProbeResult`** gain a `Transient` classifier so only reachable-server retryable failures (timeout / 5xx / 429 / 408) are masked; connection failures and auth/4xx errors surface.

### Operator override is respected

`--github-host` / `--github-api-base` still only configure the OAuth and token-exchange hosts. If an operator deliberately points the entry at a custom endpoint (e.g. a corporate proxy via `--endpoint`), that override always wins over the token's host on **both** the chat and probe paths — traffic is never silently rerouted.

## Testing

- 14 focused tests across the exchanger, request policy, plugin, and descriptor, including two end-to-end tests that drive the real OpenAI SDK pipeline through a capturing transport and assert the URL that reaches the wire (GHE token → tenant host; custom endpoint → proxy host).
- Suites green: provider/probe/copilot **209**, CLI provider/model/probe **626**, Configuration **426**.
- `dotnet slopwatch analyze`: 0 issues. `Add-FileHeaders.ps1 -Verify`: clean. Full solution builds warning-free.

An xhigh multi-agent code review was run on the diff; findings on probe-failure classification (connection failures were masked), chat/probe URL-path consistency, and secret hygiene (`SensitiveString`) are folded into this PR.

## Notes

No config-schema, system-skill, or eval changes are required: the `provider add` CLI surface, config format, and operator guidance are unchanged, and `ProviderProbeResult` is a runtime type (not a persisted `*Config`).
