### PR TITLE
fix(daemon,cli): graceful systemd stop; memory subcommand --help handling (canary findings)

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
@@ -181,6 +181,40 @@ public sealed class CliArgsParserTests
         return commands;
     }
 
+    /// <summary>
+    /// Regression coverage for the canary "help executes instead of printing help" family of
+    /// bugs (<c>netclaw memory backfill-embeddings --help</c> ran a real embed pass;
+    /// <c>netclaw daemon stop --help</c> would have actually stopped the daemon). Every fix
+    /// site (MemoryCommand, the Program.cs daemon dispatch, WebhooksCommand, ReminderCommand)
+    /// routes through this one helper, so its own scan logic only needs proving once.
+    /// </summary>
+    [Theory]
+    [InlineData(new[] { "memory", "backfill-embeddings" }, false)]
+    [InlineData(new[] { "memory", "backfill-embeddings", "--force" }, false)]
+    [InlineData(new[] { "memory", "backfill-embeddings", "--help" }, true)]
+    [InlineData(new[] { "memory", "backfill-embeddings", "-h" }, true)]
+    [InlineData(new[] { "memory", "backfill-embeddings", "help" }, true)]
+    [InlineData(new[] { "daemon", "stop" }, false)]
+    [InlineData(new[] { "daemon", "stop", "--help" }, true)]
+    public void HasTrailingHelpToken_scans_from_startIndex(string[] args, bool expected)
+    {
+        Assert.Equal(expected, CliArgsParser.HasTrailingHelpToken(args, startIndex: 2));
+    }
+
+    [Fact]
+    public void HasTrailingHelpToken_ignores_tokens_before_startIndex()
+    {
+        // The subcommand itself ("help") sits at index 1, before startIndex — this helper is
+        // only meant to scan trailing args, so it must not double-count the subcommand slot.
+        Assert.False(CliArgsParser.HasTrailingHelpToken(["memory", "help"], startIndex: 2));
+    }
+
+    [Fact]
+    public void HasTrailingHelpToken_returns_false_for_empty_tail()
+    {
+        Assert.False(CliArgsParser.HasTrailingHelpToken(["memory", "backfill-embeddings"], startIndex: 2));
+    }
+
     private static string ReadProgramCsSource() => File.ReadAllText(Path.Combine(FindRepoRoot(), "src", "Netclaw.Cli", "Program.cs"));
 
     private static string FindRepoRoot()

--- a/src/Netclaw.Cli.Tests/Cli/DaemonCommandDispatchTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonCommandDispatchTests.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonCommandDispatchTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Daemon;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+/// <summary>
+/// Regression coverage for the canary finding that <c>netclaw daemon stop --help</c> (and
+/// start/status/install/uninstall) executed the real lifecycle action instead of printing
+/// help, because Program.cs's daemon dispatch only checked the subcommand slot (args[1]) for
+/// a help token. Program.cs is top-level statements, so the decision is extracted into
+/// <see cref="DaemonCommandDispatch"/> to make it independently unit-testable — mirroring
+/// <c>DaemonCliArgs</c>'s <c>netclawd --version</c> extraction for the same reason.
+/// </summary>
+public sealed class DaemonCommandDispatchTests
+{
+    [Theory]
+    [InlineData("start")]
+    [InlineData("stop")]
+    [InlineData("status")]
+    [InlineData("install")]
+    [InlineData("uninstall")]
+    public void ShouldShowHelpInsteadOfExecuting_true_for_lifecycle_verb_with_trailing_help(string verb)
+    {
+        Assert.True(DaemonCommandDispatch.ShouldShowHelpInsteadOfExecuting(verb, ["daemon", verb, "--help"]));
+    }
+
+    [Theory]
+    [InlineData("start")]
+    [InlineData("stop")]
+    [InlineData("status")]
+    [InlineData("install")]
+    [InlineData("uninstall")]
+    public void ShouldShowHelpInsteadOfExecuting_false_for_lifecycle_verb_without_help(string verb)
+    {
+        Assert.False(DaemonCommandDispatch.ShouldShowHelpInsteadOfExecuting(verb, ["daemon", verb]));
+    }
+
+    [Theory]
+    [InlineData("pair")]
+    [InlineData("devices")]
+    [InlineData("help")]
+    public void ShouldShowHelpInsteadOfExecuting_false_for_verbs_with_their_own_help_handling(string verb)
+    {
+        // `pair`/`devices` guard their own trailing --help inline in Program.cs, and "help"
+        // itself is normalized away before this check runs — none should be double-guarded here.
+        Assert.False(DaemonCommandDispatch.ShouldShowHelpInsteadOfExecuting(verb, ["daemon", verb, "--help"]));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Cli/DaemonManagerGracefulShutdownTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonManagerGracefulShutdownTests.cs
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonManagerGracefulShutdownTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Cli.Daemon;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+/// <summary>
+/// Covers the canary daemon-stop finding: <c>systemctl --user stop netclaw.service</c> landed
+/// in <c>failed (Result: signal)</c> because <see cref="DaemonManager.StopAsync"/>'s SIGTERM
+/// grace period (previously a hardcoded 10s) was far shorter than the ~200s the daemon's own
+/// Akka CoordinatedShutdown session-drain phase is deliberately allotted — so the CLI itself
+/// gave up and force-killed the daemon long before a legitimately slow (in-flight LLM call)
+/// graceful shutdown could finish. It still died, so `netclaw daemon stop` (ExecStop) reported
+/// success, but via SIGKILL rather than a clean exit — exactly what systemd's
+/// <c>failed (Result: signal)</c> was observing.
+///
+/// These tests exercise the two testable halves of the fix: (1) the internal
+/// <see cref="DaemonManager.WaitForExitAsync"/> poll now honors an injected
+/// <see cref="TimeProvider"/> end-to-end (not just for its deadline math), so the up-to-200s
+/// wait can be driven with a <see cref="FakeTimeProvider"/> instead of a real sleep; and
+/// (2) the generated systemd unit's <c>TimeoutStopSec=</c> stays in lockstep with
+/// <see cref="DaemonConfig.GracefulShutdownBudget"/> so systemd itself never SIGKILLs the whole
+/// cgroup out from under a still-legitimately-waiting <c>ExecStop=</c>.
+/// </summary>
+public sealed class DaemonManagerGracefulShutdownTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+
+    public DaemonManagerGracefulShutdownTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public async Task WaitForExitAsync_ReturnsTrue_Immediately_WhenProcessAlreadyExited()
+    {
+        var manager = new DaemonManager(_paths, TimeProvider.System);
+        using var exited = StartAndWaitForRealExit();
+
+        var result = await manager.WaitForExitAsync(exited, TimeSpan.FromSeconds(200), CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task WaitForExitAsync_ReturnsFalse_OnceVirtualClockPassesTimeout_WithoutRealTimeDelay()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var manager = new DaemonManager(_paths, fakeTime);
+        // The current test process never exits mid-test — stands in for a daemon still
+        // draining a stuck/slow session.
+        var neverExits = Process.GetCurrentProcess();
+
+        var waitTask = manager.WaitForExitAsync(neverExits, DaemonConfig.GracefulShutdownBudget, CancellationToken.None);
+
+        // A single jump past the full budget — if the poll delay inside WaitForExitAsync were
+        // still a bare real-time `Task.Delay(200)` (the pre-fix shape), this test would need to
+        // actually wait out that real time instead of resolving from one Advance() call.
+        fakeTime.Advance(DaemonConfig.GracefulShutdownBudget + TimeSpan.FromSeconds(1));
+
+        var result = await waitTask;
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void BuildDaemonUnitContent_SetsTimeoutStopSec_ConsistentWithGracefulShutdownBudget()
+    {
+        var unit = DaemonManager.BuildDaemonUnitContent(
+            "/opt/netclaw/netclawd", "/opt/netclaw/netclaw", "/opt/netclaw/daemon.env");
+
+        var expectedTimeoutStopSec = (int)(DaemonConfig.GracefulShutdownBudget + TimeSpan.FromSeconds(30)).TotalSeconds;
+
+        Assert.Contains($"TimeoutStopSec={expectedTimeoutStopSec}", unit, StringComparison.Ordinal);
+
+        // TimeoutStopSec bounds the ENTIRE stop job (ExecStop's own runtime included), so it
+        // must leave systemd comfortably behind netclaw daemon stop's own SIGTERM-wait ceiling
+        // — otherwise systemd would SIGKILL the cgroup mid-ExecStop before the CLI's own,
+        // more-informative timeout/escalation logic ever gets to run.
+        Assert.True(
+            expectedTimeoutStopSec > DaemonConfig.GracefulShutdownBudget.TotalSeconds,
+            "Unit TimeoutStopSec must exceed DaemonManager.StopAsync's own SIGTERM wait.");
+    }
+
+    private static Process StartAndWaitForRealExit()
+    {
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", "/c exit 0")
+            : new ProcessStartInfo("/bin/sh", "-c \"exit 0\"");
+        psi.UseShellExecute = false;
+        psi.CreateNoWindow = true;
+
+        var process = Process.Start(psi)!;
+        process.WaitForExit();
+        return process;
+    }
+}

--- a/src/Netclaw.Cli.Tests/Memory/MemoryCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Memory/MemoryCommandTests.cs
@@ -76,6 +76,47 @@ public sealed class MemoryCommandTests
         Assert.Contains("AutoDownload", stderr);
     }
 
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    [InlineData("help")]
+    public async Task BackfillEmbeddings_help_flag_prints_help_and_does_not_execute(string helpToken)
+    {
+        // Canary regression: `netclaw memory backfill-embeddings --help` was executing the real
+        // provision-and-embed run (downloading models, writing embeddings) instead of printing
+        // help, because only args[1] (the subcommand slot) was checked for a help token. Prove
+        // the fix by seeding a document that WOULD be embedded if the command ran for real (as
+        // in BackfillEmbeddings_embeds_missing_documents_and_reports_a_summary above) and
+        // asserting nothing was written.
+        var paths = CreateTempPaths(prePlaceValidModel: true);
+        var config = BuildConfig(autoDownload: true);
+
+        var store = new SQLiteMemoryStore(paths.MemorySqliteDbPath, TimeProvider.System);
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+        await SeedDocumentAsync(store, "doc-1", "Doc One", "first body");
+
+        var (exitCode, stdout) = await RunCapturedAsync(["memory", "backfill-embeddings", helpToken], paths, config);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: netclaw memory <subcommand>", stdout);
+        Assert.DoesNotContain("Embedding", stdout);
+
+        var rows = await store.GetEmbeddingsForModelAsync(ModelId, TestContext.Current.CancellationToken);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public async Task TopLevelHelp_still_prints_help()
+    {
+        var paths = CreateTempPaths(prePlaceValidModel: false);
+        var config = BuildConfig(autoDownload: false);
+
+        var (exitCode, stdout) = await RunCapturedAsync(["memory", "--help"], paths, config);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: netclaw memory <subcommand>", stdout);
+    }
+
     [Fact]
     public async Task BackfillEmbeddings_with_force_re_embeds_every_recallable_document()
     {

--- a/src/Netclaw.Cli.Tests/Reminder/ReminderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Reminder/ReminderCommandTests.cs
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------
+// <copyright file="ReminderCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Reminder;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Reminder;
+
+/// <summary>
+/// Covers the missed-help pattern audited alongside the canary-reported
+/// <c>netclaw memory backfill-embeddings --help</c> bug: none of
+/// <see cref="ReminderCommand"/>'s subcommand handlers had their own <c>--help</c>
+/// check, so a trailing help token was silently ignored and the subcommand ran for
+/// real. <c>list</c> is the sharpest example — it takes no positional arguments at
+/// all, so `reminder list --help` used to reach the live daemon instead of printing
+/// help. All tests pass <c>daemonApi: null</c> to prove the help check short-circuits
+/// before the "requires a running daemon" branch is ever reached.
+/// </summary>
+public sealed class ReminderCommandTests
+{
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    [InlineData("help")]
+    public async Task List_TrailingHelpFlag_PrintsHelp_WithoutRequiringDaemon(string helpToken)
+    {
+        var (exitCode, stdout) = await RunCapturedAsync(["reminder", "list", helpToken]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: netclaw reminder <subcommand>", stdout);
+        Assert.DoesNotContain("requires a running daemon", stdout);
+    }
+
+    [Fact]
+    public async Task List_WithoutHelpFlag_StillRequiresDaemon()
+    {
+        // Regression guard: the new trailing-help scan must not swallow ordinary
+        // subcommand invocations that legitimately need the daemon.
+        var (exitCode, _, stderr) = await RunCapturedWithStderrAsync(["reminder", "list"]);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a running daemon", stderr);
+    }
+
+    [Fact]
+    public async Task Create_TrailingHelpFlag_AfterFullArgs_PrintsHelp_WithoutRequiringDaemon()
+    {
+        var (exitCode, stdout) = await RunCapturedAsync(
+            ["reminder", "create", "id", "once", "30m", "do it", "--help"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: netclaw reminder <subcommand>", stdout);
+    }
+
+    [Fact]
+    public async Task TopLevelHelp_StillPrintsHelp()
+    {
+        var (exitCode, stdout) = await RunCapturedAsync(["reminder", "--help"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: netclaw reminder <subcommand>", stdout);
+    }
+
+    private static async Task<(int ExitCode, string Stdout)> RunCapturedAsync(string[] args)
+    {
+        var (exitCode, stdout, _) = await RunCapturedWithStderrAsync(args);
+        return (exitCode, stdout);
+    }
+
+    private static async Task<(int ExitCode, string Stdout, string Stderr)> RunCapturedWithStderrAsync(string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = await ReminderCommand.RunAsync(args, daemonApi: null);
+            return (exitCode, stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Webhooks/WebhooksCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Webhooks/WebhooksCommandTests.cs
@@ -523,6 +523,36 @@ public sealed class WebhooksCommandTests : IDisposable
         Assert.Equal(0, result);
     }
 
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    public async Task List_TrailingHelpFlag_PrintsHelp_AndDoesNotList(string helpToken)
+    {
+        // A configured route WOULD show up in `webhooks list`'s output if the command ran for
+        // real, so its absence from stdout proves the help check pre-empted execution rather
+        // than just happening to print a route table that also mentions "Usage".
+        CreateValidRoute("test-route");
+
+        using var stdout = new StringWriter();
+        var result = await WebhooksCommand.RunAsync(["webhooks", "list", helpToken], _paths, stdout);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Usage: netclaw webhooks <subcommand>", stdout.ToString());
+        Assert.DoesNotContain("test-route", stdout.ToString());
+    }
+
+    [Fact]
+    public async Task Set_TrailingHelpFlag_PrintsMoreSpecificSetHelp_NotGenericHelp()
+    {
+        // `set` has its own more specific WriteSetHelp() and must not be shadowed by the
+        // generic trailing-help check added for list/show/delete/validate.
+        using var stdout = new StringWriter();
+        var result = await WebhooksCommand.RunAsync(["webhooks", "set", "test-route", "--help"], _paths, stdout);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Usage: netclaw webhooks set <route> [options]", stdout.ToString());
+    }
+
     private void CreateValidRoute(string routeName, string secret = "test-secret", string prompt = "Test prompt")
     {
         var route = new WebhookRouteConfig

--- a/src/Netclaw.Cli/CliArgsParser.cs
+++ b/src/Netclaw.Cli/CliArgsParser.cs
@@ -40,6 +40,29 @@ public static class CliArgsParser
     public static bool IsHelpToken(string token)
         => token is "help" or "-h" or "--help";
 
+    /// <summary>
+    /// Returns <c>true</c> if any argument at or after <paramref name="startIndex"/> is a help
+    /// token. Subcommand dispatchers whose action verbs take no further positional arguments
+    /// (e.g. <c>daemon stop</c>, <c>memory backfill-embeddings</c>, <c>webhooks list</c>) must
+    /// not just check the subcommand slot itself for "help"/"-h"/"--help" — a trailing help
+    /// token elsewhere in the args was otherwise silently ignored and the verb executed for
+    /// real instead of printing help (production canary: <c>netclaw memory backfill-embeddings
+    /// --help</c> ran a real provision-and-embed pass; <c>netclaw daemon stop --help</c> would
+    /// have actually stopped the daemon). Callers that DO have their own more specific
+    /// <c>--help</c> handling for a subcommand (e.g. <c>webhooks set</c>) should exclude that
+    /// subcommand from this check so the more specific help text is not shadowed.
+    /// </summary>
+    public static bool HasTrailingHelpToken(string[] args, int startIndex)
+    {
+        for (var i = startIndex; i < args.Length; i++)
+        {
+            if (IsHelpToken(args[i]))
+                return true;
+        }
+
+        return false;
+    }
+
     public static CliParseResult Parse(string[] args)
     {
         if (args.Length == 0)

--- a/src/Netclaw.Cli/Daemon/DaemonCommandDispatch.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonCommandDispatch.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonCommandDispatch.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Cli.Daemon;
+
+/// <summary>
+/// Help-token gating for <c>netclaw daemon &lt;subcommand&gt;</c>, extracted out of Program.cs's
+/// top-level-statement dispatch so it is independently unit-testable.
+/// </summary>
+/// <remarks>
+/// <c>pair</c> and <c>devices</c> take a nested action word and already guard their own
+/// trailing <c>--help</c> inline in Program.cs. The remaining lifecycle verbs
+/// (<c>start</c>/<c>stop</c>/<c>status</c>/<c>install</c>/<c>uninstall</c>) take no further
+/// positional arguments, so previously a trailing help token anywhere after the verb was
+/// silently ignored and the verb executed for real — e.g. <c>netclaw daemon stop --help</c>
+/// actually stopped the daemon instead of printing help (canary finding, same missed-help
+/// pattern audited for the memory subcommand).
+/// </remarks>
+internal static class DaemonCommandDispatch
+{
+    private static readonly HashSet<string> LifecycleVerbsRequiringTrailingHelpGuard =
+        new(StringComparer.Ordinal) { "start", "stop", "status", "install", "uninstall" };
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="subcommand"/> is one of the guarded lifecycle
+    /// verbs and <paramref name="args"/> carries a trailing help token (anywhere at or after
+    /// index 2 — i.e. after <c>netclaw daemon &lt;subcommand&gt;</c>).
+    /// </summary>
+    public static bool ShouldShowHelpInsteadOfExecuting(string subcommand, string[] args)
+        => LifecycleVerbsRequiringTrailingHelpGuard.Contains(subcommand)
+           && CliArgsParser.HasTrailingHelpToken(args, startIndex: 2);
+}

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -177,8 +177,16 @@ public sealed partial class DaemonManager
             process.Kill();
         }
 
-        // Wait up to 10 seconds for graceful exit.
-        if (!await WaitForExitAsync(process, TimeSpan.FromSeconds(10), cancellationToken))
+        // Wait for graceful exit. Matches DaemonConfig.GracefulShutdownBudget: the daemon's
+        // own Akka CoordinatedShutdown "before-service-unbind" phase is allotted this long to
+        // drain any in-flight LLM turn (TurnLlmTimeout defaults to 3 minutes) before sessions
+        // passivate. A shorter wait here (previously a hardcoded 10s) gave up and force-killed
+        // the daemon long before its own graceful drain could finish — the daemon still died,
+        // so this method reported success, but via SIGKILL mid-shutdown rather than a clean
+        // exit. That SIGKILL is exactly what systemd's `failed (Result: signal)` was observing
+        // even though `netclaw daemon stop` (ExecStop) itself exited 0 (canary finding).
+        var exitedGracefully = await WaitForExitAsync(process, DaemonConfig.GracefulShutdownBudget, cancellationToken);
+        if (!exitedGracefully)
         {
             // Timed out — hard cutoff.
             string? killError = null;
@@ -203,7 +211,18 @@ public sealed partial class DaemonManager
         }
 
         CleanupPidFile();
-        return new DaemonResult(true, $"Daemon stopped (was PID {pid}).");
+
+        // Surface whether this was a clean exit or a forced kill: a force-kill means
+        // something (typically a session mid-LLM-call) did not finish draining within
+        // DaemonConfig.GracefulShutdownBudget, which is worth an operator's attention if
+        // it recurs even though the daemon did eventually stop.
+        return exitedGracefully
+            ? new DaemonResult(true, $"Daemon stopped (was PID {pid}).")
+            : new DaemonResult(true,
+                $"Daemon stopped (was PID {pid}), but did not exit gracefully within " +
+                $"{DaemonConfig.GracefulShutdownBudget.TotalSeconds:F0}s and had to be force-killed. " +
+                "This usually means a session was still mid-LLM-call at shutdown; if it recurs, check " +
+                "for stuck sessions before stopping the daemon.");
     }
 
     /// <summary>
@@ -350,6 +369,17 @@ public sealed partial class DaemonManager
     }
 
     /// <summary>
+    /// systemd's <c>TimeoutStopSec=</c> for the generated unit: comfortably longer than
+    /// <see cref="DaemonManager.StopAsync"/>'s own graceful-shutdown wait
+    /// (<see cref="DaemonConfig.GracefulShutdownBudget"/>) so systemd never SIGKILLs the whole
+    /// cgroup out from under <c>ExecStop=</c> (<c>netclaw daemon stop</c>) while that command is
+    /// still legitimately waiting on the daemon's own CoordinatedShutdown drain. Existing
+    /// installs only pick this up after re-running <c>netclaw daemon install</c>.
+    /// </summary>
+    private static readonly int TimeoutStopSecValue =
+        (int)(DaemonConfig.GracefulShutdownBudget + TimeSpan.FromSeconds(30)).TotalSeconds;
+
+    /// <summary>
     /// Builds the systemd <c>--user</c> unit content. The daemon's shell-tool PATH is
     /// supplied out-of-band via <c>EnvironmentFile=</c> (see
     /// <see cref="DaemonPathEnvironmentFile"/>) rather than an inline
@@ -368,6 +398,7 @@ public sealed partial class DaemonManager
         Type=simple
         ExecStart={binaryPath}
         ExecStop={cliBinaryPath} daemon stop
+        TimeoutStopSec={TimeoutStopSecValue}
         Restart=always
         RestartSec=5
         Environment=DOTNET_ENVIRONMENT=Production
@@ -637,7 +668,14 @@ public sealed partial class DaemonManager
         return kill(pid, (int)signal) == 0;
     }
 
-    private async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout, CancellationToken cancellationToken)
+    /// <summary>
+    /// Polls <paramref name="process"/> until it exits or <paramref name="timeout"/> elapses.
+    /// Internal (not private) so tests can drive the up-to-200-second graceful-shutdown wait
+    /// via an injected <see cref="TimeProvider"/> without a real wall-clock sleep: the poll
+    /// delay is scheduled against <see cref="_timeProvider"/> (matching this repo's virtualized-
+    /// timer convention, e.g. <c>ConfigWatcherService</c>), not a bare <c>Task.Delay(ms)</c>.
+    /// </summary>
+    internal async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout, CancellationToken cancellationToken)
     {
         var deadline = _timeProvider.GetUtcNow() + timeout;
         while (_timeProvider.GetUtcNow() < deadline)
@@ -647,7 +685,7 @@ public sealed partial class DaemonManager
             if (process.HasExited)
                 return true;
 
-            await Task.Delay(200, cancellationToken);
+            await Task.Delay(TimeSpan.FromMilliseconds(200), _timeProvider, cancellationToken);
         }
 
         return process.HasExited;

--- a/src/Netclaw.Cli/Memory/MemoryCommand.cs
+++ b/src/Netclaw.Cli/Memory/MemoryCommand.cs
@@ -39,6 +39,14 @@ internal static class MemoryCommand
         if (subcommand is "help" or "-h" or "--help")
             return Task.FromResult(WriteHelp());
 
+        // `backfill-embeddings` takes no required positional arguments (only the optional
+        // `--force` flag), so a trailing `--help`/`-h` would otherwise be silently ignored
+        // and the real provision-and-embed run would execute instead of printing help
+        // (canary finding: `netclaw memory backfill-embeddings --help` downloaded/embedded
+        // for real). Scan the full argument list, not just the subcommand slot.
+        if (CliArgsParser.HasTrailingHelpToken(args, startIndex: 2))
+            return Task.FromResult(WriteHelp());
+
         return subcommand switch
         {
             "backfill-embeddings" => RunBackfillEmbeddingsAsync(args, paths, configuration, allowlist),

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -483,6 +483,15 @@ static async Task RunAsync(string[] args)
         if (IsHelpToken(subcommand))
             subcommand = "help";
 
+        // See DaemonCommandDispatch remarks: `pair`/`devices` guard their own trailing --help
+        // below; the remaining lifecycle verbs previously executed for real on a trailing help
+        // token (canary finding). Fail toward help, not execution.
+        if (DaemonCommandDispatch.ShouldShowHelpInsteadOfExecuting(subcommand, args))
+        {
+            WriteDaemonHelp();
+            return;
+        }
+
         var paths = new NetclawPaths();
         paths.EnsureDirectoriesExist();
         var manager = new DaemonManager(paths, TimeProvider.System);

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -37,6 +37,17 @@ internal static class ReminderCommand
             return 0;
         }
 
+        // None of the subcommands below have their own --help handling, so a trailing
+        // --help/-h was previously ignored and the subcommand ran for real — e.g.
+        // `reminder list --help` still hit the live daemon and printed reminders instead
+        // of help (same missed-help pattern reported for `netclaw memory backfill-embeddings
+        // --help`). Scan the full argument list, not just the subcommand slot.
+        if (CliArgsParser.HasTrailingHelpToken(args, startIndex: 2))
+        {
+            WriteHelp();
+            return 0;
+        }
+
         // validate is offline — no daemon needed
         if (subcommand is "validate")
             return RunValidate(args);

--- a/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
+++ b/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
@@ -23,6 +23,13 @@ internal static class WebhooksCommand
         if (subcommand is "help" or "-h" or "--help")
             return Task.FromResult(WriteHelp(output));
 
+        // list/show/delete/validate take no --help of their own, so a trailing --help/-h
+        // was previously ignored and the subcommand ran for real (e.g. `webhooks list --help`
+        // still listed routes). `set` is excluded — it already has its own more specific
+        // WriteSetHelp() gated on HasFlag(args, "--help"/"-h").
+        if (subcommand is not "set" && CliArgsParser.HasTrailingHelpToken(args, startIndex: 2))
+            return Task.FromResult(WriteHelp(output));
+
         var store = new WebhookRouteStore(paths);
 
         return Task.FromResult(subcommand switch

--- a/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
@@ -287,4 +287,26 @@ public sealed class DaemonConfigTests
 
         Assert.Contains(issues, issue => issue.Message.Contains("not-an-ip", StringComparison.OrdinalIgnoreCase));
     }
+
+    /// <summary>
+    /// Regression guard for the canary daemon-stop finding:
+    /// <see cref="DaemonConfig.GracefulShutdownBudget"/> is the single source of truth shared by
+    /// the daemon's CoordinatedShutdown session-drain phase, its generic-host ShutdownTimeout,
+    /// the CLI's SIGTERM grace period, and the generated systemd unit's TimeoutStopSec. It only
+    /// does its job if it comfortably exceeds how long a session can legitimately still be
+    /// mid-LLM-call at shutdown (<see cref="SessionConfig.TurnLlmTimeout"/>'s default) — shrink
+    /// it below that and the CLI (or systemd) will force-kill the daemon mid-graceful-drain
+    /// again, exactly the bug this constant exists to prevent.
+    /// </summary>
+    [Fact]
+    public void GracefulShutdownBudget_exceeds_default_TurnLlmTimeout()
+    {
+        var defaultTurnLlmTimeout = new SessionConfig().TurnLlmTimeout;
+
+        Assert.True(
+            DaemonConfig.GracefulShutdownBudget > defaultTurnLlmTimeout,
+            $"GracefulShutdownBudget ({DaemonConfig.GracefulShutdownBudget}) must exceed the default " +
+            $"TurnLlmTimeout ({defaultTurnLlmTimeout}) so an in-flight LLM turn can finish draining " +
+            "before the daemon's graceful-shutdown budget is exhausted.");
+    }
 }

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -21,6 +21,34 @@ public sealed record DaemonConfig
     public const int DefaultPort = 5199;
 
     /// <summary>
+    /// Worst-case time the daemon's graceful shutdown drain is allotted before something
+    /// gives up and forces termination. Sized to comfortably exceed
+    /// <see cref="SessionConfig.TurnLlmTimeout"/>'s default (3 minutes) so a session mid-LLM-call
+    /// during shutdown can finish draining instead of being interrupted.
+    ///
+    /// Single source of truth shared by four surfaces that must stay in lockstep:
+    ///   - Netclaw.Daemon's Akka <c>coordinated-shutdown.phases.before-service-unbind.timeout</c>
+    ///     HOCON override (where the actual session drain runs)
+    ///   - Netclaw.Daemon's generic-host <c>HostOptions.ShutdownTimeout</c>
+    ///   - <see cref="Netclaw.Cli.Daemon.DaemonManager"/>'s SIGTERM grace period in
+    ///     <c>netclaw daemon stop</c> (the systemd unit's <c>ExecStop=</c>)
+    ///   - the generated systemd unit's <c>TimeoutStopSec=</c>
+    ///     (see <c>DaemonManager.BuildDaemonUnitContent</c>)
+    ///
+    /// A production canary regression traced to these four being inconsistent: the CLI's
+    /// SIGTERM wait was hardcoded to 10 seconds — far short of the 200s the daemon's own
+    /// CoordinatedShutdown phase is deliberately allotted — so a session still mid-LLM-call
+    /// caused the CLI to give up and force-kill the daemon itself long before the daemon's
+    /// own graceful drain could finish. The daemon still died, so <c>netclaw daemon stop</c>
+    /// (ExecStop) reported success, but via SIGKILL mid-shutdown rather than a clean exit —
+    /// exactly what systemd's <c>failed (Result: signal)</c> was observing.
+    ///
+    /// Changing this value requires re-running <c>netclaw daemon install</c> on existing
+    /// hosts to regenerate the unit file with the new <c>TimeoutStopSec=</c>.
+    /// </summary>
+    public static readonly TimeSpan GracefulShutdownBudget = TimeSpan.FromSeconds(200);
+
+    /// <summary>
     /// IP address the daemon binds to. Defaults to loopback (<c>127.0.0.1</c>).
     /// </summary>
     public string Host { get; init; } = "127.0.0.1";

--- a/src/Netclaw.Daemon.Tests/DaemonShutdownConfigurationTests.cs
+++ b/src/Netclaw.Daemon.Tests/DaemonShutdownConfigurationTests.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonShutdownConfigurationTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Daemon;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests;
+
+/// <summary>
+/// Regression coverage for the canary daemon-stop finding (see
+/// <see cref="DaemonConfig.GracefulShutdownBudget"/> remarks): the Akka CoordinatedShutdown
+/// "before-service-unbind" phase timeout — where session draining actually happens — must
+/// track <see cref="DaemonConfig.GracefulShutdownBudget"/>, not a hardcoded literal that can
+/// silently drift out of sync with the CLI's SIGTERM wait or the generated systemd unit's
+/// TimeoutStopSec.
+/// </summary>
+public sealed class DaemonShutdownConfigurationTests
+{
+    [Fact]
+    public void BuildCoordinatedShutdownHocon_UsesGracefulShutdownBudget()
+    {
+        var hocon = DaemonShutdownConfiguration.BuildCoordinatedShutdownHocon(DaemonConfig.GracefulShutdownBudget);
+
+        Assert.Contains(
+            $"phases.before-service-unbind.timeout = {(int)DaemonConfig.GracefulShutdownBudget.TotalSeconds}s",
+            hocon,
+            StringComparison.Ordinal);
+        Assert.Contains("exit-clr = off", hocon, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(30)]
+    [InlineData(200)]
+    [InlineData(600)]
+    public void BuildCoordinatedShutdownHocon_InterpolatesArbitraryTimeouts(int seconds)
+    {
+        var hocon = DaemonShutdownConfiguration.BuildCoordinatedShutdownHocon(TimeSpan.FromSeconds(seconds));
+
+        Assert.Contains($"phases.before-service-unbind.timeout = {seconds}s", hocon, StringComparison.Ordinal);
+    }
+}

--- a/src/Netclaw.Daemon/DaemonShutdownConfiguration.cs
+++ b/src/Netclaw.Daemon/DaemonShutdownConfiguration.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonShutdownConfiguration.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon;
+
+/// <summary>
+/// Builds the Akka CoordinatedShutdown HOCON override that bounds the daemon's session-drain
+/// phase. Extracted into its own testable method (rather than an inline string literal in
+/// Program.cs's top-level statements) so a unit test can assert the interpolated timeout
+/// tracks <see cref="DaemonConfig.GracefulShutdownBudget"/> instead of drifting back to a
+/// hardcoded literal — the exact class of bug behind the canary daemon-stop finding (see
+/// <see cref="DaemonConfig.GracefulShutdownBudget"/> remarks for the full story).
+/// </summary>
+internal static class DaemonShutdownConfiguration
+{
+    /// <summary>
+    /// Coordinated-shutdown HOCON: disables the CLR-exit side effect (the daemon's own
+    /// restart loop owns process lifetime, not CoordinatedShutdown) and sizes the
+    /// <c>before-service-unbind</c> phase — where session draining
+    /// (<c>SessionDrainHelper.DrainAsync</c>) actually runs — to <paramref name="gracefulShutdownBudget"/>.
+    /// </summary>
+    public static string BuildCoordinatedShutdownHocon(TimeSpan gracefulShutdownBudget) => $$"""
+        akka.coordinated-shutdown {
+            exit-clr = off
+            phases.before-service-unbind.timeout = {{(int)gracefulShutdownBudget.TotalSeconds}}s
+        }
+        """;
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -430,7 +430,13 @@ static void ConfigureDaemonServices(
 
     services.Configure<HostOptions>(options =>
     {
-        options.ShutdownTimeout = TimeSpan.FromSeconds(30);
+        // Must comfortably exceed DaemonConfig.GracefulShutdownBudget below (the Akka
+        // `before-service-unbind` CoordinatedShutdown phase timeout, where session draining
+        // actually happens) plus headroom for the handful of default-timeout phases that run
+        // after it. Previously a bare 30s — shorter than the 200s session-drain budget, which
+        // let this host-level timeout diverge from the Akka phase it is supposed to bound
+        // (canary finding: see DaemonConfig.GracefulShutdownBudget remarks for the full story).
+        options.ShutdownTimeout = DaemonConfig.GracefulShutdownBudget + TimeSpan.FromSeconds(30);
     });
 
     // Resolve models for session config
@@ -1063,12 +1069,7 @@ static void ConfigureDaemonServices(
         // mid-LLM-call (TurnLlmTimeout defaults to 3 minutes) must finish before
         // passivation can begin.
         akkaBuilder.AddHocon(
-            """
-            akka.coordinated-shutdown {
-                exit-clr = off
-                phases.before-service-unbind.timeout = 200s
-            }
-            """,
+            DaemonShutdownConfiguration.BuildCoordinatedShutdownHocon(DaemonConfig.GracefulShutdownBudget),
             HoconAddMode.Prepend);
 
         akkaBuilder = akkaBuilder.ConfigureLoggers(setup =>


### PR DESCRIPTION
## Summary

Two production-canary regressions, root-caused and fixed.

### Bug A — `systemctl --user stop netclaw.service` lands in `failed (Result: signal)`

**Root cause:** `DaemonManager.StopAsync` (`netclaw daemon stop`, the unit's `ExecStop=`) sent SIGTERM and waited only **10 seconds** before giving up and self-escalating to SIGKILL. But the daemon's own Akka CoordinatedShutdown `before-service-unbind` phase — where `SessionDrainHelper.DrainAsync` runs — is deliberately allotted **200 seconds**, specifically because an in-flight LLM turn (`SessionConfig.TurnLlmTimeout`, default 3 minutes) must be allowed to finish before a session can passivate. When a session was genuinely still mid-LLM-call at shutdown, the CLI's 10s window elapsed long before the daemon's own graceful drain could complete, so the CLI itself sent SIGKILL. The daemon died, so `netclaw daemon stop` reported success (exit 0) — but via a hard kill mid-shutdown, not a clean exit. That SIGKILL is exactly what systemd's `failed (Result: signal)` was observing.

A secondary contributor: the generic host's `HostOptions.ShutdownTimeout` was a bare 30s, also shorter than the 200s Akka phase it's supposed to bound, and the generated systemd unit had no explicit `TimeoutStopSec=`, leaving it at systemd's own (typically ~90s) default — also short of 200s.

**Fix:** introduced `DaemonConfig.GracefulShutdownBudget` (200s) as the single source of truth, now shared by:
- the Akka `coordinated-shutdown.phases.before-service-unbind.timeout` HOCON (via a new, testable `DaemonShutdownConfiguration.BuildCoordinatedShutdownHocon`)
- the host's `HostOptions.ShutdownTimeout` (budget + 30s headroom)
- `DaemonManager.StopAsync`'s SIGTERM grace period (was hardcoded 10s, now the full budget)
- the generated systemd unit's new `TimeoutStopSec=` (budget + 30s), so systemd never SIGKILLs the whole cgroup out from under a still-legitimately-waiting `ExecStop=`

Also fixed a latent bug in `DaemonManager.WaitForExitAsync`: its poll loop used a bare real-time `Task.Delay(200)` instead of routing through the injected `TimeProvider` (the convention used everywhere else in this repo, e.g. `ConfigWatcherService`). Fixing this was required to test the new ~200s wait deterministically with `FakeTimeProvider` instead of a real sleep, and closes a design inconsistency that could otherwise mask the same class of bug in tests.

The success message now distinguishes a clean exit from a forced kill, so operators get a signal if this recurs.

**⚠️ Existing installs must re-run `netclaw daemon install` (or `netclaw daemon uninstall && netclaw daemon install`) to regenerate the unit file with the new `TimeoutStopSec=`.** Will call this out in release notes.

**Untested live**: per instructions, the live daemon on this canary host was not stopped/restarted to validate. Validated via unit tests (see below) + code reading of the Akka.Hosting/CoordinatedShutdown/systemd interaction.

### Bug B — `netclaw memory backfill-embeddings --help` executes instead of printing help

**Root cause:** `MemoryCommand.RunAsync` only checked `args[1]` (the subcommand slot) for a help token before dispatching. `netclaw memory --help` worked (subcommand *is* `--help`), but `netclaw memory backfill-embeddings --help` had subcommand `"backfill-embeddings"` — not a help token — so it fell through to `RunBackfillEmbeddingsAsync`, which has no required positional args (only optional `--force`), silently absorbed the trailing `--help`, and ran the real provision-and-embed pass.

**Fix:** added `CliArgsParser.HasTrailingHelpToken(args, startIndex)` — scans the full argument list, not just the subcommand slot — and wired it into `MemoryCommand`.

**Audit of other subcommand handlers found the same pattern in three more places, all fixed:**
- **`netclaw daemon start/stop/status/install/uninstall --help`** (Program.cs) — most severe: e.g. `daemon stop --help` would have actually stopped the daemon, `daemon install --help` would install the systemd unit, etc. Extracted into a new, independently testable `DaemonCommandDispatch.ShouldShowHelpInsteadOfExecuting` (Program.cs is top-level statements and can't be unit-tested directly — mirrors the existing `DaemonCliArgs` extraction pattern for the same reason).
- **`netclaw webhooks list/show/delete/validate --help`** — e.g. `webhooks list --help` still listed routes. Fixed; `webhooks set --help` is excluded since it already had its own more-specific `WriteSetHelp()`.
- **`netclaw reminder <subcommand> --help`** — e.g. `reminder list --help` still hit the live daemon. Fixed for all subcommands.

Audited but left unchanged (confirmed non-destructive, just a confusing error message instead of help — e.g. `netclaw mcp get --help` prints "MCP server '--help' not found" rather than crashing or mutating anything): `model`, `provider`, `mcp add/get/remove/enable/disable/auth`, `skill`, `approvals`. These all have positional-arg-count guards that catch the case before anything executes.

**Baseline impact:** none — no help *text* changed anywhere, only *when* help is shown vs. the real action runs. `tests/smoke/tapes/screenshots/help.tape` captures `netclaw --help` (top-level `WriteGeneralHelp()`), which this PR never touches, so `help.approved.png` needs no update.

## Test coverage

- `DaemonConfigTests.GracefulShutdownBudget_exceeds_default_TurnLlmTimeout` — ties the shared constant to `SessionConfig.TurnLlmTimeout`'s default.
- `DaemonShutdownConfigurationTests` — the CoordinatedShutdown HOCON interpolates the budget correctly.
- `DaemonManagerGracefulShutdownTests` — `WaitForExitAsync` returns true immediately for an already-exited process, returns false once a `FakeTimeProvider` is advanced past the budget (no real sleep — proves the poll loop is now fully virtualized), and `BuildDaemonUnitContent` emits the expected `TimeoutStopSec=`.
- `MemoryCommandTests` — `backfill-embeddings --help`/`-h`/`help` prints help and does not touch the embeddings store (seeded doc stays unembedded, vs. the existing "real run" test that embeds it).
- `CliArgsParserTests` — `HasTrailingHelpToken` unit coverage.
- `DaemonCommandDispatchTests` — the extracted daemon lifecycle-verb guard.
- `WebhooksCommandTests` — `list --help`/`-h` prints help without listing; `set --help` still shows its own more-specific help (not shadowed).
- `ReminderCommandTests` (new file) — `list --help` prints help without requiring/reaching the daemon; plain `list` still requires it (regression guard); `create <full args> --help` also short-circuits.

All new/changed suites green: Netclaw.Cli.Tests (1282), Netclaw.Daemon.Tests (858), Netclaw.Configuration.Tests (468). Full solution build clean. `dotnet slopwatch analyze`: 0 issues. Header verify: pass.

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean
- [x] `dotnet test src/Netclaw.Cli.Tests` — 1282 passed
- [x] `dotnet test src/Netclaw.Daemon.Tests` — 858 passed
- [x] `dotnet test src/Netclaw.Configuration.Tests` — 468 passed
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — pass
- [ ] Live canary validation of `systemctl --user stop netclaw.service` reaching clean `inactive` — intentionally **not** done in this session (do not restart/stop the live daemon); recommend validating on next daemon deploy/restart window.