### PR TITLE
test: serialize legacy model environment overrides

### DIFF
--- a/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ChatClientDoctorCheckTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Netclaw.Cli.Tests.Doctor;
 
+[Collection(Netclaw.Cli.Tests.LegacyModelEnvironmentCollection.Name)]
 public sealed class ChatClientDoctorCheckTests
 {
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Netclaw.Cli.Tests.Doctor;
 
+[Collection(Netclaw.Cli.Tests.LegacyModelEnvironmentCollection.Name)]
 public sealed class ConfigSchemaDoctorCheckTests
 {
     [Fact]

--- a/src/Netclaw.Cli.Tests/LegacyModelEnvironmentCollection.cs
+++ b/src/Netclaw.Cli.Tests/LegacyModelEnvironmentCollection.cs
@@ -1,0 +1,14 @@
+// -----------------------------------------------------------------------
+// <copyright file="LegacyModelEnvironmentCollection.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Cli.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class LegacyModelEnvironmentCollection
+{
+    public const string Name = "Legacy model environment";
+}


### PR DESCRIPTION
## Failure

PR #1653 exposed an unrelated Windows-only race: `ModelCommandTests.Set_ClearContextWindow_RemovesStoredClamp` failed because `NETCLAW_Models__Main__ModelId` was temporarily set by a concurrently running doctor test. The model command correctly refuses migration under that legacy override.

## Fix

Put the two test classes that mutate `NETCLAW_Models__Main__ModelId` in an xUnit collection with `DisableParallelization = true`. This serializes the process-wide environment mutation against the entire assembly while preserving parallel execution for tests that do not mutate it.

## Validation

- Full `Netclaw.Cli.Tests`: 1,252 passed
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`