### PR TITLE
test: consolidate capture/script fake chat clients into a shared helper (#1599)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
@@ -19,6 +19,7 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tests.Sessions;
+using FakeChatClient = Netclaw.Tests.Utilities.FakeChatClient;
 using Netclaw.Channels.Discord;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -36,7 +37,7 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
     private static readonly byte[] FakePngBytes = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==");
 
-    private readonly ImageCapturingChatClient _chatClient = new();
+    private readonly FakeChatClient _chatClient = new();
     private readonly RecordingDiscordReplyClient _replyClient = new();
     private readonly FakeDiscordFileHandler _httpHandler = new();
     private readonly NetclawPaths _paths = new(Path.Combine(
@@ -136,7 +137,9 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
         Assert.True(_httpHandler.RequestCount > 0, "Expected file download request");
         Assert.Contains("cdn.discordapp.com", _httpHandler.LastRequestUri?.Host ?? "");
 
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive DataContent (image) in chat messages");
 
         var sessionId = new SessionId("ch-1/msg-1000");
@@ -191,7 +194,9 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(_httpHandler.RequestCount > 0, "Expected file download request");
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive image content from attachment-only message");
     }
 
@@ -233,7 +238,9 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
                 "Expected at least one Discord reply to be posted");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.False(_chatClient.ReceivedImageContent,
+        Assert.False(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM not to receive image when scanner fails");
 
         Assert.Contains(_replyClient.Posts,
@@ -284,7 +291,9 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
                 "Expected at least one Discord reply to be posted");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive DataContent (image) via real MagicByteContentScanner");
     }
 
@@ -347,58 +356,6 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
             return Task.FromResult(response);
         }
-    }
-
-    private sealed class ImageCapturingChatClient : IChatClient
-    {
-        private int _callCount;
-        public int CallCount => _callCount;
-        public volatile bool ReceivedImageContent;
-
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            Interlocked.Increment(ref _callCount);
-
-            foreach (var msg in messages)
-            {
-                if (msg.Contents.OfType<DataContent>().Any())
-                    ReceivedImageContent = true;
-            }
-
-            var contents = new List<AIContent>
-            {
-                new TextContent($"[fake] I see your image (call #{_callCount})")
-            };
-            var response = new ChatResponse(new ChatMessage(
-                Microsoft.Extensions.AI.ChatRole.Assistant,
-                contents));
-            return Task.FromResult(response);
-        }
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => CreateStreamingAsync(messages, options, cancellationToken);
-
-        private async IAsyncEnumerable<ChatResponseUpdate> CreateStreamingAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            var response = await GetResponseAsync(messages, options, cancellationToken);
-            foreach (var update in response.ToChatResponseUpdates())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                yield return update;
-            }
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-        public void Dispose() { }
     }
 
     private sealed class ImageCapabilityResolver : IModelCapabilityResolver

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -19,6 +19,7 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tests.Sessions;
+using FakeChatClient = Netclaw.Tests.Utilities.FakeChatClient;
 using Netclaw.Channels.Slack;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -49,7 +50,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
     private static readonly byte[] FakePlainTextBytes =
         "meeting notes\n- discuss Q2 roadmap\n- assign OKRs\n"u8.ToArray();
 
-    private readonly RecordingChatClient _chatClient = new();
+    private readonly FakeChatClient _chatClient = new() { ResponseText = "ok" };
     private readonly RecordingReplyClient _replyClient = new();
     private readonly ConfigurableFakeSlackFileHandler _httpHandler = new();
     private readonly NetclawPaths _paths = new(Path.Combine(
@@ -60,6 +61,17 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
     {
         _paths.EnsureDirectoriesExist();
     }
+
+    /// <summary>
+    /// Contents of every USER-role message across all LLM calls so far, in
+    /// call order — mirrors the old <c>RecordingChatClient.ReceivedMessages</c>
+    /// accumulator that this test suite asserted against.
+    /// </summary>
+    private IReadOnlyList<IList<AIContent>> ReceivedUserMessageContents =>
+        _chatClient.ReceivedMessagesByCall
+            .SelectMany(call => call.Where(m => m.Role == Microsoft.Extensions.AI.ChatRole.User))
+            .Select(m => m.Contents)
+            .ToList();
 
     protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
     {
@@ -191,13 +203,13 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.Contains(_chatClient.ReceivedMessages,
+            Assert.Contains(ReceivedUserMessageContents,
                 contents => contents.Any(c => c is TextContent t
                     && t.Text.Contains("[attachment]", StringComparison.Ordinal)
                     && t.Text.Contains("report.pdf", StringComparison.Ordinal)));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var announcement = _chatClient.ReceivedMessages
+        var announcement = ReceivedUserMessageContents
             .SelectMany(m => m)
             .OfType<TextContent>()
             .First(t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
@@ -209,7 +221,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
         // PDFs are never handed to the LLM as DataContent — otherwise they'd
         // reach OpenAiCompatibleChatClient and be wrapped as a broken image_url.
-        var pdfDataContents = _chatClient.ReceivedMessages
+        var pdfDataContents = ReceivedUserMessageContents
             .SelectMany(m => m)
             .OfType<DataContent>()
             .Where(d => d.MediaType == "application/pdf");
@@ -254,13 +266,13 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.Contains(_chatClient.ReceivedMessages,
+            Assert.Contains(ReceivedUserMessageContents,
                 contents => contents.Any(c => c is TextContent t
                     && t.Text.Contains("[attachment]", StringComparison.Ordinal)
                     && t.Text.Contains("notes.docx", StringComparison.Ordinal)));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var announcement = _chatClient.ReceivedMessages
+        var announcement = ReceivedUserMessageContents
             .SelectMany(m => m)
             .OfType<TextContent>()
             .First(t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
@@ -270,7 +282,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
         // Docx is not inlineable — no DataContent for it should have been
         // forwarded to the LLM.
-        var docxDataContents = _chatClient.ReceivedMessages
+        var docxDataContents = ReceivedUserMessageContents
             .SelectMany(m => m)
             .OfType<DataContent>()
             .Where(d => d.MediaType?.Contains("wordprocessingml", StringComparison.Ordinal) == true);
@@ -402,7 +414,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
         // Text content "batch upload" should still have reached the LLM.
         await AwaitAssertAsync(() =>
         {
-            Assert.Contains(_chatClient.ReceivedMessages,
+            Assert.Contains(ReceivedUserMessageContents,
                 contents => contents.Any(c => c is TextContent t
                     && t.Text.Contains("batch upload", StringComparison.Ordinal)));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
@@ -509,7 +521,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.Contains(_chatClient.ReceivedMessages,
+            Assert.Contains(ReceivedUserMessageContents,
                 contents => contents.Any(c => c is TextContent t
                     && t.Text.Contains("[attachment]", StringComparison.Ordinal)
                     && t.Text.Contains("notes.txt", StringComparison.Ordinal)
@@ -555,7 +567,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.Contains(_chatClient.ReceivedMessages,
+            Assert.Contains(ReceivedUserMessageContents,
                 contents => contents.Any(c => c is TextContent t
                     && t.Text.Contains("mime=\"image/png\"", StringComparison.Ordinal))
                 && contents.Any(c => c is DataContent d && d.MediaType == "image/png"));
@@ -761,53 +773,6 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
             string filePath,
             string? fileName = null,
             CancellationToken cancellationToken = default) => Task.CompletedTask;
-    }
-
-    private sealed class RecordingChatClient : IChatClient
-    {
-        private readonly object _gate = new();
-        private readonly List<IList<AIContent>> _messages = [];
-
-        public IReadOnlyList<IList<AIContent>> ReceivedMessages
-        {
-            get
-            {
-                lock (_gate)
-                    return _messages.ToList();
-            }
-        }
-
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            lock (_gate)
-            {
-                foreach (var msg in messages)
-                {
-                    if (msg.Role == Microsoft.Extensions.AI.ChatRole.User)
-                        _messages.Add(msg.Contents);
-                }
-            }
-
-            return Task.FromResult(new ChatResponse([
-                new ChatMessage(Microsoft.Extensions.AI.ChatRole.Assistant, "ok")
-            ]));
-        }
-
-        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            await GetResponseAsync(messages, options, cancellationToken);
-            yield return new ChatResponseUpdate(Microsoft.Extensions.AI.ChatRole.Assistant, "ok");
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-
-        public void Dispose() { }
     }
 
     private sealed class AlwaysBlockContentScanner(string message) : IContentScanner

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -23,6 +23,7 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tests.Channels.TestHelpers;
 using Netclaw.Actors.Tests.Hosting;
 using Netclaw.Actors.Tests.Sessions;
+using FakeChatClient = Netclaw.Tests.Utilities.FakeChatClient;
 using Netclaw.Channels.Slack;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -46,7 +47,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
     private static readonly byte[] FakePngBytes = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==");
 
-    private readonly ImageCapturingChatClient _chatClient = new();
+    private readonly FakeChatClient _chatClient = new();
     private readonly RecordingReplyClient _replyClient = new();
     private readonly FakeSlackFileHandler _httpHandler = new();
     private readonly NetclawPaths _paths = new(Path.Combine(
@@ -176,7 +177,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         Assert.Contains("files.slack.com", _httpHandler.LastRequestUri?.Host ?? "");
 
         // Verify: the chat client received image content
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive DataContent (image) in chat messages");
 
         // Verify: file was persisted to session media directory
@@ -256,7 +259,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(_httpHandler.RequestCount > 0, "Expected file download request");
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive image content");
 
         var sessionId = new SessionId("C_TEST/2000.1");
@@ -329,7 +334,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(_httpHandler.RequestCount > 0, "Expected file download request");
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive image content from file_share message");
 
         var sessionId = new SessionId("D2/3000.1");
@@ -519,7 +526,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         await AwaitAssertAsync(() =>
         {
             Assert.Contains(_replyClient.PostedMessages,
-                message => message.Text.Contains("call #2", StringComparison.OrdinalIgnoreCase));
+                message => message.Text.Contains("Response #2", StringComparison.OrdinalIgnoreCase));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -574,11 +581,11 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         await AwaitAssertAsync(() =>
         {
             Assert.Contains(_replyClient.PostedMessages,
-                message => message.Text.Contains("call #2", StringComparison.OrdinalIgnoreCase));
+                message => message.Text.Contains("Response #2", StringComparison.OrdinalIgnoreCase));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.DoesNotContain(_replyClient.PostedMessages,
-            message => message.Text.Contains("call #1", StringComparison.OrdinalIgnoreCase));
+            message => message.Text.Contains("Response #1", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -1269,7 +1276,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 "Expected at least one Slack reply to be posted");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.True(_chatClient.ReceivedImageContent,
+        Assert.True(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM to receive DataContent (image) via real MagicByteContentScanner");
     }
 
@@ -1332,7 +1341,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 "Expected at least one Slack reply to be posted");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.False(_chatClient.ReceivedImageContent,
+        Assert.False(
+            _chatClient.LastReceivedMessages is not null
+                && _chatClient.LastReceivedMessages.SelectMany(m => m.Contents).OfType<DataContent>().Any(),
             "Expected LLM not to receive image when scanner fails");
 
         Assert.Contains(_replyClient.PostedMessages,
@@ -1527,65 +1538,6 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 PromptInjectionRisk.High,
                 "Synthetic detector for integration testing."));
         }
-    }
-
-    /// <summary>
-    /// Chat client that tracks whether it received image content in messages.
-    /// </summary>
-    private sealed class ImageCapturingChatClient : IChatClient
-    {
-        private int _callCount;
-        public int CallCount => _callCount;
-        public volatile bool ReceivedImageContent;
-        public Exception? Failure { get; set; }
-
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            Interlocked.Increment(ref _callCount);
-
-            if (Failure is not null)
-                throw Failure;
-
-            foreach (var msg in messages)
-            {
-                if (msg.Contents.OfType<DataContent>().Any())
-                    ReceivedImageContent = true;
-            }
-
-            var contents = new List<AIContent>
-            {
-                new TextContent($"[fake] I see your image (call #{_callCount})")
-            };
-            var response = new ChatResponse(new ChatMessage(
-                Microsoft.Extensions.AI.ChatRole.Assistant,
-                contents));
-            return Task.FromResult(response);
-        }
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => CreateStreamingAsync(messages, options, cancellationToken);
-
-        private async IAsyncEnumerable<ChatResponseUpdate> CreateStreamingAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            var response = await GetResponseAsync(messages, options, cancellationToken);
-            foreach (var update in response.ToChatResponseUpdates())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                yield return update;
-            }
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-        public void Dispose() { }
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -22,6 +22,7 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tests.Sessions;
+using FakeChatClient = Netclaw.Tests.Utilities.FakeChatClient;
 using Netclaw.Channels.Slack;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -40,7 +41,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
     private static readonly byte[] FakePngBytes = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==");
 
-    private readonly ContextCapturingChatClient _chatClient = new();
+    private readonly FakeChatClient _chatClient = new();
     private readonly RecordingReplyClient _replyClient = new();
     private readonly FakeSlackFileHandler _httpHandler = new();
     private readonly NetclawPaths _paths = new(Path.Combine(
@@ -164,7 +165,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         // Verify: LLM received one user turn containing history prelude + live mention.
-        var messages = _chatClient.LastMessages!;
+        var messages = _chatClient.LastReceivedMessages!;
         var userMessages = messages.Where(m => m.Role == AiChatRole.User).ToList();
         Assert.Single(userMessages);
 
@@ -390,7 +391,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Assert.True(_chatClient.CallCount > 0, "Expected at least one LLM call");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var messages = _chatClient.LastMessages!;
+        var messages = _chatClient.LastReceivedMessages!;
         var userMessages = messages.Where(m => m.Role == AiChatRole.User).ToList();
         Assert.Single(userMessages);
 
@@ -515,7 +516,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Assert.True(_chatClient.CallCount > 0, "Expected at least one LLM call");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var messages = _chatClient.LastMessages!;
+        var messages = _chatClient.LastReceivedMessages!;
         var userMessages = messages.Where(m => m.Role == AiChatRole.User).ToList();
         Assert.Single(userMessages);
 
@@ -626,7 +627,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Assert.True(_chatClient.CallCount > 0, "Expected at least one LLM call");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var messages = _chatClient.LastMessages!;
+        var messages = _chatClient.LastReceivedMessages!;
         var userMessages = messages.Where(m => m.Role == AiChatRole.User).ToList();
         Assert.Single(userMessages);
 
@@ -757,7 +758,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Assert.True(_chatClient.CallCount > 0, "Expected at least one LLM call");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var messages = _chatClient.LastMessages!;
+        var messages = _chatClient.LastReceivedMessages!;
         var userMessages = messages.Where(m => m.Role == AiChatRole.User).ToList();
         Assert.Single(userMessages);
 
@@ -970,7 +971,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
         // rejection note lives under the public-channel attachment policy).
         // Under the post-fix design the backfill is its own LLM call; the
         // subsequent live inbound is a plain message without adopted context.
-        var backfillCall = _chatClient.Calls
+        var backfillCall = _chatClient.ReceivedMessagesByCall
             .Select((messages, idx) => (messages, idx))
             .FirstOrDefault(c =>
             {
@@ -1119,54 +1120,6 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             SlackChannelId channelId, SlackThreadTs threadTs, string filePath,
             string? filename = null, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Chat client that captures the full message list sent to the LLM.
-    /// </summary>
-    private sealed class ContextCapturingChatClient : IChatClient
-    {
-        private int _callCount;
-        public int CallCount => _callCount;
-        public List<ChatMessage>? LastMessages { get; private set; }
-        public List<List<ChatMessage>> Calls { get; } = [];
-
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            Interlocked.Increment(ref _callCount);
-            LastMessages = [.. messages];
-            Calls.Add(LastMessages);
-
-            var response = new ChatResponse(new ChatMessage(
-                AiChatRole.Assistant,
-                (IList<AIContent>)[new TextContent($"[fake response #{_callCount}]")]));
-            return Task.FromResult(response);
-        }
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => StreamAsync(messages, options, cancellationToken);
-
-        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            var response = await GetResponseAsync(messages, options, cancellationToken);
-            foreach (var update in response.ToChatResponseUpdates())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                yield return update;
-            }
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-        public void Dispose() { }
     }
 
     private sealed class ImageCapabilityResolver : IModelCapabilityResolver

--- a/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryCurationEvaluatorParityTests.cs
@@ -3,7 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Runtime.CompilerServices;
 using Akka.Event;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -11,9 +10,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
 using Xunit;
-using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
-using AiChatRole = Microsoft.Extensions.AI.ChatRole;
 
 namespace Netclaw.Actors.Tests.Memory;
 
@@ -222,7 +220,7 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
             freshnessAtMs: 2000);
 
         var evaluator = new MemoryCurationEvaluator(
-            _store, (ILoggingAdapter)NoLogger.Instance, new ScriptedCurationChatClient("SKIP"));
+            _store, (ILoggingAdapter)NoLogger.Instance, new FakeChatClient { ResponseText = "SKIP" });
 
         var decision = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
 
@@ -249,11 +247,15 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
             "Netclaw GitHub repository at https://github.com/netclaw-dev/netclaw, private repo",
             freshnessAtMs: 2000);
 
-        // Empty stream (no yields) reproduces a provider that returns nothing parseable —
-        // TryLlmEvaluationAsync must surface curation_llm_no_decision and fall through to
-        // the same deterministic auto-resolve path the no-LLM matrix case exercises.
+        // ResponseText = null makes FakeChatClient emit its default marker text
+        // ("[fake] Response #1") rather than a truly empty response, but the marker
+        // still isn't a recognized SKIP/CREATE/UPDATE/CONSOLIDATE keyword, so
+        // CurationPromptBuilder.ParseResponse still returns no decision and
+        // TryLlmEvaluationAsync still surfaces curation_llm_no_decision and falls
+        // through to the same deterministic auto-resolve path the no-LLM matrix case
+        // exercises.
         var evaluator = new MemoryCurationEvaluator(
-            _store, (ILoggingAdapter)NoLogger.Instance, new ScriptedCurationChatClient(responseText: null));
+            _store, (ILoggingAdapter)NoLogger.Instance, new FakeChatClient { ResponseText = null });
 
         var decision = await evaluator.EvaluateAsync(operation, TestSessionId, ct);
 
@@ -338,35 +340,5 @@ public sealed class MemoryCurationEvaluatorParityTests : IAsyncDisposable
             Assert.Null(actual.ConsolidationTargetIds);
         else
             Assert.Equal(expected.ConsolidationTargetIds, actual.ConsolidationTargetIds);
-    }
-
-    /// <summary>
-    /// Minimal scripted <see cref="IChatClient"/>: streams <paramref name="responseText"/>
-    /// as a single update, or nothing at all when null (reproducing an empty/garbled
-    /// provider response so the deterministic fallback path can be exercised).
-    /// </summary>
-    private sealed class ScriptedCurationChatClient(string? responseText) : IChatClient
-    {
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
-            => Task.FromResult(new ChatResponse(new AiChatMessage(AiChatRole.Assistant, responseText ?? string.Empty)));
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
-            => StreamAsync(cancellationToken);
-
-        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            if (responseText is not null)
-                yield return new ChatResponseUpdate(AiChatRole.Assistant, responseText);
-
-            await Task.CompletedTask;
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/SidecarSessionCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SidecarSessionCorrelationTests.cs
@@ -3,7 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Runtime.CompilerServices;
 using Akka.Event;
 using Akka.Hosting.TestKit;
 using Microsoft.Extensions.AI;
@@ -13,8 +12,6 @@ using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Configuration;
 using Xunit;
-using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
-using AiChatRole = Microsoft.Extensions.AI.ChatRole;
 
 namespace Netclaw.Actors.Tests.Sessions;
 
@@ -39,7 +36,7 @@ public sealed class SidecarSessionCorrelationTests : TestKit
     public async Task TitleGenerator_carries_session_scoped_options()
     {
         var sessionId = new SessionId("ch/title-thread");
-        var captor = new OptionsCapturingChatClient();
+        var captor = new FakeChatClient();
 
         await SessionTitleGenerator.GenerateAsync(
             captor, sessionId, history: [], self: CreateTestProbe().Ref,
@@ -52,7 +49,7 @@ public sealed class SidecarSessionCorrelationTests : TestKit
     public async Task CompactionObserver_carries_session_scoped_options()
     {
         var sessionId = new SessionId("ch/compaction-thread");
-        var captor = new OptionsCapturingChatClient();
+        var captor = new FakeChatClient();
         var history = new List<SerializableChatMessage>
         {
             new() { Role = Netclaw.Actors.Protocol.ChatRole.User, Content = "hello" },
@@ -71,7 +68,7 @@ public sealed class SidecarSessionCorrelationTests : TestKit
     public async Task MemoryExtraction_carries_session_scoped_options()
     {
         var sessionId = new SessionId("ch/memory-extraction-thread");
-        var captor = new OptionsCapturingChatClient();
+        var captor = new FakeChatClient();
 
         await LlmSessionActor.InvokeMemoryExtractionCoreAsync(
             captor, sessionId, history: [], self: CreateTestProbe().Ref, timeout: TimeSpan.FromSeconds(5));
@@ -83,7 +80,7 @@ public sealed class SidecarSessionCorrelationTests : TestKit
     public async Task MemoryDistillation_carries_session_scoped_options()
     {
         var sessionId = new SessionId("ch/distillation-thread");
-        var captor = new OptionsCapturingChatClient();
+        var captor = new FakeChatClient();
 
         await SessionMemoryObserverActor.RunDistillationAsync(
             client: captor, sessionId: sessionId, turnCount: 5,
@@ -98,7 +95,7 @@ public sealed class SidecarSessionCorrelationTests : TestKit
     public async Task MemoryCuration_carries_session_scoped_options()
     {
         var sessionId = new SessionId("ch/curation-thread");
-        var captor = new OptionsCapturingChatClient();
+        var captor = new FakeChatClient();
         var operation = new SQLiteMemoryCurationOperation(
             Kind: "document",
             MemoryClass: "durable_fact",
@@ -126,48 +123,12 @@ public sealed class SidecarSessionCorrelationTests : TestKit
         AssertScopedTo(sessionId, captor);
     }
 
-    private static void AssertScopedTo(SessionId sessionId, OptionsCapturingChatClient captor)
+    private static void AssertScopedTo(SessionId sessionId, FakeChatClient captor)
     {
-        var scoped = Assert.IsType<SessionScopedChatOptions>(captor.CapturedOptions);
+        // FakeChatClient here is the Sessions-namespace fake (it is purpose-built for
+        // these pipeline paths); it records the options of every call, so the last entry
+        // is the most recent invocation the decorators scoped.
+        var scoped = Assert.IsType<SessionScopedChatOptions>(captor.ReceivedOptions[^1]);
         Assert.Equal(sessionId.Value, scoped.SessionId);
-    }
-
-    /// <summary>
-    /// IChatClient stub that records the <see cref="ChatOptions"/> it is invoked with — the
-    /// object the chat-client decorators read the session id from to open the routing scope.
-    /// </summary>
-    private sealed class OptionsCapturingChatClient : IChatClient
-    {
-        public ChatOptions? CapturedOptions { get; private set; }
-
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            CapturedOptions = options;
-            return Task.FromResult(new ChatResponse(new AiChatMessage(
-                AiChatRole.Assistant, (IList<AIContent>)[new TextContent("captured")])));
-        }
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            CapturedOptions = options;
-            return StreamAsync(cancellationToken);
-        }
-
-        private static async IAsyncEnumerable<ChatResponseUpdate> StreamAsync(
-            [EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            yield return new ChatResponseUpdate(AiChatRole.Assistant, "captured");
-            await Task.CompletedTask;
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-
-        public void Dispose() { }
     }
 }

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -19,6 +19,7 @@ using ApprovalOptionKeys = Netclaw.Actors.Protocol.ApprovalOptionKeys;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tests.Utilities;
+using FakeChatClient = Netclaw.Tests.Utilities.FakeChatClient;
 using Netclaw.Tools;
 using Xunit;
 using static Netclaw.Actors.SubAgents.SubAgentProtocol;
@@ -1175,7 +1176,7 @@ public class SubAgentActorTests : TestKit
     [Fact]
     public async Task LLM_failure_returns_failure()
     {
-        var throwingClient = new ThrowingChatClient();
+        var throwingClient = new FakeChatClient { Failure = new InvalidOperationException("LLM connection failed") };
         var definition = CreateDefinition();
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, throwingClient));
 
@@ -1355,131 +1356,9 @@ public class SubAgentActorTests : TestKit
         Assert.DoesNotContain("Context:", fakeClient.LastReceivedMessages[1].Text);
     }
 
-    /// <summary>
-    /// IChatClient that always throws on GetResponseAsync.
-    /// </summary>
-    private sealed class ThrowingChatClient : IChatClient
-    {
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => throw new InvalidOperationException("LLM connection failed");
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => throw new InvalidOperationException("LLM connection failed");
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-        public void Dispose() { }
-    }
-
     // Real PNG: the egress normalizer decodes every model-input image, so a
     // fake magic-byte stub would now be dropped. Small enough to pass through.
     private static readonly byte[] FakePngBytes = TestImages.SmallPng();
-}
-
-/// <summary>
-/// Fake IChatClient for SubAgentActor tests (and other test files that need it).
-/// Copied from LlmSessionIntegrationTests — kept internal for cross-file reuse.
-/// </summary>
-internal sealed class FakeChatClient : IChatClient
-{
-    private int _callCount;
-
-    public int CallCount => _callCount;
-
-    /// <summary>
-    /// Snapshot of the messages passed to the most recent call. Replaced on every call.
-    /// </summary>
-    public IReadOnlyList<ChatMessage>? LastReceivedMessages { get; private set; }
-
-    public TimeSpan Delay { get; set; } = TimeSpan.Zero;
-
-    /// <summary>
-    /// When set, the first response returns these tool calls instead of text.
-    /// Subsequent calls return normal text (simulating the LLM completing after tool results).
-    /// When <see cref="AlwaysReturnToolCalls"/> is true, every call returns tool calls
-    /// as long as tools are available in options.
-    /// </summary>
-    public List<FunctionCallContent>? ToolCallsOnFirstCall { get; set; }
-
-    /// <summary>
-    /// When true, every call returns tool calls as long as options.Tools is non-empty.
-    /// </summary>
-    public bool AlwaysReturnToolCalls { get; set; }
-
-    public string? ResponseText { get; set; }
-
-    public IReadOnlyList<string>? ResponseTextsByCall { get; set; }
-
-    /// <summary>
-    /// When set, every returned response carries these token counts as
-    /// <see cref="ChatResponse.Usage"/>. The streaming reader coalesces that back into
-    /// <c>response.Usage</c>, so a test can prove the sub-agent bills each LLM call's
-    /// tokens to <see cref="Netclaw.Actors.Telemetry.ISessionMetrics"/>.
-    /// </summary>
-    public UsageDetails? UsageOverride { get; set; }
-
-    public async Task<ChatResponse> GetResponseAsync(
-        IEnumerable<ChatMessage> messages,
-        ChatOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        Interlocked.Increment(ref _callCount);
-        LastReceivedMessages = messages.ToList();
-
-        if (Delay > TimeSpan.Zero)
-            await Task.Delay(Delay, cancellationToken);
-
-        if (ToolCallsOnFirstCall is not null)
-        {
-            var returnToolCalls = AlwaysReturnToolCalls
-                ? options?.Tools?.Count > 0
-                : _callCount == 1;
-
-            if (returnToolCalls)
-            {
-                var toolCallContents = new List<AIContent>(ToolCallsOnFirstCall);
-                var toolCallMessage = new ChatMessage(
-                    ChatRole.Assistant, toolCallContents);
-                return new ChatResponse(toolCallMessage) { Usage = UsageOverride };
-            }
-        }
-
-        var responseText = ResponseTextsByCall is { Count: > 0 } responses && _callCount <= responses.Count
-            ? responses[_callCount - 1]
-            : ResponseText ?? $"[fake] Response #{_callCount}";
-
-        var responseMessage = new ChatMessage(
-            ChatRole.Assistant,
-            [new TextContent(responseText)]);
-        return new ChatResponse(responseMessage) { Usage = UsageOverride };
-    }
-
-    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-        IEnumerable<ChatMessage> messages,
-        ChatOptions? options = null,
-        CancellationToken cancellationToken = default)
-        => CreateStreamingUpdatesAsync(messages, options, cancellationToken);
-
-    private async IAsyncEnumerable<ChatResponseUpdate> CreateStreamingUpdatesAsync(
-        IEnumerable<ChatMessage> messages,
-        ChatOptions? options,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        var response = await GetResponseAsync(messages, options, cancellationToken);
-        foreach (var update in response.ToChatResponseUpdates())
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return update;
-        }
-    }
-
-    public object? GetService(Type serviceType, object? serviceKey = null) => null;
-    public void Dispose() { }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.SubAgents;
 using Netclaw.Actors.Tests.Memory;
 using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
 using static Netclaw.Actors.SubAgents.SubAgentProtocol;

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
@@ -13,6 +13,7 @@ using Netclaw.Actors.Tests.Memory;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
+using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
 using static Netclaw.Actors.SubAgents.SubAgentProtocol;
@@ -35,7 +36,7 @@ public sealed class SubAgentSpawnerTests : TestKit
         toolRegistry.Register(new FakeNetclawTool("inspect_context", "ok"));
 
         var spawner = new SubAgentSpawner(
-            new SingleClientProvider(new NoOpChatClient()),
+            new SingleClientProvider(new FakeChatClient()),
             toolRegistry,
             new ToolAccessPolicy(
                 new ToolConfig(),
@@ -96,7 +97,7 @@ public sealed class SubAgentSpawnerTests : TestKit
         toolRegistry.Register(new FakeNetclawTool("inspect_context", "ok"));
 
         var spawner = new SubAgentSpawner(
-            new SingleClientProvider(new NoOpChatClient()),
+            new SingleClientProvider(new FakeChatClient()),
             toolRegistry,
             new ToolAccessPolicy(
                 new ToolConfig(),
@@ -211,29 +212,5 @@ public sealed class SubAgentSpawnerTests : TestKit
         // One text-only LLM call → exactly one usage record, carrying the fake's tokens.
         var call = Assert.Single(metrics.TokenUsageCalls);
         Assert.Equal((175L, 60L), call);
-    }
-
-    private sealed class NoOpChatClient : IChatClient
-    {
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "noop")));
-
-        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            await Task.CompletedTask;
-            yield break;
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -1114,32 +1114,8 @@ public class SkillToolTests : IDisposable
 
     private sealed class NoOpChatClientProvider : IChatClientProvider
     {
-        private readonly IChatClient _client = new NoOpChatClient();
+        private readonly IChatClient _client = new FakeChatClient();
 
         public IChatClient GetClient(ModelRole role) => _client;
-    }
-
-    private sealed class NoOpChatClient : IChatClient
-    {
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "noop")));
-
-        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            await Task.CompletedTask;
-            yield break;
-        }
-
-        public object? GetService(Type serviceType, object? serviceKey = null) => null;
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/src/Netclaw.Tests.Utilities/FakeChatClient.cs
+++ b/src/Netclaw.Tests.Utilities/FakeChatClient.cs
@@ -1,0 +1,134 @@
+// -----------------------------------------------------------------------
+// <copyright file="FakeChatClient.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Tests.Utilities;
+
+/// <summary>
+/// A configurable, thread-safe fake <see cref="IChatClient"/> for tests that need to
+/// capture what was sent and/or script what comes back. It covers the "capture and/or
+/// return canned output" needs that were previously spread across a dozen near-identical
+/// one-off fakes (option/message/image/context capturers, scripted-response fakes,
+/// no-ops, and the sub-agent's <c>FakeChatClient</c> copy).
+///
+/// Streaming is intentionally trivial: it runs <see cref="GetResponseAsync"/> and replays
+/// the result via <see cref="ChatResponseExtensions.ToChatResponseUpdates"/>, which also
+/// surfaces <see cref="ChatResponse.Usage"/> as a streamed <c>UsageContent</c>. Tests that
+/// assert on a *specific streaming shape* (parked/hanging/gated streams, mid-stream delta
+/// timing, or a synchronous throw whose timing is load-bearing) are deliberately NOT served
+/// by this type — those keep their own small bespoke fakes, because the stream shape is the
+/// thing under test and a flag on a general fake would read worse, not better.
+/// </summary>
+public sealed class FakeChatClient : IChatClient
+{
+    private readonly object _gate = new();
+    private readonly List<IReadOnlyList<ChatMessage>> _receivedMessagesByCall = [];
+    private int _callCount;
+
+    /// <summary>Number of times a response has been requested (either path).</summary>
+    public int CallCount => Volatile.Read(ref _callCount);
+
+    /// <summary>Snapshot of the messages passed to the most recent call.</summary>
+    public IReadOnlyList<ChatMessage>? LastReceivedMessages { get; private set; }
+
+    /// <summary>The <see cref="ChatOptions"/> passed to the most recent call.</summary>
+    public ChatOptions? LastReceivedOptions { get; private set; }
+
+    /// <summary>Snapshot of the messages passed to every call, in order.</summary>
+    public IReadOnlyList<IReadOnlyList<ChatMessage>> ReceivedMessagesByCall
+    {
+        get { lock (_gate) { return _receivedMessagesByCall.ToArray(); } }
+    }
+
+    /// <summary>When &gt; 0, the response is delayed by this amount (success path only).</summary>
+    public TimeSpan Delay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>When set, every call throws this exception instead of returning a response.</summary>
+    public Exception? Failure { get; set; }
+
+    /// <summary>Default response text when no per-call text applies. Defaults to a marker.</summary>
+    public string? ResponseText { get; set; }
+
+    /// <summary>Per-call response text, indexed by (1-based) call number.</summary>
+    public IReadOnlyList<string>? ResponseTextsByCall { get; set; }
+
+    /// <summary>
+    /// When set, a qualifying call returns these tool calls instead of text.
+    /// By default only the first call qualifies; see <see cref="AlwaysReturnToolCalls"/>.
+    /// </summary>
+    public List<FunctionCallContent>? ToolCallsOnFirstCall { get; set; }
+
+    /// <summary>When true, every call with tools available returns the tool calls.</summary>
+    public bool AlwaysReturnToolCalls { get; set; }
+
+    /// <summary>When set, every returned response carries these token counts as <see cref="ChatResponse.Usage"/>.</summary>
+    public UsageDetails? UsageOverride { get; set; }
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _callCount);
+        var snapshot = messages.ToList();
+        lock (_gate)
+        {
+            LastReceivedMessages = snapshot;
+            LastReceivedOptions = options;
+            _receivedMessagesByCall.Add(snapshot);
+        }
+
+        if (Failure is not null)
+            throw Failure;
+
+        if (Delay > TimeSpan.Zero)
+            await Task.Delay(Delay, cancellationToken);
+
+        if (ToolCallsOnFirstCall is not null)
+        {
+            var returnToolCalls = AlwaysReturnToolCalls
+                ? options?.Tools?.Count > 0
+                : CallCount == 1;
+
+            if (returnToolCalls)
+            {
+                var toolCallMessage = new ChatMessage(
+                    ChatRole.Assistant, new List<AIContent>(ToolCallsOnFirstCall));
+                return new ChatResponse(toolCallMessage) { Usage = UsageOverride };
+            }
+        }
+
+        var responseText = ResponseTextsByCall is { Count: > 0 } responses && CallCount <= responses.Count
+            ? responses[CallCount - 1]
+            : ResponseText ?? $"[fake] Response #{CallCount}";
+
+        var responseMessage = new ChatMessage(ChatRole.Assistant, [new TextContent(responseText)]);
+        return new ChatResponse(responseMessage) { Usage = UsageOverride };
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => CreateStreamingUpdatesAsync(messages, options, cancellationToken);
+
+    private async IAsyncEnumerable<ChatResponseUpdate> CreateStreamingUpdatesAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var response = await GetResponseAsync(messages, options, cancellationToken);
+        foreach (var update in response.ToChatResponseUpdates())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return update;
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose() { }
+}

--- a/src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj
+++ b/src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <!-- Windows + macOS native assets come transitively from the base SkiaSharp package
          (it depends on NativeAssets.Win32 / NativeAssets.macOS). Desktop Linux is the only


### PR DESCRIPTION
Addresses #1599. Follow-up to #1600 (which had to re-add a `UsageOverride` hook to the sub-agent's own `FakeChatClient` copy because it couldn't reuse the Sessions one).

## What

Introduces one configurable **`Netclaw.Tests.Utilities.FakeChatClient`** — captures messages/options (`LastReceivedMessages`, `LastReceivedOptions`, `ReceivedMessagesByCall`, `CallCount`), scripts responses (`ResponseText`, `ResponseTextsByCall`, `ToolCallsOnFirstCall`, `AlwaysReturnToolCalls`), and supports per-call `UsageOverride`, `Delay`, and `Failure`. Streaming is trivial (replays `GetResponseAsync` via `ToChatResponseUpdates`, which also surfaces `Usage`).

Migrates the near-identical one-off fakes onto it and **deletes ~9 duplicate/near-duplicate classes**:

| Area | Deleted |
|------|---------|
| SubAgents | copied `FakeChatClient`, `ThrowingChatClient` |
| Channels | `ImageCapturingChatClient` (Slack + Discord), `RecordingChatClient`, `ContextCapturingChatClient` |
| Sessions | `OptionsCapturingChatClient` (Sidecar now uses the purpose-built Sessions fake, which already records options) |
| Memory | `ScriptedCurationChatClient` (evaluator-parity tests) |
| Tools | the `NoOpChatClient` copy |

**Net −272 lines.**

## What is deliberately NOT consolidated

Per the "don't build a god-object fake" line:

- **Streaming/failure simulators stay bespoke** — the precise stream shape or failure *timing* is the thing under test, so a small dedicated class reads clearer than a flag on a general fake: `FailingChatClient`, `HangingStreamingChatClient`, `ControlledStreamingChatClient`, `StreamingTimeoutTestChatClient`, `ParkingChatClient`, `SequencedToolCallChatClient`.
- **The rich Sessions `FakeChatClient`** (327 lines, domain-specific recall-planning/summarizer branching, used across ~10 files) stays put — folding it into a shared util would drag Sessions domain logic in.
- **The Daemon delegate-based `FakeChatClient`** stays (separate assembly, already a flexible design).

## Not in scope on `dev`

The `RecordingCurationChatClient` and the second `ScriptedCurationChatClient` referenced in #1599 live in three Memory-redesign test files that don't exist on `dev` yet (they're on the unmerged memory-embeddings line). They'll adopt the shared fake when that work lands.

## Validation

- Full `Netclaw.Actors.Tests`: **2551 passed, 0 failed**. `Netclaw.Daemon.Tests` builds clean (verifies the `Microsoft.Extensions.AI.Abstractions` package ref added to `Netclaw.Tests.Utilities` ripples safely).
- `dotnet slopwatch analyze`: **0 issues**. Copyright headers: all present.
