### PR TITLE
fix(ci): reuse published MCP server in screenshot job

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -204,9 +204,10 @@ jobs:
 
       - name: Mark binaries executable
         run: |
-          chmod +x publish/cli/netclaw publish/daemon/netclawd
+          chmod +x publish/cli/netclaw publish/daemon/netclawd publish/mcp-server/Netclaw.SmokeMcpServer
           echo "NETCLAW_SMOKE_CLI=$(pwd)/publish/cli/netclaw" >> "$GITHUB_ENV"
           echo "NETCLAW_SMOKE_DAEMON=$(pwd)/publish/daemon/netclawd" >> "$GITHUB_ENV"
+          echo "NETCLAW_SMOKE_MCP_SERVER=$(pwd)/publish/mcp-server/Netclaw.SmokeMcpServer" >> "$GITHUB_ENV"
 
       - name: Run screenshot regression
         shell: bash


### PR DESCRIPTION
## Failure

Dependabot PR #1648 pins .NET SDK 10.0.302. The screenshot job downloads the already-published CLI, daemon, and smoke MCP server, but only exports the CLI and daemon paths. `run-smoke.sh` therefore attempts to publish the MCP server again on an SDK-less job and fails before VHS starts.

## Fix

Mark the downloaded smoke MCP server executable and export `NETCLAW_SMOKE_MCP_SERVER`, matching the native smoke jobs and preserving the SDK-less screenshot-job contract.

## Evidence

The failed artifact reports `A compatible .NET SDK was not found` while running `dotnet publish tests/Netclaw.SmokeMcpServer`. The publish artifact already contains `publish/mcp-server/Netclaw.SmokeMcpServer`.