### PR TITLE
fix: split VersionPrefix/VersionSuffix for 0.25.0-beta.1 prerelease

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.25.0-beta.1</VersionPrefix>
+    <VersionPrefix>0.25.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
     <PackageReleaseNotes>Netclaw v0.25.0-beta.1 — SkillServer native sub-agent sync, memory curation unification, systemd PATH fix
 
 **Features**


### PR DESCRIPTION
PR #1578 set the full prerelease string in `VersionPrefix`. This splits it into the correct `VersionPrefix` + `VersionSuffix` format matching all previous beta releases (e.g. 0.24.3-beta.3).