### PR TITLE
Support Discord DM reminders

### DIFF
--- a/docs/integrations/discord-channel.md
+++ b/docs/integrations/discord-channel.md
@@ -118,9 +118,20 @@ Discord channel target resolution accepts canonical channel forms:
 - `<#123...>` (channel mention)
 - `channel:123...` (explicit channel ID)
 
+Discord direct-message target resolution accepts explicit user forms:
+
+- `<@123...>` or `<@!123...>` (user mention)
+- `dm:123...` or `@123...` (explicit user ID)
+
+Bare Discord snowflakes are rejected because channel IDs and user IDs have the
+same shape. Use `channel:<channelId>` for channel delivery or `dm:<userId>` for
+direct-message delivery.
+
 Reminder channel delivery maps to the generic `send_channel_message` tool with
-`channel_key = "discord"` and a resolved destination object. Discord proactive
-DM output is not supported yet.
+`channel_key = "discord"` and a resolved destination object. Channel targets use
+`destination.kind = "destination"`; user targets use
+`destination.kind = "direct_message"` and are still gated by
+`AllowDirectMessages` and `AllowedUserIds` at send time.
 
 ## Runtime behavior and troubleshooting
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.24.0"
+  version: "2.24.1"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -33,6 +33,10 @@ Rules:
   conversational follow-ups in Slack/TUI/SignalR sessions.
 - `channel` requires both transport + address and resolves names/handles to
   canonical IDs at set time; unresolved targets fail loud.
+- Discord reminder targets must be explicit because channel IDs and user IDs are
+  both snowflakes: use `channel:<channelId>` or `<#channelId>` for channel posts,
+  and `dm:<userId>`, `@<userId>`, or `<@userId>` for DMs. Do not pass a bare
+  Discord ID.
 - `none` runs silently (history still records execution).
 - `expires_in` is not valid for `once` reminders; omit it for one-shot schedules.
 - For recurring reminders that are permanently complete (PR merged, deploy done,

--- a/src/Netclaw.Actors.Tests/Channels/DiscordReminderTargetResolverTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordReminderTargetResolverTests.cs
@@ -11,28 +11,47 @@ namespace Netclaw.Actors.Tests.Channels;
 
 public sealed class DiscordReminderTargetResolverTests
 {
-    private readonly DiscordReminderTargetResolver _resolver = new();
+    private const string ChannelId = "129847561203948576";
+    private const string UserId = "130111223344556677";
+
+    private readonly DiscordReminderTargetResolver _resolver = new(new DiscordChannelOptions
+    {
+        AllowDirectMessages = true,
+        AllowedChannelIds = [ChannelId],
+        AllowedUserIds = [UserId]
+    });
 
     [Fact]
     public async Task Resolves_channel_mention_to_canonical_channel_id()
     {
-        var result = await _resolver.ResolveAsync("<#129847561203948576>", TestContext.Current.CancellationToken);
+        var result = await _resolver.ResolveAsync($"<#{ChannelId}>", TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.Equal(ReminderTargetKind.Channel, result.Kind);
-        Assert.Equal("129847561203948576", result.ResolvedId);
+        Assert.Equal(ChannelId, result.ResolvedId);
         Assert.Null(result.ErrorMessage);
     }
 
     [Fact]
     public async Task Resolves_explicit_channel_prefix_to_canonical_channel_id()
     {
-        var result = await _resolver.ResolveAsync("channel:129847561203948576", TestContext.Current.CancellationToken);
+        var result = await _resolver.ResolveAsync($"channel:{ChannelId}", TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.Equal(ReminderTargetKind.Channel, result.Kind);
-        Assert.Equal("129847561203948576", result.ResolvedId);
+        Assert.Equal(ChannelId, result.ResolvedId);
         Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Rejects_channel_targets_outside_allowed_channels()
+    {
+        var result = await _resolver.ResolveAsync("channel:129847561203948577", TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(ReminderTargetKind.Unknown, result.Kind);
+        Assert.Null(result.ResolvedId);
+        Assert.Contains("allowed channels", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -50,26 +69,60 @@ public sealed class DiscordReminderTargetResolverTests
     [InlineData("@129847561203948576")]
     [InlineData("<@129847561203948576>")]
     [InlineData("<@!129847561203948576>")]
-    public async Task Rejects_user_targets_while_discord_reminders_are_channel_only(string input)
+    [InlineData("dm:129847561203948576")]
+    public async Task Resolves_explicit_user_targets_to_canonical_user_id(string input)
     {
-        var result = await _resolver.ResolveAsync(input, TestContext.Current.CancellationToken);
+        var resolver = new DiscordReminderTargetResolver(new DiscordChannelOptions
+        {
+            AllowDirectMessages = true,
+            AllowedUserIds = ["129847561203948576"]
+        });
 
-        Assert.False(result.Success);
-        Assert.Equal(ReminderTargetKind.Unknown, result.Kind);
-        Assert.Null(result.ResolvedId);
-        Assert.Contains("channel", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("not supported", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        var result = await resolver.ResolveAsync(input, TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal(ReminderTargetKind.User, result.Kind);
+        Assert.Equal("129847561203948576", result.ResolvedId);
+        Assert.Null(result.ErrorMessage);
     }
 
     [Fact]
-    public async Task Rejects_dm_channel_prefix_while_discord_reminders_are_channel_only()
+    public async Task Rejects_user_targets_when_direct_messages_are_disabled()
     {
-        var result = await _resolver.ResolveAsync("dm:130111223344556677", TestContext.Current.CancellationToken);
+        var resolver = new DiscordReminderTargetResolver(new DiscordChannelOptions
+        {
+            AllowDirectMessages = false,
+            AllowedUserIds = [UserId]
+        });
+
+        var result = await resolver.ResolveAsync($"dm:{UserId}", TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Equal(ReminderTargetKind.Unknown, result.Kind);
         Assert.Null(result.ResolvedId);
-        Assert.Contains("DM", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("disabled", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Rejects_user_targets_outside_allowed_users()
+    {
+        var result = await _resolver.ResolveAsync("dm:130111223344556678", TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(ReminderTargetKind.Unknown, result.Kind);
+        Assert.Null(result.ResolvedId);
+        Assert.Contains("allowed users", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Rejects_invalid_direct_message_target()
+    {
+        var result = await _resolver.ResolveAsync("dm:not-a-user-id", TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(ReminderTargetKind.Unknown, result.Kind);
+        Assert.Null(result.ResolvedId);
+        Assert.Contains("direct-message", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -80,6 +133,6 @@ public sealed class DiscordReminderTargetResolverTests
         Assert.False(result.Success);
         Assert.Equal(ReminderTargetKind.Unknown, result.Kind);
         Assert.Null(result.ResolvedId);
-        Assert.Contains("channel:<channelId>", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("user target", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -12,6 +12,7 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Tests.Hosting;
+using Netclaw.Channels.Discord;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 using Xunit;
@@ -810,7 +811,7 @@ public class SetReminderToolTests : TestKit
     }
 
     [Fact]
-    public async Task Resolves_user_target_to_dm_notify_instructions()
+    public async Task Resolves_user_target_to_direct_message_delivery_target()
     {
         var probe = CreateTestProbe();
         var resolver = new TestResolver
@@ -839,6 +840,10 @@ public class SetReminderToolTests : TestKit
         var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(DeliveryKind.Channel, cmd.Definition.Delivery.Kind);
         Assert.Equal("U0456XYZ", cmd.Definition.Delivery.Address);
+        Assert.NotNull(cmd.Definition.Delivery.Target);
+        Assert.Equal("slack", cmd.Definition.Delivery.Target!.ChannelKey);
+        Assert.Equal("direct_message", cmd.Definition.Delivery.Target.DestinationKind);
+        Assert.Equal("U0456XYZ", cmd.Definition.Delivery.Target.DestinationId);
         Assert.Equal(1, resolver.CallCount);
 
         probe.Reply(new ReminderSavedResponse(
@@ -851,7 +856,7 @@ public class SetReminderToolTests : TestKit
     }
 
     [Fact]
-    public async Task Rejects_discord_user_target_with_discord_transport()
+    public async Task Resolves_discord_user_target_to_direct_message_delivery_target()
     {
         var probe = CreateTestProbe();
         var resolver = new TestResolver
@@ -863,22 +868,94 @@ public class SetReminderToolTests : TestKit
         };
         var tool = new SetReminderTool(probe, _timeProvider, new SchedulingConfig(), [resolver]);
 
+        var execution = Task.Run(async () =>
+        {
+            return await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Id"] = "discord-user-target",
+                ["Name"] = "discord-user-target",
+                ["Prompt"] = "Send results",
+                ["ScheduleType"] = "once",
+                ["Schedule"] = "15m",
+                ["DeliveryKind"] = "channel",
+                ["DeliveryTransport"] = "discord",
+                ["DeliveryAddress"] = "<@129847561203948576>"
+            }, TestContext.Current.CancellationToken);
+        }, TestContext.Current.CancellationToken);
+
+        var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(DeliveryKind.Channel, cmd.Definition.Delivery.Kind);
+        Assert.Equal("discord", cmd.Definition.Delivery.Transport);
+        Assert.Equal("129847561203948576", cmd.Definition.Delivery.Address);
+        Assert.NotNull(cmd.Definition.Delivery.Target);
+        Assert.Equal("discord", cmd.Definition.Delivery.Target!.ChannelKey);
+        Assert.Equal("direct_message", cmd.Definition.Delivery.Target.DestinationKind);
+        Assert.Equal("129847561203948576", cmd.Definition.Delivery.Target.DestinationId);
+        Assert.Equal("129847561203948576", cmd.Definition.Delivery.Target.DestinationDisplayName);
+        Assert.Equal(1, resolver.CallCount);
+
+        probe.Reply(new ReminderSavedResponse(
+            cmd.Definition.Id,
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: _timeProvider.GetUtcNow().AddMinutes(15)));
+
+        var result = await execution;
+        Assert.StartsWith("Reminder 'discord-user-target' scheduled.", result);
+    }
+
+    [Fact]
+    public async Task Rejects_discord_direct_message_reminder_when_direct_messages_are_disabled()
+    {
+        var probe = CreateTestProbe();
+        var resolver = new DiscordReminderTargetResolver(new DiscordChannelOptions
+        {
+            AllowDirectMessages = false
+        });
+        var tool = new SetReminderTool(probe, _timeProvider, new SchedulingConfig(), [resolver]);
+
         var result = await tool.ExecuteAsync(new Dictionary<string, object?>
         {
-            ["Id"] = "discord-user-target",
-            ["Name"] = "discord-user-target",
+            ["Id"] = "discord-dm-disabled",
+            ["Name"] = "discord-dm-disabled",
             ["Prompt"] = "Send results",
             ["ScheduleType"] = "once",
             ["Schedule"] = "15m",
             ["DeliveryKind"] = "channel",
             ["DeliveryTransport"] = "discord",
-            ["DeliveryAddress"] = "<@129847561203948576>"
+            ["DeliveryAddress"] = "dm:129847561203948576"
         }, TestContext.Current.CancellationToken);
 
-        Assert.StartsWith("Error:", result);
-        Assert.Contains("guild text-channel targets only", result, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("channel:<channelId>", result, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(1, resolver.CallCount);
+        Assert.StartsWith("Error: Could not resolve delivery_address", result);
+        Assert.Contains("direct messages are disabled", result, StringComparison.OrdinalIgnoreCase);
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Rejects_discord_direct_message_reminder_when_user_is_not_allowlisted()
+    {
+        var probe = CreateTestProbe();
+        var resolver = new DiscordReminderTargetResolver(new DiscordChannelOptions
+        {
+            AllowDirectMessages = true,
+            AllowedUserIds = ["130111223344556677"]
+        });
+        var tool = new SetReminderTool(probe, _timeProvider, new SchedulingConfig(), [resolver]);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Id"] = "discord-dm-disallowed",
+            ["Name"] = "discord-dm-disallowed",
+            ["Prompt"] = "Send results",
+            ["ScheduleType"] = "once",
+            ["Schedule"] = "15m",
+            ["DeliveryKind"] = "channel",
+            ["DeliveryTransport"] = "discord",
+            ["DeliveryAddress"] = "dm:129847561203948576"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.StartsWith("Error: Could not resolve delivery_address", result);
+        Assert.Contains("allowed users", result, StringComparison.OrdinalIgnoreCase);
         await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
     }
 

--- a/src/Netclaw.Actors/Reminders/SetReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/SetReminderTool.cs
@@ -174,20 +174,13 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
                 {
                     var detail = resolution.ErrorMessage ?? "unresolvable target";
                     var hint = string.Equals(transport, "discord", StringComparison.OrdinalIgnoreCase)
-                        ? "Use channel:<channelId> or <#channelId>."
+                        ? "Use channel:<channelId>, <#channelId>, dm:<userId>, or <@userId>."
                         : "Use #channel, @user, or a valid channel ID.";
                     return $"Error: Could not resolve delivery_address '{rawDeliveryAddress}': {detail}. {hint}";
                 }
 
                 if (string.IsNullOrWhiteSpace(resolution.ResolvedId))
                     return $"Error: Could not resolve delivery_address '{rawDeliveryAddress}': resolver returned an empty canonical target ID.";
-
-                if (string.Equals(transport, "discord", StringComparison.OrdinalIgnoreCase)
-                    && resolution.Kind is not ReminderTargetKind.Channel)
-                {
-                    return "Error: Discord channel delivery currently supports guild text-channel targets only. "
-                           + "Use channel:<channelId> or <#channelId>; user and DM targets are not supported yet.";
-                }
 
                 delivery = new ReminderDelivery
                 {

--- a/src/Netclaw.Channels.Discord/DiscordReminderTargetResolver.cs
+++ b/src/Netclaw.Channels.Discord/DiscordReminderTargetResolver.cs
@@ -9,14 +9,14 @@ using Netclaw.Actors.Reminders;
 namespace Netclaw.Channels.Discord;
 
 /// <summary>
-/// Resolves Discord reminder targets to canonical guild text-channel IDs.
-/// Current reminder delivery is channel-only: proactive DM delivery is deferred
-/// until Discord gains a session model that can preserve thread context.
+/// Resolves Discord reminder targets to canonical guild text-channel or user IDs.
 /// Supported inputs:
 /// - channel mention: &lt;#123...&gt;
 /// - explicit channel ID: channel:123...
+/// - user mention: &lt;@123...&gt; or &lt;@!123...&gt;
+/// - explicit user ID: dm:123... or @123...
 /// </summary>
-public sealed class DiscordReminderTargetResolver : IReminderTargetResolver
+public sealed class DiscordReminderTargetResolver(DiscordChannelOptions options) : IReminderTargetResolver
 {
     private static readonly Regex MentionRegex =
         new("^<@!?([0-9]{17,20})>$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -44,24 +44,22 @@ public sealed class DiscordReminderTargetResolver : IReminderTargetResolver
 
         if (raw.StartsWith("dm:", StringComparison.OrdinalIgnoreCase))
         {
+            var userId = raw[3..].Trim();
+            if (SnowflakeRegex.IsMatch(userId))
+                return Task.FromResult(ResolveUser(userId));
+
             return Task.FromResult(new ReminderTargetResolution(
                 Success: false,
                 ResolvedId: null,
                 Kind: ReminderTargetKind.Unknown,
-                ErrorMessage: "Discord reminder delivery currently supports guild text channels only; DM targets are not supported. Use channel:<channelId> or <#channelId>."));
+                ErrorMessage: "Invalid Discord direct-message target. Use dm:<userId>, @<userId>, or <@userId>."));
         }
 
         if (raw.StartsWith("channel:", StringComparison.OrdinalIgnoreCase))
         {
             var channelId = raw[8..].Trim();
             if (SnowflakeRegex.IsMatch(channelId))
-            {
-                return Task.FromResult(new ReminderTargetResolution(
-                    Success: true,
-                    ResolvedId: channelId,
-                    Kind: ReminderTargetKind.Channel,
-                    ErrorMessage: null));
-            }
+                return Task.FromResult(ResolveChannel(channelId));
 
             return Task.FromResult(new ReminderTargetResolution(
                 Success: false,
@@ -73,11 +71,7 @@ public sealed class DiscordReminderTargetResolver : IReminderTargetResolver
         var channelMention = ChannelMentionRegex.Match(raw);
         if (channelMention.Success)
         {
-            return Task.FromResult(new ReminderTargetResolution(
-                Success: true,
-                ResolvedId: channelMention.Groups[1].Value,
-                Kind: ReminderTargetKind.Channel,
-                ErrorMessage: null));
+            return Task.FromResult(ResolveChannel(channelMention.Groups[1].Value));
         }
 
         if (SnowflakeRegex.IsMatch(raw))
@@ -86,23 +80,76 @@ public sealed class DiscordReminderTargetResolver : IReminderTargetResolver
                 Success: false,
                 ResolvedId: null,
                 Kind: ReminderTargetKind.Unknown,
-                ErrorMessage: "Bare Discord snowflakes are ambiguous. Use channel:<channelId> or <#channelId> for channel delivery."));
+                ErrorMessage: "Bare Discord snowflakes are ambiguous. Use channel:<channelId> or <#channelId> for channel delivery, or dm:<userId> / <@userId> for direct-message delivery."));
         }
 
         var mention = MentionRegex.Match(raw);
-        if (mention.Success || raw.StartsWith("@", StringComparison.Ordinal))
+        if (mention.Success)
         {
+            return Task.FromResult(ResolveUser(mention.Groups[1].Value));
+        }
+
+        if (raw.StartsWith("@", StringComparison.Ordinal))
+        {
+            var userId = raw[1..].Trim();
+            if (SnowflakeRegex.IsMatch(userId))
+                return Task.FromResult(ResolveUser(userId));
+
             return Task.FromResult(new ReminderTargetResolution(
                 Success: false,
                 ResolvedId: null,
                 Kind: ReminderTargetKind.Unknown,
-                ErrorMessage: "Discord reminder delivery currently supports guild text channels only; user/DM targets are not supported. Use channel:<channelId> or <#channelId>."));
+                ErrorMessage: "Invalid Discord user target. Use @<userId>, <@userId>, or dm:<userId>."));
         }
 
         return Task.FromResult(new ReminderTargetResolution(
             Success: false,
             ResolvedId: null,
             Kind: ReminderTargetKind.Unknown,
-            ErrorMessage: $"Could not resolve Discord target '{target}'. Use channel:<channelId> or <#channelId>."));
+            ErrorMessage: $"Could not resolve Discord target '{target}'. Use channel:<channelId>, <#channelId>, dm:<userId>, or <@userId>."));
     }
+
+    private ReminderTargetResolution ResolveChannel(string channelId)
+    {
+        return DiscordAclPolicy.IsAllowedChannel(new DiscordChannelId(channelId), options, GetDefaultChannelId())
+            ? new ReminderTargetResolution(
+                Success: true,
+                ResolvedId: channelId,
+                Kind: ReminderTargetKind.Channel,
+                ErrorMessage: null)
+            : new ReminderTargetResolution(
+                Success: false,
+                ResolvedId: null,
+                Kind: ReminderTargetKind.Unknown,
+                ErrorMessage: $"Discord channel '{channelId}' is not in the allowed channels list.");
+    }
+
+    private ReminderTargetResolution ResolveUser(string userId)
+    {
+        if (!options.AllowDirectMessages)
+        {
+            return new ReminderTargetResolution(
+                Success: false,
+                ResolvedId: null,
+                Kind: ReminderTargetKind.Unknown,
+                ErrorMessage: "Discord direct messages are disabled in configuration.");
+        }
+
+        return DiscordAclPolicy.IsAllowedUser(new DiscordUserId(userId), options)
+            ? new ReminderTargetResolution(
+                Success: true,
+                ResolvedId: userId,
+                Kind: ReminderTargetKind.User,
+                ErrorMessage: null)
+            : new ReminderTargetResolution(
+                Success: false,
+                ResolvedId: null,
+                Kind: ReminderTargetKind.Unknown,
+                ErrorMessage: $"Discord user '{userId}' is not in the allowed users list.");
+    }
+
+    private DiscordChannelId? GetDefaultChannelId()
+        => string.IsNullOrWhiteSpace(options.DefaultChannelId)
+            ? null
+            : new DiscordChannelId(options.DefaultChannelId);
 }

--- a/src/Netclaw.Daemon/Configuration/ChannelIntegrationRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/ChannelIntegrationRegistrationExtensions.cs
@@ -174,7 +174,7 @@ public static class ChannelIntegrationRegistrationExtensions
                     paths,
                     logger);
             })
-            .WithReminderResolver<DiscordReminderTargetResolver>()
+            .WithReminderResolver((_, options) => new DiscordReminderTargetResolver(options))
             .WithResolver((sp, options) => new DiscordAddressResolver(
                 sp.GetRequiredService<IDiscordAddressLookupClient>(),
                 options,

--- a/src/Netclaw.Daemon/Configuration/RemoteChatChannelBuilder.cs
+++ b/src/Netclaw.Daemon/Configuration/RemoteChatChannelBuilder.cs
@@ -184,6 +184,17 @@ public sealed class RemoteChatChannelBuilder<TChannel, TOptions>
         return this;
     }
 
+    /// <summary>Registers the channel's reminder target resolver.</summary>
+    public RemoteChatChannelBuilder<TChannel, TOptions> WithReminderResolver<TResolver>(
+        Func<IServiceProvider, TOptions, TResolver> factory)
+        where TResolver : class, IReminderTargetResolver
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        if (_options.Enabled)
+            _services.AddSingleton<IReminderTargetResolver>(sp => factory(sp, _options));
+        return this;
+    }
+
     /// <summary>
     /// Registers the channel's thread history fetcher, keyed by the channel
     /// key. Keying is load-bearing: an unkeyed registration would make every


### PR DESCRIPTION
## Summary
- support explicit Discord DM targets for reminders
- reject disallowed Discord reminder targets before persistence
- update reminder docs and operations skill guidance

## Tests
- dotnet test
- dotnet slopwatch analyze
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- git diff --check

Fixes #1595