### PR TITLE
refactor(tools): fork typed subagent execution context

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -127,7 +127,7 @@ Done when:
 
 - [x] Stage 1 lands required run scopes, per-call isolation, and non-null
   security/authority dependencies without compatibility shims.
-- [ ] Stage 2 lands the composed pipeline without changing existing background,
+- [x] Stage 2 lands the composed pipeline without changing existing background,
   fallback, authorization, approval, MCP, or model-visible behavior.
 - [ ] Stage 3 lands child fork/delta semantics and Git inspection only for
   non-Public runs with a declared Git project.

--- a/docs/spec/SPEC-002-session-lifecycle-and-protocol.md
+++ b/docs/spec/SPEC-002-session-lifecycle-and-protocol.md
@@ -56,6 +56,24 @@ retains synchronous execution behavior. This internal composition does not
 change MCP schemas, persisted actor messages, approval outcomes, or model-facing
 tool results.
 
+### Working Context and Child Runs
+
+For Team and Personal turns with a declared project directory, the session
+captures Git working context asynchronously before invoking the model. Git
+inspection has one aggregate deadline and produces an explicit available,
+not-repository, or unavailable result. Public turns and turns without a project
+directory do not launch Git. Continuations carry a generation number so a late
+inspection from a cancelled or superseded call cannot mutate the active turn.
+
+Each admitted subagent receives a `ChildRunScope`: a fork of immutable tool
+authority plus the parent's working-context snapshot. The child owns fresh
+activity tracking and mutable tool-call state; neither is shared with the
+parent or sibling runs. Terminal results use typed completion variants.
+Completed and partial runs carry a `WorkingContextDelta`; failed and cancelled
+runs cannot carry one. The parent merges only files the child confirms it
+changed through first-party tools. Git-observed dirty files remain diagnostic
+context and are never attributed to the child.
+
 ## Subscriber Model
 
 Subscribers join via `JoinSession` with an `OutputFilter` bitmask controlling

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.27.0"
+  version: "2.28.0"
 ---
 
 # Netclaw Operations
@@ -47,8 +47,11 @@ For Team and Personal sessions, `[working-context]` is refreshed at the start
 of each new turn. In a Git project it includes the active worktree, branch,
 HEAD, upstream divergence, and dirty counts. Treat this as turn-start
 grounding: a checkout or commit performed during the current tool loop appears
-in the next turn's snapshot. Subagents receive a read-only project/recent-file
-snapshot and return confirmed file edits to the parent when they complete.
+in the next turn's snapshot. If Git is unavailable, the turn continues with an
+explicit unavailable status rather than invented repository state. Subagents
+receive a read-only project/recent-file snapshot. Successful and partial runs
+return only file edits confirmed through their own tools; failed or cancelled
+runs contribute no parent working-context changes.
 
 ## Scheduling & Background Jobs
 

--- a/feeds/skills/.system/files/netclaw-projects/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-projects/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-projects
 description: "How to create, find, and work with project workspaces. Load when the user references a project, asks to organize work, or you need a sustained workspace."
 metadata:
   author: netclaw
-  version: "1.1.0"
+  version: "1.2.0"
 license: MIT
 compatibility: "netclaw >= 0.10.0"
 disable-model-invocation: false
@@ -64,6 +64,12 @@ re-read it manually.
 
 Use the project directory as your working directory for all project-related
 file operations. Commit meaningful changes so the project has history.
+
+Team and Personal sessions refresh Git working context at the beginning of a
+turn. That snapshot is grounding, not a live view: changes made during the turn
+appear in the next turn. A spawned subagent receives its own read-only snapshot
+and reports only changes confirmed through its tools. Do not infer that every
+dirty file in the shared worktree was changed by that subagent.
 
 ## When NOT to Create a Project
 

--- a/openspec/changes/simplify-tool-execution-context/tasks.md
+++ b/openspec/changes/simplify-tool-execution-context/tasks.md
@@ -26,7 +26,7 @@
 - [ ] 3.5 Correlate session-actor Git continuations with turn generations and discard stale results; await bounded spawn/completion snapshots at subagent async boundaries.
 - [ ] 3.6 Add deterministic tests for Public no-inspection, missing/non-Git project handling, sanitized failures, stale continuation rejection, child isolation, successful confirmed merge, and failed/cancelled no-merge without sleeps.
 - [ ] 3.7 Update engineering docs and the versioned `netclaw-operations` and `netclaw-projects` system skills for working-context and subagent behavior.
-- [ ] 3.8 Run targeted tests, prompt/tool eval suites, `dotnet test`, Slopwatch, file-header verification, and `git diff --check`; open and babysit Stage 3 through review, CI, merge, and post-merge `dev` verification.
+- [ ] 3.8 Run targeted tests, prompt/tool eval suites, `dotnet test`, Slopwatch, file-header verification, and `git diff --check`; open and babysit Stage 3 through review, CI, merge, and post-merge `dev` verification, then close GitHub issue #1633 with the acceptance evidence.
 
 ## 4. Closeout
 

--- a/openspec/changes/simplify-tool-execution-context/tasks.md
+++ b/openspec/changes/simplify-tool-execution-context/tasks.md
@@ -15,7 +15,7 @@
 - [x] 2.3 Preserve existing `_background` behavior for shell, non-shell, missing-manager, and dispatch-failure paths while removing redundant parameter plumbing.
 - [x] 2.4 Add characterization tests for audit/logging/approval/background infrastructure, malformed metadata, ACL and approval denial, supported background routing, missing-manager fallback, dispatch failure, and non-shell fallback.
 - [x] 2.5 Verify MCP request/response schemas and persisted actor contracts remain compatible; update affected engineering docs and specs, and review the versioned `netclaw-operations` system skill without changing model-visible guidance for an internal behavior-preserving refactor.
-- [ ] 2.6 Run targeted tests, the tool-definition eval suite, `dotnet test`, Slopwatch, file-header verification, and `git diff --check`; open and babysit Stage 2 through review, CI, merge, and post-merge `dev` verification.
+- [x] 2.6 Run targeted tests, the tool-definition eval suite, `dotnet test`, Slopwatch, file-header verification, and `git diff --check`; open and babysit Stage 2 through review, CI, merge, and post-merge `dev` verification.
 
 ## 3. Stage 3 — Child Context and Async Git
 
@@ -33,3 +33,4 @@
 - [ ] 4.1 Verify all three merged stages against the OpenSpec scenarios and PRD traceability from current `dev`, including serialization/recovery and MCP compatibility evidence.
 - [ ] 4.2 Sync the delta specs to main specs with `/opsx-sync`, run `/opsx-verify`, and archive the completed change with `/opsx-archive`.
 - [ ] 4.3 Run the RALPH adversarial output review, diagnostics, and after-action workflow; capture durable follow-ups without leaving undocumented behavior drift.
+- [ ] 4.4 Decide whether `IToolAuditLogger` should adapt structured tool events into the canonical `SessionLogActor` transcript or be removed; Stage 2 deliberately retained the existing disabled production diagnostics and null audit sink to avoid behavior drift.

--- a/openspec/changes/simplify-tool-execution-context/tasks.md
+++ b/openspec/changes/simplify-tool-execution-context/tasks.md
@@ -19,13 +19,13 @@
 
 ## 3. Stage 3 — Child Context and Async Git
 
-- [ ] 3.1 Introduce a framework-owned child-run scope that forks immutable parent authority and a read-only working-context snapshot while allocating independent child activity state.
-- [ ] 3.2 Introduce typed child outcomes and working-context deltas; merge only confirmed changed files from successful children and keep Git-observed changes non-attributed.
-- [ ] 3.3 Split Git process execution, snapshot composition, and rendering; make inspection asynchronous with explicit available, not-repository, and unavailable outcomes.
-- [ ] 3.4 Gate Git inspection before process launch so it occurs only for Team/Personal runs with a declared project directory that Git recognizes as a worktree.
-- [ ] 3.5 Correlate session-actor Git continuations with turn generations and discard stale results; await bounded spawn/completion snapshots at subagent async boundaries.
-- [ ] 3.6 Add deterministic tests for Public no-inspection, missing/non-Git project handling, sanitized failures, stale continuation rejection, child isolation, successful confirmed merge, and failed/cancelled no-merge without sleeps.
-- [ ] 3.7 Update engineering docs and the versioned `netclaw-operations` and `netclaw-projects` system skills for working-context and subagent behavior.
+- [x] 3.1 Introduce a framework-owned child-run scope that forks immutable parent authority and a read-only working-context snapshot while allocating independent child activity state.
+- [x] 3.2 Introduce typed child outcomes and working-context deltas; merge only confirmed changed files from successful children and keep Git-observed changes non-attributed.
+- [x] 3.3 Split Git process execution, snapshot composition, and rendering; make inspection asynchronous with explicit available, not-repository, and unavailable outcomes.
+- [x] 3.4 Gate Git inspection before process launch so it occurs only for Team/Personal runs with a declared project directory that Git recognizes as a worktree.
+- [x] 3.5 Correlate session-actor Git continuations with turn generations and discard stale results; await bounded spawn/completion snapshots at subagent async boundaries.
+- [x] 3.6 Add deterministic tests for Public no-inspection, missing/non-Git project handling, sanitized failures, stale continuation rejection, child isolation, successful confirmed merge, and failed/cancelled no-merge without sleeps.
+- [x] 3.7 Update engineering docs and the versioned `netclaw-operations` and `netclaw-projects` system skills for working-context and subagent behavior.
 - [ ] 3.8 Run targeted tests, prompt/tool eval suites, `dotnet test`, Slopwatch, file-header verification, and `git diff --check`; open and babysit Stage 3 through review, CI, merge, and post-merge `dev` verification, then close GitHub issue #1633 with the acceptance evidence.
 
 ## 4. Closeout

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -35,6 +35,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
     private readonly FakeToolExecutor _fakeToolExecutor = new();
     private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.Parse("2026-03-21T12:00:00Z"));
     private readonly RecordingSessionLifecycleObserver _lifecycleObserver = new();
+    private readonly ControllableWorkingContextSnapshotProvider _workingContextSnapshots = new();
 
     protected override bool VerifySerialization => true;
 
@@ -82,6 +83,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
         services.AddSingleton<TimeProvider>(_timeProvider);
         services.AddSingleton<ISessionLifecycleObserver>(_lifecycleObserver);
+        services.AddSingleton<IWorkingContextSnapshotProvider>(_workingContextSnapshots);
         services.AddSingleton<ISessionPipeline>(new UnusedSessionPipeline());
     }
 
@@ -1271,6 +1273,87 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
     }
 
     [Fact]
+    public async Task Working_context_provider_failure_is_nonfatal_and_starts_the_llm_call()
+    {
+        _workingContextSnapshots.Failure = new IOException("credential-bearing provider failure");
+        var sessionId = new SessionId("console/working-context-failure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("working-context-failure-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Continue despite context inspection failure"
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        var prompt = string.Join('\n', _fakeChatClient.ReceivedMessages.Single().Select(message => message.Text));
+        Assert.Contains("status: unavailable", prompt);
+        Assert.Contains("working context inspection failed", prompt);
+        Assert.DoesNotContain("credential-bearing", prompt);
+    }
+
+    [Fact]
+    public async Task Cancelled_turn_discards_stale_working_context_continuation()
+    {
+        _workingContextSnapshots.Pending = new TaskCompletionSource<WorkingContextSnapshot>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionId = new SessionId("test-channel/stale-working-context");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("stale-working-context-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Start a turn whose context inspection is delayed"
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await _workingContextSnapshots.InvocationStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}")
+            .ResolveOne(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        child.Tell(new ToolExecutionFailed { Cause = new IOException("cancel the pending turn") });
+
+        await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        child.Tell(new WorkingContextSnapshotReady(
+            Generation: 1,
+            ForceNoTools: false,
+            TurnRestartNotice: null,
+            Snapshot: new WorkingContextSnapshot
+            {
+                WorkingContext = WorkingContext.Empty.WithProjectDirectory("/stale/project"),
+                Git = new GitWorkingContextInspection.NotRepository()
+            }), TestActor);
+        child.Tell(new JoinSession(TestActor)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.None
+        }, TestActor);
+        await ExpectMsgAsync<SessionJoined>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Empty(_fakeChatClient.ReceivedMessages);
+        _workingContextSnapshots.Pending.TrySetCanceled(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task Subscriber_survives_session_actor_passivation_via_piggyback_rejoin()
     {
         var sessionId = new SessionId("test-channel/passivation-rejoin");
@@ -2003,6 +2086,31 @@ internal sealed class FakeRecallCoordinator : IMemoryRecallCoordinator
 
     public Task<AutomaticRecallResult> RecallAsync(AutomaticRecallRequest request, CancellationToken ct = default)
         => Task.FromResult(Result);
+}
+
+internal sealed class ControllableWorkingContextSnapshotProvider : IWorkingContextSnapshotProvider
+{
+    public Exception? Failure { get; set; }
+    public TaskCompletionSource<WorkingContextSnapshot>? Pending { get; set; }
+    public TaskCompletionSource InvocationStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task<WorkingContextSnapshot> CreateAsync(
+        WorkingContext context,
+        TrustAudience audience,
+        CancellationToken cancellationToken)
+    {
+        InvocationStarted.TrySetResult();
+        if (Failure is { } failure)
+            return Task.FromException<WorkingContextSnapshot>(failure);
+        if (Pending is { } pending)
+            return pending.Task;
+
+        return Task.FromResult(new WorkingContextSnapshot
+        {
+            WorkingContext = context,
+            Git = new GitWorkingContextInspection.Skipped()
+        });
+    }
 }
 
 internal sealed class RecordingSessionLifecycleObserver : ISessionLifecycleObserver

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestExtensions.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestExtensions.cs
@@ -21,6 +21,7 @@ internal static class LlmSessionTestExtensions
 {
     public static IServiceCollection AddLlmSessionCompositeRecords(this IServiceCollection services)
     {
+        services.TryAddSingleton<IGitWorkingContextInspector, GitWorkingContextInspector>();
         services.TryAddSingleton<IWorkingContextSnapshotProvider, WorkingContextSnapshotProvider>();
         services.TryAddSingleton(sp => new SessionServices(
             sp.GetRequiredService<IChatClientProvider>(),

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestExtensions.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestExtensions.cs
@@ -21,6 +21,7 @@ internal static class LlmSessionTestExtensions
 {
     public static IServiceCollection AddLlmSessionCompositeRecords(this IServiceCollection services)
     {
+        services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<IGitWorkingContextInspector, GitWorkingContextInspector>();
         services.TryAddSingleton<IWorkingContextSnapshotProvider, WorkingContextSnapshotProvider>();
         services.TryAddSingleton(sp => new SessionServices(
@@ -28,7 +29,7 @@ internal static class LlmSessionTestExtensions
             sp.GetRequiredService<ISystemPromptProvider>(),
             sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
             sp.GetRequiredService<IWorkingContextSnapshotProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
+            sp.GetRequiredService<TimeProvider>(),
             sp.GetRequiredService<NetclawPaths>()));
 
         services.TryAddSingleton(sp => new SessionMemoryServices(

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -642,7 +642,8 @@ public class SessionStateTests
         };
 
         var merged = LlmSessionActor.MergeSuccessfulSubAgentWorkingContext(
-            WorkingContext.Empty, true, child);
+            WorkingContext.Empty,
+            new ChildRunCompletion.Completed(child));
 
         Assert.Equal(["src/Changed.cs"], merged.RecentFiles);
     }
@@ -656,7 +657,21 @@ public class SessionStateTests
             ConfirmedChangedFiles = ["src/Denied.cs"]
         };
 
-        var merged = LlmSessionActor.MergeSuccessfulSubAgentWorkingContext(current, false, child);
+        var merged = LlmSessionActor.MergeSuccessfulSubAgentWorkingContext(
+            current,
+            new ChildRunCompletion.Failed(SubAgentOutcomeReason.ToolExecutionFailed));
+
+        Assert.Same(current, merged);
+    }
+
+    [Fact]
+    public void Cancelled_subagent_cannot_supply_parent_working_context_changes()
+    {
+        var current = WorkingContext.Empty.AddRecentFile("src/Existing.cs");
+
+        var merged = LlmSessionActor.MergeSuccessfulSubAgentWorkingContext(
+            current,
+            new ChildRunCompletion.Cancelled(SubAgentOutcomeReason.CancelledByParent));
 
         Assert.Same(current, merged);
     }

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -634,7 +634,7 @@ public class SessionStateTests
     [Fact]
     public void Successful_subagent_merge_adds_only_confirmed_changed_files()
     {
-        var child = new SubAgentWorkingContextInfo
+        var child = new WorkingContextDelta
         {
             ReadFiles = ["src/ReadOnly.cs"],
             ConfirmedChangedFiles = ["src/Changed.cs"],
@@ -651,7 +651,7 @@ public class SessionStateTests
     public void Failed_subagent_merge_does_not_change_parent_working_context()
     {
         var current = WorkingContext.Empty.AddRecentFile("src/Existing.cs");
-        var child = new SubAgentWorkingContextInfo
+        var child = new WorkingContextDelta
         {
             ConfirmedChangedFiles = ["src/Denied.cs"]
         };

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -178,7 +178,9 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             toolAccessPolicy,
             approvalService: null,
             promptProvider,
-            new WorkingContextSnapshotProvider(Microsoft.Extensions.Logging.Abstractions.NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<WorkingContextSnapshotProvider>.Instance),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<SubAgentSpawner>.Instance);
 
         registry.Register(new SpawnAgentTool(subAgentRegistry, spawner, subAgentPaths));

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextSnapshotTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextSnapshotTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 
@@ -14,7 +15,7 @@ public class WorkingContextSnapshotTests
     [Fact]
     public void ParseStatus_reads_branch_divergence_and_dirty_counts()
     {
-        var snapshot = WorkingContextSnapshotProvider.ParseStatus(
+        var snapshot = GitWorkingContextInspector.ParseStatus(
             "/worktrees/feature",
             "/repos/app/.git",
             """
@@ -41,7 +42,7 @@ public class WorkingContextSnapshotTests
     [Fact]
     public void ParseStatus_uses_rename_destination_as_changed_file()
     {
-        var snapshot = WorkingContextSnapshotProvider.ParseStatus(
+        var snapshot = GitWorkingContextInspector.ParseStatus(
             "/worktrees/feature",
             "/repos/app/.git",
             "2 R. N... 100644 100644 100644 aaaaaaa bbbbbbb R100 src/New Name.cs\tsrc/Old Name.cs");
@@ -57,7 +58,7 @@ public class WorkingContextSnapshotTests
             WorkingContext = WorkingContext.Empty
                 .WithProjectDirectory("/worktrees/feature")
                 .AddRecentFile("src/App.cs"),
-            Git = new GitWorkingContextSnapshot
+            Git = new GitWorkingContextInspection.Available(new GitWorkingContextSnapshot
             {
                 Worktree = "/worktrees/feature",
                 CommonDirectory = "/repos/app/.git",
@@ -67,7 +68,7 @@ public class WorkingContextSnapshotTests
                 Staged = 1,
                 Modified = 2,
                 Untracked = 3
-            }
+            })
         };
 
         var block = snapshot.ToContextBlock();
@@ -80,29 +81,188 @@ public class WorkingContextSnapshotTests
     }
 
     [Fact]
-    public void Public_audience_does_not_inspect_or_render_git()
+    public async Task Public_audience_does_not_inspect_or_render_git()
     {
+        var inspector = new RecordingGitInspector();
         var provider = new WorkingContextSnapshotProvider(
+            inspector,
             NullLogger<WorkingContextSnapshotProvider>.Instance);
         var context = WorkingContext.Empty.WithProjectDirectory("/path/that/does/not/exist");
 
-        var snapshot = provider.Create(context, TrustAudience.Public);
+        var snapshot = await provider.CreateAsync(
+            context,
+            TrustAudience.Public,
+            TestContext.Current.CancellationToken);
 
-        Assert.Null(snapshot.Git);
-        Assert.Null(snapshot.GitUnavailableReason);
+        Assert.IsType<GitWorkingContextInspection.Skipped>(snapshot.Git);
+        Assert.Equal(0, inspector.InvocationCount);
         Assert.Equal(string.Empty, snapshot.ToContextBlock());
     }
 
     [Fact]
-    public void Missing_project_directory_reports_unavailable_for_personal_audience()
+    public async Task Missing_project_directory_reports_unavailable_for_personal_audience()
     {
+        var inspector = new RecordingGitInspector();
         var provider = new WorkingContextSnapshotProvider(
+            inspector,
             NullLogger<WorkingContextSnapshotProvider>.Instance);
         var context = WorkingContext.Empty.WithProjectDirectory("/path/that/does/not/exist");
 
-        var snapshot = provider.Create(context, TrustAudience.Personal);
+        var snapshot = await provider.CreateAsync(
+            context,
+            TrustAudience.Personal,
+            TestContext.Current.CancellationToken);
 
-        Assert.Equal("project directory does not exist", snapshot.GitUnavailableReason);
+        var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(snapshot.Git);
+        Assert.Equal("project directory does not exist", unavailable.Reason);
+        Assert.Equal(0, inspector.InvocationCount);
         Assert.Contains("status: unavailable", snapshot.ToContextBlock());
+    }
+
+    [Fact]
+    public async Task Git_inspection_shares_one_deadline_across_root_and_status_commands()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.Parse("2026-07-14T12:00:00Z"));
+        var runner = new SequenceGitCommandRunner(time,
+        [
+            new TimedGitResult(TimeSpan.FromMilliseconds(1_500), GitCommandResult.Succeeded(
+                "/repo\n/repo/.git\n",
+                string.Empty)),
+            new TimedGitResult(TimeSpan.Zero, GitCommandResult.Succeeded(
+                "# branch.oid 01234567\n# branch.head dev\n",
+                string.Empty))
+        ]);
+        var inspector = new GitWorkingContextInspector(runner, time);
+
+        var result = await inspector.InspectAsync(
+            "/repo",
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<GitWorkingContextInspection.Available>(result);
+        Assert.Equal(2, runner.Timeouts.Count);
+        Assert.Equal(TimeSpan.FromSeconds(2), runner.Timeouts[0]);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), runner.Timeouts[1]);
+    }
+
+    [Fact]
+    public async Task Git_inspection_does_not_launch_status_after_aggregate_deadline_expires()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.Parse("2026-07-14T12:00:00Z"));
+        var runner = new SequenceGitCommandRunner(time,
+        [
+            new TimedGitResult(TimeSpan.FromSeconds(2), GitCommandResult.Succeeded(
+                "/repo\n/repo/.git\n",
+                string.Empty))
+        ]);
+        var inspector = new GitWorkingContextInspector(runner, time);
+
+        var result = await inspector.InspectAsync(
+            "/repo",
+            TestContext.Current.CancellationToken);
+
+        var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(result);
+        Assert.Equal("git inspection timed out", unavailable.Reason);
+        Assert.Single(runner.Timeouts);
+    }
+
+    [Fact]
+    public async Task Git_inspection_classifies_non_repository_without_status_command()
+    {
+        var time = new FakeTimeProvider();
+        var runner = new SequenceGitCommandRunner(time,
+        [
+            new TimedGitResult(TimeSpan.Zero, GitCommandResult.Failed(
+                "fatal: not a git repository",
+                stderr: "fatal: not a git repository"))
+        ]);
+        var inspector = new GitWorkingContextInspector(runner, time);
+
+        var result = await inspector.InspectAsync(
+            "/repo",
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<GitWorkingContextInspection.NotRepository>(result);
+        Assert.Single(runner.Timeouts);
+    }
+
+    [Fact]
+    public void Git_command_output_is_bounded()
+    {
+        var oversized = new string('x', 300_000);
+
+        var bounded = GitCommandRunner.Bound(oversized);
+
+        Assert.Equal(256 * 1024, bounded.Length);
+    }
+
+    [Fact]
+    public async Task Unavailable_reason_is_single_line_and_bounded_before_rendering()
+    {
+        var reason = new string('x', 300) + "\ncredential-bearing second line";
+        var provider = new WorkingContextSnapshotProvider(
+            new FixedGitInspector(new GitWorkingContextInspection.Unavailable(reason)),
+            NullLogger<WorkingContextSnapshotProvider>.Instance);
+        var context = WorkingContext.Empty.WithProjectDirectory(Path.GetTempPath());
+
+        var snapshot = await provider.CreateAsync(
+            context,
+            TrustAudience.Team,
+            TestContext.Current.CancellationToken);
+
+        var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(snapshot.Git);
+        Assert.Equal(200, unavailable.Reason.Length);
+        Assert.DoesNotContain("credential-bearing", unavailable.Reason);
+    }
+
+    private sealed class RecordingGitInspector : IGitWorkingContextInspector
+    {
+        public int InvocationCount { get; private set; }
+
+        public Task<GitWorkingContextInspection> InspectAsync(
+            string projectDirectory,
+            CancellationToken cancellationToken)
+        {
+            InvocationCount++;
+            return Task.FromResult<GitWorkingContextInspection>(
+                new GitWorkingContextInspection.NotRepository());
+        }
+    }
+
+    private sealed class FixedGitInspector(GitWorkingContextInspection result)
+        : IGitWorkingContextInspector
+    {
+        public Task<GitWorkingContextInspection> InspectAsync(
+            string projectDirectory,
+            CancellationToken cancellationToken) => Task.FromResult(result);
+    }
+
+    private sealed record TimedGitResult(TimeSpan Elapsed, GitCommandResult Result);
+
+    private sealed class SequenceGitCommandRunner : IGitCommandRunner
+    {
+        private readonly FakeTimeProvider _timeProvider;
+        private readonly Queue<TimedGitResult> _results;
+
+        public SequenceGitCommandRunner(
+            FakeTimeProvider timeProvider,
+            IReadOnlyList<TimedGitResult> results)
+        {
+            _timeProvider = timeProvider;
+            _results = new Queue<TimedGitResult>(results);
+        }
+
+        public List<TimeSpan> Timeouts { get; } = [];
+
+        public Task<GitCommandResult> RunAsync(
+            string workingDirectory,
+            IReadOnlyList<string> arguments,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            Timeouts.Add(timeout);
+            var next = _results.Dequeue();
+            _timeProvider.Advance(next.Elapsed);
+            return Task.FromResult(next.Result);
+        }
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextSnapshotTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextSnapshotTests.cs
@@ -259,6 +259,47 @@ public class WorkingContextSnapshotTests
     }
 
     [Fact]
+    public async Task Git_command_cancellation_terminates_and_awaits_process()
+    {
+        var process = new ControlledGitProcess();
+        var runner = new GitCommandRunner(new FixedGitProcessFactory(process));
+        using var cancellation = new CancellationTokenSource();
+
+        var run = runner.RunAsync(
+            "/repo",
+            ["status"],
+            Timeout.InfiniteTimeSpan,
+            cancellation.Token);
+        await process.WaitStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+        Assert.True(process.KillTreeCalled);
+        Assert.True(process.WaitedAfterTermination);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task Git_command_deadline_terminates_and_awaits_process()
+    {
+        var process = new ControlledGitProcess();
+        var runner = new GitCommandRunner(new FixedGitProcessFactory(process));
+
+        var result = await runner.RunAsync(
+            "/repo",
+            ["status"],
+            TimeSpan.Zero,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal("git inspection timed out", result.Error);
+        Assert.True(process.KillTreeCalled);
+        Assert.True(process.WaitedAfterTermination);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
     public async Task Unavailable_reason_is_single_line_and_bounded_before_rendering()
     {
         var reason = new string('x', 300) + "\ncredential-bearing second line";
@@ -349,6 +390,51 @@ public class WorkingContextSnapshotTests
             var next = _results.Dequeue();
             _timeProvider.Advance(next.Elapsed);
             return Task.FromResult(next.Result);
+        }
+    }
+
+    private sealed class FixedGitProcessFactory(IRunningGitProcess process) : IGitProcessFactory
+    {
+        public IRunningGitProcess Start(string workingDirectory, IReadOnlyList<string> arguments) => process;
+    }
+
+    private sealed class ControlledGitProcess : IRunningGitProcess
+    {
+        private readonly TaskCompletionSource _exit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource WaitStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool KillTreeCalled { get; private set; }
+        public bool WaitedAfterTermination { get; private set; }
+        public bool Disposed { get; private set; }
+        public int ExitCode => 0;
+
+        public Task<string> ReadStandardOutputAsync(CancellationToken cancellationToken) =>
+            ReadUntilExitAsync(cancellationToken);
+
+        public Task<string> ReadStandardErrorAsync(CancellationToken cancellationToken) =>
+            ReadUntilExitAsync(cancellationToken);
+
+        public async Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            WaitStarted.TrySetResult();
+            if (!cancellationToken.CanBeCanceled)
+                WaitedAfterTermination = true;
+            await _exit.Task.WaitAsync(cancellationToken);
+        }
+
+        public bool TryKillTree()
+        {
+            KillTreeCalled = true;
+            _exit.TrySetResult();
+            return true;
+        }
+
+        public void Dispose() => Disposed = true;
+
+        private async Task<string> ReadUntilExitAsync(CancellationToken cancellationToken)
+        {
+            await _exit.Task.WaitAsync(cancellationToken);
+            return string.Empty;
         }
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextSnapshotTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextSnapshotTests.cs
@@ -186,6 +186,69 @@ public class WorkingContextSnapshotTests
     }
 
     [Fact]
+    public async Task Git_inspection_reports_missing_git_without_status_command()
+    {
+        var time = new FakeTimeProvider();
+        var runner = new SequenceGitCommandRunner(time,
+        [
+            new TimedGitResult(TimeSpan.Zero, GitCommandResult.Failed(
+                "The system cannot find the file specified"))
+        ]);
+        var inspector = new GitWorkingContextInspector(runner, time);
+
+        var result = await inspector.InspectAsync(
+            "/repo",
+            TestContext.Current.CancellationToken);
+
+        var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(result);
+        Assert.Equal("The system cannot find the file specified", unavailable.Reason);
+        Assert.Single(runner.Timeouts);
+    }
+
+    [Fact]
+    public async Task Git_inspection_reports_malformed_root_response_without_status_command()
+    {
+        var time = new FakeTimeProvider();
+        var runner = new SequenceGitCommandRunner(time,
+        [
+            new TimedGitResult(TimeSpan.Zero, GitCommandResult.Succeeded("/repo\n", string.Empty))
+        ]);
+        var inspector = new GitWorkingContextInspector(runner, time);
+
+        var result = await inspector.InspectAsync(
+            "/repo",
+            TestContext.Current.CancellationToken);
+
+        var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(result);
+        Assert.Equal("git returned an unexpected repository-root response", unavailable.Reason);
+        Assert.Single(runner.Timeouts);
+    }
+
+    [Fact]
+    public async Task Git_inspection_reports_malformed_status_response()
+    {
+        var time = new FakeTimeProvider();
+        var runner = new SequenceGitCommandRunner(time,
+        [
+            new TimedGitResult(TimeSpan.Zero, GitCommandResult.Succeeded(
+                "/repo\n/repo/.git\n",
+                string.Empty)),
+            new TimedGitResult(TimeSpan.Zero, GitCommandResult.Succeeded(
+                "# branch.ab malformed\n",
+                string.Empty))
+        ]);
+        var inspector = new GitWorkingContextInspector(runner, time);
+
+        var result = await inspector.InspectAsync(
+            "/repo",
+            TestContext.Current.CancellationToken);
+
+        var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(result);
+        Assert.Equal("git returned an invalid ahead/behind response", unavailable.Reason);
+        Assert.Equal(2, runner.Timeouts.Count);
+    }
+
+    [Fact]
     public void Git_command_output_is_bounded()
     {
         var oversized = new string('x', 300_000);
@@ -212,6 +275,29 @@ public class WorkingContextSnapshotTests
         var unavailable = Assert.IsType<GitWorkingContextInspection.Unavailable>(snapshot.Git);
         Assert.Equal(200, unavailable.Reason.Length);
         Assert.DoesNotContain("credential-bearing", unavailable.Reason);
+    }
+
+    [Theory]
+    [InlineData(41, 42, true)]
+    [InlineData(42, 42, false)]
+    public void Stale_or_cancelled_working_context_continuation_is_rejected(
+        long snapshotGeneration,
+        long activeGeneration,
+        bool hasActiveLlmCall)
+    {
+        Assert.False(LlmSessionActor.ShouldApplyWorkingContextSnapshot(
+            snapshotGeneration,
+            activeGeneration,
+            hasActiveLlmCall));
+    }
+
+    [Fact]
+    public void Current_working_context_continuation_is_accepted()
+    {
+        Assert.True(LlmSessionActor.ShouldApplyWorkingContextSnapshot(
+            snapshotGeneration: 42,
+            activeGeneration: 42,
+            hasActiveLlmCall: true));
     }
 
     private sealed class RecordingGitInspector : IGitWorkingContextInspector

--- a/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
@@ -75,7 +75,9 @@ public class SpawnAgentStreamingTests : TestKit
             toolAccessPolicy,
             approvalService: null,
             new StaticSystemPromptProvider("You are a summarizer."),
-            new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             NullLogger<SubAgentSpawner>.Instance);
 
         registry.Register(new SpawnAgentTool(subAgentRegistry, spawner, paths));
@@ -165,7 +167,9 @@ public class SpawnAgentStreamingTests : TestKit
             toolAccessPolicy,
             approvalService: null,
             new StaticSystemPromptProvider("You are a summarizer."),
-            new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             NullLogger<SubAgentSpawner>.Instance);
 
         registry.Register(new SpawnAgentTool(subAgentRegistry, spawner, paths));

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -65,7 +65,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Say hello", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Say hello", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -91,7 +91,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Analyze repos", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Analyze repos", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -118,7 +118,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Analyze repos", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Analyze repos", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
@@ -153,7 +153,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Explain malformed output", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Explain malformed output", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -180,7 +180,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Say hello", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Say hello", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -206,7 +206,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Do the thing.", Timeout = TimeSpan.FromSeconds(5), Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Do the thing.", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -228,25 +228,6 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
-    public async Task Spawn_without_audience_fails_fast_with_unsuccessful_result()
-    {
-        var fakeClient = new FakeChatClient();
-        var definition = CreateDefinition();
-        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
-
-        // A RunSubAgent with no audience must not run — the sub-agent must reply
-        // with an unsuccessful result immediately, not crash and make the caller
-        // wait out the Ask timeout. A generous Ask timeout would still elapse if
-        // the actor merely threw; this asserts the prompt failure reply.
-        var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Do the thing", Timeout = TimeSpan.FromSeconds(5), Audience = null },
-            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-
-        Assert.False(result.Success);
-        Assert.Contains("audience", result.Output, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
     public async Task Tool_call_executes_and_continues()
     {
         var fakeTool = new FakeNetclawTool("greet", "Hello from tool!");
@@ -263,7 +244,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Greet the user", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Greet the user", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -293,11 +274,11 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(
+                    sessionDirectory: dir.Path,
+                    modelInputModalities: ModelModality.Text | ModelModality.Image),
                 Task = "Inspect the image.",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ParentSessionDirectory = dir.Path,
-                ModelInputModalities = ModelModality.Text | ModelModality.Image
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -330,12 +311,12 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(
+                    sessionDirectory: "/tmp/netclaw/sessions/abc",
+                    projectDirectory: "/home/user/workspaces/netclaw",
+                    recentFiles: ["src/Netclaw.Actors/SubAgents/SubAgentActor.cs"]),
                 Task = "Inspect the inherited paths.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentSessionDirectory = "/tmp/netclaw/sessions/abc",
-                ParentProjectDirectory = "/home/user/workspaces/netclaw",
-                ParentRecentFiles = ["src/Netclaw.Actors/SubAgents/SubAgentActor.cs"],
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -361,10 +342,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(sessionDirectory: "/tmp/netclaw/sessions/xyz"),
                 Task = "Inspect inherited paths.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentSessionDirectory = "/tmp/netclaw/sessions/xyz",
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -388,12 +368,12 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(
+                    sessionDirectory: "/tmp/netclaw/sessions/parent",
+                    projectDirectory: "/home/user/repos/foo",
+                    inheritedCwd: "/home/user/repos/foo"),
                 Task = "Inspect inherited cwd.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentSessionDirectory = "/tmp/netclaw/sessions/parent",
-                ParentProjectDirectory = "/home/user/repos/foo",
-                ParentCwd = "/home/user/repos/foo",
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -419,10 +399,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(),
                 Task = "Inspect null cwd.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentCwd = null,
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -451,12 +430,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(inheritedCwd: "/home/user/repos/foo"),
                 Task = "Inspect inherited cwd with no other sources.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentSessionDirectory = null,
-                ParentProjectDirectory = null,
-                ParentCwd = "/home/user/repos/foo",
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -480,10 +456,9 @@ public class SubAgentActorTests : TestKit
         var firstResult = await firstAgent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(projectDirectory: "/home/user/workspaces/project-a"),
                 Task = "First run.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentProjectDirectory = "/home/user/workspaces/project-a",
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(firstResult.Success);
@@ -499,10 +474,9 @@ public class SubAgentActorTests : TestKit
         var secondResult = await secondAgent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(projectDirectory: "/home/user/workspaces/project-b"),
                 Task = "Second run after parent project switch.",
-                Timeout = TimeSpan.FromSeconds(5),
-                ParentProjectDirectory = "/home/user/workspaces/project-b",
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(secondResult.Success);
@@ -518,7 +492,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Do the thing.", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Do the thing.", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -536,7 +510,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Do the thing.", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Do the thing.", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -564,7 +538,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy, approvalService: null));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Try the shell tool", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Try the shell tool", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
@@ -599,13 +573,13 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(
+                    sessionDirectory: "/tmp/netclaw/sessions/parent",
+                    projectDirectory: "/home/user/repos/foo",
+                    inheritedCwd: "/home/user/repos/foo",
+                    approvalBridge: approvalBridge),
                 Task = "Push to origin",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ParentSessionDirectory = "/tmp/netclaw/sessions/parent",
-                ParentProjectDirectory = "/home/user/repos/foo",
-                ParentCwd = "/home/user/repos/foo",
-                ApprovalBridge = approvalBridge,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -643,10 +617,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Run the same approval-gated tool twice",
-                Timeout = TimeSpan.FromSeconds(5),
-                ApprovalBridge = approvalBridge,
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -682,12 +655,11 @@ public class SubAgentActorTests : TestKit
         var runTask = agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Push to origin",
                 // 250ms inactivity budget — much smaller than the human delay
                 // below. Before this fix, this would always abort.
-                Timeout = TimeSpan.FromMilliseconds(250),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge
+                Timeout = TimeSpan.FromMilliseconds(250)
             },
             ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
@@ -728,10 +700,9 @@ public class SubAgentActorTests : TestKit
         var runTask = agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Push to origin",
                 Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge,
                 ActivitySink = activityChannel.Writer
             },
             ApprovalAskTimeout, TestContext.Current.CancellationToken);
@@ -785,10 +756,9 @@ public class SubAgentActorTests : TestKit
         var runTask = agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Push to origin",
                 Timeout = TimeSpan.FromSeconds(10),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge,
                 Cancellation = externalCts.Token
             },
             ApprovalAskTimeout, TestContext.Current.CancellationToken);
@@ -837,12 +807,11 @@ public class SubAgentActorTests : TestKit
         var runTask = agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Push to origin twice",
                 // 200ms budget — shorter than the assertion window below, so
                 // a non-paused watchdog would abort before release.
-                Timeout = TimeSpan.FromMilliseconds(200),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge
+                Timeout = TimeSpan.FromMilliseconds(200)
             },
             ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
@@ -882,10 +851,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Push to origin",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -916,10 +884,9 @@ public class SubAgentActorTests : TestKit
         var runTask = agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
                 Task = "Push to origin",
-                Timeout = TimeSpan.FromSeconds(10),
-                Audience = TrustAudience.Personal,
-                ApprovalBridge = approvalBridge
+                Timeout = TimeSpan.FromSeconds(10)
             },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
@@ -1024,7 +991,7 @@ public class SubAgentActorTests : TestKit
             maxToolIterations: 3));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Loop forever", Timeout = TimeSpan.FromSeconds(10) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Loop forever", Timeout = TimeSpan.FromSeconds(10) },
             TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         // After the configured tool budget, force a no-tools call which returns text.
@@ -1058,10 +1025,10 @@ public class SubAgentActorTests : TestKit
             // to Timeout, so Timeout alone no longer bounds the wait-for-first-token.)
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(),
                 Task = "Slow task",
                 Timeout = TimeSpan.FromMilliseconds(500),
-                PrefillTimeout = TimeSpan.FromMilliseconds(500),
-                Audience = TrustAudience.Personal
+                PrefillTimeout = TimeSpan.FromMilliseconds(500)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -1087,10 +1054,10 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(),
                 Task = "Silent prefill",
                 Timeout = TimeSpan.FromSeconds(30),         // inter-delta — not the governing budget here
-                PrefillTimeout = TimeSpan.FromSeconds(2),   // the budget under test
-                Audience = TrustAudience.Personal
+                PrefillTimeout = TimeSpan.FromSeconds(2)    // the budget under test
             },
             TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
 
@@ -1111,11 +1078,11 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(),
                 Task = "Wedged",
                 Timeout = TimeSpan.FromSeconds(30),           // inter-delta — not governing
                 PrefillTimeout = TimeSpan.FromSeconds(30),    // liveness — generous, not governing
-                NoProgressTimeout = TimeSpan.FromSeconds(2),  // the budget under test
-                Audience = TrustAudience.Personal
+                NoProgressTimeout = TimeSpan.FromSeconds(2)   // the budget under test
             },
             TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
 
@@ -1186,7 +1153,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, throwingClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Fail", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Fail", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
@@ -1202,7 +1169,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
         Watch(agent);
 
-        agent.Tell(new RunSubAgent { Task = "Done", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal });
+        agent.Tell(new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Done", Timeout = TimeSpan.FromSeconds(5) });
 
         // SubAgentResult arrives before Terminated — drain it first
         await ExpectMsgAsync<SubAgentResult>(cancellationToken: TestContext.Current.CancellationToken);
@@ -1247,10 +1214,11 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(
+                    audience: TrustAudience.Team,
+                    scopeId: "session/subagent-scope"),
                 Task = "Open example.com",
-                Timeout = TimeSpan.FromSeconds(5),
-                SessionScopeId = "session/subagent-scope",
-                Audience = TrustAudience.Team
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -1272,7 +1240,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Summarize research", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Summarize research", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -1293,7 +1261,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
 
         var result = await agent.Ask<SubAgentResult>(
-            new RunSubAgent { Task = "Summarize research", Timeout = TimeSpan.FromSeconds(5) , Audience = TrustAudience.Personal },
+            new RunSubAgent { Scope = SubAgentTestScope.Create(), Task = "Summarize research", Timeout = TimeSpan.FromSeconds(5) },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
@@ -1318,10 +1286,10 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(),
                 Task = "Summarize the recent commits.",
                 RuntimeContext = "Workspace is netclaw on branch feature/foo.",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -1349,9 +1317,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(),
                 Task = "Do the thing.",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -1370,11 +1338,11 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(
+                    projectDirectory: MissingProjectDirectory,
+                    recentFiles: ["src/Netclaw.Actors/Sessions/WorkingContext.cs"]),
                 Task = "Continue the implementation.",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ParentProjectDirectory = MissingProjectDirectory,
-                ParentRecentFiles = ["src/Netclaw.Actors/Sessions/WorkingContext.cs"]
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -1403,10 +1371,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(projectDirectory: MissingProjectDirectory),
                 Task = "Edit Calculator.",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ParentProjectDirectory = MissingProjectDirectory
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
@@ -1435,10 +1402,9 @@ public class SubAgentActorTests : TestKit
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
+                Scope = SubAgentTestScope.Create(projectDirectory: MissingProjectDirectory),
                 Task = "Edit Calculator.",
-                Timeout = TimeSpan.FromSeconds(5),
-                Audience = TrustAudience.Personal,
-                ParentProjectDirectory = MissingProjectDirectory
+                Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
@@ -47,10 +47,10 @@ public sealed class SubAgentObservabilityTests : TestKit
     private static RunSubAgent NewRun(string task, string? scopeId = null)
         => new()
         {
+            Scope = SubAgentTestScope.Create(
+                scopeId: scopeId ?? "test-session/subagent/test/run"),
             Task = task,
-            Timeout = TimeSpan.FromSeconds(5),
-            Audience = TrustAudience.Personal,
-            SessionScopeId = scopeId
+            Timeout = TimeSpan.FromSeconds(5)
         };
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnObservabilityTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnObservabilityTests.cs
@@ -50,7 +50,9 @@ public sealed class SubAgentSpawnObservabilityTests : IDisposable
             toolAccessPolicy: null!,
             approvalService: null,
             promptProvider: null!,
-            workingContextSnapshots: new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            workingContextSnapshots: new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             logger);
 
         // A context with a session id but no SpawnChildActor factory — the

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
@@ -50,7 +50,9 @@ public sealed class SubAgentSpawnerTests : TestKit
                 new ShellCommandPolicy()),
             approvalService: null,
             new StaticSystemPromptProvider("You are a summarizer."),
-            new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             NullLogger<SubAgentSpawner>.Instance);
 
         var childProbe = CreateTestProbe("subagent-child");
@@ -78,13 +80,14 @@ public sealed class SubAgentSpawnerTests : TestKit
             TestContext.Current.CancellationToken);
 
         var run = await childProbe.ExpectMsgAsync<RunSubAgent>(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal("/tmp/netclaw/sessions/parent", run.ParentSessionDirectory);
-        Assert.Equal("/home/user/repos/foo", run.ParentProjectDirectory);
-        Assert.Equal("/home/user/repos/foo", run.ParentCwd);
+        var bound = Assert.IsType<ToolSessionScope.Bound>(run.Scope.Authority.Session);
+        Assert.Equal("/tmp/netclaw/sessions/parent", bound.SessionDirectory);
+        Assert.Equal("/home/user/repos/foo", run.Scope.Authority.ProjectDirectory);
+        Assert.Equal("/home/user/repos/foo", run.Scope.Authority.InheritedCwd);
 
         childProbe.Reply(new SubAgentResult
         {
-            Success = true,
+            Completion = new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
             Output = "ok",
             AgentName = new AgentName(profile.Name)
         });
@@ -121,7 +124,7 @@ public sealed class SubAgentSpawnerTests : TestKit
 
         var run = await childProbe.ExpectMsgAsync<RunSubAgent>(
             cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Null(run.ApprovalBridge);
+        Assert.Null(run.Scope.Authority.ApprovalBridge);
 
         childProbe.Reply(SuccessfulResult());
         Assert.True((await spawnTask).Success);
@@ -153,7 +156,7 @@ public sealed class SubAgentSpawnerTests : TestKit
 
         var run = await childProbe.ExpectMsgAsync<RunSubAgent>(
             cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Same(approvalBridge, run.ApprovalBridge);
+        Assert.Same(approvalBridge, run.Scope.Authority.ApprovalBridge);
 
         childProbe.Reply(SuccessfulResult());
         Assert.True((await spawnTask).Success);
@@ -178,7 +181,9 @@ public sealed class SubAgentSpawnerTests : TestKit
                 new ShellCommandPolicy()),
             approvalService: null,
             new StaticSystemPromptProvider("You are a summarizer."),
-            new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             NullLogger<SubAgentSpawner>.Instance);
 
         var notifications = new List<SubAgentNotificationInfo>();
@@ -209,7 +214,7 @@ public sealed class SubAgentSpawnerTests : TestKit
         await childProbe.ExpectMsgAsync<RunSubAgent>(cancellationToken: TestContext.Current.CancellationToken);
         childProbe.Reply(new SubAgentResult
         {
-            Success = true,
+            Completion = new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
             Output = "ok",
             AgentName = new AgentName(profile.Name)
         });
@@ -232,12 +237,13 @@ public sealed class SubAgentSpawnerTests : TestKit
             new WorkingContextSnapshot
             {
                 WorkingContext = WorkingContext.Empty.WithProjectDirectory(projectDirectory),
-                Git = GitSnapshot(projectDirectory)
+                Git = new GitWorkingContextInspection.Available(GitSnapshot(projectDirectory))
             },
             new WorkingContextSnapshot
             {
                 WorkingContext = WorkingContext.Empty.WithProjectDirectory(projectDirectory),
-                Git = GitSnapshot(projectDirectory, "src/Confirmed.cs", "src/Observed.cs")
+                Git = new GitWorkingContextInspection.Available(
+                    GitSnapshot(projectDirectory, "src/Confirmed.cs", "src/Observed.cs"))
             }
         ]);
         var spawner = CreateSpawner(new SequenceWorkingContextSnapshotProvider(snapshots));
@@ -259,11 +265,11 @@ public sealed class SubAgentSpawnerTests : TestKit
         await childProbe.ExpectMsgAsync<RunSubAgent>(cancellationToken: TestContext.Current.CancellationToken);
         childProbe.Reply(SuccessfulResult() with
         {
-            WorkingContext = new SubAgentWorkingContextInfo
+            Completion = new ChildRunCompletion.Completed(new WorkingContextDelta
             {
                 ProjectDirectory = projectDirectory,
                 ConfirmedChangedFiles = [confirmedPath]
-            }
+            })
         });
 
         var result = await spawnTask;
@@ -304,7 +310,9 @@ public sealed class SubAgentSpawnerTests : TestKit
                 new ShellCommandPolicy()),
             approvalService: null,
             new StaticSystemPromptProvider("You are a summarizer."),
-            new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             NullLogger<SubAgentSpawner>.Instance,
             sessionMetrics: metrics);
 
@@ -338,6 +346,7 @@ public sealed class SubAgentSpawnerTests : TestKit
 
     private static SubAgentSpawner CreateSpawner()
         => CreateSpawner(new WorkingContextSnapshotProvider(
+            new GitWorkingContextInspector(TimeProvider.System),
             NullLogger<WorkingContextSnapshotProvider>.Instance));
 
     private static SubAgentSpawner CreateSpawner(IWorkingContextSnapshotProvider workingContextSnapshots)
@@ -380,7 +389,7 @@ public sealed class SubAgentSpawnerTests : TestKit
 
     private static SubAgentResult SuccessfulResult() => new()
     {
-        Success = true,
+        Completion = new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
         Output = "ok",
         AgentName = new AgentName("inspector")
     };
@@ -388,7 +397,10 @@ public sealed class SubAgentSpawnerTests : TestKit
     private sealed class SequenceWorkingContextSnapshotProvider(Queue<WorkingContextSnapshot> snapshots)
         : IWorkingContextSnapshotProvider
     {
-        public WorkingContextSnapshot Create(WorkingContext context, TrustAudience audience)
-            => snapshots.Dequeue();
+        public Task<WorkingContextSnapshot> CreateAsync(
+            WorkingContext context,
+            TrustAudience audience,
+            CancellationToken cancellationToken)
+            => Task.FromResult(snapshots.Dequeue());
     }
 }

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentTestScope.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentTestScope.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubAgentTestScope.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using static Netclaw.Actors.SubAgents.SubAgentProtocol;
+
+namespace Netclaw.Actors.Tests.SubAgents;
+
+internal static class SubAgentTestScope
+{
+    public static ChildRunScope Create(
+        TrustAudience audience = TrustAudience.Personal,
+        string scopeId = "test-session/subagent/test/run",
+        string? sessionDirectory = null,
+        string? projectDirectory = null,
+        string? inheritedCwd = null,
+        IReadOnlyList<string>? recentFiles = null,
+        ModelModality modelInputModalities = ModelModality.Text,
+        IParentApprovalBridge? approvalBridge = null)
+    {
+        var workingContext = new WorkingContext
+        {
+            ProjectDirectory = projectDirectory,
+            RecentFiles = [.. recentFiles ?? []]
+        };
+
+        return new ChildRunScope
+        {
+            ScopeId = new SubAgentScopeId(scopeId),
+            Authority = new ToolRunScope
+            {
+                Session = new ToolSessionScope.Bound(scopeId, sessionDirectory),
+                Audience = audience,
+                InlineOutputBudget = InlineOutputBudget.Default,
+                ModelInputModalities = modelInputModalities,
+                ApprovalBridge = approvalBridge,
+                ProjectDirectory = projectDirectory,
+                InheritedCwd = inheritedCwd,
+                RecentFiles = recentFiles ?? [],
+                SupportsInteractiveApproval = approvalBridge is not null
+            },
+            ParentWorkingContext = workingContext,
+            InitialWorkingSnapshot = new WorkingContextSnapshot
+            {
+                WorkingContext = audience == TrustAudience.Public ? WorkingContext.Empty : workingContext,
+                Git = new GitWorkingContextInspection.Skipped()
+            }
+        };
+    }
+}

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentTestScope.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentTestScope.cs
@@ -43,7 +43,6 @@ internal static class SubAgentTestScope
                 RecentFiles = recentFiles ?? [],
                 SupportsInteractiveApproval = approvalBridge is not null
             },
-            ParentWorkingContext = workingContext,
             InitialWorkingSnapshot = new WorkingContextSnapshot
             {
                 WorkingContext = audience == TrustAudience.Public ? WorkingContext.Empty : workingContext,

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -917,7 +917,9 @@ public class SkillToolTests : IDisposable
             policy,
             approvalService: null,
             NullSystemPromptProvider.Instance,
-            new WorkingContextSnapshotProvider(NullLogger<WorkingContextSnapshotProvider>.Instance),
+            new WorkingContextSnapshotProvider(
+                new GitWorkingContextInspector(TimeProvider.System),
+                NullLogger<WorkingContextSnapshotProvider>.Instance),
             NullLogger<SubAgentSpawner>.Instance);
     }
 

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -109,7 +109,7 @@ internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
     public int FindingsCount { get; init; }
     public string? MemoryDecision { get; init; }
     public string? MemoryDecisionReason { get; init; }
-    public SubAgentWorkingContextInfo? WorkingContext { get; init; }
+    public WorkingContextDelta? WorkingContext { get; init; }
 }
 
 internal sealed record AcceptedSubAgentFinding : INoSerializationVerificationNeeded

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -102,14 +102,15 @@ internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 {
     public required SubAgentRunId RunId { get; init; }
     public required SubAgents.AgentName AgentName { get; init; }
-    public required bool Success { get; init; }
-    public required SubAgentRunOutcome Outcome { get; init; }
-    public SubAgentOutcomeReason? OutcomeReason { get; init; }
+    public required ChildRunCompletion Completion { get; init; }
     public required TimeSpan Duration { get; init; }
     public int FindingsCount { get; init; }
     public string? MemoryDecision { get; init; }
     public string? MemoryDecisionReason { get; init; }
-    public WorkingContextDelta? WorkingContext { get; init; }
+    public bool Success => Completion.Success;
+    public SubAgentRunOutcome Outcome => Completion.Outcome;
+    public SubAgentOutcomeReason? OutcomeReason => Completion.Reason;
+    public WorkingContextDelta? WorkingContext => Completion.Delta;
 }
 
 internal sealed record AcceptedSubAgentFinding : INoSerializationVerificationNeeded

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -98,6 +98,22 @@ internal sealed record JobReapResolved(long Epoch, int ReapedCount, Exception? E
 
 internal sealed record ToolExecutionBatchCompleted : INoSerializationVerificationNeeded;
 
+internal sealed record WorkingContextSnapshotReady(
+    long Generation,
+    bool ForceNoTools,
+    string? TurnRestartNotice,
+    WorkingContextSnapshot Snapshot) : INoSerializationVerificationNeeded;
+
+internal sealed record WorkingContextSnapshotCancelled(long Generation)
+    : INoSerializationVerificationNeeded;
+
+internal sealed record WorkingContextSnapshotFailed(
+    long Generation,
+    bool ForceNoTools,
+    string? TurnRestartNotice,
+    WorkingContext WorkingContext,
+    Exception Cause) : INoSerializationVerificationNeeded;
+
 internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 {
     public required SubAgentRunId RunId { get; init; }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -873,7 +873,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         foreach (var run in msg.CompletedSubAgentRuns)
         {
-            MergeSuccessfulSubAgentWorkingContext(run.Success, run.WorkingContext);
+            MergeSuccessfulSubAgentWorkingContext(run.Completion);
             if (!emittedRunIds.Add(run.RunId))
                 continue;
 
@@ -2831,7 +2831,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void HandleWorkingContextSnapshotReady(WorkingContextSnapshotReady message)
     {
-        if (message.Generation != _workingContextGeneration || _activeLlmCts is null)
+        if (!ShouldApplyWorkingContextSnapshot(
+                message.Generation,
+                _workingContextGeneration,
+                _activeLlmCts is not null))
         {
             TurnLog().Debug(
                 "working_context_inspection_stale generation={Generation} activeGeneration={ActiveGeneration}",
@@ -2859,6 +2862,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         ContinueFireLlmCall(message.ForceNoTools);
     }
+
+    internal static bool ShouldApplyWorkingContextSnapshot(
+        long snapshotGeneration,
+        long activeGeneration,
+        bool hasActiveLlmCall) => hasActiveLlmCall && snapshotGeneration == activeGeneration;
 
 
     private TrustAudience CurrentTurnAudience()
@@ -3182,7 +3190,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        MergeSuccessfulSubAgentWorkingContext(msg.Result.Success, msg.Result.WorkingContext);
+        MergeSuccessfulSubAgentWorkingContext(msg.Result.Completion);
 
         var userMsg = _state.FindLastUserMessage();
         var turnEvent = new TurnRecorded
@@ -3240,23 +3248,25 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
     }
 
-    private void MergeSuccessfulSubAgentWorkingContext(
-        bool success,
-        WorkingContextDelta? workingContext)
+    private void MergeSuccessfulSubAgentWorkingContext(ChildRunCompletion completion)
     {
-        var updated = MergeSuccessfulSubAgentWorkingContext(_state.WorkingContext, success, workingContext);
+        var updated = MergeSuccessfulSubAgentWorkingContext(_state.WorkingContext, completion);
         if (!ReferenceEquals(updated, _state.WorkingContext))
             _state = _state with { WorkingContext = updated };
     }
 
     internal static WorkingContext MergeSuccessfulSubAgentWorkingContext(
         WorkingContext current,
-        bool success,
-        WorkingContextDelta? child)
-    {
-        if (!success || child is null)
-            return current;
+        ChildRunCompletion completion) => completion switch
+        {
+            ChildRunCompletion.Completed completed => MergeConfirmedChanges(current, completed.WorkingContext),
+            ChildRunCompletion.Partial partial => MergeConfirmedChanges(current, partial.WorkingContext),
+            ChildRunCompletion.Failed or ChildRunCompletion.Cancelled => current,
+            _ => throw new ArgumentOutOfRangeException(nameof(completion))
+        };
 
+    private static WorkingContext MergeConfirmedChanges(WorkingContext current, WorkingContextDelta child)
+    {
         var updated = current;
         foreach (var path in child.ConfirmedChangedFiles)
             updated = updated.AddRecentFile(path);
@@ -4507,7 +4517,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         foreach (var run in result.CompletedSubAgentRuns)
         {
-            MergeSuccessfulSubAgentWorkingContext(run.Success, run.WorkingContext);
+            MergeSuccessfulSubAgentWorkingContext(run.Completion);
             if (!emittedRunIds.Add(run.RunId))
                 continue;
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -51,6 +51,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private sealed record WorkingContextSnapshotReady(
         long Generation,
         bool ForceNoTools,
+        string? TurnRestartNotice,
         WorkingContextSnapshot Snapshot) : INoSerializationVerificationNeeded;
 
     private sealed record WorkingContextSnapshotCancelled(long Generation)
@@ -2741,6 +2742,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _ = CreateWorkingContextContinuationAsync(
                     workingContextGeneration,
                     forceNoTools,
+                    _turnRestartNotice,
                     _state.WorkingContext,
                     CurrentTurnAudience(),
                     _activeLlmCts.Token)
@@ -2811,6 +2813,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private async Task<INoSerializationVerificationNeeded> CreateWorkingContextContinuationAsync(
         long generation,
         bool forceNoTools,
+        string? turnRestartNotice,
         WorkingContext workingContext,
         TrustAudience audience,
         CancellationToken cancellationToken)
@@ -2821,7 +2824,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 workingContext,
                 audience,
                 cancellationToken).ConfigureAwait(false);
-            return new WorkingContextSnapshotReady(generation, forceNoTools, snapshot);
+            return new WorkingContextSnapshotReady(generation, forceNoTools, turnRestartNotice, snapshot);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -2849,7 +2852,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             StartupContextInjected: _startupContextInjected,
             SlashCommandSkillContent: _slashCommandSkillContent,
             SessionPromptOverlay: _sessionPromptOverlay,
-            TurnRestartNotice: _turnRestartNotice,
+            TurnRestartNotice: message.TurnRestartNotice,
             SessionId: _sessionId,
             SessionsBasePath: _sessionsBasePath,
             FileReadGranted: HasFileReadGranted(),

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -48,6 +48,14 @@ namespace Netclaw.Actors.Sessions;
 /// </summary>
 public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 {
+    private sealed record WorkingContextSnapshotReady(
+        long Generation,
+        bool ForceNoTools,
+        WorkingContextSnapshot Snapshot) : INoSerializationVerificationNeeded;
+
+    private sealed record WorkingContextSnapshotCancelled(long Generation)
+        : INoSerializationVerificationNeeded;
+
     private readonly SessionId _sessionId;
     private readonly IChatClient _chatClient;
     private readonly IChatClient _compactionClient;
@@ -150,6 +158,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Stale LlmResponseReceived/LlmCallFailed/LlmResponseDeltaReceived messages
     // from cancelled calls are ignored when their CallId doesn't match.
     private long _activeCallId;
+
+    // Correlates asynchronous working-context inspection with the call that
+    // requested it. Every call advances the generation so a late snapshot can
+    // never enter a newer turn or tool-loop continuation.
+    private long _workingContextGeneration;
 
     // Tracks whether any content was streamed this call — selects the watchdog timeout
     // (the generous prefill budget before the first token vs the tighter inter-delta
@@ -2395,6 +2408,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void CommandSubscriptionMessages()
     {
+        Command<WorkingContextSnapshotReady>(HandleWorkingContextSnapshotReady);
+        Command<WorkingContextSnapshotCancelled>(msg =>
+        {
+            if (msg.Generation == _workingContextGeneration)
+                TurnLog().Debug("working_context_inspection_cancelled generation={Generation}", msg.Generation);
+        });
+
         // Title generation result — can arrive in any behavior, always safe to apply
         Command<TitleGenerationCompleted>(msg =>
         {
@@ -2658,6 +2678,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         CancelAndDisposeLlmCts();
         _activeLlmCts = new CancellationTokenSource();
         _activeCallId++;
+        var workingContextGeneration = ++_workingContextGeneration;
 
         _turnState.ForceNoToolsActive = forceNoTools;
 
@@ -2717,29 +2738,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // through this content on every subsequent turn instead of
             // re-tokenizing it from scratch.
             _activeRecall = _recallManager.TurnRecallCache;
-            var workingContextBlock = _workingContextSnapshots
-                .Create(_state.WorkingContext, CurrentTurnAudience())
-                .ToContextBlock();
-            var volatileBlock = SessionMessageAssembler.BuildVolatileContextBlock(new ContextAssemblyInput(
-                State: _state,
-                ContextLayers: _contextLayers,
-                StartupContextInjected: _startupContextInjected,
-                SlashCommandSkillContent: _slashCommandSkillContent,
-                SessionPromptOverlay: _sessionPromptOverlay,
-                TurnRestartNotice: _turnRestartNotice,
-                SessionId: _sessionId,
-                SessionsBasePath: _sessionsBasePath,
-                FileReadGranted: HasFileReadGranted(),
-                ActiveRecall: _activeRecall,
-                WorkingContextBlock: workingContextBlock,
-                Audience: CurrentTurnAudience(),
-                SkillHint: BuildSkillHint()));
-            if (!string.IsNullOrEmpty(volatileBlock))
-            {
-                _state = _state.AddVolatileContextNudge(volatileBlock);
-            }
+            _ = CreateWorkingContextContinuationAsync(
+                    workingContextGeneration,
+                    forceNoTools,
+                    _state.WorkingContext,
+                    CurrentTurnAudience(),
+                    _activeLlmCts.Token)
+                .PipeTo(Self);
+            return;
         }
 
+        ContinueFireLlmCall(forceNoTools);
+    }
+
+    private void ContinueFireLlmCall(bool forceNoTools)
+    {
         _activeRecall = _recallManager.TurnRecallCache;
 
         // Build the full message list via the cache-stable assembler.
@@ -2793,6 +2806,58 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _activeCallId);
 
         _ = SessionLlmInvoker.InvokeAsync(client, messages, options, self, _activeCallId, _sessionId, _activeLlmCts!.Token);
+    }
+
+    private async Task<INoSerializationVerificationNeeded> CreateWorkingContextContinuationAsync(
+        long generation,
+        bool forceNoTools,
+        WorkingContext workingContext,
+        TrustAudience audience,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var snapshot = await _workingContextSnapshots.CreateAsync(
+                workingContext,
+                audience,
+                cancellationToken).ConfigureAwait(false);
+            return new WorkingContextSnapshotReady(generation, forceNoTools, snapshot);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return new WorkingContextSnapshotCancelled(generation);
+        }
+    }
+
+    private void HandleWorkingContextSnapshotReady(WorkingContextSnapshotReady message)
+    {
+        if (message.Generation != _workingContextGeneration || _activeLlmCts is null)
+        {
+            TurnLog().Debug(
+                "working_context_inspection_stale generation={Generation} activeGeneration={ActiveGeneration}",
+                message.Generation,
+                _workingContextGeneration);
+            return;
+        }
+
+        var volatileBlock = SessionMessageAssembler.BuildVolatileContextBlock(new ContextAssemblyInput(
+            State: _state,
+            ContextLayers: _contextLayers,
+            StartupContextInjected: _startupContextInjected,
+            SlashCommandSkillContent: _slashCommandSkillContent,
+            SessionPromptOverlay: _sessionPromptOverlay,
+            TurnRestartNotice: _turnRestartNotice,
+            SessionId: _sessionId,
+            SessionsBasePath: _sessionsBasePath,
+            FileReadGranted: HasFileReadGranted(),
+            ActiveRecall: _activeRecall,
+            WorkingContextBlock: message.Snapshot.ToContextBlock(),
+            Audience: CurrentTurnAudience(),
+            SkillHint: BuildSkillHint()));
+        if (!string.IsNullOrEmpty(volatileBlock))
+            _state = _state.AddVolatileContextNudge(volatileBlock);
+
+        ContinueFireLlmCall(message.ForceNoTools);
     }
 
 
@@ -3177,7 +3242,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void MergeSuccessfulSubAgentWorkingContext(
         bool success,
-        SubAgentWorkingContextInfo? workingContext)
+        WorkingContextDelta? workingContext)
     {
         var updated = MergeSuccessfulSubAgentWorkingContext(_state.WorkingContext, success, workingContext);
         if (!ReferenceEquals(updated, _state.WorkingContext))
@@ -3187,7 +3252,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     internal static WorkingContext MergeSuccessfulSubAgentWorkingContext(
         WorkingContext current,
         bool success,
-        SubAgentWorkingContextInfo? child)
+        WorkingContextDelta? child)
     {
         if (!success || child is null)
             return current;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -48,15 +48,6 @@ namespace Netclaw.Actors.Sessions;
 /// </summary>
 public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 {
-    private sealed record WorkingContextSnapshotReady(
-        long Generation,
-        bool ForceNoTools,
-        string? TurnRestartNotice,
-        WorkingContextSnapshot Snapshot) : INoSerializationVerificationNeeded;
-
-    private sealed record WorkingContextSnapshotCancelled(long Generation)
-        : INoSerializationVerificationNeeded;
-
     private readonly SessionId _sessionId;
     private readonly IChatClient _chatClient;
     private readonly IChatClient _compactionClient;
@@ -2415,6 +2406,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (msg.Generation == _workingContextGeneration)
                 TurnLog().Debug("working_context_inspection_cancelled generation={Generation}", msg.Generation);
         });
+        Command<WorkingContextSnapshotFailed>(HandleWorkingContextSnapshotFailed);
 
         // Title generation result — can arrive in any behavior, always safe to apply
         Command<TitleGenerationCompleted>(msg =>
@@ -2830,6 +2822,38 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             return new WorkingContextSnapshotCancelled(generation);
         }
+        catch (Exception ex)
+        {
+            return new WorkingContextSnapshotFailed(
+                generation,
+                forceNoTools,
+                turnRestartNotice,
+                workingContext,
+                ex);
+        }
+    }
+
+    private void HandleWorkingContextSnapshotFailed(WorkingContextSnapshotFailed message)
+    {
+        if (!ShouldApplyWorkingContextSnapshot(
+                message.Generation,
+                _workingContextGeneration,
+                _activeLlmCts is not null))
+            return;
+
+        TurnLog().Warning(
+            message.Cause,
+            "working_context_inspection_failed generation={Generation}",
+            message.Generation);
+        HandleWorkingContextSnapshotReady(new WorkingContextSnapshotReady(
+            message.Generation,
+            message.ForceNoTools,
+            message.TurnRestartNotice,
+            new WorkingContextSnapshot
+            {
+                WorkingContext = message.WorkingContext,
+                Git = new GitWorkingContextInspection.Unavailable("working context inspection failed")
+            }));
     }
 
     private void HandleWorkingContextSnapshotReady(WorkingContextSnapshotReady message)
@@ -4344,6 +4368,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         _inFlightDedup.CompleteReminder(_currentTurnSource?.ReminderId);
         _inFlightDedup.CompleteBackgroundJob(_currentTurnSource?.BackgroundJobId);
+        CancelAndDisposeLlmCts();
         CancelAndDisposeToolExecutionCts();
         _deliveryRetry.Clear();
         _pendingToolInteractions.Clear();

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -399,14 +399,14 @@ internal sealed class SessionToolExecutionPipeline
                 {
                     RunId = info.RunId,
                     AgentName = new SubAgents.AgentName(info.AgentName),
-                    Success = info.Success,
-                    Outcome = info.Outcome ?? (info.Success ? SubAgentRunOutcome.Completed : SubAgentRunOutcome.Failed),
-                    OutcomeReason = info.OutcomeReason,
+                    Completion = ChildRunCompletion.FromReportedOutcome(
+                        info.Outcome ?? (info.Success ? SubAgentRunOutcome.Completed : SubAgentRunOutcome.Failed),
+                        info.OutcomeReason,
+                        info.WorkingContext),
                     Duration = info.Duration,
                     FindingsCount = info.Findings.Count,
                     MemoryDecision = decision,
                     MemoryDecisionReason = reason,
-                    WorkingContext = info.WorkingContext
                 });
             }
 

--- a/src/Netclaw.Actors/Sessions/WorkingContext.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContext.cs
@@ -116,5 +116,9 @@ public sealed record WorkingContext : INetclawSerializableMessage
     /// emit a barren header.
     /// </summary>
     public string ToContextBlock()
-        => new WorkingContextSnapshot { WorkingContext = this }.ToContextBlock();
+        => new WorkingContextSnapshot
+        {
+            WorkingContext = this,
+            Git = new GitWorkingContextInspection.Skipped()
+        }.ToContextBlock();
 }

--- a/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
@@ -346,6 +346,17 @@ public sealed class GitWorkingContextInspector : IGitWorkingContextInspector
 internal sealed class GitCommandRunner : IGitCommandRunner
 {
     private const int MaxOutputChars = 256 * 1024;
+    private readonly IGitProcessFactory _processFactory;
+
+    public GitCommandRunner()
+        : this(new GitProcessFactory())
+    {
+    }
+
+    internal GitCommandRunner(IGitProcessFactory processFactory)
+    {
+        _processFactory = processFactory;
+    }
 
     public async Task<GitCommandResult> RunAsync(
         string workingDirectory,
@@ -355,36 +366,29 @@ internal sealed class GitCommandRunner : IGitCommandRunner
     {
         try
         {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "git",
-                    WorkingDirectory = workingDirectory,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            foreach (var argument in arguments)
-                process.StartInfo.ArgumentList.Add(argument);
-
-            process.Start();
-            var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
+            using var process = _processFactory.Start(workingDirectory, arguments);
             using var commandTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             commandTimeout.CancelAfter(timeout);
+            var stdout = process.ReadStandardOutputAsync(commandTimeout.Token);
+            var stderr = process.ReadStandardErrorAsync(commandTimeout.Token);
 
             try
             {
                 await process.WaitForExitAsync(commandTimeout.Token).ConfigureAwait(false);
                 await Task.WhenAll(stdout, stderr).WaitAsync(commandTimeout.Token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
-                TryKill(process);
-                return GitCommandResult.Failed("git inspection timed out");
+                var terminated = process.TryKillTree();
+                if (terminated)
+                    await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+                await ObserveCancelledReadAsync(stdout).ConfigureAwait(false);
+                await ObserveCancelledReadAsync(stderr).ConfigureAwait(false);
+
+                cancellationToken.ThrowIfCancellationRequested();
+                return GitCommandResult.Failed(terminated
+                    ? "git inspection timed out"
+                    : "git inspection timed out and process termination failed");
             }
 
             var standardOutput = Bound(await stdout.ConfigureAwait(false));
@@ -404,20 +408,102 @@ internal sealed class GitCommandRunner : IGitCommandRunner
         }
     }
 
-    private static void TryKill(Process process)
+    private static async Task ObserveCancelledReadAsync(Task<string> read)
     {
         try
         {
-            if (!process.HasExited)
-                process.Kill(entireProcessTree: true);
+            await read.ConfigureAwait(false);
         }
-        catch (InvalidOperationException)
+        catch (OperationCanceledException)
         {
-            // The process exited between the state check and Kill.
             return;
         }
     }
 
     internal static string Bound(string value) => value.Length <= MaxOutputChars ? value : value[..MaxOutputChars];
 
+}
+
+internal interface IGitProcessFactory
+{
+    IRunningGitProcess Start(string workingDirectory, IReadOnlyList<string> arguments);
+}
+
+internal interface IRunningGitProcess : IDisposable
+{
+    int ExitCode { get; }
+
+    Task<string> ReadStandardOutputAsync(CancellationToken cancellationToken);
+
+    Task<string> ReadStandardErrorAsync(CancellationToken cancellationToken);
+
+    Task WaitForExitAsync(CancellationToken cancellationToken);
+
+    bool TryKillTree();
+}
+
+internal sealed class GitProcessFactory : IGitProcessFactory
+{
+    public IRunningGitProcess Start(string workingDirectory, IReadOnlyList<string> arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+        foreach (var argument in arguments)
+            process.StartInfo.ArgumentList.Add(argument);
+
+        try
+        {
+            process.Start();
+            return new RunningGitProcess(process);
+        }
+        catch
+        {
+            process.Dispose();
+            throw;
+        }
+    }
+}
+
+internal sealed class RunningGitProcess(Process process) : IRunningGitProcess
+{
+    public int ExitCode => process.ExitCode;
+
+    public Task<string> ReadStandardOutputAsync(CancellationToken cancellationToken) =>
+        process.StandardOutput.ReadToEndAsync(cancellationToken);
+
+    public Task<string> ReadStandardErrorAsync(CancellationToken cancellationToken) =>
+        process.StandardError.ReadToEndAsync(cancellationToken);
+
+    public Task WaitForExitAsync(CancellationToken cancellationToken) =>
+        process.WaitForExitAsync(cancellationToken);
+
+    public bool TryKillTree()
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    public void Dispose() => process.Dispose();
 }

--- a/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
@@ -414,6 +414,7 @@ internal sealed class GitCommandRunner : IGitCommandRunner
         catch (InvalidOperationException)
         {
             // The process exited between the state check and Kill.
+            return;
         }
     }
 

--- a/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="WorkingContextSnapshot.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -27,13 +27,27 @@ public sealed record GitWorkingContextSnapshot
     public ImmutableHashSet<string> ChangedFiles { get; init; } = [];
 }
 
+public abstract record GitWorkingContextInspection
+{
+    private GitWorkingContextInspection()
+    {
+    }
+
+    public sealed record Skipped : GitWorkingContextInspection;
+
+    public sealed record Available(GitWorkingContextSnapshot Snapshot) : GitWorkingContextInspection;
+
+    public sealed record NotRepository : GitWorkingContextInspection;
+
+    public sealed record Unavailable(string Reason) : GitWorkingContextInspection;
+}
+
 public sealed record WorkingContextSnapshot
 {
     public required WorkingContext WorkingContext { get; init; }
-    public GitWorkingContextSnapshot? Git { get; init; }
-    public string? GitUnavailableReason { get; init; }
+    public required GitWorkingContextInspection Git { get; init; }
 
-    public bool IsEmpty => WorkingContext.IsEmpty && Git is null && GitUnavailableReason is null;
+    public bool IsEmpty => WorkingContext.IsEmpty && Git is GitWorkingContextInspection.Skipped or GitWorkingContextInspection.NotRepository;
 
     public string ToContextBlock()
     {
@@ -51,98 +65,196 @@ public sealed record WorkingContextSnapshot
                 sb.Append("\n  - ").Append(path);
         }
 
-        if (Git is { } git)
+        switch (Git)
         {
-            sb.Append("\ngit:")
-                .Append("\n  worktree: ").Append(git.Worktree)
-                .Append("\n  common_dir: ").Append(git.CommonDirectory)
-                .Append("\n  branch: ").Append(git.Detached ? "(detached)" : git.Branch)
-                .Append("\n  head: ").Append(git.Head ?? "(unborn)");
-            if (git.Upstream is not null)
-            {
-                sb.Append("\n  upstream: ").Append(git.Upstream)
-                    .Append("\n  ahead: ").Append(git.Ahead)
-                    .Append("\n  behind: ").Append(git.Behind);
-            }
-            sb.Append("\n  staged: ").Append(git.Staged)
-                .Append("\n  modified: ").Append(git.Modified)
-                .Append("\n  untracked: ").Append(git.Untracked);
-        }
-        else if (GitUnavailableReason is not null)
-        {
-            sb.Append("\ngit:")
-                .Append("\n  status: unavailable")
-                .Append("\n  reason: ").Append(GitUnavailableReason);
+            case GitWorkingContextInspection.Available { Snapshot: var git }:
+                sb.Append("\ngit:")
+                    .Append("\n  worktree: ").Append(git.Worktree)
+                    .Append("\n  common_dir: ").Append(git.CommonDirectory)
+                    .Append("\n  branch: ").Append(git.Detached ? "(detached)" : git.Branch)
+                    .Append("\n  head: ").Append(git.Head ?? "(unborn)");
+                if (git.Upstream is not null)
+                {
+                    sb.Append("\n  upstream: ").Append(git.Upstream)
+                        .Append("\n  ahead: ").Append(git.Ahead)
+                        .Append("\n  behind: ").Append(git.Behind);
+                }
+
+                sb.Append("\n  staged: ").Append(git.Staged)
+                    .Append("\n  modified: ").Append(git.Modified)
+                    .Append("\n  untracked: ").Append(git.Untracked);
+                break;
+            case GitWorkingContextInspection.Unavailable unavailable:
+                sb.Append("\ngit:")
+                    .Append("\n  status: unavailable")
+                    .Append("\n  reason: ").Append(unavailable.Reason);
+                break;
         }
 
         return sb.ToString();
     }
 }
 
-public interface IWorkingContextSnapshotProvider
+public interface IGitWorkingContextInspector
 {
-    WorkingContextSnapshot Create(WorkingContext context, TrustAudience audience);
+    Task<GitWorkingContextInspection> InspectAsync(
+        string projectDirectory,
+        CancellationToken cancellationToken);
 }
 
-public sealed class WorkingContextSnapshotProvider(ILogger<WorkingContextSnapshotProvider> logger)
+internal interface IGitCommandRunner
+{
+    Task<GitCommandResult> RunAsync(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout,
+        CancellationToken cancellationToken);
+}
+
+internal sealed record GitCommandResult(
+    bool Success,
+    string StandardOutput,
+    string StandardError,
+    string Error)
+{
+    public static GitCommandResult Succeeded(string stdout, string stderr) =>
+        new(true, stdout, stderr, string.Empty);
+
+    public static GitCommandResult Failed(string error, string stdout = "", string stderr = "") =>
+        new(false, stdout, stderr, error);
+}
+
+public interface IWorkingContextSnapshotProvider
+{
+    Task<WorkingContextSnapshot> CreateAsync(
+        WorkingContext context,
+        TrustAudience audience,
+        CancellationToken cancellationToken);
+}
+
+public sealed class WorkingContextSnapshotProvider(
+    IGitWorkingContextInspector gitInspector,
+    ILogger<WorkingContextSnapshotProvider> logger)
     : IWorkingContextSnapshotProvider
 {
-    internal static readonly TimeSpan GitTimeout = TimeSpan.FromSeconds(2);
-    private const int MaxOutputChars = 256 * 1024;
-
-    public WorkingContextSnapshot Create(WorkingContext context, TrustAudience audience)
+    public async Task<WorkingContextSnapshot> CreateAsync(
+        WorkingContext context,
+        TrustAudience audience,
+        CancellationToken cancellationToken)
     {
-        if (audience == TrustAudience.Public)
-            return new WorkingContextSnapshot { WorkingContext = WorkingContext.Empty };
-        if (context.ProjectDirectory is null)
-            return new WorkingContextSnapshot { WorkingContext = context };
+        ArgumentNullException.ThrowIfNull(context);
 
-        var inspection = InspectGit(context.ProjectDirectory);
-        if (inspection.Snapshot is not null)
-            return new WorkingContextSnapshot { WorkingContext = context, Git = inspection.Snapshot };
-        if (inspection.IsNotRepository)
-            return new WorkingContextSnapshot { WorkingContext = context };
+        if (audience == TrustAudience.Public || context.ProjectDirectory is null)
+        {
+            return new WorkingContextSnapshot
+            {
+                WorkingContext = audience == TrustAudience.Public ? WorkingContext.Empty : context,
+                Git = new GitWorkingContextInspection.Skipped()
+            };
+        }
 
-        logger.LogWarning("Git working-context inspection failed: {Reason}", inspection.Error);
+        var inspection = Directory.Exists(context.ProjectDirectory)
+            ? await gitInspector.InspectAsync(context.ProjectDirectory, cancellationToken).ConfigureAwait(false)
+            : new GitWorkingContextInspection.Unavailable("project directory does not exist");
+
+        if (inspection is GitWorkingContextInspection.Unavailable unavailable)
+            logger.LogWarning("Git working-context inspection failed: {Reason}", unavailable.Reason);
+
         return new WorkingContextSnapshot
         {
             WorkingContext = context,
-            GitUnavailableReason = SanitizeReason(inspection.Error)
+            Git = inspection switch
+            {
+                GitWorkingContextInspection.Unavailable failure =>
+                    new GitWorkingContextInspection.Unavailable(SanitizeReason(failure.Reason)),
+                _ => inspection
+            }
         };
     }
 
-    internal static GitInspectionResult InspectGit(string projectDirectory)
+    private static string SanitizeReason(string reason)
     {
-        if (!Directory.Exists(projectDirectory))
-            return GitInspectionResult.Failed("project directory does not exist");
+        var firstLine = reason.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()
+                        ?? "inspection failed";
+        return firstLine.Length <= 200 ? firstLine : firstLine[..200];
+    }
+}
 
-        var roots = RunGit(projectDirectory,
-            ["rev-parse", "--show-toplevel", "--path-format=absolute", "--git-common-dir"]);
+public sealed class GitWorkingContextInspector : IGitWorkingContextInspector
+{
+    internal static readonly TimeSpan GitTimeout = TimeSpan.FromSeconds(2);
+    private readonly IGitCommandRunner _commandRunner;
+    private readonly TimeProvider _timeProvider;
+
+    public GitWorkingContextInspector(TimeProvider timeProvider)
+        : this(new GitCommandRunner(), timeProvider)
+    {
+    }
+
+    internal GitWorkingContextInspector(
+        IGitCommandRunner commandRunner,
+        TimeProvider timeProvider)
+    {
+        _commandRunner = commandRunner;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<GitWorkingContextInspection> InspectAsync(
+        string projectDirectory,
+        CancellationToken cancellationToken)
+    {
+        var deadline = new GitInspectionDeadline(_timeProvider.GetUtcNow() + GitTimeout);
+        var roots = await _commandRunner.RunAsync(
+            projectDirectory,
+            ["rev-parse", "--show-toplevel", "--path-format=absolute", "--git-common-dir"],
+            deadline.Remaining(_timeProvider),
+            cancellationToken).ConfigureAwait(false);
         if (!roots.Success)
         {
-            var notRepo = roots.StandardError.Contains("not a git repository", StringComparison.OrdinalIgnoreCase);
-            return notRepo ? GitInspectionResult.NotRepository() : GitInspectionResult.Failed(roots.Error);
+            var notRepository = roots.StandardError.Contains(
+                "not a git repository",
+                StringComparison.OrdinalIgnoreCase);
+            return notRepository
+                ? new GitWorkingContextInspection.NotRepository()
+                : new GitWorkingContextInspection.Unavailable(roots.Error);
         }
 
-        var rootLines = roots.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var rootLines = roots.StandardOutput.Split(
+            '\n',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (rootLines.Length != 2)
-            return GitInspectionResult.Failed("git returned an unexpected repository-root response");
+        {
+            return new GitWorkingContextInspection.Unavailable(
+                "git returned an unexpected repository-root response");
+        }
 
-        var status = RunGit(projectDirectory, ["status", "--porcelain=v2", "--branch", "--untracked-files=normal"]);
+        var remaining = deadline.Remaining(_timeProvider);
+        if (remaining <= TimeSpan.Zero)
+            return new GitWorkingContextInspection.Unavailable("git inspection timed out");
+
+        var status = await _commandRunner.RunAsync(
+            projectDirectory,
+            ["status", "--porcelain=v2", "--branch", "--untracked-files=normal"],
+            remaining,
+            cancellationToken).ConfigureAwait(false);
         if (!status.Success)
-            return GitInspectionResult.Failed(status.Error);
+            return new GitWorkingContextInspection.Unavailable(status.Error);
 
         try
         {
-            return GitInspectionResult.Succeeded(ParseStatus(rootLines[0], rootLines[1], status.StandardOutput));
+            return new GitWorkingContextInspection.Available(
+                ParseStatus(rootLines[0], rootLines[1], status.StandardOutput));
         }
         catch (FormatException ex)
         {
-            return GitInspectionResult.Failed(ex.Message);
+            return new GitWorkingContextInspection.Unavailable(ex.Message);
         }
     }
 
-    internal static GitWorkingContextSnapshot ParseStatus(string worktree, string commonDirectory, string output)
+    internal static GitWorkingContextSnapshot ParseStatus(
+        string worktree,
+        string commonDirectory,
+        string output)
     {
         string? branch = null;
         string? head = null;
@@ -221,7 +333,25 @@ public sealed class WorkingContextSnapshotProvider(ILogger<WorkingContextSnapsho
         };
     }
 
-    private static GitCommandResult RunGit(string workingDirectory, IReadOnlyList<string> arguments)
+    internal readonly record struct GitInspectionDeadline(DateTimeOffset ExpiresAt)
+    {
+        public TimeSpan Remaining(TimeProvider provider)
+        {
+            var remaining = ExpiresAt - provider.GetUtcNow();
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+    }
+}
+
+internal sealed class GitCommandRunner : IGitCommandRunner
+{
+    private const int MaxOutputChars = 256 * 1024;
+
+    public async Task<GitCommandResult> RunAsync(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -241,56 +371,52 @@ public sealed class WorkingContextSnapshotProvider(ILogger<WorkingContextSnapsho
                 process.StartInfo.ArgumentList.Add(argument);
 
             process.Start();
-            var stdout = process.StandardOutput.ReadToEndAsync();
-            var stderr = process.StandardError.ReadToEndAsync();
-            if (!process.WaitForExit(GitTimeout))
+            var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
+            using var commandTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            commandTimeout.CancelAfter(timeout);
+
+            try
             {
-                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(commandTimeout.Token).ConfigureAwait(false);
+                await Task.WhenAll(stdout, stderr).WaitAsync(commandTimeout.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                TryKill(process);
                 return GitCommandResult.Failed("git inspection timed out");
             }
 
-            if (!Task.WaitAll([stdout, stderr], GitTimeout))
-            {
-                if (!process.HasExited)
-                    process.Kill(entireProcessTree: true);
-                return GitCommandResult.Failed("git output collection timed out");
-            }
-            var standardOutput = Bound(stdout.Result);
-            var standardError = Bound(stderr.Result);
+            var standardOutput = Bound(await stdout.ConfigureAwait(false));
+            var standardError = Bound(await stderr.ConfigureAwait(false));
             return process.ExitCode == 0
                 ? GitCommandResult.Succeeded(standardOutput, standardError)
-                : GitCommandResult.Failed(string.IsNullOrWhiteSpace(standardError)
-                    ? $"git exited with code {process.ExitCode}"
-                    : standardError, standardOutput, standardError);
+                : GitCommandResult.Failed(
+                    string.IsNullOrWhiteSpace(standardError)
+                        ? $"git exited with code {process.ExitCode}"
+                        : standardError,
+                    standardOutput,
+                    standardError);
         }
-        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or IOException or InvalidOperationException or AggregateException)
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or IOException or InvalidOperationException)
         {
-            return GitCommandResult.Failed(ex is AggregateException ? "git output collection timed out" : ex.Message);
+            return GitCommandResult.Failed(ex.Message);
         }
     }
 
-    private static string Bound(string value) => value.Length <= MaxOutputChars ? value : value[..MaxOutputChars];
-
-    private static string SanitizeReason(string reason)
+    private static void TryKill(Process process)
     {
-        var firstLine = reason.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()
-                        ?? "inspection failed";
-        return firstLine.Length <= 200 ? firstLine : firstLine[..200];
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the state check and Kill.
+        }
     }
 
-    internal sealed record GitInspectionResult(
-        GitWorkingContextSnapshot? Snapshot,
-        bool IsNotRepository,
-        string Error)
-    {
-        public static GitInspectionResult Succeeded(GitWorkingContextSnapshot snapshot) => new(snapshot, false, string.Empty);
-        public static GitInspectionResult NotRepository() => new(null, true, string.Empty);
-        public static GitInspectionResult Failed(string error) => new(null, false, error);
-    }
+    internal static string Bound(string value) => value.Length <= MaxOutputChars ? value : value[..MaxOutputChars];
 
-    private sealed record GitCommandResult(bool Success, string StandardOutput, string StandardError, string Error)
-    {
-        public static GitCommandResult Succeeded(string stdout, string stderr) => new(true, stdout, stderr, string.Empty);
-        public static GitCommandResult Failed(string error, string stdout = "", string stderr = "") => new(false, stdout, stderr, error);
-    }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -249,7 +249,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _toolExecutionContext = new ToolExecutionContext(
                 msg.Scope.Authority,
                 ToolExecutionTimeout.Default);
-            _fileActivity = new ChildFileActivityTracker(msg.Scope.ParentWorkingContext);
+            _fileActivity = new ChildFileActivityTracker(msg.Scope.InitialWorkingSnapshot.WorkingContext);
             _aiTools = ResolveExposedAiTools();
             _executionCts = new CancellationTokenSource();
             _externalCts = new CancellationTokenSource();

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -800,7 +800,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         var workingContextResult = BuildWorkingContextResult(success);
         _replyTo.Tell(new SubAgentResult
         {
-            Completion = CreateCompletion(resolvedOutcome, outcomeReason, workingContextResult),
+            Completion = ChildRunCompletion.FromReportedOutcome(resolvedOutcome, outcomeReason, workingContextResult),
             Output = output,
             AgentName = _definition.Name,
             Findings = findings,
@@ -809,22 +809,6 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Context.Stop(Self);
     }
-
-    private static ChildRunCompletion CreateCompletion(
-        SubAgentRunOutcome outcome,
-        SubAgentOutcomeReason? reason,
-        WorkingContextDelta? delta) => outcome switch
-        {
-            SubAgentRunOutcome.Completed when delta is not null => new ChildRunCompletion.Completed(delta),
-            SubAgentRunOutcome.Partial when delta is not null && reason is { } partialReason =>
-                new ChildRunCompletion.Partial(partialReason, delta),
-            SubAgentRunOutcome.Failed when reason == SubAgentOutcomeReason.CancelledByParent =>
-                new ChildRunCompletion.Cancelled(reason.Value),
-            SubAgentRunOutcome.Failed when reason is { } failureReason =>
-                new ChildRunCompletion.Failed(failureReason),
-            _ => throw new InvalidOperationException(
-                $"Invalid child completion: outcome={outcome}, reason={reason?.Value ?? "none"}, hasDelta={delta is not null}.")
-        };
 
     /// <summary>
     /// Arm the watchdog for a fresh LLM streaming call: the generous prefill

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -119,10 +119,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     // sub-agent's own session.log (SubSessionId) — matching the enriched logger's own context.
     private string? _parentSessionId;
     private string? _subSessionId;
-    private WorkingContext _workingContext = WorkingContext.Empty;
-    private readonly HashSet<string> _readFiles = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _confirmedChangedFiles = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, PendingFileActivity> _pendingFileActivities = new(StringComparer.Ordinal);
+    private ChildFileActivityTracker _fileActivity = new(WorkingContext.Empty);
 
     // Default wait-for-first-delta budget when the spawn message carries none
     // (direct/test callers). Mirrors SessionConfig.PrefillTimeout so an unset
@@ -227,11 +224,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _completed = true;
             _replyTo.Tell(new SubAgentResult
             {
-                Success = false,
+                Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.ActorStopped),
                 Output = "Subagent stopped before completion.",
                 AgentName = _definition.Name,
-                Outcome = SubAgentRunOutcome.Failed,
-                OutcomeReason = SubAgentOutcomeReason.ActorStopped,
                 Findings = [],
                 FindingsCount = 0
             });
@@ -248,52 +243,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             _replyTo = Sender;
 
-            _approvalBridge = msg.ApprovalBridge;
-
-            var scopeId = !string.IsNullOrWhiteSpace(msg.SessionScopeId)
-                ? msg.SessionScopeId!
-                : $"subagent/{_definition.Name}/{Guid.NewGuid():N}";
-            // A sub-agent inherits the spawning session's audience. A spawn with no
-            // audience is a programming error — defaulting to Personal would
-            // silently grant the sub-agent broader trust than its parent. Fail the
-            // run immediately with a result so the caller fails fast, rather than
-            // throwing (which crashes the actor and makes the caller wait out the
-            // Ask timeout).
-            if (msg.Audience is not { } subAgentAudience)
-            {
-                _log.Error(
-                    "SubAgent [{AgentName}] spawn rejected: RunSubAgent carried no trust audience.",
-                    _definition.Name);
-                Complete(
-                    success: false,
-                    "Sub-agent spawn failed: no trust audience was provided. A sub-agent "
-                    + "must inherit the spawning session's audience.",
-                    SubAgentRunOutcome.Failed,
-                    SubAgentOutcomeReason.MissingAudience);
-                return;
-            }
-
-            _toolExecutionContext = new ToolExecutionContext(new ToolRunScope
-            {
-                Session = new ToolSessionScope.Bound(scopeId, msg.ParentSessionDirectory),
-                Audience = subAgentAudience,
-                InlineOutputBudget = InlineOutputBudget.Default,
-                Boundary = msg.Boundary,
-                ChannelType = msg.ChannelType,
-                DefaultDeliveryTarget = msg.DefaultDeliveryTarget,
-                RequestedDeliveryTarget = msg.RequestedDeliveryTarget,
-                ModelInputModalities = msg.ModelInputModalities,
-                ApprovalBridge = _approvalBridge,
-                ProjectDirectory = msg.ParentProjectDirectory,
-                InheritedCwd = msg.ParentCwd,
-                RecentFiles = msg.ParentRecentFiles,
-                SupportsInteractiveApproval = _approvalBridge is not null,
-            }, ToolExecutionTimeout.Default);
-            _workingContext = new WorkingContext
-            {
-                ProjectDirectory = msg.ParentProjectDirectory,
-                RecentFiles = [.. msg.ParentRecentFiles.Take(WorkingContext.MaxRecentFiles)]
-            };
+            _approvalBridge = msg.Scope.Authority.ApprovalBridge;
+            var scopeId = msg.Scope.ScopeId.Value;
+            var subAgentAudience = msg.Scope.Authority.Audience;
+            _toolExecutionContext = new ToolExecutionContext(
+                msg.Scope.Authority,
+                ToolExecutionTimeout.Default);
+            _fileActivity = new ChildFileActivityTracker(msg.Scope.ParentWorkingContext);
             _aiTools = ResolveExposedAiTools();
             _executionCts = new CancellationTokenSource();
             _externalCts = new CancellationTokenSource();
@@ -341,7 +297,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     msg.RuntimeContext,
                     subAgentAudience == TrustAudience.Public
                         ? string.Empty
-                        : msg.WorkingContextBlock ?? _workingContext.ToContextBlock(),
+                        : msg.Scope.InitialWorkingSnapshot.ToContextBlock(),
                     msg.Task)));
 
             _log.Info("SubAgent [{AgentName}] starting (tools={ToolCount}, prefill={Prefill}, interDelta={InterDelta}, noProgress={NoProgress})",
@@ -481,16 +437,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             foreach (var result in msg.ToolResults)
             {
                 _history.Add(ChatMessageConverter.ToAiMessage(result));
-                if (result.ToolCallId is { } callId
-                    && _pendingFileActivities.Remove(callId.Value, out var activity)
-                    && IsSuccessfulFileActivity(activity.Kind, result.Content))
-                {
-                    _workingContext = _workingContext.AddRecentFile(activity.Path);
-                    if (activity.Kind == FileActivityKind.Read)
-                        _readFiles.Add(activity.Path);
-                    else
-                        _confirmedChangedFiles.Add(activity.Path);
-                }
+                if (result.ToolCallId is { } callId)
+                    _fileActivity.Complete(callId.Value, result.Content);
                 var preview = result.Content is { Length: > 200 }
                     ? result.Content[..200] + "..."
                     : result.Content ?? "(null)";
@@ -721,11 +669,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 : null;
             _turnState.TrackToolCall(toolCall.Name, argsJson);
             if (toolCall.CallId is { Length: > 0 } callId
-                && WorkingContextUpdater.TryExtractFilePath(argsJson, out var path)
-                && TryClassifyFileActivity(toolCall.Name, out var kind))
-            {
-                _pendingFileActivities[callId] = new PendingFileActivity(ResolveTrackedPath(path), kind);
-            }
+                && WorkingContextUpdater.TryExtractFilePath(argsJson, out var path))
+                _fileActivity.Begin(callId, toolCall.Name, path);
 
             // Log tool START event so tool execution spans are visible in Seq
             // (previously only tool results were logged, making it impossible to
@@ -855,18 +800,31 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         var workingContextResult = BuildWorkingContextResult(success);
         _replyTo.Tell(new SubAgentResult
         {
-            Success = success,
+            Completion = CreateCompletion(resolvedOutcome, outcomeReason, workingContextResult),
             Output = output,
             AgentName = _definition.Name,
-            Outcome = resolvedOutcome,
-            OutcomeReason = outcomeReason,
             Findings = findings,
             FindingsCount = findings.Count,
-            WorkingContext = workingContextResult
         });
 
         Context.Stop(Self);
     }
+
+    private static ChildRunCompletion CreateCompletion(
+        SubAgentRunOutcome outcome,
+        SubAgentOutcomeReason? reason,
+        WorkingContextDelta? delta) => outcome switch
+        {
+            SubAgentRunOutcome.Completed when delta is not null => new ChildRunCompletion.Completed(delta),
+            SubAgentRunOutcome.Partial when delta is not null && reason is { } partialReason =>
+                new ChildRunCompletion.Partial(partialReason, delta),
+            SubAgentRunOutcome.Failed when reason == SubAgentOutcomeReason.CancelledByParent =>
+                new ChildRunCompletion.Cancelled(reason.Value),
+            SubAgentRunOutcome.Failed when reason is { } failureReason =>
+                new ChildRunCompletion.Failed(failureReason),
+            _ => throw new InvalidOperationException(
+                $"Invalid child completion: outcome={outcome}, reason={reason?.Value ?? "none"}, hasDelta={delta is not null}.")
+        };
 
     /// <summary>
     /// Arm the watchdog for a fresh LLM streaming call: the generous prefill
@@ -997,57 +955,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         return $"Context:\n{combinedContext}\n\nTask:\n{task}";
     }
 
-    private SubAgentWorkingContextInfo? BuildWorkingContextResult(bool success)
+    private WorkingContextDelta? BuildWorkingContextResult(bool success)
     {
         if (!success)
             return null;
 
-        return new SubAgentWorkingContextInfo
-        {
-            ProjectDirectory = _workingContext.ProjectDirectory,
-            ReadFiles = _readFiles.Order(StringComparer.Ordinal).ToArray(),
-            ConfirmedChangedFiles = _confirmedChangedFiles.Order(StringComparer.Ordinal).ToArray(),
-            ObservedChangedFiles = []
-        };
-    }
-
-    private string ResolveTrackedPath(string path)
-    {
-        if (Path.IsPathRooted(path) || string.IsNullOrWhiteSpace(_workingContext.ProjectDirectory))
-            return path;
-        return Path.GetFullPath(path, _workingContext.ProjectDirectory);
-    }
-
-    private static bool TryClassifyFileActivity(string toolName, out FileActivityKind kind)
-    {
-        kind = toolName switch
-        {
-            "file_read" => FileActivityKind.Read,
-            "file_write" or "file_edit" => FileActivityKind.Changed,
-            _ => FileActivityKind.None
-        };
-        return kind != FileActivityKind.None;
-    }
-
-    private static bool IsSuccessfulFileActivity(FileActivityKind kind, string? result)
-    {
-        if (string.IsNullOrWhiteSpace(result))
-            return false;
-
-        return kind == FileActivityKind.Changed
-            ? result.StartsWith("Successfully ", StringComparison.Ordinal)
-            : !result.StartsWith("Error:", StringComparison.Ordinal)
-              && !result.StartsWith("Tool access denied:", StringComparison.Ordinal)
-              && !result.Contains("requires approval", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private sealed record PendingFileActivity(string Path, FileActivityKind Kind);
-
-    private enum FileActivityKind
-    {
-        None,
-        Read,
-        Changed
+        return _fileActivity.BuildResult();
     }
 
     private static string ExtractText(AiChatMessage message)
@@ -1428,6 +1341,77 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         // Append the headless execution and precedence contract — always at the bottom,
         // after the specialized role prompt it protects from inherited mission conflicts.
         return string.Concat(rolePrompt.TrimEnd(), "\n\n", HeadlessExecutionContract);
+    }
+
+    private sealed class ChildFileActivityTracker
+    {
+        private readonly HashSet<string> _readFiles = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _confirmedChangedFiles = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, PendingFileActivity> _pending = new(StringComparer.Ordinal);
+        private WorkingContext _workingContext;
+
+        public ChildFileActivityTracker(WorkingContext parentSnapshot)
+        {
+            _workingContext = parentSnapshot;
+        }
+
+        public void Begin(string callId, string toolName, string path)
+        {
+            var kind = toolName switch
+            {
+                "file_read" => FileActivityKind.Read,
+                "file_write" or "file_edit" => FileActivityKind.Changed,
+                _ => FileActivityKind.None
+            };
+            if (kind == FileActivityKind.None)
+                return;
+
+            var resolvedPath = Path.IsPathRooted(path) || string.IsNullOrWhiteSpace(_workingContext.ProjectDirectory)
+                ? path
+                : Path.GetFullPath(path, _workingContext.ProjectDirectory);
+            _pending[callId] = new PendingFileActivity(resolvedPath, kind);
+        }
+
+        public void Complete(string callId, string? result)
+        {
+            if (!_pending.Remove(callId, out var activity) || !Succeeded(activity.Kind, result))
+                return;
+
+            _workingContext = _workingContext.AddRecentFile(activity.Path);
+            if (activity.Kind == FileActivityKind.Read)
+                _readFiles.Add(activity.Path);
+            else
+                _confirmedChangedFiles.Add(activity.Path);
+        }
+
+        public WorkingContextDelta BuildResult() => new()
+        {
+            ProjectDirectory = _workingContext.ProjectDirectory,
+            ReadFiles = _readFiles.Order(StringComparer.Ordinal).ToArray(),
+            ConfirmedChangedFiles = _confirmedChangedFiles.Order(StringComparer.Ordinal).ToArray(),
+            ObservedChangedFiles = []
+        };
+
+        private static bool Succeeded(FileActivityKind kind, string? result)
+        {
+            if (string.IsNullOrWhiteSpace(result))
+                return false;
+
+            return kind == FileActivityKind.Changed
+                ? result.StartsWith("Successfully ", StringComparison.Ordinal)
+                : !result.StartsWith("Error:", StringComparison.Ordinal)
+                  && !result.StartsWith("Tool access denied:", StringComparison.Ordinal)
+                  && !result.Contains("requires approval", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private sealed record PendingFileActivity(string Path, FileActivityKind Kind);
+
+        private enum FileActivityKind
+        {
+            None,
+            Read,
+            Changed
+        }
     }
 
     private sealed class SubAgentCancelled

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -131,7 +131,6 @@ public sealed record ChildRunScope
 {
     public required SubAgentScopeId ScopeId { get; init; }
     public required ToolRunScope Authority { get; init; }
-    public required WorkingContext ParentWorkingContext { get; init; }
     public required WorkingContextSnapshot InitialWorkingSnapshot { get; init; }
 }
 

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -6,6 +6,7 @@
 using System.Threading.Channels;
 using Akka.Actor;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 
@@ -67,6 +68,13 @@ public static class SubAgentProtocol
 /// </summary>
 public sealed record RunSubAgent : ISubAgentCommand
 {
+    /// <summary>
+    /// Framework-owned authority and read-only working snapshot forked from
+    /// the parent invocation. The child receives no reference to parent
+    /// activity state and allocates its own output and file-activity trackers.
+    /// </summary>
+    public required ChildRunScope Scope { get; init; }
+
     /// <summary>The task for the subagent to perform (becomes part of the user message).</summary>
     public required string Task { get; init; }
 
@@ -111,68 +119,20 @@ public sealed record RunSubAgent : ISubAgentCommand
     public CancellationToken Cancellation { get; init; }
 
     /// <summary>
-    /// Optional execution scope ID used for session-scoped tool routing.
-    /// When omitted, the subagent runtime assigns a unique transient scope.
-    /// </summary>
-    public string? SessionScopeId { get; init; }
-
-    /// <summary>
-    /// Trust audience inherited from the spawning session. A parsed
-    /// <see cref="TrustAudience"/> — the sub-agent actor rejects a spawn with no
-    /// audience rather than defaulting it.
-    /// </summary>
-    public TrustAudience? Audience { get; init; }
-
-    public TrustBoundary? Boundary { get; init; }
-
-    public string? ChannelType { get; init; }
-
-    public ChannelDeliveryTargetInfo? DefaultDeliveryTarget { get; init; }
-
-    public ChannelDeliveryTargetInfo? RequestedDeliveryTarget { get; init; }
-
-    /// <summary>
-    /// Input modalities supported by the model selected for this sub-agent run.
-    /// Tools use this to decide whether model-visible media handoff is allowed.
-    /// </summary>
-    public ModelModality ModelInputModalities { get; init; } = ModelModality.Text;
-
-    /// <summary>
-    /// Parent session's session directory snapshot when the subagent was spawned.
-    /// </summary>
-    public string? ParentSessionDirectory { get; init; }
-
-    /// <summary>
-    /// Parent session's project directory snapshot when the subagent was spawned.
-    /// </summary>
-    public string? ParentProjectDirectory { get; init; }
-
-    /// <summary>Read-only parent recent-file snapshot used for child grounding.</summary>
-    public IReadOnlyList<string> ParentRecentFiles { get; init; } = [];
-
-    /// <summary>Pre-rendered, audience-filtered spawn-boundary working context.</summary>
-    public string? WorkingContextBlock { get; init; }
-
-    /// <summary>
-    /// Snapshot of the parent's <c>ToolExecutionContext.ResolveShellCwd(null)</c>
-    /// at spawn time. Seeds the child's <c>InheritedCwd</c>. Null when the
-    /// parent itself had no resolvable cwd.
-    /// </summary>
-    public string? ParentCwd { get; init; }
-
-    /// <summary>
-    /// Parent session's approval bridge. When provided, the sub-agent can route
-    /// approval requests back to the interactive user instead of auto-denying.
-    /// </summary>
-    public IParentApprovalBridge? ApprovalBridge { get; init; }
-
-    /// <summary>
     /// Optional sink for liveness/progress activity emitted while the sub-agent
     /// runs. Streaming <c>spawn_agent</c> calls provide this so the parent's
     /// per-call watchdog sees a long-but-healthy run as alive. Non-streaming
     /// callers leave it null because no parent stream is observing activity.
     /// </summary>
     public ChannelWriter<ToolActivityUpdate>? ActivitySink { get; init; }
+}
+
+public sealed record ChildRunScope
+{
+    public required SubAgentScopeId ScopeId { get; init; }
+    public required ToolRunScope Authority { get; init; }
+    public required WorkingContext ParentWorkingContext { get; init; }
+    public required WorkingContextSnapshot InitialWorkingSnapshot { get; init; }
 }
 
 // ===== Responses =====
@@ -182,8 +142,10 @@ public sealed record RunSubAgent : ISubAgentCommand
 /// </summary>
 public sealed record SubAgentResult : ISubAgentResponse
 {
+    public required ChildRunCompletion Completion { get; init; }
+
     /// <summary>Whether the subagent completed successfully.</summary>
-    public required bool Success { get; init; }
+    public bool Success => Completion.Success;
 
     /// <summary>The subagent's final text output (or error message on failure).</summary>
     public required string Output { get; init; }
@@ -192,10 +154,10 @@ public sealed record SubAgentResult : ISubAgentResponse
     public required AgentName AgentName { get; init; }
 
     /// <summary>Terminal outcome of the run, separate from the legacy success flag.</summary>
-    public SubAgentRunOutcome Outcome { get; init; } = SubAgentRunOutcome.Completed;
+    public SubAgentRunOutcome Outcome => Completion.Outcome;
 
     /// <summary>Machine-readable reason when <see cref="Outcome"/> is not completed.</summary>
-    public SubAgentOutcomeReason? OutcomeReason { get; init; }
+    public SubAgentOutcomeReason? OutcomeReason => Completion.Reason;
 
     /// <summary>Spawner-generated run id used to correlate logs and notifications.</summary>
     public SubAgentRunId? RunId { get; init; }
@@ -214,6 +176,6 @@ public sealed record SubAgentResult : ISubAgentResponse
     public int FindingsCount { get; init; }
 
     /// <summary>Structured, run-scoped file and Git context returned to the parent.</summary>
-    public SubAgentWorkingContextInfo? WorkingContext { get; init; }
+    public WorkingContextDelta? WorkingContext => Completion.Delta;
 }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -177,7 +177,6 @@ public sealed class SubAgentSpawner
                 RecentFiles = context.RecentFiles,
                 SupportsInteractiveApproval = approvalBridge is not null
             },
-            ParentWorkingContext = parentWorkingContext,
             InitialWorkingSnapshot = initialWorkingSnapshot
         };
 

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -93,11 +93,9 @@ public sealed class SubAgentSpawner
             activitySink?.TryComplete();
             return new SubAgentResult
             {
-                Success = false,
+                Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.SpawnUnavailable),
                 Output = $"Cannot spawn subagent '{profile.Name}': no session context available.",
-                AgentName = new AgentName(profile.Name),
-                Outcome = SubAgentRunOutcome.Failed,
-                OutcomeReason = SubAgentOutcomeReason.SpawnUnavailable
+                AgentName = new AgentName(profile.Name)
             };
         }
 
@@ -108,11 +106,9 @@ public sealed class SubAgentSpawner
             activitySink?.TryComplete();
             return new SubAgentResult
             {
-                Success = false,
+                Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.NoToolsAvailable),
                 Output = $"Cannot spawn subagent '{profile.Name}': no tools are available under the parent audience policy.",
-                AgentName = new AgentName(profile.Name),
-                Outcome = SubAgentRunOutcome.Failed,
-                OutcomeReason = SubAgentOutcomeReason.NoToolsAvailable
+                AgentName = new AgentName(profile.Name)
             };
         }
 
@@ -152,7 +148,38 @@ public sealed class SubAgentSpawner
             ProjectDirectory = context.ProjectDirectory,
             RecentFiles = [.. context.RecentFiles.Take(WorkingContext.MaxRecentFiles)]
         };
-        var initialWorkingSnapshot = _workingContextSnapshots.Create(parentWorkingContext, context.Audience);
+        var initialWorkingSnapshot = await _workingContextSnapshots.CreateAsync(
+            parentWorkingContext,
+            context.Audience,
+            ct).ConfigureAwait(false);
+        // A transport can own an approval channel without being able to service
+        // interactive prompts. Fork only the admitted capability, never bridge
+        // presence by itself.
+        var approvalBridge = context.SupportsInteractiveApproval == true
+            ? context.ApprovalBridge
+            : null;
+        var childScope = new ChildRunScope
+        {
+            ScopeId = scopeId,
+            Authority = new ToolRunScope
+            {
+                Session = new ToolSessionScope.Bound(scopeId.Value, context.SessionDirectory),
+                Audience = context.Audience,
+                InlineOutputBudget = InlineOutputBudget.Default,
+                Boundary = context.Boundary,
+                ChannelType = context.ChannelType,
+                DefaultDeliveryTarget = context.DefaultDeliveryTarget,
+                RequestedDeliveryTarget = context.RequestedDeliveryTarget,
+                ModelInputModalities = context.ModelInputModalities,
+                ApprovalBridge = approvalBridge,
+                ProjectDirectory = context.ProjectDirectory,
+                InheritedCwd = context.ResolveShellCwd(null),
+                RecentFiles = context.RecentFiles,
+                SupportsInteractiveApproval = approvalBridge is not null
+            },
+            ParentWorkingContext = parentWorkingContext,
+            InitialWorkingSnapshot = initialWorkingSnapshot
+        };
 
         // Spawn as child of the session actor via the context factory
         var props = SubAgentActor.CreateProps(
@@ -198,30 +225,13 @@ public sealed class SubAgentSpawner
             var result = await subAgent.Ask<SubAgentResult>(
                 new RunSubAgent
                 {
+                    Scope = childScope,
                     Task = task,
                     RuntimeContext = runtimeContext,
                     Timeout = subAgentTimeout,
                     PrefillTimeout = prefillTimeout,
                     NoProgressTimeout = noProgressTimeout,
-                    SessionScopeId = subAgentScopeId,
-                    Audience = context.Audience,
-                    Boundary = context.Boundary,
-                    ChannelType = context.ChannelType,
-                    DefaultDeliveryTarget = context.DefaultDeliveryTarget,
-                    RequestedDeliveryTarget = context.RequestedDeliveryTarget,
-                    ModelInputModalities = context.ModelInputModalities,
-                    ParentSessionDirectory = context.SessionDirectory,
-                    ParentProjectDirectory = context.ProjectDirectory,
-                    ParentRecentFiles = context.RecentFiles,
-                    WorkingContextBlock = initialWorkingSnapshot.ToContextBlock(),
-                    ParentCwd = context.ResolveShellCwd(null),
                     Cancellation = ct,
-                    // A session owns an approval channel even when its transport cannot
-                    // service prompts. Preserve the channel capability as the authority:
-                    // bridge presence alone must never make an unattended child interactive.
-                    ApprovalBridge = context.SupportsInteractiveApproval == true
-                        ? context.ApprovalBridge
-                        : null,
                     // Null for non-streaming callers such as routed skills and the
                     // legacy ExecuteAsync path; the sub-agent surfaces its progress
                     // through its own session-correlated logs regardless. Streaming
@@ -244,7 +254,11 @@ public sealed class SubAgentSpawner
 
             sw.Stop();
 
-            result = EnrichWorkingContextResult(result, initialWorkingSnapshot, context.Audience);
+            result = await EnrichWorkingContextResultAsync(
+                result,
+                initialWorkingSnapshot,
+                context.Audience,
+                ct).ConfigureAwait(false);
 
             context.Outputs.ReportSubAgentActivity(new SubAgentNotificationInfo
             {
@@ -287,11 +301,9 @@ public sealed class SubAgentSpawner
             SubAgentSpawnBreadcrumbs.RunFailed(_logger, context, profile.Name, runId, ex);
             return new SubAgentResult
             {
-                Success = false,
+                Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.SpawnError),
                 Output = $"Subagent error: {ex.Message}",
                 AgentName = new AgentName(profile.Name),
-                Outcome = SubAgentRunOutcome.Failed,
-                OutcomeReason = SubAgentOutcomeReason.SpawnError,
                 RunId = runId,
                 ScopeId = scopeId
             };
@@ -303,10 +315,11 @@ public sealed class SubAgentSpawner
         }
     }
 
-    private SubAgentResult EnrichWorkingContextResult(
+    private async Task<SubAgentResult> EnrichWorkingContextResultAsync(
         SubAgentResult result,
         WorkingContextSnapshot initialSnapshot,
-        TrustAudience audience)
+        TrustAudience audience,
+        CancellationToken cancellationToken)
     {
         if (!result.Success || result.WorkingContext is not { } childContext)
             return result;
@@ -319,7 +332,10 @@ public sealed class SubAgentSpawner
                 .Distinct(FilePathComparer)
                 .Take(WorkingContext.MaxRecentFiles)]
         };
-        var finalSnapshot = _workingContextSnapshots.Create(finalContext, audience);
+        var finalSnapshot = await _workingContextSnapshots.CreateAsync(
+            finalContext,
+            audience,
+            cancellationToken).ConfigureAwait(false);
         var initialChanged = CanonicalChangedFiles(initialSnapshot.Git);
         var observed = CanonicalChangedFiles(finalSnapshot.Git)
             .Except(initialChanged, FilePathComparer)
@@ -327,26 +343,36 @@ public sealed class SubAgentSpawner
             .Order(FilePathComparer)
             .ToArray();
 
+        var delta = childContext with
+        {
+            Worktree = AvailableSnapshot(finalSnapshot.Git)?.Worktree,
+            Branch = AvailableSnapshot(finalSnapshot.Git)?.Branch,
+            Head = AvailableSnapshot(finalSnapshot.Git)?.Head,
+            ObservedChangedFiles = observed
+        };
         return result with
         {
-            WorkingContext = childContext with
+            Completion = result.Completion switch
             {
-                Worktree = finalSnapshot.Git?.Worktree,
-                Branch = finalSnapshot.Git?.Branch,
-                Head = finalSnapshot.Git?.Head,
-                ObservedChangedFiles = observed
+                ChildRunCompletion.Completed => new ChildRunCompletion.Completed(delta),
+                ChildRunCompletion.Partial partial => new ChildRunCompletion.Partial(partial.PartialReason, delta),
+                _ => throw new InvalidOperationException("Only successful child runs can carry a working-context delta.")
             }
         };
     }
 
-    private static IEnumerable<string> CanonicalChangedFiles(GitWorkingContextSnapshot? snapshot)
+    private static IEnumerable<string> CanonicalChangedFiles(GitWorkingContextInspection inspection)
     {
+        var snapshot = AvailableSnapshot(inspection);
         if (snapshot is null)
             return [];
 
         return snapshot.ChangedFiles.Select(path =>
             Path.IsPathRooted(path) ? Path.GetFullPath(path) : Path.GetFullPath(path, snapshot.Worktree));
     }
+
+    private static GitWorkingContextSnapshot? AvailableSnapshot(GitWorkingContextInspection inspection)
+        => inspection is GitWorkingContextInspection.Available available ? available.Snapshot : null;
 
     private IReadOnlyList<INetclawTool> ResolveTools(SubAgentProfile profile, ToolInvocationContext context)
     {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -851,6 +851,7 @@ static void ConfigureDaemonServices(
 
     // Current time context layer — transient per-turn grounding for date/time-sensitive prompts
     services.AddSingleton<IContextLayerProvider, CurrentTimeContextLayer>();
+    services.AddSingleton<IGitWorkingContextInspector, GitWorkingContextInspector>();
     services.AddSingleton<IWorkingContextSnapshotProvider, WorkingContextSnapshotProvider>();
 
     // Expose all context layers as IReadOnlyList for actor DI resolution

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -24,8 +24,10 @@ public sealed record FileAttachmentInfo(string FilePath, string FileName, MimeTy
 /// Confirmed changes have first-party tool provenance; observed changes are
 /// derived from shared worktree state and do not imply authorship.
 /// </summary>
-public sealed record SubAgentWorkingContextInfo
+public sealed record WorkingContextDelta
 {
+    public static WorkingContextDelta Empty { get; } = new();
+
     public string? ProjectDirectory { get; init; }
     public string? Worktree { get; init; }
     public string? Branch { get; init; }
@@ -33,6 +35,52 @@ public sealed record SubAgentWorkingContextInfo
     public IReadOnlyList<string> ReadFiles { get; init; } = [];
     public IReadOnlyList<string> ConfirmedChangedFiles { get; init; } = [];
     public IReadOnlyList<string> ObservedChangedFiles { get; init; } = [];
+}
+
+public abstract record ChildRunCompletion
+{
+    private ChildRunCompletion()
+    {
+    }
+
+    public abstract bool Success { get; }
+    public abstract SubAgentRunOutcome Outcome { get; }
+    public abstract SubAgentOutcomeReason? Reason { get; }
+    public abstract WorkingContextDelta? Delta { get; }
+
+    public sealed record Completed(WorkingContextDelta WorkingContext) : ChildRunCompletion
+    {
+        public override bool Success => true;
+        public override SubAgentRunOutcome Outcome => SubAgentRunOutcome.Completed;
+        public override SubAgentOutcomeReason? Reason => null;
+        public override WorkingContextDelta Delta => WorkingContext;
+    }
+
+    public sealed record Partial(
+        SubAgentOutcomeReason PartialReason,
+        WorkingContextDelta WorkingContext) : ChildRunCompletion
+    {
+        public override bool Success => true;
+        public override SubAgentRunOutcome Outcome => SubAgentRunOutcome.Partial;
+        public override SubAgentOutcomeReason? Reason => PartialReason;
+        public override WorkingContextDelta Delta => WorkingContext;
+    }
+
+    public sealed record Failed(SubAgentOutcomeReason FailureReason) : ChildRunCompletion
+    {
+        public override bool Success => false;
+        public override SubAgentRunOutcome Outcome => SubAgentRunOutcome.Failed;
+        public override SubAgentOutcomeReason? Reason => FailureReason;
+        public override WorkingContextDelta? Delta => null;
+    }
+
+    public sealed record Cancelled(SubAgentOutcomeReason CancellationReason) : ChildRunCompletion
+    {
+        public override bool Success => false;
+        public override SubAgentRunOutcome Outcome => SubAgentRunOutcome.Failed;
+        public override SubAgentOutcomeReason? Reason => CancellationReason;
+        public override WorkingContextDelta? Delta => null;
+    }
 }
 
 /// <summary>
@@ -51,7 +99,7 @@ public sealed record SubAgentNotificationInfo
     public SubAgentOutcomeReason? OutcomeReason { get; init; }
     public TimeSpan Duration { get; init; }
     public IReadOnlyList<SubAgentFinding> Findings { get; init; } = [];
-    public SubAgentWorkingContextInfo? WorkingContext { get; init; }
+    public WorkingContextDelta? WorkingContext { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -48,6 +48,22 @@ public abstract record ChildRunCompletion
     public abstract SubAgentOutcomeReason? Reason { get; }
     public abstract WorkingContextDelta? Delta { get; }
 
+    public static ChildRunCompletion FromReportedOutcome(
+        SubAgentRunOutcome outcome,
+        SubAgentOutcomeReason? reason,
+        WorkingContextDelta? delta) => outcome switch
+        {
+            SubAgentRunOutcome.Completed when delta is not null => new Completed(delta),
+            SubAgentRunOutcome.Partial when delta is not null && reason is { } partialReason =>
+                new Partial(partialReason, delta),
+            SubAgentRunOutcome.Failed when reason == SubAgentOutcomeReason.CancelledByParent =>
+                new Cancelled(reason.Value),
+            SubAgentRunOutcome.Failed when reason is { } failureReason => new Failed(failureReason),
+            _ => throw new ArgumentException(
+                $"Invalid child completion: outcome={outcome}, reason={reason?.Value ?? "none"}, hasDelta={delta is not null}.",
+                nameof(outcome))
+        };
+
     public sealed record Completed(WorkingContextDelta WorkingContext) : ChildRunCompletion
     {
         public override bool Success => true;

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -60,7 +60,7 @@ public abstract record ChildRunCompletion
                 new Cancelled(reason.Value),
             SubAgentRunOutcome.Failed when reason is { } failureReason => new Failed(failureReason),
             _ => throw new ArgumentException(
-                $"Invalid child completion: outcome={outcome}, reason={reason?.Value ?? "none"}, hasDelta={delta is not null}.",
+                $"Invalid child completion: outcome={outcome}, reason={(reason is { } value ? value.Value : "none")}, hasDelta={delta is not null}.",
                 nameof(outcome))
         };
 


### PR DESCRIPTION
## Summary

- fork immutable parent authority and working context into a required `ChildRunScope`, with independent child activity state
- model child termination as typed completion variants so failed and cancelled runs cannot carry mergeable context
- make Git working-context inspection asynchronous, injectable, aggregate-bounded, and explicitly classified
- correlate actor continuations by generation and preserve turn-scoped prompt state across the async boundary
- merge only child-confirmed file changes; keep Git-observed worktree changes non-attributed
- update SPEC-002, OpenSpec tasks, and the versioned operations/projects skills

## Behavior contract

This is a behavior-preserving architecture refactor. MCP schemas and persisted actor contracts are unchanged. Public turns still never inspect Git. Git failure remains non-fatal and visibly unavailable. Successful/partial children retain confirmed-file handoff; failed/cancelled children cannot update parent context.

## Validation

- `dotnet test Netclaw.slnx --no-restore` — all runnable tests pass (Actors 2613, Daemon 827, CLI 1252, plus supporting projects; environment-gated integration tests skipped)
- focused session/subagent/Git suite — 115 passed
- `dotnet slopwatch analyze` — 0 issues
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — pass
- `openspec validate simplify-tool-execution-context --strict` — valid
- `git diff --check` — pass

The behavioral eval harness cannot run locally because no eval provider type, endpoint, or model credentials are configured. The dotnet-skills CRAP collector workflow is unavailable because this repository does not include the XPlat coverage collector; the full actor assembly passes.

Advances #1633. The issue will be closed after merge and post-merge acceptance verification.
