### PR TITLE
fix(smoke): time out the full VHS process group

### DIFF
--- a/scripts/smoke/run-native-tape.sh
+++ b/scripts/smoke/run-native-tape.sh
@@ -142,10 +142,13 @@ echo "    NETCLAW_BIN_DIR=${NETCLAW_BIN_DIR}"
 echo "    NETCLAW_HOME=${NETCLAW_HOME}"
 
 vhs_status=0
+# Do not use --foreground here. VHS supervises ttyd and browser children;
+# foreground mode explicitly excludes child processes from the timeout.
+# A separate process group plus a TERM-to-KILL deadline bounds the whole tree.
 if command -v timeout >/dev/null 2>&1; then
-  timeout --foreground "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
+  timeout --kill-after=10s "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
 elif command -v gtimeout >/dev/null 2>&1; then
-  gtimeout --foreground "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
+  gtimeout --kill-after=10s "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
 else
   echo "ERROR: no timeout tool (timeout/gtimeout) found; refusing to run vhs unbounded." >&2
   exit 1


### PR DESCRIPTION
## Failure

The macOS native-smoke job on Dependabot PR #1649 hung while starting `config-workspaces-picker`: VHS printed only the tape filename, executed no tape commands, ignored the nominal 600-second limit, and consumed the full 45-minute job budget.

## Root cause

`run-native-tape.sh` invokes GNU timeout with `--foreground`. GNU documents that foreground mode does not time out child processes. VHS supervises ttyd/browser children, so a stuck child can survive the deadline and keep the harness blocked.

## Fix

Run VHS in timeout’s separate process group and add `--kill-after=10s`. The full VHS child tree now receives the timeout signal, with a bounded escalation to SIGKILL, allowing the existing failure-artifact path to run deterministically.

## Validation

- `bash -n scripts/smoke/run-native-tape.sh`
- `git diff --check upstream/dev...HEAD`

The PR smoke workflow supplies the required Linux and macOS native-tape validation.