### PR TITLE
fix: add TSV (text/tab-separated-values) support to content scanner

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -700,6 +700,7 @@ public class WebFetchToolTests : IDisposable
     [InlineData("application/pdf", true, ".pdf")]
     [InlineData("application/json", false, ".json")]
     [InlineData("text/csv", false, ".csv")]
+    [InlineData("text/tab-separated-values", false, ".tsv")]
     [InlineData("image/png", true, ".png")]
     [InlineData("text/plain", false, ".txt")]
     public void GetFallbackExtension_returns_correct_extension(string contentType, bool isBinary, string expected)

--- a/src/Netclaw.Media/MimeTypeCatalog.cs
+++ b/src/Netclaw.Media/MimeTypeCatalog.cs
@@ -13,6 +13,7 @@ public static class MimeTypeCatalog
     public const string TextPlain = "text/plain";
     public const string TextMarkdown = "text/markdown";
     public const string TextCsv = "text/csv";
+    public const string TextTsv = "text/tab-separated-values";
     public const string TextHtml = "text/html";
     public const string ApplicationJson = "application/json";
     public const string ApplicationXml = "application/xml";
@@ -222,6 +223,7 @@ public static class MimeTypeCatalog
         Text(TextPlain, ".txt", ".txt", ".log"),
         Text(TextMarkdown, ".md", ".md", ".markdown"),
         Text(TextCsv, ".csv", ".csv"),
+        Text(TextTsv, ".tsv", ".tsv"),
         Text(TextHtml, ".html", ".html", ".htm"),
         Text(ApplicationJson, ".json", ".json"),
         Text(ApplicationXml, ".xml", ".xml"),
@@ -281,6 +283,7 @@ public static class MimeTypeCatalog
         [(".yaml", TextPlain)] = ApplicationYaml,
         [(".yml", TextPlain)] = ApplicationYaml,
         [(".csv", TextPlain)] = TextCsv,
+        [(".tsv", TextPlain)] = TextTsv,
         [(".xml", TextPlain)] = ApplicationXml,
         [(".html", TextPlain)] = TextHtml,
         [(".htm", TextPlain)] = TextHtml

--- a/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
+++ b/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="MagicByteValidatorTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -143,6 +143,7 @@ public sealed class MagicByteValidatorTests
     [InlineData(nameof(PlainTextBytes), "text/plain", "notes.txt")]
     [InlineData(nameof(PlainTextBytes), "text/markdown", "readme.md")]
     [InlineData(nameof(PlainTextBytes), "text/csv", "data.csv")]
+    [InlineData(nameof(PlainTextBytes), "text/tab-separated-values", "data.tsv")]
     public void Validate_TextContentWithMatchingMime_Allowed(string headerField, string mime, string filename)
     {
         var header = ResolveHeader(headerField);
@@ -189,6 +190,7 @@ public sealed class MagicByteValidatorTests
     [InlineData("config.yaml")]
     [InlineData("config.yml")]
     [InlineData("data.csv")]
+    [InlineData("data.tsv")]
     [InlineData("doc.xml")]
     public void Validate_StructuredTextDeclaredAsTextPlain_NormalizesAndAllows(string filename)
     {

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="MagicByteValidator.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -255,6 +255,7 @@ public static class MagicByteValidator
         ["text/plain"] = AnyContent,
         ["text/markdown"] = AnyContent,
         ["text/csv"] = AnyContent,
+        ["text/tab-separated-values"] = AnyContent,
         ["text/html"] = AnyContent,
         ["application/json"] = AnyContent,
         ["application/xml"] = AnyContent,


### PR DESCRIPTION
Closes #1632.

The content scanner rejected TSV files with MIME type `text/tab-separated-values` as unsupported. TSV is plain tab-delimited text — identical in structure to CSV — so it uses the same `AnyContent` byte-signature matcher.

**Changes:**
- **MimeTypeCatalog:** Added `TextTsv` constant, definition entry, and extension-to-MIME normalization override (.`tsv` declared as `text/plain` → normalized to `text/tab-separated-values`)
- **MagicByteValidator:** Registered `text/tab-separated-values` in the signature matcher dictionary
- **ContentPolicy:** TSV is automatically included in `DefaultAllowedMimeTypes` since it derives from the catalog
- **Tests:** Added coverage for scanner acceptance, MIME normalization, and WebFetch fallback extension

All 97 security tests and 6 WebFetch tests pass.