### PR TITLE
fix(subagents): fail closed for unattended approvals

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -148,6 +148,54 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         Assert.Empty(approvals);
     }
 
+    [Theory]
+    [InlineData(ChannelType.Headless)]
+    [InlineData(ChannelType.Reminder)]
+    [InlineData(ChannelType.Webhook)]
+    public async Task Non_interactive_turn_does_not_create_subagent_approval_bridge(ChannelType channelType)
+    {
+        var executor = new ContextCapturingExecutor();
+        var probe = CreateTestProbe($"non-interactive-{channelType}-context-probe");
+        var sessionId = new SessionId($"automation/{channelType}");
+        var source = new MessageSource
+        {
+            ChannelType = channelType,
+            SenderId = new SenderId("automation"),
+            Audience = TrustAudience.Personal,
+            Boundary = TrustBoundary.Personal,
+            Principal = PrincipalClassification.VerifiedAutomation,
+            Provenance = new SourceProvenance(TransportAuthenticity.LocalProcess, PayloadTaint.Trusted),
+            ReceivedAt = DateTimeOffset.UnixEpoch
+        };
+
+        var pipelineTask = SessionToolExecutionPipeline.ExecuteToolsAsync(
+            executor,
+            [new FunctionCallContent("call-1", "inspect_context")],
+            sessionId,
+            source,
+            auditLogger: null,
+            timeProvider: TimeProvider.System,
+            sessionDir: Path.GetTempPath(),
+            maxInlineToolResultChars: 4096,
+            timeout: TimeSpan.FromSeconds(1),
+            self: probe.Ref,
+            emitSubAgentOutput: _ => { },
+            spawnChildActor: static (_, _, _) => Task.FromResult<object>(new object()),
+            approvalChannel: new ApprovalChannel(),
+            emitApprovalRequest: _ => { },
+            approvalTimeout: Timeout.InfiniteTimeSpan,
+            ct: TestContext.Current.CancellationToken);
+
+        await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(executor.Context);
+        Assert.False(executor.Context.SupportsInteractiveApproval);
+        Assert.Null(executor.Context.ApprovalBridge);
+    }
+
     [Fact]
     public async Task Approve_once_does_not_reprompt_on_retry_execution()
     {
@@ -834,6 +882,26 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
             ct.ThrowIfCancellationRequested();
             return Task.FromResult("approved-and-ran");
+        }
+    }
+
+    private sealed class ContextCapturingExecutor : IToolExecutor
+    {
+        public ToolExecutionContext? Context { get; private set; }
+
+        public Task AuthorizeAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<string> ExecuteAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+        {
+            Context = context;
+            return Task.FromResult("ok");
         }
     }
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
@@ -8,6 +8,7 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.SubAgents;
 using Netclaw.Actors.Tests.Memory;
 using Netclaw.Actors.Tools;
@@ -88,6 +89,68 @@ public sealed class SubAgentSpawnerTests : TestKit
 
         var result = await spawnTask;
         Assert.True(result.Success);
+    }
+
+    [Theory]
+    [InlineData(ChannelType.Headless)]
+    [InlineData(ChannelType.Reminder)]
+    [InlineData(ChannelType.Webhook)]
+    public async Task Spawn_async_does_not_bridge_approval_for_non_interactive_parent(ChannelType channelType)
+    {
+        var childProbe = CreateTestProbe($"non-interactive-{channelType}-child");
+        var spawner = CreateSpawner();
+        var context = new ToolExecutionContext("automation/subagent-parent", "/tmp/netclaw/sessions/parent")
+        {
+            Audience = TrustAudience.Personal,
+            ChannelType = channelType.ToWireValue(),
+            SupportsInteractiveApproval = false,
+            ApprovalBridge = new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce),
+            SpawnChildActor = (_, _, _) => Task.FromResult<object>(childProbe.Ref)
+        };
+
+        var spawnTask = spawner.SpawnAsync(
+            CreateProfile(),
+            "Inspect the system.",
+            runtimeContext: null,
+            context,
+            TestContext.Current.CancellationToken);
+
+        var run = await childProbe.ExpectMsgAsync<RunSubAgent>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Null(run.ApprovalBridge);
+
+        childProbe.Reply(SuccessfulResult());
+        Assert.True((await spawnTask).Success);
+    }
+
+    [Fact]
+    public async Task Spawn_async_preserves_approval_bridge_for_interactive_parent()
+    {
+        var childProbe = CreateTestProbe("interactive-approval-child");
+        var approvalBridge = new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce);
+        var spawner = CreateSpawner();
+        var context = new ToolExecutionContext("interactive/subagent-parent", "/tmp/netclaw/sessions/parent")
+        {
+            Audience = TrustAudience.Personal,
+            ChannelType = ChannelType.Tui.ToWireValue(),
+            SupportsInteractiveApproval = true,
+            ApprovalBridge = approvalBridge,
+            SpawnChildActor = (_, _, _) => Task.FromResult<object>(childProbe.Ref)
+        };
+
+        var spawnTask = spawner.SpawnAsync(
+            CreateProfile(),
+            "Inspect the system.",
+            runtimeContext: null,
+            context,
+            TestContext.Current.CancellationToken);
+
+        var run = await childProbe.ExpectMsgAsync<RunSubAgent>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Same(approvalBridge, run.ApprovalBridge);
+
+        childProbe.Reply(SuccessfulResult());
+        Assert.True((await spawnTask).Success);
     }
 
     [Fact]
@@ -213,4 +276,41 @@ public sealed class SubAgentSpawnerTests : TestKit
         var call = Assert.Single(metrics.TokenUsageCalls);
         Assert.Equal((175L, 60L), call);
     }
+
+    private static SubAgentSpawner CreateSpawner()
+    {
+        var toolRegistry = new ToolRegistry();
+        toolRegistry.Register(new FakeNetclawTool("inspect_context", "ok"));
+
+        return new SubAgentSpawner(
+            new SingleClientProvider(new FakeChatClient()),
+            toolRegistry,
+            new ToolAccessPolicy(
+                new ToolConfig(),
+                new EffectivePolicyDefaults(
+                    DeploymentPosture.Personal,
+                    TrustAudience.Personal,
+                    ShellExecutionMode.HostAllowed,
+                    UsedStrictFallback: false),
+                new ShellCommandPolicy()),
+            approvalService: null,
+            new StaticSystemPromptProvider("You are an inspector."),
+            NullLogger<SubAgentSpawner>.Instance);
+    }
+
+    private static SubAgentProfile CreateProfile() => new()
+    {
+        Name = "inspector",
+        Description = "Inspect the system",
+        SystemPrompt = "You are an inspector.",
+        ToolNames = ["inspect_context"],
+        Visibility = SubAgentVisibility.UserFacing
+    };
+
+    private static SubAgentResult SuccessfulResult() => new()
+    {
+        Success = true,
+        Output = "ok",
+        AgentName = new AgentName("inspector")
+    };
 }

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -270,7 +270,9 @@ internal static class SessionToolExecutionPipeline
             context.OneTimeApprovedToolName = tc.Name;
             context.SetOneTimeApprovedPatterns(oneTimeApprovalPreSeed);
         }
-        if (approvalChannel is not null && emitApprovalRequest is not null)
+        if (approvalChannel is not null
+            && emitApprovalRequest is not null
+            && CanRequestInteractiveApproval(source, turnContext))
         {
             context.ApprovalBridge = new ParentSessionApprovalBridge(
                 approvalChannel,

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -201,7 +201,12 @@ public sealed class SubAgentSpawner
                     ParentProjectDirectory = context.ProjectDirectory,
                     ParentCwd = context.ResolveShellCwd(null),
                     Cancellation = ct,
-                    ApprovalBridge = context.ApprovalBridge,
+                    // A session owns an approval channel even when its transport cannot
+                    // service prompts. Preserve the channel capability as the authority:
+                    // bridge presence alone must never make an unattended child interactive.
+                    ApprovalBridge = context.SupportsInteractiveApproval == true
+                        ? context.ApprovalBridge
+                        : null,
                     // Null for non-streaming callers such as routed skills and the
                     // legacy ExecuteAsync path; the sub-agent surfaces its progress
                     // through its own session-correlated logs regardless. Streaming


### PR DESCRIPTION
Closes #1615

## Summary

- create parent approval bridges only for channels with an interactive requester
- defensively strip approval bridges before spawning children from non-interactive contexts
- preserve indefinite approval waits for genuinely interactive channels
- cover headless, reminder, webhook, and interactive control paths

## Validation

- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --no-restore` — 2,564 passed
- `dotnet slopwatch analyze` — 0 issues
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — passed
- `git diff --check` — passed