### PR TITLE
fix(reminders): rescan definitions before startup alerts

### DIFF
--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -105,6 +105,10 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             return;
         }
 
+        // The store can be constructed before all persisted files are present.
+        // Rescan at the actor's startup boundary so schema alerts reflect the
+        // authoritative on-disk state rather than constructor timing.
+        _definitionStore.List();
         EmitDroppedInvalidDefinitionAlerts();
         EmitRejectedLegacyDefinitionAlerts();
 


### PR DESCRIPTION
## Failure

`Startup_emits_alert_for_legacy_reminder_missing_trust_fields` intermittently observed an empty notification sink even after the actor answered its readiness query. The mailbox barrier proves `PreStart` completed, so this is not an assertion-delay problem: startup relied on a schema scan performed earlier by the store constructor and then consumed a one-shot rejection list.

## Fix

Rescan reminder definitions at the actor startup boundary, immediately before consuming and emitting schema alerts. This uses the existing `ReminderDefinitionStore.List()` path, which records legacy trust-field rejections and de-duplicates them by reminder ID.

## Validation

- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --filter FullyQualifiedName~Startup_emits_alert --no-restore`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`