### PR TITLE
chore: bump Netclaw.SkillClient to 0.4.0 stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="SlackNet" Version="$(SlackNetVersion)" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
-    <PackageVersion Include="Netclaw.SkillClient" Version="0.4.0-beta.4" />
+    <PackageVersion Include="Netclaw.SkillClient" Version="0.4.0" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
     <PackageVersion Include="Termina" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
Supersedes #1627 — bumps ``Netclaw.SkillClient`` from 0.4.0-beta.4 to **0.4.0** (stable release).

Closes #1627