### PR TITLE
fix(cli): report unresolved model references cleanly

### DIFF
--- a/docs/spec/SPEC-004-cli-contract.md
+++ b/docs/spec/SPEC-004-cli-contract.md
@@ -100,8 +100,9 @@ Behavior:
 - optional output: JSON for automation
 - exit code `0` for success
 - exit code `1` for validation, policy, or runtime failures
-- expected model-configuration migration failures are validation failures: print actionable
-  output, return exit code `1`, and do not create crash logs or emit stack traces
+- expected model-configuration failures, including migration and named-role resolution errors,
+  are validation failures: print actionable output, return exit code `1`, and do not create crash
+  logs or emit stack traces
 - exit code `2` for usage and argument errors
 
 ## Safety Rules

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.32.0"
+  version: "2.33.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/providers.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/providers.md
@@ -35,18 +35,22 @@ options instead of adding provider-specific properties to `ProviderEntry`.
 
 ### Degraded mode: No-Op chat client
 
-When Netclaw starts without an explicitly configured main model/provider
-(no `Models.Roles.Main`, an unresolved definition, no `Providers`, or the selected definition
-points to a provider that is not configured), the daemon launches in
-**degraded mode** with a No-Op chat client. Bound defaults such as
-`local-ollama/qwen3:30b` do not count as operator configuration unless those
-fields are actually present in config. Every chat turn returns a fixed
-configuration banner beginning with `"No valid model configuration detected."`
-and listing recovery steps. If no provider is configured, send the operator
-through `netclaw init`; it configures both a provider and main model. If a
-provider already exists but the main model is missing or points to the wrong
-provider name, use `netclaw model`. Manual repair means editing `netclaw.json`
-/ `secrets.json` and restarting the daemon.
+When Netclaw starts without an explicitly configured main model/provider (no
+`Models` configuration, no `Providers`, or the selected definition points to a
+provider that is not configured), the daemon launches in **degraded mode** with
+a No-Op chat client. Bound defaults such as `local-ollama/qwen3:30b` do not
+count as operator configuration unless those fields are actually present in
+config. Every chat turn returns a fixed configuration banner beginning with
+`"No valid model configuration detected."` and listing recovery steps. If no
+provider is configured, send the operator through `netclaw init`; it configures
+both a provider and main model. If a provider already exists but the main model
+is missing or points to the wrong provider name, use `netclaw model`. Manual
+repair means editing `netclaw.json` / `secrets.json` and restarting the daemon.
+
+A role that names a definition absent from `Models.Definitions` is malformed
+configuration, not degraded mode. `netclaw model list` and `netclaw doctor`
+report the exact role and missing definition. Repair the role manually or use
+`netclaw model set`; `netclaw doctor --fix` does not guess a replacement.
 
 If the operator reports seeing that banner, do not troubleshoot model behavior;
 the daemon has no working provider. Direct them through the recovery steps and
@@ -103,9 +107,10 @@ definition, including adding a property the definition deliberately omits.
 To change a preserved value you must pass the corresponding flag (a plain
 re-set will not touch it). A legacy or hand-edited entry with an unreadable
 value does not block a re-set — `model set` migrates legacy inline roles to named
-definitions and repairs the selected entry while keeping the fields
-it can still read; `model list` reports an unparseable config instead of
-crashing, and `netclaw doctor --fix` repairs it.
+definitions and repairs the selected entry while keeping the fields it can
+still read. `model list` reports an unparseable config instead of crashing.
+`netclaw doctor --fix` applies only repairs it can derive safely; it does not
+invent missing named definitions or role assignments.
 
 ### Adding GitHub Copilot
 

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -53,6 +53,38 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
     }
 
     [Fact]
+    public async Task MissingNamedDefinition_ReturnsActionableError()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new
+            {
+                Definitions = new Dictionary<string, object>
+                {
+                    ["known"] = new
+                    {
+                        Provider = "my-ollama",
+                        ModelId = "qwen3:30b"
+                    }
+                },
+                Roles = new
+                {
+                    Main = "missing"
+                }
+            }
+        });
+        var check = CreateCheck(CreateOfflineDaemonApi());
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Models:Roles:Main references unknown definition 'missing'.", result.Message);
+        Assert.Contains("Fix the Models configuration", result.Remediation);
+        Assert.DoesNotContain("doctor --fix", result.Remediation);
+    }
+
+    [Fact]
     public async Task MainModelWithoutProvider_ReturnsUnavailableWithoutDefaultProvider()
     {
         WriteConfig(new

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -596,6 +596,39 @@ public sealed class ModelCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task List_MissingNamedDefinition_SurfacesResolverErrorWithoutAutofixGuidance()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Definitions"] = new Dictionary<string, object>
+                {
+                    ["known"] = new Dictionary<string, object>
+                    {
+                        ["Provider"] = "my-ollama",
+                        ["ModelId"] = "qwen3:30b"
+                    }
+                },
+                ["Roles"] = new Dictionary<string, object>
+                {
+                    ["Main"] = "missing"
+                }
+            }
+        });
+
+        var exitCode = await ModelCommand.RunAsync(["model", "list"], _paths, output: _output);
+
+        var output = _output.ToString();
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Models:Roles:Main references unknown definition 'missing'.", output);
+        Assert.Contains("Fix the Models section", output);
+        Assert.DoesNotContain("could not be parsed", output);
+        Assert.DoesNotContain("doctor --fix", output);
+    }
+
+    [Fact]
     public async Task Set_CorruptModalityButValidWindow_PreservesWindowEndToEnd()
     {
         // End-to-end regression for the full `model set` path: a re-set over a corrupt entry that

--- a/src/Netclaw.Cli/Config/ModelEntryWriter.cs
+++ b/src/Netclaw.Cli/Config/ModelEntryWriter.cs
@@ -500,8 +500,6 @@ internal static class ModelEntryWriter
     }
 }
 
-internal sealed class ModelConfigurationException(string message) : Exception(message);
-
 /// <summary>
 /// An operator's intent for an overridable, operator-owned model attribute on <c>model set</c> —
 /// a modality set (<see cref="ModelModality"/>) or the context window (<see cref="int"/>). A plain

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -43,7 +43,19 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
         if (root is null)
             return DoctorCheckResult.Pass("Context Window", "No config file to check.");
 
-        var resolvedModels = ModelConfigurationResolver.Resolve(_configuration).Selection;
+        ModelSelection resolvedModels;
+        try
+        {
+            resolvedModels = ModelConfigurationResolver.Resolve(_configuration).Selection;
+        }
+        catch (ModelConfigurationException ex)
+        {
+            return DoctorCheckResult.Error(
+                "Context Window",
+                $"Invalid model configuration: {ex.Message}",
+                "Fix the Models configuration in netclaw.json, then rerun `netclaw doctor`.");
+        }
+
         var main = resolvedModels.Main;
 
         var runtimeValidation = ValidateRuntimeConfiguration(root);

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -47,12 +47,10 @@ internal static class ModelCommand
 
     private static int RunList(NetclawPaths paths, TextWriter writer)
     {
-        if (!TryLoadModelSelection(paths, out var models))
+        if (!TryLoadModelSelection(paths, out var models, out var error))
         {
-            // Config present but unparseable — surface it rather than showing a corrupt config as
-            // "no models configured", which would send the operator down the wrong recovery path.
-            writer.WriteLine("Error: model configuration could not be parsed.");
-            writer.WriteLine("Run `netclaw doctor` to diagnose, or `netclaw doctor --fix` to repair it.");
+            writer.WriteLine($"Error: {error}");
+            writer.WriteLine("Fix the Models section in netclaw.json, then rerun `netclaw model list`.");
             return 1;
         }
 
@@ -507,7 +505,7 @@ internal static class ModelCommand
     /// <see cref="TryLoadModelSelection"/>.
     /// </summary>
     internal static ModelSelection? LoadModelSelection(NetclawPaths paths)
-        => TryLoadModelSelection(paths, out var models) ? models : null;
+        => TryLoadModelSelection(paths, out var models, out _) ? models : null;
 
     /// <summary>
     /// Attempts to load the model selection. Returns false when the config file is present but its
@@ -515,9 +513,13 @@ internal static class ModelCommand
     /// treating it as "no models". Returns true (with null <paramref name="models"/>) when no config
     /// file or Models section exists.
     /// </summary>
-    internal static bool TryLoadModelSelection(NetclawPaths paths, out ModelSelection? models)
+    internal static bool TryLoadModelSelection(
+        NetclawPaths paths,
+        out ModelSelection? models,
+        out string? error)
     {
         models = null;
+        error = null;
         if (!File.Exists(paths.NetclawConfigPath))
             return true;
 
@@ -532,8 +534,14 @@ internal static class ModelCommand
             models = ModelConfigurationResolver.Resolve(configuration).Selection;
             return true;
         }
+        catch (ModelConfigurationException ex)
+        {
+            error = ex.Message;
+            return false;
+        }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
+            error = "model configuration could not be parsed.";
             return false;
         }
     }

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -95,7 +95,7 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
 
     public void Refresh()
     {
-        if (!Model.ModelCommand.TryLoadModelSelection(_paths, out var models))
+        if (!Model.ModelCommand.TryLoadModelSelection(_paths, out var models, out _))
         {
             Models = null;
             StatusMessage.Value = "Model configuration is invalid. Run `netclaw doctor` for details.";

--- a/src/Netclaw.Configuration.Tests/NamedModelConfigurationTests.cs
+++ b/src/Netclaw.Configuration.Tests/NamedModelConfigurationTests.cs
@@ -59,7 +59,7 @@ public sealed class NamedModelConfigurationTests
             ["Models:Roles:Main"] = "vision",
         });
 
-        var exception = Assert.Throws<InvalidOperationException>(
+        var exception = Assert.Throws<ModelConfigurationException>(
             () => ModelConfigurationResolver.Resolve(configuration));
 
         Assert.Contains("mixes legacy", exception.Message);
@@ -75,7 +75,7 @@ public sealed class NamedModelConfigurationTests
             ["Models:Roles:Main"] = "missing",
         });
 
-        var exception = Assert.Throws<InvalidOperationException>(
+        var exception = Assert.Throws<ModelConfigurationException>(
             () => ModelConfigurationResolver.Resolve(configuration));
 
         Assert.Contains("unknown definition 'missing'", exception.Message);

--- a/src/Netclaw.Configuration/NamedModelConfiguration.cs
+++ b/src/Netclaw.Configuration/NamedModelConfiguration.cs
@@ -41,7 +41,7 @@ public static class ModelConfigurationResolver
         var hasNamed = hasDefinitions || hasRoles;
 
         if (hasLegacy && hasNamed)
-            throw new InvalidOperationException(
+            throw new ModelConfigurationException(
                 "Models configuration mixes legacy inline roles with named Definitions/Roles. " +
                 "Run `netclaw doctor --fix` after removing one representation.");
 
@@ -53,7 +53,7 @@ public static class ModelConfigurationResolver
         }
 
         if (!hasDefinitions || !hasRoles)
-            throw new InvalidOperationException(
+            throw new ModelConfigurationException(
                 "Named Models configuration requires both Definitions and Roles sections.");
 
         var duplicateDefinition = modelsSection.GetSection(nameof(NamedModelConfiguration.Definitions))
@@ -62,13 +62,13 @@ public static class ModelConfigurationResolver
             .FirstOrDefault(group => group.Count() > 1);
         if (duplicateDefinition is not null)
         {
-            throw new InvalidOperationException(
+            throw new ModelConfigurationException(
                 $"Models:Definitions contains duplicate case-insensitive name '{duplicateDefinition.Key}'.");
         }
 
         var named = modelsSection.Get<NamedModelConfiguration>() ?? new NamedModelConfiguration();
         if (named.Definitions.Count == 0)
-            throw new InvalidOperationException("Models:Definitions must contain at least one model definition.");
+            throw new ModelConfigurationException("Models:Definitions must contain at least one model definition.");
 
         var selection = new ModelSelection
         {
@@ -87,7 +87,7 @@ public static class ModelConfigurationResolver
         NamedModelConfiguration named, string role, string definitionName)
     {
         if (string.IsNullOrWhiteSpace(definitionName))
-            throw new InvalidOperationException($"Models:Roles:{role} must reference a model definition.");
+            throw new ModelConfigurationException($"Models:Roles:{role} must reference a model definition.");
 
         return ResolveDefinition(named, role, definitionName);
     }
@@ -105,7 +105,7 @@ public static class ModelConfigurationResolver
             string.Equals(pair.Key, definitionName, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(match.Key))
         {
-            throw new InvalidOperationException(
+            throw new ModelConfigurationException(
                 $"Models:Roles:{role} references unknown definition '{definitionName}'.");
         }
 
@@ -124,3 +124,8 @@ public static class ModelConfigurationResolver
 }
 
 public sealed record ModelConfigurationResolution(ModelSelection Selection, bool IsLegacy);
+
+/// <summary>
+/// Represents an invalid operator-authored model configuration that cannot be resolved safely.
+/// </summary>
+public sealed class ModelConfigurationException(string message) : InvalidOperationException(message);

--- a/tests/smoke/scenarios/doctor.sh
+++ b/tests/smoke/scenarios/doctor.sh
@@ -78,5 +78,86 @@ if [[ "$json_status" -eq 1 \
 else
   fail "doctor --fix --format json: migration guard did not return structured validation output"
 fi
+
+log "Testing unresolved named model references fail cleanly..."
+cat >"$config_path" <<'JSON'
+{
+  "configVersion": 1,
+  "Providers": {
+    "local": {
+      "Type": "ollama",
+      "Endpoint": "http://localhost:11434"
+    }
+  },
+  "Models": {
+    "Definitions": {
+      "known": {
+        "Provider": "local",
+        "ModelId": "qwen3:30b"
+      }
+    },
+    "Roles": {
+      "Main": "missing"
+    }
+  }
+}
+JSON
+expected_config="${NETCLAW_HOME}/doctor-unresolved.expected.json"
+cp "$config_path" "$expected_config"
+crash_count_before="$(find "${NETCLAW_HOME}/logs" -maxdepth 1 -name 'crash-*.log' 2>/dev/null | wc -l | tr -d ' ')"
+
+model_status=0
+model_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" model list 2>&1)" || model_status=$?
+echo "$model_output"
+if [[ "$model_status" -eq 1
+      && "$model_output" == *"Models:Roles:Main references unknown definition 'missing'."*
+      && "$model_output" != *"could not be parsed"*
+      && "$model_output" != *"doctor --fix"*
+      && "$model_output" != *"Unhandled exception"*
+      && "$model_output" != *"Fatal error"* ]]; then
+  pass "model list: unresolved role reports the exact reference without autofix guidance"
+else
+  fail "model list: unresolved role was not reported cleanly"
+fi
+
+doctor_status=0
+doctor_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" doctor 2>&1)" || doctor_status=$?
+echo "$doctor_output"
+if [[ "$doctor_status" -eq 1
+      && "$doctor_output" == *"Models:Roles:Main references unknown definition 'missing'."*
+      && "$doctor_output" != *"Unhandled exception"*
+      && "$doctor_output" != *"Fatal error"* ]]; then
+  pass "doctor: unresolved role exits 1 without crashing"
+else
+  fail "doctor: unresolved role did not return a clean validation failure"
+fi
+
+json_status=0
+json_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" doctor --format json 2>&1)" || json_status=$?
+echo "$json_output"
+if [[ "$json_status" -eq 1
+      && "$json_output" == *'"exitCode": 1'*
+      && "$json_output" == *"Models:Roles:Main references unknown definition"*
+      && "$json_output" == *"missing"*
+      && "$json_output" != *"Unhandled exception"*
+      && "$json_output" != *"Fatal error"* ]]; then
+  pass "doctor --format json: unresolved role preserves the JSON error envelope"
+else
+  fail "doctor --format json: unresolved role was not structured cleanly"
+fi
+
+fix_status=0
+fix_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" doctor --fix --yes 2>&1)" || fix_status=$?
+echo "$fix_output"
+crash_count_after="$(find "${NETCLAW_HOME}/logs" -maxdepth 1 -name 'crash-*.log' 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "$fix_status" -eq 1
+      && "$fix_output" == *"Models:Roles:Main references unknown definition 'missing'."*
+      && "$fix_output" != *"Unhandled exception"*
+      && "$fix_output" != *"Fatal error"*
+      && "$crash_count_after" == "$crash_count_before" ]] && cmp -s "$config_path" "$expected_config"; then
+  pass "doctor --fix: unresolved role exits 1 without guessing, crashing, or changing config"
+else
+  fail "doctor --fix: unresolved role handling was unsafe or crashed"
+fi
 summarize
 exit $?


### PR DESCRIPTION
## Summary

- promote the existing model-configuration exception into `Netclaw.Configuration` so resolver and migration failures share one expected error contract
- surface unresolved named-role references from `netclaw model list` with manual repair guidance instead of a generic parse error and incorrect autofix direction
- convert context-window resolution failures into doctor error results so `doctor`, JSON output, and `doctor --fix` exit cleanly instead of aborting
- add unit and native real-binary regression coverage, and synchronize the CLI contract plus `netclaw-operations` guidance

Closes #1676.

## Verification

- `dotnet test src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj --no-restore --filter FullyQualifiedName~NamedModelConfigurationTests`
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --no-restore --filter "FullyQualifiedName~ModelCommandTests|FullyQualifiedName~ContextWindowDoctorCheckTests"`
- `dotnet test Netclaw.slnx --no-restore`
- `./scripts/smoke/run-smoke.sh doctor` — 7 passed, 0 failed
- `dotnet slopwatch analyze` — 0 issues
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `bash -n tests/smoke/scenarios/doctor.sh`
- `git diff --check`

## Environment limitations

- `./evals/run-evals.sh` was attempted, but this environment does not provide `NETCLAW_EVAL_PROVIDER_TYPE`, `NETCLAW_EVAL_PROVIDER_ENDPOINT`, or `NETCLAW_EVAL_MODEL_ID`.
- CRAP reporting was reviewed but cannot run because this repository has no `coverage.runsettings` or ReportGenerator tool configured.
