### PR TITLE
fix(providers): support OpenAI client 2.12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <DiscordNetVersion>3.20.1</DiscordNetVersion>
     <MattermostNetVersion>5.0.3</MattermostNetVersion>
     <MicrosoftExtensionsAIVersion>10.6.0</MicrosoftExtensionsAIVersion>
+    <OpenAIVersion>2.12.0</OpenAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.9</MicrosoftAspNetCoreVersion>
     <SkiaSharpVersion>4.148.0</SkiaSharpVersion>
     <!-- Aspire pins are exercised only by samples/Netclaw.Demo.AppHost and its
@@ -52,6 +53,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="$(MicrosoftExtensionsAIVersion)" />
+    <PackageVersion Include="OpenAI" Version="$(OpenAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftAspNetCoreVersion)" />

--- a/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiProviderPlugin.cs
@@ -44,7 +44,7 @@ public sealed class OpenAiProviderPlugin : ProviderPluginBase<OpenAiDescriptor>
             }
             var oauth = Descriptor.Auth.GetOAuthConfig()
                         ?? throw new InvalidOperationException("OpenAI OAuth configuration is unavailable.");
-            var options = new OpenAIClientOptions
+            var options = new OpenAI.Responses.ResponsesClientOptions
             {
                 Endpoint = new Uri("https://chatgpt.com/backend-api/codex")
             };


### PR DESCRIPTION
## Failure

Dependabot PR #1650 upgrades Microsoft.Extensions.AI to 10.8.0, which brings OpenAI 2.12.0. OpenAI 2.12 changes the `ResponsesClient` credential constructor from `OpenAIClientOptions` to `ResponsesClientOptions`, causing CS1503 in every publish/build leg.

## Fix

Centrally pin the transitive OpenAI client to 2.12.0 and migrate the OAuth Responses client to the response-specific options type. Pinning the transitive dependency makes this API migration buildable and testable on current `dev` before the Microsoft.Extensions.AI update lands.

## Validation

- `dotnet build Netclaw.slnx -c Release --no-incremental`
- `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj -c Release --no-build --filter FullyQualifiedName~ChatClientFactoryTests`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`

The remaining NU1109 in #1650 is the independent 10.0.10 platform floor supplied by Dependabot PR #1649.