### PR TITLE
Release 0.25.0-beta.4: update release notes and version metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,13 +9,13 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.25.0</VersionPrefix>
-    <VersionSuffix>beta.3</VersionSuffix>
-    <PackageReleaseNotes>- Discord DM reminder delivery — Reminders can now be delivered to Discord DMs via improved DiscordReminderTargetResolver (#1609)
-- Named model configuration &amp; provider runtime validation — New NamedModelConfiguration and ProviderRuntimeValidation types, config schema updates, and CLI wizard improvements for provider/model setup (#1610)
-- Model set/picker preserves hand-set modalities — Re-selecting the same model no longer wipes operator-set InputModalities/OutputModalities and ContextWindow. Added --input-modalities, --output-modalities, --clear-modalities, and --clear-context-window CLI flags (#1610)
-- Slack processing status serialization — Slack processing status updates are now serialized to prevent race conditions during concurrent sends (#1556)
-- Sub-agent token usage tracked in daily stats — Sub-agent LLM calls now record token usage, making them visible in netclaw stats (#1597)
-- Subagents fail closed for unattended approvals — When a subagent requires approval but the session is unattended, it now fails closed instead of proceeding or hanging (#1616)</PackageReleaseNotes>
+    <VersionSuffix>beta.4</VersionSuffix>
+    <PackageReleaseNotes>- Preserve Git working context across sessions and subagents — A bounded, audience-aware Git working-context snapshot stays current in the system prompt, and coding subagents inherit recent-file/project context (#1630)
+- User-written AGENTS.md for application-specific agent guidance — Operators can author ~/.netclaw/identity/AGENTS.md, layered after Netclaw's embedded operating core and inherited by sub-agents (#1622)
+- Memory curation no longer overwrites existing documents on collision — Create-decision collisions now append new content instead of silently overwriting the existing document (#1637)
+- STDIO MCP server arguments no longer rewritten — The daemon now preserves configured STDIO MCP server arguments, and uses one daemon-owned client per configured MCP server (#1636)
+- Logical skill access and authoritative inventory refresh — Skill loading now resolves through logical skill_load/skill_read_resource access with native &gt; managed-feed &gt; external precedence (#1634)
+- Bump SkillServer to stable — Netclaw.SkillClient 0.4.0-beta.4 → 0.4.0 (#1638)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # NetClaw Release Notes
 
+## 0.25.0-beta.4 (2026-07-14)
+
+### Features
+- **Preserve Git working context across sessions and subagents** — A bounded, audience-aware Git working-context snapshot (branch, worktree, repository, upstream, changed files) now stays current in the system prompt, and coding subagents inherit recent-file/project context so parent sessions merge back only confirmed successful child edits. Measured 20% → 100% success rate on a linked-worktree coding eval ([#1630](https://github.com/netclaw-dev/netclaw/pull/1630))
+- **User-written `AGENTS.md` for application-specific agent guidance** — Operators can now author `~/.netclaw/identity/AGENTS.md`, layered after Netclaw's embedded operating core and inherited by sub-agents, to give the running agent deployment-specific mission and workflow guidance. Seeded with a minimal scaffold during init without overwriting existing guidance ([#1622](https://github.com/netclaw-dev/netclaw/pull/1622))
+
+### Bug Fixes
+- **Memory curation no longer overwrites existing documents on collision** — Fixed: when a curation Create decision targeted an anchor that already had a document, the write silently overwrote the existing title, body, and classification with no history — observed 88 times in 14 days in production, including one case that destroyed an LLM-merged document. Collisions now append the new content under a dated separator instead of overwriting; a verbatim duplicate is skipped as a no-op ([#1637](https://github.com/netclaw-dev/netclaw/pull/1637))
+- **STDIO MCP server arguments no longer rewritten** — Fixed: configured STDIO MCP server arguments were being rewritten by the daemon; the daemon now preserves them as configured. Also simplified to one daemon-owned client per configured MCP server, removing Playwright-specific session-scoped process handling ([#1636](https://github.com/netclaw-dev/netclaw/pull/1636))
+
+### Improvements
+- **Logical skill access and authoritative inventory refresh** — Skill loading now resolves through logical `skill_load`/`skill_read_resource` access instead of physical skill-root paths, with native > managed-feed > external precedence. Startup, sync, watcher, and `skill_manage` inventory rebuilds are now centralized through one live-source refresher publishing atomic registry snapshots ([#1634](https://github.com/netclaw-dev/netclaw/pull/1634))
+
+### Dependency Updates
+- **Bump SkillServer to stable** — `Netclaw.SkillClient` 0.4.0-beta.4 → 0.4.0 (stable release) ([#1638](https://github.com/netclaw-dev/netclaw/pull/1638))
+
 ## 0.25.0-beta.3 (2026-07-12)
 
 ### Features


### PR DESCRIPTION
## Summary
- Add `## 0.25.0-beta.4 (2026-07-14)` section to `RELEASE_NOTES.md` covering #1630, #1622, #1637, #1636, #1634, #1638 since the last release (#1637 was the last commit on `dev`, following 0.25.0-beta.3 in #1618).
- Bump `Directory.Build.props`: `VersionSuffix` `beta.3` → `beta.4`, and sync `PackageReleaseNotes` to match.

## Test plan
- [x] `dotnet build Netclaw.slnx -c Release` — succeeds
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [x] No runtime code changes — release-notes/version-metadata only