### PR TITLE
refactor(memory): shared curation evaluator for both write pipelines (memory-core-redesign slice 1)

### DIFF
--- a/openspec/changes/memory-core-redesign/tasks.md
+++ b/openspec/changes/memory-core-redesign/tasks.md
@@ -5,10 +5,10 @@ constitution gates (tests, evals where mapped, schema/skill sync, slopwatch).
 
 ## 1. Shared curation evaluator (behavior-neutral refactor)
 
-- [ ] 1.1 Extract `MemoryCurationEvaluator` from `MemoryCurationActor.EvaluateSingleAsync` and wire the actor through it
-- [ ] 1.2 Route `MemoryCurationEngine` (daemon worker) through the same evaluator, including `GuardDestructiveUpdate`, deleting the divergent inline logic
-- [ ] 1.3 Characterization tests proving inline and daemon paths produce identical decisions for the same inputs
-- [ ] 1.4 Run full memory test suites + slopwatch; no behavior change expected (decision-mix log fields unchanged)
+- [x] 1.1 Extract `MemoryCurationEvaluator` from `MemoryCurationActor.EvaluateSingleAsync` and wire the actor through it
+- [x] 1.2 Route `MemoryCurationEngine` (daemon worker) through the same evaluator, including `GuardDestructiveUpdate`, deleting the divergent inline logic
+- [x] 1.3 Characterization tests proving inline and daemon paths produce identical decisions for the same inputs
+- [x] 1.4 Run full memory test suites + slopwatch; no behavior change expected (decision-mix log fields unchanged)
 
 ## 2. Embedding foundation
 

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
@@ -1,0 +1,372 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryCurationEvaluatorParityTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Akka.Event;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Xunit;
+using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+/// <summary>
+/// Characterization tests for memory-core-redesign Slice 1: proves the evaluator produces
+/// IDENTICAL decisions whether constructed the way the inline per-session actor constructs
+/// it (Akka <see cref="ILoggingAdapter"/>, no LLM) or the way the daemon checkpoint worker
+/// constructs it (Microsoft.Extensions.Logging <see cref="ILogger"/>, no LLM). Both
+/// evaluators share one seeded <see cref="SQLiteMemoryStore"/> so their candidate lookups
+/// see identical data. Covers the full decision matrix (record bypass, exact/fuzzy anchor
+/// tiers, gray-zone auto-resolve, and the GuardDestructiveUpdate downgrade — the one
+/// behavior that only fired on the inline path before this slice, audit finding D14) plus
+/// the LLM tier (parseable decision, empty-response fallback) using a scripted
+/// <see cref="IChatClient"/>.
+/// </summary>
+public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
+{
+    private static readonly SessionId TestSessionId = new("test-channel/curation-parity");
+
+    private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-curation-evaluator-parity-tests", Guid.NewGuid().ToString("N"));
+    private readonly string _dbPath;
+    private readonly SQLiteMemoryStore _store;
+
+    public MemoryCurationEvaluatorParityTests()
+    {
+        Directory.CreateDirectory(_baseDir);
+        _dbPath = Path.Combine(_baseDir, "netclaw.db");
+        _store = new SQLiteMemoryStore(_dbPath, TimeProvider.System);
+    }
+
+    public async ValueTask DisposeAsync() => await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
+
+    // ── record bypass ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordBypass_returns_Create_identically_on_both_paths()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        var operation = MakeOperation(
+            "any-anchor", "irrelevant content", kind: "record", updateSemantics: "immutable-record");
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Create, fromActor.Kind);
+        Assert.Contains("immutable record", fromActor.Reason);
+    }
+
+    // ── exact anchor, high overlap -> Skip ──────────────────────────
+
+    [Fact]
+    public async Task ExactAnchorHighOverlap_returns_Skip_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync("favorite-color", "doc-color", "favorite color is blue", freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation("favorite-color", "favorite color is blue", freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Skip, fromActor.Kind);
+        Assert.Equal("doc-color", fromActor.TargetDocumentId);
+    }
+
+    // ── exact anchor, newer content, guard-clean superset -> Update ─
+
+    [Fact]
+    public async Task ExactAnchorNewerSuperset_returns_Update_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync("latest-version", "doc-version", "Latest version is 1.5.62.", freshnessAtMs: 1000, ct);
+
+        // Proposal is a strict superset of the existing body, so GuardDestructiveUpdate
+        // (applied to every non-ambiguous decision, not just LLM ones) does not downgrade it.
+        var operation = MakeOperation(
+            "latest-version",
+            "Latest version is 1.5.62. Released with the new serializer.",
+            freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Update, fromActor.Kind);
+        Assert.Equal("doc-version", fromActor.TargetDocumentId);
+    }
+
+    // ── fuzzy anchor, high overlap -> Consolidate ───────────────────
+
+    [Fact]
+    public async Task FuzzyAnchorHighOverlap_returns_Consolidate_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "akka-net-latest-release", "doc-akka", "Akka.NET latest release version is 1.5.62", freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "akka-net-release", "Akka.NET latest release version is 1.5.62", freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Consolidate, fromActor.Kind);
+        Assert.NotNull(fromActor.ConsolidationTargetIds);
+        Assert.Contains("doc-akka", fromActor.ConsolidationTargetIds!);
+    }
+
+    // ── gray zone (0.4-0.8), no LLM -> deterministic auto-resolve ───
+
+    [Fact]
+    public async Task GrayZoneNoLlm_autoResolves_to_Skip_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "netclaw-github-repository",
+            "doc-repo",
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository is private.",
+            freshnessAtMs: 1000,
+            ct);
+
+        var operation = MakeOperation(
+            "netclaw-github-repo",
+            "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
+            freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Skip, fromActor.Kind);
+        Assert.Contains("auto-resolved", fromActor.Reason);
+    }
+
+    // ── fuzzy anchor, low overlap -> Create ─────────────────────────
+
+    [Fact]
+    public async Task FuzzyAnchorLowOverlap_returns_Create_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "akka-net-latest-release",
+            "doc-postgres",
+            "PostgreSQL 15 is the primary datastore for user profiles and session history",
+            freshnessAtMs: 1000,
+            ct);
+
+        var operation = MakeOperation(
+            "akka-net-release", "The CI pipeline deploys to staging on every PR merge", freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Create, fromActor.Kind);
+    }
+
+    // ── guard downgrade: Update whose proposal drops existing body -> Skip ──
+
+    [Fact]
+    public async Task GuardDowngrade_narrowerProposal_downgradesUpdateToSkip_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "widget-specs",
+            "doc-widget",
+            "Widget specs: 16 cores, 64GB RAM, 2 NICs. Pricing on file. Vendor contacts listed.",
+            freshnessAtMs: 1000,
+            ct);
+
+        // Newer, but narrower — the rules tier would pick Update (exact anchor, low
+        // overlap, fresher), and GuardDestructiveUpdate must downgrade it on BOTH paths
+        // now (audit finding D14: this guard used to run only on the inline actor path).
+        var operation = MakeOperation("widget-specs", "Widget pricing is TBD as of Q2.", freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Skip, fromActor.Kind);
+        Assert.Contains("update guarded", fromActor.Reason);
+        Assert.Equal("doc-widget", fromActor.TargetDocumentId);
+    }
+
+    // ── LLM tier: parseable decision ─────────────────────────────────
+
+    [Fact]
+    public async Task LlmPresent_parseableDecision_returns_guarded_llm_decision()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "netclaw-github-repository",
+            "doc-repo",
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository is private.",
+            freshnessAtMs: 1000,
+            ct);
+
+        var operation = MakeOperation(
+            "netclaw-github-repo",
+            "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
+            freshnessAtMs: 2000);
+
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new ScriptedCurationChatClient("SKIP"));
+
+        var decision = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Equal(CurationDecisionKind.Skip, decision.Kind);
+        Assert.Contains("LLM decision", decision.Reason);
+    }
+
+    // ── LLM tier: empty response -> deterministic fallback ──────────
+
+    [Fact]
+    public async Task LlmPresent_emptyResponse_fallsBackToDeterministicAutoResolve()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "netclaw-github-repository",
+            "doc-repo",
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository is private.",
+            freshnessAtMs: 1000,
+            ct);
+
+        var operation = MakeOperation(
+            "netclaw-github-repo",
+            "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
+            freshnessAtMs: 2000);
+
+        // Empty stream (no yields) reproduces a provider that returns nothing parseable —
+        // TryLlmEvaluationAsync must surface curation_llm_no_decision and fall through to
+        // the same deterministic auto-resolve path the no-LLM matrix case exercises.
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new ScriptedCurationChatClient(responseText: null));
+
+        var decision = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Equal(CurationDecisionKind.Skip, decision.Kind);
+        Assert.Contains("auto-resolved", decision.Reason);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private async Task<(CurationDecision FromActor, CurationDecision FromEngine)> EvaluateOnBothAsync(
+        SQLiteMemoryCurationOperation operation, CancellationToken ct)
+    {
+        // Constructed exactly as MemoryCurationActor and MemoryCurationEngine construct
+        // their evaluators today: no LLM client, differing only in which logger stack
+        // they log through.
+        var actorLike = new MemoryCurationEvaluator(_store, (ILoggingAdapter)NoLogger.Instance);
+        var engineLike = new MemoryCurationEvaluator(_store, (ILogger)NullLogger.Instance);
+
+        var fromActor = await actorLike.EvaluateAsync(operation, TestSessionId, ct);
+        var fromEngine = await engineLike.EvaluateAsync(operation, TestSessionId, ct);
+        return (fromActor, fromEngine);
+    }
+
+    private async Task SeedDocumentAsync(
+        string anchorName, string docId, string content, long freshnessAtMs, CancellationToken ct)
+    {
+        var anchor = _store.CreateDefaultAnchor(anchorName);
+        await _store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: docId,
+            Anchor: anchor,
+            MemoryClass: "durable_fact",
+            Title: $"Existing {anchorName}",
+            MarkdownBody: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: freshnessAtMs,
+            ExpiresAtMs: null,
+            CreatedAtMs: freshnessAtMs,
+            UpdatedAtMs: freshnessAtMs), ct);
+    }
+
+    private static SQLiteMemoryCurationOperation MakeOperation(
+        string anchor,
+        string content,
+        string kind = "document",
+        string updateSemantics = "merge-document",
+        long freshnessAtMs = 2000) =>
+        new(
+            Kind: kind,
+            MemoryClass: "durable_fact",
+            MemoryId: null,
+            AnchorCanonicalName: anchor,
+            AnchorType: "concept",
+            Title: $"Title for {anchor}",
+            Content: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            Relations: null,
+            UpdateSemantics: updateSemantics,
+            Boundary: TrustBoundary.TrustedInstanceValue,
+            Audience: TrustAudience.Public,
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: freshnessAtMs,
+            ExpiresAtMs: null);
+
+    private static void AssertSameDecision(CurationDecision expected, CurationDecision actual)
+    {
+        Assert.Equal(expected.Kind, actual.Kind);
+        Assert.Equal(expected.TargetDocumentId, actual.TargetDocumentId);
+        Assert.Equal(expected.CanonicalAnchorName, actual.CanonicalAnchorName);
+        Assert.Equal(expected.Reason, actual.Reason);
+
+        if (expected.ConsolidationTargetIds is null)
+            Assert.Null(actual.ConsolidationTargetIds);
+        else
+            Assert.Equal(expected.ConsolidationTargetIds, actual.ConsolidationTargetIds);
+    }
+
+    /// <summary>
+    /// Minimal scripted <see cref="IChatClient"/>: streams <paramref name="responseText"/>
+    /// as a single update, or nothing at all when null (reproducing an empty/garbled
+    /// provider response so the deterministic fallback path can be exercised).
+    /// </summary>
+    private sealed class ScriptedCurationChatClient(string? responseText) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new AiChatMessage(AiChatRole.Assistant, responseText ?? string.Empty)));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => StreamAsync(cancellationToken);
+
+        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            if (responseText is not null)
+                yield return new ChatResponseUpdate(AiChatRole.Assistant, responseText);
+
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/SidecarSessionCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SidecarSessionCorrelationTests.cs
@@ -120,8 +120,8 @@ public sealed class SidecarSessionCorrelationTests : TestKit
             FreshnessAtMs: TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
             ExpiresAtMs: null);
 
-        await MemoryCurationActor.TryLlmEvaluationAsync(
-            captor, sessionId, operation, candidates: [], log: NoLogger.Instance);
+        await MemoryCurationEvaluator.TryLlmEvaluationAsync(
+            captor, sessionId, operation, candidates: [], log: new AkkaCurationLog(NoLogger.Instance));
 
         AssertScopedTo(sessionId, captor);
     }

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -5,9 +5,6 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Event;
-using Microsoft.Extensions.AI;
-using Netclaw.Actors.Sessions;
-using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Configuration;
 using SessionId = Netclaw.Actors.Protocol.SessionId;
 
@@ -54,12 +51,10 @@ internal sealed record WriteBatchFailed(Exception Exception);
 /// </summary>
 public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 {
-    private static readonly TimeSpan LlmTimeout = TimeSpan.FromSeconds(10);
-
     private readonly SQLiteMemoryStore _store;
-    private readonly IChatClient? _llmClient;
     private readonly SessionId _sessionId;
     private readonly ILoggingAdapter _log;
+    private readonly MemoryCurationEvaluator _evaluator;
 
     private IActorRef? _currentRequester;
 
@@ -69,10 +64,12 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     {
         _store = store;
         _sessionId = sessionId;
-        _llmClient = clientProvider != null
+        _log = Context.GetLogger();
+
+        var llmClient = clientProvider != null
             ? clientProvider.GetClient(ModelRole.Compaction)
             : null;
-        _log = Context.GetLogger();
+        _evaluator = new MemoryCurationEvaluator(_store, _log, llmClient);
 
         Become(Idle);
     }
@@ -187,197 +184,10 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         });
     }
 
-    private async Task<CurationDecision> EvaluateSingleAsync(
-        SQLiteMemoryCurationOperation operation)
-    {
-        // Immutable records bypass evaluation
-        if (MemoryDomainEnumExtensions.TryFromWireValue(operation.Kind, out MemoryKind kind)
-            && kind == MemoryKind.Record)
-        {
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "immutable record bypass");
-        }
-
-        // Query existing anchors for matches (by name)
-        var anchorCandidates = await _store.FindFuzzyAnchorMatchesAsync(
-            operation.AnchorCanonicalName);
-
-        // Build a mutable candidate list — content search may add more candidates below.
-        var candidates = new List<ExistingMemoryCandidate>(anchorCandidates);
-
-        // Run content-based search when there is no exact anchor match.
-        // This catches semantically identical content under very different anchor names
-        // (e.g., "netclaw-github-repo" vs "netclaw-source-location" — different names, same info).
-        var hasExactAnchorMatch = anchorCandidates.Any(c => c.IsExactAnchorMatch);
-        if (!hasExactAnchorMatch && !string.IsNullOrWhiteSpace(operation.Content))
-        {
-            var contentTerms = operation.Content
-                .Split([' ', '\t', '\n', '\r', '.', ',', ':', ';', '!', '?', '"', '\''],
-                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Where(t => t.Length >= 3)
-                .Select(t => t.ToLowerInvariant())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Take(8)
-                .ToArray();
-
-            if (contentTerms.Length > 0)
-            {
-                var contentCandidates = await _store.FindCandidatesByContentAsync(
-                    contentTerms);
-
-                // Merge content candidates with anchor candidates, deduplicating by DocumentId.
-                if (contentCandidates.Count > 0)
-                {
-                    var existingDocIds = new HashSet<string>(
-                        candidates.Select(c => c.DocumentId), StringComparer.OrdinalIgnoreCase);
-                    foreach (var cc in contentCandidates)
-                    {
-                        if (!existingDocIds.Contains(cc.DocumentId))
-                            candidates.Add(cc);
-                    }
-
-                    _log.Debug(
-                        "curation_dual_search anchor={0} anchor_hits={1} content_hits={2} merged={3}",
-                        operation.AnchorCanonicalName,
-                        anchorCandidates.Count,
-                        contentCandidates.Count,
-                        candidates.Count);
-                }
-            }
-        }
-
-        // Apply rules tier
-        var rulesDecision = CurationRulesEvaluator.Evaluate(operation, candidates);
-
-        // If rules tier is ambiguous and LLM is available, escalate
-        if (rulesDecision.Kind == CurationDecisionKind.Ambiguous && _llmClient is not null)
-        {
-            var llmDecision = await TryLlmEvaluationAsync(_llmClient, _sessionId, operation, candidates, _log);
-            if (llmDecision is not null)
-            {
-                var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(llmDecision, operation, candidates);
-                _log.Info(
-                    "curation_llm_decision anchor={0} decision={1} reason={2}",
-                    operation.AnchorCanonicalName,
-                    guarded.Kind,
-                    guarded.Reason);
-                return guarded;
-            }
-
-            // LLM failed — fall through to deterministic auto-resolution below
-        }
-
-        // Ambiguous (LLM unavailable or failed) — try deterministic auto-resolution
-        if (rulesDecision.Kind == CurationDecisionKind.Ambiguous)
-        {
-            var autoResolved = CurationRulesEvaluator.TryAutoResolveAmbiguous(operation, candidates);
-            if (autoResolved is not null)
-            {
-                _log.Info(
-                    "curation_ambiguous_auto_resolved anchor={0} decision={1} reason={2}",
-                    operation.AnchorCanonicalName,
-                    autoResolved.Kind,
-                    autoResolved.Reason);
-                return autoResolved;
-            }
-
-            _log.Warning("curation_ambiguous_create_fallback anchor={0} llm_available={1}",
-                operation.AnchorCanonicalName, _llmClient is not null);
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null,
-                "ambiguous: auto-resolve insufficient, defaulting to create");
-        }
-
-        return CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates);
-    }
-
-    internal static async Task<CurationDecision?> TryLlmEvaluationAsync(
-        IChatClient llmClient,
-        SessionId sessionId,
-        SQLiteMemoryCurationOperation operation,
-        IReadOnlyList<ExistingMemoryCandidate> candidates,
-        ILoggingAdapter log)
-    {
-        try
-        {
-            using var cts = new CancellationTokenSource(LlmTimeout);
-
-            var messages = new List<ChatMessage>
-            {
-                new(ChatRole.System, CurationPromptBuilder.SystemPrompt),
-                new(ChatRole.User, CurationPromptBuilder.BuildUserMessage(operation, candidates))
-            };
-
-            // SessionScopedChatOptions carries the session id so this sidecar's chat-client
-            // diagnostics route to the session's session.log and correlate in Seq/OTLP (replaces
-            // the deleted SessionDiagnosticsContext AsyncLocal).
-            var options = new SessionScopedChatOptions
-            {
-                SessionId = sessionId.Value,
-                // Token cap is the THIRD line of defense, so it must never be the
-                // binding constraint. Layering: (1) reasoning suppression below is
-                // the primary fix — suppressed/non-reasoning models emit just the
-                // keyword and never approach any cap; (2) the 10s call timeout
-                // bounds wall-clock when a model ignores suppression and thinks at
-                // length. The cap only matters in the remaining window — suppression
-                // ignored but thinking finishes inside the timeout — where a tight
-                // cap truncates mid-think and reproduces the measured
-                // responseLength=0 empty-reply failure (July 2026 audit: at 512, a
-                // Qwen3.6-class model produced 0 successful curation decisions
-                // ever). Unemitted tokens cost nothing, so size this generously;
-                // it becomes the Memory.Curation.LlmMaxOutputTokens config knob in
-                // the memory-core-redesign change.
-                MaxOutputTokens = 4096,
-                // Belt: ask the serving stack not to think at all for this
-                // keyword-classification call. This expresses intent only — the raw
-                // provider-dialect field name (vLLM/llama.cpp/SGLang's
-                // chat_template_kwargs.enable_thinking, Ollama's think) is NOT this
-                // call site's business, because the model behind SessionId's
-                // provider varies per deployment and strict SDKs (official OpenAI,
-                // Anthropic) reject or ignore unknown top-level fields differently
-                // than self-hosted servers do. NetclawChatOptionKeys.SuppressReasoning
-                // is a provider-agnostic intent key; ReasoningSuppressionChatClient
-                // (Netclaw.Daemon, wrapping every chat client the daemon constructs)
-                // reads it, removes it, and maps it to the dialect the active
-                // provider plugin declares (ILlmProviderPlugin.SuppressionDialect) —
-                // or strips it with no replacement for providers with no equivalent.
-                // StripThinkBlocks in ParseResponse remains the braces.
-                AdditionalProperties = new AdditionalPropertiesDictionary
-                {
-                    [NetclawChatOptionKeys.SuppressReasoning] = true
-                }
-            };
-
-            var result = await StreamingResponseReader.ReadAsync(llmClient, messages, options, cts.Token);
-            var responseText = result.Response.Text?.Trim();
-            var decision = string.IsNullOrWhiteSpace(responseText)
-                ? null
-                : CurationPromptBuilder.ParseResponse(responseText);
-
-            if (decision is null)
-            {
-                // No silent fallback: a curation LLM that yields nothing parseable is a
-                // real signal (empty/garbled output, or a reasoning model that consumed
-                // its token budget). Surface it so the deterministic fallback that
-                // follows is observable rather than invisible.
-                log.Warning(
-                    "curation_llm_no_decision anchor={0} responseLength={1} — using deterministic fallback",
-                    operation.AnchorCanonicalName,
-                    responseText?.Length ?? 0);
-                return null;
-            }
-
-            return decision;
-        }
-        catch (OperationCanceledException)
-        {
-            log.Warning("curation_llm_timeout anchor={0}", operation.AnchorCanonicalName);
-            return null;
-        }
-        catch (Exception ex)
-        {
-            log.Warning(ex, "curation_llm_error anchor={0}", operation.AnchorCanonicalName);
-            return null;
-        }
-    }
+    // Decision logic lives in MemoryCurationEvaluator (shared with the daemon checkpoint
+    // worker — memory-core-redesign Slice 1) so the two write pipelines cannot diverge.
+    private Task<CurationDecision> EvaluateSingleAsync(SQLiteMemoryCurationOperation operation)
+        => _evaluator.EvaluateAsync(operation, _sessionId);
 
     // ── Write pipeline ──────────────────────────────────────────────
 
@@ -398,60 +208,34 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 
                 foreach (var (operation, decision) in decisions)
                 {
+                    // Decision -> write-operation mapping (including Consolidate's
+                    // re-anchor/tombstone side effects) lives in MemoryCurationEvaluator,
+                    // shared with the daemon checkpoint worker.
+                    var writeOp = await _evaluator.ApplyDecisionAsync(operation, decision);
+
                     switch (decision.Kind)
                     {
                         case CurationDecisionKind.Skip:
-                            _log.Info(
-                                "curation_skip anchor={0} reason={1}",
-                                operation.AnchorCanonicalName,
-                                decision.Reason);
                             skipped++;
                             break;
-
                         case CurationDecisionKind.Update:
-                            _log.Info(
-                                "curation_update anchor={0} targetDoc={1} reason={2}",
-                                operation.AnchorCanonicalName,
-                                decision.TargetDocumentId,
-                                decision.Reason);
-
-                            // Set the operation's MemoryId to the existing document ID
-                            // so the ON CONFLICT UPDATE fires
-                            toWrite.Add(operation with { MemoryId = decision.TargetDocumentId });
                             updated++;
                             break;
-
                         case CurationDecisionKind.Consolidate:
-                            _log.Info(
-                                "curation_consolidate anchor={0} canonicalAnchor={1} targetIds=[{2}] reason={3}",
-                                operation.AnchorCanonicalName,
-                                decision.CanonicalAnchorName,
-                                decision.ConsolidationTargetIds is not null ? string.Join(",", decision.ConsolidationTargetIds) : "",
-                                decision.Reason);
-
-                            await ExecuteConsolidationAsync(operation, decision);
-                            // After consolidation, write the new proposal under the canonical anchor
-                            var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
-                            toWrite.Add(operation with { AnchorCanonicalName = canonicalAnchor });
                             consolidated++;
                             break;
-
                         case CurationDecisionKind.Create:
-                            _log.Info(
-                                "curation_create anchor={0} reason={1}",
-                                operation.AnchorCanonicalName,
-                                decision.Reason);
-                            toWrite.Add(operation);
-                            created++;
-                            break;
-
                         case CurationDecisionKind.Ambiguous:
-                            // Should not reach here — ambiguous is resolved before writing
-                            _log.Warning("curation_unexpected_ambiguous anchor={0}, defaulting to create", operation.AnchorCanonicalName);
-                            toWrite.Add(operation);
+                        default:
+                            // Ambiguous should not reach here — it is resolved before
+                            // writing — but ApplyDecisionAsync defaults it to Create,
+                            // so the count follows the same default.
                             created++;
                             break;
                     }
+
+                    if (writeOp is not null)
+                        toWrite.Add(writeOp);
                 }
 
                 // Write all accepted operations in a single batch
@@ -472,51 +256,5 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 self.Tell(new WriteBatchFailed(ex));
             }
         });
-    }
-
-    private async Task ExecuteConsolidationAsync(
-        SQLiteMemoryCurationOperation operation,
-        CurationDecision decision)
-    {
-        if (decision.ConsolidationTargetIds is null || decision.ConsolidationTargetIds.Count == 0)
-            return;
-
-        var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
-        var canonicalAnchorId = MemoryTypedId.AnchorId(canonicalAnchor);
-
-        // For each consolidation target document, re-anchor it if it belongs to a different anchor,
-        // then tombstone the redundant anchor
-        var tombstonedAnchors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var docId in decision.ConsolidationTargetIds)
-        {
-            // Re-anchor the document to the canonical anchor
-            await _store.ReanchorDocumentAsync(docId, canonicalAnchorId);
-
-            _log.Info(
-                "curation_reanchor docId={0} newAnchor={1}",
-                docId,
-                canonicalAnchorId);
-        }
-
-        // Find and tombstone anchors that are no longer canonical
-        // We need to look up the anchor IDs for the consolidated documents
-        var candidates = await _store.FindFuzzyAnchorMatchesAsync(
-            operation.AnchorCanonicalName);
-
-        foreach (var candidate in candidates)
-        {
-            if (!string.Equals(candidate.AnchorId, canonicalAnchorId, StringComparison.OrdinalIgnoreCase)
-                && !tombstonedAnchors.Contains(candidate.AnchorId))
-            {
-                await _store.TombstoneAnchorAsync(candidate.AnchorId);
-                tombstonedAnchors.Add(candidate.AnchorId);
-
-                _log.Info(
-                    "curation_tombstone_anchor anchorId={0} canonicalName={1}",
-                    candidate.AnchorId,
-                    candidate.AnchorCanonicalName);
-            }
-        }
     }
 }

--- a/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
@@ -1,0 +1,428 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryCurationEvaluator.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Event;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Sessions.Pipelines;
+using Netclaw.Configuration;
+using SessionId = Netclaw.Actors.Protocol.SessionId;
+
+namespace Netclaw.Actors.Memory;
+
+// ── Logging seam ────────────────────────────────────────────────────
+
+/// <summary>
+/// Minimal logging seam so <see cref="MemoryCurationEvaluator"/> emits one set of log
+/// markers (<c>curation_dual_search</c>, <c>curation_llm_decision</c>,
+/// <c>curation_llm_no_decision</c>, <c>curation_llm_timeout</c>, <c>curation_llm_error</c>,
+/// <c>curation_ambiguous_auto_resolved</c>, <c>curation_ambiguous_create_fallback</c>,
+/// <c>curation_skip</c>/<c>_update</c>/<c>_consolidate</c>/<c>_create</c>,
+/// <c>curation_reanchor</c>, <c>curation_tombstone_anchor</c>) regardless of which of the
+/// two callers is driving the evaluator: the inline per-session actor
+/// (<see cref="MemoryCurationActor"/>, Akka <see cref="ILoggingAdapter"/>) or the daemon
+/// checkpoint worker (<see cref="MemoryCurationEngine"/>, Microsoft.Extensions.Logging
+/// <see cref="ILogger"/>). The July 2026 audit tooling greps daemon logs for these exact
+/// marker strings, so the message templates and argument order must not drift between the
+/// two adapters — this interface is the smallest seam that lets one evaluator body log
+/// through either stack without per-caller reformatting.
+/// </summary>
+internal interface ICurationLog
+{
+    void Info(string template, params object[] args);
+
+    void Warning(string template, params object[] args);
+
+    void Warning(Exception exception, string template, params object[] args);
+
+    void Debug(string template, params object[] args);
+}
+
+internal sealed class AkkaCurationLog(ILoggingAdapter log) : ICurationLog
+{
+    public void Info(string template, params object[] args) => log.Info(template, args);
+
+    public void Warning(string template, params object[] args) => log.Warning(template, args);
+
+    public void Warning(Exception exception, string template, params object[] args) => log.Warning(exception, template, args);
+
+    public void Debug(string template, params object[] args) => log.Debug(template, args);
+}
+
+internal sealed class MicrosoftCurationLog(ILogger log) : ICurationLog
+{
+    public void Info(string template, params object[] args) => log.LogInformation(template, args);
+
+    public void Warning(string template, params object[] args) => log.LogWarning(template, args);
+
+    public void Warning(Exception exception, string template, params object[] args) => log.LogWarning(exception, template, args);
+
+    public void Debug(string template, params object[] args) => log.LogDebug(template, args);
+}
+
+// ── Evaluator ───────────────────────────────────────────────────────
+
+/// <summary>
+/// Shared curation decision engine used identically by the inline per-session write
+/// pipeline (<see cref="MemoryCurationActor"/>) and the daemon checkpoint-worker write
+/// pipeline (<see cref="MemoryCurationEngine"/>). Extracted from
+/// <c>MemoryCurationActor.EvaluateSingleAsync</c> (memory-core-redesign Slice 1) so the two
+/// pipelines cannot re-diverge the way they had by the July 2026 audit: only the inline
+/// path applied <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/> before this
+/// slice (finding D14) and the daemon path performed no relationship evaluation at all.
+///
+/// Decision flow (<see cref="EvaluateAsync"/>): immutable records bypass evaluation; fuzzy
+/// anchor candidates are queried, then content-term candidates are added when there is no
+/// exact anchor match; <see cref="CurationRulesEvaluator.Evaluate"/> runs the deterministic
+/// tier; an Ambiguous result escalates to the LLM tier (when available) followed by
+/// <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/>, or else falls back to
+/// <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> and finally a Create default.
+/// <see cref="ApplyDecisionAsync"/> maps the resulting decision to the operation that should
+/// be written (or nothing, for Skip), executing Consolidate's re-anchor/tombstone side
+/// effects — this mapping is unified too, since a second, hand-copied switch statement per
+/// caller is exactly the kind of divergence this slice removes.
+/// </summary>
+public sealed class MemoryCurationEvaluator
+{
+    private static readonly TimeSpan LlmTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly SQLiteMemoryStore _store;
+    private readonly IChatClient? _llmClient;
+    private readonly ICurationLog _log;
+
+    /// <summary>
+    /// Constructs an evaluator that logs through Akka's actor logging (the inline
+    /// per-session path). <paramref name="llmClient"/> is genuinely optional runtime
+    /// state, not a backward-compatibility shim: absence is a real, permanent operating
+    /// mode for a session whose configured provider has no compaction-role model, in
+    /// which case Ambiguous decisions resolve via
+    /// <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> only.
+    /// </summary>
+    public MemoryCurationEvaluator(SQLiteMemoryStore store, ILoggingAdapter log, IChatClient? llmClient = null)
+        : this(store, (ICurationLog)new AkkaCurationLog(log), llmClient)
+    {
+    }
+
+    /// <summary>
+    /// Constructs an evaluator that logs through Microsoft.Extensions.Logging (the daemon
+    /// checkpoint-worker path). The daemon worker has no LLM client to give this evaluator
+    /// today — that absence is intentional and permanent for this call site, not a
+    /// placeholder to be filled in later in this slice.
+    /// </summary>
+    public MemoryCurationEvaluator(SQLiteMemoryStore store, ILogger log, IChatClient? llmClient = null)
+        : this(store, (ICurationLog)new MicrosoftCurationLog(log), llmClient)
+    {
+    }
+
+    private MemoryCurationEvaluator(SQLiteMemoryStore store, ICurationLog log, IChatClient? llmClient)
+    {
+        _store = store;
+        _log = log;
+        _llmClient = llmClient;
+    }
+
+    /// <summary>
+    /// Evaluate a single curation proposal against existing memories and return a decision.
+    /// </summary>
+    public async Task<CurationDecision> EvaluateAsync(
+        SQLiteMemoryCurationOperation operation,
+        SessionId sessionId,
+        CancellationToken ct = default)
+    {
+        // Immutable records bypass evaluation
+        if (MemoryDomainEnumExtensions.TryFromWireValue(operation.Kind, out MemoryKind kind)
+            && kind == MemoryKind.Record)
+        {
+            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "immutable record bypass");
+        }
+
+        // Query existing anchors for matches (by name)
+        var anchorCandidates = await _store.FindFuzzyAnchorMatchesAsync(operation.AnchorCanonicalName, ct);
+
+        // Build a mutable candidate list — content search may add more candidates below.
+        var candidates = new List<ExistingMemoryCandidate>(anchorCandidates);
+
+        // Run content-based search when there is no exact anchor match.
+        // This catches semantically identical content under very different anchor names
+        // (e.g., "netclaw-github-repo" vs "netclaw-source-location" — different names, same info).
+        var hasExactAnchorMatch = anchorCandidates.Any(c => c.IsExactAnchorMatch);
+        if (!hasExactAnchorMatch && !string.IsNullOrWhiteSpace(operation.Content))
+        {
+            var contentTerms = operation.Content
+                .Split([' ', '\t', '\n', '\r', '.', ',', ':', ';', '!', '?', '"', '\''],
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(t => t.Length >= 3)
+                .Select(t => t.ToLowerInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(8)
+                .ToArray();
+
+            if (contentTerms.Length > 0)
+            {
+                var contentCandidates = await _store.FindCandidatesByContentAsync(contentTerms, ct: ct);
+
+                // Merge content candidates with anchor candidates, deduplicating by DocumentId.
+                if (contentCandidates.Count > 0)
+                {
+                    var existingDocIds = new HashSet<string>(
+                        candidates.Select(c => c.DocumentId), StringComparer.OrdinalIgnoreCase);
+                    foreach (var cc in contentCandidates)
+                    {
+                        if (!existingDocIds.Contains(cc.DocumentId))
+                            candidates.Add(cc);
+                    }
+
+                    _log.Debug(
+                        "curation_dual_search anchor={0} anchor_hits={1} content_hits={2} merged={3}",
+                        operation.AnchorCanonicalName,
+                        anchorCandidates.Count,
+                        contentCandidates.Count,
+                        candidates.Count);
+                }
+            }
+        }
+
+        // Apply rules tier
+        var rulesDecision = CurationRulesEvaluator.Evaluate(operation, candidates);
+
+        // If rules tier is ambiguous and LLM is available, escalate
+        if (rulesDecision.Kind == CurationDecisionKind.Ambiguous && _llmClient is not null)
+        {
+            var llmDecision = await TryLlmEvaluationAsync(_llmClient, sessionId, operation, candidates, _log);
+            if (llmDecision is not null)
+            {
+                var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(llmDecision, operation, candidates);
+                _log.Info(
+                    "curation_llm_decision anchor={0} decision={1} reason={2}",
+                    operation.AnchorCanonicalName,
+                    guarded.Kind,
+                    guarded.Reason);
+                return guarded;
+            }
+
+            // LLM failed — fall through to deterministic auto-resolution below
+        }
+
+        // Ambiguous (LLM unavailable or failed) — try deterministic auto-resolution
+        if (rulesDecision.Kind == CurationDecisionKind.Ambiguous)
+        {
+            var autoResolved = CurationRulesEvaluator.TryAutoResolveAmbiguous(operation, candidates);
+            if (autoResolved is not null)
+            {
+                _log.Info(
+                    "curation_ambiguous_auto_resolved anchor={0} decision={1} reason={2}",
+                    operation.AnchorCanonicalName,
+                    autoResolved.Kind,
+                    autoResolved.Reason);
+                return autoResolved;
+            }
+
+            _log.Warning("curation_ambiguous_create_fallback anchor={0} llm_available={1}",
+                operation.AnchorCanonicalName, _llmClient is not null);
+            return new CurationDecision(CurationDecisionKind.Create, null, null, null,
+                "ambiguous: auto-resolve insufficient, defaulting to create");
+        }
+
+        return CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates);
+    }
+
+    internal static async Task<CurationDecision?> TryLlmEvaluationAsync(
+        IChatClient llmClient,
+        SessionId sessionId,
+        SQLiteMemoryCurationOperation operation,
+        IReadOnlyList<ExistingMemoryCandidate> candidates,
+        ICurationLog log)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(LlmTimeout);
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, CurationPromptBuilder.SystemPrompt),
+                new(ChatRole.User, CurationPromptBuilder.BuildUserMessage(operation, candidates))
+            };
+
+            // SessionScopedChatOptions carries the session id so this sidecar's chat-client
+            // diagnostics route to the session's session.log and correlate in Seq/OTLP (replaces
+            // the deleted SessionDiagnosticsContext AsyncLocal).
+            var options = new SessionScopedChatOptions
+            {
+                SessionId = sessionId.Value,
+                // Token cap is the THIRD line of defense, so it must never be the
+                // binding constraint. Layering: (1) reasoning suppression below is
+                // the primary fix — suppressed/non-reasoning models emit just the
+                // keyword and never approach any cap; (2) the 10s call timeout
+                // bounds wall-clock when a model ignores suppression and thinks at
+                // length. The cap only matters in the remaining window — suppression
+                // ignored but thinking finishes inside the timeout — where a tight
+                // cap truncates mid-think and reproduces the measured
+                // responseLength=0 empty-reply failure (July 2026 audit: at 512, a
+                // Qwen3.6-class model produced 0 successful curation decisions
+                // ever). Unemitted tokens cost nothing, so size this generously;
+                // it becomes the Memory.Curation.LlmMaxOutputTokens config knob in
+                // the memory-core-redesign change.
+                MaxOutputTokens = 4096,
+                // Belt: ask the serving stack not to think at all for this
+                // keyword-classification call. This expresses intent only — the raw
+                // provider-dialect field name (vLLM/llama.cpp/SGLang's
+                // chat_template_kwargs.enable_thinking, Ollama's think) is NOT this
+                // call site's business, because the model behind SessionId's
+                // provider varies per deployment and strict SDKs (official OpenAI,
+                // Anthropic) reject or ignore unknown top-level fields differently
+                // than self-hosted servers do. NetclawChatOptionKeys.SuppressReasoning
+                // is a provider-agnostic intent key; ReasoningSuppressionChatClient
+                // (Netclaw.Daemon, wrapping every chat client the daemon constructs)
+                // reads it, removes it, and maps it to the dialect the active
+                // provider plugin declares (ILlmProviderPlugin.SuppressionDialect) —
+                // or strips it with no replacement for providers with no equivalent.
+                // StripThinkBlocks in ParseResponse remains the braces.
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    [NetclawChatOptionKeys.SuppressReasoning] = true
+                }
+            };
+
+            var result = await StreamingResponseReader.ReadAsync(llmClient, messages, options, cts.Token);
+            var responseText = result.Response.Text?.Trim();
+            var decision = string.IsNullOrWhiteSpace(responseText)
+                ? null
+                : CurationPromptBuilder.ParseResponse(responseText);
+
+            if (decision is null)
+            {
+                // No silent fallback: a curation LLM that yields nothing parseable is a
+                // real signal (empty/garbled output, or a reasoning model that consumed
+                // its token budget). Surface it so the deterministic fallback that
+                // follows is observable rather than invisible.
+                log.Warning(
+                    "curation_llm_no_decision anchor={0} responseLength={1} — using deterministic fallback",
+                    operation.AnchorCanonicalName,
+                    responseText?.Length ?? 0);
+                return null;
+            }
+
+            return decision;
+        }
+        catch (OperationCanceledException)
+        {
+            log.Warning("curation_llm_timeout anchor={0}", operation.AnchorCanonicalName);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            log.Warning(ex, "curation_llm_error anchor={0}", operation.AnchorCanonicalName);
+            return null;
+        }
+    }
+
+    // ── Decision application (shared write-mapping + consolidation side effects) ──
+
+    /// <summary>
+    /// Maps a decision to the operation that should be written (null for Skip), executing
+    /// Consolidate's re-anchor/tombstone side effects against the store. Shared so this
+    /// mapping is identical from both the actor's write phase and the daemon's
+    /// checkpoint-apply phase — before this slice only the actor performed it at all.
+    /// </summary>
+    public async Task<SQLiteMemoryCurationOperation?> ApplyDecisionAsync(
+        SQLiteMemoryCurationOperation operation,
+        CurationDecision decision,
+        CancellationToken ct = default)
+    {
+        switch (decision.Kind)
+        {
+            case CurationDecisionKind.Skip:
+                _log.Info(
+                    "curation_skip anchor={0} reason={1}",
+                    operation.AnchorCanonicalName,
+                    decision.Reason);
+                return null;
+
+            case CurationDecisionKind.Update:
+                _log.Info(
+                    "curation_update anchor={0} targetDoc={1} reason={2}",
+                    operation.AnchorCanonicalName,
+                    decision.TargetDocumentId!,
+                    decision.Reason);
+
+                // Set the operation's MemoryId to the existing document ID
+                // so the ON CONFLICT UPDATE fires
+                return operation with { MemoryId = decision.TargetDocumentId };
+
+            case CurationDecisionKind.Consolidate:
+                _log.Info(
+                    "curation_consolidate anchor={0} canonicalAnchor={1} targetIds=[{2}] reason={3}",
+                    operation.AnchorCanonicalName,
+                    decision.CanonicalAnchorName!,
+                    decision.ConsolidationTargetIds is not null ? string.Join(",", decision.ConsolidationTargetIds) : "",
+                    decision.Reason);
+
+                await ExecuteConsolidationAsync(operation, decision, ct);
+                // After consolidation, write the new proposal under the canonical anchor
+                var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
+                return operation with { AnchorCanonicalName = canonicalAnchor };
+
+            case CurationDecisionKind.Create:
+                _log.Info(
+                    "curation_create anchor={0} reason={1}",
+                    operation.AnchorCanonicalName,
+                    decision.Reason);
+                return operation;
+
+            case CurationDecisionKind.Ambiguous:
+            default:
+                // Should not reach here — ambiguous is resolved before writing
+                _log.Warning("curation_unexpected_ambiguous anchor={0}, defaulting to create", operation.AnchorCanonicalName);
+                return operation;
+        }
+    }
+
+    private async Task ExecuteConsolidationAsync(
+        SQLiteMemoryCurationOperation operation,
+        CurationDecision decision,
+        CancellationToken ct)
+    {
+        if (decision.ConsolidationTargetIds is null || decision.ConsolidationTargetIds.Count == 0)
+            return;
+
+        var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
+        var canonicalAnchorId = MemoryTypedId.AnchorId(canonicalAnchor);
+
+        // For each consolidation target document, re-anchor it if it belongs to a different anchor,
+        // then tombstone the redundant anchor
+        var tombstonedAnchors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var docId in decision.ConsolidationTargetIds)
+        {
+            // Re-anchor the document to the canonical anchor
+            await _store.ReanchorDocumentAsync(docId, canonicalAnchorId, ct);
+
+            _log.Info(
+                "curation_reanchor docId={0} newAnchor={1}",
+                docId,
+                canonicalAnchorId);
+        }
+
+        // Find and tombstone anchors that are no longer canonical
+        // We need to look up the anchor IDs for the consolidated documents
+        var candidates = await _store.FindFuzzyAnchorMatchesAsync(operation.AnchorCanonicalName, ct);
+
+        foreach (var candidate in candidates)
+        {
+            if (!string.Equals(candidate.AnchorId, canonicalAnchorId, StringComparison.OrdinalIgnoreCase)
+                && !tombstonedAnchors.Contains(candidate.AnchorId))
+            {
+                await _store.TombstoneAnchorAsync(candidate.AnchorId, ct);
+                tombstonedAnchors.Add(candidate.AnchorId);
+
+                _log.Info(
+                    "curation_tombstone_anchor anchorId={0} canonicalName={1}",
+                    candidate.AnchorId,
+                    candidate.AnchorCanonicalName);
+            }
+        }
+    }
+}

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -520,6 +520,17 @@ public sealed class MemoryCurationEngine(
 
     private readonly ILogger<MemoryCurationEngine> _logger = logger ?? NullLogger<MemoryCurationEngine>.Instance;
 
+    // Same evaluator the inline per-session actor uses (memory-core-redesign Slice 1),
+    // constructed with no LLM client: the daemon checkpoint worker has none to give it
+    // today, so every Ambiguous decision here resolves via
+    // CurationRulesEvaluator.TryAutoResolveAmbiguous rather than escalating. This is the
+    // one place the daemon path previously performed no dedup/relationship evaluation at
+    // all beyond the fingerprint check below — routing through the shared evaluator is
+    // what makes GuardDestructiveUpdate (previously inline-actor-only; audit finding D14)
+    // apply here too.
+    private readonly MemoryCurationEvaluator _evaluator =
+        new(store, (ILogger)(logger ?? NullLogger<MemoryCurationEngine>.Instance), llmClient: null);
+
     public async Task<IReadOnlyList<SQLiteMemoryCurationOperation>> CurateAsync(
         SQLiteMemoryCheckpoint checkpoint,
         CancellationToken ct = default)
@@ -569,7 +580,7 @@ public sealed class MemoryCurationEngine(
             return [];
         }
 
-        return candidates.Select(c => new SQLiteMemoryCurationOperation(
+        var operations = candidates.Select(c => new SQLiteMemoryCurationOperation(
             Kind: c.Kind.ToWireValue(),
             MemoryClass: c.MemoryClass.ToWireValue(),
             MemoryId: c.MemoryId,
@@ -590,6 +601,37 @@ public sealed class MemoryCurationEngine(
             FreshnessAtMs: c.FreshnessAtMs,
             ExpiresAtMs: c.ExpiresAtMs,
             SupersedesRecordId: c.SupersedesRecordId)).ToArray();
+
+        return await EvaluateAndApplyAsync(operations, checkpoint, ct);
+    }
+
+    /// <summary>
+    /// Runs each extracted candidate through the shared evaluator (dedup/relationship
+    /// decision, then the decision-to-write-operation mapping) before the caller persists
+    /// the result via <see cref="SQLiteMemoryStore.ApplyCurationBatchAsync"/> — the same
+    /// evaluate-then-apply sequence the inline actor's write phase runs. A Skip decision
+    /// drops the candidate here rather than at the caller.
+    /// </summary>
+    private async Task<IReadOnlyList<SQLiteMemoryCurationOperation>> EvaluateAndApplyAsync(
+        IReadOnlyList<SQLiteMemoryCurationOperation> operations,
+        SQLiteMemoryCheckpoint checkpoint,
+        CancellationToken ct)
+    {
+        if (operations.Count == 0)
+            return operations;
+
+        var sessionId = (SessionId)checkpoint.SessionId;
+        var results = new List<SQLiteMemoryCurationOperation>(operations.Count);
+
+        foreach (var operation in operations)
+        {
+            var decision = await _evaluator.EvaluateAsync(operation, sessionId, ct);
+            var writeOp = await _evaluator.ApplyDecisionAsync(operation, decision, ct);
+            if (writeOp is not null)
+                results.Add(writeOp);
+        }
+
+        return results;
     }
 
     private void LogCheckpointDropped(


### PR DESCRIPTION
## Summary

Implements Slice 1 (tasks 1.1–1.4) of the `memory-core-redesign` OpenSpec change (#1570): extracts a shared `MemoryCurationEvaluator` used by **both** memory write pipelines, so the inline per-session actor path and the daemon checkpoint-worker path can never diverge again.

### What unified

`MemoryCurationActor.EvaluateSingleAsync` (record bypass → fuzzy anchor candidates → content-term candidate search → `CurationRulesEvaluator.Evaluate` → LLM tier + `GuardDestructiveUpdate` → `TryAutoResolveAmbiguous` → Create fallback) and the actor's decision→write-operation mapping (including Consolidate's re-anchor/tombstone side effects) now live in one `MemoryCurationEvaluator` (`src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs`). The actor delegates to it; `MemoryCurationEngine.CurateAsync` (daemon) routes every extracted candidate through the same `EvaluateAsync` → `ApplyDecisionAsync` sequence before `ApplyCurationBatchAsync` persists the result.

**Structural finding:** the daemon path previously performed *no* per-candidate relationship evaluation at all — only `MemoryRulesFirstExtractor` extraction (with its fingerprint literal-duplicate check) followed by a direct write. It never called `CurationRulesEvaluator` and never guarded updates. Unification here means routing its candidates through the evaluator for the first time, exactly as anticipated by the change's design doc (D4).

### The ONE intended behavioral delta

The daemon path gains `GuardDestructiveUpdate` — closing **audit finding D14** (the lossless-update guard existed only on the inline actor path). An Update decision whose proposal does not preserve the existing body is downgraded to Skip on both paths now. The daemon engine constructs the evaluator **without** an LLM client (its worker has none), preserving today's deterministic-only behavior there; Ambiguous decisions resolve via `TryAutoResolveAmbiguous`.

### Marker-stability guarantee

The evaluator logs through a minimal internal `ICurationLog` seam with two adapters (`AkkaCurationLog` for the actor's `ILoggingAdapter`, `MicrosoftCurationLog` for the engine's MEL `ILogger`). Message templates and argument order are byte-identical to the pre-refactor actor code, so the July 2026 audit tooling's grep targets keep firing unchanged from both paths: `curation_dual_search`, `curation_llm_decision`, `curation_llm_no_decision`, `curation_llm_timeout`, `curation_llm_error`, `curation_ambiguous_auto_resolved`, `curation_ambiguous_create_fallback`, `curation_skip`/`_update`/`_consolidate`/`_create`, `curation_reanchor`, `curation_tombstone_anchor`.

### Characterization matrix (`MemoryCurationEvaluatorParityTests`, 9 tests, all green)

Both constructions (actor-style `ILoggingAdapter` / engine-style `ILogger`, no LLM) driven against one seeded store, asserting decision equality:

| Case | Decision | Parity |
|---|---|---|
| Record bypass | Create | identical |
| Exact anchor + high overlap | Skip | identical |
| Exact anchor + newer superset | Update | identical |
| Fuzzy anchor > 0.8 overlap | Consolidate | identical |
| Gray zone 0.4–0.8, no LLM | auto-resolve → Skip | identical |
| Fuzzy anchor < 0.4 overlap | Create | identical |
| Guard downgrade (proposal drops existing body) | Update → Skip | identical — **now fires on BOTH paths (D14)** |
| Scripted LLM, parseable `SKIP` | LLM decision honored + guarded | — |
| Scripted LLM, empty response | falls back to deterministic auto-resolve | — |

### Validation

- `dotnet test src/Netclaw.Actors.Tests` — **2540/2540 passed**
- `dotnet test src/Netclaw.Daemon.Tests` — **825/825 passed**
- `dotnet slopwatch analyze` — 0 issues
- `Add-FileHeaders.ps1 -Verify` — all files have headers
- Memory eval gate (openai-compatible @ spark-acad, `nvidia/Qwen3.6-27B-NVFP4`, 5 runs/case):

```
Category: Memory Pipeline
  [PASS] memory_recall_active           5/5 (1.00)  — recall active, not degraded
  [FAIL] memory_identity_preference_routing 3/5 (0.60)  — durable user preference routed to memory, not SOUL.md
  [PASS] memory_explicit_store          5/5 (1.00)  — explicit remember request uses store_memory
  [PASS] memory_checkpoint_enqueue      5/5 (1.00)  — checkpoint enqueued for non-identity fact
  [PASS] memory_recall_filters          5/5 (1.00)  — candidate selection with score filtering
  Category: 4/5 passed (YELLOW)
Overall: 4/5 cases passed (80.0%)
```

The single failing case is an instrumentation false negative, not a regression from this PR: in both "failing" runs the model behaved exactly as the eval's own comment defines correct ("already saved — I can see 'Favorite Color — Chartreuse' in my durable memories", no SOUL.md edit), but the assertion greps for the literal substring `memory`, which does not match the word "memories". A first eval attempt scored 2/5 because the vLLM endpoint restarted mid-run (15/25 prompts got `Connection refused`); the retry above is the clean run. This case is untouched by this refactor (which only affects the post-proposal curation write pipeline, not model tool routing or response text) and the same code scored 5/5 on it in the earlier partial run.

### OpenSpec

- Change: `memory-core-redesign` (merged in #1570), design D4 + Migration Plan item 1
- Tasks 1.1–1.4 checked in `openspec/changes/memory-core-redesign/tasks.md`
