### PR TITLE
feat(memory): kNN-nominate/LLM-decide dedup + lossless merges (memory-core-redesign slice 3)

### DIFF
--- a/feeds/skills/.system/files/netclaw-memory/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-memory/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-memory
 description: "REQUIRED when the user asks what you remember, recall, or know from past conversations, previous sessions, cross-session memory, memory classes, or memory types. Also before using memory tools: find_memories, get_memories, store_memory, update_memory."
 metadata:
   author: netclaw
-  version: "1.8.0"
+  version: "1.9.0"
 ---
 
 # Netclaw Memory
@@ -45,6 +45,13 @@ Both gates must pass for memory to function.
 - **Explicit tools** are a manual-control layer on top of automatic recall.
 - Memory is SQLite-backed and cross-session only within the active
   domain/boundary policy envelope.
+- **Duplicate detection is semantic when embeddings are enabled**
+  (`Memory.Embeddings.Enabled`): a near-duplicate proposal is nominated by
+  embedding similarity and adjudicated by the curator LLM (skip, update,
+  consolidate, or create) — similarity alone never merges or skips anything.
+  Merges are lossless-or-append: the curator writes a merged body that keeps
+  every source fact, and a deterministic guard falls back to appending the
+  proposal instead of overwriting when that check fails.
 - Memory IDs shown by automatic recall, `find_memories`, and `get_memories`
   (e.g. `doc-…` / `rec-…`) are stable, opaque handles. Copy them **verbatim**
   into `get_memories` or `update_memory` — do not rewrite or reformat them.

--- a/openspec/changes/memory-core-redesign/tasks.md
+++ b/openspec/changes/memory-core-redesign/tasks.md
@@ -31,10 +31,10 @@ constitution gates (tests, evals where mapped, schema/skill sync, slopwatch).
 ## 3. Write-side nominate→decide + lossless merge
 
 - [ ] 3.1 Nominator in the shared evaluator: kNN shortlist at `Memory.Curation.NominatorSimilarityThreshold`/`NominatorK`; any nominee forces the LLM tier; no-nominee-no-anchor creates without LLM; lexical candidate search becomes the logged degraded path
-- [ ] 3.2 Extend `CurationPromptBuilder` response protocol: CONSOLIDATE/UPDATE emit a merged body; `CurationDecision.MergedBody`; full-content previews for nominated candidates
-- [ ] 3.3 Implement `MergeGuard` (load-bearing-token retention ≥95%, length collapse check) with structural-append fallback producing `AppendDocument` semantics
-- [ ] 3.4 Route all curation UPDATE/CONSOLIDATE writes through guard-validated merged bodies; make raw whole-body overwrite unreachable from curation decisions
-- [ ] 3.5 Config: `Memory.Curation { NominatorSimilarityThreshold, NominatorK, LlmMaxOutputTokens, LlmTimeoutSeconds }` (replacing hardcoded constants) + schema sync
+- [x] 3.2 Extend `CurationPromptBuilder` response protocol: CONSOLIDATE/UPDATE emit a merged body; `CurationDecision.MergedBody`; full-content previews for nominated candidates
+- [x] 3.3 Implement `MergeGuard` (load-bearing-token retention ≥95%, length collapse check) with structural-append fallback producing `AppendDocument` semantics
+- [x] 3.4 Route all curation UPDATE/CONSOLIDATE writes through guard-validated merged bodies; make raw whole-body overwrite unreachable from curation decisions
+- [x] 3.5 Config: `Memory.Curation { NominatorSimilarityThreshold, NominatorK, LlmMaxOutputTokens, LlmTimeoutSeconds }` (replacing hardcoded constants) + schema sync
 - [ ] 3.6 Tests: paraphrase-dupe nomination (fixture pairs from the audit corpus shape), sibling pairs never auto-merge, MergeGuard property tests, append fallback, both-pipelines parity
 - [ ] 3.7 Eval suite (memory category) + skill sync; update decision-mix expectations (consolidate share should rise from ~0.1%)
 

--- a/openspec/changes/memory-core-redesign/tasks.md
+++ b/openspec/changes/memory-core-redesign/tasks.md
@@ -30,13 +30,13 @@ constitution gates (tests, evals where mapped, schema/skill sync, slopwatch).
 
 ## 3. Write-side nominate→decide + lossless merge
 
-- [ ] 3.1 Nominator in the shared evaluator: kNN shortlist at `Memory.Curation.NominatorSimilarityThreshold`/`NominatorK`; any nominee forces the LLM tier; no-nominee-no-anchor creates without LLM; lexical candidate search becomes the logged degraded path
+- [x] 3.1 Nominator in the shared evaluator: kNN shortlist at `Memory.Curation.NominatorSimilarityThreshold`/`NominatorK`; any nominee forces the LLM tier; no-nominee-no-anchor creates without LLM; lexical candidate search becomes the logged degraded path
 - [x] 3.2 Extend `CurationPromptBuilder` response protocol: CONSOLIDATE/UPDATE emit a merged body; `CurationDecision.MergedBody`; full-content previews for nominated candidates
 - [x] 3.3 Implement `MergeGuard` (load-bearing-token retention ≥95%, length collapse check) with structural-append fallback producing `AppendDocument` semantics
 - [x] 3.4 Route all curation UPDATE/CONSOLIDATE writes through guard-validated merged bodies; make raw whole-body overwrite unreachable from curation decisions
 - [x] 3.5 Config: `Memory.Curation { NominatorSimilarityThreshold, NominatorK, LlmMaxOutputTokens, LlmTimeoutSeconds }` (replacing hardcoded constants) + schema sync
-- [ ] 3.6 Tests: paraphrase-dupe nomination (fixture pairs from the audit corpus shape), sibling pairs never auto-merge, MergeGuard property tests, append fallback, both-pipelines parity
-- [ ] 3.7 Eval suite (memory category) + skill sync; update decision-mix expectations (consolidate share should rise from ~0.1%)
+- [x] 3.6 Tests: paraphrase-dupe nomination (fixture pairs from the audit corpus shape), sibling pairs never auto-merge, MergeGuard property tests, append fallback, both-pipelines parity
+- [x] 3.7 Eval suite (memory category) + skill sync; update decision-mix expectations (consolidate share should rise from ~0.1%)
 
 ## 4. Read-side hybrid recall + absolute floor
 

--- a/src/Netclaw.Actors.Tests/Memory/CurationPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/CurationPromptBuilderTests.cs
@@ -101,6 +101,104 @@ public sealed class CurationPromptBuilderTests
         Assert.Null(CurationPromptBuilder.ParseResponse("<think>reasoning with no closing tag and no answer"));
     }
 
+    // ── ParseResponse: merged-body protocol (memory-core-redesign Slice 3 task 3.2) ──
+
+    [Fact]
+    public void ParseResponse_parses_UPDATE_with_merged_body()
+    {
+        var response = "UPDATE doc-abc123\n---\nConfig path is /etc/app/config.yaml (previously /etc/app/config.json).";
+
+        var decision = CurationPromptBuilder.ParseResponse(response);
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Update, decision.Kind);
+        Assert.Equal("doc-abc123", decision.TargetDocumentId);
+        Assert.Equal(
+            "Config path is /etc/app/config.yaml (previously /etc/app/config.json).",
+            decision.MergedBody);
+        Assert.True(decision.FromLlmTier);
+    }
+
+    [Fact]
+    public void ParseResponse_parses_CONSOLIDATE_with_merged_body()
+    {
+        var response =
+            "CONSOLIDATE doc-abc123 doc-def456\n---\n" +
+            "Akka.NET GitHub repository: https://github.com/akkadotnet/akka.net.\n" +
+            "Latest stable release is 1.5.62 (previously 1.5.60).";
+
+        var decision = CurationPromptBuilder.ParseResponse(response);
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Consolidate, decision.Kind);
+        Assert.Equal(2, decision.ConsolidationTargetIds!.Count);
+        Assert.NotNull(decision.MergedBody);
+        Assert.Contains("1.5.62", decision.MergedBody);
+        Assert.Contains("1.5.60", decision.MergedBody);
+        Assert.True(decision.FromLlmTier);
+    }
+
+    [Fact]
+    public void ParseResponse_UPDATE_keyword_only_still_valid_with_no_body()
+    {
+        var decision = CurationPromptBuilder.ParseResponse("UPDATE doc-42");
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Update, decision.Kind);
+        Assert.Equal("doc-42", decision.TargetDocumentId);
+        Assert.Null(decision.MergedBody);
+    }
+
+    [Fact]
+    public void ParseResponse_CONSOLIDATE_keyword_only_still_valid_with_no_body()
+    {
+        var decision = CurationPromptBuilder.ParseResponse("CONSOLIDATE doc-1 doc-2");
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Consolidate, decision.Kind);
+        Assert.Equal(2, decision.ConsolidationTargetIds!.Count);
+        Assert.Null(decision.MergedBody);
+    }
+
+    [Fact]
+    public void ParseResponse_UPDATE_with_malformed_empty_body_treats_body_as_absent()
+    {
+        // Separator present but nothing meaningful follows it (just whitespace).
+        var decision = CurationPromptBuilder.ParseResponse("UPDATE doc-42\n---\n   \n  ");
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Update, decision.Kind);
+        Assert.Null(decision.MergedBody);
+    }
+
+    [Fact]
+    public void ParseResponse_SKIP_and_CREATE_never_carry_a_merged_body_even_with_a_separator()
+    {
+        // SKIP/CREATE are keyword-only per protocol; a stray "---" after them should not be
+        // misread as introducing a body for a decision kind that never carries one.
+        var skip = CurationPromptBuilder.ParseResponse("SKIP\n---\nirrelevant trailing text");
+        var create = CurationPromptBuilder.ParseResponse("CREATE\n---\nirrelevant trailing text");
+
+        Assert.NotNull(skip);
+        Assert.Null(skip.MergedBody);
+        Assert.NotNull(create);
+        Assert.Null(create.MergedBody);
+    }
+
+    [Fact]
+    public void ParseResponse_strips_think_block_before_parsing_merged_body()
+    {
+        var response =
+            "<think>These are the same fact, worded differently.</think>\n" +
+            "UPDATE doc-abc123\n---\nMerged content preserving both sources.";
+
+        var decision = CurationPromptBuilder.ParseResponse(response);
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Update, decision.Kind);
+        Assert.Equal("Merged content preserving both sources.", decision.MergedBody);
+    }
+
     // ── BuildUserMessage ────────────────────────────────────────────
 
     [Fact]
@@ -213,6 +311,62 @@ public sealed class CurationPromptBuilderTests
         // Full 500-char content should NOT appear
         Assert.DoesNotContain(longContent, message);
     }
+
+    [Fact]
+    public void BuildUserMessage_truncates_candidate_content_by_default()
+    {
+        // Legacy default (task 3.2): candidates shown as a 700-char preview, same as today,
+        // until Stage B passes useFullCandidateContent: true for nominated candidates.
+        var longCandidateContent = new string('y', 1_000);
+        var proposal = MakeMinimalProposal();
+        var candidates = new[] { MakeCandidate(longCandidateContent) };
+
+        var message = CurationPromptBuilder.BuildUserMessage(proposal, candidates);
+
+        Assert.DoesNotContain(longCandidateContent, message);
+    }
+
+    [Fact]
+    public void BuildUserMessage_shows_full_candidate_content_when_requested()
+    {
+        var longCandidateContent = new string('y', 1_000);
+        var proposal = MakeMinimalProposal();
+        var candidates = new[] { MakeCandidate(longCandidateContent) };
+
+        var message = CurationPromptBuilder.BuildUserMessage(proposal, candidates, useFullCandidateContent: true);
+
+        Assert.Contains(longCandidateContent, message);
+    }
+
+    private static SQLiteMemoryCurationOperation MakeMinimalProposal() => new(
+        Kind: "document",
+        MemoryClass: "durable_fact",
+        MemoryId: null,
+        AnchorCanonicalName: "test",
+        AnchorType: "concept",
+        Title: "Test",
+        Content: "proposal content",
+        AliasesJson: null,
+        FacetsJson: null,
+        SlotsJson: null,
+        Relations: null,
+        UpdateSemantics: "merge-document",
+        Boundary: TrustBoundary.TrustedInstanceValue,
+        Audience: TrustAudience.Team,
+        Sensitivity: "normal",
+        RecallMode: "auto",
+        Confidence: 0.9,
+        FreshnessAtMs: 1000,
+        ExpiresAtMs: null);
+
+    private static ExistingMemoryCandidate MakeCandidate(string content) => new(
+        DocumentId: "doc-abc123",
+        AnchorId: "anchor:existing",
+        AnchorCanonicalName: "existing",
+        Content: content,
+        FreshnessAtMs: 900,
+        Confidence: 0.85,
+        IsExactAnchorMatch: false);
 
     // ── SystemPrompt ────────────────────────────────────────────────
 

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationActorNominatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationActorNominatorTests.cs
@@ -1,0 +1,217 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryCurationActorNominatorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Xunit;
+using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+/// <summary>
+/// Actor-level end-to-end coverage for the embedding kNN nominator (memory-core-redesign
+/// Slice 3 Stage B, task 3.6): drives a proposal through the REAL <see cref="MemoryCurationActor"/>
+/// with a fake embedder + scripted LLM, all the way to a committed store write. Complements
+/// <see cref="MemoryCurationNominatorTests"/>'s evaluator-level coverage by proving the same
+/// contract holds through the actor's full Idle -> Evaluating -> Writing state machine, using
+/// <c>AwaitAssertAsync</c> to poll for the LLM call rather than a sleep. Mirrors
+/// <see cref="Netclaw.Actors.Tests.Sessions.SessionMemoryObserverStorageIntegrationTests"/>'s
+/// temp-store/try-finally-cleanup shape for driving <see cref="MemoryCurationActor"/> directly.
+/// </summary>
+public sealed class MemoryCurationActorNominatorTests : TestKit
+{
+    private const string ModelId = "test-nominator-model";
+    private const int Dimensions = 2;
+
+    // Same hand-crafted 0.93-cosine pair as MemoryCurationNominatorTests.
+    private static readonly float[] ExistingVector = [1f, 0f];
+    private static readonly float[] QueryVectorAt093 = [0.93f, 0.367623f];
+
+    private readonly string _dbDir = Path.Combine(
+        Path.GetTempPath(), "netclaw-curation-actor-nominator-tests", Guid.NewGuid().ToString("N"));
+
+    public MemoryCurationActorNominatorTests(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // No persistence or hosting needed — MemoryCurationActor is a plain ReceiveActor.
+    }
+
+    [Fact]
+    public async Task Proposal_with_a_forced_nominee_reaches_the_LLM_and_commits_two_documents_end_to_end()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (store, dbPath) = await CreateStoreAsync();
+
+        try
+        {
+            const string existingBody = "The build pipeline stores intermediate render artifacts in a graphite-backed cache layer.";
+            var anchor = store.CreateDefaultAnchor("graphite-render-cache");
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            await store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+                DocumentId: "doc-existing",
+                Anchor: anchor,
+                MemoryClass: "durable_fact",
+                Title: "Existing",
+                MarkdownBody: existingBody,
+                AliasesJson: null,
+                FacetsJson: null,
+                SlotsJson: null,
+                UpdateSemantics: "merge-document",
+                Sensitivity: "normal",
+                RecallMode: "auto",
+                Confidence: 0.9,
+                FreshnessAtMs: now,
+                ExpiresAtMs: null,
+                CreatedAtMs: now,
+                UpdatedAtMs: now), ct);
+            await store.UpsertEmbeddingAsync(
+                "doc-existing", MemoryEmbedOnWriteCoordinator.DocumentItemKind, ModelId, "hash-existing", ExistingVector, ct);
+
+            var embedderHolder = new MemoryEmbedderHolder(new ScriptedEmbedder(ModelId, Dimensions, QueryVectorAt093));
+            var vectorIndexHolder = new MemoryVectorIndexHolder(store);
+            var chatClient = new RecordingCurationChatClient("CREATE");
+            var clientProvider = new SingleClientProvider(chatClient);
+
+            var curationActor = Sys.ActorOf(
+                MemoryCurationActor.CreateProps(
+                    store, new SessionId("test-session"), new MemoryCurationConfig(),
+                    clientProvider, embedderHolder, vectorIndexHolder),
+                "curation-nominator");
+
+            var probe = CreateTestProbe("curation-nominator-probe");
+            var operation = MakeOperation(
+                "sunfish-deploy-queue", "Deployment jobs wait in a queue before promotion to production.");
+
+            curationActor.Tell(new EvaluateProposals([operation]), probe.Ref);
+
+            // No sleeps: poll until the scripted LLM has actually been reached, proving the
+            // nominee forced the LLM tier, before asserting the final reply/store state.
+            await AwaitAssertAsync(
+                () => Assert.True(chatClient.CallCount >= 1,
+                    $"Expected the nominee to force an LLM call, but CallCount={chatClient.CallCount}"),
+                cancellationToken: ct);
+
+            var completed = await probe.ExpectMsgAsync<CurationCompleted>(TimeSpan.FromSeconds(10), cancellationToken: ct);
+            Assert.Equal(1, completed.Evaluated);
+            Assert.Equal(1, completed.Created);
+            Assert.Equal(0, completed.Skipped);
+            Assert.Equal(0, completed.Updated);
+            Assert.Equal(0, completed.Consolidated);
+
+            // By the time CurationCompleted is sent, ApplyInlineCurationBatchAsync has already
+            // committed (StartWriting awaits it before replying) — both the pre-existing
+            // sibling and the newly created proposal survive as separate documents, never merged.
+            await using var conn = new SqliteConnection($"Data Source={dbPath}");
+            await conn.OpenAsync(ct);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM memory_documents WHERE update_semantics != 'tombstone';";
+            var count = Convert.ToInt32(await cmd.ExecuteScalarAsync(ct));
+            Assert.Equal(2, count);
+        }
+        finally
+        {
+            await CleanupAsync();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(SQLiteMemoryStore Store, string DbPath)> CreateStoreAsync()
+    {
+        Directory.CreateDirectory(_dbDir);
+        var dbPath = Path.Combine(_dbDir, "test.db");
+        var store = new SQLiteMemoryStore(dbPath, TimeProvider.System);
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+        return (store, dbPath);
+    }
+
+    private Task CleanupAsync() => SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_dbDir);
+
+    private static SQLiteMemoryCurationOperation MakeOperation(string anchor, string content) =>
+        new(
+            Kind: "document",
+            MemoryClass: "durable_fact",
+            MemoryId: null,
+            AnchorCanonicalName: anchor,
+            AnchorType: "concept",
+            Title: $"Title for {anchor}",
+            Content: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            Relations: null,
+            UpdateSemantics: "merge-document",
+            Boundary: TrustBoundary.TrustedInstanceValue,
+            Audience: TrustAudience.Public,
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ExpiresAtMs: null);
+
+    private sealed class SingleClientProvider(IChatClient client) : IChatClientProvider
+    {
+        public IChatClient GetClient(ModelRole role) => client;
+    }
+
+    private sealed class ScriptedEmbedder(string modelId, int dimensions, float[] queryVector) : IMemoryEmbedder
+    {
+        public string ModelId => modelId;
+
+        public int Dimensions => dimensions;
+
+        public bool IsAvailable => true;
+
+        public ValueTask<ReadOnlyMemory<float>> EmbedAsync(string text, CancellationToken ct)
+            => ValueTask.FromResult<ReadOnlyMemory<float>>(queryVector);
+
+        public ValueTask<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct)
+            => ValueTask.FromResult<IReadOnlyList<ReadOnlyMemory<float>>>(
+                texts.Select(_ => (ReadOnlyMemory<float>)queryVector).ToList());
+    }
+
+    private sealed class RecordingCurationChatClient(string? responseText) : IChatClient
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new ChatResponse(new AiChatMessage(AiChatRole.Assistant, responseText ?? string.Empty)));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return StreamAsync(cancellationToken);
+        }
+
+        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            if (responseText is not null)
+                yield return new ChatResponseUpdate(AiChatRole.Assistant, responseText);
+
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
@@ -222,9 +222,9 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
             freshnessAtMs: 2000);
 
         var evaluator = new MemoryCurationEvaluator(
-            _store, (ILoggingAdapter)NoLogger.Instance, new ScriptedCurationChatClient("SKIP"));
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(), new ScriptedCurationChatClient("SKIP"));
 
-        var decision = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        var decision = (await evaluator.EvaluateAsync(operation, TestSessionId, ct)).Decision;
 
         Assert.Equal(CurationDecisionKind.Skip, decision.Kind);
         Assert.Contains("LLM decision", decision.Reason);
@@ -253,9 +253,9 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
         // TryLlmEvaluationAsync must surface curation_llm_no_decision and fall through to
         // the same deterministic auto-resolve path the no-LLM matrix case exercises.
         var evaluator = new MemoryCurationEvaluator(
-            _store, (ILoggingAdapter)NoLogger.Instance, new ScriptedCurationChatClient(responseText: null));
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(), new ScriptedCurationChatClient(responseText: null));
 
-        var decision = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        var decision = (await evaluator.EvaluateAsync(operation, TestSessionId, ct)).Decision;
 
         Assert.Equal(CurationDecisionKind.Skip, decision.Kind);
         Assert.Contains("auto-resolved", decision.Reason);
@@ -269,11 +269,11 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
         // Constructed exactly as MemoryCurationActor and MemoryCurationEngine construct
         // their evaluators today: no LLM client, differing only in which logger stack
         // they log through.
-        var actorLike = new MemoryCurationEvaluator(_store, (ILoggingAdapter)NoLogger.Instance);
-        var engineLike = new MemoryCurationEvaluator(_store, (ILogger)NullLogger.Instance);
+        var actorLike = new MemoryCurationEvaluator(_store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig());
+        var engineLike = new MemoryCurationEvaluator(_store, (ILogger)NullLogger.Instance, new MemoryCurationConfig());
 
-        var fromActor = await actorLike.EvaluateAsync(operation, TestSessionId, ct);
-        var fromEngine = await engineLike.EvaluateAsync(operation, TestSessionId, ct);
+        var fromActor = (await actorLike.EvaluateAsync(operation, TestSessionId, ct)).Decision;
+        var fromEngine = (await engineLike.EvaluateAsync(operation, TestSessionId, ct)).Decision;
         return (fromActor, fromEngine);
     }
 

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
@@ -261,6 +261,66 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
         Assert.Contains("auto-resolved", decision.Reason);
     }
 
+    // ── Nominator-present parity (memory-core-redesign Slice 3 Stage B) ──
+
+    /// <summary>
+    /// Extends the parity contract to the embedding kNN nominator (task 3.1): both evaluator
+    /// constructions — actor-style (<see cref="ILoggingAdapter"/>) and engine-style
+    /// (<see cref="ILogger"/>) — must reach the SAME forced-LLM decision when a nominee fires,
+    /// sharing one <see cref="MemoryEmbedderHolder"/> and <see cref="MemoryVectorIndexHolder"/>
+    /// exactly as <see cref="EvaluateOnBothAsync"/> shares one <see cref="SQLiteMemoryStore"/>.
+    /// </summary>
+    [Fact]
+    public async Task NomineePresent_returns_identical_forced_LLM_decision_on_both_paths()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string existingBody = "The build pipeline stores intermediate render artifacts in a graphite-backed cache layer.";
+        var anchor = _store.CreateDefaultAnchor("graphite-render-cache");
+        await _store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: "doc-existing",
+            Anchor: anchor,
+            MemoryClass: "durable_fact",
+            Title: "Existing",
+            MarkdownBody: existingBody,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: 1000,
+            ExpiresAtMs: null,
+            CreatedAtMs: 1000,
+            UpdatedAtMs: 1000), ct);
+        await _store.UpsertEmbeddingAsync(
+            "doc-existing", MemoryEmbedOnWriteCoordinator.DocumentItemKind, "test-nominator-model", "hash-existing",
+            new float[] { 1f, 0f }, ct);
+
+        var operation = MakeOperation(
+            "sunfish-deploy-queue", "Deployment jobs wait in a queue before promotion to production.", freshnessAtMs: 2000);
+
+        var embedderHolder = new MemoryEmbedderHolder(
+            new ScriptedEmbedder("test-nominator-model", dimensions: 2, [0.93f, 0.367623f]));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+
+        var actorLike = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient("SKIP"), embedderHolder, vectorIndexHolder);
+        var engineLike = new MemoryCurationEvaluator(
+            _store, (ILogger)NullLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient("SKIP"), embedderHolder, vectorIndexHolder);
+
+        var fromActor = (await actorLike.EvaluateAsync(operation, TestSessionId, ct)).Decision;
+        var fromEngine = (await engineLike.EvaluateAsync(operation, TestSessionId, ct)).Decision;
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.True(fromActor.FromLlmTier);
+        Assert.Equal(CurationDecisionKind.Skip, fromActor.Kind);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────
 
     private async Task<(CurationDecision FromActor, CurationDecision FromEngine)> EvaluateOnBothAsync(
@@ -368,5 +428,26 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
         public void Dispose()
         {
         }
+    }
+
+    /// <summary>
+    /// Fake embedder that ignores its input text and always returns the same hand-crafted query
+    /// vector — sufficient for <see cref="NomineePresent_returns_identical_forced_LLM_decision_on_both_paths"/>,
+    /// which embeds at most one proposal per evaluator.
+    /// </summary>
+    private sealed class ScriptedEmbedder(string modelId, int dimensions, float[] queryVector) : IMemoryEmbedder
+    {
+        public string ModelId => modelId;
+
+        public int Dimensions => dimensions;
+
+        public bool IsAvailable => true;
+
+        public ValueTask<ReadOnlyMemory<float>> EmbedAsync(string text, CancellationToken ct)
+            => ValueTask.FromResult<ReadOnlyMemory<float>>(queryVector);
+
+        public ValueTask<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct)
+            => ValueTask.FromResult<IReadOnlyList<ReadOnlyMemory<float>>>(
+                texts.Select(_ => (ReadOnlyMemory<float>)queryVector).ToList());
     }
 }

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationMergeRoutingTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationMergeRoutingTests.cs
@@ -1,0 +1,314 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryCurationMergeRoutingTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Akka.Event;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Xunit;
+using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+/// <summary>
+/// End-to-end coverage for memory-core-redesign Slice 3 task 3.4's guard-validated write
+/// routing, exercised through the REAL <see cref="MemoryCurationEvaluator"/> +
+/// <see cref="SQLiteMemoryStore"/> (not just the pure decision layer): a guard-failing or
+/// body-absent LLM UPDATE/CONSOLIDATE decision must land as a structural append with
+/// AppendDocument semantics, never a raw overwrite of the target's body, and the target's
+/// original content must survive intact as a prefix. The deterministic tier's exact-anchor
+/// UPDATE keeps its pre-Slice-3 raw-overwrite behavior — a regression guard proves that.
+/// </summary>
+public sealed class MemoryCurationMergeRoutingTests : IAsyncDisposable
+{
+    private static readonly SessionId TestSessionId = new("test-channel/merge-routing");
+
+    private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-curation-merge-routing-tests", Guid.NewGuid().ToString("N"));
+    private readonly string _dbPath;
+    private readonly SQLiteMemoryStore _store;
+
+    public MemoryCurationMergeRoutingTests()
+    {
+        Directory.CreateDirectory(_baseDir);
+        _dbPath = Path.Combine(_baseDir, "netclaw.db");
+        _store = new SQLiteMemoryStore(_dbPath, TimeProvider.System);
+    }
+
+    public async ValueTask DisposeAsync() => await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
+
+    // ── Guard failure -> append fallback (overwrite-unreachable) ──────
+
+    [Fact]
+    public async Task LlmUpdate_withLossyMergedBody_appendsInsteadOfOverwriting()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string originalBody =
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository is private.";
+        await SeedDocumentAsync("netclaw-github-repository", "doc-repo", originalBody, freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "netclaw-github-repo",
+            "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
+            freshnessAtMs: 2000);
+
+        // Lossy: drops the URL entirely — MergeGuard must reject this.
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient("UPDATE doc-repo\n---\nRepository details updated."));
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        Assert.Equal(CurationDecisionKind.Update, evaluation.Decision.Kind);
+        Assert.True(evaluation.Decision.FromLlmTier);
+        Assert.NotNull(evaluation.Decision.MergedBody);
+
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        Assert.NotNull(writeOp);
+        await _store.ApplyInlineCurationBatchAsync([writeOp!], ct);
+
+        var stored = await GetDocumentAsync("doc-repo", ct);
+        Assert.NotNull(stored);
+
+        // Overwrite-unreachable: the original body is NOT replaced by the lossy merge — the
+        // rejected merged body ("Repository details updated.") is discarded entirely, and the
+        // append fallback appends the ORIGINAL PROPOSAL content instead (never the untrusted
+        // merged text), on top of the target's untouched original body.
+        Assert.StartsWith(originalBody, stored!.Value.Body, StringComparison.Ordinal);
+        Assert.Contains(operation.Content, stored.Value.Body);
+        Assert.DoesNotContain("Repository details updated.", stored.Value.Body);
+        Assert.Contains("---", stored.Value.Body);
+        Assert.Equal("append-document", stored.Value.UpdateSemantics);
+    }
+
+    [Fact]
+    public async Task LlmUpdate_withNoMergedBody_appendsInsteadOfOverwriting()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string originalBody =
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository is private.";
+        await SeedDocumentAsync("netclaw-github-repository", "doc-repo", originalBody, freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "netclaw-github-repo",
+            "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
+            freshnessAtMs: 2000);
+
+        // Keyword-only LLM response — no "---" body at all.
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient("UPDATE doc-repo"));
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        Assert.Equal(CurationDecisionKind.Update, evaluation.Decision.Kind);
+        Assert.True(evaluation.Decision.FromLlmTier);
+        Assert.Null(evaluation.Decision.MergedBody);
+
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        await _store.ApplyInlineCurationBatchAsync([writeOp!], ct);
+
+        var stored = await GetDocumentAsync("doc-repo", ct);
+        Assert.NotNull(stored);
+        Assert.StartsWith(originalBody, stored!.Value.Body, StringComparison.Ordinal);
+        Assert.Contains(operation.Content, stored.Value.Body);
+        Assert.Equal("append-document", stored.Value.UpdateSemantics);
+    }
+
+    // ── Guard pass -> merged body written ─────────────────────────────
+
+    [Fact]
+    public async Task LlmUpdate_withFaithfulMergedBody_writesMergedBody()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string originalBody =
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository is private.";
+        await SeedDocumentAsync("netclaw-github-repository", "doc-repo", originalBody, freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "netclaw-github-repo",
+            "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
+            freshnessAtMs: 2000);
+
+        const string mergedBody =
+            "Netclaw GitHub repository: https://github.com/netclaw-dev/netclaw. The repository remains private.";
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient($"UPDATE doc-repo\n---\n{mergedBody}"));
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        await _store.ApplyInlineCurationBatchAsync([writeOp!], ct);
+
+        var stored = await GetDocumentAsync("doc-repo", ct);
+        Assert.NotNull(stored);
+        Assert.Equal(mergedBody, stored!.Value.Body);
+        Assert.Equal("merge-document", stored.Value.UpdateSemantics);
+    }
+
+    // ── Deterministic tier regression: exact-anchor Update keeps raw overwrite ─
+
+    [Fact]
+    public async Task DeterministicUpdate_exactAnchorSuperset_stillOverwritesRawly()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync("latest-version", "doc-version", "Latest version is 1.5.62.", freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "latest-version",
+            "Latest version is 1.5.62. Released with the new serializer.",
+            freshnessAtMs: 2000);
+
+        // No LLM client — this exercises the deterministic exact-anchor path only.
+        var evaluator = new MemoryCurationEvaluator(_store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig());
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        Assert.Equal(CurationDecisionKind.Update, evaluation.Decision.Kind);
+        Assert.False(evaluation.Decision.FromLlmTier);
+
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        await _store.ApplyInlineCurationBatchAsync([writeOp!], ct);
+
+        var stored = await GetDocumentAsync("doc-version", ct);
+        Assert.NotNull(stored);
+        // Raw overwrite: the stored body IS the proposal's content verbatim, not appended.
+        Assert.Equal(operation.Content, stored!.Value.Body);
+        Assert.Equal("merge-document", stored.Value.UpdateSemantics);
+    }
+
+    // ── Consolidate: deterministic tier (no LLM, no merged body) also appends ─
+
+    [Fact]
+    public async Task DeterministicConsolidate_appendsRatherThanOverwriting()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string originalBody = "Akka.NET latest release version is 1.5.62";
+        await SeedDocumentAsync("akka-net-latest-release", "doc-akka", originalBody, freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "akka-net-release", "Akka.NET latest release version is 1.5.62", freshnessAtMs: 2000);
+
+        // No LLM client — fuzzy match >80% overlap resolves to Consolidate deterministically.
+        var evaluator = new MemoryCurationEvaluator(_store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig());
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        Assert.Equal(CurationDecisionKind.Consolidate, evaluation.Decision.Kind);
+        Assert.False(evaluation.Decision.FromLlmTier);
+        Assert.Null(evaluation.Decision.MergedBody);
+
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        Assert.NotNull(writeOp);
+        Assert.Equal("doc-akka", writeOp!.MemoryId);
+        await _store.ApplyInlineCurationBatchAsync([writeOp], ct);
+
+        var stored = await GetDocumentAsync("doc-akka", ct);
+        Assert.NotNull(stored);
+        Assert.StartsWith(originalBody, stored!.Value.Body, StringComparison.Ordinal);
+        Assert.Equal("append-document", stored.Value.UpdateSemantics);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private async Task SeedDocumentAsync(
+        string anchorName, string docId, string content, long freshnessAtMs, CancellationToken ct)
+    {
+        var anchor = _store.CreateDefaultAnchor(anchorName);
+        await _store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: docId,
+            Anchor: anchor,
+            MemoryClass: "durable_fact",
+            Title: $"Existing {anchorName}",
+            MarkdownBody: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: freshnessAtMs,
+            ExpiresAtMs: null,
+            CreatedAtMs: freshnessAtMs,
+            UpdatedAtMs: freshnessAtMs), ct);
+    }
+
+    private async Task<(string Body, string UpdateSemantics)?> GetDocumentAsync(string documentId, CancellationToken ct)
+    {
+        var handles = await _store.ResolveMemoryHandlesAsync(
+            [documentId], TrustBoundary.TrustedInstanceValue, TrustAudience.Public, ct);
+        var resolved = handles.FirstOrDefault(h => h.Resolved);
+        if (resolved is null)
+            return null;
+
+        var hydrated = await _store.GetMemoriesByResolvedHandlesAsync(
+            [resolved], TrustBoundary.TrustedInstanceValue, TrustAudience.Public, ct);
+        var item = hydrated.FirstOrDefault();
+        return item is null ? null : (item.Content, item.UpdateSemantics);
+    }
+
+    private static SQLiteMemoryCurationOperation MakeOperation(
+        string anchor,
+        string content,
+        string kind = "document",
+        string updateSemantics = "merge-document",
+        long freshnessAtMs = 2000) =>
+        new(
+            Kind: kind,
+            MemoryClass: "durable_fact",
+            MemoryId: null,
+            AnchorCanonicalName: anchor,
+            AnchorType: "concept",
+            Title: $"Title for {anchor}",
+            Content: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            Relations: null,
+            UpdateSemantics: updateSemantics,
+            Boundary: TrustBoundary.TrustedInstanceValue,
+            Audience: TrustAudience.Public,
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: freshnessAtMs,
+            ExpiresAtMs: null);
+
+    /// <summary>
+    /// Minimal scripted <see cref="IChatClient"/>: streams <paramref name="responseText"/> as a
+    /// single update. Mirrors <c>MemoryCurationEvaluatorParityTests.ScriptedCurationChatClient</c>
+    /// (kept as a separate private copy rather than shared test infra — small and self-contained).
+    /// </summary>
+    private sealed class ScriptedCurationChatClient(string responseText) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new AiChatMessage(AiChatRole.Assistant, responseText)));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => StreamAsync(cancellationToken);
+
+        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            yield return new ChatResponseUpdate(AiChatRole.Assistant, responseText);
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationNominatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationNominatorTests.cs
@@ -1,0 +1,400 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryCurationNominatorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Akka.Event;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Xunit;
+using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+/// <summary>
+/// Covers the embedding kNN nominator in <see cref="MemoryCurationEvaluator"/>
+/// (memory-core-redesign Slice 3 Stage B, tasks 3.1/3.6). All fixtures are synthetic — no
+/// operator corpus content — and cosine similarity is engineered directly via hand-crafted
+/// unit vectors rather than a real embedding model, so every scenario is exact and
+/// deterministic rather than dependent on a specific model's output.
+///
+/// <para>
+/// The central invariant under test throughout this file (design D4, corroborated by
+/// <c>docs/research/memory-recall-findings-2026-05.md</c> and
+/// <c>docs/research/memory-audit-2026-07.md</c> §5): cosine similarity NOMINATES ONLY. It
+/// forces a decision to the LLM tier; it never itself decides skip, merge, or create.
+/// </para>
+/// </summary>
+public sealed class MemoryCurationNominatorTests : IAsyncDisposable
+{
+    private const string ModelId = "test-nominator-model";
+    private const int Dimensions = 2;
+
+    // Hand-crafted unit vectors with cosine similarity == 0.93 exactly (0.93^2 + 0.367623^2 ==
+    // 0.999999...): the paraphrase-pair cosine the May 2026 measurement places inside the band
+    // where duplicates and merely-related siblings are indistinguishable by threshold alone
+    // (siblings measured at 0.905-0.941, design D4/proposal.md).
+    private static readonly float[] ExistingVector = [1f, 0f];
+    private static readonly float[] QueryVectorAt093 = [0.93f, 0.367623f];
+
+    private static readonly SessionId TestSessionId = new("test-channel/nominator");
+
+    private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-curation-nominator-tests", Guid.NewGuid().ToString("N"));
+    private readonly string _dbPath;
+    private readonly SQLiteMemoryStore _store;
+
+    public MemoryCurationNominatorTests()
+    {
+        Directory.CreateDirectory(_baseDir);
+        _dbPath = Path.Combine(_baseDir, "netclaw.db");
+        _store = new SQLiteMemoryStore(_dbPath, TimeProvider.System);
+    }
+
+    public async ValueTask DisposeAsync() => await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
+
+    // ── Nomination forcing ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Paraphrase_pair_at_cosine_0_93_forces_LLM_tier_even_though_Jaccard_band_would_have_said_Create()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string existingBody = "The build pipeline stores intermediate render artifacts in a graphite-backed cache layer.";
+        const string proposalContent = "Deployment jobs wait in a queue before promotion to production.";
+
+        // Unrelated anchor names, near-zero word overlap: the pre-Slice-3 lexical/anchor tier
+        // finds NO candidates at all here (CurationRulesEvaluator: "no existing candidates" ->
+        // Create, zero LLM calls) — cosine nomination is the ONLY signal that finds this pair.
+        Assert.True(WordJaccard(existingBody, proposalContent) < 0.4, "fixture must have low word overlap");
+
+        await SeedDocumentWithEmbeddingAsync("graphite-render-cache", "doc-existing", existingBody, freshnessAtMs: 1000, ct);
+        var operation = MakeOperation("sunfish-deploy-queue", proposalContent, freshnessAtMs: 2000);
+
+        var embedderHolder = new MemoryEmbedderHolder(new ScriptedEmbedder(ModelId, Dimensions, QueryVectorAt093));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+        var chatClient = new RecordingCurationChatClient("CREATE");
+
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(), chatClient, embedderHolder, vectorIndexHolder);
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Equal(1, chatClient.CallCount);
+        Assert.True(evaluation.Decision.FromLlmTier);
+        Assert.Contains(evaluation.Candidates, c => c.DocumentId == "doc-existing" && c.CosineSimilarity is not null);
+    }
+
+    // ── Sibling never-auto-merge ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Nominee_present_LLM_says_Create_persists_two_separate_documents_not_a_merge()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string existingBody = "The build pipeline stores intermediate render artifacts in a graphite-backed cache layer.";
+        await SeedDocumentWithEmbeddingAsync("graphite-render-cache", "doc-existing", existingBody, freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "sunfish-deploy-queue", "Deployment jobs wait in a queue before promotion to production.", freshnessAtMs: 2000);
+
+        var embedderHolder = new MemoryEmbedderHolder(new ScriptedEmbedder(ModelId, Dimensions, QueryVectorAt093));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+        var chatClient = new RecordingCurationChatClient("CREATE");
+
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(), chatClient, embedderHolder, vectorIndexHolder);
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        Assert.Equal(CurationDecisionKind.Create, evaluation.Decision.Kind);
+        Assert.Equal(1, chatClient.CallCount);
+
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        Assert.NotNull(writeOp);
+        await _store.ApplyInlineCurationBatchAsync([writeOp!], ct);
+
+        // Two documents survive — the nominee (a cosine-adjacent sibling in this fixture, per
+        // the LLM's own CREATE call) was never auto-merged into the existing one.
+        Assert.Equal(2, await CountNonTombstonedDocumentsAsync(ct));
+    }
+
+    [Fact]
+    public async Task Nominee_present_with_no_LLM_available_conservatively_creates_never_auto_merges()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string existingBody = "The build pipeline stores intermediate render artifacts in a graphite-backed cache layer.";
+        await SeedDocumentWithEmbeddingAsync("graphite-render-cache", "doc-existing", existingBody, freshnessAtMs: 1000, ct);
+
+        var operation = MakeOperation(
+            "sunfish-deploy-queue", "Deployment jobs wait in a queue before promotion to production.", freshnessAtMs: 2000);
+
+        var embedderHolder = new MemoryEmbedderHolder(new ScriptedEmbedder(ModelId, Dimensions, QueryVectorAt093));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+
+        // No LLM client at all — the daemon-checkpoint-worker shape today. A nominee here must
+        // NOT fall to TryAutoResolveAmbiguous (which could return Skip); the outcome must be
+        // Create, never a merge decided by cosine alone.
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(), llmClient: null,
+            embedderHolder: embedderHolder, vectorIndexHolder: vectorIndexHolder);
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+        Assert.Equal(CurationDecisionKind.Create, evaluation.Decision.Kind);
+        Assert.False(evaluation.Decision.FromLlmTier);
+        Assert.Contains("conservative create", evaluation.Decision.Reason);
+        Assert.Contains("no auto-merge on cosine alone", evaluation.Decision.Reason);
+
+        var writeOp = await evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
+        Assert.NotNull(writeOp);
+        await _store.ApplyInlineCurationBatchAsync([writeOp!], ct);
+
+        Assert.Equal(2, await CountNonTombstonedDocumentsAsync(ct));
+    }
+
+    // ── Novel proposal skips the curator ─────────────────────────────────
+
+    [Fact]
+    public async Task Novel_proposal_with_no_nominee_and_no_anchor_match_skips_the_curator_entirely()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        // Empty store: no anchor to match, and the vector index has nothing to nominate — the
+        // "median nominee count on a random write is 0" common case (design D4 point 3).
+        var operation = MakeOperation(
+            "brand-new-topic", "Completely novel content nobody has proposed before.", freshnessAtMs: 1000);
+
+        var embedderHolder = new MemoryEmbedderHolder(new ScriptedEmbedder(ModelId, Dimensions, QueryVectorAt093));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+        var chatClient = new RecordingCurationChatClient("CREATE");
+
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(), chatClient, embedderHolder, vectorIndexHolder);
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Equal(CurationDecisionKind.Create, evaluation.Decision.Kind);
+        Assert.False(evaluation.Decision.FromLlmTier);
+        Assert.Equal(0, chatClient.CallCount);
+    }
+
+    // ── Degraded path ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Embedder_unavailable_falls_back_to_lexical_search_and_logs_the_degraded_marker()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string existingBody = "Deployment jobs wait in a queue before promotion to production servers.";
+        const string proposalContent = "Deployment jobs wait in a queue before reaching production.";
+
+        // Substantial lexical overlap (unlike the nomination-forcing fixture above) so the
+        // degraded path's lexical content-term search actually surfaces this document.
+        Assert.True(WordJaccard(existingBody, proposalContent) > 0.4, "fixture must have high word overlap");
+
+        await SeedDocumentWithEmbeddingAsync("totally-different-topic", "doc-existing", existingBody, freshnessAtMs: 1000, ct);
+        var operation = MakeOperation("another-unrelated-subject", proposalContent, freshnessAtMs: 2000);
+
+        var recordingLogger = new RecordingLogger();
+        var embedderHolder = new MemoryEmbedderHolder(new UnavailableMemoryEmbedder(ModelId, "not provisioned"));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILogger)recordingLogger, new MemoryCurationConfig(), llmClient: null, embedderHolder, vectorIndexHolder);
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Contains(recordingLogger.Entries, e => e.Contains("curation_nominator_degraded", StringComparison.Ordinal));
+        Assert.Contains(evaluation.Candidates, c => c.DocumentId == "doc-existing");
+        // Lexical-path candidates never carry cosine evidence.
+        Assert.All(evaluation.Candidates, c => Assert.Null(c.CosineSimilarity));
+    }
+
+    [Fact]
+    public async Task Null_embedder_holder_is_treated_identically_to_unavailable_and_degrades()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        const string existingBody = "Deployment jobs wait in a queue before promotion to production servers.";
+        const string proposalContent = "Deployment jobs wait in a queue before reaching production.";
+
+        await SeedDocumentWithEmbeddingAsync("totally-different-topic", "doc-existing", existingBody, freshnessAtMs: 1000, ct);
+        var operation = MakeOperation("another-unrelated-subject", proposalContent, freshnessAtMs: 2000);
+
+        var recordingLogger = new RecordingLogger();
+
+        // No embedder holder AND no vector index holder at all — a test harness / build that
+        // never wired up the embedding subsystem, same as the pre-Slice-3 constructor shape.
+        var evaluator = new MemoryCurationEvaluator(
+            _store, (ILogger)recordingLogger, new MemoryCurationConfig());
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Contains(recordingLogger.Entries, e => e.Contains("curation_nominator_degraded", StringComparison.Ordinal));
+        Assert.Contains(evaluation.Candidates, c => c.DocumentId == "doc-existing");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private async Task SeedDocumentWithEmbeddingAsync(
+        string anchorName, string docId, string content, long freshnessAtMs, CancellationToken ct)
+    {
+        var anchor = _store.CreateDefaultAnchor(anchorName);
+        await _store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: docId,
+            Anchor: anchor,
+            MemoryClass: "durable_fact",
+            Title: $"Existing {anchorName}",
+            MarkdownBody: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: freshnessAtMs,
+            ExpiresAtMs: null,
+            CreatedAtMs: freshnessAtMs,
+            UpdatedAtMs: freshnessAtMs), ct);
+
+        await _store.UpsertEmbeddingAsync(
+            docId, MemoryEmbedOnWriteCoordinator.DocumentItemKind, ModelId, contentHash: $"hash-{docId}", ExistingVector, ct);
+    }
+
+    private async Task<int> CountNonTombstonedDocumentsAsync(CancellationToken ct)
+    {
+        await using var conn = new SqliteConnection($"Data Source={_dbPath}");
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM memory_documents WHERE update_semantics != 'tombstone';";
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync(ct));
+    }
+
+    private static double WordJaccard(string a, string b)
+    {
+        var wordsA = Tokenize(a);
+        var wordsB = Tokenize(b);
+        var union = wordsA.Union(wordsB).Count();
+        return union == 0 ? 0 : (double)wordsA.Intersect(wordsB).Count() / union;
+
+        static HashSet<string> Tokenize(string text) =>
+            text.Split([' ', '.', ',', ':', ';', '!', '?'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(w => w.Trim().ToLowerInvariant())
+                .Where(w => w.Length > 0)
+                .ToHashSet();
+    }
+
+    private static SQLiteMemoryCurationOperation MakeOperation(
+        string anchor,
+        string content,
+        string kind = "document",
+        string updateSemantics = "merge-document",
+        long freshnessAtMs = 2000) =>
+        new(
+            Kind: kind,
+            MemoryClass: "durable_fact",
+            MemoryId: null,
+            AnchorCanonicalName: anchor,
+            AnchorType: "concept",
+            Title: $"Title for {anchor}",
+            Content: content,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            Relations: null,
+            UpdateSemantics: updateSemantics,
+            Boundary: TrustBoundary.TrustedInstanceValue,
+            Audience: TrustAudience.Public,
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: freshnessAtMs,
+            ExpiresAtMs: null);
+
+    /// <summary>
+    /// Fake embedder that ignores its input text and always returns the same, hand-crafted
+    /// query vector — sufficient here because every test in this file embeds at most one
+    /// proposal, and the geometry (not the input text) is what needs to be controlled.
+    /// </summary>
+    private sealed class ScriptedEmbedder(string modelId, int dimensions, float[] queryVector) : IMemoryEmbedder
+    {
+        public string ModelId => modelId;
+
+        public int Dimensions => dimensions;
+
+        public bool IsAvailable => true;
+
+        public ValueTask<ReadOnlyMemory<float>> EmbedAsync(string text, CancellationToken ct)
+            => ValueTask.FromResult<ReadOnlyMemory<float>>(queryVector);
+
+        public ValueTask<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct)
+            => ValueTask.FromResult<IReadOnlyList<ReadOnlyMemory<float>>>(
+                texts.Select(_ => (ReadOnlyMemory<float>)queryVector).ToList());
+    }
+
+    /// <summary>
+    /// Scripted <see cref="IChatClient"/> that records how many times it was invoked, so tests
+    /// can assert the LLM tier was (or was never) reached — the nomination-forcing contract's
+    /// core observable. Mirrors <c>MemoryCurationEvaluatorParityTests.ScriptedCurationChatClient</c>
+    /// plus a call counter (kept as a separate private copy per that file's own convention).
+    /// </summary>
+    private sealed class RecordingCurationChatClient(string? responseText) : IChatClient
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new ChatResponse(new AiChatMessage(AiChatRole.Assistant, responseText ?? string.Empty)));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return StreamAsync(cancellationToken);
+        }
+
+        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            if (responseText is not null)
+                yield return new ChatResponseUpdate(AiChatRole.Assistant, responseText);
+
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>Records every log line emitted through the Microsoft.Extensions.Logging ctor.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(formatter(state, exception));
+    }
+}

--- a/src/Netclaw.Actors.Tests/Memory/MergeGuardTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MergeGuardTests.cs
@@ -1,0 +1,250 @@
+// -----------------------------------------------------------------------
+// <copyright file="MergeGuardTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Memory;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+/// <summary>
+/// Table/property tests for <see cref="MergeGuard"/> (memory-core-redesign Slice 3 task 3.3):
+/// load-bearing token extraction (URLs, numbers/versions/dates, identifiers, file paths), the
+/// 95% retention boundary, the 60% length-collapse floor, and pass-through on faithful unions.
+/// </summary>
+public sealed class MergeGuardTests
+{
+    // ── Faithful merges pass ─────────────────────────────────────────
+
+    [Fact]
+    public void Validate_passes_when_merged_body_is_a_faithful_union()
+    {
+        var sources = new[]
+        {
+            "Widget specs: 16 cores, 64GB RAM, 2 NICs.",
+            "Widget pricing is TBD as of 2026-05-13."
+        };
+        var merged = "Widget specs: 16 cores, 64GB RAM, 2 NICs. Pricing is TBD as of 2026-05-13.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.True(result.Passed);
+        Assert.Empty(result.MissingTokens);
+    }
+
+    [Fact]
+    public void Validate_passes_when_merged_body_reorders_and_rewords_but_keeps_every_token()
+    {
+        var sources = new[]
+        {
+            "Akka.NET GitHub repository: https://github.com/akkadotnet/akka.net. Latest stable release is 1.5.60 as of 2026-04-02.",
+            "Akka.NET release version is now 1.5.62."
+        };
+        var merged =
+            "Akka.NET GitHub repository: https://github.com/akkadotnet/akka.net. " +
+            "Latest stable release is 1.5.62 (previously 1.5.60 as of 2026-04-02).";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.True(result.Passed);
+    }
+
+    [Fact]
+    public void Validate_passes_trivially_when_there_are_no_source_bodies()
+    {
+        var result = MergeGuard.Validate([], "anything");
+
+        Assert.True(result.Passed);
+        Assert.Contains("no source bodies", result.Reason);
+    }
+
+    // ── Token-category retention ─────────────────────────────────────
+
+    [Fact]
+    public void Validate_fails_when_a_url_is_dropped()
+    {
+        var sources = new[] { "Repo lives at https://github.com/netclaw-dev/netclaw." };
+        var merged = "Repo lives at the usual place.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains(result.MissingTokens, t => t.Contains("github.com", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_fails_when_a_version_number_is_dropped()
+    {
+        var sources = new[] { "Latest version is 1.5.62, released with the new serializer." };
+        var merged = "Latest version was released with the new serializer.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains("1.5.62", result.MissingTokens);
+    }
+
+    [Fact]
+    public void Validate_fails_when_a_date_is_dropped()
+    {
+        var sources = new[] { "Config path moved to /etc/app/config.yaml on 2026-06-01." };
+        var merged = "Config path moved to /etc/app/config.yaml.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains("2026-06-01", result.MissingTokens);
+    }
+
+    [Fact]
+    public void Validate_fails_when_a_written_date_is_dropped()
+    {
+        var sources = new[] { "Release shipped on May 13, 2026 after code freeze." };
+        var merged = "Release shipped after code freeze.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.False(result.Passed);
+    }
+
+    [Fact]
+    public void Validate_fails_when_a_camelCase_identifier_is_dropped()
+    {
+        var sources = new[] { "The knob is called maxOutputTokens and defaults to 4096." };
+        var merged = "The token cap defaults to 4096.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains("maxOutputTokens", result.MissingTokens);
+    }
+
+    [Fact]
+    public void Validate_fails_when_a_file_path_is_dropped()
+    {
+        var sources = new[] { "The guard lives in src/Netclaw.Actors/Memory/MergeGuard.cs." };
+        var merged = "The guard lives in the memory module.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains(result.MissingTokens, t => t.Contains("MergeGuard.cs", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_retention_is_case_insensitive()
+    {
+        var sources = new[] { "Endpoint is HTTPS://EXAMPLE.COM/api." };
+        var merged = "Endpoint is https://example.com/api and it is stable.";
+
+        var result = MergeGuard.Validate(sources, merged);
+
+        Assert.True(result.Passed);
+    }
+
+    // ── 95% retention boundary ────────────────────────────────────────
+
+    [Fact]
+    public void Validate_passes_at_exactly_the_95_percent_retention_boundary()
+    {
+        // 20 distinct load-bearing integers; merged keeps 19/20 = 95% exactly.
+        var tokens = Enumerable.Range(100, 20).Select(n => n.ToString()).ToArray();
+        var source = "Values: " + string.Join(", ", tokens) + ".";
+        var merged = "Values: " + string.Join(", ", tokens.Take(19)) + ".";
+
+        var result = MergeGuard.Validate([source], merged);
+
+        Assert.True(result.Passed);
+        Assert.Single(result.MissingTokens);
+    }
+
+    [Fact]
+    public void Validate_fails_just_below_the_95_percent_retention_boundary()
+    {
+        // Same 20 tokens; merged keeps 18/20 = 90%, below the floor.
+        var tokens = Enumerable.Range(100, 20).Select(n => n.ToString()).ToArray();
+        var source = "Values: " + string.Join(", ", tokens) + ".";
+        var merged = "Values: " + string.Join(", ", tokens.Take(18)) + ".";
+
+        var result = MergeGuard.Validate([source], merged);
+
+        Assert.False(result.Passed);
+        Assert.Equal(2, result.MissingTokens.Count);
+    }
+
+    [Fact]
+    public void Validate_counts_the_union_across_multiple_sources_not_per_source()
+    {
+        var sourceA = "Value alpha is 111.";
+        var sourceB = "Value beta is 222.";
+        // Merged keeps only one of the two distinct tokens across the union of both sources.
+        var merged = "Value alpha is 111 and beta was updated.";
+
+        var result = MergeGuard.Validate([sourceA, sourceB], merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains("222", result.MissingTokens);
+    }
+
+    // ── Length-collapse floor ─────────────────────────────────────────
+
+    [Fact]
+    public void Validate_fails_on_length_collapse_even_when_tokens_are_retained()
+    {
+        // Merged repeats every load-bearing token but discards all surrounding prose,
+        // collapsing well below 60% of the longest source's length.
+        var longSource = "Config value is 42. " + new string('x', 200);
+        var merged = "42";
+
+        var result = MergeGuard.Validate([longSource], merged);
+
+        Assert.False(result.Passed);
+        Assert.Contains("collapse", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_passes_at_exactly_the_60_percent_length_boundary()
+    {
+        var longSource = new string('a', 100);
+        var merged = new string('a', 60);
+
+        var result = MergeGuard.Validate([longSource], merged);
+
+        Assert.True(result.Passed);
+    }
+
+    [Fact]
+    public void Validate_fails_just_below_the_60_percent_length_boundary()
+    {
+        var longSource = new string('a', 100);
+        var merged = new string('a', 59);
+
+        var result = MergeGuard.Validate([longSource], merged);
+
+        Assert.False(result.Passed);
+    }
+
+    [Fact]
+    public void Validate_uses_the_longest_source_for_the_length_floor()
+    {
+        var shortSource = "Short note.";
+        var longSource = new string('b', 200);
+        // Merged is well above 60% of the SHORT source but not the long one.
+        var merged = new string('b', 100);
+
+        var result = MergeGuard.Validate([shortSource, longSource], merged);
+
+        Assert.False(result.Passed);
+    }
+
+    // ── Empty/null handling ────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_treats_empty_source_bodies_as_contributing_nothing()
+    {
+        var result = MergeGuard.Validate(["", "  ", "real content here"], "real content here, unchanged");
+
+        Assert.True(result.Passed);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
@@ -60,7 +60,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         try
         {
             var curationActor = Sys.ActorOf(
-                MemoryCurationActor.CreateProps(store, new SessionId("test-session")),
+                MemoryCurationActor.CreateProps(store, new SessionId("test-session"), new MemoryCurationConfig()),
                 "curation-create");
 
             var probe = CreateTestProbe("curation-create-probe");
@@ -106,7 +106,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         try
         {
             var curationActor = Sys.ActorOf(
-                MemoryCurationActor.CreateProps(store, new SessionId("test-session")),
+                MemoryCurationActor.CreateProps(store, new SessionId("test-session"), new MemoryCurationConfig()),
                 "curation-batch");
 
             var probe = CreateTestProbe("curation-batch-probe");
@@ -163,7 +163,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         try
         {
             var curationActor = Sys.ActorOf(
-                MemoryCurationActor.CreateProps(store, new SessionId("test-session")),
+                MemoryCurationActor.CreateProps(store, new SessionId("test-session"), new MemoryCurationConfig()),
                 "curation-empty");
 
             var probe = CreateTestProbe("curation-empty-probe");

--- a/src/Netclaw.Actors.Tests/Sessions/SidecarSessionCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SidecarSessionCorrelationTests.cs
@@ -121,7 +121,8 @@ public sealed class SidecarSessionCorrelationTests : TestKit
             ExpiresAtMs: null);
 
         await MemoryCurationEvaluator.TryLlmEvaluationAsync(
-            captor, sessionId, operation, candidates: [], log: new AkkaCurationLog(NoLogger.Instance));
+            captor, sessionId, operation, candidates: [], log: new AkkaCurationLog(NoLogger.Instance),
+            curationConfig: new MemoryCurationConfig());
 
         AssertScopedTo(sessionId, captor);
     }

--- a/src/Netclaw.Actors/Memory/CurationPromptBuilder.cs
+++ b/src/Netclaw.Actors/Memory/CurationPromptBuilder.cs
@@ -70,26 +70,57 @@ public static class CurationPromptBuilder
         CREATE — Genuinely new, OR distinct from the candidates in what it is
         ABOUT (different date, entity, event, or reading).
 
+        For UPDATE and CONSOLIDATE only: after the keyword line, write a line
+        containing only "---", then the complete merged document body — a
+        LOSSLESS union of the proposal and every candidate you named. You are
+        combining, not summarizing: every fact, identifier, number, URL, and date
+        from every source must still appear somewhere in the merged body. State
+        the newest value first; keep a superseded dated value inline rather than
+        deleting it, e.g. "current value is 42 (previously 30 as of 2026-05-13)".
+        SKIP and CREATE never include a body — respond with the keyword alone.
+
         SAME fact, merge: "DB pool size is 20" and "the database connection pool
         max is set to 20".
         DISTINCT, create: a CPU temperature logged at 14:00 vs the same metric at
         15:00; a staging-server config vs a production-server config.
 
-        Respond with ONLY the decision keyword and any required IDs. No explanation.
+        Respond with ONLY the decision keyword, any required IDs, and — for
+        UPDATE/CONSOLIDATE — the merged body after the "---" separator. No other
+        explanation.
 
         Examples:
           SKIP
+
           UPDATE doc-abc123
+          ---
+          Config path is /etc/app/config.yaml (previously /etc/app/config.json as
+          of 2026-06-01). Default timeout is 30s.
+
           CONSOLIDATE doc-abc123 doc-def456
+          ---
+          Akka.NET GitHub repository: https://github.com/akkadotnet/akka.net.
+          Latest stable release is 1.5.62 (previously 1.5.60 as of 2026-04-02).
+
           CREATE
         """;
 
     /// <summary>
     /// Build the user message for a curation evaluation request.
     /// </summary>
+    /// <param name="useFullCandidateContent">
+    /// When false (the legacy default, used by the content-search/fuzzy-anchor candidate
+    /// path), each candidate's content is truncated to <see cref="ContentPreviewMaxChars"/>
+    /// like the proposal's own content always is. When true, candidates are shown in full —
+    /// the decider needs complete bodies to synthesize a lossless merge (memory-core-redesign
+    /// Slice 3 task 3.2). Nothing in this change sets it true yet: the embedding kNN
+    /// nominator that will pass full-content nominated candidates is Stage B (task 3.1),
+    /// still to come — this parameter exists now so that work does not need to touch the
+    /// prompt-building signature again.
+    /// </param>
     public static string BuildUserMessage(
         SQLiteMemoryCurationOperation proposal,
-        IReadOnlyList<ExistingMemoryCandidate> candidates)
+        IReadOnlyList<ExistingMemoryCandidate> candidates,
+        bool useFullCandidateContent = false)
     {
         var sb = new StringBuilder();
 
@@ -111,7 +142,7 @@ public static class CurationPromptBuilder
             {
                 var c = candidates[i];
                 sb.AppendLine($"[{i + 1}] id={c.DocumentId} anchor={c.AnchorCanonicalName}");
-                sb.AppendLine($"    content: {TruncateContent(c.Content)}");
+                sb.AppendLine($"    content: {(useFullCandidateContent ? c.Content : TruncateContent(c.Content))}");
                 sb.AppendLine($"    timestamp: {c.FreshnessAtMs}");
             }
         }
@@ -120,8 +151,10 @@ public static class CurationPromptBuilder
     }
 
     /// <summary>
-    /// Parse a single-keyword LLM response into a curation decision.
-    /// Returns null if the response cannot be parsed.
+    /// Parse an LLM response into a curation decision: a keyword line, optionally (for
+    /// UPDATE/CONSOLIDATE) followed by a "---" separator line and a merged markdown body
+    /// (memory-core-redesign Slice 3 task 3.2). Returns null if the response cannot be
+    /// parsed.
     /// </summary>
     public static CurationDecision? ParseResponse(string response)
     {
@@ -131,7 +164,7 @@ public static class CurationPromptBuilder
         // Reasoning models may inline hidden chain-of-thought wrapped in
         // <think>...</think>; strip it so the bare decision keyword is what we parse.
         // When the serving stack emits reasoning on a separate channel, the text is
-        // already just the keyword and this is a no-op.
+        // already just the keyword (and optional body) and this is a no-op.
         var trimmed = StripThinkBlocks(response).Trim();
         if (trimmed.Length == 0)
             return null;
@@ -139,25 +172,35 @@ public static class CurationPromptBuilder
         // SKIP
         if (trimmed.StartsWith("SKIP", StringComparison.OrdinalIgnoreCase))
         {
-            return new CurationDecision(CurationDecisionKind.Skip, null, null, null, "LLM decision: SKIP");
+            return new CurationDecision(CurationDecisionKind.Skip, null, null, null, "LLM decision: SKIP", FromLlmTier: true);
         }
 
         // CREATE
         if (trimmed.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase))
         {
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "LLM decision: CREATE");
+            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "LLM decision: CREATE", FromLlmTier: true);
         }
 
-        // UPDATE <id>
+        // UPDATE <id> [---\n<merged body>]
         var updateMatch = Regex.Match(trimmed, @"^UPDATE\s+(\S+)", RegexOptions.IgnoreCase);
         if (updateMatch.Success)
         {
             var targetId = updateMatch.Groups[1].Value;
-            return new CurationDecision(CurationDecisionKind.Update, targetId, null, null, $"LLM decision: UPDATE {targetId}");
+            return new CurationDecision(
+                CurationDecisionKind.Update,
+                targetId,
+                null,
+                null,
+                $"LLM decision: UPDATE {targetId}",
+                MergedBody: ExtractMergedBody(trimmed),
+                FromLlmTier: true);
         }
 
-        // CONSOLIDATE <id> [<id>...]
-        var consolidateMatch = Regex.Match(trimmed, @"^CONSOLIDATE\s+(.+)$", RegexOptions.IgnoreCase);
+        // CONSOLIDATE <id> [<id>...] [---\n<merged body>]
+        // Captures only the rest of the FIRST line: unlike the pre-Slice-3 shape (always a
+        // single keyword line), a merged body may follow on subsequent lines, and `.`
+        // without RegexOptions.Singleline cannot cross the newline before it.
+        var consolidateMatch = Regex.Match(trimmed, @"^CONSOLIDATE\s+([^\r\n]+)", RegexOptions.IgnoreCase);
         if (consolidateMatch.Success)
         {
             var ids = consolidateMatch.Groups[1].Value
@@ -170,11 +213,32 @@ public static class CurationPromptBuilder
                     null,
                     ids,
                     null,
-                    $"LLM decision: CONSOLIDATE {string.Join(" ", ids)}");
+                    $"LLM decision: CONSOLIDATE {string.Join(" ", ids)}",
+                    MergedBody: ExtractMergedBody(trimmed),
+                    FromLlmTier: true);
             }
         }
 
         return null;
+    }
+
+    private static readonly Regex MergedBodySeparatorPattern = new(@"(?m)^-{3,}\s*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Finds the first "---" separator line and returns everything after it, trimmed.
+    /// Returns null when there is no separator, or when the text after it is empty once
+    /// trimmed (a malformed/empty body is treated as absent, per task 3.2) — the caller
+    /// then falls back to the keyword-only decision semantics (task 3.4's append-fallback
+    /// routing for a body-absent LLM UPDATE/CONSOLIDATE).
+    /// </summary>
+    private static string? ExtractMergedBody(string trimmedResponse)
+    {
+        var separator = MergedBodySeparatorPattern.Match(trimmedResponse);
+        if (!separator.Success)
+            return null;
+
+        var body = trimmedResponse[(separator.Index + separator.Length)..].Trim();
+        return body.Length == 0 ? null : body;
     }
 
     private static string StripThinkBlocks(string text)

--- a/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
@@ -29,6 +29,16 @@ public enum CurationDecisionKind
 /// <summary>
 /// An existing memory document that is a candidate for matching against a proposal.
 /// </summary>
+/// <param name="CosineSimilarity">
+/// The embedding cosine similarity that nominated this candidate via
+/// <see cref="MemoryVectorIndex.TopK"/> (memory-core-redesign Slice 3 Stage B, task 3.1). Null
+/// for candidates sourced only from anchor-name matching or lexical content search — those
+/// carry no embedding evidence. A non-null value here is what
+/// <see cref="MemoryCurationEvaluator.EvaluateAsync"/> uses to force the decision to the LLM
+/// tier: per design D4, cosine similarity is nomination evidence only and must never itself
+/// decide skip/merge/create, so this field is read for "is a nominee present" and then handed
+/// to the curator LLM as context — never compared against a threshold to auto-decide.
+/// </param>
 public sealed record ExistingMemoryCandidate(
     string DocumentId,
     string AnchorId,
@@ -36,7 +46,8 @@ public sealed record ExistingMemoryCandidate(
     string Content,
     long? FreshnessAtMs,
     double Confidence,
-    bool IsExactAnchorMatch);
+    bool IsExactAnchorMatch,
+    double? CosineSimilarity = null);
 
 /// <summary>
 /// Result of curation evaluation for a single proposal.

--- a/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
@@ -41,12 +41,38 @@ public sealed record ExistingMemoryCandidate(
 /// <summary>
 /// Result of curation evaluation for a single proposal.
 /// </summary>
+/// <param name="MergedBody">
+/// The complete, lossless-union markdown body synthesized by the curation LLM for an
+/// UPDATE/CONSOLIDATE decision (memory-core-redesign Slice 3, design D5;
+/// <see cref="CurationPromptBuilder.ParseResponse"/> is the only producer). Null for
+/// SKIP/CREATE, for any decision produced by the deterministic rules tier (which never
+/// synthesizes a body), and for keyword-only LLM UPDATE/CONSOLIDATE responses.
+/// <see cref="MemoryCurationEvaluator.ApplyDecisionAsync"/> validates this against every
+/// source body via <see cref="MergeGuard"/> before writing it; on guard failure or when
+/// this is null for an LLM-tier decision, the write degrades to a structural append
+/// instead of the raw overwrite this field's absence would otherwise imply.
+/// </param>
+/// <param name="FromLlmTier">
+/// True when <see cref="CurationPromptBuilder.ParseResponse"/> produced this decision, as
+/// opposed to the deterministic rules tier (<see cref="CurationRulesEvaluator"/>). Governs
+/// write routing in <see cref="MemoryCurationEvaluator.ApplyDecisionAsync"/>: the
+/// deterministic tier's UPDATE (exact-anchor path) keeps its pre-Slice-3 guarantee — a raw
+/// overwrite that <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/> has already
+/// verified is a proposal-preserves-existing-content superset — while every LLM-tier
+/// UPDATE/CONSOLIDATE routes through <see cref="MergeGuard"/>-validated merge or structural
+/// append instead. Deterministic-tier CONSOLIDATE never sets this either, but it flows
+/// through the same guarded path anyway because it never carries a <see cref="MergedBody"/>
+/// (the rules tier does not synthesize one) — see <see cref="MemoryCurationEvaluator"/>'s
+/// remarks for why that unification is safe.
+/// </param>
 public sealed record CurationDecision(
     CurationDecisionKind Kind,
     string? TargetDocumentId,
     IReadOnlyList<string>? ConsolidationTargetIds,
     string? CanonicalAnchorName,
-    string Reason);
+    string Reason,
+    string? MergedBody = null,
+    bool FromLlmTier = false);
 
 /// <summary>
 /// Deterministic rules-based evaluator for memory curation decisions.

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -36,7 +36,7 @@ public sealed record CurationFailed(string Reason);
 // ── Internal messages ───────────────────────────────────────────────
 
 internal sealed record EvaluationBatchResult(
-    IReadOnlyList<(SQLiteMemoryCurationOperation Operation, CurationDecision Decision)> Decisions);
+    IReadOnlyList<(SQLiteMemoryCurationOperation Operation, CurationEvaluation Evaluation)> Evaluations);
 
 internal sealed record WriteBatchResult(CurationCompleted Summary);
 
@@ -61,6 +61,12 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 
     public IStash Stash { get; set; } = null!;
 
+    /// <param name="curationConfig">
+    /// Write-side curation settings (memory-core-redesign Slice 3): nominator threshold/K
+    /// (not yet consumed — Stage B) and the curation LLM's timeout/token-cap, threaded to
+    /// <see cref="MemoryCurationEvaluator"/> in place of the hardcoded constants Slice 1
+    /// shipped with.
+    /// </param>
     /// <param name="embedderHolder">
     /// Resolves the process's <see cref="IMemoryEmbedder"/> at write time (memory-core-redesign
     /// Slice 2, task 2.8). Optional like <paramref name="clientProvider"/> above: a null holder
@@ -71,6 +77,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     public MemoryCurationActor(
         SQLiteMemoryStore store,
         SessionId sessionId,
+        MemoryCurationConfig curationConfig,
         IChatClientProvider? clientProvider = null,
         MemoryEmbedderHolder? embedderHolder = null)
     {
@@ -82,7 +89,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         var llmClient = clientProvider != null
             ? clientProvider.GetClient(ModelRole.Compaction)
             : null;
-        _evaluator = new MemoryCurationEvaluator(_store, _log, llmClient);
+        _evaluator = new MemoryCurationEvaluator(_store, _log, curationConfig, llmClient);
 
         Become(Idle);
     }
@@ -93,9 +100,10 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     public static Props CreateProps(
         SQLiteMemoryStore store,
         SessionId sessionId,
+        MemoryCurationConfig curationConfig,
         IChatClientProvider? clientProvider = null,
         MemoryEmbedderHolder? embedderHolder = null)
-        => Props.Create(() => new MemoryCurationActor(store, sessionId, clientProvider, embedderHolder));
+        => Props.Create(() => new MemoryCurationActor(store, sessionId, curationConfig, clientProvider, embedderHolder));
 
     // ── Idle behavior ───────────────────────────────────────────────
 
@@ -121,8 +129,8 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     {
         Receive<EvaluationBatchResult>(msg =>
         {
-            _log.Info("curation_actor_evaluated decisionCount={0}", msg.Decisions.Count);
-            StartWriting(msg.Decisions);
+            _log.Info("curation_actor_evaluated decisionCount={0}", msg.Evaluations.Count);
+            StartWriting(msg.Evaluations);
         });
 
         // Stash incoming proposals while evaluating
@@ -184,15 +192,15 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         {
             try
             {
-                var decisions = new List<(SQLiteMemoryCurationOperation, CurationDecision)>();
+                var evaluations = new List<(SQLiteMemoryCurationOperation, CurationEvaluation)>();
 
                 foreach (var operation in operations)
                 {
-                    var decision = await EvaluateSingleAsync(operation);
-                    decisions.Add((operation, decision));
+                    var evaluation = await EvaluateSingleAsync(operation);
+                    evaluations.Add((operation, evaluation));
                 }
 
-                self.Tell(new EvaluationBatchResult(decisions));
+                self.Tell(new EvaluationBatchResult(evaluations));
             }
             catch (Exception ex)
             {
@@ -203,12 +211,12 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 
     // Decision logic lives in MemoryCurationEvaluator (shared with the daemon checkpoint
     // worker — memory-core-redesign Slice 1) so the two write pipelines cannot diverge.
-    private Task<CurationDecision> EvaluateSingleAsync(SQLiteMemoryCurationOperation operation)
+    private Task<CurationEvaluation> EvaluateSingleAsync(SQLiteMemoryCurationOperation operation)
         => _evaluator.EvaluateAsync(operation, _sessionId);
 
     // ── Write pipeline ──────────────────────────────────────────────
 
-    private void StartWriting(IReadOnlyList<(SQLiteMemoryCurationOperation Operation, CurationDecision Decision)> decisions)
+    private void StartWriting(IReadOnlyList<(SQLiteMemoryCurationOperation Operation, CurationEvaluation Evaluation)> evaluations)
     {
         Become(Writing);
         var self = Self;
@@ -223,12 +231,15 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 var created = 0;
                 var toWrite = new List<SQLiteMemoryCurationOperation>();
 
-                foreach (var (operation, decision) in decisions)
+                foreach (var (operation, evaluation) in evaluations)
                 {
+                    var decision = evaluation.Decision;
+
                     // Decision -> write-operation mapping (including Consolidate's
-                    // re-anchor/tombstone side effects) lives in MemoryCurationEvaluator,
-                    // shared with the daemon checkpoint worker.
-                    var writeOp = await _evaluator.ApplyDecisionAsync(operation, decision);
+                    // re-anchor/tombstone side effects and Slice 3's guard-validated
+                    // merge/append routing) lives in MemoryCurationEvaluator, shared with
+                    // the daemon checkpoint worker.
+                    var writeOp = await _evaluator.ApplyDecisionAsync(operation, decision, evaluation.Candidates);
 
                     switch (decision.Kind)
                     {
@@ -269,7 +280,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 }
 
                 self.Tell(new WriteBatchResult(new CurationCompleted(
-                    Evaluated: decisions.Count,
+                    Evaluated: evaluations.Count,
                     Skipped: skipped,
                     Updated: updated,
                     Consolidated: consolidated,

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -62,24 +62,31 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     public IStash Stash { get; set; } = null!;
 
     /// <param name="curationConfig">
-    /// Write-side curation settings (memory-core-redesign Slice 3): nominator threshold/K
-    /// (not yet consumed — Stage B) and the curation LLM's timeout/token-cap, threaded to
-    /// <see cref="MemoryCurationEvaluator"/> in place of the hardcoded constants Slice 1
-    /// shipped with.
+    /// Write-side curation settings (memory-core-redesign Slice 3): nominator threshold/K and
+    /// the curation LLM's timeout/token-cap, threaded to <see cref="MemoryCurationEvaluator"/>
+    /// in place of the hardcoded constants Slice 1 shipped with.
     /// </param>
     /// <param name="embedderHolder">
-    /// Resolves the process's <see cref="IMemoryEmbedder"/> at write time (memory-core-redesign
-    /// Slice 2, task 2.8). Optional like <paramref name="clientProvider"/> above: a null holder
-    /// is a genuine operating mode (a test harness or a session wired without the embedding
-    /// subsystem), not a placeholder — <see cref="MemoryEmbedOnWriteCoordinator"/> treats a null
-    /// holder identically to an unavailable embedder and skips embedding with a debug log.
+    /// Resolves the process's <see cref="IMemoryEmbedder"/> for embed-on-write (memory-core-
+    /// redesign Slice 2, task 2.8) AND for the evaluator's embedding kNN nominator (Slice 3
+    /// Stage B, task 3.1) — the same holder serves both. Optional like
+    /// <paramref name="clientProvider"/> above: a null holder is a genuine operating mode (a
+    /// test harness or a session wired without the embedding subsystem), not a placeholder —
+    /// both <see cref="MemoryEmbedOnWriteCoordinator"/> and <see cref="MemoryCurationEvaluator"/>
+    /// treat a null holder identically to an unavailable embedder and degrade accordingly.
+    /// </param>
+    /// <param name="vectorIndexHolder">
+    /// Resolves the process's <see cref="MemoryVectorIndex"/> for the nominator (Slice 3 Stage
+    /// B). Provided alongside <paramref name="embedderHolder"/> in production; independently
+    /// nullable for the same test-harness reason.
     /// </param>
     public MemoryCurationActor(
         SQLiteMemoryStore store,
         SessionId sessionId,
         MemoryCurationConfig curationConfig,
         IChatClientProvider? clientProvider = null,
-        MemoryEmbedderHolder? embedderHolder = null)
+        MemoryEmbedderHolder? embedderHolder = null,
+        MemoryVectorIndexHolder? vectorIndexHolder = null)
     {
         _store = store;
         _sessionId = sessionId;
@@ -89,7 +96,8 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         var llmClient = clientProvider != null
             ? clientProvider.GetClient(ModelRole.Compaction)
             : null;
-        _evaluator = new MemoryCurationEvaluator(_store, _log, curationConfig, llmClient);
+        _evaluator = new MemoryCurationEvaluator(
+            _store, _log, curationConfig, llmClient, embedderHolder, vectorIndexHolder);
 
         Become(Idle);
     }
@@ -102,8 +110,10 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         SessionId sessionId,
         MemoryCurationConfig curationConfig,
         IChatClientProvider? clientProvider = null,
-        MemoryEmbedderHolder? embedderHolder = null)
-        => Props.Create(() => new MemoryCurationActor(store, sessionId, curationConfig, clientProvider, embedderHolder));
+        MemoryEmbedderHolder? embedderHolder = null,
+        MemoryVectorIndexHolder? vectorIndexHolder = null)
+        => Props.Create(() => new MemoryCurationActor(
+            store, sessionId, curationConfig, clientProvider, embedderHolder, vectorIndexHolder));
 
     // ── Idle behavior ───────────────────────────────────────────────
 

--- a/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
@@ -17,9 +17,11 @@ namespace Netclaw.Actors.Memory;
 
 /// <summary>
 /// Minimal logging seam so <see cref="MemoryCurationEvaluator"/> emits one set of log
-/// markers (<c>curation_dual_search</c>, <c>curation_llm_decision</c>,
-/// <c>curation_llm_no_decision</c>, <c>curation_llm_timeout</c>, <c>curation_llm_error</c>,
-/// <c>curation_ambiguous_auto_resolved</c>, <c>curation_ambiguous_create_fallback</c>,
+/// markers (<c>curation_dual_search</c>, <c>curation_nominated</c>,
+/// <c>curation_nominator_degraded</c>, <c>curation_nominee_no_llm_decision</c>,
+/// <c>curation_llm_decision</c>, <c>curation_llm_no_decision</c>, <c>curation_llm_timeout</c>,
+/// <c>curation_llm_error</c>, <c>curation_ambiguous_auto_resolved</c>,
+/// <c>curation_ambiguous_create_fallback</c>,
 /// <c>curation_skip</c>/<c>_update</c>/<c>_consolidate</c>/<c>_create</c>,
 /// <c>curation_reanchor</c>, <c>curation_tombstone_anchor</c>) regardless of which of the
 /// two callers is driving the evaluator: the inline per-session actor
@@ -75,10 +77,20 @@ internal sealed class MicrosoftCurationLog(ILogger log) : ICurationLog
 /// slice (finding D14) and the daemon path performed no relationship evaluation at all.
 ///
 /// Decision flow (<see cref="EvaluateAsync"/>): immutable records bypass evaluation; fuzzy
-/// anchor candidates are queried, then content-term candidates are added when there is no
-/// exact anchor match; <see cref="CurationRulesEvaluator.Evaluate"/> runs the deterministic
-/// tier; an Ambiguous result escalates to the LLM tier (when available) followed by
-/// <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/>, or else falls back to
+/// anchor candidates are queried; on an exact anchor match, the deterministic fast path
+/// (<see cref="CurationRulesEvaluator.Evaluate"/>'s <c>EvaluateExactMatch</c>) decides Skip/Update
+/// with no further evidence gathering. Otherwise, the embedding kNN nominator (memory-core-
+/// redesign Slice 3 Stage B, task 3.1, design D4) queries <see cref="MemoryVectorIndex.TopK"/>
+/// when the embedder is available: <b>any nominee forces the decision to the LLM tier</b>,
+/// regardless of what the lexical rules tier would have decided — the May 2026 measurement
+/// (<c>docs/research/memory-recall-findings-2026-05.md</c>; corroborated at corpus scale in
+/// <c>docs/research/memory-audit-2026-07.md</c> §5) found no cosine threshold that separates true
+/// duplicates from merely-related siblings, so cosine similarity is nomination evidence ONLY —
+/// it never auto-merges and never auto-skips. When no nominee fires (or the embedder is
+/// unavailable, in which case the pre-Slice-3 lexical content-term search runs instead as an
+/// explicitly-logged degraded path), <see cref="CurationRulesEvaluator.Evaluate"/> runs the
+/// deterministic tier as before; an Ambiguous result escalates to the LLM tier (when available)
+/// followed by <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/>, or else falls back to
 /// <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> and finally a Create default.
 /// <see cref="ApplyDecisionAsync"/> maps the resulting decision to the operation that should
 /// be written (or nothing, for Skip), executing Consolidate's re-anchor/tombstone side
@@ -109,6 +121,8 @@ public sealed class MemoryCurationEvaluator
     private readonly IChatClient? _llmClient;
     private readonly ICurationLog _log;
     private readonly MemoryCurationConfig _curationConfig;
+    private readonly MemoryEmbedderHolder? _embedderHolder;
+    private readonly MemoryVectorIndexHolder? _vectorIndexHolder;
 
     /// <summary>
     /// Constructs an evaluator that logs through Akka's actor logging (the inline
@@ -118,9 +132,27 @@ public sealed class MemoryCurationEvaluator
     /// which case Ambiguous decisions resolve via
     /// <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> only.
     /// </summary>
+    /// <param name="embedderHolder">
+    /// Resolves the process's <see cref="IMemoryEmbedder"/> for the kNN nominator
+    /// (memory-core-redesign Slice 3 Stage B). Optional like <paramref name="llmClient"/>: a
+    /// null holder is a genuine operating mode (a test harness, or a build with the embedding
+    /// subsystem not wired up at all) — <see cref="EvaluateAsync"/> treats it identically to an
+    /// unavailable embedder and runs the lexical degraded path.
+    /// </param>
+    /// <param name="vectorIndexHolder">
+    /// Resolves the process's <see cref="MemoryVectorIndex"/> for the same nominator. Optional
+    /// for the same reason as <paramref name="embedderHolder"/> — the two are provided together
+    /// in production (see <c>Netclaw.Daemon.Program</c>), but each is independently nullable so
+    /// a caller missing one still degrades safely rather than throwing.
+    /// </param>
     public MemoryCurationEvaluator(
-        SQLiteMemoryStore store, ILoggingAdapter log, MemoryCurationConfig curationConfig, IChatClient? llmClient = null)
-        : this(store, (ICurationLog)new AkkaCurationLog(log), curationConfig, llmClient)
+        SQLiteMemoryStore store,
+        ILoggingAdapter log,
+        MemoryCurationConfig curationConfig,
+        IChatClient? llmClient = null,
+        MemoryEmbedderHolder? embedderHolder = null,
+        MemoryVectorIndexHolder? vectorIndexHolder = null)
+        : this(store, (ICurationLog)new AkkaCurationLog(log), curationConfig, llmClient, embedderHolder, vectorIndexHolder)
     {
     }
 
@@ -128,21 +160,37 @@ public sealed class MemoryCurationEvaluator
     /// Constructs an evaluator that logs through Microsoft.Extensions.Logging (the daemon
     /// checkpoint-worker path). The daemon worker has no LLM client to give this evaluator
     /// today — that absence is intentional and permanent for this call site, not a
-    /// placeholder to be filled in later in this slice.
+    /// placeholder to be filled in later in this slice. <paramref name="embedderHolder"/> and
+    /// <paramref name="vectorIndexHolder"/> ARE wired here (memory-core-redesign Slice 3 Stage
+    /// B): the nominator runs on both write pipelines even though only the inline pipeline has
+    /// an LLM client — a nominee found with no LLM available still forces the conservative
+    /// no-auto-merge Create outcome documented on <see cref="EvaluateAsync"/>.
     /// </summary>
     public MemoryCurationEvaluator(
-        SQLiteMemoryStore store, ILogger log, MemoryCurationConfig curationConfig, IChatClient? llmClient = null)
-        : this(store, (ICurationLog)new MicrosoftCurationLog(log), curationConfig, llmClient)
+        SQLiteMemoryStore store,
+        ILogger log,
+        MemoryCurationConfig curationConfig,
+        IChatClient? llmClient = null,
+        MemoryEmbedderHolder? embedderHolder = null,
+        MemoryVectorIndexHolder? vectorIndexHolder = null)
+        : this(store, (ICurationLog)new MicrosoftCurationLog(log), curationConfig, llmClient, embedderHolder, vectorIndexHolder)
     {
     }
 
     private MemoryCurationEvaluator(
-        SQLiteMemoryStore store, ICurationLog log, MemoryCurationConfig curationConfig, IChatClient? llmClient)
+        SQLiteMemoryStore store,
+        ICurationLog log,
+        MemoryCurationConfig curationConfig,
+        IChatClient? llmClient,
+        MemoryEmbedderHolder? embedderHolder,
+        MemoryVectorIndexHolder? vectorIndexHolder)
     {
         _store = store;
         _log = log;
         _curationConfig = curationConfig;
         _llmClient = llmClient;
+        _embedderHolder = embedderHolder;
+        _vectorIndexHolder = vectorIndexHolder;
     }
 
     /// <summary>
@@ -173,44 +221,144 @@ public sealed class MemoryCurationEvaluator
         // Build a mutable candidate list — content search may add more candidates below.
         var candidates = new List<ExistingMemoryCandidate>(anchorCandidates);
 
-        // Run content-based search when there is no exact anchor match.
-        // This catches semantically identical content under very different anchor names
-        // (e.g., "netclaw-github-repo" vs "netclaw-source-location" — different names, same info).
+        // Embedding kNN nomination (memory-core-redesign Slice 3 Stage B, task 3.1, design D4)
+        // vs. the pre-Slice-3 lexical content-term search: these are alternatives, not additive.
+        // An exact anchor match already resolves deterministically below with no further
+        // evidence gathering (the "existing exact-anchor deterministic fast path" design D4
+        // calls out as unchanged), so neither runs in that case.
         var hasExactAnchorMatch = anchorCandidates.Any(c => c.IsExactAnchorMatch);
-        if (!hasExactAnchorMatch && !string.IsNullOrWhiteSpace(operation.Content))
+        if (!hasExactAnchorMatch)
         {
-            var contentTerms = operation.Content
-                .Split([' ', '\t', '\n', '\r', '.', ',', ':', ';', '!', '?', '"', '\''],
-                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Where(t => t.Length >= 3)
-                .Select(t => t.ToLowerInvariant())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Take(8)
-                .ToArray();
-
-            if (contentTerms.Length > 0)
+            var embedder = _embedderHolder?.Current;
+            if (embedder is not null && embedder.IsAvailable && _vectorIndexHolder is not null)
             {
-                var contentCandidates = await _store.FindCandidatesByContentAsync(contentTerms, ct: ct);
-
-                // Merge content candidates with anchor candidates, deduplicating by DocumentId.
-                if (contentCandidates.Count > 0)
+                var (nominees, topCosine) = await NominateAsync(embedder, operation, ct);
+                if (nominees.Count > 0)
                 {
-                    var existingDocIds = new HashSet<string>(
-                        candidates.Select(c => c.DocumentId), StringComparer.OrdinalIgnoreCase);
-                    foreach (var cc in contentCandidates)
+                    // Merge like the content-term path below: dedup by DocumentId, but a nominee
+                    // that is ALSO already present (e.g. it also fuzzy-matched by anchor name)
+                    // must keep its cosine tag rather than being dropped as a duplicate.
+                    var byDocId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    for (var i = 0; i < candidates.Count; i++)
+                        byDocId[candidates[i].DocumentId] = i;
+
+                    foreach (var nominee in nominees)
                     {
-                        if (!existingDocIds.Contains(cc.DocumentId))
-                            candidates.Add(cc);
+                        if (byDocId.TryGetValue(nominee.DocumentId, out var existingIndex))
+                            candidates[existingIndex] = candidates[existingIndex] with { CosineSimilarity = nominee.CosineSimilarity };
+                        else
+                            candidates.Add(nominee);
                     }
 
-                    _log.Debug(
-                        "curation_dual_search anchor={0} anchor_hits={1} content_hits={2} merged={3}",
+                    _log.Info(
+                        "curation_nominated anchor={0} count={1} topCosine={2}",
                         operation.AnchorCanonicalName,
-                        anchorCandidates.Count,
-                        contentCandidates.Count,
-                        candidates.Count);
+                        nominees.Count,
+                        topCosine.ToString("F4", System.Globalization.CultureInfo.InvariantCulture));
                 }
             }
+            else
+            {
+                // Degraded path (design D4 point 4): no healthy embedder/index, so fall back to
+                // the lexical content-term search exactly as before Slice 3 — this catches
+                // semantically identical content under very different anchor names (e.g.,
+                // "netclaw-github-repo" vs "netclaw-source-location") when there is no embedding
+                // evidence available to do better. Logged unconditionally in this branch (not
+                // gated on content being non-blank) so the degraded condition itself is always
+                // observable, independent of whether a search ends up running. Debug level, not
+                // Warning: "embedder unavailable" is the default operating mode while
+                // Memory.Embeddings.Enabled is false (task 3.1's target default), so this would
+                // otherwise be Warning-level spam on every single curation evaluation in the
+                // common case — the loud, once-per-transition signal already exists at startup
+                // (EmbeddingWarmupHostedService's memory_embedding_unavailable /
+                // memory_embedding_disabled) and in doctor/status, matching
+                // MemoryEmbedOnWriteCoordinator's identical reasoning for its own
+                // embedder-unavailable skip log.
+                _log.Debug(
+                    "curation_nominator_degraded anchor={0} reason={1}",
+                    operation.AnchorCanonicalName,
+                    embedder is null ? "no_embedder_configured" : !embedder.IsAvailable ? "embedder_unavailable" : "vector_index_unavailable");
+
+                if (!string.IsNullOrWhiteSpace(operation.Content))
+                {
+                    var contentTerms = operation.Content
+                        .Split([' ', '\t', '\n', '\r', '.', ',', ':', ';', '!', '?', '"', '\''],
+                            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .Where(t => t.Length >= 3)
+                        .Select(t => t.ToLowerInvariant())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Take(8)
+                        .ToArray();
+
+                    if (contentTerms.Length > 0)
+                    {
+                        var contentCandidates = await _store.FindCandidatesByContentAsync(contentTerms, ct: ct);
+
+                        // Merge content candidates with anchor candidates, deduplicating by DocumentId.
+                        if (contentCandidates.Count > 0)
+                        {
+                            var existingDocIds = new HashSet<string>(
+                                candidates.Select(c => c.DocumentId), StringComparer.OrdinalIgnoreCase);
+                            foreach (var cc in contentCandidates)
+                            {
+                                if (!existingDocIds.Contains(cc.DocumentId))
+                                    candidates.Add(cc);
+                            }
+
+                            _log.Debug(
+                                "curation_dual_search anchor={0} anchor_hits={1} content_hits={2} merged={3}",
+                                operation.AnchorCanonicalName,
+                                anchorCandidates.Count,
+                                contentCandidates.Count,
+                                candidates.Count);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Any nominee forces the LLM tier, regardless of what the lexical rules tier below would
+        // have decided (design D4: "no cosine threshold separates duplicates from siblings," so
+        // similarity nominates only — it never auto-merges or auto-skips on its own).
+        var hasNominee = candidates.Any(c => c.CosineSimilarity.HasValue);
+        if (hasNominee)
+        {
+            if (_llmClient is not null)
+            {
+                var nomineeLlmDecision = await TryLlmEvaluationAsync(
+                    _llmClient, sessionId, operation, candidates, _log, _curationConfig, useFullCandidateContent: true);
+                if (nomineeLlmDecision is not null)
+                {
+                    // GuardDestructiveUpdate is deliberately NOT applied here — see this class's
+                    // remarks; write-time MergeGuard/structural-append routing supersedes it for
+                    // every LLM-tier decision.
+                    _log.Info(
+                        "curation_llm_decision anchor={0} decision={1} reason={2}",
+                        operation.AnchorCanonicalName,
+                        nomineeLlmDecision.Kind,
+                        nomineeLlmDecision.Reason);
+                    return new CurationEvaluation(nomineeLlmDecision, candidates);
+                }
+
+                // LLM failed to produce a parseable decision — fall through to the conservative
+                // no-LLM handling below rather than a second (Jaccard-based) attempt.
+            }
+
+            // No LLM available, or the LLM call failed: a nominee is semantic-near evidence that
+            // TryAutoResolveAmbiguous's Jaccard heuristics cannot safely adjudicate (that is
+            // exactly the ambiguity the May 2026 measurement showed deterministic logic cannot
+            // resolve), so this does NOT call TryAutoResolveAmbiguous — doing so risks an
+            // auto-Skip driven by cosine-adjacent content that is actually a distinct sibling.
+            // The conservative outcome is Create: the cost is a possible duplicate document,
+            // recoverable by a future curation pass; a wrong auto-merge is not.
+            _log.Warning(
+                "curation_nominee_no_llm_decision anchor={0} llm_available={1} — conservative create",
+                operation.AnchorCanonicalName,
+                _llmClient is not null);
+            return new CurationEvaluation(
+                new CurationDecision(CurationDecisionKind.Create, null, null, null,
+                    "nominee present but no LLM decision available: conservative create (no auto-merge on cosine alone)"),
+                candidates);
         }
 
         // Apply rules tier
@@ -266,13 +414,86 @@ public sealed class MemoryCurationEvaluator
             candidates);
     }
 
+    /// <summary>
+    /// Embedding kNN nomination step (memory-core-redesign Slice 3 Stage B, task 3.1). Embeds
+    /// the proposal's <c>"{title}\n{content}"</c> text — the exact concatenation
+    /// <see cref="MemoryEmbedOnWriteCoordinator"/> embeds a written document with, so a proposal
+    /// and its eventual stored form land in the same region of embedding space — queries
+    /// <paramref name="embedder"/>'s current <see cref="MemoryVectorIndex"/> for up to
+    /// <see cref="MemoryCurationConfig.NominatorK"/> neighbors at or above
+    /// <see cref="MemoryCurationConfig.NominatorSimilarityThreshold"/>, then hydrates the
+    /// matched document ids into full-content candidates tagged with their cosine.
+    ///
+    /// <para>
+    /// <b>Cost:</b> curation runs off the interactive turn path (checkpoint/session-boundary
+    /// triggered, via the daemon worker or the inline actor's post-turn write phase) — unlike
+    /// the sub-150ms recall-query budget (design D6), there is no per-turn latency budget here,
+    /// so the ~210ms median / ~280ms mean single-embed cost measured for the nominator model
+    /// (<c>docs/research/memory-audit-2026-07.md</c> §4, snowflake-arctic-embed 137M) is
+    /// acceptable — it does not block a user-visible response.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Known limitation (intra-batch nomination):</b> a proposal is nominated against the
+    /// store's already-committed embeddings only — it cannot nominate itself (it has not been
+    /// written yet), which is correct. But when a caller evaluates several proposals as one
+    /// batch (both write pipelines evaluate a checkpoint's candidates in a loop before any of
+    /// them commits), two mutually-near-duplicate proposals within that SAME batch will not see
+    /// each other, because neither is in the index yet when the other is nominated. This is an
+    /// accepted gap for this slice, not a design goal: cross-batch and steady-state dedup (the
+    /// overwhelming majority of write traffic) both work correctly, and closing the intra-batch
+    /// case would require either serializing writes mid-batch or a second batch-local similarity
+    /// pass — deferred until evidence shows same-batch near-duplicates are common enough to
+    /// justify the added complexity.
+    /// </para>
+    /// </summary>
+    private async Task<(IReadOnlyList<ExistingMemoryCandidate> Nominees, double TopCosine)> NominateAsync(
+        IMemoryEmbedder embedder,
+        SQLiteMemoryCurationOperation operation,
+        CancellationToken ct)
+    {
+        var vectorIndex = await _vectorIndexHolder!.GetCurrentAsync(embedder, ct);
+        if (vectorIndex is null)
+            return ([], 0);
+
+        var queryVector = await embedder.EmbedAsync($"{operation.Title}\n{operation.Content}", ct);
+        var matches = vectorIndex.TopK(
+            queryVector.Span, _curationConfig.NominatorK, _curationConfig.NominatorSimilarityThreshold);
+        if (matches.Count == 0)
+            return ([], 0);
+
+        // Only "document" items are ever embedded (MemoryEmbedOnWriteCoordinator.DocumentItemKind)
+        // — immutable records bypass curation and are never embedded — but filter defensively
+        // rather than assume, since a future item kind sharing this model's embedding table
+        // would otherwise be silently mis-hydrated as a document candidate.
+        var documentIds = matches
+            .Where(m => string.Equals(m.ItemKind, MemoryEmbedOnWriteCoordinator.DocumentItemKind, StringComparison.Ordinal))
+            .Select(m => m.ItemId)
+            .ToArray();
+        if (documentIds.Length == 0)
+            return ([], 0);
+
+        var hydrated = await _store.GetCandidatesByIdsAsync(documentIds, ct);
+        if (hydrated.Count == 0)
+            return ([], 0);
+
+        var cosineByDocId = matches.ToDictionary(m => m.ItemId, m => m.Cosine, StringComparer.Ordinal);
+        var tagged = hydrated
+            .Select(c => cosineByDocId.TryGetValue(c.DocumentId, out var cosine) ? c with { CosineSimilarity = cosine } : c)
+            .ToArray();
+
+        // matches is already sorted descending by cosine (MemoryVectorIndex.TopK's contract).
+        return (tagged, matches[0].Cosine);
+    }
+
     internal static async Task<CurationDecision?> TryLlmEvaluationAsync(
         IChatClient llmClient,
         SessionId sessionId,
         SQLiteMemoryCurationOperation operation,
         IReadOnlyList<ExistingMemoryCandidate> candidates,
         ICurationLog log,
-        MemoryCurationConfig curationConfig)
+        MemoryCurationConfig curationConfig,
+        bool useFullCandidateContent = false)
     {
         try
         {
@@ -281,7 +502,7 @@ public sealed class MemoryCurationEvaluator
             var messages = new List<ChatMessage>
             {
                 new(ChatRole.System, CurationPromptBuilder.SystemPrompt),
-                new(ChatRole.User, CurationPromptBuilder.BuildUserMessage(operation, candidates))
+                new(ChatRole.User, CurationPromptBuilder.BuildUserMessage(operation, candidates, useFullCandidateContent))
             };
 
             // SessionScopedChatOptions carries the session id so this sidecar's chat-client

--- a/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
@@ -84,14 +84,31 @@ internal sealed class MicrosoftCurationLog(ILogger log) : ICurationLog
 /// be written (or nothing, for Skip), executing Consolidate's re-anchor/tombstone side
 /// effects — this mapping is unified too, since a second, hand-copied switch statement per
 /// caller is exactly the kind of divergence this slice removes.
+///
+/// Guard-validated write routing (memory-core-redesign Slice 3, design D5): an LLM-tier
+/// UPDATE/CONSOLIDATE decision (<see cref="CurationDecision.FromLlmTier"/>) never overwrites
+/// a target's raw body. When it carries a synthesized <see cref="CurationDecision.MergedBody"/>,
+/// <see cref="ApplyDecisionAsync"/> validates it with <see cref="MergeGuard"/> against every
+/// source body and writes it only on a pass; on guard failure, or when no merged body was
+/// produced, the write degrades to a structural append (<see cref="ApplyGuardedMergeOrAppend"/>)
+/// so information is never silently dropped. The deterministic tier's UPDATE (the exact-anchor
+/// path in <see cref="CurationRulesEvaluator"/>) is the one decision shape that keeps its
+/// pre-Slice-3 behavior unchanged: <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/>
+/// already proves the proposal is a content superset of the target before that decision can
+/// reach Update, so its raw overwrite is provably non-lossy on its own terms — appending there
+/// too would just bloat documents that are legitimately single-value replacements (e.g. a
+/// version bump) for no safety benefit. GuardDestructiveUpdate is therefore no longer applied
+/// to LLM-tier decisions in <see cref="EvaluateAsync"/>: its raw-proposal containment check
+/// would reject a legitimate reworded merge (the unmerged proposal rarely contains the
+/// target's exact wording verbatim), and the write-time guard above supersedes it for that
+/// tier anyway.
 /// </summary>
 public sealed class MemoryCurationEvaluator
 {
-    private static readonly TimeSpan LlmTimeout = TimeSpan.FromSeconds(10);
-
     private readonly SQLiteMemoryStore _store;
     private readonly IChatClient? _llmClient;
     private readonly ICurationLog _log;
+    private readonly MemoryCurationConfig _curationConfig;
 
     /// <summary>
     /// Constructs an evaluator that logs through Akka's actor logging (the inline
@@ -101,8 +118,9 @@ public sealed class MemoryCurationEvaluator
     /// which case Ambiguous decisions resolve via
     /// <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> only.
     /// </summary>
-    public MemoryCurationEvaluator(SQLiteMemoryStore store, ILoggingAdapter log, IChatClient? llmClient = null)
-        : this(store, (ICurationLog)new AkkaCurationLog(log), llmClient)
+    public MemoryCurationEvaluator(
+        SQLiteMemoryStore store, ILoggingAdapter log, MemoryCurationConfig curationConfig, IChatClient? llmClient = null)
+        : this(store, (ICurationLog)new AkkaCurationLog(log), curationConfig, llmClient)
     {
     }
 
@@ -112,22 +130,30 @@ public sealed class MemoryCurationEvaluator
     /// today — that absence is intentional and permanent for this call site, not a
     /// placeholder to be filled in later in this slice.
     /// </summary>
-    public MemoryCurationEvaluator(SQLiteMemoryStore store, ILogger log, IChatClient? llmClient = null)
-        : this(store, (ICurationLog)new MicrosoftCurationLog(log), llmClient)
+    public MemoryCurationEvaluator(
+        SQLiteMemoryStore store, ILogger log, MemoryCurationConfig curationConfig, IChatClient? llmClient = null)
+        : this(store, (ICurationLog)new MicrosoftCurationLog(log), curationConfig, llmClient)
     {
     }
 
-    private MemoryCurationEvaluator(SQLiteMemoryStore store, ICurationLog log, IChatClient? llmClient)
+    private MemoryCurationEvaluator(
+        SQLiteMemoryStore store, ICurationLog log, MemoryCurationConfig curationConfig, IChatClient? llmClient)
     {
         _store = store;
         _log = log;
+        _curationConfig = curationConfig;
         _llmClient = llmClient;
     }
 
     /// <summary>
-    /// Evaluate a single curation proposal against existing memories and return a decision.
+    /// Evaluate a single curation proposal against existing memories and return a decision
+    /// together with the candidates it was evaluated against — <see cref="ApplyDecisionAsync"/>
+    /// needs those same candidate bodies (memory-core-redesign Slice 3) to validate or build a
+    /// merged/appended write, and re-querying the store at apply time could see a different
+    /// (possibly stale-in-the-other-direction) snapshot than the one the decision was actually
+    /// made against.
     /// </summary>
-    public async Task<CurationDecision> EvaluateAsync(
+    public async Task<CurationEvaluation> EvaluateAsync(
         SQLiteMemoryCurationOperation operation,
         SessionId sessionId,
         CancellationToken ct = default)
@@ -136,7 +162,9 @@ public sealed class MemoryCurationEvaluator
         if (MemoryDomainEnumExtensions.TryFromWireValue(operation.Kind, out MemoryKind kind)
             && kind == MemoryKind.Record)
         {
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "immutable record bypass");
+            return new CurationEvaluation(
+                new CurationDecision(CurationDecisionKind.Create, null, null, null, "immutable record bypass"),
+                []);
         }
 
         // Query existing anchors for matches (by name)
@@ -191,16 +219,21 @@ public sealed class MemoryCurationEvaluator
         // If rules tier is ambiguous and LLM is available, escalate
         if (rulesDecision.Kind == CurationDecisionKind.Ambiguous && _llmClient is not null)
         {
-            var llmDecision = await TryLlmEvaluationAsync(_llmClient, sessionId, operation, candidates, _log);
+            var llmDecision = await TryLlmEvaluationAsync(
+                _llmClient, sessionId, operation, candidates, _log, _curationConfig);
             if (llmDecision is not null)
             {
-                var guarded = CurationRulesEvaluator.GuardDestructiveUpdate(llmDecision, operation, candidates);
+                // GuardDestructiveUpdate is deliberately NOT applied here — see this class's
+                // remarks. LLM-tier UPDATE/CONSOLIDATE write safety is now the write-time
+                // MergeGuard/structural-append routing in ApplyDecisionAsync, which handles
+                // both the has-a-merged-body and no-merged-body cases without needing this
+                // decision downgraded first.
                 _log.Info(
                     "curation_llm_decision anchor={0} decision={1} reason={2}",
                     operation.AnchorCanonicalName,
-                    guarded.Kind,
-                    guarded.Reason);
-                return guarded;
+                    llmDecision.Kind,
+                    llmDecision.Reason);
+                return new CurationEvaluation(llmDecision, candidates);
             }
 
             // LLM failed — fall through to deterministic auto-resolution below
@@ -217,16 +250,20 @@ public sealed class MemoryCurationEvaluator
                     operation.AnchorCanonicalName,
                     autoResolved.Kind,
                     autoResolved.Reason);
-                return autoResolved;
+                return new CurationEvaluation(autoResolved, candidates);
             }
 
             _log.Warning("curation_ambiguous_create_fallback anchor={0} llm_available={1}",
                 operation.AnchorCanonicalName, _llmClient is not null);
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null,
-                "ambiguous: auto-resolve insufficient, defaulting to create");
+            return new CurationEvaluation(
+                new CurationDecision(CurationDecisionKind.Create, null, null, null,
+                    "ambiguous: auto-resolve insufficient, defaulting to create"),
+                candidates);
         }
 
-        return CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates);
+        return new CurationEvaluation(
+            CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates),
+            candidates);
     }
 
     internal static async Task<CurationDecision?> TryLlmEvaluationAsync(
@@ -234,11 +271,12 @@ public sealed class MemoryCurationEvaluator
         SessionId sessionId,
         SQLiteMemoryCurationOperation operation,
         IReadOnlyList<ExistingMemoryCandidate> candidates,
-        ICurationLog log)
+        ICurationLog log,
+        MemoryCurationConfig curationConfig)
     {
         try
         {
-            using var cts = new CancellationTokenSource(LlmTimeout);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(curationConfig.LlmTimeoutSeconds));
 
             var messages = new List<ChatMessage>
             {
@@ -255,17 +293,16 @@ public sealed class MemoryCurationEvaluator
                 // Token cap is the THIRD line of defense, so it must never be the
                 // binding constraint. Layering: (1) reasoning suppression below is
                 // the primary fix — suppressed/non-reasoning models emit just the
-                // keyword and never approach any cap; (2) the 10s call timeout
+                // keyword and never approach any cap; (2) the call timeout above
                 // bounds wall-clock when a model ignores suppression and thinks at
                 // length. The cap only matters in the remaining window — suppression
                 // ignored but thinking finishes inside the timeout — where a tight
                 // cap truncates mid-think and reproduces the measured
                 // responseLength=0 empty-reply failure (July 2026 audit: at 512, a
                 // Qwen3.6-class model produced 0 successful curation decisions
-                // ever). Unemitted tokens cost nothing, so size this generously;
-                // it becomes the Memory.Curation.LlmMaxOutputTokens config knob in
-                // the memory-core-redesign change.
-                MaxOutputTokens = 4096,
+                // ever). Unemitted tokens cost nothing, so this is sized generously by
+                // default — see Memory.Curation.LlmMaxOutputTokens (MemoryCurationConfig).
+                MaxOutputTokens = curationConfig.LlmMaxOutputTokens,
                 // Belt: ask the serving stack not to think at all for this
                 // keyword-classification call. This expresses intent only — the raw
                 // provider-dialect field name (vLLM/llama.cpp/SGLang's
@@ -327,9 +364,16 @@ public sealed class MemoryCurationEvaluator
     /// mapping is identical from both the actor's write phase and the daemon's
     /// checkpoint-apply phase — before this slice only the actor performed it at all.
     /// </summary>
+    /// <param name="candidates">
+    /// The exact candidate set <paramref name="decision"/> was evaluated against
+    /// (<see cref="EvaluateAsync"/>'s <see cref="CurationEvaluation.Candidates"/>) — the
+    /// source of the target/consolidation-target bodies that guard-validated write routing
+    /// (memory-core-redesign Slice 3) merges or appends against.
+    /// </param>
     public async Task<SQLiteMemoryCurationOperation?> ApplyDecisionAsync(
         SQLiteMemoryCurationOperation operation,
         CurationDecision decision,
+        IReadOnlyList<ExistingMemoryCandidate> candidates,
         CancellationToken ct = default)
     {
         switch (decision.Kind)
@@ -342,15 +386,7 @@ public sealed class MemoryCurationEvaluator
                 return null;
 
             case CurationDecisionKind.Update:
-                _log.Info(
-                    "curation_update anchor={0} targetDoc={1} reason={2}",
-                    operation.AnchorCanonicalName,
-                    decision.TargetDocumentId!,
-                    decision.Reason);
-
-                // Set the operation's MemoryId to the existing document ID
-                // so the ON CONFLICT UPDATE fires
-                return operation with { MemoryId = decision.TargetDocumentId };
+                return ApplyUpdate(operation, decision, candidates);
 
             case CurationDecisionKind.Consolidate:
                 _log.Info(
@@ -361,9 +397,7 @@ public sealed class MemoryCurationEvaluator
                     decision.Reason);
 
                 await ExecuteConsolidationAsync(operation, decision, ct);
-                // After consolidation, write the new proposal under the canonical anchor
-                var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
-                return operation with { AnchorCanonicalName = canonicalAnchor };
+                return ApplyConsolidate(operation, decision, candidates);
 
             case CurationDecisionKind.Create:
                 _log.Info(
@@ -378,6 +412,171 @@ public sealed class MemoryCurationEvaluator
                 _log.Warning("curation_unexpected_ambiguous anchor={0}, defaulting to create", operation.AnchorCanonicalName);
                 return operation;
         }
+    }
+
+    /// <summary>
+    /// Write routing for an Update decision. The deterministic tier (exact-anchor path,
+    /// <see cref="CurationDecision.FromLlmTier"/> false) keeps its pre-Slice-3 raw overwrite —
+    /// see this class's remarks for why that is still provably non-lossy. Every LLM-tier
+    /// Update routes through <see cref="ApplyGuardedMergeOrAppend"/> instead.
+    /// </summary>
+    private SQLiteMemoryCurationOperation ApplyUpdate(
+        SQLiteMemoryCurationOperation operation,
+        CurationDecision decision,
+        IReadOnlyList<ExistingMemoryCandidate> candidates)
+    {
+        _log.Info(
+            "curation_update anchor={0} targetDoc={1} reason={2}",
+            operation.AnchorCanonicalName,
+            decision.TargetDocumentId!,
+            decision.Reason);
+
+        if (!decision.FromLlmTier)
+        {
+            // Deterministic exact-anchor path: GuardDestructiveUpdate has already verified
+            // (in EvaluateAsync) that the proposal preserves the target's content, so this
+            // overwrite cannot drop information. Set MemoryId so the ON CONFLICT UPDATE fires
+            // against the existing document.
+            return operation with { MemoryId = decision.TargetDocumentId };
+        }
+
+        var target = candidates.FirstOrDefault(
+            c => string.Equals(c.DocumentId, decision.TargetDocumentId, StringComparison.Ordinal));
+        if (target is null)
+        {
+            // The LLM named a document id outside the evaluated candidate set — there is no
+            // known existing body to merge with or safely append to. Rather than trust an
+            // unverified id for an overwrite, fall through as a plain create.
+            _log.Warning(
+                "curation_update_target_unknown anchor={0} targetId={1} — creating instead",
+                operation.AnchorCanonicalName,
+                decision.TargetDocumentId ?? "(null)");
+            return operation;
+        }
+
+        return ApplyGuardedMergeOrAppend(
+            operation, decision.MergedBody, target.DocumentId, target.Content, [target.Content, operation.Content]);
+    }
+
+    /// <summary>
+    /// Write routing for a Consolidate decision, after <see cref="ExecuteConsolidationAsync"/>'s
+    /// re-anchor/tombstone side effects. Both tiers flow through
+    /// <see cref="ApplyGuardedMergeOrAppend"/> uniformly: the deterministic tier (fuzzy match
+    /// ≥80% overlap, no LLM call) never produces a <see cref="CurationDecision.MergedBody"/>,
+    /// so it always takes that method's append branch — the only lossless option available
+    /// without an LLM-synthesized merge. This also fixes the pre-Slice-3 gap where a
+    /// deterministic Consolidate reached the store with no guard at all
+    /// (<see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/> is a no-op for Consolidate).
+    /// </summary>
+    private SQLiteMemoryCurationOperation ApplyConsolidate(
+        SQLiteMemoryCurationOperation operation,
+        CurationDecision decision,
+        IReadOnlyList<ExistingMemoryCandidate> candidates)
+    {
+        var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
+        var operationWithAnchor = operation with { AnchorCanonicalName = canonicalAnchor };
+
+        var consolidationTargets = decision.ConsolidationTargetIds is null
+            ? []
+            : candidates
+                .Where(c => decision.ConsolidationTargetIds.Contains(c.DocumentId, StringComparer.Ordinal))
+                .ToArray();
+
+        if (consolidationTargets.Length == 0)
+        {
+            // No known candidate content to merge/append against (e.g. an id the LLM invented,
+            // or a decision with no target ids at all) — nothing to preserve, so the store's
+            // own anchor-based lookup resolves the target document as it did before this slice.
+            return operationWithAnchor;
+        }
+
+        // Deterministic pick of the primary consolidation target: same ordering
+        // CurationRulesEvaluator uses for "best" (confidence, then freshness). Pinning the
+        // write to this SAME document — rather than trusting the store's separate
+        // updated_at-based anchor lookup — guarantees the write lands on the document
+        // MergeGuard actually validated content against.
+        var primary = consolidationTargets
+            .OrderByDescending(c => c.Confidence)
+            .ThenByDescending(c => c.FreshnessAtMs ?? 0)
+            .First();
+
+        var allSourceBodies = consolidationTargets.Select(c => c.Content).Append(operation.Content).ToArray();
+
+        return ApplyGuardedMergeOrAppend(
+            operationWithAnchor, decision.MergedBody, primary.DocumentId, primary.Content, allSourceBodies);
+    }
+
+    /// <summary>
+    /// Shared write routing for LLM-tier Update and deterministic/LLM-tier Consolidate
+    /// (memory-core-redesign Slice 3, design D5): validates a synthesized
+    /// <paramref name="mergedBody"/> against every source body via <see cref="MergeGuard"/>;
+    /// on pass, writes the merged body with MergeDocument semantics (the existing merge path).
+    /// On guard failure, or when no merged body was produced at all, falls back to a
+    /// structural append (existing target body + dated separator + proposal) with
+    /// AppendDocument semantics — unconditionally lossless because it is concatenation, unlike
+    /// an overwrite. This is what makes <see cref="MemoryUpdateSemantics.AppendDocument"/> a
+    /// real, reachable write path for the first time.
+    /// </summary>
+    private SQLiteMemoryCurationOperation ApplyGuardedMergeOrAppend(
+        SQLiteMemoryCurationOperation operation,
+        string? mergedBody,
+        string targetDocumentId,
+        string targetBody,
+        IReadOnlyList<string> allSourceBodies)
+    {
+        if (!string.IsNullOrWhiteSpace(mergedBody))
+        {
+            var guardResult = MergeGuard.Validate(allSourceBodies, mergedBody);
+            if (guardResult.Passed)
+            {
+                _log.Info(
+                    "curation_merge_guard_passed anchor={0} targetDoc={1} reason={2}",
+                    operation.AnchorCanonicalName,
+                    targetDocumentId,
+                    guardResult.Reason);
+
+                return operation with
+                {
+                    MemoryId = targetDocumentId,
+                    Content = mergedBody,
+                    UpdateSemantics = MemoryUpdateSemantics.MergeDocument.ToWireValue()
+                };
+            }
+
+            _log.Warning(
+                "curation_merge_guard_failed anchor={0} targetDoc={1} missingTokens=[{2}] reason={3}",
+                operation.AnchorCanonicalName,
+                targetDocumentId,
+                string.Join(",", guardResult.MissingTokens),
+                guardResult.Reason);
+        }
+
+        var appendedBody = BuildAppendedBody(targetBody, operation.Content);
+        _log.Info(
+            "curation_append_fallback anchor={0} targetDoc={1} hadMergedBody={2}",
+            operation.AnchorCanonicalName,
+            targetDocumentId,
+            !string.IsNullOrWhiteSpace(mergedBody));
+
+        return operation with
+        {
+            MemoryId = targetDocumentId,
+            Content = appendedBody,
+            UpdateSemantics = MemoryUpdateSemantics.AppendDocument.ToWireValue()
+        };
+    }
+
+    /// <summary>
+    /// Builds the structural-append body: the existing content, a dated provenance separator,
+    /// then the proposal — plain concatenation, so no source content can be lost. The date
+    /// comes from the store's own <see cref="TimeProvider"/> (<see cref="SQLiteMemoryStore.TimeProvider"/>)
+    /// rather than a second injected clock, so it stays consistent with the row's own
+    /// persisted timestamps and stays virtualizable in tests via the same seam.
+    /// </summary>
+    private string BuildAppendedBody(string existingBody, string proposalContent)
+    {
+        var isoDate = _store.TimeProvider.GetUtcNow().ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+        return $"{existingBody}\n\n---\n_[merged {isoDate}]_\n{proposalContent}";
     }
 
     private async Task ExecuteConsolidationAsync(
@@ -426,3 +625,13 @@ public sealed class MemoryCurationEvaluator
         }
     }
 }
+
+/// <summary>
+/// A curation decision paired with the exact candidate set it was evaluated against — see
+/// <see cref="MemoryCurationEvaluator.EvaluateAsync"/>'s remarks for why
+/// <see cref="MemoryCurationEvaluator.ApplyDecisionAsync"/> needs the same candidates rather
+/// than re-querying the store.
+/// </summary>
+public sealed record CurationEvaluation(
+    CurationDecision Decision,
+    IReadOnlyList<ExistingMemoryCandidate> Candidates);

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -510,7 +510,9 @@ public sealed class MemoryCurationEngine(
     SQLiteMemoryStore store,
     MemoryRulesFirstExtractor rules,
     MemoryConfig memoryConfig,
-    ILogger<MemoryCurationEngine>? logger = null)
+    ILogger<MemoryCurationEngine>? logger = null,
+    MemoryEmbedderHolder? embedderHolder = null,
+    MemoryVectorIndexHolder? vectorIndexHolder = null)
 {
     private const string CheckpointDroppedEvent = "memory_checkpoint_dropped_before_curation";
     private const string CheckpointDroppedTemplate =
@@ -529,8 +531,15 @@ public sealed class MemoryCurationEngine(
     // all beyond the fingerprint check below — routing through the shared evaluator is
     // what makes GuardDestructiveUpdate (previously inline-actor-only; audit finding D14)
     // apply here too.
+    //
+    // embedderHolder/vectorIndexHolder ARE wired here (memory-core-redesign Slice 3 Stage B,
+    // task 3.1): the embedding kNN nominator runs on this pipeline too, even with no LLM
+    // client — a nominee found with no LLM available forces the conservative no-auto-merge
+    // Create outcome documented on MemoryCurationEvaluator.EvaluateAsync, never a silent
+    // auto-skip/auto-merge on cosine alone.
     private readonly MemoryCurationEvaluator _evaluator =
-        new(store, (ILogger)(logger ?? NullLogger<MemoryCurationEngine>.Instance), memoryConfig.Curation, llmClient: null);
+        new(store, (ILogger)(logger ?? NullLogger<MemoryCurationEngine>.Instance), memoryConfig.Curation,
+            llmClient: null, embedderHolder, vectorIndexHolder);
 
     public async Task<IReadOnlyList<SQLiteMemoryCurationOperation>> CurateAsync(
         SQLiteMemoryCheckpoint checkpoint,

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -509,6 +509,7 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
 public sealed class MemoryCurationEngine(
     SQLiteMemoryStore store,
     MemoryRulesFirstExtractor rules,
+    MemoryConfig memoryConfig,
     ILogger<MemoryCurationEngine>? logger = null)
 {
     private const string CheckpointDroppedEvent = "memory_checkpoint_dropped_before_curation";
@@ -529,7 +530,7 @@ public sealed class MemoryCurationEngine(
     // what makes GuardDestructiveUpdate (previously inline-actor-only; audit finding D14)
     // apply here too.
     private readonly MemoryCurationEvaluator _evaluator =
-        new(store, (ILogger)(logger ?? NullLogger<MemoryCurationEngine>.Instance), llmClient: null);
+        new(store, (ILogger)(logger ?? NullLogger<MemoryCurationEngine>.Instance), memoryConfig.Curation, llmClient: null);
 
     public async Task<IReadOnlyList<SQLiteMemoryCurationOperation>> CurateAsync(
         SQLiteMemoryCheckpoint checkpoint,
@@ -625,8 +626,8 @@ public sealed class MemoryCurationEngine(
 
         foreach (var operation in operations)
         {
-            var decision = await _evaluator.EvaluateAsync(operation, sessionId, ct);
-            var writeOp = await _evaluator.ApplyDecisionAsync(operation, decision, ct);
+            var evaluation = await _evaluator.EvaluateAsync(operation, sessionId, ct);
+            var writeOp = await _evaluator.ApplyDecisionAsync(operation, evaluation.Decision, evaluation.Candidates, ct);
             if (writeOp is not null)
                 results.Add(writeOp);
         }

--- a/src/Netclaw.Actors/Memory/MemoryVectorIndexHolder.cs
+++ b/src/Netclaw.Actors/Memory/MemoryVectorIndexHolder.cs
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryVectorIndexHolder.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Memory;
+
+/// <summary>
+/// Process-singleton owner of the <see cref="MemoryVectorIndex"/> the embedding kNN nominator
+/// queries (memory-core-redesign Slice 3 Stage B, task 3.1). Mirrors
+/// <see cref="MemoryEmbedderHolder"/>'s reason for existing as a mutable holder rather than a
+/// plain DI singleton: <see cref="MemoryVectorIndex"/> requires a known, positive
+/// <see cref="MemoryVectorIndex.Dimensions"/> at construction, but the real embedder (and its
+/// dimensions) is only known once <c>EmbeddingWarmupHostedService</c> finishes provisioning —
+/// which runs after every other singleton has already resolved its constructor dependencies.
+/// This holder defers index construction to first use, and rebuilds it if the active embedder's
+/// model id ever changes (an operator flipping <c>Memory.Embeddings.ModelId</c> and restarting).
+///
+/// <para>
+/// <b>Callers must call <see cref="GetCurrentAsync"/> at the time they actually need to query</b>
+/// — never cache the returned index across calls — so a model change or the transition from
+/// unavailable to available surfaces without a process restart, exactly like
+/// <see cref="MemoryEmbedderHolder.Current"/>.
+/// </para>
+/// </summary>
+public sealed class MemoryVectorIndexHolder
+{
+    private readonly SQLiteMemoryStore _store;
+    private readonly object _gate = new();
+    private MemoryVectorIndex? _index;
+
+    public MemoryVectorIndexHolder(SQLiteMemoryStore store)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        _store = store;
+    }
+
+    /// <summary>
+    /// Returns the vector index for <paramref name="embedder"/>'s current model, reloaded to the
+    /// store's latest committed embeddings (memory-core-redesign Slice 3: cheap when nothing
+    /// changed — <see cref="MemoryVectorIndex.ReloadIfStaleAsync"/> only does real work when
+    /// <see cref="SQLiteMemoryStore.EmbeddingDataVersion"/> has advanced). Returns null when
+    /// <paramref name="embedder"/> cannot currently produce vectors — there is nothing to index,
+    /// and callers should treat this identically to "no vector evidence available" (the
+    /// degraded/lexical path).
+    /// </summary>
+    public async Task<MemoryVectorIndex?> GetCurrentAsync(IMemoryEmbedder embedder, CancellationToken ct)
+    {
+        if (!embedder.IsAvailable)
+            return null;
+
+        var index = Volatile.Read(ref _index);
+        if (index is null || !string.Equals(index.ModelId, embedder.ModelId, StringComparison.Ordinal))
+        {
+            lock (_gate)
+            {
+                index = _index;
+                if (index is null || !string.Equals(index.ModelId, embedder.ModelId, StringComparison.Ordinal))
+                {
+                    index = new MemoryVectorIndex(_store, embedder.ModelId, embedder.Dimensions);
+                    Volatile.Write(ref _index, index);
+                }
+            }
+        }
+
+        await index.ReloadIfStaleAsync(ct).ConfigureAwait(false);
+        return index;
+    }
+}

--- a/src/Netclaw.Actors/Memory/MergeGuard.cs
+++ b/src/Netclaw.Actors/Memory/MergeGuard.cs
@@ -1,0 +1,183 @@
+// -----------------------------------------------------------------------
+// <copyright file="MergeGuard.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Actors.Memory;
+
+/// <summary>
+/// Result of a single <see cref="MergeGuard.Validate"/> call.
+/// </summary>
+public sealed record MergeGuardResult(bool Passed, IReadOnlyList<string> MissingTokens, string Reason);
+
+/// <summary>
+/// Deterministic validator for LLM-synthesized merge bodies (memory-core-redesign design
+/// D5). The curation LLM occasionally drops information when combining several source
+/// documents into one — the May 2026 decider eval measured ~27% wrong-merge on hard
+/// near-duplicates. Trusting the merge blindly risks silent, unrecoverable data loss;
+/// refusing to merge at all just recreates the duplicate-accumulation problem curation
+/// exists to fix. This guard turns a bad merge into a <b>recoverable</b> state instead: on
+/// failure, <see cref="MemoryCurationEvaluator.ApplyDecisionAsync"/> falls back to a
+/// structural append, so every source's content survives even though the synthesis didn't
+/// land — over-appending is the acceptable failure mode, silent loss is not.
+///
+/// Two independent checks, both must pass:
+/// 1. <b>Retention</b> — every load-bearing token (URL; number/version/quantity/date;
+///    camelCase/snake_case/kebab-case/dotted.path/ALL_CAPS identifier; file path) extracted
+///    from ANY source body must be case-insensitively present in the merged body, for at
+///    least 95% of the token union across all sources. The 5% slack tolerates trivial LLM
+///    rewording of genuinely incidental tokens (e.g. a URL repeated verbatim in two sources).
+/// 2. <b>Collapse</b> — the merged body must be at least 60% as long as the longest single
+///    source. Catches an LLM that "merges" by discarding everything but a short summary,
+///    which could otherwise pass the retention check if the summary happens to repeat every
+///    load-bearing token without preserving the surrounding prose.
+///
+/// Pure function, no I/O — safe to property-test with generated source/merged bodies.
+/// </summary>
+public static class MergeGuard
+{
+    private const double RetentionThreshold = 0.95;
+    private const double LengthCollapseThreshold = 0.60;
+
+    private const string MonthNames =
+        "Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|" +
+        "Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?";
+
+    // URLs (trailing sentence punctuation is trimmed in ExtractLoadBearingTokens below).
+    private static readonly Regex UrlPattern = new(
+        @"https?://[^\s""'<>\)\]]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // ISO-8601 dates, with or without a time component: 2026-05-13, 2026-05-13T10:00:00Z.
+    private static readonly Regex IsoDatePattern = new(
+        @"\b\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?Z?)?\b", RegexOptions.Compiled);
+
+    // Slash-separated dates: 05/13/2026, 5/13/26.
+    private static readonly Regex SlashDatePattern = new(
+        @"\b\d{1,2}/\d{1,2}/\d{2,4}\b", RegexOptions.Compiled);
+
+    // Written dates in either order: "May 13, 2026" / "13 May 2026".
+    private static readonly Regex WrittenDatePattern = new(
+        $@"\b(?:{MonthNames})\.?\s+\d{{1,2}}(?:st|nd|rd|th)?,?\s+\d{{4}}\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex ReverseWrittenDatePattern = new(
+        $@"\b\d{{1,2}}\s+(?:{MonthNames})\.?,?\s+\d{{4}}\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // Dotted/multi-segment versions: 1.2.3, 1.5.62, 10.0.
+    private static readonly Regex VersionPattern = new(
+        @"\b\d+(?:\.\d+){1,3}\b", RegexOptions.Compiled);
+
+    // Quantities: a number immediately followed by a short unit — 64GB, 300ms, 72h, 10s.
+    private static readonly Regex QuantityPattern = new(
+        @"\b\d+(?:\.\d+)?[a-zA-Z]{1,6}\b", RegexOptions.Compiled);
+
+    // Bare integers not already part of a version, quantity, or identifier: the lookarounds
+    // exclude a digit preceded by "<digit>." (the "62" inside "1.5.62") or a letter/underscore
+    // (mid-identifier), and a digit followed by a letter/underscore (the "20" inside "20GB")
+    // or ".<digit>" (the "1" inside "1.5"). Ordinary sentence punctuation immediately after a
+    // number — "cost is 111." — is deliberately NOT excluded here, unlike a naive
+    // "no dot allowed after" rule would: a trailing period with no digit after it is not part
+    // of a version/decimal, so the number is still load-bearing and must be captured.
+    private static readonly Regex BareIntegerPattern = new(
+        @"(?<![a-zA-Z_])(?<!\d\.)\d+(?![a-zA-Z_])(?!\.\d)", RegexOptions.Compiled);
+
+    // File paths: at least one path separator plus a final dotted extension.
+    private static readonly Regex FilePathPattern = new(
+        @"\b(?:[A-Za-z]:\\|~?/)?(?:[\w.-]+[\\/])+[\w.-]+\.[A-Za-z0-9]{1,6}\b", RegexOptions.Compiled);
+
+    // Dotted identifier paths: Netclaw.Configuration.MemoryConfig, MemoryConfig.Curation.
+    private static readonly Regex DottedPathPattern = new(
+        @"\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*){1,}\b", RegexOptions.Compiled);
+
+    // camelCase: maxOutputTokens.
+    private static readonly Regex CamelCasePattern = new(
+        @"\b[a-z]+[A-Z][a-zA-Z0-9]*\b", RegexOptions.Compiled);
+
+    // snake_case: nominator_similarity_threshold.
+    private static readonly Regex SnakeCasePattern = new(
+        @"\b[a-zA-Z][a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)+\b", RegexOptions.Compiled);
+
+    // kebab-case: memory-core-redesign.
+    private static readonly Regex KebabCasePattern = new(
+        @"\b[a-zA-Z][a-zA-Z0-9]*(?:-[a-zA-Z0-9]+)+\b", RegexOptions.Compiled);
+
+    // ALL_CAPS identifiers: NOMINATOR_K, SKU42. Minimum 3 characters total to avoid
+    // flagging short conversational acronyms (OK, US, ID) as load-bearing.
+    private static readonly Regex AllCapsPattern = new(
+        @"\b[A-Z][A-Z0-9_]{2,}\b", RegexOptions.Compiled);
+
+    private static readonly Regex[] TokenPatterns =
+    [
+        UrlPattern,
+        IsoDatePattern, WrittenDatePattern, ReverseWrittenDatePattern, SlashDatePattern,
+        VersionPattern, QuantityPattern,
+        FilePathPattern, DottedPathPattern,
+        CamelCasePattern, SnakeCasePattern, KebabCasePattern, AllCapsPattern,
+        BareIntegerPattern
+    ];
+
+    /// <summary>
+    /// Validates a synthesized merge body against every source body it claims to combine.
+    /// </summary>
+    /// <param name="sourceBodies">
+    /// Every body the merge is supposed to losslessly union — for an UPDATE decision, the
+    /// target document's current content plus the proposal; for CONSOLIDATE, every
+    /// consolidation target's content plus the proposal.
+    /// </param>
+    /// <param name="mergedBody">The LLM-synthesized merged body to validate.</param>
+    public static MergeGuardResult Validate(IReadOnlyList<string> sourceBodies, string mergedBody)
+    {
+        ArgumentNullException.ThrowIfNull(sourceBodies);
+        mergedBody ??= string.Empty;
+
+        if (sourceBodies.Count == 0)
+            return new MergeGuardResult(true, [], "no source bodies to validate against");
+
+        var union = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var longestSourceLength = 0;
+        foreach (var source in sourceBodies)
+        {
+            if (string.IsNullOrEmpty(source))
+                continue;
+
+            longestSourceLength = Math.Max(longestSourceLength, source.Length);
+            foreach (var token in ExtractLoadBearingTokens(source))
+                union.Add(token);
+        }
+
+        var missing = union
+            .Where(token => !mergedBody.Contains(token, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        var retainedCount = union.Count - missing.Length;
+        var retentionRatio = union.Count == 0 ? 1.0 : (double)retainedCount / union.Count;
+        var retentionOk = retentionRatio >= RetentionThreshold;
+
+        var lengthRatio = longestSourceLength == 0 ? 1.0 : (double)mergedBody.Length / longestSourceLength;
+        var lengthOk = lengthRatio >= LengthCollapseThreshold;
+
+        var passed = retentionOk && lengthOk;
+        var reason = !retentionOk
+            ? $"retention {retentionRatio:P0} below {RetentionThreshold:P0} floor — missing {missing.Length}/{union.Count} load-bearing tokens"
+            : !lengthOk
+                ? $"merged length {mergedBody.Length} is only {lengthRatio:P0} of longest source ({longestSourceLength} chars), below the {LengthCollapseThreshold:P0} collapse floor"
+                : $"retained {retainedCount}/{union.Count} load-bearing tokens ({retentionRatio:P0}); merged length {mergedBody.Length} is {lengthRatio:P0} of longest source ({longestSourceLength} chars)";
+
+        return new MergeGuardResult(passed, missing, reason);
+    }
+
+    private static IEnumerable<string> ExtractLoadBearingTokens(string text)
+    {
+        foreach (var pattern in TokenPatterns)
+        {
+            foreach (Match match in pattern.Matches(text))
+            {
+                var token = match.Value.TrimEnd('.', ',', ':', ';', ')', ']');
+                if (token.Length > 0)
+                    yield return token;
+            }
+        }
+    }
+}

--- a/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
@@ -1223,6 +1223,63 @@ public sealed class SQLiteMemoryStore
     }
 
     /// <summary>
+    /// Hydrates documents by id into full-content <see cref="ExistingMemoryCandidate"/> rows —
+    /// how the embedding kNN nominator (memory-core-redesign Slice 3 Stage B, task 3.1) turns
+    /// <see cref="MemoryVectorIndex.TopK"/> nominee ids into candidates the curation evaluator
+    /// can reason about (and hand full-content to the curator LLM,
+    /// <see cref="CurationPromptBuilder"/>'s <c>useFullCandidateContent</c>). Non-tombstoned
+    /// documents under active anchors only, mirroring <see cref="FindFuzzyAnchorMatchesAsync"/>'s
+    /// filters. <see cref="ExistingMemoryCandidate.IsExactAnchorMatch"/> is always false here —
+    /// cosine nomination is a distinct signal from anchor-name matching, tagged onto the result
+    /// by the caller (which already has each id's cosine from <see cref="MemoryVectorIndex.TopK"/>).
+    /// One id per query, over a single connection, mirroring
+    /// <see cref="GetMemoriesByResolvedHandlesAsync"/>'s per-id loop rather than a dynamic SQL
+    /// IN clause — the nominee count is bounded by <c>Memory.Curation.NominatorK</c> (default 5),
+    /// so this is never a large batch.
+    /// </summary>
+    public async Task<IReadOnlyList<ExistingMemoryCandidate>> GetCandidatesByIdsAsync(
+        IReadOnlyList<string> documentIds,
+        CancellationToken ct = default)
+    {
+        if (documentIds.Count == 0)
+            return [];
+
+        return await WithConnectionAsync(async (conn, ct) =>
+        {
+        var results = new List<ExistingMemoryCandidate>();
+        foreach (var documentId in documentIds)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                SELECT a.anchor_id, a.canonical_name,
+                       d.document_id, d.markdown_body, d.freshness_at, d.confidence
+                FROM memory_documents d
+                JOIN memory_anchors a ON d.anchor_id = a.anchor_id
+                WHERE d.document_id = $id
+                  AND a.status = 'active'
+                  AND d.update_semantics != '{MemoryUpdateSemantics.Tombstone.ToWireValue()}';
+                """;
+            cmd.Parameters.AddWithValue("$id", documentId);
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            if (await reader.ReadAsync(ct))
+            {
+                results.Add(new ExistingMemoryCandidate(
+                    DocumentId: reader.GetString(2),
+                    AnchorId: reader.GetString(0),
+                    AnchorCanonicalName: reader.GetString(1),
+                    Content: reader.GetString(3),
+                    FreshnessAtMs: reader.IsDBNull(4) ? null : reader.GetInt64(4),
+                    Confidence: reader.IsDBNull(5) ? 0.0 : reader.GetDouble(5),
+                    IsExactAnchorMatch: false));
+            }
+        }
+
+        return (IReadOnlyList<ExistingMemoryCandidate>)results;
+        }, ct);
+    }
+
+    /// <summary>
     /// Coverage diagnostics for <paramref name="modelId"/> (memory-embeddings spec: "Embedding
     /// coverage diagnostics"). <see cref="MemoryEmbeddingCoverage.EmbeddedCurrentHashCount"/>
     /// requires recomputing <see cref="MemoryContentHasher.ComputeHash"/> per document in

--- a/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
@@ -30,6 +30,15 @@ public sealed class SQLiteMemoryStore
     }
 
     /// <summary>
+    /// The clock this store persists timestamps with. Exposed so callers that need dates
+    /// consistent with the store's own persisted timestamps (e.g.
+    /// <see cref="MemoryCurationEvaluator"/>'s structural-append fallback separator,
+    /// memory-core-redesign Slice 3) reuse this instance instead of threading a second
+    /// <see cref="TimeProvider"/> dependency through the same call chain.
+    /// </summary>
+    public TimeProvider TimeProvider => _timeProvider;
+
+    /// <summary>
     /// Process-local monotonic counter bumped whenever <c>memory_embeddings</c> rows change
     /// (a real write in <see cref="UpsertEmbeddingAsync"/>, or a deletion via
     /// <see cref="TombstoneDocumentAsync"/>). <see cref="MemoryVectorIndex"/> uses this to

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -70,6 +70,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly ISessionLifecycleObserver? _lifecycleObserver;
     private readonly Memory.SQLiteMemoryStore? _memoryStore;
     private readonly Memory.MemoryEmbedderHolder? _memoryEmbedderHolder;
+    private readonly Memory.MemoryVectorIndexHolder? _memoryVectorIndexHolder;
     private readonly IChatClientProvider _clientProvider;
     private readonly ILoggingAdapter _log;
 
@@ -241,6 +242,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _memoryCheckpointSink = memory?.CheckpointSink ?? NullMemoryCheckpointSink.Instance;
         _memoryStore = memory?.MemoryStore;
         _memoryEmbedderHolder = memory?.EmbedderHolder;
+        _memoryVectorIndexHolder = memory?.VectorIndexHolder;
         _memoryConfig = memory?.MemoryConfig ?? new MemoryConfig();
         _timeProvider = services.TimeProvider;
         _sessionsBasePath = services.Paths.SessionsDirectory;
@@ -315,7 +317,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             {
                 _curationActor = Context.ActorOf(
                     Memory.MemoryCurationActor.CreateProps(
-                        _memoryStore, _sessionId, _memoryConfig.Curation, _clientProvider, _memoryEmbedderHolder),
+                        _memoryStore, _sessionId, _memoryConfig.Curation, _clientProvider,
+                        _memoryEmbedderHolder, _memoryVectorIndexHolder),
                     "memory-curation");
 
                 // Distillation processes a full transcript — allow 5x normal sidecar timeout

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -314,7 +314,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (_memoryStore is not null)
             {
                 _curationActor = Context.ActorOf(
-                    Memory.MemoryCurationActor.CreateProps(_memoryStore, _sessionId, _clientProvider, _memoryEmbedderHolder),
+                    Memory.MemoryCurationActor.CreateProps(
+                        _memoryStore, _sessionId, _memoryConfig.Curation, _clientProvider, _memoryEmbedderHolder),
                     "memory-curation");
 
                 // Distillation processes a full transcript — allow 5x normal sidecar timeout

--- a/src/Netclaw.Actors/Sessions/SessionDependencies.cs
+++ b/src/Netclaw.Actors/Sessions/SessionDependencies.cs
@@ -41,9 +41,10 @@ public sealed record SessionToolServices(
 /// <summary>
 /// Memory infrastructure for recall, checkpoint, and curation.
 /// <see cref="EmbedderHolder"/> resolves the process's embedder for embed-on-write
-/// (memory-core-redesign Slice 2). Null is a genuine state — same as
-/// <see cref="MemoryStore"/> being null — for any session/test harness that has not wired
-/// up the embedding subsystem at all.
+/// (memory-core-redesign Slice 2) and for the curation evaluator's embedding kNN nominator
+/// (Slice 3 Stage B, task 3.1); <see cref="VectorIndexHolder"/> resolves the nominator's
+/// vector index. Null is a genuine state — same as <see cref="MemoryStore"/> being null —
+/// for any session/test harness that has not wired up the embedding subsystem at all.
 /// </summary>
 public sealed record SessionMemoryServices(
     IMemoryExtractor MemoryExtractor,
@@ -51,7 +52,8 @@ public sealed record SessionMemoryServices(
     IMemoryCheckpointSink CheckpointSink,
     SQLiteMemoryStore? MemoryStore,
     MemoryConfig? MemoryConfig = null,
-    MemoryEmbedderHolder? EmbedderHolder = null);
+    MemoryEmbedderHolder? EmbedderHolder = null,
+    MemoryVectorIndexHolder? VectorIndexHolder = null);
 
 /// <summary>
 /// Metrics and lifecycle observation.

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -152,6 +152,61 @@ public sealed class ConfigSchemaDoctorCheckTests
     }
 
     [Fact]
+    public async Task ReturnsPass_WhenMemoryCurationConfigMatchesSchemaV1()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Memory": {
+                "Enabled": true,
+                "Curation": {
+                  "NominatorSimilarityThreshold": 0.9,
+                  "NominatorK": 3,
+                  "LlmMaxOutputTokens": 2048,
+                  "LlmTimeoutSeconds": 15
+                }
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenMemoryCurationHasAnUnknownProperty()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Memory": {
+                "Curation": {
+                  "NominatorK": 3,
+                  "NotARealProperty": "oops"
+                }
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+    }
+
+    [Fact]
     public async Task ReturnsPass_WhenReverseProxyTrustedProxiesLookValid()
     {
         var basePath = CreateTempBasePath();

--- a/src/Netclaw.Configuration.Tests/MemoryConfigDefaultsTests.cs
+++ b/src/Netclaw.Configuration.Tests/MemoryConfigDefaultsTests.cs
@@ -43,4 +43,34 @@ public sealed class MemoryConfigDefaultsTests
         var config = new MemoryConfig();
         Assert.True(config.Enabled);
     }
+
+    // ── MemoryCurationConfig (memory-core-redesign Slice 3, task 3.5) ──
+
+    [Fact]
+    public void Curation_nominator_similarity_threshold_defaults_to_0_86()
+    {
+        var config = new MemoryConfig();
+        Assert.Equal(0.86, config.Curation.NominatorSimilarityThreshold);
+    }
+
+    [Fact]
+    public void Curation_nominator_k_defaults_to_5()
+    {
+        var config = new MemoryConfig();
+        Assert.Equal(5, config.Curation.NominatorK);
+    }
+
+    [Fact]
+    public void Curation_llm_max_output_tokens_defaults_to_4096()
+    {
+        var config = new MemoryConfig();
+        Assert.Equal(4096, config.Curation.LlmMaxOutputTokens);
+    }
+
+    [Fact]
+    public void Curation_llm_timeout_seconds_defaults_to_10()
+    {
+        var config = new MemoryConfig();
+        Assert.Equal(10, config.Curation.LlmTimeoutSeconds);
+    }
 }

--- a/src/Netclaw.Configuration/MemoryConfig.cs
+++ b/src/Netclaw.Configuration/MemoryConfig.cs
@@ -84,16 +84,16 @@ public sealed class MemoryCurationConfig
     /// Embedding cosine similarity threshold above which an existing memory is nominated as a
     /// dedup candidate, forcing the curator LLM to adjudicate the relationship (design D4: "no
     /// cosine threshold separates duplicates from siblings," so similarity only nominates —
-    /// it never auto-merges or auto-skips). <b>Not yet consumed</b>: the kNN nominator that
-    /// reads this is Slice 3 Stage B (task 3.1), a later change. Defined here now so the
-    /// config surface and schema exist ahead of that wiring.
+    /// it never auto-merges or auto-skips). Consumed by
+    /// <see cref="Netclaw.Actors.Memory.MemoryCurationEvaluator"/>'s embedding kNN nominator
+    /// (memory-core-redesign Slice 3 Stage B, task 3.1) via
+    /// <c>Netclaw.Actors.Memory.MemoryVectorIndex.TopK</c>.
     /// </summary>
     public double NominatorSimilarityThreshold { get; set; } = 0.86;
 
     /// <summary>
     /// Maximum number of nearest-neighbor nominees the kNN nominator shortlists per proposal.
-    /// <b>Not yet consumed</b> — see <see cref="NominatorSimilarityThreshold"/>'s remarks;
-    /// this is also Stage B (task 3.1).
+    /// See <see cref="NominatorSimilarityThreshold"/>'s remarks — same Slice 3 Stage B consumer.
     /// </summary>
     public int NominatorK { get; set; } = 5;
 

--- a/src/Netclaw.Configuration/MemoryConfig.cs
+++ b/src/Netclaw.Configuration/MemoryConfig.cs
@@ -32,6 +32,12 @@ public sealed class MemoryConfig
     /// foundation). See <see cref="MemoryEmbeddingsConfig.Enabled"/> for why this defaults off.
     /// </summary>
     public MemoryEmbeddingsConfig Embeddings { get; set; } = new();
+
+    /// <summary>
+    /// Write-side curation settings (memory-core-redesign Slice 3: nominate→decide +
+    /// lossless merge). See <see cref="MemoryCurationConfig"/>.
+    /// </summary>
+    public MemoryCurationConfig Curation { get; set; } = new();
 }
 
 /// <summary>
@@ -66,4 +72,48 @@ public sealed class MemoryEmbeddingsConfig
     /// offline.
     /// </summary>
     public bool AutoDownload { get; set; } = true;
+}
+
+/// <summary>
+/// Configuration for write-side curation: the embedding kNN nominator and the curation LLM
+/// call (memory-core-redesign Slice 3, design D4/D5).
+/// </summary>
+public sealed class MemoryCurationConfig
+{
+    /// <summary>
+    /// Embedding cosine similarity threshold above which an existing memory is nominated as a
+    /// dedup candidate, forcing the curator LLM to adjudicate the relationship (design D4: "no
+    /// cosine threshold separates duplicates from siblings," so similarity only nominates —
+    /// it never auto-merges or auto-skips). <b>Not yet consumed</b>: the kNN nominator that
+    /// reads this is Slice 3 Stage B (task 3.1), a later change. Defined here now so the
+    /// config surface and schema exist ahead of that wiring.
+    /// </summary>
+    public double NominatorSimilarityThreshold { get; set; } = 0.86;
+
+    /// <summary>
+    /// Maximum number of nearest-neighbor nominees the kNN nominator shortlists per proposal.
+    /// <b>Not yet consumed</b> — see <see cref="NominatorSimilarityThreshold"/>'s remarks;
+    /// this is also Stage B (task 3.1).
+    /// </summary>
+    public int NominatorK { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum output tokens for the curation LLM call
+    /// (<see cref="Netclaw.Actors.Memory.MemoryCurationEvaluator"/>'s
+    /// <c>TryLlmEvaluationAsync</c>). Sized generously by default: the token cap is the third
+    /// line of defense against a truncated reply (after reasoning suppression and the call
+    /// timeout below), so it must never be the binding constraint — the July 2026 audit found
+    /// a 512-token cap produced zero successful curation decisions ever, because a
+    /// reasoning-capable model was truncated mid-think before emitting its answer. Raising
+    /// this further is nearly free (unemitted tokens cost nothing); lowering it below what a
+    /// verbose merged body needs risks reproducing that failure with the new merged-body
+    /// protocol (task 3.2).
+    /// </summary>
+    public int LlmMaxOutputTokens { get; set; } = 4096;
+
+    /// <summary>
+    /// Wall-clock timeout, in seconds, for the curation LLM call. Bounds latency when a model
+    /// ignores reasoning suppression and thinks at length regardless of the token cap above.
+    /// </summary>
+    public int LlmTimeoutSeconds { get; set; } = 10;
 }

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -386,6 +386,40 @@
             }
           },
           "additionalProperties": false
+        },
+        "Curation": {
+          "type": "object",
+          "description": "Write-side curation settings: embedding kNN nominator and curation LLM call (memory-core-redesign Slice 3).",
+          "properties": {
+            "NominatorSimilarityThreshold": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "default": 0.86,
+              "description": "Embedding cosine similarity threshold above which an existing memory is nominated for the curator LLM to adjudicate. Not yet consumed (Slice 3 Stage B)."
+            },
+            "NominatorK": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 5,
+              "description": "Maximum number of nearest-neighbor nominees the kNN nominator shortlists per proposal. Not yet consumed (Slice 3 Stage B)."
+            },
+            "LlmMaxOutputTokens": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 4096,
+              "description": "Maximum output tokens for the curation LLM call. Sized generously — the token cap is a defense-in-depth bound, not the primary control."
+            },
+            "LlmTimeoutSeconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 300,
+              "default": 10,
+              "description": "Wall-clock timeout in seconds for the curation LLM call."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -752,6 +752,13 @@ static void ConfigureDaemonServices(
             EmbeddingModelProvisioner.Allowlist));
         services.AddSingleton(new MemoryEmbedderHolder(
             new UnavailableMemoryEmbedder(memoryConfig.Embeddings.ModelId, "embedding warmup has not completed yet")));
+
+        // Vector index for the curation evaluator's embedding kNN nominator (memory-core-
+        // redesign Slice 3 Stage B, task 3.1). Registered alongside MemoryEmbedderHolder above:
+        // both are optional dependencies of MemoryCurationActor/MemoryCurationEngine that
+        // degrade to the lexical content-term search when either is absent or the embedder is
+        // unavailable.
+        services.AddSingleton(new MemoryVectorIndexHolder(memoryStore));
         services.AddSingleton<EmbeddingWarmupHostedService>();
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<EmbeddingWarmupHostedService>());
     }
@@ -1002,7 +1009,8 @@ static void ConfigureDaemonServices(
         sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
         sp.GetService<SQLiteMemoryStore>(),
         sp.GetService<MemoryConfig>(),
-        sp.GetService<MemoryEmbedderHolder>()));
+        sp.GetService<MemoryEmbedderHolder>(),
+        sp.GetService<MemoryVectorIndexHolder>()));
 
     services.AddSingleton(sp => new SessionObservability(
         sp.GetService<Netclaw.Actors.Telemetry.ISessionMetrics>(),


### PR DESCRIPTION
Implements Slice 3 of the `memory-core-redesign` OpenSpec change (#1570): write-side dedup becomes **kNN-nominate → LLM-decide**, and curation merges become **lossless-or-append**. Closes tasks 3.1–3.7.

## Stage A — lossless merge machinery (landed on this branch previously)

- **Merged-body response protocol** (task 3.2): `CurationPromptBuilder` UPDATE/CONSOLIDATE responses now emit a complete merged document body after a `---` separator (`CurationDecision.MergedBody`); candidates can be rendered full-content for the decider.
- **`MergeGuard`** (task 3.3): deterministic lossless-merge validator — load-bearing tokens (URLs, numbers, versions, dates, code identifiers) from every source body must survive at ≥95% retention, and the merged body must not length-collapse.
- **Guard-validated write routing** (task 3.4): every LLM-tier UPDATE/CONSOLIDATE and every deterministic CONSOLIDATE routes through `ApplyGuardedMergeOrAppend` — guard-pass writes the merged body (`MergeDocument`), guard-fail or body-absent degrades to a structural append (existing body + dated separator + proposal, `AppendDocument` — reachable for the first time since the enum was written). The raw `markdown_body = excluded.markdown_body` overwrite is **unreachable from curation decisions**. The overwrite-unreachable trace closed three paths: LLM UPDATE (guard or append), LLM CONSOLIDATE (guard or append), and the previously **unguarded deterministic Consolidate** — pre-Slice-3, a fuzzy-anchor ≥80%-overlap Consolidate reached the store with no guard at all (`GuardDestructiveUpdate` is a no-op for Consolidate); it now always appends, since the rules tier never synthesizes a merged body. The one deliberate exception: the deterministic exact-anchor UPDATE keeps its raw overwrite because `GuardDestructiveUpdate` already proves the proposal is a content superset of the target before that decision can exist.
- **Config surface** (task 3.5): `Memory.Curation { NominatorSimilarityThreshold=0.86, NominatorK=5, LlmMaxOutputTokens=4096, LlmTimeoutSeconds=10 }` + schema sync, replacing Slice-1 hardcoded constants.

## Stage B — embedding kNN nominator (this PR's new commits)

**Evaluation order in the shared `MemoryCurationEvaluator`** (design D4), identical on both write pipelines:

1. Record bypass and exact-anchor deterministic fast paths — unchanged.
2. Embedder available + no exact anchor match → embed the proposal (`{title}\n{content}`, the exact concatenation embed-on-write uses, so proposals and stored documents share embedding space), query `MemoryVectorIndex.TopK(NominatorK, NominatorSimilarityThreshold)`, hydrate nominees into full-content candidates tagged with their cosine (`ExistingMemoryCandidate.CosineSimilarity`; anchor/lexical candidates carry null).
3. **Any nominee forces the LLM tier** with full-content candidate previews — regardless of Jaccard bands.
4. No nominee + no anchor match → Create with **zero** LLM calls (median nominee count on a random write is 0 — the common case stays cheap).
5. Embedder unavailable → the pre-existing lexical content-term search runs unchanged as the degraded path (`curation_nominator_degraded` marker).

**Invariants — cosine nominates ONLY:**

- The May 2026 measurement (ratified in the OpenSpec design; corroborated at corpus scale in the July audit §5) found **no cosine threshold separates true duplicates from merely-related siblings — siblings live at 0.905–0.941, inside the duplicate band**. Cosine similarity therefore never auto-merges and never auto-skips, anywhere.
- Nominee present but **no LLM available** (the daemon checkpoint worker today) or LLM call fails → **conservative Create**, deliberately bypassing `TryAutoResolveAmbiguous`: semantic-near content is exactly the ambiguity the May data says deterministic Jaccard logic cannot adjudicate, and a duplicate document is recoverable where a wrong auto-merge is not.
- Known limitation (documented on `NominateAsync`): proposals evaluated within one batch cannot nominate each other — neither is committed/indexed while the other is evaluated. Cross-batch and steady-state dedup are unaffected.

**Wiring:** new `MemoryVectorIndexHolder` (defers index construction until the warmed-up embedder's model id/dimensions exist — same rationale as `MemoryEmbedderHolder`) registered in daemon DI and threaded into **both** pipelines: inline actor via `MemoryCurationActor.CreateProps`/`SessionMemoryServices`, daemon worker via `MemoryCurationEngine`'s constructor. New store hydration query `SQLiteMemoryStore.GetCandidatesByIdsAsync`. New markers: `curation_nominated count/topCosine`, `curation_nominator_degraded`, `curation_nominee_no_llm_decision`; all existing markers intact.

## Test matrix (task 3.6 — all synthetic fixtures, hand-crafted cosine geometry)

- **Nomination forcing:** paraphrase pair at cosine 0.93 with word-Jaccard <0.4 → LLM tier invoked (recording `IChatClient`) even though the lexical tier finds zero candidates and would have silently said Create.
- **Sibling never-auto-merge:** scripted LLM answers CREATE → two separate documents persist; no-LLM variant → conservative Create — never a merge without the LLM.
- **Novel-skips-curator:** no nominee + no anchor → Create with zero `IChatClient` invocations.
- **Degraded path:** unavailable embedder (and null-holder variant) → lexical candidates still produced, `curation_nominator_degraded` fires.
- **Both-pipelines parity:** `MemoryCurationEvaluatorParityTests` extended — actor-style vs engine-style construction with a shared embedder/index reach identical forced-LLM decisions.
- **Actor e2e (Akka.TestKit):** proposal through the real `MemoryCurationActor` with fake embedder + scripted LLM to a committed store write; `AwaitAssertAsync`, no sleeps.
- Stage A matrix (MergeGuard property tests, append fallback, merge routing) landed with Stage A.

## Gates

- `Netclaw.Actors.Tests` 2614/2614, `Netclaw.Daemon.Tests` 832/832, `Netclaw.Cli.Tests` 1231/1231, `Netclaw.Configuration.Tests` 461/461, `Netclaw.Embeddings.Tests` 18/18 — all green (Release).
- Full solution Release build: 0 warnings / 0 errors.
- `dotnet slopwatch analyze`: 0 issues. `Add-FileHeaders.ps1 -Verify`: clean.
- Memory eval gate (`NETCLAW_EVAL_CATEGORY=Memory`, Qwen3.6-27B @ spark-acad): scoreboard below. Note: embeddings default OFF, so the nominator idles in the eval daemon — this gate protects the shared curation paths against regressions.

```
Category: Memory Pipeline
  [PASS] memory_recall_active           5/5 (1.00)  — recall active, not degraded
  [PASS] memory_identity_preference_routing 5/5 (1.00)  — durable user preference routed to memory, not SOUL.md
  [PASS] memory_explicit_store          4/5 (0.80)  — explicit remember request uses store_memory
  [PASS] memory_checkpoint_enqueue      5/5 (1.00)  — checkpoint enqueued for non-identity fact
  [PASS] memory_recall_filters          5/5 (1.00)  — candidate selection with score filtering
  Category: 5/5 passed (GREEN)

─────────────────────────────────────────────────
Overall: 5/5 cases passed (100.0%)
```

(An earlier run of the same gate scored 4/5: `memory_checkpoint_enqueue` 3/5 — investigated per the eval-debugging protocol, the two failing runs' stdout contained only `[error] LLM provider transport error: Connection refused (spark-acad…:8000)` — the remote endpoint dropped mid-suite, so those turns never executed. Endpoint recovered; the clean rerun above is the gate result.)

## Skill sync

`netclaw-memory` SKILL.md bumped 1.8.0 → 1.9.0: documents that with embeddings enabled, near-duplicate proposals are adjudicated by the curation LLM (skip/update/consolidate/create) — similarity alone never merges — and merges are lossless-or-append.

OpenSpec change: `memory-core-redesign` (#1570) — tasks 3.1–3.7 checked.
