### PR TITLE
fix(release): extract only the latest RELEASE_NOTES section for the GitHub release body

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         $content = Get-Content RELEASE_NOTES.md -Raw
         # Match from the first #### heading to just before the second one
-        if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+        if ($content -match '(?s)(## \d.+?)(?=\n## \d|\z)') {
           $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
         } else {
           $content | Set-Content RELEASE_NOTES_LATEST.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ prerelease — or the workflow's version gate fails the release.
 
 1. Bump `<VersionPrefix>` in `Directory.Build.props` (e.g. `0.22.1` → `0.22.2`); leave
    `<VersionSuffix>` empty.
-2. Add a release-notes section to `RELEASE_NOTES.md` (`#### X.Y.Z YYYY-MM-DD ####`).
+2. Add a release-notes section to `RELEASE_NOTES.md` (`## X.Y.Z (YYYY-MM-DD)`).
 3. Commit, then tag and push the bare version:
    ```bash
    git tag 0.22.2 && git push origin 0.22.2


### PR DESCRIPTION
## Summary
- The "Extract latest release notes" step in `.github/workflows/publish_release_binaries.yml` used a regex expecting `####` headings (`(?s)(####.+?)(?=\n####|\z)`), but `RELEASE_NOTES.md` actually uses `## X.Y.Z (YYYY-MM-DD)` headings. The regex never matched, so the `else` branch fired and dumped the **entire** `RELEASE_NOTES.md` (every historical version) into `RELEASE_NOTES_LATEST.md`, which became the GitHub release body.
- This happened on the `0.25.0-beta.1` and `0.25.0-beta.2` releases — both release bodies contain the full changelog history instead of just their own section.
- Fix: change the regex to match the real heading format — `'(?s)(## \d.+?)(?=\n## \d|\z)'` — capturing from a `## <digit>...` heading up to (but not including) the next one, or end of file.
- Also corrected `CONTRIBUTING.md`'s Releasing section, which documented the heading format as `#### X.Y.Z YYYY-MM-DD ####` instead of the actual `## X.Y.Z (YYYY-MM-DD)` format used in `RELEASE_NOTES.md`.

## Verification
Ran the equivalent Python regex against the current `RELEASE_NOTES.md` (Python's `\Z` ≈ PowerShell/.NET `\z` here):

```bash
python3 -c "import re,sys; c=open('RELEASE_NOTES.md').read(); m=re.search(r'(?s)(## \d.+?)(?=\n## \d|\Z)', c); print(m.group(1).strip() if m else 'NO MATCH')"
```

Output starts with `## 0.25.0-beta.2 (2026-07-07)` and stops before `## 0.25.0-beta.1` / `## 0.24.4` — confirming only the latest section is extracted.

## Test plan
- [x] Verified the corrected regex extracts only the latest `RELEASE_NOTES.md` section (see above)
- [ ] Next tag push will exercise the real workflow end-to-end and confirm the GitHub release body only contains the current version's notes