### PR TITLE
fix(tests): make FakeChatClient thread-safe to fix racy compaction test

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -1675,13 +1675,39 @@ internal sealed class FakeChatClient : IChatClient
 
     public int CallCount => _callCount;
 
-    public List<IReadOnlyList<ChatMessage>> ReceivedMessages { get; } = [];
-    public List<IReadOnlyList<string>> ReceivedToolNames { get; } = [];
+    // GetResponseAsync is invoked concurrently from multiple actor dispatcher / ThreadPool
+    // threads on one shared instance (main-model turn + compaction summarizer sidecar +
+    // fire-and-forget memory-extraction sidecar), while test threads enumerate and index the
+    // recorded collections. This gate serializes every append below, and the public getters
+    // return a snapshot copy taken under it. Locking the writes alone is NOT sufficient: a
+    // caller's List<T> enumeration still throws "Collection was modified" if an Add interleaves
+    // its MoveNext, so the read side must copy under the same lock. Never held across an await.
+    private readonly object _recordingGate = new();
+
+    private readonly List<IReadOnlyList<ChatMessage>> _receivedMessages = [];
+    private readonly List<IReadOnlyList<string>> _receivedToolNames = [];
+    private readonly List<ChatOptions?> _receivedOptions = [];
+
+    /// <summary>Snapshot copy taken under <see cref="_recordingGate"/> so a test can safely
+    /// enumerate / index / LINQ over it while actor threads keep appending.</summary>
+    public IReadOnlyList<IReadOnlyList<ChatMessage>> ReceivedMessages
+    {
+        get { lock (_recordingGate) { return _receivedMessages.ToArray(); } }
+    }
+
+    /// <summary>Snapshot copy taken under <see cref="_recordingGate"/>; see <see cref="ReceivedMessages"/>.</summary>
+    public IReadOnlyList<IReadOnlyList<string>> ReceivedToolNames
+    {
+        get { lock (_recordingGate) { return _receivedToolNames.ToArray(); } }
+    }
 
     /// <summary>The <see cref="ChatOptions"/> object passed on each call, so tests can
     /// assert the session actor threads a <c>SessionScopedChatOptions</c> carrier through
-    /// for per-session log correlation.</summary>
-    public List<ChatOptions?> ReceivedOptions { get; } = [];
+    /// for per-session log correlation. Snapshot copy taken under <see cref="_recordingGate"/>.</summary>
+    public IReadOnlyList<ChatOptions?> ReceivedOptions
+    {
+        get { lock (_recordingGate) { return _receivedOptions.ToArray(); } }
+    }
 
     public TimeSpan Delay { get; set; } = TimeSpan.Zero;
 
@@ -1778,16 +1804,26 @@ internal sealed class FakeChatClient : IChatClient
         ChatOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        if (PlannedExceptions.Count > 0)
-            throw PlannedExceptions.Dequeue();
-
+        // Materialize the caller's own enumerables outside the lock — they are private to this
+        // call and can be non-trivial to enumerate; only the shared-list appends need guarding.
         var messageList = messages.ToList();
-        ReceivedMessages.Add(messageList);
-        ReceivedOptions.Add(options);
-        ReceivedToolNames.Add(options?.Tools?
+        var toolNames = options?.Tools?
             .Select(t => t is AIFunction f ? f.Name : t.GetType().Name)
             .ToList()
-            ?? []);
+            ?? [];
+
+        lock (_recordingGate)
+        {
+            // Consume a planned exception before recording so a failed call is not counted
+            // (CallCount / recorded-messages contract). Every call path — main model and both
+            // sidecars — reaches this on a different thread, so the check+dequeue must be guarded.
+            if (PlannedExceptions.Count > 0)
+                throw PlannedExceptions.Dequeue();
+
+            _receivedMessages.Add(messageList);
+            _receivedOptions.Add(options);
+            _receivedToolNames.Add(toolNames);
+        }
         Interlocked.Increment(ref _callCount);
 
         if (Delay > TimeSpan.Zero)


### PR DESCRIPTION
## Problem

`CompactionIntegrationTests.Successive_compactions_preserve_prior_summary_in_observer_system_prompt` failed on **ubuntu CI only** ([run 28690821775](https://github.com/netclaw-dev/netclaw/actions/runs/28690821775/job/85091666339)) — Windows and macOS passed, the classic racy-test signature:

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
  at System.Collections.Generic.List`1.Enumerator.MoveNext()
  at System.Linq...ToList()
  at CompactionIntegrationTests.cs:line 617
```

## Root cause

`FakeChatClient` is a single shared instance whose `GetResponseAsync` is invoked **concurrently** from multiple actor dispatcher / ThreadPool threads — the main-model turn, the compaction summarizer sidecar, and a fire-and-forget memory-extraction sidecar that `LlmSessionActor` launches one line *after* it emits `CompactionOutput` (`LlmSessionActor.cs:1273`). It appended to three plain `List<T>` fields (`ReceivedMessages` / `ReceivedOptions` / `ReceivedToolNames`) with **no synchronization**, while the test thread enumerated `ReceivedMessages` via `.Select().Where().ToList()` at line 617. Only `_callCount` was `Interlocked`-guarded — a partial fix that left the lists exposed.

The test's `ExpectMsg<CompactionOutput>` barrier proves the summarizer call landed but does **not** quiesce the collection, so the enumeration raced a concurrent `Add`. Ubuntu-only reproduction is scheduling sensitivity — the bug is platform-independent.

## Fix

Back the three recording collections with private lists and expose them as `IReadOnlyList<T>` getters that return a **snapshot copy taken under a single `_recordingGate` lock**; guard the appends (and the `PlannedExceptions` check) under the same lock. The lock is never held across an `await`.

**Snapshot-on-read is load-bearing** — locking the writes alone would not stop a caller's `List<T>` enumeration from throwing when an `Add` interleaves its `MoveNext`. The racing writer (memory-extraction, `"memory extraction assistant"` prompt) is filtered out of the assertion's `.Where(Contains("session summarizer"))` predicate, and the two summarizer calls the test inspects are ordered-before their `CompactionOutput` via the mailbox — so a thread-safe fake alone makes the test deterministic without adding an actor-side barrier.

## Scope

Tightly scoped to the three recording collections + `PlannedExceptions` (the one field every call path touches). The deeper queue dequeues (`PlannedToolCallDecisions` / `PlannedUsageOverrides` / `PlannedResponses`) share the pattern but aren't reached concurrently in the current suite (sidecars branch earlier; one session's main-model calls are actor-serialized), so they were left alone to avoid widening the blast radius.

Follow-up worth filing: `CompactionOutput` isn't a "compaction fully settled" barrier because memory extraction fires fire-and-forget afterward with no completion signal. Fine for this test, but any future test asserting on the extraction call itself would need a real ack.

## Verification (on Linux — the platform that reproduced it)

- ✅ Build: 0 warnings / 0 errors (private lists proved no external mutator; all ~10 caller files compile against the `IReadOnlyList` shape)
- ✅ Target test: 25/25
- ✅ Full `Netclaw.Actors.Tests`: **2531 passed, 0 failed** (was 2530 / 1-failed in CI)
- ✅ `dotnet slopwatch analyze`: 0 issues

🤖 Analysis by akka-net-specialist + dotnet-concurrency-specialist via `/analyze-racy-test`.