### PR TITLE
fix(daemon): log effective model capabilities with provenance

### DIFF
--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -468,30 +468,37 @@ static void ConfigureDaemonServices(
             .GetAwaiter().GetResult();
         var resolved = ModelCapabilityResolution.ResolveModelCapabilities(models, detected, logger: logger);
 
-        if (detected is not null)
+        // Report the *effective* capabilities the runtime will use, with per-field
+        // provenance — not the raw detector output. Precedence mirrors
+        // ModelCapabilityResolution: configured override > detected > default. The
+        // previous version logged the detected values, so setting an InputModalities
+        // override on a provider that reports no modalities but does report a context
+        // window (e.g. vLLM) printed "input=unknown" and looked like the override had
+        // been ignored, even though it was applied.
+        var inputSource = models.Main.InputModalities is not null ? "configured"
+            : detected?.InputModalities is not null ? "detected" : "default";
+        var outputSource = models.Main.OutputModalities is not null ? "configured"
+            : detected?.OutputModalities is not null ? "detected" : "default";
+        var contextSource = models.Main.ContextWindow is not null ? "configured"
+            : detected?.ContextWindowTokens is > 0 ? "detected" : "default";
+
+        logger.LogInformation(
+            "Resolved model capabilities for {ModelId}: input={Input} ({InputSource}), "
+            + "output={Output} ({OutputSource}), context_window={ContextWindow} ({ContextSource})",
+            models.Main.ModelId,
+            resolved.InputModalities, inputSource,
+            resolved.OutputModalities, outputSource,
+            resolved.ContextWindowTokens, contextSource);
+
+        // Nudge for the common trap: a multimodal model behind a provider that
+        // advertises no modality metadata runs text-only until an operator sets the
+        // override. Fires only when nothing supplied input modalities.
+        if (inputSource == "default")
         {
             logger.LogInformation(
-                "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                models.Main.ModelId,
-                detected.InputModalities?.ToString() ?? "unknown",
-                detected.OutputModalities?.ToString() ?? "unknown",
-                detected.ContextWindowTokens?.ToString() ?? "unknown");
-        }
-        else if (models.Main.ContextWindow is not null
-                 || models.Main.InputModalities is not null
-                 || models.Main.OutputModalities is not null)
-        {
-            logger.LogInformation(
-                "Using configured model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                models.Main.ModelId,
-                resolved.InputModalities,
-                resolved.OutputModalities,
-                resolved.ContextWindowTokens);
-        }
-        else
-        {
-            logger.LogInformation(
-                "Model {ModelId} not found in capability oracles; defaulting to text-only",
+                "{ModelId} resolved to text-only input; no modality data came from the provider or "
+                + "capability oracles. If this model accepts images, set Models:Main:InputModalities "
+                + "to \"Text, Image\" to enable vision.",
                 models.Main.ModelId);
         }
 


### PR DESCRIPTION
## Summary

The startup model-capability log reported the **detector's raw output** rather than the **effective** resolved capabilities. When an operator sets an `InputModalities` override on a provider that reports a context window but no modality metadata (e.g. vLLM), the detector returns a non-null partial result, so the log took the "auto-detected" branch and printed `input=unknown` — even though `ModelCapabilityResolution` had correctly applied the override. This made an applied override look ignored and sent at least one operator down a debugging rabbit hole.

## Change

- Log the **resolved (effective)** capability values instead of the detector output, annotated with **per-field provenance** (`configured` / `detected` / `default`). Precedence mirrors `ModelCapabilityResolution`: configured override > detected > default, so an applied override can no longer be misreported.
- Add a one-line nudge — fired only when input modalities fall through to the default — pointing operators at `Models:Main:InputModalities` to enable vision on multimodal models behind metadata-less providers.

Example output now:

```
Resolved model capabilities for nvidia/Qwen3.6-27B-NVFP4: input=Text, Image (configured), output=Text (default), context_window=262144 (configured)
```

Related to the operator-experience side of #1127 (inline overrides on `Models.Main` were being wiped by `doctor --fix`; separately, when present they were being misreported by this log).

## Test plan

- [x] `dotnet build src/Netclaw.Daemon` clean (0 warnings)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `Add-FileHeaders.ps1 -Verify` — all headers present
- [x] `ModelCapabilityResolution` tests 6/6 pass (resolution precedence this log mirrors is already covered)

No log-string assertion test added: log output is brittle to assert on and low-value per the repo testing guidelines; the underlying precedence is covered by the resolver tests.