### PR TITLE
test: skip SearXNG container test on Windows

### DIFF
--- a/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
@@ -27,6 +27,12 @@ public class SearXngBackendIntegrationTests : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("SearXNG container integration tests are not supported on Windows.");
+            return;
+        }
+
         var settingsYml = LoadFixture("searxng-settings.yml");
         IContainer? container = null;
 


### PR DESCRIPTION
## Summary
- skip the SearXNG container integration test on Windows before Testcontainers initialization
- retain existing Docker availability handling on supported platforms

## Context
The Windows validation job for commit `98994920` failed while `ContainerBuilder(string)` parsed the SearXNG image reference. That happens before `StartAsync()` can report Docker as unavailable, so the existing exception-based skip never runs.

## Validation
- `dotnet test src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj -c Release --filter FullyQualifiedName~SearXngBackendIntegrationTests`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`