### PR TITLE
Release 0.25.0-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,20 +8,21 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.24.4</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.24.4 — Environment-variable-only configuration support, remote daemon CLI fix
+    <VersionPrefix>0.25.0-beta.1</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.25.0-beta.1 — SkillServer native sub-agent sync, memory curation unification, systemd PATH fix
+
+**Features**
+
+* **SkillServer native sub-agent sync** — Optional native manifest sidecar sync for server-managed sub-agents. Local sub-agent files load before server-feed files so user-authored definitions always win. ([#1539](https://github.com/netclaw-dev/netclaw/pull/1539))
 
 **Bug Fixes**
 
-* **Environment-variable-only configuration** — Fixed doctor misdiagnosis and OAuth config-file side effect that prevented daemon startup when configuration is supplied entirely via environment variables. ([#1569](https://github.com/netclaw-dev/netclaw/pull/1569))
+* **Systemd shell tool PATH** — Fixed: daemon now captures the operator's full PATH into the systemd EnvironmentFile instead of relying on a hardcoded list. ([#1565](https://github.com/netclaw-dev/netclaw/pull/1565))
 
-* **Remote daemon CLI** — Fixed: CLI no longer demands a local daemon config file when the daemon is explicitly configured as remote. ([#1567](https://github.com/netclaw-dev/netclaw/pull/1567))
+**Memory**
 
-**Dependency Updates**
-
-* **Bump Anthropic SDK** — 12.34.1 → 12.35.1. ([#1561](https://github.com/netclaw-dev/netclaw/pull/1561))
-
-* **Bump Akka group** — Akka.Cluster.Sharding and Akka.Persistence 1.5.69 → 1.5.70. ([#1560](https://github.com/netclaw-dev/netclaw/pull/1560))</PackageReleaseNotes>
+* **Shared curation evaluator** — Unified curation logic across both memory write pipelines so they can never diverge again. ([#1575](https://github.com/netclaw-dev/netclaw/pull/1575))
+* **Memory audit quick wins** — July 2026 audit: revived curation LLM, balanced prompt, and recall precision re-tune. ([#1568](https://github.com/netclaw-dev/netclaw/pull/1568))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # NetClaw Release Notes
 
+## 0.25.0-beta.1 (2026-07-05)
+
+### Features
+- **SkillServer native sub-agent sync** — Optional native manifest sidecar sync for server-managed sub-agents, keeping RFC skill sync primary while downloading verified native artifacts when available. Local sub-agent files load before server-feed files so user-authored definitions always win ([#1539](https://github.com/netclaw-dev/netclaw/pull/1539))
+
+### Bug Fixes
+- **Systemd shell tool PATH** — Fixed: daemon now captures the operator's full PATH into the systemd EnvironmentFile instead of relying on a hardcoded list, so tools like `~/.dotnet/dotnet` are visible to the shell tool ([#1565](https://github.com/netclaw-dev/netclaw/pull/1565))
+
+### Memory
+- **Shared curation evaluator** — Unified curation logic across both memory write pipelines (inline per-session actor and daemon checkpoint-worker) so they can never diverge again ([#1575](https://github.com/netclaw-dev/netclaw/pull/1575))
+- **Memory audit quick wins** — July 2026 audit: revived curation LLM, balanced prompt, and recall precision re-tune ([#1568](https://github.com/netclaw-dev/netclaw/pull/1568))
+
 ## 0.24.4 (2026-07-03)
 
 ### Bug Fixes


### PR DESCRIPTION
## Changes

### Features
- **SkillServer native sub-agent sync** — Optional native manifest sidecar sync for server-managed sub-agents ([#1539])

### Bug Fixes
- **Systemd shell tool PATH** — Daemon now captures the operator's full PATH into the systemd EnvironmentFile ([#1565])

### Memory
- **Shared curation evaluator** — Unified curation logic across both memory write pipelines ([#1575])
- **Memory audit quick wins** — Revived curation LLM, balanced prompt, recall precision re-tune ([#1568])

---

See [RELEASE_NOTES.md](https://github.com/netclaw-dev/netclaw/blob/release/v0.25.0-beta.1/RELEASE_NOTES.md) for full details.