### PR TITLE
ci: run required checks for merge queue groups

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -1,6 +1,11 @@
 name: pr_validation
 
 on:
+  # Merge queues test a synthetic merge group rather than the pull request ref.
+  # Required checks must subscribe to this event or queued PRs will never merge.
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - master

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,11 @@ name: smoke
 # surface via GitHub's built-in Actions notifications.
 
 on:
+  # Merge queues test a synthetic merge group rather than the pull request ref.
+  # Required checks must subscribe to this event or queued PRs will never merge.
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
   schedule:
     # 07:00 UTC daily — catches external-dependency drift during quiet


### PR DESCRIPTION
## Summary

- subscribe the required PR validation workflow to `merge_group` check requests
- subscribe the required native smoke workflow to `merge_group` check requests
- preserve the existing PR, push, schedule, and manual triggers

## Why

GitHub merge queues validate synthetic merge-group refs. Without these triggers, the checks required by the `dev` ruleset would never start for queued pull requests, leaving queue entries blocked.

## Validation

- parsed both changed workflow files as YAML
- ran `git diff --check`
- reviewed workflow expressions for pull-request-only fields; smoke concurrency already falls back to `github.ref` for merge groups

## Rollout

Merge this PR before enabling **Require merge queue** in the `dev` ruleset. After it lands, configure the queue and test it with two harmless pull requests.
