### PR TITLE
fix(memory): explicit stores must never silently drop on anchor-guard rejection

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
@@ -175,10 +175,19 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
         Assert.Equal(CurationDecisionKind.Create, fromActor.Kind);
     }
 
-    // ── guard downgrade: Update whose proposal drops existing body -> Skip ──
+    // ── guard downgrade: Update whose proposal drops existing body -> falls through ──
 
+    /// <summary>
+    /// Guard-fallthrough fix (July 2026 audit, eval run <c>ad9a2312</c>): before this fix, a
+    /// guard-rejected anchor-matched Update terminated as Skip — an explicit proposal silently
+    /// becoming a no-op with zero writes. No other candidate exists in this store for the
+    /// fallen-through content search or embedding nominator (both unavailable/empty here) to
+    /// find, so the terminal decision is the Create default the flow's remarks document — NOT
+    /// the old Skip. This is the same fixture <c>GuardDowngrade_narrowerProposal_downgradesUpdateToSkip_identically</c>
+    /// used pre-fix (renamed here since Skip was exactly the bug).
+    /// </summary>
     [Fact]
-    public async Task GuardDowngrade_narrowerProposal_downgradesUpdateToSkip_identically()
+    public async Task GuardDowngrade_narrowerProposal_noOtherCandidates_fallsThroughToCreate_identically()
     {
         var ct = TestContext.Current.CancellationToken;
         await _store.InitializeAsync(ct);
@@ -189,17 +198,167 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
             freshnessAtMs: 1000,
             ct);
 
-        // Newer, but narrower — the rules tier would pick Update (exact anchor, low
-        // overlap, fresher), and GuardDestructiveUpdate must downgrade it on BOTH paths
-        // now (audit finding D14: this guard used to run only on the inline actor path).
+        // Newer, but narrower — the rules tier would pick Update (exact anchor, low overlap,
+        // fresher), and GuardDestructiveUpdate downgrades it on BOTH paths (audit finding D14:
+        // this guard used to run only on the inline actor path). Pre-fix, that downgrade was
+        // returned as the terminal Skip decision — the silent-fallback bug. Post-fix, the guard
+        // rejection triggers a fall-through re-evaluation (no exact anchor match, nomination/
+        // content search run for the first time, rules tier re-runs as pure fuzzy) which here
+        // finds nothing else to match against and lands on Create.
         var operation = MakeOperation("widget-specs", "Widget pricing is TBD as of Q2.", freshnessAtMs: 2000);
 
         var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
 
         AssertSameDecision(fromActor, fromEngine);
+        Assert.Equal(CurationDecisionKind.Create, fromActor.Kind);
+        Assert.Contains("fuzzy anchor match but low content overlap", fromActor.Reason);
+    }
+
+    /// <summary>
+    /// Regression companion to the Create case above: when the guard-rejected proposal IS close
+    /// enough in content to the anchor target to clear the deterministic auto-resolve thresholds
+    /// (<see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/>'s 60% content-overlap / 50%
+    /// anchor-Jaccard bars) once re-evaluated as an ordinary fuzzy candidate, the fall-through
+    /// must NOT force Create — it must let the normal ambiguous/auto-resolve machinery decide,
+    /// which correctly lands on Skip here. This proves the fix doesn't trade "always drops the
+    /// fact" for "never skips a real duplicate" — the fall-through defers to whatever the rest of
+    /// the flow genuinely produces.
+    /// </summary>
+    [Fact]
+    public async Task GuardDowngrade_contentCloseEnoughToAutoResolve_fallsThroughToLegitimateSkip_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "widget-specs",
+            "doc-widget",
+            "Widget specs: 16 cores, 64GB RAM, 2 NICs. Warranty is 3 years from Acme Corp in Denver.",
+            freshnessAtMs: 1000,
+            ct);
+
+        // Reworded/reordered restatement of the SAME facts: word-level overlap is ~62% (inside
+        // the exact-match tier's Update band, ≤80%) but GuardDestructiveUpdate's stricter
+        // substring-containment check fails (the words are reordered, not a literal superset),
+        // so the guard still rejects. Re-evaluated as a fuzzy candidate after fall-through, that
+        // same ~62% overlap clears TryAutoResolveAmbiguous's 60% content / 100% anchor-Jaccard
+        // (identical anchor name) thresholds, so this is genuine skip territory rather than the
+        // guard's blunt termination.
+        var operation = MakeOperation(
+            "widget-specs",
+            "Acme Corp widget in Denver: 2 NICs, 64GB RAM, 16 cores, and a 3 year warranty included.",
+            freshnessAtMs: 2000);
+
+        var (fromActor, fromEngine) = await EvaluateOnBothAsync(operation, ct);
+
+        AssertSameDecision(fromActor, fromEngine);
         Assert.Equal(CurationDecisionKind.Skip, fromActor.Kind);
-        Assert.Contains("update guarded", fromActor.Reason);
+        Assert.Contains("auto-resolved", fromActor.Reason);
         Assert.Equal("doc-widget", fromActor.TargetDocumentId);
+    }
+
+    /// <summary>
+    /// Asserts the structured <c>curation_guard_fallthrough</c> marker fires with the rejected
+    /// anchor and target — the July 2026 audit tooling greps daemon logs for this exact string
+    /// (per this class's remarks), so the marker itself is a load-bearing observability
+    /// contract, not incidental.
+    /// </summary>
+    [Fact]
+    public async Task GuardDowngrade_logsStructuredFallthroughMarker()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedDocumentAsync(
+            "widget-specs",
+            "doc-widget",
+            "Widget specs: 16 cores, 64GB RAM, 2 NICs. Pricing on file. Vendor contacts listed.",
+            freshnessAtMs: 1000,
+            ct);
+
+        var operation = MakeOperation("widget-specs", "Widget pricing is TBD as of Q2.", freshnessAtMs: 2000);
+
+        var recordingLogger = new RecordingLogger();
+        var evaluator = new MemoryCurationEvaluator(_store, (ILogger)recordingLogger, new MemoryCurationConfig());
+
+        var evaluation = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
+
+        Assert.Equal(CurationDecisionKind.Create, evaluation.Decision.Kind);
+        Assert.Contains(
+            recordingLogger.Entries,
+            e => e.Contains("curation_guard_fallthrough", StringComparison.Ordinal)
+                 && e.Contains("widget-specs", StringComparison.Ordinal)
+                 && e.Contains("doc-widget", StringComparison.Ordinal));
+    }
+
+    // ── guard downgrade + nominator: near-dupe elsewhere still forces the LLM tier ──
+
+    /// <summary>
+    /// A guard-rejected anchor Update must not merely fall through to Create/auto-resolve when a
+    /// real embedding nominee is available — the fall-through re-runs nomination (this proposal's
+    /// exact anchor match previously short-circuited it entirely, so it had never run at all), and
+    /// a nominee at or above <see cref="MemoryCurationConfig.NominatorSimilarityThreshold"/> must
+    /// still force the LLM tier exactly as it would for a proposal with no anchor match in the
+    /// first place (design D4: cosine nominates, it never auto-decides).
+    /// </summary>
+    [Fact]
+    public async Task GuardDowngrade_withNominatorNearDupe_forcesLlmTier_identically()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+
+        // Same anchor-collision shape as the eval-run repro: an exact anchor match whose content
+        // is unrelated to the proposal (guard will reject the Update), PLUS a real near-duplicate
+        // elsewhere in the store that only the embedding nominator — never run on the first pass
+        // because the exact anchor match short-circuited it — can find.
+        await SeedDocumentAsync(
+            "the",
+            "doc-unrelated-junk-anchor",
+            "Unrelated content that happens to share the same junk anchor name.",
+            freshnessAtMs: 1000,
+            ct);
+
+        const string nearDupeBody = "The build pipeline stores intermediate render artifacts in a graphite-backed cache layer.";
+        var nearDupeAnchor = _store.CreateDefaultAnchor("graphite-render-cache");
+        await _store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: "doc-near-dupe",
+            Anchor: nearDupeAnchor,
+            MemoryClass: "durable_fact",
+            Title: "Existing near-dupe",
+            MarkdownBody: nearDupeBody,
+            AliasesJson: null,
+            FacetsJson: null,
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: 1000,
+            ExpiresAtMs: null,
+            CreatedAtMs: 1000,
+            UpdatedAtMs: 1000), ct);
+        await _store.UpsertEmbeddingAsync(
+            "doc-near-dupe", MemoryEmbedOnWriteCoordinator.DocumentItemKind, "test-nominator-model", "hash-near-dupe",
+            new float[] { 1f, 0f }, ct);
+
+        var operation = MakeOperation(
+            "the", "Deployment jobs wait in a queue before promotion to production.", freshnessAtMs: 2000);
+
+        var embedderHolder = new MemoryEmbedderHolder(
+            new ScriptedEmbedder("test-nominator-model", dimensions: 2, [0.93f, 0.367623f]));
+        var vectorIndexHolder = new MemoryVectorIndexHolder(_store);
+
+        var actorLike = new MemoryCurationEvaluator(
+            _store, (ILoggingAdapter)NoLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient("SKIP"), embedderHolder, vectorIndexHolder);
+        var engineLike = new MemoryCurationEvaluator(
+            _store, (ILogger)NullLogger.Instance, new MemoryCurationConfig(),
+            new ScriptedCurationChatClient("SKIP"), embedderHolder, vectorIndexHolder);
+
+        var fromActor = (await actorLike.EvaluateAsync(operation, TestSessionId, ct)).Decision;
+        var fromEngine = (await engineLike.EvaluateAsync(operation, TestSessionId, ct)).Decision;
+
+        AssertSameDecision(fromActor, fromEngine);
+        Assert.True(fromActor.FromLlmTier);
+        Assert.Equal(CurationDecisionKind.Skip, fromActor.Kind);
     }
 
     // ── LLM tier: parseable decision ─────────────────────────────────
@@ -449,5 +608,26 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
         public ValueTask<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct)
             => ValueTask.FromResult<IReadOnlyList<ReadOnlyMemory<float>>>(
                 texts.Select(_ => (ReadOnlyMemory<float>)queryVector).ToList());
+    }
+
+    /// <summary>
+    /// Records every log line emitted through the Microsoft.Extensions.Logging ctor path, so the
+    /// <c>curation_guard_fallthrough</c> marker can be asserted directly rather than only
+    /// inferred from the resulting decision shape. Mirrors
+    /// <c>MemoryCurationNominatorTests.RecordingLogger</c> (kept as a separate private copy per
+    /// that file's own convention for test-only doubles).
+    /// </summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(formatter(state, exception));
     }
 }

--- a/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationEvaluator.cs
@@ -21,7 +21,7 @@ namespace Netclaw.Actors.Memory;
 /// <c>curation_nominator_degraded</c>, <c>curation_nominee_no_llm_decision</c>,
 /// <c>curation_llm_decision</c>, <c>curation_llm_no_decision</c>, <c>curation_llm_timeout</c>,
 /// <c>curation_llm_error</c>, <c>curation_ambiguous_auto_resolved</c>,
-/// <c>curation_ambiguous_create_fallback</c>,
+/// <c>curation_ambiguous_create_fallback</c>, <c>curation_guard_fallthrough</c>,
 /// <c>curation_skip</c>/<c>_update</c>/<c>_consolidate</c>/<c>_create</c>,
 /// <c>curation_reanchor</c>, <c>curation_tombstone_anchor</c>) regardless of which of the
 /// two callers is driving the evaluator: the inline per-session actor
@@ -79,23 +79,47 @@ internal sealed class MicrosoftCurationLog(ILogger log) : ICurationLog
 /// Decision flow (<see cref="EvaluateAsync"/>): immutable records bypass evaluation; fuzzy
 /// anchor candidates are queried; on an exact anchor match, the deterministic fast path
 /// (<see cref="CurationRulesEvaluator.Evaluate"/>'s <c>EvaluateExactMatch</c>) decides Skip/Update
-/// with no further evidence gathering. Otherwise, the embedding kNN nominator (memory-core-
-/// redesign Slice 3 Stage B, task 3.1, design D4) queries <see cref="MemoryVectorIndex.TopK"/>
-/// when the embedder is available: <b>any nominee forces the decision to the LLM tier</b>,
-/// regardless of what the lexical rules tier would have decided — the May 2026 measurement
-/// (<c>docs/research/memory-recall-findings-2026-05.md</c>; corroborated at corpus scale in
-/// <c>docs/research/memory-audit-2026-07.md</c> §5) found no cosine threshold that separates true
-/// duplicates from merely-related siblings, so cosine similarity is nomination evidence ONLY —
-/// it never auto-merges and never auto-skips. When no nominee fires (or the embedder is
-/// unavailable, in which case the pre-Slice-3 lexical content-term search runs instead as an
-/// explicitly-logged degraded path), <see cref="CurationRulesEvaluator.Evaluate"/> runs the
-/// deterministic tier as before; an Ambiguous result escalates to the LLM tier (when available)
-/// followed by <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/>, or else falls back to
-/// <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> and finally a Create default.
-/// <see cref="ApplyDecisionAsync"/> maps the resulting decision to the operation that should
-/// be written (or nothing, for Skip), executing Consolidate's re-anchor/tombstone side
+/// with no further evidence gathering — UNLESS that Update is downgraded by
+/// <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/> (see "Guard fall-through" below),
+/// in which case evidence gathering resumes rather than terminating. Otherwise, the embedding
+/// kNN nominator (memory-core-redesign Slice 3 Stage B, task 3.1, design D4) queries
+/// <see cref="MemoryVectorIndex.TopK"/> when the embedder is available: <b>any nominee forces the
+/// decision to the LLM tier</b>, regardless of what the lexical rules tier would have decided —
+/// the May 2026 measurement (<c>docs/research/memory-recall-findings-2026-05.md</c>; corroborated
+/// at corpus scale in <c>docs/research/memory-audit-2026-07.md</c> §5) found no cosine threshold
+/// that separates true duplicates from merely-related siblings, so cosine similarity is
+/// nomination evidence ONLY — it never auto-merges and never auto-skips. When no nominee fires
+/// (or the embedder is unavailable, in which case the pre-Slice-3 lexical content-term search
+/// runs instead as an explicitly-logged degraded path), <see cref="CurationRulesEvaluator.Evaluate"/>
+/// runs the deterministic tier as before; an Ambiguous result escalates to the LLM tier (when
+/// available) followed by <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/>, or else
+/// falls back to <see cref="CurationRulesEvaluator.TryAutoResolveAmbiguous"/> and finally a Create
+/// default. <see cref="ApplyDecisionAsync"/> maps the resulting decision to the operation that
+/// should be written (or nothing, for Skip), executing Consolidate's re-anchor/tombstone side
 /// effects — this mapping is unified too, since a second, hand-copied switch statement per
 /// caller is exactly the kind of divergence this slice removes.
+///
+/// <para>
+/// <b>Guard fall-through (memory-core-redesign, July 2026 audit finding, eval run
+/// <c>ad9a2312</c>):</b> when the exact-anchor deterministic path picks Update and
+/// <see cref="CurationRulesEvaluator.GuardDestructiveUpdate"/> downgrades it to Skip because the
+/// proposal would not preserve the target's content, that Skip must NOT be returned as the final
+/// decision — an explicit <c>store_memory</c> proposal silently ending as a no-op (no write, no
+/// further evidence gathering) is a silent-fallback violation, observed when an LLM-emitted junk
+/// anchor (e.g. the bare stopword <c>the</c>) collided with an unrelated existing document sharing
+/// the same junk anchor text. The guard's protective effect is correct and must be kept — the
+/// mismatched target must never be overwritten — but the correct response to "this anchor match
+/// doesn't apply" is to re-run evaluation exactly as if there had been no exact anchor match at
+/// all: every candidate that carried <c>IsExactAnchorMatch</c> is demoted to an ordinary fuzzy
+/// candidate (so the rules tier cannot re-derive the same Update/guard-reject pair and loop), then
+/// the embedding nominator / lexical content-term search that the exact-match fast path had
+/// short-circuited runs for the first time, followed by the usual rules-tier/LLM-tier/auto-resolve
+/// chain with a Create default. This is deliberately NOT a fix to anchor-name hygiene — junk
+/// anchors like <c>the</c> should arguably never be stored or fuzzy-matched at all, but filtering
+/// them is a broader behavior change to anchor matching left as a follow-up; this fall-through
+/// fixes the narrower "explicit store becomes a silent no-op" failure regardless of why the guard
+/// rejected the match.
+/// </para>
 ///
 /// Guard-validated write routing (memory-core-redesign Slice 3, design D5): an LLM-tier
 /// UPDATE/CONSOLIDATE decision (<see cref="CurationDecision.FromLlmTier"/>) never overwrites
@@ -221,12 +245,38 @@ public sealed class MemoryCurationEvaluator
         // Build a mutable candidate list — content search may add more candidates below.
         var candidates = new List<ExistingMemoryCandidate>(anchorCandidates);
 
+        return await EvaluateCandidatesAsync(
+            operation, sessionId, candidates, anchorCandidates.Any(c => c.IsExactAnchorMatch), ct);
+    }
+
+    /// <summary>
+    /// The evaluation body proper, factored out of <see cref="EvaluateAsync"/> so the guard
+    /// fall-through case (see this class's remarks) can re-run the same evidence-gathering and
+    /// decision chain a second time with <paramref name="hasExactAnchorMatch"/> forced false —
+    /// exactly as if the anchor query at the top of <see cref="EvaluateAsync"/> had found no
+    /// exact match — without re-querying the store for anchors a second time.
+    /// </summary>
+    private async Task<CurationEvaluation> EvaluateCandidatesAsync(
+        SQLiteMemoryCurationOperation operation,
+        SessionId sessionId,
+        List<ExistingMemoryCandidate> candidates,
+        bool hasExactAnchorMatch,
+        CancellationToken ct)
+    {
         // Embedding kNN nomination (memory-core-redesign Slice 3 Stage B, task 3.1, design D4)
         // vs. the pre-Slice-3 lexical content-term search: these are alternatives, not additive.
         // An exact anchor match already resolves deterministically below with no further
         // evidence gathering (the "existing exact-anchor deterministic fast path" design D4
-        // calls out as unchanged), so neither runs in that case.
-        var hasExactAnchorMatch = anchorCandidates.Any(c => c.IsExactAnchorMatch);
+        // calls out as unchanged), so neither runs in that case — unless the guard fall-through
+        // below re-invokes this method with hasExactAnchorMatch forced false, in which case this
+        // runs for the first time for this proposal.
+        //
+        // Captured before any mutation below: on the first (normal) call this is exactly the
+        // anchor-name-fuzzy-match hit count `curation_dual_search` below reports; on a guard
+        // fall-through re-entry it is that same anchor-hit count with the rejected match(es)
+        // demoted rather than removed, which is the correct "anchor_hits" figure for this pass
+        // either way (no nomination/content-search candidates have been merged in yet).
+        var anchorHitCount = candidates.Count;
         if (!hasExactAnchorMatch)
         {
             var embedder = _embedderHolder?.Current;
@@ -308,7 +358,7 @@ public sealed class MemoryCurationEvaluator
                             _log.Debug(
                                 "curation_dual_search anchor={0} anchor_hits={1} content_hits={2} merged={3}",
                                 operation.AnchorCanonicalName,
-                                anchorCandidates.Count,
+                                anchorHitCount,
                                 contentCandidates.Count,
                                 candidates.Count);
                         }
@@ -409,9 +459,38 @@ public sealed class MemoryCurationEvaluator
                 candidates);
         }
 
-        return new CurationEvaluation(
-            CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates),
-            candidates);
+        var guardedDecision = CurationRulesEvaluator.GuardDestructiveUpdate(rulesDecision, operation, candidates);
+
+        // Guard fall-through (see this class's remarks): the ONLY decision shape
+        // GuardDestructiveUpdate ever changes is Update -> Skip, and Update can only be
+        // produced by the exact-anchor deterministic fast path (CurationRulesEvaluator's fuzzy
+        // tier never returns Update) — so this downgrade is only reachable when
+        // hasExactAnchorMatch was true for this call. Terminating on that Skip would silently
+        // drop an explicit proposal with no further evidence gathering (the July 2026 audit
+        // bug); instead, demote every exact-anchor-matched candidate to an ordinary fuzzy
+        // candidate and re-run the full evaluation chain as if there had been no exact anchor
+        // match at all. The demotion is what keeps this from looping: with no candidate left
+        // claiming IsExactAnchorMatch, CurationRulesEvaluator.Evaluate cannot re-derive the same
+        // Update decision on the re-run, so this branch cannot fire twice for one proposal.
+        if (hasExactAnchorMatch
+            && rulesDecision.Kind == CurationDecisionKind.Update
+            && guardedDecision.Kind == CurationDecisionKind.Skip)
+        {
+            _log.Warning(
+                "curation_guard_fallthrough anchor={0} rejectedTarget={1}",
+                operation.AnchorCanonicalName,
+                guardedDecision.TargetDocumentId ?? "(unknown)");
+
+            for (var i = 0; i < candidates.Count; i++)
+            {
+                if (candidates[i].IsExactAnchorMatch)
+                    candidates[i] = candidates[i] with { IsExactAnchorMatch = false };
+            }
+
+            return await EvaluateCandidatesAsync(operation, sessionId, candidates, hasExactAnchorMatch: false, ct);
+        }
+
+        return new CurationEvaluation(guardedDecision, candidates);
     }
 
     /// <summary>


### PR DESCRIPTION
## Bug (eval run `ad9a2312`, daemon log lines 856/903/943/1036)

`MemoryCurationEvaluator.EvaluateAsync` has an exact-anchor deterministic fast
path: when a proposal's anchor exact-matches an existing document, the rules
tier decides Skip/Update with no further evidence gathering. When that
decision is Update, `CurationRulesEvaluator.GuardDestructiveUpdate` checks
that the proposal actually preserves the target's existing content before
letting the raw overwrite through — if it doesn't, the guard downgrades the
decision to Skip.

That downgraded Skip was being returned as the **final** decision. In 4/5
repro runs, an LLM-emitted junk anchor name (the bare stopword `the`)
collided with an unrelated existing document that happened to carry the same
junk anchor text. The guard correctly refused to overwrite the unrelated
doc's content with the new proposal's — but nothing then created the
requested fact, and the embedding kNN nominator / lexical content-term search
never ran at all, because the exact-anchor fast path short-circuits ahead of
both. An explicit `store_memory` proposal silently became a no-op:
`operations=0` on the checkpoint, with only a debug-level skip marker as a
trace. That's a silent-fallback violation.

## Fix

In the shared evaluator (both the inline per-session actor and the daemon
checkpoint-worker pipelines get this automatically post-Slice-1):

When `GuardDestructiveUpdate` downgrades an anchor-matched Update to Skip,
the evaluator no longer terminates. It demotes every exact-anchor-matched
candidate to an ordinary fuzzy candidate and re-runs the *entire* remaining
evaluation chain exactly as if there had been no exact anchor match in the
first place: embedding nomination (when the embedder/vector index are
available), then the lexical content-term search, then the deterministic
rules tier / LLM tier / auto-resolve chain, with Create as the terminal
default. The demotion is what prevents the re-run from looping back into the
same Update → guard-reject pair.

**The guard's protective effect is preserved** — the mismatched target is
never overwritten by the raw anchor-path Update. Only the *termination* was
wrong; the fix corrects that without touching the guard's actual safety
check.

A new structured marker, `curation_guard_fallthrough anchor={name}
rejectedTarget={id}`, fires whenever this path triggers, so it's observable
in daemon logs going forward. Existing skip/degraded markers are untouched.

**Explicitly out of scope:** anchor-name hygiene / stopword filtering. Junk
anchors like `the` arguably shouldn't be stored or fuzzy-matched at all, but
fixing that changes anchor-matching behavior broadly across the system. Left
as a follow-up with a code comment at the relevant site — this PR only fixes
the narrower "explicit store becomes a silent no-op" failure, regardless of
why the guard rejected the match.

## Tests

`MemoryCurationEvaluatorParityTests` (both Akka `ILoggingAdapter` and
Microsoft.Extensions.Logging `ILogger` construction paths, proving parity
holds for the new decision shapes):

- Guard-rejected anchor Update with no other candidates → **Create** (was
  Skip pre-fix; this is the fix, asserted directly).
- Guard-rejected anchor Update + a scripted embedder/vector index where a
  real near-duplicate exists above the nominator similarity threshold → the
  nominator runs for the first time (it never ran on the short-circuited
  first pass) and forces the LLM tier.
- Regression: a guard rejection whose content, once re-evaluated as an
  ordinary fuzzy candidate, clears `TryAutoResolveAmbiguous`'s thresholds →
  genuine auto-resolved **Skip**. This proves the fall-through doesn't
  over-correct into "never skip a real duplicate" — it defers to whatever the
  rest of the flow legitimately produces.
- The `curation_guard_fallthrough` marker fires with the anchor name and
  rejected target document id.

## Gates

- `Netclaw.Actors.Tests`: 2617 passed
- `Netclaw.Daemon.Tests`: 832 passed
- `Netclaw.Cli.Tests`: 1231 passed
- `Netclaw.Configuration.Tests`: 461 passed
- `Netclaw.Embeddings.Tests`: 18 passed
- Release build (`Netclaw.slnx -c Release`): 0 warnings, 0 errors
- `dotnet slopwatch analyze`: 0 issues
- `Add-FileHeaders.ps1 -Verify`: all files have headers