### PR TITLE
fix(tests): make Windows actor checks deterministic

### DIFF
--- a/src/Netclaw.Actors.Tests/Hosting/TestAkkaExtensions.cs
+++ b/src/Netclaw.Actors.Tests/Hosting/TestAkkaExtensions.cs
@@ -33,6 +33,7 @@ internal static class TestAkkaExtensions
                     "Akka.Actor.Identify, Akka" = json
                     "Akka.Actor.ReceiveTimeout, Akka" = json
                     "Akka.Dispatch.SysMsg.StopChild, Akka" = json
+                    "Akka.Hosting.TestKit.TestKit+StableTestProbeRef+UpdateTarget, Akka.Hosting.TestKit" = json
                     "Akka.Persistence.Journal.AsyncWriteJournal+Desequenced, Akka.Persistence" = json
                     "Akka.Persistence.RecoveryPermitGranted, Akka.Persistence" = json
                     "Akka.Persistence.RequestRecoveryPermit, Akka.Persistence" = json

--- a/src/Netclaw.Actors.Tests/Hosting/TestAkkaExtensionsTests.cs
+++ b/src/Netclaw.Actors.Tests/Hosting/TestAkkaExtensionsTests.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestAkkaExtensionsTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Serialization;
+using Netclaw.Actors.Hosting;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Hosting;
+
+public sealed class TestAkkaExtensionsTests : TestKit
+{
+    public TestAkkaExtensionsTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithNetclawSerialization()
+            .WithSerializationVerification();
+    }
+
+    [Fact]
+    public void Test_probe_retarget_message_round_trips_with_strict_serialization()
+    {
+        var messageType = Type.GetType(
+            "Akka.Hosting.TestKit.TestKit+StableTestProbeRef+UpdateTarget, Akka.Hosting.TestKit",
+            throwOnError: true)!;
+        var original = Activator.CreateInstance(messageType, TestActor)!;
+        var serializer = Sys.Serialization.FindSerializerFor(original);
+        var bytes = serializer.ToBinary(original);
+        var manifest = serializer is SerializerWithStringManifest serializerWithManifest
+            ? serializerWithManifest.Manifest(original)
+            : messageType.AssemblyQualifiedName!;
+
+        var roundTripped = Sys.Serialization.Deserialize(bytes, serializer.Identifier, manifest);
+        var target = (IActorRef)messageType.GetProperty("Target")!.GetValue(roundTripped)!;
+
+        Assert.Equal(TestActor, target);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -9,6 +9,7 @@ using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
 using Akka.Reminders;
 using Akka.Reminders.Sharding;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
@@ -24,6 +25,7 @@ namespace Netclaw.Actors.Tests.Reminders;
 public class ReminderManagerActorTests : TestKit
 {
     private readonly string _basePath = Path.Combine(Path.GetTempPath(), $"netclaw-reminder-tests-{Guid.NewGuid():N}");
+    private readonly FakeTimeProvider _timeProvider = new(TimeProvider.System.GetUtcNow());
     private ReminderDefinitionStore _definitionStore = null!;
     private TestNotificationSink _notificationSink = null!;
 
@@ -70,7 +72,7 @@ public class ReminderManagerActorTests : TestKit
                     pipeline,
                     defaults,
                     new SchedulingConfig(),
-                    TimeProvider.System,
+                    _timeProvider,
                     definitionStore,
                     historyStore,
                     _notificationSink,
@@ -912,76 +914,88 @@ public class ReminderManagerActorTests : TestKit
         await manager.Ask<ReminderManagerActor.ReconcileCompleted>(
             ReminderManagerActor.ReconcileReminders.Instance, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        var originalTimeout = ReminderExecutionActor.DeliveryObservedTimeout;
-        ReminderExecutionActor.DeliveryObservedTimeout = TimeSpan.FromMilliseconds(700);
-        try
+        var gatewayProbe = CreateTestProbe("deferred-expiry-gateway");
+        var autoAckRef = Sys.ActorOf(
+            Props.Create(() => new AutoAckTrustedGateway(gatewayProbe.Ref)),
+            "auto-ack-deferred-expiry");
+        ActorRegistry.For(Sys).Register<SlackGatewayActorKey>(autoAckRef);
+
+        // Save before dispatch so filesystem latency cannot consume any test
+        // timing window while execution slots are being filled.
+        for (var i = 0; i < ReminderManagerActor.MaxConcurrentExecutions; i++)
         {
-            var gatewayProbe = CreateTestProbe("deferred-expiry-gateway");
-            var autoAckRef = Sys.ActorOf(
-                Props.Create(() => new AutoAckTrustedGateway(gatewayProbe.Ref)),
-                "auto-ack-deferred-expiry");
-            ActorRegistry.For(Sys).Register<SlackGatewayActorKey>(autoAckRef);
-
-            // Saturate execution slots with CurrentSession reminders waiting for
-            // delivery observation timeout.
-            for (var i = 0; i < ReminderManagerActor.MaxConcurrentExecutions; i++)
-            {
-                var id = $"blocking-{i}";
-                _definitionStore.Save(CreateCurrentSessionDefinition(id, deliveryRequired: true));
-                manager.Tell(CreateEnvelope(id));
-            }
-
-            var now = TimeProvider.System.GetUtcNow();
-            var expiringId = "queued-expiring";
-            var expiringReminder = new ReminderDefinition
-            {
-                Id = new ReminderId(expiringId),
-                Title = "Queued expiring reminder",
-                Instructions = "Should not execute after expiry",
-                Delivery = new ReminderDelivery { Kind = DeliveryKind.None },
-                Schedule = new ReminderSchedule
-                {
-                    Type = ReminderScheduleType.Interval,
-                    Interval = TimeSpan.FromMinutes(30),
-                    FireAt = now.AddMinutes(30)
-                },
-                ExpiresAt = now.AddMilliseconds(200),
-                Audience = TrustAudience.Team,
-                Boundary = TrustBoundary.Team,
-                Enabled = true,
-                CreatedBy = "test",
-                CreatedAt = now,
-                UpdatedAt = now
-            };
-            _definitionStore.Save(expiringReminder);
-
-            manager.Tell(CreateEnvelope(expiringId));
-
-            await AwaitAssertAsync(async () =>
-            {
-                var health = await manager.Ask<ReminderHealthResponse>(
-                    GetReminderHealthQuery.Instance,
-                    TimeSpan.FromSeconds(3),
-                    TestContext.Current.CancellationToken);
-
-                Assert.Equal(ReminderManagerActor.MaxConcurrentExecutions, health.ActiveExecutions);
-            }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
-
-            await AwaitAssertAsync(async () =>
-            {
-                var stored = _definitionStore.Get(new ReminderId(expiringId));
-                Assert.NotNull(stored);
-                Assert.False(stored!.Enabled);
-            }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
-
-            Assert.DoesNotContain(_notificationSink.Alerts, alert =>
-                alert.Category == AlertType.ReminderExecutionFailed
-                && alert.Source == expiringId);
+            var id = $"blocking-{i}";
+            _definitionStore.Save(CreateCurrentSessionDefinition(id, deliveryRequired: true));
         }
-        finally
+
+        for (var i = 0; i < ReminderManagerActor.MaxConcurrentExecutions; i++)
+            manager.Tell(CreateEnvelope($"blocking-{i}"));
+
+        var blockers = new List<DeliverTrustedSessionTurn>();
+        for (var i = 0; i < ReminderManagerActor.MaxConcurrentExecutions; i++)
         {
-            ReminderExecutionActor.DeliveryObservedTimeout = originalTimeout;
+            var delivered = await gatewayProbe.ExpectMsgAsync<DeliverTrustedSessionTurn>(
+                TimeSpan.FromSeconds(5),
+                cancellationToken: TestContext.Current.CancellationToken);
+            Assert.NotNull(delivered.Source.ReminderId);
+            Assert.NotNull(delivered.Source.DeliveryObserver);
+            blockers.Add(delivered);
         }
+
+        var now = _timeProvider.GetUtcNow();
+        var expiringId = "queued-expiring";
+        var expiringReminder = new ReminderDefinition
+        {
+            Id = new ReminderId(expiringId),
+            Title = "Queued expiring reminder",
+            Instructions = "Should not execute after expiry",
+            Delivery = new ReminderDelivery { Kind = DeliveryKind.None },
+            Schedule = new ReminderSchedule
+            {
+                Type = ReminderScheduleType.Interval,
+                Interval = TimeSpan.FromMinutes(30),
+                FireAt = now.AddMinutes(30)
+            },
+            ExpiresAt = now.AddMinutes(1),
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            Enabled = true,
+            CreatedBy = "test",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _definitionStore.Save(expiringReminder);
+
+        // The query comes from the same sender as the fire, so its reply is a
+        // mailbox-order barrier proving the fire was handled while all three
+        // blockers were still active.
+        var controlProbe = CreateTestProbe("deferred-expiry-control");
+        controlProbe.Send(manager, CreateEnvelope(expiringId));
+        controlProbe.Send(manager, GetReminderHealthQuery.Instance);
+        var health = await controlProbe.ExpectMsgAsync<ReminderHealthResponse>(
+            TimeSpan.FromSeconds(5),
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(ReminderManagerActor.MaxConcurrentExecutions, health.ActiveExecutions);
+
+        _timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var blocker = blockers[0];
+        blocker.Source.DeliveryObserver!.Tell(new ReminderDeliveryResult(
+            blocker.Source.ReminderId!.Value,
+            ChannelType.Slack,
+            Delivered: true,
+            ObservedAtMs: _timeProvider.GetUtcNow().ToUnixTimeMilliseconds()));
+
+        await AwaitAssertAsync(() =>
+        {
+            var stored = _definitionStore.Get(new ReminderId(expiringId));
+            Assert.NotNull(stored);
+            Assert.False(stored!.Enabled);
+        }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(_notificationSink.Alerts, alert =>
+            alert.Category == AlertType.ReminderExecutionFailed
+            && alert.Source == expiringId);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Windows validation on PR #1659 failed in two unrelated actor-test races:

- Akka.Hosting.TestKit recovered a test actor lost during host startup, but strict message serialization rejected its internal probe-retarget message.
- The deferred reminder expiry test used a 700 ms global backstop and 200 ms wall-clock expiry without proving all execution slots were occupied. On Windows, one blocker completed early and the reminder under test started instead of being queued.

## Fix

- Bind the narrow Akka.Hosting.TestKit StableTestProbeRef.UpdateTarget control message and add a strict-serialization round-trip regression.
- Replace the reminder test's real-time orchestration with FakeTimeProvider, three observed gateway deliveries as the saturation barrier, same-sender mailbox ordering, and an explicit delivery result to release one slot.
- Keep production and CI timeout thresholds unchanged. Do not bind Akka Streams internal stage messages.

## Validation

- Focused regressions: 2/2 pass
- Affected classes: 62/62 pass
- Focused stress: 20 consecutive runs, all pass
- Full Netclaw.Actors.Tests: 2,627/2,627 pass
- Slopwatch: 0 issues
- Copyright headers: pass
- Diff check: pass
