### PR TITLE
test: add failing tests for BOM frontmatter and missing SkillName

### DIFF
--- a/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
@@ -830,6 +830,45 @@ public class SkillScannerTests : IDisposable
         Assert.Equal("A skill with BOM", result.Description);
     }
 
+    [Theory]
+    [InlineData("---\n---\n")]           // empty frontmatter body
+    [InlineData("﻿---\n---\n")]      // BOM-prefixed empty frontmatter body
+    [InlineData("---\n---")]              // no trailing newline
+    public void ExtractFrontmatter_returns_null_for_degenerate_block_without_throwing(string content)
+    {
+        // A degenerate block like "---\n---" has an empty YAML body: the opening line's
+        // newline IS the closing delimiter's newline. The slice must not compute a
+        // negative-length range (ArgumentOutOfRangeException) — it must return null so the
+        // file is reported as invalid frontmatter rather than crashing the scan.
+        var result = SkillScanner.ExtractFrontmatter(content);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Scan_does_not_abort_on_skill_with_degenerate_frontmatter()
+    {
+        // Regression: a SKILL.md whose frontmatter is an empty "---\n---" block previously
+        // threw ArgumentOutOfRangeException out of the unguarded parse call, aborting the
+        // entire discovery pass so that no skills loaded at all. Scan must instead skip the
+        // bad skill (recording an issue) and continue discovering healthy siblings.
+        WriteSkill("degenerate", "---\n---\n\n# Body\n");
+        WriteSkill("healthy", """
+            ---
+            name: healthy
+            description: A perfectly good skill.
+            ---
+
+            # Healthy
+            """);
+
+        var result = SkillScanner.Scan(_skillsDir);
+
+        Assert.Contains(result.AcceptedSkills, s => s.Name == "healthy");
+        Assert.Contains(result.Issues, i =>
+            i.Path.EndsWith(Path.Combine("degenerate", "SKILL.md"), StringComparison.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public void SkillScanIssue_populates_skill_name_for_broken_frontmatter()
     {
@@ -858,6 +897,31 @@ public class SkillScannerTests : IDisposable
             Assert.NotNull(i.SkillName);
             Assert.Equal("broken-frontmatter", i.SkillName);
         });
+    }
+
+    [Fact]
+    public void SkillScanIssue_normalizes_skill_name_from_mixed_case_directory()
+    {
+        // Issue SkillNames must be the canonical (lowercased) skill name — the same
+        // representation accepted skills use — so that errored and accepted rows render
+        // consistently regardless of the on-disk directory casing.
+        WriteSkill("Mixed-Case", """
+            ---
+            name: Mixed-Case
+            description: [invalid yaml {{{
+            ---
+
+            # Broken
+            """);
+
+        var result = SkillScanner.Scan(_skillsDir);
+
+        var issuesForSkill = result.Issues
+            .Where(i => i.Path.EndsWith(Path.Combine("Mixed-Case", "SKILL.md"), StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.NotEmpty(issuesForSkill);
+        Assert.All(issuesForSkill, i => Assert.Equal("mixed-case", i.SkillName));
     }
 
 }

--- a/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Skills;
 using Netclaw.Configuration;
+using System.Linq;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Skills;
@@ -813,4 +814,50 @@ public class SkillScannerTests : IDisposable
             # {skillName}
             """);
     }
+
+    [Fact]
+    public void ExtractFrontmatter_handles_utf8_bom()
+    {
+        // SKILL.md files saved by some editors (e.g., Notepad on Windows) include
+        // a UTF-8 BOM (\uFEFF) at the start of the file. ExtractFrontmatter should
+        // strip the BOM and still parse the frontmatter correctly.
+        var content = "\uFEFF---\nname: bom-skill\ndescription: \"A skill with BOM\"\n---\n\n# Content\n";
+
+        var result = SkillScanner.ExtractFrontmatter(content);
+
+        Assert.NotNull(result);
+        Assert.Equal("bom-skill", result.Name);
+        Assert.Equal("A skill with BOM", result.Description);
+    }
+
+    [Fact]
+    public void SkillScanIssue_populates_skill_name_for_broken_frontmatter()
+    {
+        // When a SKILL.md has invalid frontmatter, the resulting SkillScanIssue
+        // should include the SkillName (derived from the parent directory name)
+        // so that issue reporting can identify the skill by name.
+        WriteSkill("broken-frontmatter", """
+            ---
+            name: broken-frontmatter
+            description: [invalid yaml {{{
+            ---
+
+            # Broken
+            """);
+
+        var result = SkillScanner.Scan(_skillsDir);
+
+        Assert.Empty(result.AcceptedSkills); // broken frontmatter => skill rejected
+        var issuesForSkill = result.Issues
+            .Where(i => i.Path.EndsWith(Path.Combine("broken-frontmatter", "SKILL.md"), StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.NotEmpty(issuesForSkill);
+        Assert.All(issuesForSkill, i =>
+        {
+            Assert.NotNull(i.SkillName);
+            Assert.Equal("broken-frontmatter", i.SkillName);
+        });
+    }
+
 }

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SkillScanner.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -280,24 +280,29 @@ public static partial class SkillScanner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            var skillName = Path.GetFileName(Path.GetDirectoryName(canonicalSkillFilePath)!);
             issues.Add(new SkillScanIssue(
                 Path: canonicalSkillFilePath,
                 Kind: SkillScanIssueKind.UnreadableFile,
-                Message: $"Failed to read skill file: {ex.Message}"));
+                Message: $"Failed to read skill file: {ex.Message}",
+                SkillName: skillName));
             return null;
         }
 
         var frontmatter = ExtractFrontmatter(content);
         if (frontmatter is null)
         {
+            var skillName = Path.GetFileName(Path.GetDirectoryName(canonicalSkillFilePath)!);
+            var hasFrontmatterStart = content.TrimStart('\uFEFF').StartsWith("---", StringComparison.Ordinal);
             issues.Add(new SkillScanIssue(
                 Path: canonicalSkillFilePath,
-                Kind: content.StartsWith("---", StringComparison.Ordinal)
+                Kind: hasFrontmatterStart
                     ? SkillScanIssueKind.InvalidFrontmatter
                     : SkillScanIssueKind.MissingFrontmatter,
-                Message: content.StartsWith("---", StringComparison.Ordinal)
+                Message: hasFrontmatterStart
                     ? "Skill frontmatter is invalid or unparseable."
-                    : "Skill file must start with YAML frontmatter."));
+                    : "Skill file must start with YAML frontmatter.",
+                SkillName: skillName));
             return null;
         }
 
@@ -329,32 +334,27 @@ public static partial class SkillScanner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            var skillName = Path.GetFileNameWithoutExtension(canonicalPath);
             issues.Add(new SkillScanIssue(
                 Path: canonicalPath,
                 Kind: SkillScanIssueKind.UnreadableFile,
-                Message: $"Failed to read flat skill file: {ex.Message}"));
+                Message: $"Failed to read flat skill file: {ex.Message}",
+                SkillName: skillName));
             return null;
         }
 
         var frontmatter = ExtractFrontmatter(content);
         if (frontmatter is null)
         {
-            if (allowFrontmatterlessFlatFiles && !content.StartsWith("---", StringComparison.Ordinal))
+            if (allowFrontmatterlessFlatFiles && !content.TrimStart('\uFEFF').StartsWith("---", StringComparison.Ordinal))
                 return BuildFlatSkillEntryWithoutFrontmatter(canonicalPath, canonicalRoot, content, issues);
 
+            var skillName = Path.GetFileNameWithoutExtension(canonicalPath);
             issues.Add(new SkillScanIssue(
                 Path: canonicalPath,
                 Kind: SkillScanIssueKind.FlatFileMissingFrontmatter,
-                Message: "Flat .md file found but lacks valid YAML frontmatter. Add frontmatter with name and description, or move into a skill-name/SKILL.md directory."));
-            return null;
-        }
-
-        if (string.IsNullOrWhiteSpace(frontmatter.Description))
-        {
-            issues.Add(new SkillScanIssue(
-                Path: canonicalPath,
-                Kind: SkillScanIssueKind.FlatFileNoDescription,
-                Message: "Flat .md file has frontmatter but missing description field."));
+                Message: "Flat .md file found but lacks valid YAML frontmatter. Add frontmatter with name and description, or move into a skill-name/SKILL.md directory.",
+                SkillName: skillName));
             return null;
         }
 
@@ -363,6 +363,16 @@ public static partial class SkillScanner
         var name = !string.IsNullOrWhiteSpace(frontmatter.Name)
             ? NormalizeSkillName(frontmatter.Name)
             : NormalizeSkillName(fileNameWithoutExt);
+
+        if (string.IsNullOrWhiteSpace(frontmatter.Description))
+        {
+            issues.Add(new SkillScanIssue(
+                Path: canonicalPath,
+                Kind: SkillScanIssueKind.FlatFileNoDescription,
+                Message: "Flat .md file has frontmatter but missing description field.",
+                SkillName: name));
+            return null;
+        }
 
         if (strictNameMatch && !string.IsNullOrWhiteSpace(frontmatter.Name))
         {
@@ -405,6 +415,8 @@ public static partial class SkillScanner
     /// </summary>
     public static SkillFrontmatter? ExtractFrontmatter(string content)
     {
+        // Strip UTF-8 BOM — some editors (e.g., Notepad on Windows) prepend \uFEFF
+        content = content.TrimStart('\uFEFF');
         if (!content.StartsWith("---", StringComparison.Ordinal))
             return null;
 
@@ -451,10 +463,14 @@ public static partial class SkillScanner
         // Description is required per AgentSkills.io spec
         if (string.IsNullOrWhiteSpace(fm.Description))
         {
+            var skillName = !string.IsNullOrWhiteSpace(fm.Name)
+                ? NormalizeSkillName(fm.Name)
+                : NormalizeSkillName(Path.GetFileName(skillDirectory));
             issues.Add(new SkillScanIssue(
                 Path: filePath,
                 Kind: SkillScanIssueKind.MissingDescription,
-                Message: "Skill frontmatter must include a non-empty description."));
+                Message: "Skill frontmatter must include a non-empty description.",
+                SkillName: skillName));
             return null;
         }
 
@@ -581,10 +597,12 @@ public static partial class SkillScanner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            var skillName = Path.GetFileName(Path.GetDirectoryName(skillDirectory)!);
             issues.Add(new SkillScanIssue(
                 Path: skillDirectory,
                 Kind: SkillScanIssueKind.ResourceEnumerationFailed,
-                Message: $"Failed to enumerate resources: {ex.Message}"));
+                Message: $"Failed to enumerate resources: {ex.Message}",
+                SkillName: skillName));
             return null;
         }
 
@@ -632,10 +650,12 @@ public static partial class SkillScanner
         var description = ExtractFirstNonEmptyMarkdownLine(content);
         if (string.IsNullOrWhiteSpace(description))
         {
+            var skillName = NormalizeSkillName(Path.GetFileNameWithoutExtension(canonicalPath));
             issues.Add(new SkillScanIssue(
                 Path: canonicalPath,
                 Kind: SkillScanIssueKind.FlatFileNoDescription,
-                Message: "Flat .md file without frontmatter must contain at least one non-empty line to infer a description."));
+                Message: "Flat .md file without frontmatter must contain at least one non-empty line to infer a description.",
+                SkillName: skillName));
             return null;
         }
 

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -280,7 +280,7 @@ public static partial class SkillScanner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            var skillName = Path.GetFileName(Path.GetDirectoryName(canonicalSkillFilePath)!);
+            var skillName = NormalizeSkillName(Path.GetFileName(Path.GetDirectoryName(canonicalSkillFilePath)!));
             issues.Add(new SkillScanIssue(
                 Path: canonicalSkillFilePath,
                 Kind: SkillScanIssueKind.UnreadableFile,
@@ -292,8 +292,10 @@ public static partial class SkillScanner
         var frontmatter = ExtractFrontmatter(content);
         if (frontmatter is null)
         {
-            var skillName = Path.GetFileName(Path.GetDirectoryName(canonicalSkillFilePath)!);
-            var hasFrontmatterStart = content.TrimStart('\uFEFF').StartsWith("---", StringComparison.Ordinal);
+            var skillName = NormalizeSkillName(Path.GetFileName(Path.GetDirectoryName(canonicalSkillFilePath)!));
+            // content is from File.ReadAllText, which already strips any UTF-8 BOM, so no TrimStart
+            // is needed here; BOM tolerance for direct-string callers lives in ExtractFrontmatter.
+            var hasFrontmatterStart = content.StartsWith("---", StringComparison.Ordinal);
             issues.Add(new SkillScanIssue(
                 Path: canonicalSkillFilePath,
                 Kind: hasFrontmatterStart
@@ -334,7 +336,7 @@ public static partial class SkillScanner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            var skillName = Path.GetFileNameWithoutExtension(canonicalPath);
+            var skillName = NormalizeSkillName(Path.GetFileNameWithoutExtension(canonicalPath));
             issues.Add(new SkillScanIssue(
                 Path: canonicalPath,
                 Kind: SkillScanIssueKind.UnreadableFile,
@@ -346,10 +348,11 @@ public static partial class SkillScanner
         var frontmatter = ExtractFrontmatter(content);
         if (frontmatter is null)
         {
-            if (allowFrontmatterlessFlatFiles && !content.TrimStart('\uFEFF').StartsWith("---", StringComparison.Ordinal))
+            // content is from File.ReadAllText (BOM already stripped), so no TrimStart needed.
+            if (allowFrontmatterlessFlatFiles && !content.StartsWith("---", StringComparison.Ordinal))
                 return BuildFlatSkillEntryWithoutFrontmatter(canonicalPath, canonicalRoot, content, issues);
 
-            var skillName = Path.GetFileNameWithoutExtension(canonicalPath);
+            var skillName = NormalizeSkillName(Path.GetFileNameWithoutExtension(canonicalPath));
             issues.Add(new SkillScanIssue(
                 Path: canonicalPath,
                 Kind: SkillScanIssueKind.FlatFileMissingFrontmatter,
@@ -425,7 +428,16 @@ public static partial class SkillScanner
         if (closingIndex < 0)
             return null;
 
-        var yamlBlock = content[(content.IndexOf('\n', 0) + 1)..closingIndex];
+        // Guard degenerate blocks like "---\n---" where the opening line's newline IS the
+        // closing delimiter: the YAML body is empty, so there is nothing to deserialize.
+        // Without this, content[(firstNewline+1)..closingIndex] slices a negative-length
+        // range and throws ArgumentOutOfRangeException, which propagates out of Scan (the
+        // parse calls are unguarded) and aborts the entire skill-discovery pass.
+        var firstNewline = content.IndexOf('\n', StringComparison.Ordinal);
+        if (firstNewline < 0 || firstNewline >= closingIndex)
+            return null;
+
+        var yamlBlock = content[(firstNewline + 1)..closingIndex];
 
         try
         {
@@ -597,7 +609,9 @@ public static partial class SkillScanner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            var skillName = Path.GetFileName(Path.GetDirectoryName(skillDirectory)!);
+            // skillDirectory is already the skill's own directory, so its leaf name IS the
+            // skill name — do not climb to the parent (that yields the container dir, e.g. "files").
+            var skillName = NormalizeSkillName(Path.GetFileName(skillDirectory));
             issues.Add(new SkillScanIssue(
                 Path: skillDirectory,
                 Kind: SkillScanIssueKind.ResourceEnumerationFailed,


### PR DESCRIPTION
Fixes the two `SkillScanner` bugs from #1582 — and, following review, hardens a related crash path. This PR ships both the tests **and** the fixes (all green).

close #1582 

## Fixes

1. **UTF-8 BOM frontmatter parsing** — SKILL.md files saved with a UTF-8 BOM were rejected by `ExtractFrontmatter` because `content.StartsWith("---")` failed when the BOM preceded the delimiter. `ExtractFrontmatter` now strips the leading BOM before the delimiter check, so BOM-prefixed skills parse correctly. (Note: on the disk-scan path `File.ReadAllText` already strips the BOM; the strip in `ExtractFrontmatter` covers direct-string API callers.)

2. **Missing SkillName on issues** — every `SkillScanIssue` now populates `SkillName`, so `netclaw skill issues` can identify which skill is broken. Names are canonicalized via `NormalizeSkillName` so errored rows render the same lowercased name as accepted skills.

## Review-driven hardening

3. **Scan-aborting crash on degenerate frontmatter** — a degenerate `---\n---` block (empty YAML body) made `ExtractFrontmatter` slice a negative-length range and throw `ArgumentOutOfRangeException`. Because `Scan`'s parse calls are unguarded, this propagated out and aborted the **entire** skill-discovery pass (no skills loaded at all) — reachable on disk since `File.ReadAllText` strips the BOM down to a plain `---\n---`. Now guarded to return `null`, reported as invalid frontmatter.

4. **`ResourceEnumerationFailed` SkillName** — was derived from the *parent* directory (`Path.GetDirectoryName(skillDirectory)`), yielding the container name (e.g. `files`) instead of the skill name. Fixed to use the leaf directory.

5. **Dead-code cleanup** — removed no-op caller-side `content.TrimStart('﻿')` guards; BOM tolerance now lives solely in `ExtractFrontmatter`.

## Tests

- `ExtractFrontmatter` handles UTF-8 BOM
- `SkillScanIssue` populates `SkillName` for broken frontmatter, and normalizes it from a mixed-case directory
- `ExtractFrontmatter` returns `null` (does not throw) for degenerate blocks — plain, BOM-prefixed, and no-trailing-newline
- `Scan` does not abort on a degenerate-frontmatter skill and keeps discovering healthy siblings

All 45 `SkillScannerTests` pass; `dotnet slopwatch analyze` reports 0 issues.
