### PR TITLE
ci: run PR validation for feature/* base branches

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -6,11 +6,13 @@ on:
       - master
       - dev
       - main
+      - feature/*
   pull_request:
     branches:
       - master
       - dev
       - main
+      - feature/*
 
 permissions:
   contents: read

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,9 +20,11 @@ on:
   push:
     branches:
       - dev
+      - feature/*
   pull_request:
     branches:
       - dev
+      - feature/*
     types:
       - opened
       - synchronize

--- a/.github/workflows/validate_docker_image.yml
+++ b/.github/workflows/validate_docker_image.yml
@@ -13,6 +13,7 @@ on:
       - master
       - dev
       - main
+      - feature/*
     paths:
       - 'docker/Dockerfile'
       - 'docker/entrypoint.sh'
@@ -28,6 +29,7 @@ on:
       - master
       - dev
       - main
+      - feature/*
     paths:
       - 'docker/Dockerfile'
       - 'docker/entrypoint.sh'


### PR DESCRIPTION
## Summary
Add `feature/*` base-branch support to PR-validation workflows so feature branches (e.g. `feature/memory-embeddings`) run full CI validation on their own PRs.

GitHub's `pull_request` and `push` branch filters match the base branch and branch head respectively. Without explicit `feature/*` entries, feature-targeted PRs were skipping validation.

## Workflows Modified

| Workflow | Trigger | Change | Reason |
|----------|---------|--------|--------|
| pr_validation.yml | push + pull_request | Added `feature/*` | Unit tests, slopwatch, copyright checks |
| smoke.yml | push + pull_request | Added `feature/*` | Native end-to-end smoke harness |
| validate_docker_image.yml | push + pull_request | Added `feature/*` | Docker build validation (paths filter preserved) |

## Workflows Unchanged

| Workflow | Trigger | Reason |
|----------|---------|--------|
| demo_smoke.yml | workflow_dispatch | Manual-only, not PR gating |
| publish_release_binaries.yml | push (tags) | Release workflow, tag-triggered |
| publish_skills.yml | workflow_call + workflow_dispatch | Publishing only, called from publish_release_binaries |
| website-rebuild.yml | release (published) | Publishing only, not validation |

## YAML Validation
All modified workflows pass Python yaml.safe_load() validation.