### PR TITLE
fix(cli): don't demand local daemon config when the daemon is explicitly remote

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/CliConfigPreflightTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliConfigPreflightTests.cs
@@ -65,6 +65,41 @@ public sealed class CliConfigPreflightTests : IDisposable
     }
 
     [Fact]
+    public void TryWriteMissingConfig_RemoteEndpointEnvVar_AllowsCommand()
+    {
+        Environment.SetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT", "http://127.0.0.1:5299");
+        try
+        {
+            using var writer = new StringWriter();
+
+            var blocked = CliConfigPreflight.TryWriteMissingConfig(_paths, jsonOutput: false, writer, out var exitCode);
+
+            // The daemon is explicitly remote — its config lives on the daemon
+            // host, so a missing local config must not block the command.
+            Assert.False(blocked);
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, writer.ToString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT", null);
+        }
+    }
+
+    [Fact]
+    public void TryWriteMissingConfig_PairedClientEndpoint_AllowsCommand()
+    {
+        Netclaw.Cli.Config.ClientConfigFile.WriteEndpoint(_paths, "https://daemon.example.net:5299");
+        using var writer = new StringWriter();
+
+        var blocked = CliConfigPreflight.TryWriteMissingConfig(_paths, jsonOutput: false, writer, out var exitCode);
+
+        Assert.False(blocked);
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, writer.ToString());
+    }
+
+    [Fact]
     public void TryWriteMissingChatConfig_HeadlessJson_PrintsJsonPayload()
     {
         using var writer = new StringWriter();

--- a/src/Netclaw.Cli/CliConfigPreflight.cs
+++ b/src/Netclaw.Cli/CliConfigPreflight.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Nodes;
+using Netclaw.Cli.Config;
 using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
@@ -40,6 +41,21 @@ internal static class CliConfigPreflight
         out int exitCode)
     {
         if (File.Exists(paths.NetclawConfigPath))
+        {
+            exitCode = 0;
+            return false;
+        }
+
+        // A missing local daemon config only means "not initialized" when THIS
+        // machine hosts the daemon. When the caller explicitly targets a remote
+        // daemon (NETCLAW_DAEMON_ENDPOINT) or this install is a paired client
+        // (client.json endpoint), the daemon's configuration lives on the
+        // daemon host — blocking here regressed paired/remote clients and the
+        // containerized eval harness after #1540. These are exactly the
+        // endpoint sources DaemonApi.ResolveEndpoint prefers over the local
+        // daemon config.
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT"))
+            || ClientConfigFile.ReadEndpoint(paths) is not null)
         {
             exitCode = 0;
             return false;


### PR DESCRIPTION
## Problem

#1540 added a chat preflight that blocks with `daemon not configured - please run netclaw init` whenever the local `netclaw.json` is missing. But "no local daemon config file" does not mean "no daemon": two supported client topologies are file-less by design, and both regressed:

- **Env-endpoint clients**: `NETCLAW_DAEMON_ENDPOINT=… netclaw chat` against a daemon configured elsewhere (this is how the containerized eval harness drives its daemon — every eval case has failed 0/5 with this message since #1540; last green run was 2026-06-24 on 0.24.1).
- **Paired clients**: a client paired to a remote daemon has `client.json` (endpoint) but no local `netclaw.json`.

The daemon side was never broken — a container daemon configured purely via `NETCLAW_*` env vars starts healthy. The CLI preflight just conflated "no local config file" with "nothing to talk to."

## Fix

The preflight stands down when either remote-endpoint source is present — the exact sources `DaemonApi.ResolveEndpoint` already prefers over local daemon config:

1. `NETCLAW_DAEMON_ENDPOINT` environment variable
2. paired-client `client.json` endpoint

#1540's protection is preserved for the case it was written for: a truly local, truly unconfigured install still gets the clean init guidance instead of a degraded startup.

## Testing

- Two new tests: env-var endpoint allows the command; paired-client endpoint allows the command.
- All 6 `CliConfigPreflightTests` pass.
- Verified end-to-end: the eval harness goes from 0/5 instant failures (`daemon not configured` before any prompt reached the daemon) to executing cases normally with this fix applied.

Found while running the memory-pipeline eval gate for the (separate, upcoming) memory quick-wins PR.