### PR TITLE
fix(memory): relevance-gate cold-start — keep-warm ticks, envelope-derived gate budget (canary finding)

### DIFF
--- a/docs/runbooks/memory-health-and-evals.md
+++ b/docs/runbooks/memory-health-and-evals.md
@@ -141,25 +141,34 @@ netclaw doctor
      enabled; otherwise provision manually and restart.
 
 2. Check the degradation log line. When the gate is skipped for a turn
-   (model unavailable, its ~60 ms sub-budget exceeded, or recall running in
-   lexical mode because there's no query vector), the coordinator logs a
-   rate-limited marker instead of silently changing what gets injected:
+   (model unavailable, its sub-budget exceeded — a 120 ms ceiling clamped to
+   whatever remains of the outer 300 ms `Memory.RecallTimeoutMs` envelope, so
+   a turn where earlier stages already ran long gets less than 120 ms; raised
+   from a fixed 60 ms by a 2026-07 production-canary finding of cold-start
+   timeouts — or recall running in lexical mode because there's no query
+   vector), the coordinator logs a rate-limited marker instead of silently
+   changing what gets injected:
 
 ```
-memory_recall_gate_degraded session=<id> reason=<reason>
+memory_recall_gate_degraded session=<id> reason=<reason> elapsedMs=<ms>
 ```
 
    `reason` is one of `gate_disabled_by_config`, `no_scorer_configured`,
    `scorer_unavailable`, `sub_budget_exceeded`, or `score_failed:<ExceptionType>`.
-   Logged at `Warning` when the gate is enabled but a turn still degraded (a
-   genuine runtime condition worth noticing); logged at `Debug` when the gate
-   is off by config (the default, intentional state — not spam). Rate-limited
-   per-reason with the same cooldown as `memory_recall_vector_degraded`, so
-   expect at most one `Warning` line per reason per cooldown window even
-   under sustained degradation, not one per turn.
+   `elapsedMs` is 0 for the first three (no scoring attempt ever started) and
+   the measured time spent before degrading for the latter two — useful for
+   telling a genuine cold-start/contention timeout apart from an instant
+   failure. Logged at `Warning` when the gate is enabled but a turn still
+   degraded (a genuine runtime condition worth noticing); logged at `Debug`
+   when the gate is off by config (the default, intentional state — not
+   spam). Rate-limited per-reason with the same cooldown as
+   `memory_recall_vector_degraded`, so expect at most one `Warning` line per
+   reason per cooldown window even under sustained degradation, not one per
+   turn.
 
-3. Read `gateScores`/`droppedByGate` on `memory_retrieval_final` when
-   diagnosing over- or under-injection:
+3. Read `gateScores`/`droppedByGate`/`gateElapsedMs` on `memory_retrieval_final`
+   when diagnosing over- or under-injection or quantifying gate latency
+   margin against the 120 ms ceiling:
 
 ```bash
 grep memory_retrieval_final "$HOME/.netclaw/logs/daemon-$(date +%F).log" | tail -20

--- a/openspec/changes/memory-relevance-gate/design.md
+++ b/openspec/changes/memory-relevance-gate/design.md
@@ -224,10 +224,13 @@ vector was available): the floor already reduced the candidate set to
 candidate-generation protocol — the gate never sees a candidate the floor
 would not already have admitted). Each survivor is paired with the query and
 scored via `RelevanceScorerHolder.Current.ScoreAsync`, under a CE sub-budget
-(~60 ms) nested inside the overall `RecallTimeoutMs` via a linked
+(ceiling 120 ms, envelope-clamped — raised from 60 ms and clamped to
+whatever remains of the outer envelope by a 2026-07 production-canary
+finding: two live cold-start timeouts, see the Open Questions entry below)
+nested inside the overall `RecallTimeoutMs` via a linked
 `CancellationTokenSource` — the same pattern the query-embedding sub-budget
 already uses (measured p95 35 ms for 3 pairs leaves roughly 1.7x headroom
-before the sub-budget itself is hit). Candidates scoring below the
+before the sub-budget itself is hit on a warm session). Candidates scoring below the
 manifest/config threshold are dropped; **zero survivors after the gate is a
 "nothing injected" outcome**, identical in kind to zero survivors at the
 floor — the `[memory-recall]` block continues to be omitted entirely, not
@@ -327,15 +330,25 @@ selectivity without one of these signals firing.
   (397 MB), the operator's measured total is ≈763 MB against a 1 GB K8s pod
   limit — inside budget, but the margin (≈260 MB) is not so large that a
   future addition to the memory runtime gets it for free. Mitigated by
-  measuring rather than assuming, and by keeping the CE sub-budget (~60 ms)
-  small relative to the overall 300 ms recall timeout so a degraded gate
-  never risks the turn itself.
-- [Nested sub-budgets: query-embedding (~150 ms) + gate (~60 ms) inside one
-  300 ms `RecallTimeoutMs`] → worst case both sub-budgets fully elapse
-  (210 ms) before any lexical/ranking work runs, leaving less slack than
-  Slice 4 alone had. Not yet measured end-to-end under production
-  contention. Flagged as an open question (below), not silently assumed
-  safe.
+  measuring rather than assuming, and by keeping the CE sub-budget
+  (120 ms ceiling, envelope-clamped) small relative to the overall 300 ms
+  recall timeout so a degraded gate never risks the turn itself.
+- [Nested sub-budgets: query-embedding (~150 ms) + gate (120 ms ceiling,
+  envelope-clamped) inside one 300 ms `RecallTimeoutMs`] → worst case both
+  sub-budgets fully elapse before any lexical/ranking work runs, leaving less
+  slack than Slice 4 alone had. **2026-07 production-canary update: this
+  materialized.** Two live `memory_recall_gate_degraded` events (reason
+  `score_failed:TaskCanceledException`) in scheduled-reminder sessions waking
+  from an idle period measured total turn latency already past the entire
+  300 ms envelope by the time the gate started scoring — a cold ONNX session
+  (paged-out weights) plus host contention, not a per-call latency
+  regression. Fix landed as (1) a periodic keep-warm tick in
+  `EmbeddingWarmupHostedService` keeping both ONNX sessions' working sets
+  resident, and (2) raising the gate ceiling to 120 ms while clamping the
+  actually-applied sub-budget to whatever remains of the outer envelope (the
+  linked CTS was already the hard cap; this just derives the sub-budget from
+  it instead of assuming a fixed value is always affordable). The Open
+  Questions entry below is resolved by this same finding.
 - [Two-holders-become-three] → `MemoryEmbedderHolder` +
   `MemoryVectorIndexHolder` + the new `RelevanceScorerHolder` is more moving
   parts than a consolidated holder would be. Accepted for this change (D4)
@@ -431,12 +444,16 @@ scorecard, the frozen threshold, the pinned model SHA-256) enter the repo.
 
 ## Open Questions
 
-- Combined worst-case latency of the query-embedding sub-budget (~150 ms)
+- ~~Combined worst-case latency of the query-embedding sub-budget (~150 ms)
   plus the new CE sub-budget (~60 ms) inside the single 300 ms
   `RecallTimeoutMs`, measured end-to-end under realistic contention rather
-  than each sub-budget's own isolated measurement — gates this change's
-  sub-budget sizing the same way Slice 4 gated its own latency assumption
-  before shipping.
+  than each sub-budget's own isolated measurement.~~ **Resolved by the
+  2026-07 production-canary finding**: it materialized under real cold-start
+  contention (two live `score_failed:TaskCanceledException` degradations,
+  reminder sessions waking from idle). Fix: `EmbeddingWarmupHostedService`
+  keep-warm tick (keeps both ONNX sessions resident) + gate sub-budget
+  raised to a 120 ms ceiling, clamped to whatever remains of the outer
+  envelope rather than a fixed value.
 - Whether the deferred R2-mirroring decision for the embedding model artifact
   (memory-core-redesign, post-PoC) should extend to this second (relevance)
   model artifact once that decision is made.

--- a/src/Netclaw.Actors.Tests/Sessions/SQLiteMemoryRecallGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SQLiteMemoryRecallGateTests.cs
@@ -160,9 +160,10 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         await _store.InitializeAsync(ct);
         await SeedFloorSurvivingDocumentAsync("doc-timeout", ct);
 
-        // Never completes on its own; only the coordinator's ~60ms sub-budget CTS can cancel it.
-        // Task.Delay inside a fake is the sanctioned way to simulate latency deterministically —
-        // no Thread.Sleep/Task.Delay appears in this test's own orchestration.
+        // Never completes on its own; only the coordinator's envelope-clamped sub-budget CTS
+        // (ceiling 120ms, default 300ms RecallTimeoutMs here so the ceiling itself governs) can
+        // cancel it. Task.Delay inside a fake is the sanctioned way to simulate latency
+        // deterministically — no Thread.Sleep/Task.Delay appears in this test's own orchestration.
         var scorer = new HangingRelevanceScorer(RelevanceModelId);
         var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer));
 
@@ -170,6 +171,49 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
 
         Assert.False(result.Degraded);
         Assert.Contains(result.Items, i => i.Id.Value == "doc-timeout");
+    }
+
+    // ── Envelope-derived sub-budget (2026-07 production-canary fix, task 3) ────
+
+    [Fact]
+    public async Task Gate_sub_budget_is_capped_by_the_remaining_outer_envelope_not_just_the_ceiling()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedFloorSurvivingDocumentAsync("doc-envelope-exhausted", ct);
+
+        // A real 50ms delay comfortably UNDER the 120ms gate-sub-budget ceiling -- if the fixed
+        // ceiling alone governed the gate's CTS, this scorer would complete in time and its
+        // (rejecting) score would apply. An almost-zero outer RecallTimeoutMs forces the
+        // envelope-derived clamp to hand the gate far less than 120ms instead, so the scorer gets
+        // cancelled and the turn degrades to the floor's unfiltered result.
+        var scorer = new DelayedRelevanceScorer(RelevanceModelId, TimeSpan.FromMilliseconds(50), score: 0.0);
+        var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer), recallTimeoutMs: 1);
+
+        var result = await coordinator.RecallAsync(BuildRequest("gate/envelope-exhausted"), ct);
+
+        Assert.False(result.Degraded);
+        Assert.Contains(result.Items, i => i.Id.Value == "doc-envelope-exhausted");
+    }
+
+    [Fact]
+    public async Task Gate_runs_to_completion_when_the_outer_envelope_still_has_headroom()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _store.InitializeAsync(ct);
+        await SeedFloorSurvivingDocumentAsync("doc-envelope-headroom", ct);
+
+        // Same 50ms real delay and same rejecting score as the test above -- the only difference
+        // is a generous outer envelope. Proves the previous test's degradation was caused by the
+        // exhausted envelope specifically, not merely by the fake being slow: with headroom, the
+        // gate runs to completion and its score is honored (candidate dropped, not degraded).
+        var scorer = new DelayedRelevanceScorer(RelevanceModelId, TimeSpan.FromMilliseconds(50), score: 0.0);
+        var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer), recallTimeoutMs: 5000);
+
+        var result = await coordinator.RecallAsync(BuildRequest("gate/envelope-headroom"), ct);
+
+        Assert.False(result.Degraded);
+        Assert.DoesNotContain(result.Items, i => i.Id.Value == "doc-envelope-headroom");
     }
 
     [Fact]
@@ -342,12 +386,14 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         bool embeddingsEnabled = true,
         bool? relevanceGateEnabled = null,
         double? thresholdOverride = null,
-        ILogger<SQLiteMemoryRecallCoordinator>? logger = null)
+        ILogger<SQLiteMemoryRecallCoordinator>? logger = null,
+        int recallTimeoutMs = 300)
         => new(
             _store,
             logger ?? NullLogger<SQLiteMemoryRecallCoordinator>.Instance,
             new MemoryConfig
             {
+                RecallTimeoutMs = recallTimeoutMs,
                 Embeddings = new MemoryEmbeddingsConfig { Enabled = embeddingsEnabled },
                 Recall = new MemoryRecallConfig
                 {
@@ -463,6 +509,29 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Fake relevance scorer that completes after a fixed, finite real-wall-clock delay (2026-07
+    /// production-canary envelope-derived-budget tests) rather than hanging forever like
+    /// <see cref="HangingRelevanceScorer"/> — this file's own copy of a "slow but not infinite"
+    /// fake, needed to prove the gate's sub-budget is actually smaller than the fixed
+    /// <c>RelevanceGateSubBudgetMs</c> ceiling when the outer envelope is nearly exhausted. The
+    /// delay itself is real (Task.Delay inside the fake, not this test's own orchestration) — the
+    /// sanctioned way to simulate latency deterministically per this repo's testing guidelines.
+    /// </summary>
+    private sealed class DelayedRelevanceScorer(string modelId, TimeSpan delay, double score) : IRelevanceScorer
+    {
+        public string ModelId => modelId;
+
+        public bool IsAvailable => true;
+
+        [SlopwatchSuppress("SW004", "Intentional latency simulation inside a fake (never in test orchestration) -- proves the envelope-derived sub-budget clamp actually cancels a scorer that would otherwise complete within the fixed 120ms ceiling.")]
+        public async ValueTask<IReadOnlyList<double>> ScoreAsync(string query, IReadOnlyList<string> candidates, CancellationToken ct)
+        {
+            await Task.Delay(delay, ct);
+            return candidates.Select(_ => score).ToArray();
+        }
+    }
+
     /// <summary>Records every (level, message) pair logged through the generic ILogger ctor seam.</summary>
     private sealed class RecordingLogger<T> : ILogger<T>
     {
@@ -477,4 +546,24 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
             Func<TState, Exception?, string> formatter)
             => Entries.Add((logLevel, formatter(state, exception)));
     }
+}
+
+/// <summary>
+/// Lightweight stand-in for Slopwatch's suppression attribute (mirrors
+/// <c>samples/Netclaw.Demo.AppHost.IntegrationTests/DemoEndToEndSmokeTests.cs</c>'s own copy) so
+/// this project can build without taking a hard dependency on the slopwatch tooling. Slopwatch
+/// reads the attribute name as text via the source file, so an internal definition with matching
+/// shape is enough.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Constructor, AllowMultiple = true)]
+internal sealed class SlopwatchSuppressAttribute : Attribute
+{
+    public SlopwatchSuppressAttribute(string ruleId, string reason)
+    {
+        RuleId = ruleId;
+        Reason = reason;
+    }
+
+    public string RuleId { get; }
+    public string Reason { get; }
 }

--- a/src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs
+++ b/src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs
@@ -80,7 +80,9 @@ namespace Netclaw.Actors.Sessions;
 /// <b>Post-floor relevance gate (memory-relevance-gate, design D5/D6/D8):</b> in hybrid mode
 /// only, once <see cref="ScoreHybrid"/> produces its floor survivors, a tiny cross-encoder
 /// (<c>relevanceScorerHolder</c>) scores each of the top <c>AutoRecallMaxItems</c> survivors
-/// jointly against the query — under its own <see cref="RelevanceGateSubBudgetMs"/> sub-budget,
+/// jointly against the query — under a sub-budget capped at <see cref="RelevanceGateSubBudgetMs"/>
+/// but never larger than whatever remains of the caller's outer <c>RecallTimeoutMs</c> envelope
+/// (2026-07 production-canary finding; see <see cref="RelevanceGateSubBudgetMs"/>'s remarks),
 /// linked-CTS-nested exactly like the query-embedding sub-budget above — and drops anything
 /// below the active threshold (<see cref="MemoryRelevanceGateConfig.Threshold"/> if set,
 /// otherwise the scorer's manifest-carried <see cref="RelevanceScorerHolder.CalibratedThreshold"/>).
@@ -107,6 +109,13 @@ public sealed class SQLiteMemoryRecallCoordinator(
 {
     private readonly SessionTuning _sessionTuning = sessionTuning ?? new SessionTuning();
     private readonly MemoryRecallConfig _recallConfig = memoryConfig.Recall;
+
+    // Outer recall envelope (memory-relevance-gate 2026-07 canary fix): read once at
+    // construction, same lifecycle assumption as every other Memory.* setting. Used to derive the
+    // relevance gate's ACTUAL sub-budget from how much of the envelope is left when the gate
+    // stage is reached, not just the fixed RelevanceGateSubBudgetMs ceiling — see that constant's
+    // remarks.
+    private readonly int _recallTimeoutMs = memoryConfig.RecallTimeoutMs;
 
     // memory-query-prefix design D3: null (default) follows the active embedder's
     // manifest-carried calibration (embedderHolder.CalibratedMinCosineSimilarity, resolved per
@@ -182,14 +191,40 @@ public sealed class SQLiteMemoryRecallCoordinator(
     private const int VectorEmbedSubBudgetMs = 150;
 
     /// <summary>
-    /// Sub-budget, in milliseconds, for the per-turn cross-encoder relevance-gate scoring call
-    /// (memory-relevance-gate design D5), applied via a CTS linked to (nested inside) the
+    /// Sub-budget CEILING, in milliseconds, for the per-turn cross-encoder relevance-gate scoring
+    /// call (memory-relevance-gate design D5), applied via a CTS linked to (nested inside) the
     /// caller's overall recall <c>ct</c> — the same nesting pattern as
     /// <see cref="VectorEmbedSubBudgetMs"/>. Not a config knob: design D5 measured ~11ms p50 /
-    /// ~35ms p95 to score 3 pairs (quantized int8) on the reference CPU, so 60ms leaves roughly
-    /// 1.7x headroom before the sub-budget itself is hit.
+    /// ~35ms p95 to score 3 pairs (quantized int8) on the reference CPU, so this leaves headroom
+    /// before the sub-budget itself is hit under normal (warm) conditions.
+    ///
+    /// <para>
+    /// <b>This is a CEILING, not the sub-budget actually applied.</b> <see cref="TryApplyRelevanceGateAsync"/>
+    /// clamps the real sub-budget to <c>min(RelevanceGateSubBudgetMs, time remaining in the
+    /// caller's outer <see cref="MemoryConfig.RecallTimeoutMs"/> envelope)</c> before calling
+    /// <c>CancelAfter</c> — the outer linked CTS is already the hard cap on the whole turn, so
+    /// this clamp can never let the gate blow past it: on a turn where earlier stages (query
+    /// embed, hybrid fusion) already consumed most of the envelope, the gate gets whatever sliver
+    /// is left (possibly far less than this ceiling, possibly ~0 which degrades immediately),
+    /// never more than the ceiling on a turn with headroom to spare.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>2026-07 production-canary finding (raised from 60ms):</b> two live
+    /// <c>memory_recall_gate_degraded</c> events (reason <c>score_failed:TaskCanceledException</c>)
+    /// both fired in scheduled-reminder sessions waking from an idle period, on a VM host. Log
+    /// timestamps showed total turn latency (plan → candidate selection → query embed → hybrid
+    /// fusion → gate) already past the entire 300ms <c>RecallTimeoutMs</c> envelope by the time
+    /// the gate reached its own scoring call — a cold ONNX session (paged-out weights after the
+    /// idle gap) plus host CPU contention at reminder-fire time, not a per-call latency
+    /// regression against design D5's reference-box measurement, which still held. The paired fix
+    /// is <see cref="Netclaw.Daemon.Services.EmbeddingWarmupHostedService"/>'s periodic keep-warm
+    /// tick (keeps both ONNX sessions' working sets resident across idle gaps) plus this raised,
+    /// envelope-clamped ceiling — more headroom on a turn that still has budget left, without
+    /// ever exceeding the hard 300ms cap.
+    /// </para>
     /// </summary>
-    private const int RelevanceGateSubBudgetMs = 60;
+    private const int RelevanceGateSubBudgetMs = 120;
 
     /// <summary>Shared empty instance for turns where the gate never ran (disabled, degraded, or lexical mode).</summary>
     private static readonly IReadOnlyDictionary<string, double> EmptyGateScores = new Dictionary<string, double>(0, StringComparer.Ordinal);
@@ -244,6 +279,12 @@ public sealed class SQLiteMemoryRecallCoordinator(
 
     public async Task<AutomaticRecallResult> RecallAsync(AutomaticRecallRequest request, CancellationToken ct = default)
     {
+        // Turn-start timestamp (memory-relevance-gate 2026-07 canary fix): approximates when the
+        // caller's own outer RecallTimeoutMs-bounded CTS started (SessionRecallManager creates it
+        // immediately before calling RecallAsync), so the relevance gate can later derive how much
+        // of that envelope is actually left rather than assuming a fixed sub-budget is always
+        // affordable. TimeProvider-based so tests can virtualize it.
+        var turnStartedAtTs = timeProvider.GetTimestamp();
         try
         {
             if (_sessionTuning.DeterministicRetrievalEnabled)
@@ -345,14 +386,20 @@ public sealed class SQLiteMemoryRecallCoordinator(
                 var gated = aboveFloor;
                 var droppedByGate = 0;
                 IReadOnlyDictionary<string, double> gateScores = EmptyGateScores;
+                var gateElapsedMs = 0.0;
                 if (mode == "hybrid" && aboveFloor.Length > 0)
                 {
-                    var gateOutcome = await TryApplyRelevanceGateAsync(request, aboveFloor, deterministicMaxItems, ct);
-                    if (gateOutcome is { } outcome)
+                    // Envelope-derived sub-budget (memory-relevance-gate 2026-07 canary fix): the
+                    // gate never gets more than what's actually left of the caller's outer
+                    // RecallTimeoutMs envelope — see RelevanceGateSubBudgetMs's remarks.
+                    var remainingEnvelope = TimeSpan.FromMilliseconds(_recallTimeoutMs) - timeProvider.GetElapsedTime(turnStartedAtTs);
+                    var gateOutcome = await TryApplyRelevanceGateAsync(request, aboveFloor, deterministicMaxItems, remainingEnvelope, ct);
+                    gateElapsedMs = gateOutcome.ElapsedMs;
+                    if (gateOutcome.Applied)
                     {
-                        gated = outcome.Survivors;
-                        gateScores = outcome.Scores;
-                        droppedByGate = outcome.Dropped;
+                        gated = gateOutcome.Survivors;
+                        gateScores = gateOutcome.Scores;
+                        droppedByGate = gateOutcome.Dropped;
                     }
                 }
 
@@ -387,7 +434,7 @@ public sealed class SQLiteMemoryRecallCoordinator(
                 var deterministicItems = budgeted.ToArray();
 
                 logger.LogInformation(
-                    "memory_retrieval_final session={SessionId} mode={Mode} injectedCount={InjectedCount} filteredByFloor={FilteredByFloor} appliedFloor={AppliedFloor:F3} floorSource={FloorSource} injectedChars={InjectedChars} droppedByBudget={DroppedByBudget} droppedByGate={DroppedByGate} gateScores={GateScores} items={Items}",
+                    "memory_retrieval_final session={SessionId} mode={Mode} injectedCount={InjectedCount} filteredByFloor={FilteredByFloor} appliedFloor={AppliedFloor:F3} floorSource={FloorSource} injectedChars={InjectedChars} droppedByBudget={DroppedByBudget} droppedByGate={DroppedByGate} gateElapsedMs={GateElapsedMs:F1} gateScores={GateScores} items={Items}",
                     request.SessionId,
                     mode,
                     deterministicItems.Length,
@@ -397,6 +444,7 @@ public sealed class SQLiteMemoryRecallCoordinator(
                     injectedChars,
                     droppedByBudget,
                     droppedByGate,
+                    gateElapsedMs,
                     string.Join("|", gateScores.Select(kv => $"{kv.Key}={kv.Value:F3}")),
                     string.Join("|", deterministicItems.Select(i => $"{i.Id.Value}=score{i.Score:F3}")));
 
@@ -525,58 +573,71 @@ public sealed class SQLiteMemoryRecallCoordinator(
     /// <paramref name="maxItems"/>).
     ///
     /// <para>
-    /// Returns null for every degradation reason — gate disabled by config, no scorer configured,
-    /// scorer unavailable, sub-budget exceeded, or the scoring call itself throwing — mirroring
-    /// <see cref="TryEmbedQueryAsync"/>'s "never throws, null means skip" contract exactly.
-    /// Callers treat null as "inject the floor's own result unfiltered," identically regardless of
-    /// which reason produced it.
+    /// Returns a not-applied <see cref="RelevanceGateOutcome"/> for every degradation reason —
+    /// gate disabled by config, no scorer configured, scorer unavailable, sub-budget exceeded, or
+    /// the scoring call itself throwing — mirroring <see cref="TryEmbedQueryAsync"/>'s "never
+    /// throws" contract exactly. Callers treat <see cref="RelevanceGateOutcome.Applied"/> false as
+    /// "inject the floor's own result unfiltered," identically regardless of which reason produced
+    /// it, while <see cref="RelevanceGateOutcome.ElapsedMs"/> still reports whatever time WAS
+    /// spent (2026-07 canary observability follow-up: <c>memory_retrieval_final</c> logs this
+    /// unconditionally so soak data can quantify margins even on a degraded turn).
     /// </para>
     /// </summary>
-    private async Task<(RankedCandidate[] Survivors, IReadOnlyDictionary<string, double> Scores, int Dropped)?> TryApplyRelevanceGateAsync(
-        AutomaticRecallRequest request, RankedCandidate[] aboveFloor, int maxItems, CancellationToken ct)
+    private async Task<RelevanceGateOutcome> TryApplyRelevanceGateAsync(
+        AutomaticRecallRequest request, RankedCandidate[] aboveFloor, int maxItems, TimeSpan remainingEnvelope, CancellationToken ct)
     {
         if (!_relevanceGateEnabledByConfig)
         {
             LogGateDegraded(request.SessionId.Value, "gate_disabled_by_config");
-            return null;
+            return RelevanceGateOutcome.NotApplied;
         }
 
         var scorer = relevanceScorerHolder?.Current;
         if (scorer is null)
         {
             LogGateDegraded(request.SessionId.Value, "no_scorer_configured");
-            return null;
+            return RelevanceGateOutcome.NotApplied;
         }
 
         if (!scorer.IsAvailable)
         {
             LogGateDegraded(request.SessionId.Value, "scorer_unavailable");
-            return null;
+            return RelevanceGateOutcome.NotApplied;
         }
 
         var candidatesToScore = aboveFloor.Length > maxItems ? aboveFloor[..maxItems] : aboveFloor;
         var texts = candidatesToScore.Select(x => x.Item.Content ?? string.Empty).ToArray();
 
+        // Envelope-derived sub-budget (2026-07 production-canary finding; see
+        // RelevanceGateSubBudgetMs's remarks): never grants more than what's actually left of the
+        // caller's outer RecallTimeoutMs envelope, so the outer linked CTS stays the hard cap
+        // regardless of how much of it earlier stages already spent.
+        var subBudgetMs = (int)Math.Max(0.0, Math.Min(RelevanceGateSubBudgetMs, remainingEnvelope.TotalMilliseconds));
+
+        var gateStartTs = timeProvider.GetTimestamp();
         IReadOnlyList<double> scores;
         try
         {
             using var gateCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            gateCts.CancelAfter(RelevanceGateSubBudgetMs);
+            gateCts.CancelAfter(subBudgetMs);
             scores = await scorer.ScoreAsync(request.Query, texts, gateCts.Token);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             // The sub-budget's own timer fired, not the caller's outer recall ct — degrade to
             // floor-only rather than propagating a cancellation that would fail the whole turn.
-            LogGateDegraded(request.SessionId.Value, "sub_budget_exceeded");
-            return null;
+            var elapsedMs = timeProvider.GetElapsedTime(gateStartTs).TotalMilliseconds;
+            LogGateDegraded(request.SessionId.Value, "sub_budget_exceeded", elapsedMs);
+            return RelevanceGateOutcome.NotApplied with { ElapsedMs = elapsedMs };
         }
         catch (Exception ex)
         {
-            LogGateDegraded(request.SessionId.Value, $"score_failed:{ex.GetType().Name}");
-            return null;
+            var elapsedMs = timeProvider.GetElapsedTime(gateStartTs).TotalMilliseconds;
+            LogGateDegraded(request.SessionId.Value, $"score_failed:{ex.GetType().Name}", elapsedMs);
+            return RelevanceGateOutcome.NotApplied with { ElapsedMs = elapsedMs };
         }
 
+        var gateElapsedMs = timeProvider.GetElapsedTime(gateStartTs).TotalMilliseconds;
         var threshold = _relevanceGateThresholdOverride ?? relevanceScorerHolder!.CalibratedThreshold;
         var scoreByItemId = new Dictionary<string, double>(candidatesToScore.Length, StringComparer.Ordinal);
         var survivors = new List<RankedCandidate>(candidatesToScore.Length);
@@ -592,7 +653,7 @@ public sealed class SQLiteMemoryRecallCoordinator(
                 dropped++;
         }
 
-        return (survivors.ToArray(), scoreByItemId, dropped);
+        return new RelevanceGateOutcome(true, survivors.ToArray(), scoreByItemId, dropped, gateElapsedMs);
     }
 
     /// <summary>
@@ -796,7 +857,13 @@ public sealed class SQLiteMemoryRecallCoordinator(
     /// unavailable, sub-budget exceeded, scoring threw) — a genuine runtime condition an operator
     /// should notice.
     /// </summary>
-    private void LogGateDegraded(string sessionId, string reason)
+    /// <param name="elapsedMs">
+    /// Milliseconds actually spent before this degradation was detected (2026-07 canary
+    /// observability follow-up) — 0 for reasons where no scoring attempt ever started
+    /// (<c>gate_disabled_by_config</c>, <c>no_scorer_configured</c>, <c>scorer_unavailable</c>),
+    /// the measured elapsed time for <c>sub_budget_exceeded</c>/<c>score_failed:*</c>.
+    /// </param>
+    private void LogGateDegraded(string sessionId, string reason, double elapsedMs = 0)
     {
         var nowMs = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
         if (_lastGateDegradedLogMs.TryGetValue(reason, out var lastMs)
@@ -806,9 +873,9 @@ public sealed class SQLiteMemoryRecallCoordinator(
         _lastGateDegradedLogMs[reason] = nowMs;
 
         if (_relevanceGateEnabledByConfig)
-            logger.LogWarning("memory_recall_gate_degraded session={SessionId} reason={Reason}", sessionId, reason);
+            logger.LogWarning("memory_recall_gate_degraded session={SessionId} reason={Reason} elapsedMs={ElapsedMs:F1}", sessionId, reason, elapsedMs);
         else
-            logger.LogDebug("memory_recall_gate_degraded session={SessionId} reason={Reason}", sessionId, reason);
+            logger.LogDebug("memory_recall_gate_degraded session={SessionId} reason={Reason} elapsedMs={ElapsedMs:F1}", sessionId, reason, elapsedMs);
     }
 
     private static int RecallRank(SQLiteMemoryHydratedItem document)
@@ -855,4 +922,25 @@ public sealed class SQLiteMemoryRecallCoordinator(
     /// never recorded, but any value below a positive floor rejects identically).
     /// </summary>
     private readonly record struct RankedCandidate(SQLiteMemoryHydratedItem Item, double Composite, double? Cosine);
+
+    /// <summary>
+    /// Outcome of one <see cref="TryApplyRelevanceGateAsync"/> attempt (memory-relevance-gate
+    /// 2026-07 canary observability follow-up). <see cref="Applied"/> false covers every
+    /// degradation reason (gate disabled, no scorer, unavailable, sub-budget exceeded, scoring
+    /// threw) — callers treat it identically to the pre-canary-fix "returns null" contract,
+    /// falling back to the floor's own unfiltered result. <see cref="ElapsedMs"/> is populated
+    /// whenever a scoring attempt actually started (success or failure) so
+    /// <c>memory_retrieval_final</c> can log gate latency regardless of outcome; it stays 0 only
+    /// when the gate was never engaged at all (disabled/no scorer/unavailable), since no time was
+    /// spent gating in those cases.
+    /// </summary>
+    private readonly record struct RelevanceGateOutcome(
+        bool Applied,
+        RankedCandidate[] Survivors,
+        IReadOnlyDictionary<string, double> Scores,
+        int Dropped,
+        double ElapsedMs)
+    {
+        public static readonly RelevanceGateOutcome NotApplied = new(false, [], EmptyGateScores, 0, 0.0);
+    }
 }

--- a/src/Netclaw.Daemon.Tests/Services/EmbeddingWarmupHostedServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/EmbeddingWarmupHostedServiceTests.cs
@@ -6,6 +6,7 @@
 using System.Security.Cryptography;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Memory;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Services;
@@ -285,6 +286,127 @@ public sealed class EmbeddingWarmupHostedServiceTests : IAsyncLifetime
         Assert.Same(initialRelevance, relevanceHolder.Current);
     }
 
+    // ── Keep-warm ticks (memory-relevance-gate 2026-07 canary fix) ──
+    //
+    // These tests exercise KeepWarmTickAsync/KeepWarmLoopAsync directly against simple signaling
+    // fakes rather than going through StartAsync -- StartAsync also fires the real, fixture-backed
+    // WarmUpAsync in the background (task 2.7's own coverage above), which would race to overwrite
+    // whatever embedder/scorer these tests plant in the holders. Testing the keep-warm loop's own
+    // scheduling/cancellation contract in isolation is both faster and immune to that race.
+
+    [Fact]
+    public async Task Keep_warm_tick_calls_both_the_embedder_and_the_scorer_exactly_once()
+    {
+        var embedder = new SignalingEmbedder(ModelId, Dimensions);
+        var scorer = new SignalingRelevanceScorer(RelevanceModelId);
+        var holder = new MemoryEmbedderHolder(embedder, initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: null);
+        var relevanceHolder = new RelevanceScorerHolder(scorer, initialCalibratedThreshold: 0.0);
+        var memoryConfig = new MemoryConfig { Embeddings = { Enabled = true } };
+        var service = CreateService(holder, memoryConfig, relevanceHolder, EmptyRelevanceAllowlist);
+
+        await service.KeepWarmTickAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, embedder.CallCount);
+        Assert.Equal(1, scorer.CallCount);
+    }
+
+    [Fact]
+    public async Task Keep_warm_tick_swallows_a_scorer_exception_without_throwing()
+    {
+        var embedder = new SignalingEmbedder(ModelId, Dimensions);
+        var scorer = new SignalingRelevanceScorer(RelevanceModelId, throwOnScore: new InvalidOperationException("simulated ONNX scoring failure"));
+        var holder = new MemoryEmbedderHolder(embedder, initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: null);
+        var relevanceHolder = new RelevanceScorerHolder(scorer, initialCalibratedThreshold: 0.0);
+        var memoryConfig = new MemoryConfig { Embeddings = { Enabled = true } };
+        var service = CreateService(holder, memoryConfig, relevanceHolder, EmptyRelevanceAllowlist);
+
+        // Must not throw -- a keep-warm tick failure is background maintenance, never a caller-
+        // visible fault.
+        await service.KeepWarmTickAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, embedder.CallCount);
+        Assert.Equal(1, scorer.CallCount);
+    }
+
+    [Fact]
+    public async Task Keep_warm_tick_skips_whichever_side_is_unavailable()
+    {
+        var embedder = new SignalingEmbedder(ModelId, Dimensions, isAvailable: false);
+        var scorer = new SignalingRelevanceScorer(RelevanceModelId, isAvailable: false);
+        var holder = new MemoryEmbedderHolder(embedder, initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: null);
+        var relevanceHolder = new RelevanceScorerHolder(scorer, initialCalibratedThreshold: 0.0);
+        var memoryConfig = new MemoryConfig { Embeddings = { Enabled = true } };
+        var service = CreateService(holder, memoryConfig, relevanceHolder, EmptyRelevanceAllowlist);
+
+        await service.KeepWarmTickAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, embedder.CallCount);
+        Assert.Equal(0, scorer.CallCount);
+    }
+
+    [Fact]
+    public async Task Keep_warm_loop_never_ticks_when_embeddings_are_disabled()
+    {
+        var embedder = new SignalingEmbedder(ModelId, Dimensions);
+        var scorer = new SignalingRelevanceScorer(RelevanceModelId);
+        var holder = new MemoryEmbedderHolder(embedder, initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: null);
+        var relevanceHolder = new RelevanceScorerHolder(scorer, initialCalibratedThreshold: 0.0);
+        var memoryConfig = new MemoryConfig { Embeddings = { Enabled = false } };
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var service = CreateService(holder, memoryConfig, relevanceHolder, EmptyRelevanceAllowlist, time);
+
+        // Returns immediately (config checked up front, before the timer is even armed).
+        await service.KeepWarmLoopAsync(TestContext.Current.CancellationToken);
+
+        // Advancing time after the fact proves no timer was ever armed either.
+        time.Advance(EmbeddingWarmupHostedService.KeepWarmInterval * 3);
+        Assert.Equal(0, embedder.CallCount);
+        Assert.Equal(0, scorer.CallCount);
+    }
+
+    [Fact]
+    public async Task Keep_warm_loop_ticks_on_schedule_and_stops_cleanly_on_cancellation()
+    {
+        var embedder = new SignalingEmbedder(ModelId, Dimensions);
+        var scorer = new SignalingRelevanceScorer(RelevanceModelId);
+        var holder = new MemoryEmbedderHolder(embedder, initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: null);
+        var relevanceHolder = new RelevanceScorerHolder(scorer, initialCalibratedThreshold: 0.0);
+        var memoryConfig = new MemoryConfig { Embeddings = { Enabled = true } };
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var service = CreateService(holder, memoryConfig, relevanceHolder, EmptyRelevanceAllowlist, time);
+
+        using var cts = new CancellationTokenSource();
+        // This is the exact cancellation contract StopAsync relies on internally (cancel the
+        // token passed to KeepWarmLoopAsync, then await the loop task) -- driving it directly here
+        // avoids also triggering StartAsync's real, fixture-backed WarmUpAsync (see this section's
+        // header comment).
+        var loopTask = service.KeepWarmLoopAsync(cts.Token);
+
+        time.Advance(EmbeddingWarmupHostedService.KeepWarmInterval);
+        await embedder.WaitForCallAsync(TestContext.Current.CancellationToken);
+        await scorer.WaitForCallAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(1, embedder.CallCount);
+        Assert.Equal(1, scorer.CallCount);
+
+        // A second tick proves this is a recurring schedule, not a one-shot.
+        time.Advance(EmbeddingWarmupHostedService.KeepWarmInterval);
+        await embedder.WaitForCallAsync(TestContext.Current.CancellationToken);
+        await scorer.WaitForCallAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, embedder.CallCount);
+        Assert.Equal(2, scorer.CallCount);
+
+        await cts.CancelAsync();
+        // PeriodicTimer.WaitForNextTickAsync throws OperationCanceledException when its token is
+        // cancelled (mirrors PidFileWatchdogService.StopAsync's own SuppressThrowing usage) --
+        // that is how the loop unwinds, not a normal return.
+        await loopTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+        // Further time advances after cancellation must not produce more ticks.
+        time.Advance(EmbeddingWarmupHostedService.KeepWarmInterval * 3);
+        Assert.Equal(2, embedder.CallCount);
+        Assert.Equal(2, scorer.CallCount);
+    }
+
     private EmbeddingWarmupHostedService CreateService(MemoryEmbedderHolder holder, MemoryConfig memoryConfig)
         => CreateService(holder, memoryConfig, CreateRelevanceScorerHolder(), EmptyRelevanceAllowlist);
 
@@ -292,9 +414,10 @@ public sealed class EmbeddingWarmupHostedServiceTests : IAsyncLifetime
         MemoryEmbedderHolder holder,
         MemoryConfig memoryConfig,
         RelevanceScorerHolder relevanceScorerHolder,
-        IReadOnlyDictionary<string, RelevanceModelManifestEntry> relevanceAllowlist)
+        IReadOnlyDictionary<string, RelevanceModelManifestEntry> relevanceAllowlist,
+        TimeProvider? timeProvider = null)
         => new(_provisioner, _store, holder, relevanceScorerHolder, _allowlist, relevanceAllowlist, memoryConfig, _paths,
-            NullLogger<EmbeddingWarmupHostedService>.Instance);
+            timeProvider ?? TimeProvider.System, NullLogger<EmbeddingWarmupHostedService>.Instance);
 
     private static RelevanceScorerHolder CreateRelevanceScorerHolder()
         => new(new UnavailableRelevanceScorer(RelevanceModelId, "warmup not yet run"), initialCalibratedThreshold: 0.0);
@@ -365,6 +488,66 @@ public sealed class EmbeddingWarmupHostedServiceTests : IAsyncLifetime
             {
                 await Task.Delay(25 * (i + 1));
             }
+        }
+    }
+
+    /// <summary>
+    /// Fake embedder for the keep-warm tests above: counts calls and signals a waiter each time
+    /// <see cref="EmbedAsync"/> runs, so a test driving a <c>FakeTimeProvider</c>-scheduled
+    /// <see cref="PeriodicTimer"/> can await the tick's actual completion deterministically instead
+    /// of racing a real-time delay against the background loop task.
+    /// </summary>
+    private sealed class SignalingEmbedder(string modelId, int dimensions, bool isAvailable = true) : IMemoryEmbedder
+    {
+        private readonly SemaphoreSlim _signal = new(0);
+        private int _callCount;
+
+        public string ModelId => modelId;
+
+        public int Dimensions => dimensions;
+
+        public bool IsAvailable => isAvailable;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public Task WaitForCallAsync(CancellationToken ct) => _signal.WaitAsync(ct);
+
+        public ValueTask<ReadOnlyMemory<float>> EmbedAsync(string text, EmbeddingPurpose purpose, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _callCount);
+            _signal.Release();
+            return ValueTask.FromResult<ReadOnlyMemory<float>>(new float[dimensions]);
+        }
+
+        public ValueTask<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(IReadOnlyList<string> texts, EmbeddingPurpose purpose, CancellationToken ct)
+            => throw new NotSupportedException("Keep-warm ticks only ever call EmbedAsync, never the batch path.");
+    }
+
+    /// <summary>
+    /// Fake relevance scorer for the keep-warm tests above — mirrors <see cref="SignalingEmbedder"/>'s
+    /// call-counting/signaling shape, plus an optional <paramref name="throwOnScore"/> to exercise
+    /// the tick's own exception-swallowing contract.
+    /// </summary>
+    private sealed class SignalingRelevanceScorer(string modelId, bool isAvailable = true, Exception? throwOnScore = null) : IRelevanceScorer
+    {
+        private readonly SemaphoreSlim _signal = new(0);
+        private int _callCount;
+
+        public string ModelId => modelId;
+
+        public bool IsAvailable => isAvailable;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public Task WaitForCallAsync(CancellationToken ct) => _signal.WaitAsync(ct);
+
+        public ValueTask<IReadOnlyList<double>> ScoreAsync(string query, IReadOnlyList<string> candidates, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _callCount);
+            _signal.Release();
+            if (throwOnScore is not null)
+                throw throwOnScore;
+            return ValueTask.FromResult<IReadOnlyList<double>>(candidates.Select(_ => 1.0).ToArray());
         }
     }
 }

--- a/src/Netclaw.Daemon/Services/EmbeddingWarmupHostedService.cs
+++ b/src/Netclaw.Daemon/Services/EmbeddingWarmupHostedService.cs
@@ -33,6 +33,21 @@ namespace Netclaw.Daemon.Services;
 /// rather than blocking <see cref="StartAsync"/> so a slow/hanging download can never delay the
 /// rest of the host's startup sequence either.
 /// </para>
+///
+/// <para>
+/// <b>Keep-warm (memory-relevance-gate 2026-07 canary fix):</b> the one-shot warm-up call above
+/// only pays first-call ONNX session / JIT cost once, at startup. On a long-lived daemon a
+/// subsequent idle gap (no memory-touching turns for a while — the exact shape of a scheduled
+/// reminder session waking up) lets the OS page out an ONNX session's working set entirely; the
+/// next real turn then pays a full cold-start cost that a fixed per-turn sub-budget was never
+/// sized for. A live production canary caught exactly this: two <c>memory_recall_gate_degraded</c>
+/// events with <c>TaskCanceledException</c>, both in reminder sessions firing after an idle
+/// period. <see cref="KeepWarmLoopAsync"/> re-exercises both ONNX sessions on a periodic tick
+/// while embeddings are enabled, so neither ever goes cold enough to blow its sub-budget on the
+/// next real turn — see <see cref="Netclaw.Actors.Sessions.SQLiteMemoryRecallCoordinator"/>'s
+/// relevance-gate sub-budget remarks for the other half of this fix (the envelope-derived
+/// sub-budget clamp).
+/// </para>
 /// </summary>
 internal sealed class EmbeddingWarmupHostedService(
     EmbeddingModelProvisioner provisioner,
@@ -43,7 +58,8 @@ internal sealed class EmbeddingWarmupHostedService(
     IReadOnlyDictionary<string, RelevanceModelManifestEntry> relevanceAllowlist,
     MemoryConfig memoryConfig,
     NetclawPaths paths,
-    ILogger<EmbeddingWarmupHostedService> logger) : IHostedService
+    TimeProvider timeProvider,
+    ILogger<EmbeddingWarmupHostedService> logger) : IHostedService, IDisposable
 {
     /// <summary>
     /// Gap-repair batch size. Kept small and yielding between batches (task 2.7) so a large
@@ -52,13 +68,122 @@ internal sealed class EmbeddingWarmupHostedService(
     /// </summary>
     internal const int GapRepairBatchSize = 16;
 
+    /// <summary>
+    /// Keep-warm tick period (memory-relevance-gate 2026-07 canary fix). Frequent enough that
+    /// neither ONNX session's working set gets fully paged out between ticks on the idle-reminder
+    /// shape the canary caught, cheap enough (one tiny embed + one tiny 1-pair score, a handful of
+    /// milliseconds warm) that it is negligible background CPU for a daemon otherwise doing
+    /// nothing.
+    /// </summary>
+    internal static readonly TimeSpan KeepWarmInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>Fixed, tiny keep-warm query/candidate text — content is irrelevant, only inference-path exercise matters.</summary>
+    private const string KeepWarmQueryText = "netclaw keep-warm probe";
+
+    private const string KeepWarmCandidateText = "netclaw keep-warm reference candidate";
+
+    /// <summary>Minimum interval between two keep-warm-failure debug log lines, mirroring the recall coordinator's degradation-log cooldowns.</summary>
+    private static readonly TimeSpan KeepWarmFailureLogCooldown = TimeSpan.FromMinutes(5);
+
+    private readonly CancellationTokenSource _keepWarmCts = new();
+    private Task? _keepWarmLoop;
+    // 0 (not long.MinValue) is the safe "never logged" sentinel: any real Unix-ms timestamp minus
+    // 0 is astronomically larger than KeepWarmFailureLogCooldown, so the very first failure always
+    // logs, and there is no risk of the subtraction below overflowing.
+    private long _lastKeepWarmFailureLogMs;
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _ = Task.Run(() => WarmUpAsync(CancellationToken.None), CancellationToken.None);
+        _keepWarmLoop = Task.Run(() => KeepWarmLoopAsync(_keepWarmCts.Token), CancellationToken.None);
         return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _keepWarmCts.CancelAsync();
+        if (_keepWarmLoop is not null)
+            await _keepWarmLoop.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+    }
+
+    public void Dispose() => _keepWarmCts.Dispose();
+
+    /// <summary>
+    /// Periodic keep-warm loop (memory-relevance-gate 2026-07 canary fix): ticks every
+    /// <see cref="KeepWarmInterval"/> for as long as embeddings are enabled, re-exercising both
+    /// ONNX sessions via <see cref="KeepWarmTickAsync"/> so an idle gap between real turns never
+    /// lets either session's working set page out entirely. Built on <see cref="PeriodicTimer"/>
+    /// over the injected <see cref="TimeProvider"/> — the same virtualizable-timer pattern
+    /// <c>McpReconnectionService</c> already uses for its own periodic tick — so tests can drive
+    /// ticks deterministically with a <c>FakeTimeProvider</c> instead of real wall-clock delays.
+    /// A disabled config is checked once up front rather than per tick: an operator flip requires
+    /// a restart, same as every other <c>Memory.*</c> setting this service already assumes.
+    /// </summary>
+    internal async Task KeepWarmLoopAsync(CancellationToken ct)
+    {
+        if (!memoryConfig.Embeddings.Enabled)
+            return;
+
+        using var timer = new PeriodicTimer(KeepWarmInterval, timeProvider);
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+        {
+            await KeepWarmTickAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// One keep-warm tick: a single tiny embed (<see cref="EmbeddingPurpose.RetrievalQuery"/>,
+    /// mirroring the shape of a real recall turn's query embed) and a single tiny 1-pair
+    /// cross-encoder score, each only attempted while its holder currently reports
+    /// <c>IsAvailable</c> (a holder still pointed at an <c>Unavailable*</c> stub — warmup not yet
+    /// complete, or a load that failed — has nothing to keep warm). Never throws: any failure
+    /// (a transient ONNX error, a holder swapped mid-tick) is caught and rate-limited-logged at
+    /// Debug, since a missed keep-warm tick is not itself a user-visible degradation — the next
+    /// tick or the next real turn's own degradation path is what would actually surface a
+    /// persistently broken model.
+    /// </summary>
+    internal async Task KeepWarmTickAsync(CancellationToken ct)
+    {
+        try
+        {
+            var embedder = holder.Current;
+            if (embedder.IsAvailable)
+                await embedder.EmbedAsync(KeepWarmQueryText, EmbeddingPurpose.RetrievalQuery, ct).ConfigureAwait(false);
+
+            var scorer = relevanceScorerHolder.Current;
+            if (scorer.IsAvailable)
+                await scorer.ScoreAsync(KeepWarmQueryText, [KeepWarmCandidateText], ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Host shutdown mid-tick -- let this propagate so KeepWarmLoopAsync's own
+            // WaitForNextTickAsync(ct) loop unwinds normally instead of being masked as a tick
+            // failure.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogKeepWarmFailed(ex);
+        }
+    }
+
+    /// <summary>
+    /// Rate-limited keep-warm-failure log: at most one Debug line per
+    /// <see cref="KeepWarmFailureLogCooldown"/>, the same cooldown-throttle shape
+    /// <c>SQLiteMemoryRecallCoordinator</c>'s degradation logs use, so a persistently failing
+    /// keep-warm tick (e.g. a model that failed to load) does not spam the log every 5 minutes
+    /// forever.
+    /// </summary>
+    private void LogKeepWarmFailed(Exception ex)
+    {
+        var nowMs = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        var lastMs = Interlocked.Read(ref _lastKeepWarmFailureLogMs);
+        if (nowMs - lastMs < KeepWarmFailureLogCooldown.TotalMilliseconds)
+            return;
+
+        Interlocked.Exchange(ref _lastKeepWarmFailureLogMs, nowMs);
+        logger.LogDebug(ex, "memory_embedding_keep_warm_failed");
+    }
 
     /// <summary>Internal entry point so tests can await warmup to completion deterministically.</summary>
     internal async Task WarmUpAsync(CancellationToken ct)


### PR DESCRIPTION
## Summary

Production canary (`~/.netclaw/logs/daemon-2026-07-09.log`) caught two
`memory_recall_gate_degraded` events with reason
`score_failed:TaskCanceledException`, both in scheduled-reminder sessions
firing after an idle period:

- `05:06:52.718` — session `D0AC6CKBK5K/1778733767.940429`
- `12:00:00.422` — session `reminder/vendor-price-alert/1783598400066`

**Root cause (verified against the log, not assumed):** in both events, the
gap from `memory_retrieval_request_plan` to `memory_recall_gate_degraded`
was 318ms and 339ms respectively — already past the entire 300ms
`Memory.RecallTimeoutMs` envelope before the relevance gate's cross-encoder
even started scoring. Both turns show `mode=hybrid` (the query embed
succeeded), so the whole pipeline — plan → candidate selection → query embed
→ hybrid fusion → gate — was slow, consistent with a cold ONNX session
(paged-out weights after the idle gap) plus host CPU contention at
reminder-fire time, not a per-call latency regression against design D5's
reference-box measurement (~11ms p50 / ~35ms p95 for 3 pairs), which still
holds on a warm session.

**Re-verified prior "3–12% coverage-gap" claim:** the two events' own
`memory_recall_coverage_gap` lines show `gapCandidates=3/totalCandidates=61`
(4.9%) and `gapCandidates=7/totalCandidates=57` (12.3%) — these are the
pre-existing, already-designed-for candidate-pool coverage-gap counters
(documents not yet backfilled with an embedding for the current model,
memory-core-redesign Slice 4 / design D6 gap-repair), **not** gate failures.
Confirmed unrelated to the timeout finding.

## The fix (three parts)

1. **Keep-warm** — `EmbeddingWarmupHostedService` now runs a periodic
   keep-warm loop (every 5 minutes, while `Memory.Embeddings.Enabled`) that
   re-exercises both ONNX sessions with one tiny embed
   (`EmbeddingPurpose.RetrievalQuery`) and one tiny 1-pair cross-encoder
   score, so an idle gap never lets either session's working set page out
   entirely. Built on `PeriodicTimer` over the injected `TimeProvider` — the
   same virtualizable pattern `McpReconnectionService` already uses — never
   throws out of a tick (rate-limited Debug log on failure), skips whichever
   side is currently unavailable, no-ops when embeddings are disabled, and
   stops cleanly via the existing `IHostedService.StopAsync` +
   `CancellationTokenSource` pattern.

2. **Budget** — `SQLiteMemoryRecallCoordinator`'s relevance-gate sub-budget
   is now `min(RelevanceGateSubBudgetMs, time remaining in the outer
   RecallTimeoutMs envelope)` instead of a fixed value; the ceiling itself
   is raised from 60ms to 120ms. The outer linked CTS remains the hard cap,
   so this can never blow the 300ms envelope — a turn with headroom gets
   more slack than before, while a turn where earlier stages already
   consumed the envelope degrades immediately instead of assuming a fixed
   budget is always affordable. Same degraded-path semantics on
   timeout/failure.

3. **Observability** — `memory_retrieval_final` now logs `gateElapsedMs`
   (gate scoring latency regardless of outcome), and
   `memory_recall_gate_degraded` now logs `elapsedMs` too, so soak data can
   quantify margins against the new ceiling.

Also updated `openspec/changes/memory-relevance-gate/design.md`'s 60ms
figures to 120ms (envelope-clamped) with a canary-finding note, and marked
the "combined sub-budget worst-case latency" Open Question as resolved by
this same finding. `netclaw-memory` skill does not mention the 60ms figure,
so it was left unchanged (checked, no hit).

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean, 0 warnings/errors
- [x] `dotnet test` on `Netclaw.Actors.Tests` — 2671 passed
- [x] `dotnet test` on `Netclaw.Daemon.Tests` — 848 passed
- [x] `dotnet test` on `Netclaw.Embeddings.Tests` — 48 passed
- [x] `dotnet slopwatch analyze` — 0 issues (added a scoped
      `[SlopwatchSuppress("SW004", ...)]` on the new test-only
      `DelayedRelevanceScorer` fake's intentional latency simulation)
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [x] New keep-warm tests: tick fires on schedule and calls embedder+scorer
      exactly once per tick; swallows scorer exceptions without throwing;
      skips whichever side is unavailable; no ticks when embeddings
      disabled; stops cleanly on cancellation — all `FakeTimeProvider`-driven,
      no `Thread.Sleep`/`Task.Delay` in test orchestration
- [x] New budget tests: an envelope-exhausted `RecallTimeoutMs` + a
      slower-than-instant-but-under-the-ceiling fake scorer degrades to the
      floor's unfiltered result; the same scorer with a fresh/generous
      envelope runs to completion and its score is honored
- [x] Updated the existing sub-budget-timeout test's stale "~60ms" comment