### PR TITLE
Fix xUnit discovery race in demo smoke tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,6 +82,7 @@
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-off" Version="4.0.0-pre.128" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="CsCheck" Version="4.7.0" />

--- a/samples/Netclaw.Demo.AppHost.IntegrationTests/Netclaw.Demo.AppHost.IntegrationTests.csproj
+++ b/samples/Netclaw.Demo.AppHost.IntegrationTests/Netclaw.Demo.AppHost.IntegrationTests.csproj
@@ -11,7 +11,11 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <!-- xUnit 3.2.2 can append its foreground-thread diagnostic to the assembly-info
+         JSON consumed by the VS adapter, making discovery fail nondeterministically.
+         The protocol fix shipped in 4.0.0-pre.116; pre.128 is the first fixed build
+         published to NuGet. Keep prerelease consumption local until xUnit 4 is stable. -->
+    <PackageReference Include="xunit.v3.mtp-off" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <!-- Promote the transitive MessagePack (via Aspire/StreamJsonRpc) to the patched
          2.5.301 to clear NuGetAudit GHSA-hv8m-jj95-wg3x. See Directory.Packages.props. -->


### PR DESCRIPTION
## Summary

- replace xunit.v3 3.2.2 with the fixed xunit.v3.mtp-off 4.0.0-pre.128 only in the Demo AppHost integration-test project
- preserve the existing VSTest execution path and avoid a repository-wide MTP migration
- document the upstream assembly-info JSON corruption race fixed after 4.0.0-pre.116

## Root cause

The Windows CI failure matches xunit/xunit#3576 exactly: xUnit 3.2.2 can append `Waiting 10 seconds for foreground threads to exit...` to the assembly-info JSON consumed by the Visual Studio adapter, causing nondeterministic discovery failures. This is a runner protocol race, not a test timeout.

## Validation

- 100/100 direct `-assemblyInfo` invocations emitted exactly one valid JSON object
- affected test project restored, built, and discovered successfully
- opt-in smoke test executed and skipped correctly without `NETCLAW_RUN_DEMO_SMOKE=1`
- `dotnet slopwatch analyze` passed with 0 issues
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` passed
- `git diff --check` passed

No timeout values, sleeps, or retries were added.