### PR TITLE
chore: bump SkillServer to 0.4.0-beta.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="SlackNet" Version="$(SlackNetVersion)" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
-    <PackageVersion Include="Netclaw.SkillClient" Version="0.4.0-beta.1" />
+    <PackageVersion Include="Netclaw.SkillClient" Version="0.4.0-beta.3" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
     <PackageVersion Include="Termina" Version="0.15.0" />
   </ItemGroup>

--- a/src/Netclaw.Daemon.IntegrationTests/SkillServerNativeSidecarIntegrationTests.cs
+++ b/src/Netclaw.Daemon.IntegrationTests/SkillServerNativeSidecarIntegrationTests.cs
@@ -25,7 +25,7 @@ namespace Netclaw.Daemon.IntegrationTests;
 [Trait("Category", "Integration")]
 public sealed class SkillServerNativeSidecarIntegrationTests : IAsyncLifetime
 {
-    private const string Image = "ghcr.io/netclaw-dev/skillserver:0.4.0-beta.1";
+    private const string Image = "ghcr.io/netclaw-dev/skillserver:0.4.0-beta.3";
     private const string ApiKey = "sk-test-native-sidecar-sync";
     private const int ContainerPort = 8080;
     private const int HostPort = 18080;

--- a/src/Netclaw.Daemon.Tests/Services/ServerFeedSkillSyncServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ServerFeedSkillSyncServiceTests.cs
@@ -146,7 +146,7 @@ public sealed class ServerFeedSkillSyncServiceTests : IDisposable
             """,
             "application/json");
         handler.AddStringResponse(BaseUrl + "skills/feed-skill/1.0.0/SKILL.md", skillContent, "text/markdown");
-        handler.AddErrorResponse(BaseUrl + "manifest.json", HttpStatusCode.NotFound);
+        handler.AddErrorResponse(BaseUrl + "subagents/v1/index.json", HttpStatusCode.NotFound);
 
         var service = CreateService(handler);
         await service.SyncOnceAsync(CancellationToken.None);
@@ -412,9 +412,7 @@ public sealed class ServerFeedSkillSyncServiceTests : IDisposable
         byte[] artifactContent,
         string expectedDigest)
     {
-        // New client (0.4.0-beta.3) hits /subagents/v1/... directly — no manifest navigation
-        // The client's ResolveHref returns paths starting with "/" as-is, so hrefs in responses
-        // must be absolute paths for the client to resolve them correctly.
+        // Use absolute hrefs so the client resolves direct native index traversal correctly.
         handler.AddStringResponse(
             BaseUrl + "subagents/v1/index.json",
             """

--- a/src/Netclaw.Daemon.Tests/Services/ServerFeedSkillSyncServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ServerFeedSkillSyncServiceTests.cs
@@ -412,72 +412,60 @@ public sealed class ServerFeedSkillSyncServiceTests : IDisposable
         byte[] artifactContent,
         string expectedDigest)
     {
+        // New client (0.4.0-beta.3) hits /subagents/v1/... directly — no manifest navigation
+        // The client's ResolveHref returns paths starting with "/" as-is, so hrefs in responses
+        // must be absolute paths for the client to resolve them correctly.
         handler.AddStringResponse(
-            BaseUrl + "manifest.json",
-            """
-            {
-              "$schema": "https://schemas.netclaw.dev/skillserver/native-manifest/v1.json",
-              "generatedAt": "2026-06-30T00:00:00Z",
-              "links": {
-                "self": { "href": "manifest.json" },
-                "rfcSkills": { "href": ".well-known/agent-skills/index.json" },
-                "skills": { "href": "manifest/skills/index.json" },
-                "subagents": { "href": "manifest/subagents/index.json" }
-              }
-            }
-            """,
-            "application/json");
-        handler.AddStringResponse(
-            BaseUrl + "manifest/subagents/index.json",
+            BaseUrl + "subagents/v1/index.json",
             """
             {
               "kind": "subagent-collection-index",
-              "links": { "self": { "href": "manifest/subagents/index.json" } },
+              "links": { "self": { "href": "/subagents/v1/index.json" } },
               "pages": [
-                { "range": "a-z", "href": "manifest/subagents/pages/a-z.json" }
+                { "range": "a-z", "href": "/subagents/v1/pages/a-z.json" }
               ]
             }
             """,
             "application/json");
         handler.AddStringResponse(
-            BaseUrl + "manifest/subagents/pages/a-z.json",
+            BaseUrl + "subagents/v1/pages/a-z.json",
             $$"""
             {
               "kind": "subagent-collection-page",
               "range": "a-z",
-              "links": { "self": { "href": "manifest/subagents/pages/a-z.json" } },
+              "links": { "self": { "href": "/subagents/v1/pages/a-z.json" } },
               "items": [
                 {
                   "name": "{{name}}",
                   "latestVersion": "{{version}}",
                   "versionRange": { "min": "{{version}}", "max": "{{version}}", "count": 1 },
-                  "href": "manifest/subagents/{{name}}/index.json"
+                  "href": "/subagents/v1/{{name}}/index.json"
                 }
               ]
             }
             """,
             "application/json");
         handler.AddStringResponse(
-            BaseUrl + $"manifest/subagents/{name}/index.json",
+            BaseUrl + $"subagents/v1/{name}/index.json",
             $$"""
             {
               "kind": "subagent-identity-index",
               "name": "{{name}}",
               "latestVersion": "{{version}}",
-              "links": { "self": { "href": "manifest/subagents/{{name}}/index.json" } },
+              "links": { "self": { "href": "/subagents/v1/{{name}}/index.json" } },
               "versions": [
                 {
                   "version": "{{version}}",
                   "publishedAt": "2026-06-30T00:00:00Z",
                   "digest": "sha256:{{expectedDigest}}",
-                  "href": "manifest/subagents/{{name}}/versions/{{version}}.json"
+                  "href": "/subagents/v1/{{name}}/versions/{{version}}.json"
                 }
               ]
             }
             """,
             "application/json");
         handler.AddStringResponse(
-            BaseUrl + $"manifest/subagents/{name}/versions/{version}.json",
+            BaseUrl + $"subagents/v1/{name}/versions/{version}.json",
             $$"""
             {
               "kind": "subagent-version-detail",
@@ -487,7 +475,7 @@ public sealed class ServerFeedSkillSyncServiceTests : IDisposable
               "description": "Test sub-agent",
               "url": "{{BaseUrl}}subagents/{{name}}/{{version}}/agent.md",
               "digest": "sha256:{{expectedDigest}}",
-              "links": { "self": { "href": "manifest/subagents/{{name}}/versions/{{version}}.json" } }
+              "links": { "self": { "href": "/subagents/v1/{{name}}/versions/{{version}}.json" } }
             }
             """,
             "application/json");

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ServerFeedSkillSyncService.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -373,16 +373,7 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
 
-            var manifest = await client.GetManifestAsync(cts.Token);
-            if (manifest?.Links?.SubAgents is not { Href.Length: > 0 } subAgentsLink)
-            {
-                _logger.LogDebug(
-                    "Server feed '{FeedName}' native sidecar is unavailable or does not advertise sub-agents",
-                    feed.Name);
-                return;
-            }
-
-            subAgentIndex = await client.GetNativeSubAgentIndexAsync(subAgentsLink, cts.Token);
+            subAgentIndex = await client.GetNativeSubAgentIndexAsync(cts.Token);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {


### PR DESCRIPTION
## Changes

- **Directory.Packages.props**: `Netclaw.SkillClient` 0.4.0-beta.1 → 0.4.0-beta.3
- **SkillServerNativeSidecarIntegrationTests.cs**: container image 0.4.0-beta.1 → 0.4.0-beta.3
- **ServerFeedSkillSyncService.cs**: adapt to API change — `NativeRootManifest` no longer has `Links`, replaced manifest navigation with direct `GetNativeSubAgentIndexAsync(ct)` call

Build verified clean (0 warnings, 0 errors).