### PR TITLE
fix(cli): model set/picker preserve hand-set modalities on re-set (#1127)

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -103,24 +103,28 @@ keys used by model references.
 
 ### Models
 
-Named model roles. Each role points to a provider and model ID.
+Named model definitions own provider/model identity and metadata. Roles reference definitions,
+so changing Main or Fallback does not destroy overrides belonging to the previous model.
 
 ```json
 {
   "Models": {
-    "Main": {
+    "Definitions": {
+      "qwen-main": {
       "Provider": "remote-gpu",
       "ModelId": "qwen3:30b",
       "ContextWindow": 32768
+      },
+      "qwen-small": {
+        "Provider": "remote-gpu",
+        "ModelId": "qwen3:8b",
+        "ContextWindow": 32768
+      }
     },
-    "Fallback": {
-      "Provider": "remote-gpu",
-      "ModelId": "qwen3:8b",
-      "ContextWindow": 32768
-    },
-    "Compaction": {
-      "Provider": "remote-gpu",
-      "ModelId": "qwen3:8b"
+    "Roles": {
+      "Main": "qwen-main",
+      "Fallback": "qwen-small",
+      "Compaction": "qwen-small"
     }
   }
 }
@@ -481,8 +485,9 @@ following the standard .NET convention.
 
 ```bash
 # Override the main model
-export NETCLAW_Models__Main__Provider="openrouter"
-export NETCLAW_Models__Main__ModelId="anthropic/claude-sonnet-4"
+export NETCLAW_Models__Definitions__claude__Provider="openrouter"
+export NETCLAW_Models__Definitions__claude__ModelId="anthropic/claude-sonnet-4"
+export NETCLAW_Models__Roles__Main="claude"
 
 # Set a provider API key
 export NETCLAW_Providers__openrouter__ApiKey="sk-or-v1-..."
@@ -520,14 +525,20 @@ export NETCLAW_Session__MaxToolIterationsPerTurn="60"
     }
   },
   "Models": {
-    "Main": {
-      "Provider": "local",
-      "ModelId": "qwen3:30b",
-      "ContextWindow": 32768
+    "Definitions": {
+      "qwen-main": {
+        "Provider": "local",
+        "ModelId": "qwen3:30b",
+        "ContextWindow": 32768
+      },
+      "qwen-small": {
+        "Provider": "local",
+        "ModelId": "qwen3:8b"
+      }
     },
-    "Compaction": {
-      "Provider": "local",
-      "ModelId": "qwen3:8b"
+    "Roles": {
+      "Main": "qwen-main",
+      "Compaction": "qwen-small"
     }
   },
   "Session": {

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.25.0"
+  version: "2.26.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.24.1"
+  version: "2.25.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -36,7 +36,7 @@ options instead of adding provider-specific properties to `ProviderEntry`.
 ### Degraded mode: No-Op chat client
 
 When Netclaw starts without an explicitly configured main model/provider
-(no `Models:Main`, incomplete `Models:Main`, no `Providers`, or `Models:Main`
+(no `Models.Roles.Main`, an unresolved definition, no `Providers`, or the selected definition
 points to a provider that is not configured), the daemon launches in
 **degraded mode** with a No-Op chat client. Bound defaults such as
 `local-ollama/qwen3:30b` do not count as operator configuration unless those
@@ -80,13 +80,13 @@ openai` defaults to the ChatGPT OAuth device flow. Use `--auth api-key
 
 ### Assigning models to roles and overriding metadata
 
-`netclaw model set <role> <provider> <model-id>` assigns a model to a role
-(`main`, `fallback`, `compaction`). Two attributes can be overridden by the
+`netclaw model set <role> <provider> <model-id>` creates or reuses a named model
+definition and assigns it to a role (`main`, `fallback`, `compaction`). Definitions
+own provider/model identity and metadata, while roles only reference definitions.
+Switching away from a model and back therefore preserves its overrides. Two attributes can be overridden by the
 operator and are **operator-owned**: the context window and the input/output
-modalities. Provider discovery seeds them on a first-time set or a model
-switch, but never clobbers a value already on disk when you re-set the **same**
-`(provider, model-id)` — so re-running `model set` (or re-picking in the TUI)
-preserves a hand-tuned clamp or modality override.
+modalities. Provider discovery seeds a new definition but never changes an existing
+definition, including adding a property the definition deliberately omits.
 
 - `--context-window <tokens>` clamps the session budget and takes precedence
   over provider-reported detection. Supplying it configures the model manually
@@ -102,7 +102,8 @@ preserves a hand-tuned clamp or modality override.
 
 To change a preserved value you must pass the corresponding flag (a plain
 re-set will not touch it). A legacy or hand-edited entry with an unreadable
-value does not block a re-set — `model set` repairs it while keeping the fields
+value does not block a re-set — `model set` migrates legacy inline roles to named
+definitions and repairs the selected entry while keeping the fields
 it can still read; `model list` reports an unparseable config instead of
 crashing, and `netclaw doctor --fix` repairs it.
 

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -78,6 +78,34 @@ When adding an OpenAI provider from the CLI, `netclaw provider add <name>
 openai` defaults to the ChatGPT OAuth device flow. Use `--auth api-key
 --api-key <key>` to force platform API-key auth instead.
 
+### Assigning models to roles and overriding metadata
+
+`netclaw model set <role> <provider> <model-id>` assigns a model to a role
+(`main`, `fallback`, `compaction`). Two attributes can be overridden by the
+operator and are **operator-owned**: the context window and the input/output
+modalities. Provider discovery seeds them on a first-time set or a model
+switch, but never clobbers a value already on disk when you re-set the **same**
+`(provider, model-id)` — so re-running `model set` (or re-picking in the TUI)
+preserves a hand-tuned clamp or modality override.
+
+- `--context-window <tokens>` clamps the session budget and takes precedence
+  over provider-reported detection. Supplying it configures the model manually
+  and skips the metadata probe.
+- `--input-modalities <list>` / `--output-modalities <list>` override detected
+  modalities with a comma-separated list of named flags (`Text`, `Image`,
+  `Audio`, `Video`). These do **not** skip the probe — the model is still
+  validated and its context window discovered; the override just wins over the
+  discovered modalities.
+- `--clear-context-window` and `--clear-modalities` remove the respective
+  override so runtime capability detection resolves it again (use these after a
+  provider enlarges a model's window or fixes mis-reported modalities).
+
+To change a preserved value you must pass the corresponding flag (a plain
+re-set will not touch it). A legacy or hand-edited entry with an unreadable
+value does not block a re-set — `model set` repairs it while keeping the fields
+it can still read; `model list` reports an unparseable config instead of
+crashing, and `netclaw doctor --fix` repairs it.
+
 ### Adding GitHub Copilot
 
 GitHub Copilot uses the OAuth device flow only — no API key. The operator

--- a/openspec/changes/preserve-model-definitions-across-role-switches/.openspec.yaml
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/preserve-model-definitions-across-role-switches/design.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Model metadata is currently embedded in three runtime role entries. Those entries are both the operator's durable configuration and the runtime consumer shape, so assigning a different model destroys metadata belonging to the previous model. Existing deployments and the current stable Docker image use this legacy shape.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Store model-owned metadata once in named definitions and make roles reference definitions.
+- Keep manual JSON editing obvious: property absence means runtime detection, with no tombstones.
+- Run legacy configuration without an eager write, and migrate deterministically on explicit mutation/fix.
+- Resolve and validate references before persistence and runtime client construction.
+
+**Non-Goals:**
+
+- Downgrade compatibility after the configuration has been migrated.
+- Automatic conflict resolution or model-definition garbage collection.
+- Changes to provider discovery or actor/persistence protocols.
+
+## Decisions
+
+### New canonical shape
+
+`Models.Definitions` is a dictionary of operator-chosen names to complete `ModelReference` values. `Models.Roles` contains `Main`, `Fallback`, and `Compaction` definition-name references. Runtime code receives the existing resolved `ModelSelection`, keeping actor and chat-client boundaries unchanged.
+
+This is preferred over a hidden metadata cache or role-entry tombstones because it gives manual editors one visible source of truth and preserves property absence as runtime detection.
+
+### Dual-shape reader, single-shape writer
+
+A shared configuration resolver accepts either the complete legacy inline shape or the complete named shape. Mixed shapes, missing definitions, duplicate/invalid names, and conflicting migration candidates fail loudly. Daemon startup reads legacy configuration without rewriting it. CLI/TUI writes and `doctor --fix` migrate legacy input atomically before applying the requested mutation.
+
+The schema accepts both complete shapes during the compatibility window. New writers emit only the named shape.
+
+### Deterministic legacy migration
+
+Each distinct case-insensitive `(Provider, ModelId)` becomes one definition. A deterministic slug is derived from provider and model ID, with a stable numeric suffix for name collisions. When multiple legacy roles identify the same model, their optional metadata must agree; otherwise migration fails with the conflicting role names and fields.
+
+### Upgrade smoke
+
+The smoke harness creates a disposable directory/volume, runs the latest stable image to produce or consume a legacy configuration, stops it, builds a uniquely tagged local image, and starts that image against the same isolated volume. Assertions verify startup, legacy resolution, explicit migration, and preservation after role switching. Cleanup removes only resources carrying the test's unique label/name.
+
+## Risks / Trade-offs
+
+- **Older binaries cannot read the named shape after migration** → document that rollback requires restoring the pre-migration backup; migration writes atomically and retains a backup.
+- **Dual-shape support can become permanent complexity** → centralize it in one resolver and have every writer emit only the canonical shape.
+- **Conflicting legacy roles could be silently merged** → reject conflicts and report exact fields/roles.
+- **Docker smoke could touch operator state** → require an absolute temporary path created by the harness and unique container/image names; never use default Netclaw volumes.
+- **Stable image availability/network failures** → make the Docker upgrade scenario explicit and fail with actionable diagnostics; unit migration fixtures remain mandatory offline proof.
+
+## Migration Plan
+
+1. Ship a reader that supports both shapes and schema validation for both.
+2. Verify an untouched legacy stable configuration starts with the new daemon.
+3. On the first explicit model/config write or `doctor --fix`, validate, back up, migrate, re-resolve, then atomically persist.
+4. Document rollback as restoring the generated legacy backup before running an older image.
+
+## Open Questions
+
+- The exact stable tag is resolved from the release manifest at smoke execution time rather than hard-coded.

--- a/openspec/changes/preserve-model-definitions-across-role-switches/proposal.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+PRD-004 and PRD-005 allow operators to select models and override provider-reported capabilities, but the current `Models.Main` / `Fallback` / `Compaction` entries combine role assignment with model-owned metadata. Switching a role therefore destroys manually maintained context-window and modality overrides, especially for vLLM deployments that cannot report modalities.
+
+## What Changes
+
+- Add human-readable named model definitions whose metadata is independent of role assignment.
+- Make model roles reference named definitions, so switching roles does not rewrite a definition.
+- Continue accepting the existing inline role shape on upgrade and provide deterministic migration to the named shape.
+- Reject ambiguous mixed or conflicting configuration instead of silently choosing a representation.
+- Add isolated stable-container to locally-built-container upgrade smoke coverage using a disposable volume.
+- Preserve absence of optional metadata as runtime detection; no hidden tombstone values are introduced.
+
+In scope: configuration binding, CLI/TUI model assignment, schema, doctor/migration behavior, operational guidance, automated compatibility proof, and Docker upgrade smoke coverage.
+
+Out of scope: automatic model discovery beyond existing probes, changing provider APIs, and supporting downgrade from the new shape to an older Netclaw binary.
+
+## Capabilities
+
+### New Capabilities
+
+- `named-model-definitions`: Model-owned definitions, role references, legacy resolution, migration, and conflict behavior.
+
+### Modified Capabilities
+
+- `netclaw-model-providers`: Primary, fallback, and compaction assignments reference persistent model definitions.
+- `netclaw-cli`: Model commands and TUI preserve model metadata across role switches and expose migration failures.
+- `netclaw-testing`: Upgrade compatibility is proven with legacy configuration and an isolated container-volume smoke.
+
+## Impact
+
+Affected areas include `Netclaw.Configuration` model types and schema, daemon/CLI configuration binding, model CLI and TUI persistence, provider rename behavior, doctor repair, system operational guidance, and smoke tooling. Startup remains fail-closed for invalid references. Existing inline deployments remain readable and runnable without an eager startup rewrite.
+
+Security impact is limited to configuration integrity: unresolved or conflicting role references fail before persistence or runtime client construction. Operationally, configuration is migrated only by an explicit writing/fix operation, and the upgrade smoke never mounts the operator's real Netclaw home.

--- a/openspec/changes/preserve-model-definitions-across-role-switches/specs/named-model-definitions/spec.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/specs/named-model-definitions/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Model-owned named definitions
+The system SHALL store provider identity, model ID, context-window override, modality overrides, and provenance in named model definitions independent of runtime role assignment. Roles SHALL reference definitions by name.
+
+#### Scenario: Switching away and back preserves overrides
+- **GIVEN** definition `vision` has a manual `InputModalities` override
+- **WHEN** Main switches from `vision` to another definition and back
+- **THEN** the `vision` definition SHALL remain unchanged
+- **AND** Main SHALL resolve to its original override
+
+#### Scenario: Manual absence remains runtime detection
+- **GIVEN** an existing definition omits an optional capability property
+- **WHEN** the definition is assigned to another role
+- **THEN** the property SHALL remain absent
+- **AND** no tombstone or discovered replacement SHALL be persisted
+
+### Requirement: Legacy model configuration compatibility
+The system SHALL accept the legacy inline Main/Fallback/Compaction shape without rewriting it during startup and SHALL resolve it to the same runtime model selection.
+
+#### Scenario: Existing deployment starts after upgrade
+- **GIVEN** a valid configuration written by the latest stable Netclaw image
+- **WHEN** the upgraded daemon starts
+- **THEN** startup SHALL succeed with equivalent model role values and capabilities
+- **AND** the configuration file SHALL not be rewritten merely by startup
+
+#### Scenario: Explicit mutation migrates legacy shape
+- **GIVEN** a valid legacy configuration
+- **WHEN** an operator performs a model-writing command or runs doctor fix
+- **THEN** the system SHALL atomically persist the named shape before completing the mutation
+- **AND** the persisted named shape SHALL resolve to the same runtime values
+
+#### Scenario: Ambiguous shape fails loudly
+- **GIVEN** configuration contains both legacy role objects and named role references
+- **WHEN** configuration is validated or loaded
+- **THEN** the operation SHALL fail with remediation identifying the mixed shape
+
+### Requirement: Reference integrity
+Every persisted role reference SHALL resolve to an existing definition before persistence and startup.
+
+#### Scenario: Missing definition is rejected
+- **WHEN** a role references an unknown definition
+- **THEN** validation SHALL fail before runtime client construction
+- **AND** no partial configuration write SHALL occur
+
+#### Scenario: Conflicting legacy duplicates are rejected
+- **GIVEN** two legacy roles identify the same provider/model but contain conflicting overrides
+- **WHEN** migration is requested
+- **THEN** migration SHALL fail with the conflicting roles and fields
+- **AND** the legacy file SHALL remain unchanged

--- a/openspec/changes/preserve-model-definitions-across-role-switches/specs/netclaw-cli/spec.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/specs/netclaw-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Named model role management
+Model CLI and TUI operations SHALL assign roles by changing references and SHALL edit model metadata only through the selected definition.
+
+#### Scenario: Assign existing definition
+- **WHEN** an operator assigns an existing named definition to Main
+- **THEN** only the Main role reference SHALL change
+- **AND** no definition metadata SHALL change
+
+#### Scenario: Mutating legacy configuration
+- **GIVEN** the CLI loads a valid legacy model configuration
+- **WHEN** a model mutation is requested
+- **THEN** the CLI SHALL migrate and validate the canonical shape before persistence
+- **AND** failure SHALL leave the original file unchanged

--- a/openspec/changes/preserve-model-definitions-across-role-switches/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/specs/netclaw-model-providers/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Primary and fallback model
+The system SHALL support configuring primary, fallback, and compaction roles as references to persistent named model definitions. Changing a role SHALL NOT change the referenced definition. When the primary model is unavailable due to rate limiting, timeout, or error, the system SHALL automatically switch to the fallback model. Fallback activation SHALL be logged for operator visibility.
+
+#### Scenario: Primary model succeeds
+- **GIVEN** both primary and fallback roles reference valid definitions
+- **WHEN** the primary model responds successfully
+- **THEN** the primary model response SHALL be used
+- **AND** no fallback activation SHALL occur
+
+#### Scenario: Automatic fallback on primary failure
+- **GIVEN** both primary and fallback roles reference valid definitions
+- **WHEN** the primary model returns a rate limit, timeout, or error response
+- **THEN** the system SHALL retry using the fallback definition
+- **AND** a log entry SHALL record the fallback activation with the failure reason
+
+#### Scenario: Role switch preserves model definition
+- **GIVEN** a named model definition contains operator capability overrides
+- **WHEN** Main or Fallback is assigned to another definition
+- **THEN** the previous definition SHALL remain unchanged and available for reassignment

--- a/openspec/changes/preserve-model-definitions-across-role-switches/specs/netclaw-testing/spec.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/specs/netclaw-testing/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Container upgrade compatibility proof
+The smoke suite SHALL verify upgrade from the latest stable Netclaw container to a locally built image using only an isolated temporary configuration volume.
+
+#### Scenario: Stable-to-local upgrade
+- **GIVEN** the latest stable image has written or consumed a legacy config in a disposable volume
+- **WHEN** a uniquely tagged local image starts against the same volume
+- **THEN** the new image SHALL become healthy without modifying the file on startup
+- **AND** an explicit migration SHALL preserve effective role and capability values
+- **AND** switching away from and back to a definition SHALL preserve its overrides
+
+#### Scenario: Production state isolation
+- **WHEN** the upgrade smoke runs
+- **THEN** it SHALL use a newly created absolute temporary directory or uniquely named test volume
+- **AND** it SHALL NOT mount or inspect the default or operator-provided Netclaw home

--- a/openspec/changes/preserve-model-definitions-across-role-switches/tasks.md
+++ b/openspec/changes/preserve-model-definitions-across-role-switches/tasks.md
@@ -1,0 +1,20 @@
+## 1. Canonical configuration and compatibility
+
+- [x] 1.1 Add named definition and role-reference configuration types plus one resolver for legacy and canonical shapes
+- [x] 1.2 Add deterministic, conflict-detecting legacy migration with atomic persistence and backup behavior
+- [x] 1.3 Update the JSON schema to accept legacy or canonical models while rejecting mixed/invalid shapes
+- [x] 1.4 Route daemon, CLI, doctor, provider rename, wizard, and TUI consumers through resolved canonical configuration
+
+## 2. Operator workflows
+
+- [x] 2.1 Update model CLI commands to create/edit definitions and switch roles without mutating definitions
+- [x] 2.2 Update the model-manager TUI and initialization writer to emit canonical configuration
+- [x] 2.3 Update `netclaw-operations` guidance and CLI help, including migration and rollback behavior
+
+## 3. Automated proof
+
+- [x] 3.1 Add legacy load, conflict rejection, canonical round-trip, and role A→B→A preservation tests
+- [x] 3.2 Add CLI/TUI tests proving invalid references are rejected before persistence
+- [x] 3.3 Add isolated latest-stable-container → local-image upgrade smoke and semantic assertions
+- [ ] 3.4 Run targeted/full tests, native TUI smoke, evals, Slopwatch, and copyright verification
+- [x] 3.5 Validate OpenSpec implementation alignment and prepare spec synchronization

--- a/scripts/docker/test-model-config-upgrade.sh
+++ b/scripts/docker/test-model-config-upgrade.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Verify that the latest stable image's inline model configuration survives an upgrade to a
+# locally built image and migrates without losing operator-owned model metadata.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/docker/lib/smoke-lib.sh
+. "$SCRIPT_DIR/lib/smoke-lib.sh"
+
+LOCAL_IMAGE="${1:?usage: test-model-config-upgrade.sh <local-image> [stable-image]}"
+STABLE_IMAGE="${2:-ghcr.io/netclaw-dev/netclaw:latest}"
+RUN_ID="model-upgrade-$PPID-$$"
+CONTAINER="netclaw-$RUN_ID"
+ROOT="$(mktemp -d -t netclaw-model-upgrade.XXXXXX)"
+HOME_DIR="$ROOT/home"
+CONFIG_DIR="$HOME_DIR/config"
+CONFIG="$CONFIG_DIR/netclaw.json"
+
+cleanup() {
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker run --rm --entrypoint chmod -v "$ROOT:/cleanup" "$LOCAL_IMAGE" \
+        -R a+rwX /cleanup >/dev/null 2>&1 || true
+    rm -rf "$ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$CONFIG_DIR"
+chmod 0777 "$HOME_DIR" "$CONFIG_DIR"
+
+cat >"$CONFIG" <<'JSON'
+{
+  "configVersion": 1,
+  "Providers": {
+    "vllm": {
+      "Type": "openai-compatible",
+      "Endpoint": "http://127.0.0.1:8000"
+    }
+  },
+  "Models": {
+    "Main": {
+      "Provider": "vllm",
+      "ModelId": "qwen-vl",
+      "ContextWindow": 32768,
+      "InputModalities": "Text, Image",
+      "OutputModalities": "Text"
+    },
+    "Fallback": {
+      "Provider": "vllm",
+      "ModelId": "llama-text"
+    }
+  }
+}
+JSON
+chmod 0666 "$CONFIG"
+
+echo "==> Latest stable consumes the isolated legacy configuration: $STABLE_IMAGE"
+docker run --rm --entrypoint /usr/local/bin/netclaw \
+    -v "$HOME_DIR:/home/netclaw/.netclaw" "$STABLE_IMAGE" model list >/dev/null
+
+legacy_hash="$(sha256sum "$CONFIG" | awk '{print $1}')"
+
+echo "==> Locally built daemon starts against the same legacy configuration without rewriting it"
+docker run -d --name "$CONTAINER" -v "$HOME_DIR:/home/netclaw/.netclaw" "$LOCAL_IMAGE" >/dev/null
+netclaw_wait_healthy "$CONTAINER" 5199 60
+[[ "$(sha256sum "$CONFIG" | awk '{print $1}')" == "$legacy_hash" ]] \
+    || { echo "ERROR: startup rewrote the legacy configuration" >&2; exit 1; }
+docker rm -f "$CONTAINER" >/dev/null
+
+run_local_cli() {
+    docker run --rm --entrypoint /usr/local/bin/netclaw \
+        -v "$HOME_DIR:/home/netclaw/.netclaw" "$LOCAL_IMAGE" "$@"
+}
+
+echo "==> Explicit model mutation migrates, then A -> B -> A preserves A's overrides"
+run_local_cli model set main vllm llama-text --context-window 65536 >/dev/null
+run_local_cli model set main vllm qwen-vl >/dev/null
+
+jq -e '
+  .Models.Main == null and
+  .Models.Roles.Main as $active |
+  .Models.Definitions[$active] |
+  .Provider == "vllm" and
+  .ModelId == "qwen-vl" and
+  .ContextWindow == 32768 and
+  .InputModalities == "Text, Image" and
+  .OutputModalities == "Text"
+' "$CONFIG" >/dev/null
+
+test -f "$CONFIG.legacy-models.bak"
+jq -e '.Models.Main.ModelId == "qwen-vl"' "$CONFIG.legacy-models.bak" >/dev/null
+
+echo "✓ stable legacy config starts unchanged, migrates explicitly, and preserves model metadata"

--- a/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
+++ b/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
@@ -76,7 +76,7 @@ public class ModelEntryWriterTests
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
             ContextWindowOverride.Set(131072), ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("Text, Image", entry["InputModalities"]); // preserved (#1127)
         Assert.Equal(131072, entry["ContextWindow"]);          // explicit override applied
     }
@@ -98,7 +98,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal(32000, entry["ContextWindow"]);
     }
 
@@ -113,7 +113,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal(128000, entry["ContextWindow"]);
     }
 
@@ -133,8 +133,24 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Clear, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.False(entry.ContainsKey("ContextWindow")); // clamp removed → runtime detection
+    }
+
+    [Fact]
+    public void WriteRole_SameDefinitionWithoutWindow_DiscoveryDoesNotResurrect()
+    {
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        Assert.False(ActiveEntry(models, "Main").ContainsKey("ContextWindow"));
     }
 
     [Fact]
@@ -153,7 +169,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(input: ModelModality.Text, output: ModelModality.Text));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("Text, Image", entry["InputModalities"]);
     }
 
@@ -174,7 +190,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(input: ModelModality.Text | ModelModality.Image));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.False(entry.ContainsKey("InputModalities")); // stays cleared, not resurrected
     }
 
@@ -193,7 +209,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset,
             ModalityOverride.Set(ModelModality.Text), ModalityOverride.Unset, discovered: null);
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("Text", entry["InputModalities"]);
     }
 
@@ -212,7 +228,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Clear, ModalityOverride.Clear,
             Discovered(input: ModelModality.Text | ModelModality.Image));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.False(entry.ContainsKey("InputModalities"));
         Assert.False(entry.ContainsKey("OutputModalities"));
     }
@@ -232,7 +248,7 @@ public class ModelEntryWriterTests
             models, "Main", "local-ollama", "qwen3:30b", ModelDiscoverySource.Manual,
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("qwen3:30b", entry["ModelId"]);
         Assert.False(entry.ContainsKey("InputModalities")); // stray modality dropped, not carried over
     }
@@ -251,7 +267,7 @@ public class ModelEntryWriterTests
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
             ContextWindowOverride.Set(131072), ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("Live", entry["Provenance"]); // origin preserved, not downgraded to Manual
         Assert.Equal(131072, entry["ContextWindow"]);
     }
@@ -271,7 +287,7 @@ public class ModelEntryWriterTests
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Defaults,
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("Live", entry["Provenance"]);
     }
 
@@ -290,7 +306,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("Live", entry["Provenance"]);
     }
 
@@ -311,9 +327,9 @@ public class ModelEntryWriterTests
             Discovered(contextWindow: 128000)));
 
         Assert.Null(ex);
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("qwen-vl", entry["ModelId"]);
-        Assert.Equal(128000, entry["ContextWindow"]);          // no stored window, so discovery seeds it
+        Assert.False(entry.ContainsKey("ContextWindow"));      // existing absence stays runtime detection
         Assert.False(entry.ContainsKey("InputModalities"));    // corrupt value dropped, not frozen
     }
 
@@ -333,7 +349,7 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal(32768, entry["ContextWindow"]);         // operator clamp preserved, not clobbered
         Assert.False(entry.ContainsKey("InputModalities"));  // unparseable override dropped
     }
@@ -353,31 +369,44 @@ public class ModelEntryWriterTests
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
-        var entry = (Dictionary<string, object>)models["Main"];
+        var entry = ActiveEntry(models, "Main");
         Assert.Equal("qwen-vl", entry["ModelId"]);
         Assert.Equal(128000, entry["ContextWindow"]);  // discovered window, not the other model's 32768
     }
 
     [Fact]
-    public void WriteRole_DifferentModel_DropsPreviousModelModalities()
+    public void WriteRole_SwitchAwayAndBack_PreservesPreviousModelModalities()
     {
         var models = Models(
             """
             { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Text, Image" } }
             """);
 
-        // Switching to a DIFFERENT model must not carry the old model's modalities over.
+        // Switching roles changes only the role reference. The old definition remains intact.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "other-model", ModelDiscoverySource.Manual,
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
-        var entry = (Dictionary<string, object>)models["Main"];
-        Assert.Equal("other-model", entry["ModelId"]);
-        Assert.False(entry.ContainsKey("InputModalities"));
+        Assert.Equal("other-model", ActiveEntry(models, "Main")["ModelId"]);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+
+        Assert.Equal("Text, Image", ActiveEntry(models, "Main")["InputModalities"]);
     }
 
     private static Dictionary<string, object> Models(string json)
         => JsonSerializer.Deserialize<Dictionary<string, object>>(json)!;
+
+    private static Dictionary<string, object> ActiveEntry(
+        Dictionary<string, object> models, string role)
+    {
+        var roles = (Dictionary<string, object>)models["Roles"];
+        var definitionName = (string)roles[role];
+        var definitions = (Dictionary<string, object>)models["Definitions"];
+        return (Dictionary<string, object>)definitions[definitionName];
+    }
 
     private static DiscoveredModel Discovered(
         int? contextWindow = null, ModelModality? input = null, ModelModality? output = null)

--- a/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
+++ b/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
@@ -62,16 +62,16 @@ public class ModelEntryWriterTests
     [Fact]
     public void WriteRole_SameModelWithoutModalities_PreservesHandSetModalities()
     {
-        // On-disk shape: an operator hand-edited InputModalities (the only way to set it).
-        var models = JsonSerializer.Deserialize<Dictionary<string, object>>(
+        // On-disk shape: an operator-set InputModalities override.
+        var models = Models(
             """
             { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "ContextWindow": 262144, "InputModalities": "Text, Image" } }
-            """)!;
+            """);
 
-        // Re-set the same model with only a context-window change; no modalities supplied.
+        // Re-set the same model with only a context-window change; no modality intent supplied.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
-            contextWindow: 131072, inputModalities: null, outputModalities: null);
+            contextWindow: 131072, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("Text, Image", entry["InputModalities"]); // preserved (#1127)
@@ -79,20 +79,209 @@ public class ModelEntryWriterTests
     }
 
     [Fact]
-    public void WriteRole_DifferentModel_DropsPreviousModelModalities()
+    public void WriteRole_SameModel_PreservesExistingClampOverDiscoveredWindow()
     {
-        var models = JsonSerializer.Deserialize<Dictionary<string, object>>(
+        // Operator clamped ContextWindow below what the provider reports.
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "ContextWindow": 32000 } }
+            """);
+
+        // Re-select the same model (picker path): no explicit --context-window, but the probe
+        // reports the model's full window. The operator's clamp must win (#1610): ContextWindow
+        // is documented to take precedence over provider-reported detection.
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal(32000, entry["ContextWindow"]);
+    }
+
+    [Fact]
+    public void WriteRole_FirstTimeSet_UsesDiscoveredWindow()
+    {
+        // No existing entry for the role: discovery is the fallback that seeds the value.
+        var models = new Dictionary<string, object>();
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal(128000, entry["ContextWindow"]);
+    }
+
+    [Fact]
+    public void WriteRole_SameModelFreshProbe_DoesNotOverrideExistingModalities()
+    {
+        // Operator override on disk; a fresh probe reports a coarser Text-only capability.
+        var models = Models(
             """
             { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Text, Image" } }
-            """)!;
+            """);
+
+        // The stored override wins — discovery never silently overwrites it (#1610 / #5). This is
+        // the same rule as ContextWindow: the field is documented to bypass automated detection.
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(input: ModelModality.Text, output: ModelModality.Text));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("Text, Image", entry["InputModalities"]);
+    }
+
+    [Fact]
+    public void WriteRole_ExplicitModalityOverride_ReplacesExisting()
+    {
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Text, Image" } }
+            """);
+
+        // Explicit operator input (--input-modalities Text) is the authority: it replaces the
+        // stored override so the operator can actually change a value discovery no longer touches.
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
+            contextWindow: null,
+            ModalityOverride.Set(ModelModality.Text), ModalityOverride.Unset, discovered: null);
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("Text", entry["InputModalities"]);
+    }
+
+    [Fact]
+    public void WriteRole_ClearModalities_RemovesOverrideEvenWhenProbeReportsOne()
+    {
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Text, Image", "OutputModalities": "Text" } }
+            """);
+
+        // --clear-modalities removes both overrides so runtime detection resolves them; clear
+        // wins over BOTH the stored value and a probe that still reports modalities (#1610 / #4).
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
+            contextWindow: null, ModalityOverride.Clear, ModalityOverride.Clear,
+            Discovered(input: ModelModality.Text | ModelModality.Image));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.False(entry.ContainsKey("InputModalities"));
+        Assert.False(entry.ContainsKey("OutputModalities"));
+    }
+
+    [Fact]
+    public void WriteRole_ExistingEntryOmitsModelId_DoesNotFalseMatchDefaultModel()
+    {
+        // The entry omits ModelId; ModelReference would default it to the stock "qwen3:30b".
+        // Setting the stock default model must NOT treat this as the same model and carry the
+        // stray modalities onto a model the entry never named (#1610).
+        var models = Models(
+            """
+            { "Main": { "Provider": "local-ollama", "InputModalities": "Text, Image" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "local-ollama", "qwen3:30b", ModelDiscoverySource.Manual,
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("qwen3:30b", entry["ModelId"]);
+        Assert.False(entry.ContainsKey("InputModalities")); // stray modality dropped, not carried over
+    }
+
+    [Fact]
+    public void WriteRole_SameModelManualReSet_PreservesDiscoveredProvenance()
+    {
+        // The model ID was originally resolved Live. A --context-window-only re-set (no probe,
+        // so the caller passes Manual) must not relabel the ID's origin as Manual (#1610).
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "Live", "ContextWindow": 262144 } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
+            contextWindow: 131072, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("Live", entry["Provenance"]); // origin preserved, not downgraded to Manual
+        Assert.Equal(131072, entry["ContextWindow"]);
+    }
+
+    [Fact]
+    public void WriteRole_SameModelFreshDiscovery_UpdatesProvenance()
+    {
+        // A fresh probe legitimately re-resolves the ID, so a Live discovery updates a stale
+        // Defaults origin rather than being pinned to it.
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "Defaults" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("Live", entry["Provenance"]);
+    }
+
+    [Fact]
+    public void WriteRole_CorruptExistingEntry_OverwritesInsteadOfThrowing()
+    {
+        // A legacy/hand-corrupted entry: "Vision" is not a valid ModelModality enum name, so
+        // deserializing it throws JsonException. `model set` must still succeed and repair it
+        // (#1610) rather than aborting on an entry it is about to overwrite.
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Vision" } }
+            """);
+
+        var ex = Record.Exception(() => ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000)));
+
+        Assert.Null(ex);
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("qwen-vl", entry["ModelId"]);
+        Assert.Equal(128000, entry["ContextWindow"]);          // clean rewrite, nothing preserved
+        Assert.False(entry.ContainsKey("InputModalities"));    // corrupt value dropped, not frozen
+    }
+
+    [Fact]
+    public void WriteRole_DifferentModel_DropsPreviousModelModalities()
+    {
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Text, Image" } }
+            """);
 
         // Switching to a DIFFERENT model must not carry the old model's modalities over.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "other-model", ModelDiscoverySource.Manual,
-            contextWindow: null, inputModalities: null, outputModalities: null);
+            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("other-model", entry["ModelId"]);
         Assert.False(entry.ContainsKey("InputModalities"));
     }
+
+    private static Dictionary<string, object> Models(string json)
+        => JsonSerializer.Deserialize<Dictionary<string, object>>(json)!;
+
+    private static DiscoveredModel Discovered(
+        int? contextWindow = null, ModelModality? input = null, ModelModality? output = null)
+        => new()
+        {
+            ModelId = new ModelId("qwen-vl"),
+            ContextWindowTokens = contextWindow,
+            InputModalities = input,
+            OutputModalities = output,
+        };
 }

--- a/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
+++ b/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 using Xunit;
@@ -56,5 +57,42 @@ public class ModelEntryWriterTests
         Assert.True(entry.ContainsKey("Provider"));
         Assert.False(entry.ContainsKey("ModelId"));
         Assert.False(entry.ContainsKey("Provenance"));
+    }
+
+    [Fact]
+    public void WriteRole_SameModelWithoutModalities_PreservesHandSetModalities()
+    {
+        // On-disk shape: an operator hand-edited InputModalities (the only way to set it).
+        var models = JsonSerializer.Deserialize<Dictionary<string, object>>(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "ContextWindow": 262144, "InputModalities": "Text, Image" } }
+            """)!;
+
+        // Re-set the same model with only a context-window change; no modalities supplied.
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
+            contextWindow: 131072, inputModalities: null, outputModalities: null);
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("Text, Image", entry["InputModalities"]); // preserved (#1127)
+        Assert.Equal(131072, entry["ContextWindow"]);          // explicit override applied
+    }
+
+    [Fact]
+    public void WriteRole_DifferentModel_DropsPreviousModelModalities()
+    {
+        var models = JsonSerializer.Deserialize<Dictionary<string, object>>(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "InputModalities": "Text, Image" } }
+            """)!;
+
+        // Switching to a DIFFERENT model must not carry the old model's modalities over.
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "other-model", ModelDiscoverySource.Manual,
+            contextWindow: null, inputModalities: null, outputModalities: null);
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("other-model", entry["ModelId"]);
+        Assert.False(entry.ContainsKey("InputModalities"));
     }
 }

--- a/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
+++ b/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
@@ -7,6 +7,8 @@ using System.Text.Json;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 using Xunit;
+using ModalityOverride = Netclaw.Cli.Config.ValueOverride<Netclaw.Configuration.ModelModality>;
+using ContextWindowOverride = Netclaw.Cli.Config.ValueOverride<int>;
 
 namespace Netclaw.Cli.Tests.Config;
 
@@ -14,7 +16,8 @@ namespace Netclaw.Cli.Tests.Config;
 /// Guards the single persist path shared by `model set`, the init wizard, and the TUI
 /// model manager. The rule under test: modalities are written only when the discovery
 /// source genuinely reported them, so an unknown is never frozen into config as a
-/// permanent "Text" override (#1290).
+/// permanent "Text" override (#1290), and operator-owned overrides survive re-selection
+/// (#1127 / #1610).
 /// </summary>
 public class ModelEntryWriterTests
 {
@@ -71,7 +74,7 @@ public class ModelEntryWriterTests
         // Re-set the same model with only a context-window change; no modality intent supplied.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
-            contextWindow: 131072, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+            ContextWindowOverride.Set(131072), ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("Text, Image", entry["InputModalities"]); // preserved (#1127)
@@ -92,7 +95,7 @@ public class ModelEntryWriterTests
         // is documented to take precedence over provider-reported detection.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
         var entry = (Dictionary<string, object>)models["Main"];
@@ -107,11 +110,31 @@ public class ModelEntryWriterTests
 
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal(128000, entry["ContextWindow"]);
+    }
+
+    [Fact]
+    public void WriteRole_ClearContextWindow_DropsStoredClampAndDiscoveredWindow()
+    {
+        // Operator clamped the window; now --clear-context-window removes the clamp so runtime
+        // detection resolves it. Clear wins over BOTH the stored value and a probe that reports
+        // a window (#1610) — mirroring --clear-modalities.
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "ContextWindow": 32000 } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            ContextWindowOverride.Clear, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.False(entry.ContainsKey("ContextWindow")); // clamp removed → runtime detection
     }
 
     [Fact]
@@ -127,11 +150,32 @@ public class ModelEntryWriterTests
         // the same rule as ContextWindow: the field is documented to bypass automated detection.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(input: ModelModality.Text, output: ModelModality.Text));
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("Text, Image", entry["InputModalities"]);
+    }
+
+    [Fact]
+    public void WriteRole_SameModelEntryClearedModality_DiscoveryDoesNotResurrect()
+    {
+        // The entry exists for this model but carries NO modality — the on-disk shape left behind
+        // by a prior --clear-modalities. A later same-model re-set that carries a probe result must
+        // NOT re-add the discovered modality, or it would silently undo the operator's clear and
+        // re-demote a multimodal-misreporting model on next boot (#1610).
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(input: ModelModality.Text | ModelModality.Image));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.False(entry.ContainsKey("InputModalities")); // stays cleared, not resurrected
     }
 
     [Fact]
@@ -146,7 +190,7 @@ public class ModelEntryWriterTests
         // stored override so the operator can actually change a value discovery no longer touches.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
-            contextWindow: null,
+            ContextWindowOverride.Unset,
             ModalityOverride.Set(ModelModality.Text), ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
@@ -165,7 +209,7 @@ public class ModelEntryWriterTests
         // wins over BOTH the stored value and a probe that still reports modalities (#1610 / #4).
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
-            contextWindow: null, ModalityOverride.Clear, ModalityOverride.Clear,
+            ContextWindowOverride.Unset, ModalityOverride.Clear, ModalityOverride.Clear,
             Discovered(input: ModelModality.Text | ModelModality.Image));
 
         var entry = (Dictionary<string, object>)models["Main"];
@@ -186,7 +230,7 @@ public class ModelEntryWriterTests
 
         ModelEntryWriter.WriteRole(
             models, "Main", "local-ollama", "qwen3:30b", ModelDiscoverySource.Manual,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("qwen3:30b", entry["ModelId"]);
@@ -205,11 +249,30 @@ public class ModelEntryWriterTests
 
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
-            contextWindow: 131072, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+            ContextWindowOverride.Set(131072), ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("Live", entry["Provenance"]); // origin preserved, not downgraded to Manual
         Assert.Equal(131072, entry["ContextWindow"]);
+    }
+
+    [Fact]
+    public void WriteRole_SameModelProbeFailedDefaults_PreservesLiveProvenance()
+    {
+        // The ID was originally resolved Live. A same-model re-pick whose probe FAILED passes
+        // Defaults (not Manual). That is still "did not freshly resolve the ID", so it must not
+        // downgrade the stored Live origin — only a fresh Live discovery re-stamps it (#1610).
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "Live" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Defaults,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("Live", entry["Provenance"]);
     }
 
     [Fact]
@@ -224,7 +287,7 @@ public class ModelEntryWriterTests
 
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000));
 
         var entry = (Dictionary<string, object>)models["Main"];
@@ -244,14 +307,55 @@ public class ModelEntryWriterTests
 
         var ex = Record.Exception(() => ModelEntryWriter.WriteRole(
             models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
             Discovered(contextWindow: 128000)));
 
         Assert.Null(ex);
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("qwen-vl", entry["ModelId"]);
-        Assert.Equal(128000, entry["ContextWindow"]);          // clean rewrite, nothing preserved
+        Assert.Equal(128000, entry["ContextWindow"]);          // no stored window, so discovery seeds it
         Assert.False(entry.ContainsKey("InputModalities"));    // corrupt value dropped, not frozen
+    }
+
+    [Fact]
+    public void WriteRole_CorruptModalityButValidWindow_PreservesWindow()
+    {
+        // A hand-edited entry with a VALID ContextWindow clamp but an unparseable InputModalities
+        // string. Discarding the whole entry (the old catch behavior) would silently clobber the
+        // operator's still-valid window; the field-tolerant read must preserve it (#1610).
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "ContextWindow": 32768, "InputModalities": "text_and_image" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal(32768, entry["ContextWindow"]);         // operator clamp preserved, not clobbered
+        Assert.False(entry.ContainsKey("InputModalities"));  // unparseable override dropped
+    }
+
+    [Fact]
+    public void WriteRole_CorruptEntryForDifferentModel_DoesNotLeakWindow()
+    {
+        // A corrupt entry that names a DIFFERENT model must not have its ContextWindow carried
+        // onto the model being set — the resilient read only preserves a same-model entry.
+        var models = Models(
+            """
+            { "Main": { "Provider": "spark", "ModelId": "other-model", "ContextWindow": 32768, "InputModalities": "Vision" } }
+            """);
+
+        ModelEntryWriter.WriteRole(
+            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
+            Discovered(contextWindow: 128000));
+
+        var entry = (Dictionary<string, object>)models["Main"];
+        Assert.Equal("qwen-vl", entry["ModelId"]);
+        Assert.Equal(128000, entry["ContextWindow"]);  // discovered window, not the other model's 32768
     }
 
     [Fact]
@@ -265,7 +369,7 @@ public class ModelEntryWriterTests
         // Switching to a DIFFERENT model must not carry the old model's modalities over.
         ModelEntryWriter.WriteRole(
             models, "Main", "spark", "other-model", ModelDiscoverySource.Manual,
-            contextWindow: null, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
+            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = (Dictionary<string, object>)models["Main"];
         Assert.Equal("other-model", entry["ModelId"]);

--- a/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
+++ b/src/Netclaw.Cli.Tests/Config/ModelEntryWriterTests.cs
@@ -253,61 +253,26 @@ public class ModelEntryWriterTests
         Assert.False(entry.ContainsKey("InputModalities")); // stray modality dropped, not carried over
     }
 
-    [Fact]
-    public void WriteRole_SameModelManualReSet_PreservesDiscoveredProvenance()
+    [Theory]
+    [InlineData(ModelDiscoverySource.Live, ModelDiscoverySource.Manual, ModelDiscoverySource.Live)]
+    [InlineData(ModelDiscoverySource.Live, ModelDiscoverySource.Defaults, ModelDiscoverySource.Live)]
+    [InlineData(ModelDiscoverySource.Defaults, ModelDiscoverySource.Live, ModelDiscoverySource.Live)]
+    public void WriteRole_SameModel_PreservesProvenanceUnlessFreshlyDiscovered(
+        ModelDiscoverySource existing,
+        ModelDiscoverySource incoming,
+        ModelDiscoverySource expected)
     {
-        // The model ID was originally resolved Live. A --context-window-only re-set (no probe,
-        // so the caller passes Manual) must not relabel the ID's origin as Manual (#1610).
         var models = Models(
-            """
-            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "Live", "ContextWindow": 262144 } }
+            $$"""
+            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "{{existing}}" } }
             """);
 
         ModelEntryWriter.WriteRole(
-            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Manual,
-            ContextWindowOverride.Set(131072), ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
-
-        var entry = ActiveEntry(models, "Main");
-        Assert.Equal("Live", entry["Provenance"]); // origin preserved, not downgraded to Manual
-        Assert.Equal(131072, entry["ContextWindow"]);
-    }
-
-    [Fact]
-    public void WriteRole_SameModelProbeFailedDefaults_PreservesLiveProvenance()
-    {
-        // The ID was originally resolved Live. A same-model re-pick whose probe FAILED passes
-        // Defaults (not Manual). That is still "did not freshly resolve the ID", so it must not
-        // downgrade the stored Live origin — only a fresh Live discovery re-stamps it (#1610).
-        var models = Models(
-            """
-            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "Live" } }
-            """);
-
-        ModelEntryWriter.WriteRole(
-            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Defaults,
+            models, "Main", "spark", "qwen-vl", incoming,
             ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset, discovered: null);
 
         var entry = ActiveEntry(models, "Main");
-        Assert.Equal("Live", entry["Provenance"]);
-    }
-
-    [Fact]
-    public void WriteRole_SameModelFreshDiscovery_UpdatesProvenance()
-    {
-        // A fresh probe legitimately re-resolves the ID, so a Live discovery updates a stale
-        // Defaults origin rather than being pinned to it.
-        var models = Models(
-            """
-            { "Main": { "Provider": "spark", "ModelId": "qwen-vl", "Provenance": "Defaults" } }
-            """);
-
-        ModelEntryWriter.WriteRole(
-            models, "Main", "spark", "qwen-vl", ModelDiscoverySource.Live,
-            ContextWindowOverride.Unset, ModalityOverride.Unset, ModalityOverride.Unset,
-            Discovered(contextWindow: 128000));
-
-        var entry = ActiveEntry(models, "Main");
-        Assert.Equal("Live", entry["Provenance"]);
+        Assert.Equal(expected.ToString(), entry["Provenance"]);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/DoctorFixServiceTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/DoctorFixServiceTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Cli.Daemon;
+using System.Text.Json;
 using Netclaw.Cli.Doctor;
 using Netclaw.Configuration;
 using Xunit;
@@ -18,6 +19,40 @@ public sealed class DoctorFixServiceTests
 
     // ── Config-file fixes (systemd PATH rehydration disabled so these stay hermetic
     //    on machines where netclaw is actually installed as a --user service) ──
+
+    [Fact]
+    public async Task MigratesLegacyModelsWithoutChangingEffectiveMetadata()
+    {
+        var paths = NewPaths();
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Models": {
+                "Main": {
+                  "Provider": "vllm",
+                  "ModelId": "qwen-vl",
+                  "ContextWindow": 32768,
+                  "InputModalities": "Text, Image"
+                }
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var service = ConfigOnlyService(paths);
+        var plan = await service.BuildPlanAsync(TestContext.Current.CancellationToken);
+        await service.ApplyAsync(plan, TestContext.Current.CancellationToken);
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(
+            paths.NetclawConfigPath, TestContext.Current.CancellationToken));
+        var models = document.RootElement.GetProperty("Models");
+        var name = models.GetProperty("Roles").GetProperty("Main").GetString()!;
+        var definition = models.GetProperty("Definitions").GetProperty(name);
+        Assert.Equal("qwen-vl", definition.GetProperty("ModelId").GetString());
+        Assert.Equal(32768, definition.GetProperty("ContextWindow").GetInt32());
+        Assert.Equal("Text, Image", definition.GetProperty("InputModalities").GetString());
+        Assert.True(File.Exists(paths.NetclawConfigPath + ".legacy-models.bak"));
+    }
 
     [Fact]
     public async Task PlansConfigVersionFix_WhenMissing()

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -401,6 +401,95 @@ public sealed class ModelCommandTests : IDisposable
         Assert.Equal("qwen3:8b", fallback.GetProperty("ModelId").GetString());
     }
 
+    [Fact]
+    public async Task Set_InputModalities_WritesOverrideWithoutProbing()
+    {
+        WriteConfig(ProvidersOnly());
+
+        // A non-OAuth provider never probes; --input-modalities is the manual override channel.
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities", "Text, Image"],
+            _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
+    }
+
+    [Fact]
+    public async Task Set_ClearModalities_RemovesExistingOverride()
+    {
+        WriteConfig(WithMainModalities("Text, Image"));
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--clear-modalities"],
+            _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.False(main.TryGetProperty("InputModalities", out _)); // cleared → runtime detection
+    }
+
+    [Fact]
+    public async Task Set_InvalidModalities_ReturnsErrorWithoutWriting()
+    {
+        WriteConfig(ProvidersOnly());
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities", "Vision"],
+            _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("invalid modalities", _output.ToString());
+        // Parsing fails before any config load/write, so no Models section is created.
+        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
+    }
+
+    [Fact]
+    public async Task Set_SameModelReSetWithContextWindow_PreservesExistingModalities()
+    {
+        WriteConfig(WithMainModalities("Text, Image"));
+
+        // End-to-end: a --context-window-only re-set of the same model must keep the operator's
+        // modality override (#1127 / #5) — discovery/rebuild no longer wipes it.
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--context-window", "65536"],
+            _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
+        Assert.Equal(65536, main.GetProperty("ContextWindow").GetInt32());
+    }
+
+    private static Dictionary<string, object> ProvidersOnly() => new()
+    {
+        ["configVersion"] = 1,
+        ["Providers"] = new Dictionary<string, object>
+        {
+            ["my-ollama"] = new Dictionary<string, object>
+            {
+                ["Type"] = "ollama",
+                ["Endpoint"] = "http://localhost:11434"
+            }
+        }
+    };
+
+    private static Dictionary<string, object> WithMainModalities(string inputModalities)
+    {
+        var config = ProvidersOnly();
+        config["Models"] = new Dictionary<string, object>
+        {
+            ["Main"] = new Dictionary<string, object>
+            {
+                ["Provider"] = "my-ollama",
+                ["ModelId"] = "qwen3:30b",
+                ["InputModalities"] = inputModalities
+            }
+        };
+        return config;
+    }
+
     private void WriteConfig(Dictionary<string, object> data)
     {
         File.WriteAllText(_paths.NetclawConfigPath,

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -462,6 +462,208 @@ public sealed class ModelCommandTests : IDisposable
         Assert.Equal(65536, main.GetProperty("ContextWindow").GetInt32());
     }
 
+    [Fact]
+    public async Task Set_TrailingModalityFlagWithoutValue_ReturnsError()
+    {
+        WriteConfig(ProvidersOnly());
+
+        // --input-modalities is the final token: its value is missing. It must fail loudly rather
+        // than be silently dropped while the command still reports success (#1610).
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities"],
+            _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--input-modalities requires a value", _output.ToString());
+        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
+    }
+
+    [Fact]
+    public async Task Set_UnknownArgument_ReturnsError()
+    {
+        WriteConfig(ProvidersOnly());
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalites", "Text"],
+            _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("unknown argument '--input-modalites'", _output.ToString());
+        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
+    }
+
+    [Fact]
+    public async Task Set_NumericModalities_ReturnsError()
+    {
+        WriteConfig(ProvidersOnly());
+
+        // A raw integer must not be coerced into flags: "3" would otherwise become Text|Image.
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities", "3"],
+            _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("invalid modalities", _output.ToString());
+        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
+    }
+
+    [Fact]
+    public async Task Set_ClearContextWindow_RemovesStoredClamp()
+    {
+        var config = ProvidersOnly();
+        config["Models"] = new Dictionary<string, object>
+        {
+            ["Main"] = new Dictionary<string, object>
+            {
+                ["Provider"] = "my-ollama",
+                ["ModelId"] = "qwen3:30b",
+                ["ContextWindow"] = 32768
+            }
+        };
+        WriteConfig(config);
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--clear-context-window"],
+            _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.False(main.TryGetProperty("ContextWindow", out _)); // clamp removed → runtime detection
+    }
+
+    [Fact]
+    public async Task Set_ContextWindowAndClearContextWindow_ReturnsError()
+    {
+        WriteConfig(ProvidersOnly());
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--context-window", "32768", "--clear-context-window"],
+            _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("cannot be combined", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Set_OAuthModelWithModalityOverride_StillProbesAndValidates()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["openai-codex"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+        _fakeProbe.NextResult = new ProviderProbeResult(true, null,
+        [
+            new DiscoveredModel
+            {
+                ModelId = new Netclaw.Configuration.ModelId("gpt-new-codex"),
+                ContextWindowTokens = 512000,
+                InputModalities = ModelModality.Text | ModelModality.Image,
+                OutputModalities = ModelModality.Text,
+            }
+        ]);
+
+        // A modality override no longer short-circuits the probe: the probe must still run to
+        // validate the model and discover the context window, while the operator's modality wins.
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "openai-codex", "gpt-new-codex", "--input-modalities", "Text"],
+            _paths, _fakeProbe, output: _output);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _fakeProbe.ProbeCallCount);            // probe ran despite the modality flag
+        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.Equal("Live", main.GetProperty("Provenance").GetString());     // resolved via probe
+        Assert.Equal(512000, main.GetProperty("ContextWindow").GetInt32());   // discovered window captured
+        Assert.Equal("Text", main.GetProperty("InputModalities").GetString());// operator override wins
+    }
+
+    [Fact]
+    public async Task Set_OAuthModelWithModalityOverride_WhenModelNotReturned_ReturnsError()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["openai-codex"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+        _fakeProbe.NextResult = new ProviderProbeResult(true, null,
+        [
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("gpt-other-codex") }
+        ]);
+
+        // The modality flag must not let an unvalidated model slip through: the probe reports a
+        // different model, so the set must fail rather than write an unverified entry (#1610).
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "openai-codex", "gpt-new-codex", "--input-modalities", "Text"],
+            _paths, _fakeProbe, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not returned", _output.ToString());
+        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
+    }
+
+    [Fact]
+    public async Task List_CorruptModalityConfig_ReturnsErrorWithoutCrashing()
+    {
+        // A config with an unparseable modality enum string must not crash `model list` with an
+        // unhandled JsonException, nor be silently reported as "no models configured" (#1610).
+        WriteConfig(WithMainEntry(new Dictionary<string, object>
+        {
+            ["Provider"] = "my-ollama",
+            ["ModelId"] = "qwen3:30b",
+            ["ContextWindow"] = 32768,
+            ["InputModalities"] = "text_and_image"
+        }));
+
+        var exitCode = await ModelCommand.RunAsync(["model", "list"], _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("could not be parsed", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Set_CorruptModalityButValidWindow_PreservesWindowEndToEnd()
+    {
+        // End-to-end regression for the full `model set` path: a re-set over a corrupt entry that
+        // has a VALID ContextWindow must succeed and keep the window (repairing the bad modality),
+        // not crash in the downgrade-check load path before reaching the writer (#1610).
+        WriteConfig(WithMainEntry(new Dictionary<string, object>
+        {
+            ["Provider"] = "my-ollama",
+            ["ModelId"] = "qwen3:30b",
+            ["ContextWindow"] = 32768,
+            ["InputModalities"] = "text_and_image"
+        }));
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b"], _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.Equal(32768, main.GetProperty("ContextWindow").GetInt32()); // valid clamp preserved
+        Assert.False(main.TryGetProperty("InputModalities", out _));        // corrupt override dropped
+    }
+
+    private static Dictionary<string, object> WithMainEntry(Dictionary<string, object> main)
+    {
+        var config = ProvidersOnly();
+        config["Models"] = new Dictionary<string, object> { ["Main"] = main };
+        return config;
+    }
+
     private static Dictionary<string, object> ProvidersOnly() => new()
     {
         ["configVersion"] = 1,

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -88,7 +88,7 @@ public sealed class ModelCommandTests : IDisposable
 
         var config = ReadConfigFile(_paths.NetclawConfigPath);
         Assert.True(config.RootElement.TryGetProperty("Models", out var models));
-        Assert.True(models.TryGetProperty("Main", out var main));
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("my-ollama", main.GetProperty("Provider").GetString());
         Assert.Equal("qwen3:30b", main.GetProperty("ModelId").GetString());
         Assert.Equal("Manual", main.GetProperty("Provenance").GetString());
@@ -127,7 +127,7 @@ public sealed class ModelCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         var config = ReadConfigFile(_paths.NetclawConfigPath);
-        var main = config.RootElement.GetProperty("Models").GetProperty("Main");
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("Live", main.GetProperty("Provenance").GetString());
         Assert.Equal(512000, main.GetProperty("ContextWindow").GetInt32());
         Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
@@ -354,8 +354,9 @@ public sealed class ModelCommandTests : IDisposable
 
         var config = ReadConfigFile(_paths.NetclawConfigPath);
         Assert.True(config.RootElement.TryGetProperty("Models", out var models));
-        Assert.True(models.TryGetProperty("Main", out _)); // Main still exists
-        Assert.False(models.TryGetProperty("Fallback", out _)); // Fallback removed
+        var roles = models.GetProperty("Roles");
+        Assert.True(roles.TryGetProperty("Main", out _)); // Main still exists
+        Assert.False(roles.TryGetProperty("Fallback", out _)); // Fallback removed
     }
 
     [Fact]
@@ -396,8 +397,9 @@ public sealed class ModelCommandTests : IDisposable
 
         var config = ReadConfigFile(_paths.NetclawConfigPath);
         var models = config.RootElement.GetProperty("Models");
-        Assert.True(models.TryGetProperty("Main", out _)); // Main preserved
-        Assert.True(models.TryGetProperty("Fallback", out var fallback));
+        var roles = models.GetProperty("Roles");
+        Assert.True(roles.TryGetProperty("Main", out _)); // Main preserved
+        var fallback = ReadActiveModel(config, "Fallback");
         Assert.Equal("qwen3:8b", fallback.GetProperty("ModelId").GetString());
     }
 
@@ -412,7 +414,8 @@ public sealed class ModelCommandTests : IDisposable
             _paths, output: _output);
 
         Assert.Equal(0, exitCode);
-        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
     }
 
@@ -426,7 +429,8 @@ public sealed class ModelCommandTests : IDisposable
             _paths, output: _output);
 
         Assert.Equal(0, exitCode);
-        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(config, "Main");
         Assert.False(main.TryGetProperty("InputModalities", out _)); // cleared → runtime detection
     }
 
@@ -457,7 +461,8 @@ public sealed class ModelCommandTests : IDisposable
             _paths, output: _output);
 
         Assert.Equal(0, exitCode);
-        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
         Assert.Equal(65536, main.GetProperty("ContextWindow").GetInt32());
     }
@@ -527,7 +532,8 @@ public sealed class ModelCommandTests : IDisposable
             _paths, output: _output);
 
         Assert.Equal(0, exitCode);
-        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        using var written = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(written, "Main");
         Assert.False(main.TryGetProperty("ContextWindow", out _)); // clamp removed → runtime detection
     }
 
@@ -578,7 +584,8 @@ public sealed class ModelCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         Assert.Equal(1, _fakeProbe.ProbeCallCount);            // probe ran despite the modality flag
-        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("Live", main.GetProperty("Provenance").GetString());     // resolved via probe
         Assert.Equal(512000, main.GetProperty("ContextWindow").GetInt32());   // discovered window captured
         Assert.Equal("Text", main.GetProperty("InputModalities").GetString());// operator override wins
@@ -652,7 +659,8 @@ public sealed class ModelCommandTests : IDisposable
             ["model", "set", "main", "my-ollama", "qwen3:30b"], _paths, output: _output);
 
         Assert.Equal(0, exitCode);
-        var main = ReadConfigFile(_paths.NetclawConfigPath).RootElement.GetProperty("Models").GetProperty("Main");
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal(32768, main.GetProperty("ContextWindow").GetInt32()); // valid clamp preserved
         Assert.False(main.TryGetProperty("InputModalities", out _));        // corrupt override dropped
     }
@@ -662,6 +670,13 @@ public sealed class ModelCommandTests : IDisposable
         var config = ProvidersOnly();
         config["Models"] = new Dictionary<string, object> { ["Main"] = main };
         return config;
+    }
+
+    private static JsonElement ReadActiveModel(JsonDocument config, string role)
+    {
+        var models = config.RootElement.GetProperty("Models");
+        var definitionName = models.GetProperty("Roles").GetProperty(role).GetString()!;
+        return models.GetProperty("Definitions").GetProperty(definitionName);
     }
 
     private static Dictionary<string, object> ProvidersOnly() => new()

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -434,18 +434,24 @@ public sealed class ModelCommandTests : IDisposable
         Assert.False(main.TryGetProperty("InputModalities", out _)); // cleared → runtime detection
     }
 
-    [Fact]
-    public async Task Set_InvalidModalities_ReturnsErrorWithoutWriting()
+    [Theory]
+    [InlineData("invalid modalities", "--input-modalities", "Vision")]
+    [InlineData("--input-modalities requires a value", "--input-modalities")]
+    [InlineData("unknown argument '--input-modalites'", "--input-modalites", "Text")]
+    [InlineData("invalid modalities", "--input-modalities", "3")]
+    [InlineData("cannot be combined", "--context-window", "32768", "--clear-context-window")]
+    public async Task Set_InvalidOptions_ReturnErrorWithoutWriting(
+        string expectedError,
+        params string[] options)
     {
         WriteConfig(ProvidersOnly());
 
         var exitCode = await ModelCommand.RunAsync(
-            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities", "Vision"],
+            ["model", "set", "main", "my-ollama", "qwen3:30b", .. options],
             _paths, output: _output);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("invalid modalities", _output.ToString());
-        // Parsing fails before any config load/write, so no Models section is created.
+        Assert.Contains(expectedError, _output.ToString());
         Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
     }
 
@@ -465,51 +471,6 @@ public sealed class ModelCommandTests : IDisposable
         var main = ReadActiveModel(config, "Main");
         Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
         Assert.Equal(65536, main.GetProperty("ContextWindow").GetInt32());
-    }
-
-    [Fact]
-    public async Task Set_TrailingModalityFlagWithoutValue_ReturnsError()
-    {
-        WriteConfig(ProvidersOnly());
-
-        // --input-modalities is the final token: its value is missing. It must fail loudly rather
-        // than be silently dropped while the command still reports success (#1610).
-        var exitCode = await ModelCommand.RunAsync(
-            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities"],
-            _paths, output: _output);
-
-        Assert.Equal(1, exitCode);
-        Assert.Contains("--input-modalities requires a value", _output.ToString());
-        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
-    }
-
-    [Fact]
-    public async Task Set_UnknownArgument_ReturnsError()
-    {
-        WriteConfig(ProvidersOnly());
-
-        var exitCode = await ModelCommand.RunAsync(
-            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalites", "Text"],
-            _paths, output: _output);
-
-        Assert.Equal(1, exitCode);
-        Assert.Contains("unknown argument '--input-modalites'", _output.ToString());
-        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
-    }
-
-    [Fact]
-    public async Task Set_NumericModalities_ReturnsError()
-    {
-        WriteConfig(ProvidersOnly());
-
-        // A raw integer must not be coerced into flags: "3" would otherwise become Text|Image.
-        var exitCode = await ModelCommand.RunAsync(
-            ["model", "set", "main", "my-ollama", "qwen3:30b", "--input-modalities", "3"],
-            _paths, output: _output);
-
-        Assert.Equal(1, exitCode);
-        Assert.Contains("invalid modalities", _output.ToString());
-        Assert.False(ReadConfigFile(_paths.NetclawConfigPath).RootElement.TryGetProperty("Models", out _));
     }
 
     [Fact]
@@ -535,19 +496,6 @@ public sealed class ModelCommandTests : IDisposable
         using var written = ReadConfigFile(_paths.NetclawConfigPath);
         var main = ReadActiveModel(written, "Main");
         Assert.False(main.TryGetProperty("ContextWindow", out _)); // clamp removed → runtime detection
-    }
-
-    [Fact]
-    public async Task Set_ContextWindowAndClearContextWindow_ReturnsError()
-    {
-        WriteConfig(ProvidersOnly());
-
-        var exitCode = await ModelCommand.RunAsync(
-            ["model", "set", "main", "my-ollama", "qwen3:30b", "--context-window", "32768", "--clear-context-window"],
-            _paths, output: _output);
-
-        Assert.Equal(1, exitCode);
-        Assert.Contains("cannot be combined", _output.ToString());
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -159,7 +159,7 @@ public sealed class ModelManagerViewModelTests : IDisposable
 
         // Verify config
         var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
-        var main = config.RootElement.GetProperty("Models").GetProperty("Main");
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("my-ollama", main.GetProperty("Provider").GetString());
         Assert.Equal("model-a", main.GetProperty("ModelId").GetString());
         Assert.Equal("Live", main.GetProperty("Provenance").GetString());
@@ -205,7 +205,7 @@ public sealed class ModelManagerViewModelTests : IDisposable
         vm.ConfirmAssignment();
 
         var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
-        var main = config.RootElement.GetProperty("Models").GetProperty("Main");
+        var main = ReadActiveModel(config, "Main");
         Assert.Equal("Live", main.GetProperty("Provenance").GetString());
         Assert.Equal(512000, main.GetProperty("ContextWindow").GetInt32());
         Assert.Equal("Text, Image", main.GetProperty("InputModalities").GetString());
@@ -391,8 +391,9 @@ public sealed class ModelManagerViewModelTests : IDisposable
 
         var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
         var models = config.RootElement.GetProperty("Models");
-        Assert.True(models.TryGetProperty("Main", out _));
-        Assert.False(models.TryGetProperty("Fallback", out _));
+        var roles = models.GetProperty("Roles");
+        Assert.True(roles.TryGetProperty("Main", out _));
+        Assert.False(roles.TryGetProperty("Fallback", out _));
     }
 
     [Fact]
@@ -497,9 +498,43 @@ public sealed class ModelManagerViewModelTests : IDisposable
         Assert.Equal("ollama", vm.Providers[0].DisplayName);
     }
 
+    [Fact]
+    public void Refresh_MissingNamedDefinition_SurfacesInvalidConfiguration()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Definitions"] = new Dictionary<string, object>
+                {
+                    ["known"] = new Dictionary<string, object>
+                    {
+                        ["Provider"] = "my-ollama",
+                        ["ModelId"] = "qwen3:30b"
+                    }
+                },
+                ["Roles"] = new Dictionary<string, object> { ["Main"] = "missing" }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        Assert.Null(vm.Models);
+        Assert.Contains("invalid", vm.StatusMessage.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
     private ModelManagerViewModel CreateViewModel()
     {
         return new ModelManagerViewModel(_paths, _fakeProbe);
+    }
+
+    private static JsonElement ReadActiveModel(JsonDocument config, string role)
+    {
+        var models = config.RootElement.GetProperty("Models");
+        var definitionName = models.GetProperty("Roles").GetProperty(role).GetString()!;
+        return models.GetProperty("Definitions").GetProperty(definitionName);
     }
 
     private void WriteConfig(Dictionary<string, object> data)

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/SectionEditorLeafTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/SectionEditorLeafTests.cs
@@ -29,6 +29,8 @@ public sealed class ProviderSectionEditorTests : SectionEditorTestBase<ProviderS
         Assert.Equal(SectionSecretActionKind.Set, action.Action);
         Assert.NotNull(action.Value);
         Assert.Equal("sk-test", action.Value.Value);
+        Assert.DoesNotContain(contribution.FieldActionsOrEmpty, field =>
+            field.Path.StartsWith("Models", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
@@ -83,7 +83,9 @@ public sealed class WizardConfigBuilderTests : WizardStepTestBase
         var config = builder.BuildConfigDictionary();
 
         var models = (Dictionary<string, object>)config["Models"];
-        var main = (Dictionary<string, object>)models["Main"];
+        var roles = (Dictionary<string, object>)models["Roles"];
+        var definitions = (Dictionary<string, object>)models["Definitions"];
+        var main = (Dictionary<string, object>)definitions[(string)roles["Main"]];
         Assert.Equal("openai", main["Provider"]);
         Assert.Equal("gpt-4.1", main["ModelId"]);
     }

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -159,7 +159,41 @@ internal static class ConfigFileHelper
     /// Serialize a config dictionary and write it to disk, creating parent directories if needed.
     /// </summary>
     internal static void WriteConfigFile(string path, Dictionary<string, object> data)
-        => AtomicFile.WriteAllText(path, JsonSerializer.Serialize(data, JsonDefaults.ConfigFile));
+    {
+        PreserveLegacyModelsBackup(path, data);
+        AtomicFile.WriteAllText(path, JsonSerializer.Serialize(data, JsonDefaults.ConfigFile));
+    }
+
+    private static void PreserveLegacyModelsBackup(string path, Dictionary<string, object> data)
+    {
+        if (!File.Exists(path)
+            || GetSectionOrNull(data, "Models") is not { } newModels
+            || !newModels.ContainsKey("Definitions"))
+            return;
+
+        using var existing = JsonDocument.Parse(File.ReadAllText(path));
+        if (!existing.RootElement.TryGetProperty("Models", out var oldModels)
+            || oldModels.ValueKind != JsonValueKind.Object
+            || !oldModels.TryGetProperty("Main", out _))
+            return;
+
+        var legacyEnvironmentOverride = Environment.GetEnvironmentVariables().Keys
+            .OfType<string>()
+            .FirstOrDefault(key => key.StartsWith("NETCLAW_Models__Main__", StringComparison.OrdinalIgnoreCase)
+                                   || key.StartsWith("NETCLAW_Models__Fallback__", StringComparison.OrdinalIgnoreCase)
+                                   || key.StartsWith("NETCLAW_Models__Compaction__", StringComparison.OrdinalIgnoreCase));
+        if (legacyEnvironmentOverride is not null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot migrate Models while legacy environment override '{legacyEnvironmentOverride}' is set. " +
+                "Move model overrides to NETCLAW_Models__Definitions__<name>__* and " +
+                "NETCLAW_Models__Roles__* first.");
+        }
+
+        var backupPath = path + ".legacy-models.bak";
+        if (!File.Exists(backupPath))
+            File.Copy(path, backupPath);
+    }
 
     /// <summary>
     /// Serialize and write secrets.json using hardened permissions and encryption-at-rest.

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -177,11 +177,7 @@ internal static class ConfigFileHelper
             || !oldModels.TryGetProperty("Main", out _))
             return;
 
-        var legacyEnvironmentOverride = Environment.GetEnvironmentVariables().Keys
-            .OfType<string>()
-            .FirstOrDefault(key => key.StartsWith("NETCLAW_Models__Main__", StringComparison.OrdinalIgnoreCase)
-                                   || key.StartsWith("NETCLAW_Models__Fallback__", StringComparison.OrdinalIgnoreCase)
-                                   || key.StartsWith("NETCLAW_Models__Compaction__", StringComparison.OrdinalIgnoreCase));
+        var legacyEnvironmentOverride = ModelEntryWriter.FindLegacyEnvironmentOverride();
         if (legacyEnvironmentOverride is not null)
         {
             throw new InvalidOperationException(

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Config;
@@ -17,15 +18,34 @@ namespace Netclaw.Cli.Config;
 internal static class ModelEntryWriter
 {
     /// <summary>
-    /// Write a role's model entry into <paramref name="modelsSection"/>
-    /// non-destructively. When the role already points at the SAME
-    /// <c>(provider, modelId)</c>, operator-set attributes the caller did not supply are
-    /// preserved instead of dropped — chiefly the modalities, which have no CLI input
-    /// and can only be hand-edited, so rebuilding the entry from scratch is exactly how
-    /// a re-set or a context-window tweak silently deleted a hand-set
-    /// <c>InputModalities</c> (#1127). Switching a role to a <em>different</em> model
-    /// does not carry the old model's attributes over — they belonged to that model.
+    /// Write a role's model entry into <paramref name="modelsSection"/> non-destructively.
+    /// Two on-disk attributes are treated as operator-owned overrides that provider discovery
+    /// must never silently clobber on a same-<c>(provider, modelId)</c> re-set:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <c>ContextWindow</c> and the modalities are documented to "take precedence over
+    /// provider-reported capability detection". So the precedence for each is:
+    /// explicit operator input (this call) &gt; existing stored value &gt; probe. A fresh probe
+    /// tops up a first-time set or a model switch, but never overwrites a value already on disk
+    /// — that overwrite was the #1127 loss (a re-set wiped a hand-set modality) and its
+    /// context-window twin (#1610).
+    /// </description></item>
+    /// </list>
+    /// Because the stored value now wins, the operator needs a way to *change* it: an explicit
+    /// <see cref="ModalityOverride.Set"/> replaces it and <see cref="ModalityOverride.Clear"/>
+    /// removes it (falling back to runtime detection). Switching a role to a <em>different</em>
+    /// model does not carry the old model's attributes over — they belonged to that model.
     /// </summary>
+    /// <param name="contextWindow">
+    /// The explicit operator override (<c>--context-window</c>). When supplied it wins over
+    /// everything; the picker, which has no such input, passes null.
+    /// </param>
+    /// <param name="inputModalities">Operator intent for input modalities (set / clear / unset).</param>
+    /// <param name="outputModalities">Operator intent for output modalities (set / clear / unset).</param>
+    /// <param name="discovered">
+    /// The probe result, if a probe ran. Its context window and modalities seed a first-time set
+    /// or a model switch only; an existing stored value wins over them.
+    /// </param>
     internal static void WriteRole(
         Dictionary<string, object> modelsSection,
         string roleKey,
@@ -33,20 +53,41 @@ internal static class ModelEntryWriter
         string? modelId,
         ModelDiscoverySource? provenance,
         int? contextWindow,
-        ModelModality? inputModalities,
-        ModelModality? outputModalities)
+        ModalityOverride inputModalities,
+        ModalityOverride outputModalities,
+        DiscoveredModel? discovered)
     {
         var existing = ReadSameModelEntry(modelsSection, roleKey, provider, modelId);
-        if (existing is not null)
-        {
-            contextWindow ??= existing.ContextWindow;
-            inputModalities ??= existing.InputModalities;
-            outputModalities ??= existing.OutputModalities;
-        }
+
+        // Provenance records how the model ID was resolved, not how the entry was last
+        // edited. A same-model re-set that did not itself resolve the ID (no probe → the
+        // caller passes Manual) must not downgrade a previously discovered origin
+        // (Live/Defaults) to Manual; only a fresh discovery updates it (#1610).
+        if (existing?.Provenance is { } priorProvenance && provenance == ModelDiscoverySource.Manual)
+            provenance = priorProvenance;
+
+        // Precedence for every operator-owned attribute: explicit input > existing stored value
+        // > probe. Collapsing the explicit and discovered values in the caller defeated
+        // preservation, because the probe/picker paths always pass a discovered value, so the
+        // stored value was overwritten on every re-selection.
+        contextWindow ??= existing?.ContextWindow ?? discovered?.ContextWindowTokens;
+        var resolvedInput = ResolveModality(inputModalities, existing?.InputModalities, discovered?.InputModalities);
+        var resolvedOutput = ResolveModality(outputModalities, existing?.OutputModalities, discovered?.OutputModalities);
 
         modelsSection[roleKey] = BuildModelEntry(
-            provider, modelId, provenance, contextWindow, inputModalities, outputModalities);
+            provider, modelId, provenance, contextWindow, resolvedInput, resolvedOutput);
     }
+
+    /// <summary>
+    /// Resolves the modality actually written: an explicit operator set or clear wins outright
+    /// (the operator is the authority on a manual override); otherwise an existing stored value
+    /// is preserved, and provider discovery only fills a genuine gap (first set / model switch).
+    /// </summary>
+    private static ModelModality? ResolveModality(
+        ModalityOverride @override, ModelModality? existing, ModelModality? discovered)
+        => @override.Supplied
+            ? @override.Value            // Set(value) → value; Clear → null (key omitted downstream)
+            : existing ?? discovered;    // preserve on-disk value; discovery only seeds a gap
 
     /// <summary>
     /// The role's current entry, but only when it already references the same
@@ -59,7 +100,31 @@ internal static class ModelEntryWriter
         if (!modelsSection.TryGetValue(roleKey, out var raw) || raw is null)
             return null;
 
-        var existing = ConfigFileHelper.DeserializeSection<ModelReference>(raw);
+        // ModelReference defaults Provider/ModelId to the stock local-ollama model, so an
+        // entry that OMITS either key deserializes to that default and would false-match a
+        // re-set of the stock model — carrying stray attributes onto a model the entry never
+        // actually named. Only treat the entry as the same model when it explicitly declares
+        // both keys (#1610).
+        if (!RawContainsProperty(raw, nameof(ModelReference.Provider))
+            || !RawContainsProperty(raw, nameof(ModelReference.ModelId)))
+            return null;
+
+        // A legacy or hand-corrupted entry (e.g. an unrecognized modality enum string, or a
+        // shape that predates a schema change) must not abort `model set`: we are about to
+        // overwrite this role anyway, and before the non-destructive rewrite existed the
+        // command simply clobbered it. Degrade an unreadable existing entry to "nothing to
+        // preserve" so the operator can still repair it, rather than throwing JsonException
+        // out of a write they explicitly requested.
+        ModelReference? existing;
+        try
+        {
+            existing = ConfigFileHelper.DeserializeSection<ModelReference>(raw);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
         if (existing is null)
             return null;
 
@@ -67,6 +132,37 @@ internal static class ModelEntryWriter
             && string.Equals(existing.ModelId, modelId, StringComparison.OrdinalIgnoreCase)
             ? existing
             : null;
+    }
+
+    /// <summary>
+    /// Whether the raw config value explicitly declares <paramref name="propertyName"/>. The
+    /// value is either a <see cref="JsonElement"/> (loaded from disk) or an in-memory
+    /// dictionary (rewritten this run) — the two shapes <see cref="ConfigFileHelper.DeserializeSection{T}"/>
+    /// accepts. The match is case-insensitive to mirror the case-insensitive deserialization.
+    /// </summary>
+    private static bool RawContainsProperty(object raw, string propertyName)
+    {
+        switch (raw)
+        {
+            case JsonElement { ValueKind: JsonValueKind.Object } element:
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+
+                return false;
+            case IDictionary<string, object> dict:
+                foreach (var key in dict.Keys)
+                {
+                    if (string.Equals(key, propertyName, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+
+                return false;
+            default:
+                return false;
+        }
     }
 
     /// <summary>
@@ -107,4 +203,24 @@ internal static class ModelEntryWriter
 
         return entry;
     }
+}
+
+/// <summary>
+/// An operator's intent for a modality field on <c>model set</c>. A plain
+/// <see cref="ModelModality"/>? cannot express it, because two of the three states both
+/// resolve to null yet behave oppositely: "not supplied" must preserve any existing override,
+/// while "clear" must win over it. The tri-state is: <see cref="Unset"/> (leave it to the
+/// stored value / discovery), <see cref="Set"/> (replace with an explicit value), and
+/// <see cref="Clear"/> (remove the override so runtime detection resolves it).
+/// </summary>
+internal readonly record struct ModalityOverride(bool Supplied, ModelModality? Value)
+{
+    /// <summary>Operator said nothing — preserve the stored value, else fall back to discovery.</summary>
+    internal static ModalityOverride Unset => default;
+
+    /// <summary>Operator asked to remove the override so runtime capability detection resolves it.</summary>
+    internal static ModalityOverride Clear => new(true, null);
+
+    /// <summary>Operator supplied an explicit modality set that replaces whatever is stored.</summary>
+    internal static ModalityOverride Set(ModelModality value) => new(true, value);
 }

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -18,6 +18,22 @@ namespace Netclaw.Cli.Config;
 /// </summary>
 internal static class ModelEntryWriter
 {
+    internal static bool MigrateLegacy(Dictionary<string, object> modelsSection)
+    {
+        if (modelsSection.ContainsKey("Definitions") || modelsSection.ContainsKey("Roles"))
+            return false;
+        if (!modelsSection.Keys.Any(key => key is "Main" or "Fallback" or "Compaction"))
+            return false;
+        EnsureNamedShape(modelsSection);
+        return true;
+    }
+
+    internal static bool ClearRole(Dictionary<string, object> modelsSection, string roleKey)
+    {
+        var (_, roles) = EnsureNamedShape(modelsSection);
+        return roles.Remove(roleKey);
+    }
+
     /// <summary>
     /// Write a role's model entry into <paramref name="modelsSection"/> non-destructively.
     /// Two on-disk attributes are treated as operator-owned overrides that provider discovery
@@ -59,7 +75,10 @@ internal static class ModelEntryWriter
         ValueOverride<ModelModality> outputModalities,
         DiscoveredModel? discovered)
     {
-        var existing = ReadSameModelEntry(modelsSection, roleKey, provider, modelId);
+        var (definitions, roles) = EnsureNamedShape(modelsSection, roleKey);
+        var definitionName = FindDefinition(definitions, provider, modelId)
+                             ?? CreateDefinitionName(definitions, provider, modelId);
+        var existing = ReadSameModelEntry(definitions, definitionName, provider, modelId);
 
         // Provenance records how the model ID was resolved, not how the entry was last edited. A
         // same-model re-set that did not itself freshly resolve the ID — no probe (the caller
@@ -73,13 +92,170 @@ internal static class ModelEntryWriter
         // preservation, because the probe/picker paths always pass a discovered value, so the
         // stored value was overwritten on every re-selection.
         var sameModelEntry = existing is not null;
-        var resolvedWindow = ResolveContextWindow(contextWindow, existing?.ContextWindow, discovered?.ContextWindowTokens);
+        var resolvedWindow = ResolveContextWindow(
+            contextWindow, sameModelEntry, existing?.ContextWindow, discovered?.ContextWindowTokens);
         var resolvedInput = ResolveModality(inputModalities, sameModelEntry, existing?.InputModalities, discovered?.InputModalities);
         var resolvedOutput = ResolveModality(outputModalities, sameModelEntry, existing?.OutputModalities, discovered?.OutputModalities);
 
-        modelsSection[roleKey] = BuildModelEntry(
+        definitions[definitionName] = BuildModelEntry(
             provider, modelId, provenance, resolvedWindow, resolvedInput, resolvedOutput);
+        roles[roleKey] = definitionName;
     }
+
+    private static (Dictionary<string, object> Definitions, Dictionary<string, object> Roles)
+        EnsureNamedShape(Dictionary<string, object> modelsSection, string? overwrittenRole = null)
+    {
+        var hasNamed = modelsSection.ContainsKey("Definitions") || modelsSection.ContainsKey("Roles");
+        var hasLegacy = modelsSection.Keys.Any(key =>
+            key is "Main" or "Fallback" or "Compaction");
+
+        if (hasNamed && hasLegacy)
+            throw new InvalidOperationException("Models configuration mixes legacy roles with Definitions/Roles.");
+
+        if (hasNamed)
+        {
+            if (!modelsSection.ContainsKey("Definitions") || !modelsSection.ContainsKey("Roles"))
+                throw new InvalidOperationException("Named Models configuration requires Definitions and Roles.");
+
+            return (GetDictionary(modelsSection, "Definitions"), GetDictionary(modelsSection, "Roles"));
+        }
+
+        var definitions = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        var roles = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var role in new[] { "Main", "Fallback", "Compaction" })
+        {
+            if (!modelsSection.TryGetValue(role, out var raw) || raw is null)
+                continue;
+
+            if (!RawContainsProperty(raw, nameof(ModelReference.Provider))
+                || !RawContainsProperty(raw, nameof(ModelReference.ModelId)))
+            {
+                if (string.Equals(role, overwrittenRole, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                throw new InvalidOperationException(
+                    $"Models:{role} must explicitly declare Provider and ModelId before migration.");
+            }
+
+            ModelReference model;
+            try
+            {
+                model = ConfigFileHelper.DeserializeSection<ModelReference>(raw)
+                        ?? throw new InvalidOperationException($"Models:{role} could not be parsed.");
+            }
+            catch (JsonException)
+            {
+                model = ReadLegacyIdentity(raw)
+                        ?? throw new InvalidOperationException($"Models:{role} could not be repaired.");
+            }
+            var existingName = FindDefinition(definitions, model.Provider, model.ModelId);
+            if (existingName is not null)
+            {
+                var existing = ConfigFileHelper.DeserializeSection<ModelReference>(definitions[existingName])!;
+                if (!Equivalent(existing, model))
+                {
+                    throw new InvalidOperationException(
+                        $"Legacy model roles conflict for {model.Provider}/{model.ModelId}; " +
+                        $"align their metadata before migration.");
+                }
+
+                roles[role] = existingName;
+                continue;
+            }
+
+            var name = CreateDefinitionName(definitions, model.Provider, model.ModelId);
+            definitions[name] = BuildModelEntry(
+                model.Provider, model.ModelId, model.Provenance, model.ContextWindow,
+                model.InputModalities, model.OutputModalities);
+            roles[role] = name;
+        }
+
+        modelsSection.Clear();
+        modelsSection["Definitions"] = definitions;
+        modelsSection["Roles"] = roles;
+        return (definitions, roles);
+    }
+
+    private static ModelReference? ReadLegacyIdentity(object raw)
+    {
+        var json = raw is JsonElement element
+            ? element.GetRawText()
+            : JsonSerializer.Serialize(raw, JsonDefaults.ConfigFile);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object
+            || !TryGetString(root, nameof(ModelReference.Provider), out var provider)
+            || !TryGetString(root, nameof(ModelReference.ModelId), out var modelId))
+            return null;
+
+        var model = new ModelReference { Provider = provider, ModelId = modelId };
+        if (TryGetInt32(root, nameof(ModelReference.ContextWindow), out var contextWindow))
+            model.ContextWindow = contextWindow;
+        return model;
+    }
+
+    private static Dictionary<string, object> GetDictionary(Dictionary<string, object> parent, string key)
+    {
+        var raw = parent[key];
+        if (raw is Dictionary<string, object> dictionary)
+            return dictionary;
+        if (raw is JsonElement { ValueKind: JsonValueKind.Object } element)
+        {
+            dictionary = JsonSerializer.Deserialize<Dictionary<string, object>>(element.GetRawText()) ?? [];
+            parent[key] = dictionary;
+            return dictionary;
+        }
+
+        throw new InvalidOperationException($"Models:{key} must be an object.");
+    }
+
+    private static string? FindDefinition(
+        Dictionary<string, object> definitions, string provider, string? modelId)
+    {
+        foreach (var (name, raw) in definitions)
+        {
+            ModelReference? model;
+            try
+            {
+                model = ConfigFileHelper.DeserializeSection<ModelReference>(raw);
+            }
+            catch (JsonException)
+            {
+                model = ReadLegacyIdentity(raw);
+            }
+
+            if (model is not null
+                && string.Equals(model.Provider, provider, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(model.ModelId, modelId, StringComparison.OrdinalIgnoreCase))
+                return name;
+        }
+
+        return null;
+    }
+
+    private static string CreateDefinitionName(
+        Dictionary<string, object> definitions, string provider, string? modelId)
+    {
+        var raw = $"{provider}-{modelId}";
+        var stem = string.Join('-', raw.ToLowerInvariant()
+            .Split(['/', ':', '.', '_', ' '], StringSplitOptions.RemoveEmptyEntries))
+            .Trim('-');
+        if (string.IsNullOrWhiteSpace(stem))
+            stem = "model";
+
+        var candidate = stem;
+        for (var suffix = 2; definitions.ContainsKey(candidate); suffix++)
+            candidate = $"{stem}-{suffix}";
+        return candidate;
+    }
+
+    private static bool Equivalent(ModelReference left, ModelReference right)
+        => string.Equals(left.Provider, right.Provider, StringComparison.OrdinalIgnoreCase)
+           && string.Equals(left.ModelId, right.ModelId, StringComparison.OrdinalIgnoreCase)
+           && left.ContextWindow == right.ContextWindow
+           && left.Provenance == right.Provenance
+           && left.InputModalities == right.InputModalities
+           && left.OutputModalities == right.OutputModalities;
 
     /// <summary>
     /// Resolves the modality actually written. An explicit operator set or clear wins outright
@@ -100,17 +276,15 @@ internal static class ModelEntryWriter
     /// <summary>
     /// Resolves the context window actually written. Mirrors <see cref="ResolveModality"/> for the
     /// explicit cases: <c>--context-window</c> (Set) or <c>--clear-context-window</c> (Clear) wins,
-    /// otherwise the stored clamp is preserved and discovery only seeds a gap. Unlike modalities
-    /// this deliberately does NOT pin a same-model entry against discovery — a re-detected window
-    /// equals what runtime detection would produce anyway, so there is no misreporting-demotion
-    /// hazard (the reason a cleared modality must stay cleared), and letting a fresh probe fill an
-    /// absent window is safe and useful.
+    /// otherwise an existing definition is honored verbatim, including absence. Discovery seeds
+    /// only a new definition. This keeps manual JSON edits and explicit clears stable without a
+    /// hidden tombstone representation.
     /// </summary>
     private static int? ResolveContextWindow(
-        ValueOverride<int> @override, int? existing, int? discovered)
+        ValueOverride<int> @override, bool sameModelEntryExists, int? existing, int? discovered)
         => @override.Supplied
             ? @override.Value            // Set(n) → n; Clear → null (drop the clamp → runtime detects)
-            : existing ?? discovered;    // preserve the stored clamp; discovery seeds a first set / gap
+            : sameModelEntryExists ? existing : discovered;
 
     /// <summary>
     /// The role's current entry, but only when it already references the same

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Config;
@@ -32,13 +33,14 @@ internal static class ModelEntryWriter
     /// </description></item>
     /// </list>
     /// Because the stored value now wins, the operator needs a way to *change* it: an explicit
-    /// <see cref="ModalityOverride.Set"/> replaces it and <see cref="ModalityOverride.Clear"/>
+    /// <see cref="ValueOverride{T}.Set"/> replaces it and <see cref="ValueOverride{T}.Clear"/>
     /// removes it (falling back to runtime detection). Switching a role to a <em>different</em>
     /// model does not carry the old model's attributes over — they belonged to that model.
     /// </summary>
     /// <param name="contextWindow">
-    /// The explicit operator override (<c>--context-window</c>). When supplied it wins over
-    /// everything; the picker, which has no such input, passes null.
+    /// Operator intent for the context window (set / clear / unset). <c>--context-window</c> sets
+    /// it (wins over everything), <c>--clear-context-window</c> removes the clamp so detection
+    /// resolves it, and the picker — which has no such input — passes <see cref="ValueOverride{T}.Unset"/>.
     /// </param>
     /// <param name="inputModalities">Operator intent for input modalities (set / clear / unset).</param>
     /// <param name="outputModalities">Operator intent for output modalities (set / clear / unset).</param>
@@ -52,42 +54,63 @@ internal static class ModelEntryWriter
         string provider,
         string? modelId,
         ModelDiscoverySource? provenance,
-        int? contextWindow,
-        ModalityOverride inputModalities,
-        ModalityOverride outputModalities,
+        ValueOverride<int> contextWindow,
+        ValueOverride<ModelModality> inputModalities,
+        ValueOverride<ModelModality> outputModalities,
         DiscoveredModel? discovered)
     {
         var existing = ReadSameModelEntry(modelsSection, roleKey, provider, modelId);
 
-        // Provenance records how the model ID was resolved, not how the entry was last
-        // edited. A same-model re-set that did not itself resolve the ID (no probe → the
-        // caller passes Manual) must not downgrade a previously discovered origin
-        // (Live/Defaults) to Manual; only a fresh discovery updates it (#1610).
-        if (existing?.Provenance is { } priorProvenance && provenance == ModelDiscoverySource.Manual)
+        // Provenance records how the model ID was resolved, not how the entry was last edited. A
+        // same-model re-set that did not itself freshly resolve the ID — no probe (the caller
+        // passes Manual) or a probe that failed (Defaults) — must not downgrade a previously
+        // discovered origin. Only a fresh successful discovery (Live) re-stamps it (#1610).
+        if (existing?.Provenance is { } priorProvenance && provenance != ModelDiscoverySource.Live)
             provenance = priorProvenance;
 
         // Precedence for every operator-owned attribute: explicit input > existing stored value
         // > probe. Collapsing the explicit and discovered values in the caller defeated
         // preservation, because the probe/picker paths always pass a discovered value, so the
         // stored value was overwritten on every re-selection.
-        contextWindow ??= existing?.ContextWindow ?? discovered?.ContextWindowTokens;
-        var resolvedInput = ResolveModality(inputModalities, existing?.InputModalities, discovered?.InputModalities);
-        var resolvedOutput = ResolveModality(outputModalities, existing?.OutputModalities, discovered?.OutputModalities);
+        var sameModelEntry = existing is not null;
+        var resolvedWindow = ResolveContextWindow(contextWindow, existing?.ContextWindow, discovered?.ContextWindowTokens);
+        var resolvedInput = ResolveModality(inputModalities, sameModelEntry, existing?.InputModalities, discovered?.InputModalities);
+        var resolvedOutput = ResolveModality(outputModalities, sameModelEntry, existing?.OutputModalities, discovered?.OutputModalities);
 
         modelsSection[roleKey] = BuildModelEntry(
-            provider, modelId, provenance, contextWindow, resolvedInput, resolvedOutput);
+            provider, modelId, provenance, resolvedWindow, resolvedInput, resolvedOutput);
     }
 
     /// <summary>
-    /// Resolves the modality actually written: an explicit operator set or clear wins outright
-    /// (the operator is the authority on a manual override); otherwise an existing stored value
-    /// is preserved, and provider discovery only fills a genuine gap (first set / model switch).
+    /// Resolves the modality actually written. An explicit operator set or clear wins outright
+    /// (the operator is the authority on a manual override). Otherwise, when the same model already
+    /// has an entry on disk, that entry is honored verbatim — including a deliberately-cleared
+    /// (absent) modality, so a later probe cannot silently resurrect an override the operator
+    /// removed with <c>--clear-modalities</c> (#1610). Provider discovery only seeds a genuine gap:
+    /// a first-time set or a switch to a different model, where no entry exists yet.
     /// </summary>
     private static ModelModality? ResolveModality(
-        ModalityOverride @override, ModelModality? existing, ModelModality? discovered)
+        ValueOverride<ModelModality> @override, bool sameModelEntryExists,
+        ModelModality? existing, ModelModality? discovered)
         => @override.Supplied
-            ? @override.Value            // Set(value) → value; Clear → null (key omitted downstream)
-            : existing ?? discovered;    // preserve on-disk value; discovery only seeds a gap
+            ? @override.Value                 // Set(value) → value; Clear → null (key omitted downstream)
+            : sameModelEntryExists ? existing  // same model on disk: honor it, incl. a cleared (null) value
+                : discovered;                  // first set / model switch: seed from discovery
+
+    /// <summary>
+    /// Resolves the context window actually written. Mirrors <see cref="ResolveModality"/> for the
+    /// explicit cases: <c>--context-window</c> (Set) or <c>--clear-context-window</c> (Clear) wins,
+    /// otherwise the stored clamp is preserved and discovery only seeds a gap. Unlike modalities
+    /// this deliberately does NOT pin a same-model entry against discovery — a re-detected window
+    /// equals what runtime detection would produce anyway, so there is no misreporting-demotion
+    /// hazard (the reason a cleared modality must stay cleared), and letting a fresh probe fill an
+    /// absent window is safe and useful.
+    /// </summary>
+    private static int? ResolveContextWindow(
+        ValueOverride<int> @override, int? existing, int? discovered)
+        => @override.Supplied
+            ? @override.Value            // Set(n) → n; Clear → null (drop the clamp → runtime detects)
+            : existing ?? discovered;    // preserve the stored clamp; discovery seeds a first set / gap
 
     /// <summary>
     /// The role's current entry, but only when it already references the same
@@ -112,9 +135,7 @@ internal static class ModelEntryWriter
         // A legacy or hand-corrupted entry (e.g. an unrecognized modality enum string, or a
         // shape that predates a schema change) must not abort `model set`: we are about to
         // overwrite this role anyway, and before the non-destructive rewrite existed the
-        // command simply clobbered it. Degrade an unreadable existing entry to "nothing to
-        // preserve" so the operator can still repair it, rather than throwing JsonException
-        // out of a write they explicitly requested.
+        // command simply clobbered it.
         ModelReference? existing;
         try
         {
@@ -122,7 +143,11 @@ internal static class ModelEntryWriter
         }
         catch (JsonException)
         {
-            return null;
+            // Strict deserialization failed — in practice a stale/unknown modality or provenance
+            // enum string, which JsonStringEnumConverter rejects by throwing. Discarding the whole
+            // entry here would silently clobber a still-valid operator-owned ContextWindow (#1610),
+            // so recover the throw-proof fields and drop only the unparseable overrides.
+            return ReadResilient(raw, provider, modelId);
         }
 
         if (existing is null)
@@ -132,6 +157,75 @@ internal static class ModelEntryWriter
             && string.Equals(existing.ModelId, modelId, StringComparison.OrdinalIgnoreCase)
             ? existing
             : null;
+    }
+
+    /// <summary>
+    /// Recovers the preservation-worthy fields from an entry that failed strict deserialization.
+    /// Provider, ModelId and ContextWindow are plain strings/int that never throw, so they are read
+    /// directly; the modality/provenance overrides — the fields that failed to parse — are dropped
+    /// (left null) because a value we could not read must not be preserved. Returns null when the
+    /// recovered entry names a different model (its attributes must not carry over) or is not a
+    /// JSON object.
+    /// </summary>
+    private static ModelReference? ReadResilient(object raw, string provider, string? modelId)
+    {
+        var json = raw is JsonElement element
+            ? element.GetRawText()
+            : JsonSerializer.Serialize(raw, JsonDefaults.ConfigFile);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+            return null;
+
+        // Confirm the poisoned entry still names the model being set before preserving anything.
+        if (!TryGetString(root, nameof(ModelReference.Provider), out var storedProvider)
+            || !TryGetString(root, nameof(ModelReference.ModelId), out var storedModelId)
+            || !string.Equals(storedProvider, provider, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(storedModelId, modelId, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var recovered = new ModelReference { Provider = storedProvider, ModelId = storedModelId };
+        if (TryGetInt32(root, nameof(ModelReference.ContextWindow), out var window))
+            recovered.ContextWindow = window;
+
+        return recovered;
+    }
+
+    private static bool TryGetString(JsonElement root, string name, out string value)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase)
+                && property.Value.ValueKind == JsonValueKind.String)
+            {
+                value = property.Value.GetString()!;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static bool TryGetInt32(JsonElement root, string name, out int value)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Web-default reads coerce numeric strings, so accept both a JSON number and a
+            // stringified integer to match what the strict path would have parsed.
+            if (property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetInt32(out value))
+                return true;
+            if (property.Value.ValueKind == JsonValueKind.String
+                && int.TryParse(property.Value.GetString(), out value))
+                return true;
+        }
+
+        value = 0;
+        return false;
     }
 
     /// <summary>
@@ -206,21 +300,23 @@ internal static class ModelEntryWriter
 }
 
 /// <summary>
-/// An operator's intent for a modality field on <c>model set</c>. A plain
-/// <see cref="ModelModality"/>? cannot express it, because two of the three states both
-/// resolve to null yet behave oppositely: "not supplied" must preserve any existing override,
-/// while "clear" must win over it. The tri-state is: <see cref="Unset"/> (leave it to the
-/// stored value / discovery), <see cref="Set"/> (replace with an explicit value), and
-/// <see cref="Clear"/> (remove the override so runtime detection resolves it).
+/// An operator's intent for an overridable, operator-owned model attribute on <c>model set</c> —
+/// a modality set (<see cref="ModelModality"/>) or the context window (<see cref="int"/>). A plain
+/// <c>T?</c> cannot express it, because two of the three states both resolve to null yet behave
+/// oppositely: "not supplied" must preserve any existing override, while "clear" must win over it.
+/// The tri-state is: <see cref="Unset"/> (leave it to the stored value / discovery),
+/// <see cref="Set"/> (replace with an explicit value), and <see cref="Clear"/> (remove the override
+/// so runtime detection resolves it).
 /// </summary>
-internal readonly record struct ModalityOverride(bool Supplied, ModelModality? Value)
+internal readonly record struct ValueOverride<T>(bool Supplied, T? Value)
+    where T : struct
 {
     /// <summary>Operator said nothing — preserve the stored value, else fall back to discovery.</summary>
-    internal static ModalityOverride Unset => default;
+    internal static ValueOverride<T> Unset => default;
 
     /// <summary>Operator asked to remove the override so runtime capability detection resolves it.</summary>
-    internal static ModalityOverride Clear => new(true, null);
+    internal static ValueOverride<T> Clear => new(true, null);
 
-    /// <summary>Operator supplied an explicit modality set that replaces whatever is stored.</summary>
-    internal static ModalityOverride Set(ModelModality value) => new(true, value);
+    /// <summary>Operator supplied an explicit value that replaces whatever is stored.</summary>
+    internal static ValueOverride<T> Set(T value) => new(true, value);
 }

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -18,6 +18,19 @@ namespace Netclaw.Cli.Config;
 /// </summary>
 internal static class ModelEntryWriter
 {
+    private static readonly string[] LegacyEnvironmentPrefixes =
+    [
+        "NETCLAW_Models__Main__",
+        "NETCLAW_Models__Fallback__",
+        "NETCLAW_Models__Compaction__",
+    ];
+
+    internal static string? FindLegacyEnvironmentOverride()
+        => Environment.GetEnvironmentVariables().Keys
+            .OfType<string>()
+            .FirstOrDefault(key => LegacyEnvironmentPrefixes.Any(prefix =>
+                key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)));
+
     internal static bool MigrateLegacy(Dictionary<string, object> modelsSection)
     {
         if (modelsSection.ContainsKey("Definitions") || modelsSection.ContainsKey("Roles"))

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -17,6 +17,59 @@ namespace Netclaw.Cli.Config;
 internal static class ModelEntryWriter
 {
     /// <summary>
+    /// Write a role's model entry into <paramref name="modelsSection"/>
+    /// non-destructively. When the role already points at the SAME
+    /// <c>(provider, modelId)</c>, operator-set attributes the caller did not supply are
+    /// preserved instead of dropped — chiefly the modalities, which have no CLI input
+    /// and can only be hand-edited, so rebuilding the entry from scratch is exactly how
+    /// a re-set or a context-window tweak silently deleted a hand-set
+    /// <c>InputModalities</c> (#1127). Switching a role to a <em>different</em> model
+    /// does not carry the old model's attributes over — they belonged to that model.
+    /// </summary>
+    internal static void WriteRole(
+        Dictionary<string, object> modelsSection,
+        string roleKey,
+        string provider,
+        string? modelId,
+        ModelDiscoverySource? provenance,
+        int? contextWindow,
+        ModelModality? inputModalities,
+        ModelModality? outputModalities)
+    {
+        var existing = ReadSameModelEntry(modelsSection, roleKey, provider, modelId);
+        if (existing is not null)
+        {
+            contextWindow ??= existing.ContextWindow;
+            inputModalities ??= existing.InputModalities;
+            outputModalities ??= existing.OutputModalities;
+        }
+
+        modelsSection[roleKey] = BuildModelEntry(
+            provider, modelId, provenance, contextWindow, inputModalities, outputModalities);
+    }
+
+    /// <summary>
+    /// The role's current entry, but only when it already references the same
+    /// <c>(provider, modelId)</c>; null when the role is unset or points at a different
+    /// model (whose attributes must not carry over to the newly-set one).
+    /// </summary>
+    private static ModelReference? ReadSameModelEntry(
+        Dictionary<string, object> modelsSection, string roleKey, string provider, string? modelId)
+    {
+        if (!modelsSection.TryGetValue(roleKey, out var raw) || raw is null)
+            return null;
+
+        var existing = ConfigFileHelper.DeserializeSection<ModelReference>(raw);
+        if (existing is null)
+            return null;
+
+        return string.Equals(existing.Provider, provider, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(existing.ModelId, modelId, StringComparison.OrdinalIgnoreCase)
+            ? existing
+            : null;
+    }
+
+    /// <summary>
     /// Builds the dictionary written under <c>Models[role]</c>.
     /// </summary>
     /// <remarks>

--- a/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ChatClientDoctorCheck.cs
@@ -61,7 +61,7 @@ public sealed class ChatClientDoctorCheck : IDoctorCheck
         try
         {
             providers = ProviderConfigurationLoader.Load(_configuration.GetSection("Providers"));
-            models = _configuration.GetSection("Models").Get<ModelSelection>() ?? new ModelSelection();
+            models = ModelConfigurationResolver.Resolve(_configuration).Selection;
             // File present: read explicit provider types from the file (matches
             // historical behavior). Env-only: derive them from the bound
             // configuration, exactly like the daemon does at startup.

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -43,8 +43,8 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
         if (root is null)
             return DoctorCheckResult.Pass("Context Window", "No config file to check.");
 
-        var models = root["Models"] as JsonObject;
-        var main = models?["Main"] as JsonObject;
+        var resolvedModels = ModelConfigurationResolver.Resolve(_configuration).Selection;
+        var main = resolvedModels.Main;
 
         var runtimeValidation = ValidateRuntimeConfiguration(root);
         if (runtimeValidation.Status != ProviderRuntimeStatus.Valid)
@@ -55,7 +55,7 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
                 BuildInferenceRemediation(runtimeValidation.AvailableProviders));
         }
 
-        if (main is null)
+        if (string.IsNullOrWhiteSpace(main.Provider) || string.IsNullOrWhiteSpace(main.ModelId))
         {
             return DoctorCheckResult.Warning(
                 "Context Window",
@@ -63,15 +63,12 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
                 "Run `netclaw init` to configure a provider and main model, or add Models.Main to netclaw.json.");
         }
 
-        var contextWindow = main["ContextWindow"];
-        if (contextWindow is null)
+        if (main.ContextWindow is null)
         {
-            var modelId = _configuration.GetSection("Models:Main:ModelId").Value ?? "unknown";
-            var providerName = _configuration.GetSection("Models:Main:Provider").Value ?? "unknown";
-            return await ResolveEffectiveContextWindowAsync(modelId, providerName, cancellationToken);
+            return await ResolveEffectiveContextWindowAsync(main.ModelId, main.Provider, cancellationToken);
         }
 
-        if (TryGetInt32(contextWindow, out var cw) && cw > 0)
+        if (main.ContextWindow is > 0 and var cw)
         {
             // Runtime (ContextWindowResolution.ResolveRuntimeAsync) prefers the
             // daemon's live context window over the pinned config when the daemon
@@ -100,8 +97,7 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
     private ProviderRuntimeValidation ValidateRuntimeConfiguration(JsonObject root)
     {
         var providers = ProviderConfigurationLoader.Load(_configuration.GetSection("Providers"));
-        var models = _configuration.GetSection("Models")
-            .Get<ModelSelection>() ?? new ModelSelection();
+        var models = ModelConfigurationResolver.Resolve(_configuration).Selection;
 
         return ProviderRuntimeValidation.Evaluate(
             providers,

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Nodes;
+using System.Text.Json;
 using Json.Schema;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Daemon;
@@ -63,6 +64,27 @@ public sealed class DoctorFixService
             return Task.FromResult(new DoctorFixPlan(fixes));
 
         var appliedFixes = new List<string>();
+
+        if (obj["Models"] is JsonObject modelsNode)
+        {
+            var legacyEnvironmentOverride = Environment.GetEnvironmentVariables().Keys
+                .OfType<string>()
+                .FirstOrDefault(key => key.StartsWith("NETCLAW_Models__Main__", StringComparison.OrdinalIgnoreCase)
+                                       || key.StartsWith("NETCLAW_Models__Fallback__", StringComparison.OrdinalIgnoreCase)
+                                       || key.StartsWith("NETCLAW_Models__Compaction__", StringComparison.OrdinalIgnoreCase));
+            if (legacyEnvironmentOverride is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot migrate Models while legacy environment override '{legacyEnvironmentOverride}' is set.");
+            }
+
+            var models = JsonSerializer.Deserialize<Dictionary<string, object>>(modelsNode.ToJsonString())!;
+            if (ModelEntryWriter.MigrateLegacy(models))
+            {
+                obj["Models"] = JsonNode.Parse(JsonSerializer.Serialize(models, JsonDefaults.ConfigFile));
+                appliedFixes.Add("named model definitions");
+            }
+        }
 
         // --- Manual fixes (not derivable from schema alone) ---
 
@@ -256,7 +278,7 @@ public sealed class DoctorFixService
             UpdatedText: updated));
     }
 
-    public async Task ApplyAsync(DoctorFixPlan plan, CancellationToken cancellationToken = default)
+    public Task ApplyAsync(DoctorFixPlan plan, CancellationToken cancellationToken = default)
     {
         foreach (var fix in plan.Fixes)
         {
@@ -267,8 +289,19 @@ public sealed class DoctorFixService
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            await File.WriteAllTextAsync(fix.FilePath, fix.UpdatedText, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (fix.Description.Contains("named model definitions", StringComparison.Ordinal)
+                && File.Exists(fix.FilePath))
+            {
+                var backupPath = fix.FilePath + ".legacy-models.bak";
+                if (!File.Exists(backupPath))
+                    File.Copy(fix.FilePath, backupPath);
+            }
+
+            AtomicFile.WriteAllText(fix.FilePath, fix.UpdatedText);
         }
+
+        return Task.CompletedTask;
     }
 
 }

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -67,15 +67,13 @@ public sealed class DoctorFixService
 
         if (obj["Models"] is JsonObject modelsNode)
         {
-            var legacyEnvironmentOverride = Environment.GetEnvironmentVariables().Keys
-                .OfType<string>()
-                .FirstOrDefault(key => key.StartsWith("NETCLAW_Models__Main__", StringComparison.OrdinalIgnoreCase)
-                                       || key.StartsWith("NETCLAW_Models__Fallback__", StringComparison.OrdinalIgnoreCase)
-                                       || key.StartsWith("NETCLAW_Models__Compaction__", StringComparison.OrdinalIgnoreCase));
+            var legacyEnvironmentOverride = ModelEntryWriter.FindLegacyEnvironmentOverride();
             if (legacyEnvironmentOverride is not null)
             {
                 throw new InvalidOperationException(
-                    $"Cannot migrate Models while legacy environment override '{legacyEnvironmentOverride}' is set.");
+                    $"Cannot migrate Models while legacy environment override '{legacyEnvironmentOverride}' is set. " +
+                    "Move model overrides to NETCLAW_Models__Definitions__<name>__* and " +
+                    "NETCLAW_Models__Roles__* first.");
             }
 
             var models = JsonSerializer.Deserialize<Dictionary<string, object>>(modelsNode.ToJsonString())!;

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -170,15 +170,17 @@ internal static class ModelCommand
         var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        var modelEntry = ModelEntryWriter.BuildModelEntry(
+        // Non-destructive: re-setting the same model (or only its context window) keeps
+        // hand-set modalities, which cannot be supplied on the command line (#1127).
+        ModelEntryWriter.WriteRole(
+            modelsSection,
+            roleKey,
             providerName,
             modelId,
             provenance,
             contextWindow ?? discoveredModel?.ContextWindowTokens,
             discoveredModel?.InputModalities,
             discoveredModel?.OutputModalities);
-
-        modelsSection[roleKey] = modelEntry;
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
 
         writer.WriteLine($"Set {role} model to {providerName}/{modelId}");

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -37,7 +37,15 @@ internal static class ModelCommand
 
     private static int RunList(NetclawPaths paths, TextWriter writer)
     {
-        var models = LoadModelSelection(paths);
+        if (!TryLoadModelSelection(paths, out var models))
+        {
+            // Config present but unparseable — surface it rather than showing a corrupt config as
+            // "no models configured", which would send the operator down the wrong recovery path.
+            writer.WriteLine("Error: model configuration could not be parsed.");
+            writer.WriteLine("Run `netclaw doctor` to diagnose, or `netclaw doctor --fix` to repair it.");
+            return 1;
+        }
+
         if (models is null)
         {
             writer.WriteLine("No models configured.");
@@ -78,7 +86,7 @@ internal static class ModelCommand
         //        [--output-modalities <list>] [--clear-modalities]
         if (args.Length < 5)
         {
-            writer.WriteLine("Usage: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]");
+            writer.WriteLine("Usage: netclaw model set <role> <provider> <model-id> [--context-window <tokens>] [--clear-context-window]");
             writer.WriteLine("                       [--input-modalities <list>] [--output-modalities <list>] [--clear-modalities]");
             writer.WriteLine();
             writer.WriteLine("Roles: main, fallback, compaction");
@@ -89,6 +97,7 @@ internal static class ModelCommand
         var providerName = args[3];
         var modelId = args[4];
         int? contextWindow = null;
+        var clearContextWindow = false;
         ModelModality? inputModalitySet = null;
         ModelModality? outputModalitySet = null;
         var clearModalities = false;
@@ -97,8 +106,14 @@ internal static class ModelCommand
         {
             switch (args[i])
             {
-                case "--context-window" when i + 1 < args.Length:
-                    if (!int.TryParse(args[++i], out var cw) || cw <= 0)
+                case "--context-window":
+                    if (!TryTakeValue(args, ref i, out var cwRaw))
+                    {
+                        writer.WriteLine("Error: --context-window requires a value.");
+                        return 1;
+                    }
+
+                    if (!int.TryParse(cwRaw, out var cw) || cw <= 0)
                     {
                         writer.WriteLine("Error: --context-window must be a positive integer.");
                         return 1;
@@ -106,8 +121,17 @@ internal static class ModelCommand
 
                     contextWindow = cw;
                     break;
-                case "--input-modalities" when i + 1 < args.Length:
-                    if (!TryParseModalities(args[++i], out var input, out var inputError))
+                case "--clear-context-window":
+                    clearContextWindow = true;
+                    break;
+                case "--input-modalities":
+                    if (!TryTakeValue(args, ref i, out var inputRaw))
+                    {
+                        writer.WriteLine("Error: --input-modalities requires a value.");
+                        return 1;
+                    }
+
+                    if (!TryParseModalities(inputRaw, out var input, out var inputError))
                     {
                         writer.WriteLine(inputError);
                         return 1;
@@ -115,8 +139,14 @@ internal static class ModelCommand
 
                     inputModalitySet = input;
                     break;
-                case "--output-modalities" when i + 1 < args.Length:
-                    if (!TryParseModalities(args[++i], out var outputModality, out var outputError))
+                case "--output-modalities":
+                    if (!TryTakeValue(args, ref i, out var outputRaw))
+                    {
+                        writer.WriteLine("Error: --output-modalities requires a value.");
+                        return 1;
+                    }
+
+                    if (!TryParseModalities(outputRaw, out var outputModality, out var outputError))
                     {
                         writer.WriteLine(outputError);
                         return 1;
@@ -127,17 +157,35 @@ internal static class ModelCommand
                 case "--clear-modalities":
                     clearModalities = true;
                     break;
+                default:
+                    // Fail loudly on a stray token: a trailing flag with a missing value, a
+                    // mistyped flag name, or an unexpected positional would otherwise be silently
+                    // ignored while the command still reported success.
+                    writer.WriteLine($"Error: unknown argument '{args[i]}'.");
+                    return 1;
             }
         }
+
+        if (contextWindow.HasValue && clearContextWindow)
+        {
+            writer.WriteLine("Error: --context-window and --clear-context-window cannot be combined.");
+            return 1;
+        }
+
+        // An explicit --context-window sets the clamp; --clear-context-window removes it so
+        // detection resolves it; neither leaves the stored value / discovery to decide.
+        var contextWindowOverride = contextWindow is { } cwv
+            ? ValueOverride<int>.Set(cwv)
+            : clearContextWindow ? ValueOverride<int>.Clear : ValueOverride<int>.Unset;
 
         // An explicit --input/--output-modalities set wins over --clear-modalities (regardless of
         // arg order); --clear-modalities applies to whichever side was not explicitly set.
         var inputOverride = inputModalitySet is { } iv
-            ? ModalityOverride.Set(iv)
-            : clearModalities ? ModalityOverride.Clear : ModalityOverride.Unset;
+            ? ValueOverride<ModelModality>.Set(iv)
+            : clearModalities ? ValueOverride<ModelModality>.Clear : ValueOverride<ModelModality>.Unset;
         var outputOverride = outputModalitySet is { } ov
-            ? ModalityOverride.Set(ov)
-            : clearModalities ? ModalityOverride.Clear : ModalityOverride.Unset;
+            ? ValueOverride<ModelModality>.Set(ov)
+            : clearModalities ? ValueOverride<ModelModality>.Clear : ValueOverride<ModelModality>.Unset;
 
         // Validate role
         var roleKey = role switch
@@ -166,7 +214,9 @@ internal static class ModelCommand
             return 1;
         }
 
-        // Check for context window downgrade
+        // Check for context window downgrade. LoadModelSelection degrades a corrupt current config
+        // to null (this re-set is about to overwrite/repair it), so a bad existing entry skips the
+        // advisory warning instead of aborting the repair.
         var currentModels = LoadModelSelection(paths);
         if (roleKey == "Main" && currentModels?.Main.ContextWindow is > 0 && contextWindow.HasValue)
         {
@@ -177,10 +227,13 @@ internal static class ModelCommand
             }
         }
 
-        // Explicitly-supplied metadata (a context window or any modality intent) means the
-        // operator is configuring manually, so skip the probe — mirroring how --context-window
-        // has always short-circuited it. The supplied values win over discovery anyway.
-        var manualMetadataSupplied = contextWindow.HasValue || inputOverride.Supplied || outputOverride.Supplied;
+        // Only an explicit --context-window short-circuits the probe: it supplies the one datum the
+        // probe would discover, so it is the documented "configure this model manually" escape
+        // hatch. A modality override must NOT skip the probe — the probe also validates the model
+        // exists and discovers the context window, and WriteRole already lets an explicit modality
+        // override win over any discovered value, so it is safe to keep probing. --clear-context-window
+        // likewise keeps the probe: "re-detect" is exactly what the probe does.
+        var manualMetadataSupplied = contextWindow.HasValue;
 
         DiscoveredModel? discoveredModel = null;
         var provenance = ModelDiscoverySource.Manual;
@@ -223,7 +276,7 @@ internal static class ModelCommand
             providerName,
             modelId,
             provenance,
-            contextWindow,
+            contextWindowOverride,
             inputOverride,
             outputOverride,
             discoveredModel);
@@ -247,18 +300,46 @@ internal static class ModelCommand
     {
         const ModelModality all = ModelModality.Text | ModelModality.Image | ModelModality.Audio | ModelModality.Video;
         modalities = default;
+        error = $"Error: invalid modalities '{value}'. Use a comma-separated list of: Text, Image, Audio, Video "
+                + "(or --clear-modalities to remove the override).";
 
-        if (Enum.TryParse(value, ignoreCase: true, out ModelModality parsed)
-            && parsed != ModelModality.None
-            && (parsed & ~all) == 0)
+        var result = ModelModality.None;
+        foreach (var token in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            modalities = parsed;
-            error = string.Empty;
+            // Enum.TryParse also accepts the underlying integer ("3" → Text|Image), but the contract
+            // advertised in the help text and error message is named flags only. Enum.IsDefined
+            // rejects a numeric token because its parsed value is not a single declared member, so a
+            // mistyped or scripted number is not silently coerced into a modality set.
+            if (!Enum.TryParse(token, ignoreCase: true, out ModelModality parsed)
+                || !Enum.IsDefined(parsed)
+                || parsed == ModelModality.None)
+                return false;
+
+            result |= parsed;
+        }
+
+        if (result == ModelModality.None || (result & ~all) != 0)
+            return false;
+
+        modalities = result;
+        error = string.Empty;
+        return true;
+    }
+
+    /// <summary>
+    /// Consumes the value token following a value-requiring flag, advancing <paramref name="i"/>.
+    /// Returns false when the flag is the final token (its value is missing) so the caller can
+    /// reject it rather than silently dropping the flag.
+    /// </summary>
+    private static bool TryTakeValue(string[] args, ref int i, out string value)
+    {
+        if (i + 1 < args.Length)
+        {
+            value = args[++i];
             return true;
         }
 
-        error = $"Error: invalid modalities '{value}'. Use a comma-separated list of: Text, Image, Audio, Video "
-                + "(or --clear-modalities to remove the override).";
+        value = string.Empty;
         return false;
     }
 
@@ -392,18 +473,42 @@ internal static class ModelCommand
     }
 
     /// <summary>
-    /// Load model selection from config file.
+    /// Loads the model selection, or null when no config / Models section exists OR the config is
+    /// present but unparseable (e.g. a legacy or hand-edited entry with an unrecognized modality
+    /// enum string, which the strict enum-aware deserializer rejects by throwing). The <c>model</c>
+    /// commands are the repair surface for exactly such configs, so they must degrade rather than
+    /// abort with an unhandled JsonException. Callers that must distinguish "absent" from "corrupt"
+    /// — to fail loudly instead of showing a corrupt config as empty — use
+    /// <see cref="TryLoadModelSelection"/>.
     /// </summary>
     internal static ModelSelection? LoadModelSelection(NetclawPaths paths)
+        => TryLoadModelSelection(paths, out var models) ? models : null;
+
+    /// <summary>
+    /// Attempts to load the model selection. Returns false when the config file is present but its
+    /// Models section cannot be parsed, so the caller can report the corruption rather than silently
+    /// treating it as "no models". Returns true (with null <paramref name="models"/>) when no config
+    /// file or Models section exists.
+    /// </summary>
+    internal static bool TryLoadModelSelection(NetclawPaths paths, out ModelSelection? models)
     {
+        models = null;
         if (!File.Exists(paths.NetclawConfigPath))
-            return null;
+            return true;
 
-        using var doc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
-        if (!doc.RootElement.TryGetProperty("Models", out var modelsElement))
-            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
+            if (!doc.RootElement.TryGetProperty("Models", out var modelsElement))
+                return true;
 
-        return JsonSerializer.Deserialize<ModelSelection>(modelsElement.GetRawText(), JsonDefaults.EnumAware);
+            models = JsonSerializer.Deserialize<ModelSelection>(modelsElement.GetRawText(), JsonDefaults.EnumAware);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     private static int WriteHelp(TextWriter writer)
@@ -422,6 +527,7 @@ internal static class ModelCommand
         writer.WriteLine();
         writer.WriteLine("Options for 'set':");
         writer.WriteLine("  --context-window <tokens>    Override context window size");
+        writer.WriteLine("  --clear-context-window       Remove the context-window override (re-detect from provider)");
         writer.WriteLine("  --input-modalities <list>    Override input modalities, e.g. \"Text, Image\"");
         writer.WriteLine("  --output-modalities <list>   Override output modalities, e.g. \"Text\"");
         writer.WriteLine("  --clear-modalities           Remove modality overrides (fall back to runtime detection)");
@@ -433,6 +539,7 @@ internal static class ModelCommand
         writer.WriteLine("  netclaw model list");
         writer.WriteLine("  netclaw model discover my-ollama");
         writer.WriteLine("  netclaw model set main my-ollama qwen3:30b --context-window 32768");
+        writer.WriteLine("  netclaw model set main my-openai gpt-x --clear-context-window");
         writer.WriteLine("  netclaw model set main my-vllm qwen-vl --input-modalities \"Text, Image\"");
         writer.WriteLine("  netclaw model set main my-ollama qwen3:30b --clear-modalities");
         writer.WriteLine("  netclaw model clear fallback");

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -73,10 +73,13 @@ internal static class ModelCommand
     private static async Task<int> RunSetAsync(
         string[] args, NetclawPaths paths, IProviderProbe? probe, TextWriter writer)
     {
-        // Parse: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]
+        // Parse: netclaw model set <role> <provider> <model-id>
+        //        [--context-window <tokens>] [--input-modalities <list>]
+        //        [--output-modalities <list>] [--clear-modalities]
         if (args.Length < 5)
         {
             writer.WriteLine("Usage: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]");
+            writer.WriteLine("                       [--input-modalities <list>] [--output-modalities <list>] [--clear-modalities]");
             writer.WriteLine();
             writer.WriteLine("Roles: main, fallback, compaction");
             return 1;
@@ -86,20 +89,55 @@ internal static class ModelCommand
         var providerName = args[3];
         var modelId = args[4];
         int? contextWindow = null;
+        ModelModality? inputModalitySet = null;
+        ModelModality? outputModalitySet = null;
+        var clearModalities = false;
 
         for (var i = 5; i < args.Length; i++)
         {
-            if (args[i] is "--context-window" && i + 1 < args.Length)
+            switch (args[i])
             {
-                if (!int.TryParse(args[++i], out var cw) || cw <= 0)
-                {
-                    writer.WriteLine("Error: --context-window must be a positive integer.");
-                    return 1;
-                }
+                case "--context-window" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], out var cw) || cw <= 0)
+                    {
+                        writer.WriteLine("Error: --context-window must be a positive integer.");
+                        return 1;
+                    }
 
-                contextWindow = cw;
+                    contextWindow = cw;
+                    break;
+                case "--input-modalities" when i + 1 < args.Length:
+                    if (!TryParseModalities(args[++i], out var input, out var inputError))
+                    {
+                        writer.WriteLine(inputError);
+                        return 1;
+                    }
+
+                    inputModalitySet = input;
+                    break;
+                case "--output-modalities" when i + 1 < args.Length:
+                    if (!TryParseModalities(args[++i], out var outputModality, out var outputError))
+                    {
+                        writer.WriteLine(outputError);
+                        return 1;
+                    }
+
+                    outputModalitySet = outputModality;
+                    break;
+                case "--clear-modalities":
+                    clearModalities = true;
+                    break;
             }
         }
+
+        // An explicit --input/--output-modalities set wins over --clear-modalities (regardless of
+        // arg order); --clear-modalities applies to whichever side was not explicitly set.
+        var inputOverride = inputModalitySet is { } iv
+            ? ModalityOverride.Set(iv)
+            : clearModalities ? ModalityOverride.Clear : ModalityOverride.Unset;
+        var outputOverride = outputModalitySet is { } ov
+            ? ModalityOverride.Set(ov)
+            : clearModalities ? ModalityOverride.Clear : ModalityOverride.Unset;
 
         // Validate role
         var roleKey = role switch
@@ -139,9 +177,14 @@ internal static class ModelCommand
             }
         }
 
+        // Explicitly-supplied metadata (a context window or any modality intent) means the
+        // operator is configuring manually, so skip the probe — mirroring how --context-window
+        // has always short-circuited it. The supplied values win over discovery anyway.
+        var manualMetadataSupplied = contextWindow.HasValue || inputOverride.Supplied || outputOverride.Supplied;
+
         DiscoveredModel? discoveredModel = null;
         var provenance = ModelDiscoverySource.Manual;
-        if (contextWindow is null && ShouldProbeForMetadata(providerEntry))
+        if (!manualMetadataSupplied && ShouldProbeForMetadata(providerEntry))
         {
             probe ??= ProviderCommand.CreateDefaultRegistry();
             ProviderProbeResult probeResult;
@@ -170,17 +213,20 @@ internal static class ModelCommand
         var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        // Non-destructive: re-setting the same model (or only its context window) keeps
-        // hand-set modalities, which cannot be supplied on the command line (#1127).
+        // Non-destructive: stored ContextWindow and modalities are operator-owned overrides that
+        // discovery never clobbers on a same-model re-set (#1127, #1610). Explicit operator input
+        // (--context-window / --input-modalities / --clear-modalities) wins; the probe result only
+        // seeds a first-time set or a model switch.
         ModelEntryWriter.WriteRole(
             modelsSection,
             roleKey,
             providerName,
             modelId,
             provenance,
-            contextWindow ?? discoveredModel?.ContextWindowTokens,
-            discoveredModel?.InputModalities,
-            discoveredModel?.OutputModalities);
+            contextWindow,
+            inputOverride,
+            outputOverride,
+            discoveredModel);
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
 
         writer.WriteLine($"Set {role} model to {providerName}/{modelId}");
@@ -190,6 +236,31 @@ internal static class ModelCommand
     private static bool ShouldProbeForMetadata(ProviderEntry entry)
         => string.Equals(entry.Type, "openai", StringComparison.OrdinalIgnoreCase)
            && entry.AuthMethod is AuthMethod.OAuthDevice or AuthMethod.OAuthPkce;
+
+    /// <summary>
+    /// Parses a <c>--input/output-modalities</c> value: a comma-separated list of
+    /// <see cref="ModelModality"/> flags (e.g. <c>Text</c>, <c>"Text, Image"</c>). Rejects
+    /// <c>None</c> and any unknown flag so only schema-valid overrides reach config — a model
+    /// with no modalities is meaningless, and <c>--clear-modalities</c> is the way to remove one.
+    /// </summary>
+    private static bool TryParseModalities(string value, out ModelModality modalities, out string error)
+    {
+        const ModelModality all = ModelModality.Text | ModelModality.Image | ModelModality.Audio | ModelModality.Video;
+        modalities = default;
+
+        if (Enum.TryParse(value, ignoreCase: true, out ModelModality parsed)
+            && parsed != ModelModality.None
+            && (parsed & ~all) == 0)
+        {
+            modalities = parsed;
+            error = string.Empty;
+            return true;
+        }
+
+        error = $"Error: invalid modalities '{value}'. Use a comma-separated list of: Text, Image, Audio, Video "
+                + "(or --clear-modalities to remove the override).";
+        return false;
+    }
 
     /// <summary>
     /// The endpoint the probe will actually hit, for display. When a provider has no
@@ -351,11 +422,19 @@ internal static class ModelCommand
         writer.WriteLine();
         writer.WriteLine("Options for 'set':");
         writer.WriteLine("  --context-window <tokens>    Override context window size");
+        writer.WriteLine("  --input-modalities <list>    Override input modalities, e.g. \"Text, Image\"");
+        writer.WriteLine("  --output-modalities <list>   Override output modalities, e.g. \"Text\"");
+        writer.WriteLine("  --clear-modalities           Remove modality overrides (fall back to runtime detection)");
+        writer.WriteLine();
+        writer.WriteLine("  Modality and context-window overrides are preserved when you re-set the same model;");
+        writer.WriteLine("  provider discovery never overwrites them. Use these flags (or --clear-modalities) to change them.");
         writer.WriteLine();
         writer.WriteLine("Examples:");
         writer.WriteLine("  netclaw model list");
         writer.WriteLine("  netclaw model discover my-ollama");
         writer.WriteLine("  netclaw model set main my-ollama qwen3:30b --context-window 32768");
+        writer.WriteLine("  netclaw model set main my-vllm qwen-vl --input-modalities \"Text, Image\"");
+        writer.WriteLine("  netclaw model set main my-ollama qwen3:30b --clear-modalities");
         writer.WriteLine("  netclaw model clear fallback");
         return 0;
     }

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Json;
 using Netclaw.Cli.Provider;
@@ -266,10 +267,9 @@ internal static class ModelCommand
         var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        // Non-destructive: stored ContextWindow and modalities are operator-owned overrides that
-        // discovery never clobbers on a same-model re-set (#1127, #1610). Explicit operator input
-        // (--context-window / --input-modalities / --clear-modalities) wins; the probe result only
-        // seeds a first-time set or a model switch.
+        // Definitions own model metadata, so role switches never destroy another model's
+        // operator-owned overrides. Discovery seeds only a new definition; explicit input edits
+        // an existing definition and absence remains runtime detection (#1127, #1610).
         ModelEntryWriter.WriteRole(
             modelsSection,
             roleKey,
@@ -459,13 +459,29 @@ internal static class ModelCommand
         var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
         var modelsSection = ConfigFileHelper.GetSectionOrNull(config, "Models");
 
-        if (modelsSection is null || !modelsSection.ContainsKey(roleKey))
+        if (modelsSection is null)
         {
             writer.WriteLine($"Role '{role}' is not configured.");
             return 0;
         }
 
-        modelsSection.Remove(roleKey);
+        bool removed;
+        try
+        {
+            removed = ModelEntryWriter.ClearRole(modelsSection, roleKey);
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            writer.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+
+        if (!removed)
+        {
+            writer.WriteLine($"Role '{role}' is not configured.");
+            return 0;
+        }
+
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
 
         writer.WriteLine($"Cleared {role} model role.");
@@ -498,14 +514,16 @@ internal static class ModelCommand
 
         try
         {
-            using var doc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
-            if (!doc.RootElement.TryGetProperty("Models", out var modelsElement))
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile(paths.NetclawConfigPath, optional: false, reloadOnChange: false)
+                .Build();
+            if (!configuration.GetSection("Models").Exists())
                 return true;
 
-            models = JsonSerializer.Deserialize<ModelSelection>(modelsElement.GetRawText(), JsonDefaults.EnumAware);
+            models = ModelConfigurationResolver.Resolve(configuration).Selection;
             return true;
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             return false;
         }
@@ -532,8 +550,8 @@ internal static class ModelCommand
         writer.WriteLine("  --output-modalities <list>   Override output modalities, e.g. \"Text\"");
         writer.WriteLine("  --clear-modalities           Remove modality overrides (fall back to runtime detection)");
         writer.WriteLine();
-        writer.WriteLine("  Modality and context-window overrides are preserved when you re-set the same model;");
-        writer.WriteLine("  provider discovery never overwrites them. Use these flags (or --clear-modalities) to change them.");
+        writer.WriteLine("  Overrides live on named model definitions and survive role switches;");
+        writer.WriteLine("  discovery never rewrites a definition. Use the set or matching clear flag to change it.");
         writer.WriteLine();
         writer.WriteLine("Examples:");
         writer.WriteLine("  netclaw model list");

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -2001,8 +2001,7 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
 static ModelCapabilities BuildModelCapabilities(IConfiguration configuration, DaemonApi daemonApi)
 {
     var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
-    var models = configuration.GetSection("Models")
-        .Get<ModelSelection>() ?? new ModelSelection();
+    var models = ModelConfigurationResolver.Resolve(configuration).Selection;
     var validation = ProviderRuntimeValidation.Evaluate(
         providers,
         models,

--- a/src/Netclaw.Cli/Provider/ProviderRenamer.cs
+++ b/src/Netclaw.Cli/Provider/ProviderRenamer.cs
@@ -96,6 +96,27 @@ internal static class ProviderRenamer
         var models = ConfigFileHelper.GetSectionOrNull(config, "Models");
         if (models is null) return reassigned;
 
+        if (models.ContainsKey("Definitions"))
+        {
+            var definitions = ConfigFileHelper.GetSectionOrNull(models, "Definitions")
+                              ?? throw new InvalidOperationException("Models:Definitions must be an object.");
+            foreach (var definitionName in definitions.Keys.ToList())
+            {
+                var definition = ConfigFileHelper.GetSectionOrNull(definitions, definitionName);
+                if (definition is null || !definition.TryGetValue("Provider", out var providerValue))
+                    continue;
+                var current = providerValue is JsonElement element
+                    ? element.GetString()
+                    : providerValue as string;
+                if (!string.Equals(current, oldName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                definition["Provider"] = newName;
+                reassigned.Add(definitionName);
+            }
+
+            return reassigned;
+        }
+
         foreach (var roleName in ModelRoleNames)
         {
             var role = ConfigFileHelper.GetSectionOrNull(models, roleName);

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -196,9 +196,9 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
             SelectedProvider,
             SelectedModelId,
             provenance,
-            contextWindow: null,
-            ModalityOverride.Unset,
-            ModalityOverride.Unset,
+            ValueOverride<int>.Unset,
+            ValueOverride<ModelModality>.Unset,
+            ValueOverride<ModelModality>.Unset,
             discoveredModel);
         ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
 

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -95,7 +95,15 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
 
     public void Refresh()
     {
-        Models = Model.ModelCommand.LoadModelSelection(_paths);
+        if (!Model.ModelCommand.TryLoadModelSelection(_paths, out var models))
+        {
+            Models = null;
+            StatusMessage.Value = "Model configuration is invalid. Run `netclaw doctor` for details.";
+        }
+        else
+        {
+            Models = models;
+        }
         Providers.Clear();
         var loaded = Provider.ProviderCommand.LoadProviders(_paths);
         foreach (var (name, entry) in loaded.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
@@ -230,7 +238,7 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
 
         var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
         var modelsSection = ConfigFileHelper.GetSectionOrNull(config, "Models");
-        if (modelsSection?.Remove(roleKey) == true)
+        if (modelsSection is not null && ModelEntryWriter.ClearRole(modelsSection, roleKey))
         {
             ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
             Refresh();

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -186,7 +186,11 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        modelsSection[roleKey] = ModelEntryWriter.BuildModelEntry(
+        // Non-destructive: re-assigning the same model preserves hand-set modalities,
+        // which the picker cannot supply (#1127).
+        ModelEntryWriter.WriteRole(
+            modelsSection,
+            roleKey,
             SelectedProvider,
             SelectedModelId,
             provenance,

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -186,17 +186,20 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
         var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
 
-        // Non-destructive: re-assigning the same model preserves hand-set modalities,
-        // which the picker cannot supply (#1127).
+        // Non-destructive: re-assigning the same model preserves an existing context-window
+        // clamp and modality overrides, none of which the picker can supply (#1127, #1610). The
+        // picker has no manual-override inputs, so it passes no explicit context window and Unset
+        // modality intent — the probe result seeds a first-time set only; existing values win.
         ModelEntryWriter.WriteRole(
             modelsSection,
             roleKey,
             SelectedProvider,
             SelectedModelId,
             provenance,
-            discoveredModel?.ContextWindowTokens,
-            discoveredModel?.InputModalities,
-            discoveredModel?.OutputModalities);
+            contextWindow: null,
+            ModalityOverride.Unset,
+            ModalityOverride.Unset,
+            discoveredModel);
         ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
 
         Refresh();

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -559,14 +559,8 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel, ISectionEditor
         var providerType = vm.SelectedProviderType.ToLowerInvariant();
         var fieldActions = new List<SectionFieldAction>
         {
-            new("Providers", SectionFieldActionKind.Set, BuildProvidersDictionary(vm, providerType)),
-            new("Models.Main.Provider", SectionFieldActionKind.Set, providerType)
+            new("Providers", SectionFieldActionKind.Set, BuildProvidersDictionary(vm, providerType))
         };
-
-        if (string.IsNullOrWhiteSpace(vm.SelectedModelId))
-            fieldActions.Add(new SectionFieldAction("Models.Main.ModelId", SectionFieldActionKind.Delete));
-        else
-            fieldActions.Add(new SectionFieldAction("Models.Main.ModelId", SectionFieldActionKind.Set, vm.SelectedModelId));
 
         var secretPath = $"Providers.{providerType}";
         var secretActions = new List<SectionSecretAction>();

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -135,13 +135,22 @@ public sealed class WizardConfigBuilder
         if (Model is not null)
         {
             var models = ConfigFileHelper.GetOrCreateSection(config, "Models");
-            models["Main"] = ModelEntryWriter.BuildModelEntry(
+            ModelEntryWriter.WriteRole(
+                models,
+                "Main",
                 Model.Provider,
                 Model.ModelId,
                 Model.Provenance,
-                Model.ContextWindow,
-                Model.InputModalities,
-                Model.OutputModalities);
+                Model.ContextWindow is { } contextWindow
+                    ? ValueOverride<int>.Set(contextWindow)
+                    : ValueOverride<int>.Unset,
+                Model.InputModalities is { } input
+                    ? ValueOverride<ModelModality>.Set(input)
+                    : ValueOverride<ModelModality>.Unset,
+                Model.OutputModalities is { } output
+                    ? ValueOverride<ModelModality>.Set(output)
+                    : ValueOverride<ModelModality>.Unset,
+                discovered: null);
         }
 
         // Slack section

--- a/src/Netclaw.Configuration.Tests/NamedModelConfigurationTests.cs
+++ b/src/Netclaw.Configuration.Tests/NamedModelConfigurationTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="NamedModelConfigurationTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class NamedModelConfigurationTests
+{
+    [Fact]
+    public void Resolve_LegacyShape_PreservesRuntimeValues()
+    {
+        var configuration = Build(new Dictionary<string, string?>
+        {
+            ["Models:Main:Provider"] = "vllm",
+            ["Models:Main:ModelId"] = "qwen-vl",
+            ["Models:Main:ContextWindow"] = "32768",
+            ["Models:Main:InputModalities"] = "Text, Image",
+        });
+
+        var result = ModelConfigurationResolver.Resolve(configuration);
+
+        Assert.True(result.IsLegacy);
+        Assert.Equal("vllm", result.Selection.Main.Provider);
+        Assert.Equal(32768, result.Selection.Main.ContextWindow);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.Selection.Main.InputModalities);
+    }
+
+    [Fact]
+    public void Resolve_NamedShape_ResolvesRoleWithoutMutatingDefinition()
+    {
+        var configuration = Build(new Dictionary<string, string?>
+        {
+            ["Models:Definitions:vision:Provider"] = "vllm",
+            ["Models:Definitions:vision:ModelId"] = "qwen-vl",
+            ["Models:Definitions:vision:InputModalities"] = "Text, Image",
+            ["Models:Roles:Main"] = "vision",
+        });
+
+        var result = ModelConfigurationResolver.Resolve(configuration);
+
+        Assert.False(result.IsLegacy);
+        Assert.Equal("qwen-vl", result.Selection.Main.ModelId);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.Selection.Main.InputModalities);
+    }
+
+    [Fact]
+    public void Resolve_MixedShape_FailsLoudly()
+    {
+        var configuration = Build(new Dictionary<string, string?>
+        {
+            ["Models:Main:Provider"] = "vllm",
+            ["Models:Main:ModelId"] = "qwen-vl",
+            ["Models:Definitions:vision:Provider"] = "vllm",
+            ["Models:Definitions:vision:ModelId"] = "qwen-vl",
+            ["Models:Roles:Main"] = "vision",
+        });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ModelConfigurationResolver.Resolve(configuration));
+
+        Assert.Contains("mixes legacy", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_MissingDefinition_FailsLoudly()
+    {
+        var configuration = Build(new Dictionary<string, string?>
+        {
+            ["Models:Definitions:vision:Provider"] = "vllm",
+            ["Models:Definitions:vision:ModelId"] = "qwen-vl",
+            ["Models:Roles:Main"] = "missing",
+        });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ModelConfigurationResolver.Resolve(configuration));
+
+        Assert.Contains("unknown definition 'missing'", exception.Message);
+    }
+
+    private static IConfiguration Build(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}

--- a/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
+++ b/src/Netclaw.Configuration.Tests/ProviderRuntimeValidationTests.cs
@@ -3,12 +3,46 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace Netclaw.Configuration.Tests;
 
 public sealed class ProviderRuntimeValidationTests
 {
+    [Theory]
+    [InlineData("vision", true, true, true)]
+    [InlineData("VISION", true, true, true)]
+    [InlineData("missing", true, false, false)]
+    [InlineData("provider-only", true, true, false)]
+    [InlineData(null, false, false, false)]
+    public void NamedRolePresence_ComesFromReferencedDefinition(
+        string? roleReference,
+        bool roleConfigured,
+        bool providerConfigured,
+        bool modelIdConfigured)
+    {
+        var models = JsonNode.Parse(
+            """
+            {
+              "Definitions": {
+                "vision": { "Provider": "vllm", "ModelId": "qwen-vl" },
+                "provider-only": { "Provider": "vllm" }
+              },
+              "Roles": {}
+            }
+            """)!.AsObject();
+        if (roleReference is not null)
+            models["Roles"]!["Main"] = roleReference;
+
+        var root = new JsonObject { ["Models"] = models };
+        var result = ProviderRuntimeConfiguration.FromJson(root).Main;
+
+        Assert.Equal(roleConfigured, result.RoleConfigured);
+        Assert.Equal(providerConfigured, result.ProviderConfigured);
+        Assert.Equal(modelIdConfigured, result.ModelIdConfigured);
+    }
+
     [Fact]
     public void MainModelAbsent_DefaultModelSelection_ReturnsNoProviderConfigured()
     {

--- a/src/Netclaw.Configuration/NamedModelConfiguration.cs
+++ b/src/Netclaw.Configuration/NamedModelConfiguration.cs
@@ -1,0 +1,126 @@
+// -----------------------------------------------------------------------
+// <copyright file="NamedModelConfiguration.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Configuration;
+
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Canonical model configuration. Definitions own model metadata; roles only select definitions.
+/// </summary>
+public sealed class NamedModelConfiguration
+{
+    public Dictionary<string, ModelReference> Definitions { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public ModelRoleAssignments Roles { get; set; } = new();
+}
+
+public sealed class ModelRoleAssignments
+{
+    public string Main { get; set; } = string.Empty;
+    public string? Fallback { get; set; }
+    public string? Compaction { get; set; }
+}
+
+/// <summary>
+/// Resolves either the legacy inline role shape or the canonical named-definition shape into the
+/// runtime representation consumed by provider and actor composition. Mixed shapes fail loudly.
+/// </summary>
+public static class ModelConfigurationResolver
+{
+    private static readonly string[] LegacyRoles = ["Main", "Fallback", "Compaction"];
+
+    public static ModelConfigurationResolution Resolve(IConfigurationSection modelsSection)
+    {
+        var hasLegacy = LegacyRoles.Any(role => modelsSection.GetSection(role).Exists());
+        var hasDefinitions = modelsSection.GetSection(nameof(NamedModelConfiguration.Definitions)).Exists();
+        var hasRoles = modelsSection.GetSection(nameof(NamedModelConfiguration.Roles)).Exists();
+        var hasNamed = hasDefinitions || hasRoles;
+
+        if (hasLegacy && hasNamed)
+            throw new InvalidOperationException(
+                "Models configuration mixes legacy inline roles with named Definitions/Roles. " +
+                "Run `netclaw doctor --fix` after removing one representation.");
+
+        if (!hasNamed)
+        {
+            return new ModelConfigurationResolution(
+                modelsSection.Get<ModelSelection>() ?? new ModelSelection(),
+                IsLegacy: hasLegacy);
+        }
+
+        if (!hasDefinitions || !hasRoles)
+            throw new InvalidOperationException(
+                "Named Models configuration requires both Definitions and Roles sections.");
+
+        var duplicateDefinition = modelsSection.GetSection(nameof(NamedModelConfiguration.Definitions))
+            .GetChildren()
+            .GroupBy(child => child.Key, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateDefinition is not null)
+        {
+            throw new InvalidOperationException(
+                $"Models:Definitions contains duplicate case-insensitive name '{duplicateDefinition.Key}'.");
+        }
+
+        var named = modelsSection.Get<NamedModelConfiguration>() ?? new NamedModelConfiguration();
+        if (named.Definitions.Count == 0)
+            throw new InvalidOperationException("Models:Definitions must contain at least one model definition.");
+
+        var selection = new ModelSelection
+        {
+            Main = ResolveRequired(named, nameof(named.Roles.Main), named.Roles.Main),
+            Fallback = ResolveOptional(named, nameof(named.Roles.Fallback), named.Roles.Fallback),
+            Compaction = ResolveOptional(named, nameof(named.Roles.Compaction), named.Roles.Compaction),
+        };
+
+        return new ModelConfigurationResolution(selection, IsLegacy: false);
+    }
+
+    public static ModelConfigurationResolution Resolve(IConfiguration configuration)
+        => Resolve(configuration.GetSection("Models"));
+
+    private static ModelReference ResolveRequired(
+        NamedModelConfiguration named, string role, string definitionName)
+    {
+        if (string.IsNullOrWhiteSpace(definitionName))
+            throw new InvalidOperationException($"Models:Roles:{role} must reference a model definition.");
+
+        return ResolveDefinition(named, role, definitionName);
+    }
+
+    private static ModelReference? ResolveOptional(
+        NamedModelConfiguration named, string role, string? definitionName)
+        => string.IsNullOrWhiteSpace(definitionName)
+            ? null
+            : ResolveDefinition(named, role, definitionName);
+
+    private static ModelReference ResolveDefinition(
+        NamedModelConfiguration named, string role, string definitionName)
+    {
+        var match = named.Definitions.FirstOrDefault(pair =>
+            string.Equals(pair.Key, definitionName, StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrEmpty(match.Key))
+        {
+            throw new InvalidOperationException(
+                $"Models:Roles:{role} references unknown definition '{definitionName}'.");
+        }
+
+        return Clone(match.Value);
+    }
+
+    private static ModelReference Clone(ModelReference source) => new()
+    {
+        Provider = source.Provider,
+        ModelId = source.ModelId,
+        ContextWindow = source.ContextWindow,
+        Provenance = source.Provenance,
+        InputModalities = source.InputModalities,
+        OutputModalities = source.OutputModalities,
+    };
+}
+
+public sealed record ModelConfigurationResolution(ModelSelection Selection, bool IsLegacy);

--- a/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
+++ b/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
@@ -182,6 +182,18 @@ public sealed record ProviderRuntimeConfiguration(
         var models = configuration.GetSection("Models");
         var providers = configuration.GetSection("Providers");
 
+        if (models.GetSection(nameof(NamedModelConfiguration.Definitions)).Exists()
+            || models.GetSection(nameof(NamedModelConfiguration.Roles)).Exists())
+        {
+            var selection = ModelConfigurationResolver.Resolve(models).Selection;
+            return FromExplicitRoles(
+                ProviderConfigurationLoader.Load(providers),
+                main: !string.IsNullOrWhiteSpace(selection.Main.Provider)
+                      && !string.IsNullOrWhiteSpace(selection.Main.ModelId),
+                fallback: selection.Fallback is not null,
+                compaction: selection.Compaction is not null);
+        }
+
         return new ProviderRuntimeConfiguration(
             Main: ModelReferenceRuntimeConfiguration.FromConfiguration(models.GetSection("Main")),
             Fallback: ModelReferenceRuntimeConfiguration.FromConfiguration(models.GetSection("Fallback")),
@@ -196,6 +208,20 @@ public sealed record ProviderRuntimeConfiguration(
     {
         var models = root?["Models"] as JsonObject;
         var providers = root?["Providers"] as JsonObject;
+
+        if (models?["Roles"] is JsonObject roles)
+        {
+            return new ProviderRuntimeConfiguration(
+                Main: ModelReferenceRuntimeConfiguration.FromCompleteRole(HasNonEmptyString(roles, "Main")),
+                Fallback: ModelReferenceRuntimeConfiguration.FromCompleteRole(HasNonEmptyString(roles, "Fallback")),
+                Compaction: ModelReferenceRuntimeConfiguration.FromCompleteRole(HasNonEmptyString(roles, "Compaction")),
+                ProvidersWithExplicitType: providers is null
+                    ? []
+                    : providers
+                        .Where(provider => provider.Value is JsonObject obj && HasProperty(obj, nameof(ProviderEntry.Type)))
+                        .Select(provider => provider.Key)
+                        .ToList());
+        }
 
         return new ProviderRuntimeConfiguration(
             Main: ModelReferenceRuntimeConfiguration.FromJson(models?["Main"] as JsonObject),
@@ -227,6 +253,9 @@ public sealed record ProviderRuntimeConfiguration(
 
     internal static bool HasProperty(JsonObject obj, string propertyName) =>
         obj.Any(property => string.Equals(property.Key, propertyName, StringComparison.OrdinalIgnoreCase));
+
+    private static bool HasNonEmptyString(JsonObject obj, string propertyName)
+        => obj[propertyName]?.GetValue<string>() is { Length: > 0 };
 }
 
 public sealed record ModelReferenceRuntimeConfiguration(

--- a/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
+++ b/src/Netclaw.Configuration/ProviderRuntimeValidation.cs
@@ -211,10 +211,11 @@ public sealed record ProviderRuntimeConfiguration(
 
         if (models?["Roles"] is JsonObject roles)
         {
+            var definitions = models["Definitions"] as JsonObject;
             return new ProviderRuntimeConfiguration(
-                Main: ModelReferenceRuntimeConfiguration.FromCompleteRole(HasNonEmptyString(roles, "Main")),
-                Fallback: ModelReferenceRuntimeConfiguration.FromCompleteRole(HasNonEmptyString(roles, "Fallback")),
-                Compaction: ModelReferenceRuntimeConfiguration.FromCompleteRole(HasNonEmptyString(roles, "Compaction")),
+                Main: ModelReferenceRuntimeConfiguration.FromNamedRole(roles, definitions, "Main"),
+                Fallback: ModelReferenceRuntimeConfiguration.FromNamedRole(roles, definitions, "Fallback"),
+                Compaction: ModelReferenceRuntimeConfiguration.FromNamedRole(roles, definitions, "Compaction"),
                 ProvidersWithExplicitType: providers is null
                     ? []
                     : providers
@@ -254,8 +255,6 @@ public sealed record ProviderRuntimeConfiguration(
     internal static bool HasProperty(JsonObject obj, string propertyName) =>
         obj.Any(property => string.Equals(property.Key, propertyName, StringComparison.OrdinalIgnoreCase));
 
-    private static bool HasNonEmptyString(JsonObject obj, string propertyName)
-        => obj[propertyName]?.GetValue<string>() is { Length: > 0 };
 }
 
 public sealed record ModelReferenceRuntimeConfiguration(
@@ -277,6 +276,33 @@ public sealed record ModelReferenceRuntimeConfiguration(
             RoleConfigured: obj is not null,
             ProviderConfigured: obj is not null && ProviderRuntimeConfiguration.HasProperty(obj, nameof(ModelReference.Provider)),
             ModelIdConfigured: obj is not null && ProviderRuntimeConfiguration.HasProperty(obj, nameof(ModelReference.ModelId)));
+    }
+
+    public static ModelReferenceRuntimeConfiguration FromNamedRole(
+        JsonObject roles, JsonObject? definitions, string roleName)
+    {
+        var role = roles.FirstOrDefault(property =>
+            string.Equals(property.Key, roleName, StringComparison.OrdinalIgnoreCase));
+        if (role.Value is not JsonValue roleValue
+            || !roleValue.TryGetValue<string>(out var definitionName)
+            || string.IsNullOrWhiteSpace(definitionName))
+        {
+            return FromCompleteRole(false);
+        }
+
+        var definition = definitions?
+            .FirstOrDefault(property => string.Equals(
+                property.Key, definitionName, StringComparison.OrdinalIgnoreCase))
+            .Value as JsonObject;
+
+        return new ModelReferenceRuntimeConfiguration(
+            RoleConfigured: true,
+            ProviderConfigured: definition is not null
+                                && ProviderRuntimeConfiguration.HasProperty(
+                                    definition, nameof(ModelReference.Provider)),
+            ModelIdConfigured: definition is not null
+                               && ProviderRuntimeConfiguration.HasProperty(
+                                   definition, nameof(ModelReference.ModelId)));
     }
 
     public static ModelReferenceRuntimeConfiguration FromCompleteRole(bool configured) =>

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -333,14 +333,40 @@
       "additionalProperties": true
     },
     "Models": {
-      "type": "object",
-      "description": "Model selection by role (Main, Fallback, Compaction).",
-      "properties": {
-        "Main": { "$ref": "#/$defs/ModelReference" },
-        "Fallback": { "$ref": "#/$defs/ModelReference" },
-        "Compaction": { "$ref": "#/$defs/ModelReference" }
-      },
-      "additionalProperties": false
+      "description": "Named model definitions and role assignments. The legacy inline role shape remains accepted for upgrades.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "Main": { "$ref": "#/$defs/ModelReference" },
+            "Fallback": { "$ref": "#/$defs/ModelReference" },
+            "Compaction": { "$ref": "#/$defs/ModelReference" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["Definitions", "Roles"],
+          "properties": {
+            "Definitions": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": { "$ref": "#/$defs/ModelReference" }
+            },
+            "Roles": {
+              "type": "object",
+              "required": ["Main"],
+              "properties": {
+                "Main": { "type": "string", "minLength": 1 },
+                "Fallback": { "type": ["string", "null"] },
+                "Compaction": { "type": ["string", "null"] }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "Memory": {
       "type": "object",

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -360,8 +360,7 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
     // No silent fallback to local-ollama: an empty Providers section yields
     // the NoProviderConfigured outcome and the host registers NoOpChatClientProvider.
     var providers = ProviderConfigurationLoader.Load(configuration.GetSection("Providers"));
-    var models = configuration.GetSection("Models")
-        .Get<ModelSelection>() ?? new ModelSelection();
+    var models = ModelConfigurationResolver.Resolve(configuration).Selection;
     var validation = ProviderRuntimeValidation.Evaluate(
         providers,
         models,
@@ -398,9 +397,15 @@ static void ConfigureDaemonServices(
     services.AddHostedService<ExposureModeValidationService>();
     services.AddHostedService<BootstrapCompletionMarkerService>();
 
+    var resolvedModels = ModelConfigurationResolver.Resolve(configuration).Selection;
     services
         .AddOptions<ModelSelection>()
-        .Bind(configuration.GetSection("Models"))
+        .Configure(options =>
+        {
+            options.Main = resolvedModels.Main;
+            options.Fallback = resolvedModels.Fallback;
+            options.Compaction = resolvedModels.Compaction;
+        })
         .ValidateOnStart();
     services.AddSingleton<IValidateOptions<ModelSelection>, ModelSelectionValidator>();
     services
@@ -418,8 +423,7 @@ static void ConfigureDaemonServices(
     });
 
     // Resolve models for session config
-    var models = configuration.GetSection("Models")
-        .Get<ModelSelection>() ?? new ModelSelection();
+    var models = resolvedModels;
     services.AddSingleton(models);
 
     // Auto-detect model capabilities via the runtime IModelCapabilityResolver

--- a/tests/smoke/assertions/init-wizard.sh
+++ b/tests/smoke/assertions/init-wizard.sh
@@ -47,8 +47,9 @@ fi
 echo "init-wizard: checking expected fields in netclaw.json..."
 assert_field '.Providers.ollama.Type'       'ollama'                   "$config_json" || :
 assert_field '.Providers.ollama.Endpoint'   'http://localhost:11434'   "$config_json" || :
-assert_field '.Models.Main.Provider'        'ollama'                   "$config_json" || :
-assert_field '.Models.Main.ModelId'         'qwen2:0.5b'               "$config_json" || :
+assert_field '.Models.Roles.Main'                                  'ollama-qwen2-0-5b' "$config_json" || :
+assert_field '.Models.Definitions[.Models.Roles.Main].Provider'     'ollama'             "$config_json" || :
+assert_field '.Models.Definitions[.Models.Roles.Main].ModelId'      'qwen2:0.5b'         "$config_json" || :
 assert_field '.Security.DeploymentPosture'  'Personal'                 "$config_json" || :
 
 echo "init-wizard: checking identity/SOUL.md for typed user name..."


### PR DESCRIPTION
## Summary

Re-selecting a model that is **already configured** silently wiped operator-set attributes
on it — the concrete #1127 loss. The write path rebuilt the `Models[role]` entry from
scratch via `ModelEntryWriter`, which only wrote what it was *handed* (a probe result), so a
manual `netclaw model set`, a context-window tweak, or the TUI picker re-selecting the same
model passed `null` and deleted a hand-set `InputModalities`/`OutputModalities`.

The fix establishes a single principle: **`ContextWindow` and the modalities are
operator-owned overrides** — both are documented to *"take precedence over provider-reported
capability detection"* — so provider discovery may **seed** them but must never **clobber**
them. `ModelEntryWriter.WriteRole` is the non-destructive persist that enforces one
precedence rule everywhere: **explicit operator input > existing stored value > probe.**
`model set` and the TUI model manager route through it; the init wizard is unchanged (fresh
config, nothing to clobber).

**No config-shape or schema change**, so this is fully backwards compatible — existing
configs and older daemons read it exactly as before.

## Commits

**1. `b8b49d10` — non-destructive `WriteRole`.** When the role already points at the same
`(provider, modelId)`, preserve the modalities and context window the caller didn't supply;
switching to a *different* model still starts clean (the old attributes belonged to the old
model).

**2. `d38b1586` — make the preservation robust and the overrides editable.** Review of the
first commit surfaced that "preserve when the caller passed null" was defeated on exactly the
paths that matter (probe/picker always pass a discovered value), plus several edge cases:

- **ContextWindow clamp preserved on same-model re-set.** The old callers collapsed the
  explicit `--context-window` and the probe default (`contextWindow ?? discovered`), so the
  probe/picker paths always passed a non-null value and the operator's clamp was overwritten
  on every re-selection. The two are now passed separately.
- **Modalities are no longer silently overwritten by discovery.** A probe that reported
  modalities used to replace a stored override (the #1127 loss's twin); now the stored value
  wins, matching the field's "manual override bypasses detection" contract.
- **Operators can change/remove those overrides.** Since discovery no longer edits them,
  `model set` gains `--input-modalities`, `--output-modalities`, and `--clear-modalities`.
  Explicit set replaces the stored value; clear removes it (runtime detection resolves).
  Supplying any of them (like `--context-window`) skips the probe as manual configuration.
- **Corrupt/legacy existing entry no longer aborts the command.** A malformed entry (e.g. an
  unrecognized modality enum string) is degraded to "nothing to preserve" and overwritten,
  instead of throwing `JsonException` out of a write the operator requested.
- **No false-match on `ModelReference` defaults.** `Provider`/`ModelId` default to the stock
  local-ollama model, so an entry omitting either key deserialized to that default and would
  false-match a re-set of the stock model; preservation now requires both keys present.
- **Provenance not downgraded.** A same-model re-set that did not re-resolve the ID (no probe
  → Manual) keeps a previously discovered origin (Live/Defaults); only a fresh discovery
  updates it.

## Reproduced and verified against the shipped binary

Using a throwaway containerized stock instance (isolated volume, no host config touched):

| Binary | `model set main <same-model> --context-window 262144` | `InputModalities` |
|---|---|---|
| Stock beta `0.25.0` | rebuilds entry | ❌ wiped |
| This branch | merges | ✅ `Text, Image` preserved |

> **Note on `doctor --fix`:** the container repro showed `doctor --fix` does **not** wipe
> modalities on either `0.24.4` or `0.25.0` — the trigger is model (re)selection, matching
> #1127's title. The original report attributing it to `doctor --fix` was a model-selection
> step in that flow.

## Scope

Fixes re-setting / tweaking an already-configured model (and the TUI re-selecting the same
model), and makes modality overrides first-class — settable and clearable from the CLI. It
does **not** address *switch to a different model and back* preserving the old model's
overrides — inline config only stores the current role's model. That "properties survive
across model switches" behavior is the named-model registry follow-up (#1127 structural
change); this fix is a prerequisite it needs anyway.

## Test plan

- [x] Unit: full `ModelEntryWriter` precedence matrix — clamp-over-probe,
      probe-does-not-override-existing-modalities, explicit set, clear-over-probe, first-time
      seeding, default-model false-match, corrupt-entry overwrite, provenance preserve/update
- [x] CLI end-to-end (`ModelCommandTests`): `--input-modalities` write, `--clear-modalities`
      removal, invalid-value rejection, same-model re-set preserves existing modalities
- [x] Touched CLI suites green (822 tests across Model / Config / Tui / Wizard)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `Add-FileHeaders.ps1 -Verify` — clean
- [x] `run-smoke.sh model-manager` — native model-picker tape passes
- [x] (initial commit) Full CLI test project green + `run-smoke.sh light` (22 tapes, 9 scenarios)
- [x] End-to-end repro against stock beta `0.25.0` (wipes) vs this branch (preserves)

close #1127.
