### PR TITLE
fix: split VersionPrefix/VersionSuffix for 0.25.0-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.25.0-beta.1</VersionPrefix>
+    <VersionPrefix>0.25.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
     <PackageReleaseNotes>Netclaw v0.25.0-beta.1 — SkillServer native sub-agent sync, memory curation unification, systemd PATH fix
 
 **Features**


### PR DESCRIPTION
CI validation requires prerelease versions to split the suffix into `<VersionSuffix>`:\n\n- `<VersionPrefix>0.25.0</VersionPrefix>`\n- `<VersionSuffix>beta.1</VersionSuffix>`\n\nThis fixes the 'Validate tag matches VersionPrefix/VersionSuffix' CI step that blocked the v0.25.0-beta.1 tag.