### PR TITLE
fix: support environment-variable-only configuration (doctor misdiagnosis + OAuth config-file side effect)

### DIFF
--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -311,6 +311,45 @@ public sealed class ChatClientDoctorCheckTests
         Assert.Contains("must be a string", result.Message);
     }
 
+    [Fact]
+    public async Task EvaluatesBoundConfiguration_OnEnvOnlyInstance()
+    {
+        // No netclaw.json at all — configuration arrives entirely through the
+        // bound IConfiguration (in production: NETCLAW_ env vars). The check
+        // must evaluate what the daemon will actually run with, not report
+        // "not configured" because the file is absent.
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Providers:openrouter:Type"] = "openrouter",
+                ["Providers:openrouter:AuthMethod"] = "ApiKey",
+                ["Providers:openrouter:ApiKey"] = "sk-test",
+                ["Models:Main:Provider"] = "openrouter",
+                ["Models:Main:ModelId"] = "anthropic/claude-haiku-4",
+            })
+            .Build();
+
+        // Trip the reader's env-config detection (process-level signal that
+        // this is an env-configured instance rather than an unconfigured one).
+        Environment.SetEnvironmentVariable("NETCLAW_Models__Main__ModelId", "anthropic/claude-haiku-4");
+        try
+        {
+            var check = new ChatClientDoctorCheck(paths, configuration, ProviderCommand.CreateDefaultRegistry());
+            var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(DoctorSeverity.Pass, result.Severity);
+            Assert.Contains("Real chat client configured", result.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NETCLAW_Models__Main__ModelId", null);
+        }
+    }
+
     private static NetclawPaths CreatePathsWithConfig(string configJson)
     {
         var basePath = CreateTempBasePath();

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -27,6 +27,51 @@ public sealed class ConfigSchemaDoctorCheckTests
     }
 
     [Fact]
+    public async Task ReturnsPass_WhenConfigFileMissingButEnvConfigPresent()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        // An env-only instance: no netclaw.json, configuration bound from
+        // NETCLAW_ env vars. Schema validation applies to the file only —
+        // warning "run netclaw init" here would misdiagnose a healthy daemon.
+        Environment.SetEnvironmentVariable("NETCLAW_Models__Main__ModelId", "test-model");
+        try
+        {
+            var check = new ConfigSchemaDoctorCheck(paths);
+            var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(DoctorSeverity.Pass, result.Severity);
+            Assert.Contains("environment configuration detected", result.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NETCLAW_Models__Main__ModelId", null);
+        }
+    }
+
+    [Fact]
+    public void HasEnvironmentConfig_CountsOnlyConfigBindingVariables()
+    {
+        // Control variables (path/endpoint resolution) are not daemon config.
+        Assert.False(DoctorJsonConfigReader.HasEnvironmentConfig(
+            new System.Collections.Hashtable
+            {
+                ["NETCLAW_HOME"] = "/tmp/x",
+                ["NETCLAW_DAEMON_ENDPOINT"] = "http://127.0.0.1:5299",
+                ["UNRELATED"] = "1",
+            }));
+
+        // Double-underscore section keys are configuration binding.
+        Assert.True(DoctorJsonConfigReader.HasEnvironmentConfig(
+            new System.Collections.Hashtable
+            {
+                ["NETCLAW_Providers__eval__Type"] = "openai-compatible",
+            }));
+    }
+
+    [Fact]
     public async Task ReturnsPass_WhenConfigMatchesSchemaV1()
     {
         var basePath = CreateTempBasePath();

--- a/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
@@ -36,10 +36,17 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
     public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
     {
         var (root, error) = DoctorJsonConfigReader.TryReadConfig(_paths);
-        if (error is not null)
+
+        // This check's job is "is a real provider configured" — the daemon
+        // answers that from the BOUND configuration (env vars over an optional
+        // JSON file), so a missing file with NETCLAW_ env config present is
+        // not a short-circuit: evaluate exactly what the host will evaluate.
+        // The reader signals that state with a Pass-severity result.
+        var envOnly = root is null && error is { Severity: DoctorSeverity.Pass };
+        if (error is not null && !envOnly)
             return Task.FromResult(error);
 
-        if (TryFindNonStringInferenceValue(root, out var invalidPath))
+        if (root is not null && TryFindNonStringInferenceValue(root, out var invalidPath))
         {
             return Task.FromResult(DoctorCheckResult.Error(
                 CheckName,
@@ -55,7 +62,12 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
         {
             providers = ProviderConfigurationLoader.Load(_configuration.GetSection("Providers"));
             models = _configuration.GetSection("Models").Get<ModelSelection>() ?? new ModelSelection();
-            runtimeConfiguration = ProviderRuntimeConfiguration.FromJson(root);
+            // File present: read explicit provider types from the file (matches
+            // historical behavior). Env-only: derive them from the bound
+            // configuration, exactly like the daemon does at startup.
+            runtimeConfiguration = root is not null
+                ? ProviderRuntimeConfiguration.FromJson(root)
+                : ProviderRuntimeConfiguration.FromConfiguration(_configuration);
             validation = ProviderRuntimeValidation.Evaluate(
                 providers,
                 models,

--- a/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
@@ -17,6 +17,17 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
     {
         if (!File.Exists(paths.NetclawConfigPath))
         {
+            // Schema validation applies to netclaw.json specifically. An
+            // env-only instance (NETCLAW_ config-binding env vars, no file)
+            // is configured — warning "run netclaw init" would misdiagnose a
+            // healthy deployment.
+            if (DoctorJsonConfigReader.HasEnvironmentConfig())
+            {
+                return Task.FromResult(DoctorCheckResult.Pass(
+                    "Config Schema",
+                    "No netclaw.json; NETCLAW_ environment configuration detected — schema validation applies to the file only."));
+            }
+
             return Task.FromResult(DoctorCheckResult.Warning(
                 "Config Schema",
                 CliConfigPreflight.MissingConfigMessage,

--- a/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
@@ -32,10 +32,44 @@ internal static class DoctorJsonConfigReader
             .Cast<string>()];
     }
 
+    /// <summary>
+    /// True when NETCLAW_-prefixed configuration-binding environment variables
+    /// are present (double-underscore section keys, e.g.
+    /// <c>NETCLAW_Models__Main__ModelId</c>). Plain control variables like
+    /// <c>NETCLAW_HOME</c> or <c>NETCLAW_DAEMON_ENDPOINT</c> do not count —
+    /// they configure path/endpoint resolution, not the daemon itself.
+    /// </summary>
+    public static bool HasEnvironmentConfig(System.Collections.IDictionary? environment = null)
+    {
+        environment ??= Environment.GetEnvironmentVariables();
+        foreach (var key in environment.Keys)
+        {
+            if (key is string name
+                && name.StartsWith("NETCLAW_", StringComparison.Ordinal)
+                && name.Contains("__", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static (JsonObject? Root, DoctorCheckResult? Error) TryReadConfig(NetclawPaths paths)
     {
         if (!File.Exists(paths.NetclawConfigPath))
         {
+            // An env-only instance is configured, just not via this file — a
+            // "not configured, run init" warning here is a misdiagnosis (the
+            // daemon binds NETCLAW_ env vars over an optional JSON file).
+            // File-content checks are legitimately skipped; say so truthfully.
+            if (HasEnvironmentConfig())
+            {
+                return (null, DoctorCheckResult.Pass(
+                    "Config File",
+                    "No netclaw.json; NETCLAW_ environment configuration detected — file-based checks skipped."));
+            }
+
             return (null, DoctorCheckResult.Warning(
                 "Config File",
                 CliConfigPreflight.MissingConfigMessage,

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTokenPersistenceTests.cs
@@ -19,6 +19,9 @@ public sealed class OAuthTokenPersistenceTests
         using var dir = new DisposableTempDir();
         var paths = new NetclawPaths(dir.Path);
         paths.EnsureDirectoriesExist();
+        // Init-based installs always have netclaw.json; expiry persistence
+        // updates it (and never creates it — see the env-only test below).
+        File.WriteAllText(paths.NetclawConfigPath, "{}");
 
         OAuthTokenPersistence.PersistTokens(
             paths,
@@ -91,5 +94,31 @@ public sealed class OAuthTokenPersistenceTests
         Assert.Equal("access-2", provider.GetProperty("OAuthAccessToken").GetString());
         Assert.Equal("refresh-2", provider.GetProperty("OAuthRefreshToken").GetString());
         Assert.Equal("account-2", provider.GetProperty("OAuthAccountId").GetString());
+    }
+
+    [Fact]
+    public void PersistTokens_DoesNotCreateConfigFileOnEnvOnlyInstance()
+    {
+        using var dir = new DisposableTempDir();
+        var paths = new NetclawPaths(dir.Path);
+        paths.EnsureDirectoriesExist();
+        // No netclaw.json — an instance configured purely via NETCLAW_ env
+        // vars. A token refresh must not silently materialize a config file
+        // (turns the deployment stateful; throws on a read-only home).
+
+        OAuthTokenPersistence.PersistTokens(
+            paths,
+            "copilot",
+            new OAuthDeviceFlowResult(
+                new SensitiveString("access-1"),
+                new SensitiveString("refresh-1"),
+                DateTimeOffset.Parse("2026-06-01T00:00:00+00:00"),
+                null));
+
+        // Secrets still persist (they live in secrets.json), but the expiry —
+        // refresh-timing metadata that belongs in netclaw.json — is skipped
+        // rather than creating the file.
+        Assert.True(File.Exists(paths.SecretsPath));
+        Assert.False(File.Exists(paths.NetclawConfigPath));
     }
 }

--- a/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
@@ -67,12 +67,15 @@ public static class OAuthTokenPersistence
 
     private static void PersistTokenExpiry(NetclawPaths paths, string providerName, DateTimeOffset? expiresAt)
     {
-        if (!expiresAt.HasValue && !File.Exists(paths.NetclawConfigPath))
+        // Never CREATE netclaw.json here: an instance configured purely via
+        // NETCLAW_ environment variables has no config file by design, and a
+        // token refresh silently materializing one turns the deployment
+        // stateful (and throws on a read-only home). Expiry is refresh-timing
+        // metadata, not required state — when there is no file to update, skip.
+        if (!File.Exists(paths.NetclawConfigPath))
             return;
 
-        var configJson = File.Exists(paths.NetclawConfigPath)
-            ? File.ReadAllText(paths.NetclawConfigPath)
-            : "{}";
+        var configJson = File.ReadAllText(paths.NetclawConfigPath);
         var configRoot = JsonNode.Parse(configJson)?.AsObject() ?? [];
         var configProviders = configRoot["Providers"]?.AsObject();
 


### PR DESCRIPTION
## Context

Investigated whether an instance configured **solely via `NETCLAW_` environment variables** (no `netclaw.json` on disk) is treated as uninitialized. **The daemon core is correct**: the JSON file loads as `optional: true`, env vars bind over it, the #1540 degraded-startup gate evaluates the *bound* configuration, and the hot-reload watcher tolerates a missing file. An env-only daemon boots healthy (this is exactly how the containerized eval harness runs).

Two adjacent components, however, conflate "no config file" with "not configured":

## Fix 1 — `netclaw doctor` misdiagnoses env-only instances

Every check consulting `DoctorJsonConfigReader.TryReadConfig` warned `daemon not configured - please run netclaw init` purely on file absence — false alarm on a healthy env-only deployment.

- `TryReadConfig`: when the file is missing but `NETCLAW_` **config-binding** env vars are present (double-underscore section keys like `NETCLAW_Models__Main__ModelId`; control vars like `NETCLAW_HOME`/`NETCLAW_DAEMON_ENDPOINT` don't count), checks short-circuit with a truthful Pass ("file-based checks skipped") instead of the init warning.
- `ChatClientDoctorCheck` goes further: it evaluates the **bound** configuration exactly like the daemon does at startup (`ProviderRuntimeConfiguration.FromConfiguration`), so "is a real provider configured" gets a real answer for env-only instances.
- `ConfigSchemaDoctorCheck`: schema validation applies to `netclaw.json` specifically; says so honestly instead of "not configured".

Genuinely unconfigured installs (no file, no env config) still get the existing init guidance.

## Fix 2 — OAuth token refresh silently creates `netclaw.json`

`OAuthTokenPersistence.PersistTokenExpiry` materialized a stub config file (`{"Providers":{"<name>":{"OAuthTokenExpiry":…}}}`) whenever a refresh returned an expiry and no file existed — an env-only deployment silently becomes stateful, and on a read-only home directory the write throws from inside the refresh path. Expiry is refresh-timing metadata, not required state (fresh configs ship without it): it's now updated when the file exists and skipped when it doesn't. Secrets persistence (`secrets.json`) is unchanged.

## Testing

- New: env-only ChatClient evaluation (Pass with real provider verdict), env-only ConfigSchema (truthful Pass), `HasEnvironmentConfig` classification (control vars excluded), OAuth refresh on env-only instance creates no file.
- Updated: OAuth persistence fixtures now seed `netclaw.json` like init-based installs (they previously relied on the create-on-missing side effect).
- Full `Netclaw.Cli.Tests` (1,194) and `Netclaw.Configuration.Tests` (447) green; slopwatch clean; headers verified.

## Related

- #1567 fixed the same conflation in the CLI chat preflight (`NETCLAW_DAEMON_ENDPOINT`/paired clients). This PR covers the remaining env-only surfaces. Independent of both #1567 and the memory PR (#1568).