### PR TITLE
feat(install): automate shell PATH integration

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -184,6 +184,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: "Install shell integration test dependencies"
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes fish zsh
+
       - name: "install.sh smoke test"
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -198,6 +198,11 @@ jobs:
         shell: pwsh
         run: ./scripts/smoke/install-smoke.ps1
 
+      - name: "install.ps1 Windows PowerShell 5.1 smoke test"
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: ./scripts/smoke/install-smoke.ps1
+
   semver-conformance:
     name: SemVer Conformance
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -100,7 +100,13 @@ curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta
 
 # Pin a specific version (e.g. a prerelease)
 NETCLAW_VERSION=0.17.1 curl -sSL https://releases.netclaw.dev/install.sh | bash
+
+# Install without modifying your shell profile
+curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --skip-shell
 ```
+
+By default, the Unix installer updates the detected Bash, zsh, or fish startup
+configuration so new shells include Netclaw on `PATH`.
 
 **macOS** (Apple Silicon — M1 or later — installs CLI + daemon to `~/.netclaw/bin`):
 
@@ -119,8 +125,9 @@ available on macOS ([#1015](https://github.com/netclaw-dev/netclaw/issues/1015))
 iwr -useb https://releases.netclaw.dev/install.ps1 | iex
 ```
 
-The `-Component cli|daemon`, `-Channel beta`, and `-Version` options work the same
-way as their Linux counterparts (download the script and run it with the flag).
+The installer adds Netclaw to your User PATH. The `-Component cli|daemon`,
+`-Channel beta`, `-Version`, and `-SkipShell` options work the same way as their
+Linux counterparts (download the script and run it with the flag).
 
 **Docker** (multi-arch: amd64/arm64):
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,6 +7,7 @@
 #   .\install.ps1 -InstallDir C:\tools\netclaw
 #   .\install.ps1 -Channel beta      # Opt into prereleases
 #   .\install.ps1 -DryRun
+#   .\install.ps1 -SkipShell         # Don't modify PATH
 #
 # -Channel beta installs the newest prerelease (or latest stable if no prerelease
 # exists). -Version pins an exact version and overrides -Channel (e.g. 0.19.0-beta.1).
@@ -24,7 +25,10 @@ param(
     [string]$Channel = "stable",
 
     # Resolve and report what would be installed, but install nothing.
-    [switch]$DryRun
+    [switch]$DryRun,
+
+    # Skip automatic PATH modification.
+    [switch]$SkipShell
 )
 
 $ErrorActionPreference = "Stop"
@@ -256,21 +260,54 @@ try {
         }
     }
 
-    # Check PATH and offer to add if missing
+    # ── Add to PATH ──
     Write-Host ""
-    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-    $pathEntries = $userPath -split ';' | ForEach-Object { $_.TrimEnd('\') }
-    $installDirNormalized = $InstallDir.TrimEnd('\')
 
-    if ($pathEntries -contains $installDirNormalized) {
-        Write-Host "Installation complete! netclaw is already on your PATH."
+    if (-not $SkipShell) {
+        $installDirNormalized = $InstallDir.TrimEnd('\')
+
+        $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        $pathEntries = if ([string]::IsNullOrEmpty($userPath)) { @() } else {
+            $userPath -split ';' | ForEach-Object { $_.TrimEnd('\') }
+        }
+
+        if ($pathEntries -contains $installDirNormalized) {
+            Write-Host "Installation complete! netclaw is already on your PATH."
+        } else {
+            # Check length limit (Windows API caps at 32767)
+            $newPath = "$installDirNormalized;$userPath"
+            if ($newPath.Length -gt 32700) {
+                Write-Warning "PATH is near its 32,767 character limit ($($newPath.Length) chars)."
+                Write-Host "Please manually add $InstallDir to your PATH."
+            } else {
+                [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+                # Also update current session
+                $env:PATH = $newPath
+
+                # Broadcast WM_SETTINGCHANGE to Explorer so new terminal windows pick up the change
+                Add-Type -Namespace WinAPI -Name Func -MemberDefinition @'
+                    [DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Auto)]
+                    public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint msg,
+                        UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+                [WinAPI.Func]::SendMessageTimeout(
+                    [IntPtr]0xFFFF, 0x001A, [UIntPtr]::Zero, "Environment", 2, 1000, [ref][UIntPtr]::Zero
+                ) | Out-Null
+
+                Write-Host "Installation complete! netclaw is on your PATH."
+                Write-Host ""
+                Write-Host "Start a new terminal, or run in the current session:"
+                Write-Host ""
+                Write-Host "  `$env:PATH += ';$InstallDir'"
+            }
+        }
     } else {
-        Write-Host "Installation complete!"
+        Write-Host "Installation complete! (PATH modification skipped)"
         Write-Host ""
         Write-Host "Add Netclaw to your PATH by running:"
         Write-Host ""
         Write-Host "  `$userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')"
-        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$userPath`", 'User')"
+        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"`$InstallDir;`$userPath`", 'User')"
         Write-Host ""
         Write-Host "Then restart your terminal."
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -264,42 +264,69 @@ try {
     Write-Host ""
 
     if (-not $SkipShell) {
-        $installDirNormalized = $InstallDir.TrimEnd('\')
+        $installDirNormalized = [System.IO.Path]::TrimEndingDirectorySeparator($InstallDir)
 
         $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-        $pathEntries = if ([string]::IsNullOrEmpty($userPath)) { @() } else {
-            $userPath -split ';' | ForEach-Object { $_.TrimEnd('\') }
+        $userPathEntries = if ([string]::IsNullOrEmpty($userPath)) { @() } else {
+            $userPath -split ';' |
+                Where-Object { -not [string]::IsNullOrEmpty($_) } |
+                ForEach-Object { [System.IO.Path]::TrimEndingDirectorySeparator($_) }
         }
 
-        if ($pathEntries -contains $installDirNormalized) {
-            Write-Host "Installation complete! netclaw is already on your PATH."
-        } else {
-            # Check length limit (Windows API caps at 32767)
-            $newPath = "$installDirNormalized;$userPath"
-            if ($newPath.Length -gt 32700) {
-                Write-Warning "PATH is near its 32,767 character limit ($($newPath.Length) chars)."
-                Write-Host "Please manually add $InstallDir to your PATH."
+        $userPathChanged = $false
+        if ($userPathEntries -notcontains $installDirNormalized) {
+            $newUserPath = if ([string]::IsNullOrEmpty($userPath)) {
+                $installDirNormalized
             } else {
-                [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
-                # Also update current session
-                $env:PATH = $newPath
+                "$installDirNormalized;$userPath"
+            }
 
-                # Broadcast WM_SETTINGCHANGE to Explorer so new terminal windows pick up the change
-                Add-Type -Namespace WinAPI -Name Func -MemberDefinition @'
+            if ($newUserPath.Length -gt 32700) {
+                Write-Warning "User PATH is near its 32,767 character limit ($($newUserPath.Length) chars)."
+                Write-Host "Please manually add $InstallDir to your User PATH."
+            } else {
+                [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
+                $userPathChanged = $true
+            }
+        }
+
+        $processPath = $env:PATH
+        $processPathEntries = if ([string]::IsNullOrEmpty($processPath)) { @() } else {
+            $processPath -split ';' |
+                Where-Object { -not [string]::IsNullOrEmpty($_) } |
+                ForEach-Object { [System.IO.Path]::TrimEndingDirectorySeparator($_) }
+        }
+        if ($processPathEntries -notcontains $installDirNormalized) {
+            $env:PATH = if ([string]::IsNullOrEmpty($processPath)) {
+                $installDirNormalized
+            } else {
+                "$installDirNormalized;$processPath"
+            }
+        }
+
+        if ($userPathChanged) {
+            if (-not ("NetclawInstaller.NativeMethods" -as [type])) {
+                Add-Type -Namespace NetclawInstaller -Name NativeMethods -MemberDefinition @'
                     [DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Auto)]
                     public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint msg,
                         UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
 '@
-                [WinAPI.Func]::SendMessageTimeout(
-                    [IntPtr]0xFFFF, 0x001A, [UIntPtr]::Zero, "Environment", 2, 1000, [ref][UIntPtr]::Zero
-                ) | Out-Null
-
-                Write-Host "Installation complete! netclaw is on your PATH."
-                Write-Host ""
-                Write-Host "Start a new terminal, or run in the current session:"
-                Write-Host ""
-                Write-Host "  `$env:PATH += ';$InstallDir'"
             }
+
+            $broadcastOutput = [UIntPtr]::Zero
+            $broadcastResult = [NetclawInstaller.NativeMethods]::SendMessageTimeout(
+                [IntPtr]0xFFFF, 0x001A, [UIntPtr]::Zero, "Environment", 2, 1000, [ref]$broadcastOutput)
+            if ($broadcastResult -eq [IntPtr]::Zero) {
+                Write-Warning "User PATH was updated, but Windows did not acknowledge the environment-change notification. New terminals may require sign-out or restart."
+            }
+        }
+
+        if ($userPathEntries -contains $installDirNormalized) {
+            Write-Host "Installation complete! netclaw is already on your User PATH."
+        } elseif ($userPathChanged) {
+            Write-Host "Installation complete! netclaw was added to your User PATH."
+        } else {
+            Write-Host "Installation complete! netclaw is on PATH for this terminal only."
         }
     } else {
         Write-Host "Installation complete! (PATH modification skipped)"
@@ -307,7 +334,7 @@ try {
         Write-Host "Add Netclaw to your PATH by running:"
         Write-Host ""
         Write-Host "  `$userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')"
-        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"`$InstallDir;`$userPath`", 'User')"
+        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$userPath`", 'User')"
         Write-Host ""
         Write-Host "Then restart your terminal."
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -98,6 +98,11 @@ if (-not $InstallDir) {
     $InstallDir = $DefaultInstallDir
 }
 
+$InstallDir = [System.IO.Path]::GetFullPath($InstallDir)
+if ($InstallDir.Contains(';') -or $InstallDir.Contains("`r") -or $InstallDir.Contains("`n")) {
+    throw "InstallDir cannot contain semicolons, carriage returns, or newlines when used on PATH."
+}
+
 Write-Host "Netclaw installer"
 Write-Host "  Platform: win-x64"
 Write-Host "  Install dir: $InstallDir"
@@ -266,28 +271,66 @@ try {
     if (-not $SkipShell) {
         $installDirNormalized = [System.IO.Path]::TrimEndingDirectorySeparator($InstallDir)
 
-        $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-        $userPathEntries = if ([string]::IsNullOrEmpty($userPath)) { @() } else {
-            $userPath -split ';' |
-                Where-Object { -not [string]::IsNullOrEmpty($_) } |
-                ForEach-Object { [System.IO.Path]::TrimEndingDirectorySeparator($_) }
+        # Read the raw registry value so an existing REG_EXPAND_SZ PATH keeps both
+        # its %VAR% references and its registry type when we prepend Netclaw.
+        $userEnvironmentKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+        if ($null -eq $userEnvironmentKey) {
+            throw "Cannot open the current user's Environment registry key for PATH update."
         }
 
-        $userPathChanged = $false
-        if ($userPathEntries -notcontains $installDirNormalized) {
-            $newUserPath = if ([string]::IsNullOrEmpty($userPath)) {
-                $installDirNormalized
+        try {
+            $pathValueExists = $userEnvironmentKey.GetValueNames() -contains "Path"
+            $userPath = if ($pathValueExists) {
+                $userEnvironmentKey.GetValue(
+                    "Path",
+                    $null,
+                    [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
             } else {
-                "$installDirNormalized;$userPath"
+                ""
             }
 
-            if ($newUserPath.Length -gt 32700) {
-                Write-Warning "User PATH is near its 32,767 character limit ($($newUserPath.Length) chars)."
-                Write-Host "Please manually add $InstallDir to your User PATH."
-            } else {
-                [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
-                $userPathChanged = $true
+            if ($null -ne $userPath -and $userPath -isnot [string]) {
+                throw "The current user's PATH registry value is not a string."
             }
+
+            $userPathKind = if ($pathValueExists) {
+                $userEnvironmentKey.GetValueKind("Path")
+            } else {
+                [Microsoft.Win32.RegistryValueKind]::String
+            }
+            if ($userPathKind -notin @(
+                    [Microsoft.Win32.RegistryValueKind]::String,
+                    [Microsoft.Win32.RegistryValueKind]::ExpandString)) {
+                throw "The current user's PATH registry value has unsupported type $userPathKind."
+            }
+
+            $userPathEntries = if ([string]::IsNullOrEmpty($userPath)) { @() } else {
+                $userPath -split ';' |
+                    Where-Object { -not [string]::IsNullOrEmpty($_) } |
+                    ForEach-Object {
+                        $expandedEntry = [Environment]::ExpandEnvironmentVariables($_)
+                        [System.IO.Path]::TrimEndingDirectorySeparator($expandedEntry)
+                    }
+            }
+
+            $userPathChanged = $false
+            if ($userPathEntries -notcontains $installDirNormalized) {
+                $newUserPath = if ([string]::IsNullOrEmpty($userPath)) {
+                    $installDirNormalized
+                } else {
+                    "$installDirNormalized;$userPath"
+                }
+
+                if ($newUserPath.Length -gt 32700) {
+                    Write-Warning "User PATH is near its 32,767 character limit ($($newUserPath.Length) chars)."
+                    Write-Host "Please manually add $InstallDir to your User PATH."
+                } else {
+                    $userEnvironmentKey.SetValue("Path", $newUserPath, $userPathKind)
+                    $userPathChanged = $true
+                }
+            }
+        } finally {
+            $userEnvironmentKey.Dispose()
         }
 
         $processPath = $env:PATH
@@ -331,10 +374,9 @@ try {
     } else {
         Write-Host "Installation complete! (PATH modification skipped)"
         Write-Host ""
-        Write-Host "Add Netclaw to your PATH by running:"
+        Write-Host "Add this directory to your User PATH using Windows Environment Variables settings:"
         Write-Host ""
-        Write-Host "  `$userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')"
-        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$userPath`", 'User')"
+        Write-Host "  $InstallDir"
         Write-Host ""
         Write-Host "Then restart your terminal."
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -33,6 +33,29 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Remove-TrailingDirectorySeparators {
+    param([string]$Path)
+
+    if ([string]::IsNullOrEmpty($Path)) {
+        return $Path
+    }
+
+    $root = [System.IO.Path]::GetPathRoot($Path)
+    if ($Path -eq $root) {
+        return $Path
+    }
+
+    $separators = [char[]]@(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar)
+    $trimmed = $Path.TrimEnd($separators)
+    if ([string]::IsNullOrEmpty($trimmed) -and -not [string]::IsNullOrEmpty($root)) {
+        return $root
+    }
+
+    return $trimmed
+}
+
 function Invoke-DownloadWithProgress {
     param(
         [string]$Uri,
@@ -269,13 +292,16 @@ try {
     Write-Host ""
 
     if (-not $SkipShell) {
-        $installDirNormalized = [System.IO.Path]::TrimEndingDirectorySeparator($InstallDir)
+        $installDirNormalized = Remove-TrailingDirectorySeparators $InstallDir
 
         # Read the raw registry value so an existing REG_EXPAND_SZ PATH keeps both
         # its %VAR% references and its registry type when we prepend Netclaw.
-        $userEnvironmentKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+        # HKCU is writable by the current user and does not require elevation.
+        # CreateSubKey opens the normal existing key and also supports minimal
+        # profiles where the per-user Environment key has not been created yet.
+        $userEnvironmentKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey("Environment")
         if ($null -eq $userEnvironmentKey) {
-            throw "Cannot open the current user's Environment registry key for PATH update."
+            throw "Cannot create or open the current user's Environment registry key for PATH update."
         }
 
         try {
@@ -304,12 +330,17 @@ try {
                 throw "The current user's PATH registry value has unsupported type $userPathKind."
             }
 
+            if ($userPathKind -eq [Microsoft.Win32.RegistryValueKind]::ExpandString `
+                -and $installDirNormalized.Contains('%')) {
+                throw "InstallDir containing '%' cannot be safely added to an expandable User PATH. Choose a directory without '%' or rerun with -SkipShell."
+            }
+
             $userPathEntries = if ([string]::IsNullOrEmpty($userPath)) { @() } else {
                 $userPath -split ';' |
                     Where-Object { -not [string]::IsNullOrEmpty($_) } |
                     ForEach-Object {
                         $expandedEntry = [Environment]::ExpandEnvironmentVariables($_)
-                        [System.IO.Path]::TrimEndingDirectorySeparator($expandedEntry)
+                        Remove-TrailingDirectorySeparators $expandedEntry
                     }
             }
 
@@ -337,7 +368,7 @@ try {
         $processPathEntries = if ([string]::IsNullOrEmpty($processPath)) { @() } else {
             $processPath -split ';' |
                 Where-Object { -not [string]::IsNullOrEmpty($_) } |
-                ForEach-Object { [System.IO.Path]::TrimEndingDirectorySeparator($_) }
+                ForEach-Object { Remove-TrailingDirectorySeparators $_ }
         }
         if ($processPathEntries -notcontains $installDirNormalized) {
             $env:PATH = if ([string]::IsNullOrEmpty($processPath)) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -181,6 +181,13 @@ check_deps
 RID=$(detect_platform)
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.netclaw/bin}"
 
+# PATH uses ':' as its entry separator, and startup files are line-oriented.
+# These names cannot be represented without changing their meaning.
+if [[ "$INSTALL_DIR" == *:* || "$INSTALL_DIR" == *$'\n'* || "$INSTALL_DIR" == *$'\r'* ]]; then
+    echo "Error: INSTALL_DIR cannot contain ':', carriage returns, or newlines when used on PATH." >&2
+    exit 1
+fi
+
 echo "Netclaw installer"
 echo "  Platform: $RID"
 echo "  Install dir: $INSTALL_DIR"
@@ -307,6 +314,10 @@ if [ "$DRY_RUN" = true ]; then
     exit 0
 fi
 
+# The directory now exists. Persist its physical absolute path so a relative
+# invocation is not tied to the installer's current working directory.
+INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
+
 # ── Persist UpdateChannel into config ──
 # Only runs when --channel was explicitly passed. Without this guard a plain
 # upgrade (`install.sh` with no flags) would silently overwrite an existing
@@ -352,7 +363,7 @@ shell_quote() {
 INSTALL_DIR_QUOTED="$(shell_quote "$INSTALL_DIR")"
 ENV_SCRIPT_QUOTED="$(shell_quote "$ENV_SCRIPT")"
 SOURCE_LINE=". $ENV_SCRIPT_QUOTED"
-MANUAL_PATH_LINE="export PATH=$INSTALL_DIR_QUOTED:\$PATH"
+MANUAL_PATH_LINE="export PATH=$INSTALL_DIR_QUOTED\${PATH:+:\"\$PATH\"}"
 
 detect_shell() {
     # $SHELL is inherited from the parent login shell — it reflects the user's
@@ -397,11 +408,15 @@ write_posix_env_script() {
 #!/bin/sh
 # netclaw shell setup
 netclaw_bin=$INSTALL_DIR_QUOTED
-case ":\${PATH}:" in
+case ":\${PATH:-}:" in
     *:"\${netclaw_bin}":*)
         ;;
     *)
-        export PATH="\${netclaw_bin}:\${PATH}"
+        if [ -n "\${PATH:-}" ]; then
+            export PATH="\${netclaw_bin}:\${PATH}"
+        else
+            export PATH="\${netclaw_bin}"
+        fi
         ;;
 esac
 unset netclaw_bin

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@
 #   curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- cli            # CLI only
 #   curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- daemon         # Daemon only
 #   curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --channel beta # Opt into prereleases
+#   curl -sSL https://releases.netclaw.dev/install.sh | bash -s -- --skip-shell   # Don't modify shell profile
 #   INSTALL_DIR=/opt/netclaw curl -sSL https://releases.netclaw.dev/install.sh | bash
 #
 # Arguments:
@@ -13,6 +14,7 @@
 #   --channel stable|beta   — Release channel (default: stable). 'beta' installs the
 #                             newest prerelease (or latest stable if no prerelease exists).
 #   --dry-run               — Resolve and report what would happen; install nothing.
+#   --skip-shell            — Skip automatic shell profile modification.
 #
 # Environment variables:
 #   INSTALL_DIR     — Install directory (default: ~/.netclaw/bin)
@@ -36,9 +38,11 @@ COMPONENT="all"        # "all", "cli", or "daemon"
 DRY_RUN=false          # --dry-run: resolve and report what would happen, install nothing
 CHANNEL="stable"       # release channel: "stable" (default) or "beta" (opt into prereleases)
 CHANNEL_EXPLICIT=false # true when --channel was explicitly passed
+SKIP_SHELL=false       # --skip-shell: don't modify shell profile
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=true; shift ;;
+        --skip-shell) SKIP_SHELL=true; shift ;;
         --channel)
             if [ $# -lt 2 ]; then
                 echo "Error: --channel requires a value (stable|beta)" >&2; exit 1
@@ -46,7 +50,7 @@ while [ $# -gt 0 ]; do
             CHANNEL="$2"; CHANNEL_EXPLICIT=true; shift 2 ;;
         --channel=*) CHANNEL="${1#*=}"; CHANNEL_EXPLICIT=true; shift ;;
         all|cli|daemon) COMPONENT="$1"; shift ;;
-        *) echo "Usage: install.sh [all|cli|daemon] [--channel stable|beta] [--dry-run]" >&2; exit 1 ;;
+        *) echo "Usage: install.sh [all|cli|daemon] [--channel stable|beta] [--dry-run] [--skip-shell]" >&2; exit 1 ;;
     esac
 done
 
@@ -197,7 +201,7 @@ download_component() {
         block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"component\"\\s*:\\s*\"${component}\"[^}]*\"rid\"\\s*:\\s*\"${RID}\"[^}]*}" | head -1)
         if [ -z "$block" ]; then
             # Try reversed order
-            block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"rid\"\\s*:\\s*\"${RID}\"[^}]*\"component\"\\s*:\\s*\"${component}\"[^}]*}" | head -1)
+            block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"rid\"\\s*:\\s*\"${RID}\"[^}]*\"component\"\\s*:\\s*\"${RID}\"[^}]*}" | head -1)
         fi
         url=$(echo "$block" | grep -oP '"url"\s*:\s*"\K[^"]+')
         sha256=$(echo "$block" | grep -oP '"sha256"\s*:\s*"\K[^"]+')
@@ -304,16 +308,137 @@ if [ "$CHANNEL_EXPLICIT" = true ]; then
     fi
 fi
 
-# PATH instructions
-echo ""
-if echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
-    echo "Installation complete! netclaw is already on your PATH."
+# ── Shell integration ─────────────────────────────────────────────────────
+# Write an intermediary env script (~/.netclaw/env) and source it from the
+# user's shell RC file. The env script self-guards at runtime so duplicate
+# PATH entries cannot occur even if the RC is sourced multiple times.
+
+# Derive the parent directory of INSTALL_DIR — this is where the env script
+# lives. For the default (~/.netclaw/bin) that's ~/.netclaw.
+# We use dirname because the install dir may not yet exist when this block runs
+# (e.g., if the user passes --skip-shell and no component needs the dir).
+INSTALL_ROOT="$(dirname "$INSTALL_DIR")"
+ENV_SCRIPT="$INSTALL_ROOT/env"
+SOURCE_LINE=". \"$ENV_SCRIPT\""
+
+detect_shell() {
+    # $SHELL is inherited from the parent login shell — it reflects the user's
+    # configured shell even when this script is piped via `curl | bash`.
+    local shell_name
+    shell_name="$(basename "${SHELL:-/bin/sh}")"
+    echo "$shell_name"
+}
+
+get_rc_file() {
+    local shell_name="$1"
+    local os
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+    case "$shell_name" in
+        zsh)
+            echo "${ZDOTDIR:-$HOME}/.zshrc"
+            ;;
+        bash)
+            # macOS login shells read ~/.profile; Linux interactive shells
+            # read ~/.bashrc. We prefer .bashrc on Linux and .profile on macOS.
+            if [ "$os" = "darwin" ]; then
+                echo "$HOME/.profile"
+            else
+                echo "$HOME/.bashrc"
+            fi
+            ;;
+        fish)
+            local fish_conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d"
+            echo "$fish_conf_dir/netclaw.fish"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+write_env_script() {
+    # Create the self-guarding env script. Uses a colon-affixed case guard
+    # (rustup/fzf pattern) to prevent duplicate PATH entries at runtime.
+    mkdir -p "$(dirname "$ENV_SCRIPT")"
+    cat > "$ENV_SCRIPT" <<ENVEOF
+#!/bin/sh
+# netclaw shell setup
+case ":\${PATH}:" in
+    *:"$INSTALL_DIR":*)
+        ;;
+    *)
+        export PATH="$INSTALL_DIR:\${PATH}"
+        ;;
+esac
+ENVEOF
+    chmod +x "$ENV_SCRIPT"
+}
+
+modify_rc_file() {
+    local shell_name="$1"
+    local rc_file
+
+    rc_file="$(get_rc_file "$shell_name")"
+    if [ -z "$rc_file" ]; then
+        echo "  Shell '$shell_name' is not supported for automatic PATH setup."
+        echo "  Add this to your shell profile:"
+        echo ""
+        echo "    $SOURCE_LINE"
+        return 0
+    fi
+
+    # Ensure the RC file's parent directory exists (fish conf.d may not)
+    mkdir -p "$(dirname "$rc_file")"
+
+    # Touch the file so it exists — some users have no RC file yet
+    touch "$rc_file"
+
+    # Guard: check if the source line already exists
+    if grep -qxF "$SOURCE_LINE" "$rc_file" 2>/dev/null; then
+        echo "  Shell profile '$rc_file' already sources netclaw."
+        return 0
+    fi
+
+    # Ensure a trailing newline before appending
+    if [ -s "$rc_file" ] && [ "$(tail -c1 "$rc_file" | wc -l)" -eq 0 ]; then
+        echo "" >> "$rc_file"
+    fi
+
+    # Append the marker comment and source line
+    {
+        echo "# netclaw shell setup"
+        echo "$SOURCE_LINE"
+    } >> "$rc_file"
+
+    echo "  Modified '$rc_file' to add netclaw to PATH."
+}
+
+if [ "$SKIP_SHELL" = false ]; then
+    SHELL_NAME="$(detect_shell)"
+    echo ""
+    echo "Setting up shell integration..."
+
+    # Write env script first — it must exist before we tell the RC to source it
+    write_env_script
+
+    # Modify the RC file to source the env script
+    modify_rc_file "$SHELL_NAME"
+
+    echo ""
+    echo "Installation complete! netclaw is on your PATH."
+    echo ""
+    echo "Start a new shell, or run:"
+    echo ""
+    echo "  $SOURCE_LINE"
 else
-    echo "Installation complete!"
+    # --skip-shell was passed
     echo ""
-    echo "Add Netclaw to your PATH by adding this to your shell profile:"
+    echo "Installation complete! (shell integration skipped)"
     echo ""
-    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo "Add netclaw to your PATH by adding this to your shell profile:"
+    echo ""
+    echo "  $SOURCE_LINE"
     echo ""
     echo "Then restart your shell or run:"
     echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -201,7 +201,7 @@ download_component() {
         block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"component\"\\s*:\\s*\"${component}\"[^}]*\"rid\"\\s*:\\s*\"${RID}\"[^}]*}" | head -1)
         if [ -z "$block" ]; then
             # Try reversed order
-            block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"rid\"\\s*:\\s*\"${RID}\"[^}]*\"component\"\\s*:\\s*\"${RID}\"[^}]*}" | head -1)
+            block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"rid\"\\s*:\\s*\"${RID}\"[^}]*\"component\"\\s*:\\s*\"${component}\"[^}]*}" | head -1)
         fi
         url=$(echo "$block" | grep -oP '"url"\s*:\s*"\K[^"]+')
         sha256=$(echo "$block" | grep -oP '"sha256"\s*:\s*"\K[^"]+')
@@ -309,17 +309,20 @@ if [ "$CHANNEL_EXPLICIT" = true ]; then
 fi
 
 # ── Shell integration ─────────────────────────────────────────────────────
-# Write an intermediary env script (~/.netclaw/env) and source it from the
-# user's shell RC file. The env script self-guards at runtime so duplicate
-# PATH entries cannot occur even if the RC is sourced multiple times.
+# Bash and zsh source a small POSIX env file. Fish gets native syntax in its
+# dedicated conf.d file; fish cannot source POSIX `case ... esac` syntax.
+ENV_SCRIPT="$HOME/.netclaw/env"
 
-# Derive the parent directory of INSTALL_DIR — this is where the env script
-# lives. For the default (~/.netclaw/bin) that's ~/.netclaw.
-# We use dirname because the install dir may not yet exist when this block runs
-# (e.g., if the user passes --skip-shell and no component needs the dir).
-INSTALL_ROOT="$(dirname "$INSTALL_DIR")"
-ENV_SCRIPT="$INSTALL_ROOT/env"
-SOURCE_LINE=". \"$ENV_SCRIPT\""
+shell_quote() {
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
+}
+
+INSTALL_DIR_QUOTED="$(shell_quote "$INSTALL_DIR")"
+ENV_SCRIPT_QUOTED="$(shell_quote "$ENV_SCRIPT")"
+SOURCE_LINE=". $ENV_SCRIPT_QUOTED"
+MANUAL_PATH_LINE="export PATH=$INSTALL_DIR_QUOTED:\$PATH"
 
 detect_shell() {
     # $SHELL is inherited from the parent login shell — it reflects the user's
@@ -339,17 +342,18 @@ get_rc_file() {
             echo "${ZDOTDIR:-$HOME}/.zshrc"
             ;;
         bash)
-            # macOS login shells read ~/.profile; Linux interactive shells
-            # read ~/.bashrc. We prefer .bashrc on Linux and .profile on macOS.
             if [ "$os" = "darwin" ]; then
-                echo "$HOME/.profile"
+                # A login shell reads only the first existing file in this list.
+                if [ -f "$HOME/.bash_profile" ]; then
+                    echo "$HOME/.bash_profile"
+                elif [ -f "$HOME/.bash_login" ]; then
+                    echo "$HOME/.bash_login"
+                else
+                    echo "$HOME/.profile"
+                fi
             else
                 echo "$HOME/.bashrc"
             fi
-            ;;
-        fish)
-            local fish_conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d"
-            echo "$fish_conf_dir/netclaw.fish"
             ;;
         *)
             echo ""
@@ -357,55 +361,37 @@ get_rc_file() {
     esac
 }
 
-write_env_script() {
-    # Create the self-guarding env script. Uses a colon-affixed case guard
-    # (rustup/fzf pattern) to prevent duplicate PATH entries at runtime.
+write_posix_env_script() {
     mkdir -p "$(dirname "$ENV_SCRIPT")"
     cat > "$ENV_SCRIPT" <<ENVEOF
 #!/bin/sh
 # netclaw shell setup
+netclaw_bin=$INSTALL_DIR_QUOTED
 case ":\${PATH}:" in
-    *:"$INSTALL_DIR":*)
+    *:"\${netclaw_bin}":*)
         ;;
     *)
-        export PATH="$INSTALL_DIR:\${PATH}"
+        export PATH="\${netclaw_bin}:\${PATH}"
         ;;
 esac
+unset netclaw_bin
 ENVEOF
-    chmod +x "$ENV_SCRIPT"
 }
 
-modify_rc_file() {
-    local shell_name="$1"
-    local rc_file
-
-    rc_file="$(get_rc_file "$shell_name")"
-    if [ -z "$rc_file" ]; then
-        echo "  Shell '$shell_name' is not supported for automatic PATH setup."
-        echo "  Add this to your shell profile:"
-        echo ""
-        echo "    $SOURCE_LINE"
-        return 0
-    fi
-
-    # Ensure the RC file's parent directory exists (fish conf.d may not)
+modify_posix_rc_file() {
+    local rc_file="$1"
     mkdir -p "$(dirname "$rc_file")"
-
-    # Touch the file so it exists — some users have no RC file yet
     touch "$rc_file"
 
-    # Guard: check if the source line already exists
     if grep -qxF "$SOURCE_LINE" "$rc_file" 2>/dev/null; then
         echo "  Shell profile '$rc_file' already sources netclaw."
         return 0
     fi
 
-    # Ensure a trailing newline before appending
     if [ -s "$rc_file" ] && [ "$(tail -c1 "$rc_file" | wc -l)" -eq 0 ]; then
         echo "" >> "$rc_file"
     fi
 
-    # Append the marker comment and source line
     {
         echo "# netclaw shell setup"
         echo "$SOURCE_LINE"
@@ -414,35 +400,58 @@ modify_rc_file() {
     echo "  Modified '$rc_file' to add netclaw to PATH."
 }
 
+write_fish_config() {
+    local fish_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d"
+    local fish_config="$fish_config_dir/netclaw.fish"
+    mkdir -p "$fish_config_dir"
+    cat > "$fish_config" <<FISHEOF
+# netclaw shell setup
+set -l netclaw_bin $INSTALL_DIR_QUOTED
+if not contains -- \$netclaw_bin \$PATH
+    set -gx PATH \$netclaw_bin \$PATH
+end
+FISHEOF
+    echo "  Wrote '$fish_config' to add netclaw to PATH."
+}
+
 if [ "$SKIP_SHELL" = false ]; then
     SHELL_NAME="$(detect_shell)"
     echo ""
     echo "Setting up shell integration..."
 
-    # Write env script first — it must exist before we tell the RC to source it
-    write_env_script
-
-    # Modify the RC file to source the env script
-    modify_rc_file "$SHELL_NAME"
-
-    echo ""
-    echo "Installation complete! netclaw is on your PATH."
-    echo ""
-    echo "Start a new shell, or run:"
-    echo ""
-    echo "  $SOURCE_LINE"
+    case "$SHELL_NAME" in
+        bash|zsh)
+            RC_FILE="$(get_rc_file "$SHELL_NAME")"
+            write_posix_env_script
+            modify_posix_rc_file "$RC_FILE"
+            echo ""
+            echo "Installation complete! netclaw will be on PATH in new shells."
+            echo "To update this shell, run:"
+            echo ""
+            echo "  $SOURCE_LINE"
+            ;;
+        fish)
+            write_fish_config
+            echo ""
+            echo "Installation complete! netclaw will be on PATH in new fish shells."
+            echo "To update this shell, run:"
+            echo ""
+            echo "  set -gx PATH $INSTALL_DIR_QUOTED \$PATH"
+            ;;
+        *)
+            echo "  Shell '$SHELL_NAME' is not supported for automatic PATH setup."
+            echo "  No shell profile was changed. Add this to your shell profile:"
+            echo ""
+            echo "    $MANUAL_PATH_LINE"
+            ;;
+    esac
 else
-    # --skip-shell was passed
     echo ""
     echo "Installation complete! (shell integration skipped)"
     echo ""
     echo "Add netclaw to your PATH by adding this to your shell profile:"
     echo ""
-    echo "  $SOURCE_LINE"
-    echo ""
-    echo "Then restart your shell or run:"
-    echo ""
-    echo "  source ~/.bashrc  # or ~/.zshrc"
+    echo "  $MANUAL_PATH_LINE"
 fi
 
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -137,6 +137,44 @@ json_field() {
     fi
 }
 
+json_asset_field() {
+    local json="$1" version="$2" component="$3" rid="$4" field="$5"
+
+    # Release manifests contain flat release and asset objects. Splitting object
+    # boundaries lets POSIX awk select an asset without depending on property order
+    # or GNU-only regular-expression extensions.
+    printf '%s\n' "$json" | tr '{' '\n' | tr '}' '\n' | awk \
+        -v wanted_version="$version" \
+        -v wanted_component="$component" \
+        -v wanted_rid="$rid" \
+        -v wanted_field="$field" '
+        function string_field(record, name, value) {
+            if (index(record, "\"" name "\"") == 0) {
+                return ""
+            }
+
+            value = record
+            sub(".*\"" name "\"[[:space:]]*:[[:space:]]*\"", "", value)
+            sub("\".*", "", value)
+            return value
+        }
+
+        {
+            release_version = string_field($0, "version")
+            if (release_version != "") {
+                current_version = release_version
+            }
+
+            if (current_version == wanted_version &&
+                string_field($0, "component") == wanted_component &&
+                string_field($0, "rid") == wanted_rid) {
+                print string_field($0, wanted_field)
+                exit
+            }
+        }
+    '
+}
+
 # ── Main ──
 check_deps
 
@@ -195,16 +233,8 @@ download_component() {
         url=$(echo "$MANIFEST" | jq -r ".releases[] | select(.version==\"$VERSION\") | .assets[] | select(.component==\"$component\" and .rid==\"$RID\") | .url")
         sha256=$(echo "$MANIFEST" | jq -r ".releases[] | select(.version==\"$VERSION\") | .assets[] | select(.component==\"$component\" and .rid==\"$RID\") | .sha256")
     else
-        # Fallback: extract URL and sha256 using grep (fragile but works for well-formed JSON)
-        # Find the block for this component+rid
-        local block
-        block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"component\"\\s*:\\s*\"${component}\"[^}]*\"rid\"\\s*:\\s*\"${RID}\"[^}]*}" | head -1)
-        if [ -z "$block" ]; then
-            # Try reversed order
-            block=$(echo "$MANIFEST" | tr '\n' ' ' | grep -oP "\"rid\"\\s*:\\s*\"${RID}\"[^}]*\"component\"\\s*:\\s*\"${component}\"[^}]*}" | head -1)
-        fi
-        url=$(echo "$block" | grep -oP '"url"\s*:\s*"\K[^"]+')
-        sha256=$(echo "$block" | grep -oP '"sha256"\s*:\s*"\K[^"]+')
+        url=$(json_asset_field "$MANIFEST" "$VERSION" "$component" "$RID" "url")
+        sha256=$(json_asset_field "$MANIFEST" "$VERSION" "$component" "$RID" "sha256")
     fi
 
     if [ -z "$url" ] || [ "$url" = "null" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,18 +175,23 @@ json_asset_field() {
     '
 }
 
+validate_install_dir_for_path() {
+    local install_dir="$1"
+
+    # PATH uses ':' as its entry separator, and startup files are line-oriented.
+    # These names cannot be represented without changing their meaning.
+    if [[ "$install_dir" == *:* || "$install_dir" == *$'\n'* || "$install_dir" == *$'\r'* ]]; then
+        echo "Error: INSTALL_DIR cannot contain ':', carriage returns, or newlines when used on PATH." >&2
+        return 1
+    fi
+}
+
 # ── Main ──
 check_deps
 
 RID=$(detect_platform)
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.netclaw/bin}"
-
-# PATH uses ':' as its entry separator, and startup files are line-oriented.
-# These names cannot be represented without changing their meaning.
-if [[ "$INSTALL_DIR" == *:* || "$INSTALL_DIR" == *$'\n'* || "$INSTALL_DIR" == *$'\r'* ]]; then
-    echo "Error: INSTALL_DIR cannot contain ':', carriage returns, or newlines when used on PATH." >&2
-    exit 1
-fi
+validate_install_dir_for_path "$INSTALL_DIR"
 
 echo "Netclaw installer"
 echo "  Platform: $RID"
@@ -287,11 +292,18 @@ download_component() {
         return 1
     fi
 
-    mkdir -p "$INSTALL_DIR"
     cp "$binary_path" "$INSTALL_DIR/$binary_name"
     chmod +x "$INSTALL_DIR/$binary_name"
     echo "  Installed $binary_name to $INSTALL_DIR/"
 }
+
+if [ "$DRY_RUN" = false ]; then
+    # Resolve symlinks before installing so the exact path persisted into shell
+    # startup files is the same path that passed delimiter validation.
+    mkdir -p "$INSTALL_DIR"
+    INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
+    validate_install_dir_for_path "$INSTALL_DIR"
+fi
 
 # Download requested components
 SUCCESS=true
@@ -313,10 +325,6 @@ if [ "$DRY_RUN" = true ]; then
     echo "Dry run complete — nothing was installed."
     exit 0
 fi
-
-# The directory now exists. Persist its physical absolute path so a relative
-# invocation is not tied to the installer's current working directory.
-INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
 
 # ── Persist UpdateChannel into config ──
 # Only runs when --channel was explicitly passed. Without this guard a plain
@@ -374,13 +382,21 @@ detect_shell() {
 }
 
 get_rc_file() {
-    local shell_name="$1"
+    local shell_name="$1" shell_path="$2"
     local os
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
     case "$shell_name" in
         zsh)
-            echo "${ZDOTDIR:-$HOME}/.zshrc"
+            local effective_zdotdir
+            # ZDOTDIR is often assigned without export in ~/.zshenv, so ask zsh
+            # for the value it actually uses rather than relying on Bash's env.
+            effective_zdotdir="$("$shell_path" -c "printf '%s' \"\${ZDOTDIR:-\$HOME}\"")" || return 1
+            if [[ -z "$effective_zdotdir" || "$effective_zdotdir" != /* || \
+                  "$effective_zdotdir" == *$'\n'* || "$effective_zdotdir" == *$'\r'* ]]; then
+                return 1
+            fi
+            echo "$effective_zdotdir/.zshrc"
             ;;
         bash)
             if [ "$os" = "darwin" ]; then
@@ -465,8 +481,8 @@ if [ "$SKIP_SHELL" = false ]; then
     echo "Setting up shell integration..."
 
     case "$SHELL_NAME" in
-        bash|zsh)
-            RC_FILE="$(get_rc_file "$SHELL_NAME")"
+        bash)
+            RC_FILE="$(get_rc_file "$SHELL_NAME" "${SHELL:-/bin/bash}")"
             write_posix_env_script
             modify_posix_rc_file "$RC_FILE"
             echo ""
@@ -474,6 +490,22 @@ if [ "$SKIP_SHELL" = false ]; then
             echo "To update this shell, run:"
             echo ""
             echo "  $SOURCE_LINE"
+            ;;
+        zsh)
+            if RC_FILE="$(get_rc_file "$SHELL_NAME" "${SHELL:-/bin/zsh}")"; then
+                write_posix_env_script
+                modify_posix_rc_file "$RC_FILE"
+                echo ""
+                echo "Installation complete! netclaw will be on PATH in new shells."
+                echo "To update this shell, run:"
+                echo ""
+                echo "  $SOURCE_LINE"
+            else
+                echo "  Could not safely resolve zsh's effective ZDOTDIR."
+                echo "  No shell profile was changed. Add this to the appropriate zsh profile:"
+                echo ""
+                echo "    $MANUAL_PATH_LINE"
+            fi
             ;;
         fish)
             write_fish_config
@@ -485,9 +517,9 @@ if [ "$SKIP_SHELL" = false ]; then
             ;;
         *)
             echo "  Shell '$SHELL_NAME' is not supported for automatic PATH setup."
-            echo "  No shell profile was changed. Add this to your shell profile:"
+            echo "  No shell profile was changed. Add this directory to PATH using your shell's syntax:"
             echo ""
-            echo "    $MANUAL_PATH_LINE"
+            echo "    $INSTALL_DIR"
             ;;
     esac
 else

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -25,6 +25,8 @@ function Fail([string]$m) { Write-Host "FAIL: $m"; $script:Fail++ }
 $Work = Join-Path ([System.IO.Path]::GetTempPath()) ("netclaw-install-smoke-" + [Guid]::NewGuid().ToString('N'))
 $Serve = Join-Path $Work "serve"
 $BinDir = Join-Path $Work "bin"
+$OriginalUserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+$OriginalProcessPath = $env:PATH
 New-Item -ItemType Directory -Path $Serve, $BinDir -Force | Out-Null
 
 $ServerProc = $null
@@ -122,13 +124,10 @@ try {
     Write-Host ""
     Write-Host "=== real install ==="
     $installDir = Join-Path $Work "installed"
-    $installOut = & pwsh -NoProfile -File $InstallPs1 -InstallDir $installDir 2>&1 | Out-String
+    $existingUserEntry = Join-Path $Work "existing-user-bin"
+    [Environment]::SetEnvironmentVariable("PATH", $existingUserEntry, "User")
+    $installOut = & $InstallPs1 -InstallDir $installDir *>&1 | Out-String
     Write-Host ($installOut.TrimEnd())
-    if ($LASTEXITCODE -eq 0) {
-        Pass "install: exited 0"
-    } else {
-        Fail "install: exited $LASTEXITCODE"
-    }
     foreach ($name in @("netclaw", "netclawd")) {
         $exe = Join-Path $installDir "$name.exe"
         if ((Test-Path $exe) -and ((Get-Item $exe).Length -gt 0)) {
@@ -138,66 +137,51 @@ try {
         }
     }
 
-    # 7. Verify PATH automation output
-    # The installer now auto-modifies PATH. Verify the output reflects this.
+    # 7. Verify the real installer changed User PATH without replacing the
+    # current process's inherited Machine PATH entries.
     Write-Host ""
-    Write-Host "=== PATH automation output ==="
-    if ($installOut -match 'netclaw is (already )?on your PATH') {
-        Pass "PATH output: indicates netclaw is on PATH"
+    Write-Host "=== PATH automation ==="
+    $persistedEntries = @([Environment]::GetEnvironmentVariable("PATH", "User") -split ';')
+    if ($persistedEntries[0] -eq $installDir `
+        -and $persistedEntries -contains $existingUserEntry `
+        -and @($persistedEntries | Where-Object { $_ -eq $installDir }).Count -eq 1) {
+        Pass "PATH: install directory prepended once and existing User PATH preserved"
     } else {
-        Fail "PATH output: missing PATH confirmation message"
+        Fail "PATH: persisted User PATH has unexpected contents"
     }
 
-    # 7b. Verify PATH is actually modified (not just printed)
-    # We can't hermetically test SetEnvironmentVariable("User") since it touches the registry,
-    # but we CAN test the decision logic with fake PATH values.
-    Write-Host ""
-    Write-Host "=== PATH automation logic ==="
-
-    # Test: duplicate detection — directory not yet in PATH
-    $fakePath1 = "C:\existing\path;C:\another\path"
-    $testDir = "C:\Users\test\.netclaw\bin"
-    $testDirNorm = $testDir.TrimEnd('\')
-    $entries1 = ($fakePath1 -split ';' | ForEach-Object { $_.TrimEnd('\') })
-    if ($entries1 -notcontains $testDirNorm) {
-        Pass "PATH logic: new entry not in PATH (would be added)"
+    $originalProcessEntries = @($OriginalProcessPath -split ';' | Where-Object { $_ })
+    $currentProcessEntries = @($env:PATH -split ';' | Where-Object { $_ })
+    $missingProcessEntries = @($originalProcessEntries | Where-Object { $currentProcessEntries -notcontains $_ })
+    if ($currentProcessEntries[0] -eq $installDir `
+        -and @($currentProcessEntries | Where-Object { $_ -eq $installDir }).Count -eq 1 `
+        -and $missingProcessEntries.Count -eq 0) {
+        Pass "PATH: current process prepended once and inherited entries preserved"
     } else {
-        Fail "PATH logic: false negative — new entry detected as present"
+        Fail "PATH: current process lost inherited entries or contains duplicates"
     }
 
-    # Test: duplicate detection — directory already in PATH
-    $fakePath2 = "$testDir;C:\existing\path"
-    $entries2 = ($fakePath2 -split ';' | ForEach-Object { $_.TrimEnd('\') })
-    if ($entries2 -contains $testDirNorm) {
-        Pass "PATH logic: existing entry detected (would skip)"
+    # A persisted entry must still repair a stale current process, and a
+    # trailing separator must not create a duplicate User PATH entry.
+    $env:PATH = $OriginalProcessPath
+    $userPathBeforeRepeat = [Environment]::GetEnvironmentVariable("PATH", "User")
+    & $InstallPs1 -InstallDir "$installDir\" *>&1 | Out-Null
+    $userPathAfterRepeat = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $repeatProcessEntries = @($env:PATH -split ';' | Where-Object { $_ })
+    if ($userPathAfterRepeat -eq $userPathBeforeRepeat `
+        -and $repeatProcessEntries[0] -eq $installDir `
+        -and @($repeatProcessEntries | Where-Object { $_ -eq $installDir }).Count -eq 1) {
+        Pass "PATH: repeat install is idempotent and repairs current process"
     } else {
-        Fail "PATH logic: false negative — existing entry not detected"
-    }
-
-    # Test: trailing backslash normalization
-    $fakePath3 = "C:\Users\test\.netclaw\bin`;C:\existing"
-    $entries3 = ($fakePath3 -split ';' | ForEach-Object { $_.TrimEnd('\') })
-    if ($entries3 -contains $testDirNorm) {
-        Pass "PATH logic: trailing backslash normalized"
-    } else {
-        Fail "PATH logic: trailing backslash not normalized"
-    }
-
-    # Test: empty User PATH (null)
-    $fakePath4 = $null
-    $entries4 = if ([string]::IsNullOrEmpty($fakePath4)) { @() } else {
-        $fakePath4 -split ';' | ForEach-Object { $_.TrimEnd('\') }
-    }
-    if (@($entries4).Count -eq 0) {
-        Pass "PATH logic: null User PATH treated as empty"
-    } else {
-        Fail "PATH logic: null User PATH not handled"
+        Fail "PATH: repeat install changed User PATH or duplicated process entry"
     }
 
     # 7c. Test -SkipShell flag
     Write-Host ""
     Write-Host "=== -SkipShell flag ==="
     $skipDir = Join-Path $Work "skip-install"
+    $skipUserPathBefore = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $skipProcessPathBefore = $env:PATH
     $skipOut = & pwsh -NoProfile -File $InstallPs1 -InstallDir $skipDir -SkipShell 2>&1 | Out-String
     if ($LASTEXITCODE -eq 0) {
         Pass "-SkipShell: install completes without error"
@@ -208,6 +192,13 @@ try {
         Pass "-SkipShell: output mentions PATH modification skipped"
     } else {
         Fail "-SkipShell: missing 'skipped' message"
+    }
+    if ([Environment]::GetEnvironmentVariable("PATH", "User") -eq $skipUserPathBefore `
+        -and $env:PATH -eq $skipProcessPathBefore `
+        -and $skipOut -match [regex]::Escape($skipDir)) {
+        Pass "-SkipShell: PATH is unchanged and manual command contains resolved install directory"
+    } else {
+        Fail "-SkipShell: changed PATH or printed an unusable manual command"
     }
 
     # 8. Release channel resolution (dry-run)
@@ -246,7 +237,7 @@ try {
     $freshDir = Join-Path $Work "fresh-beta"
     $freshConfigDir = Join-Path $Work "fresh-beta-config"
     $env:NETCLAW_CONFIG_DIR = $freshConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $freshDir -Channel beta 2>&1 | Out-Null
+    & pwsh -NoProfile -File $InstallPs1 -InstallDir $freshDir -Channel beta -SkipShell 2>&1 | Out-Null
     $freshConfig = Join-Path $freshConfigDir "netclaw.json"
     if ((Test-Path $freshConfig)) {
         $c = Get-Content -Raw $freshConfig | ConvertFrom-Json
@@ -265,7 +256,7 @@ try {
     New-Item -ItemType Directory -Path $existConfigDir -Force | Out-Null
     '{"configVersion":1,"Daemon":{"ExposureMode":"local"}}' | Set-Content -Path (Join-Path $existConfigDir "netclaw.json") -Encoding UTF8
     $env:NETCLAW_CONFIG_DIR = $existConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $existDir -Channel beta 2>&1 | Out-Null
+    & pwsh -NoProfile -File $InstallPs1 -InstallDir $existDir -Channel beta -SkipShell 2>&1 | Out-Null
     $c = Get-Content -Raw (Join-Path $existConfigDir "netclaw.json") | ConvertFrom-Json
     if ($c.Daemon.UpdateChannel -eq "beta" -and $c.Daemon.ExposureMode -eq "local") {
         Pass "config: -Channel beta patches existing config, preserves other Daemon keys"
@@ -279,7 +270,7 @@ try {
     New-Item -ItemType Directory -Path $noflagConfigDir -Force | Out-Null
     '{"configVersion":1,"Daemon":{"UpdateChannel":"beta"}}' | Set-Content -Path (Join-Path $noflagConfigDir "netclaw.json") -Encoding UTF8
     $env:NETCLAW_CONFIG_DIR = $noflagConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $noflagDir 2>&1 | Out-Null
+    & pwsh -NoProfile -File $InstallPs1 -InstallDir $noflagDir -SkipShell 2>&1 | Out-Null
     $c = Get-Content -Raw (Join-Path $noflagConfigDir "netclaw.json") | ConvertFrom-Json
     if ($c.Daemon.UpdateChannel -eq "beta") {
         Pass "config: plain upgrade preserves existing beta channel"
@@ -293,7 +284,7 @@ try {
     New-Item -ItemType Directory -Path $downConfigDir -Force | Out-Null
     '{"configVersion":1,"Daemon":{"UpdateChannel":"beta"}}' | Set-Content -Path (Join-Path $downConfigDir "netclaw.json") -Encoding UTF8
     $env:NETCLAW_CONFIG_DIR = $downConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $downDir -Channel stable 2>&1 | Out-Null
+    & pwsh -NoProfile -File $InstallPs1 -InstallDir $downDir -Channel stable -SkipShell 2>&1 | Out-Null
     $c = Get-Content -Raw (Join-Path $downConfigDir "netclaw.json") | ConvertFrom-Json
     if ($c.Daemon.UpdateChannel -eq "stable") {
         Pass "config: -Channel stable overwrites existing beta"
@@ -303,6 +294,8 @@ try {
 }
 finally {
     if ($ServerProc -and -not $ServerProc.HasExited) { $ServerProc.Kill() }
+    [Environment]::SetEnvironmentVariable("PATH", $OriginalUserPath, "User")
+    $env:PATH = $OriginalProcessPath
     $env:MANIFEST_URL = $null
     $env:NETCLAW_CONFIG_DIR = $null
     Remove-Item -Path $Work -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -188,7 +188,7 @@ try {
     $entries4 = if ([string]::IsNullOrEmpty($fakePath4)) { @() } else {
         $fakePath4 -split ';' | ForEach-Object { $_.TrimEnd('\') }
     }
-    if ($entries4.Count -eq 0) {
+    if (@($entries4).Count -eq 0) {
         Pass "PATH logic: null User PATH treated as empty"
     } else {
         Fail "PATH logic: null User PATH not handled"

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -147,12 +147,6 @@ try {
     } else {
         Fail "PATH output: missing PATH confirmation message"
     }
-    # The -SkipShell path still prints instructions — verify they use User scope
-    if ($installOut -match '\$env:PATH') {
-        Fail "PATH output: uses `$env:PATH (corrupts User PATH by merging Machine entries)"
-    } else {
-        Pass "PATH output: does not use `$env:PATH"
-    }
 
     # 7b. Verify PATH is actually modified (not just printed)
     # We can't hermetically test SetEnvironmentVariable("User") since it touches the registry,

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -22,10 +22,52 @@ $script:Fail = 0
 function Pass([string]$m) { Write-Host "PASS: $m"; $script:Pass++ }
 function Fail([string]$m) { Write-Host "FAIL: $m"; $script:Fail++ }
 
+function Get-UserPathRegistryState {
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+    if ($null -eq $key) { throw "Cannot open the current user's Environment registry key." }
+    try {
+        $exists = $key.GetValueNames() -contains "Path"
+        [PSCustomObject]@{
+            Exists = $exists
+            Value = if ($exists) {
+                $key.GetValue(
+                    "Path",
+                    $null,
+                    [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            } else {
+                $null
+            }
+            Kind = if ($exists) { $key.GetValueKind("Path") } else { $null }
+        }
+    } finally {
+        $key.Dispose()
+    }
+}
+
+function Set-UserPathRegistryState {
+    param(
+        [bool]$Exists,
+        [AllowNull()][string]$Value,
+        [AllowNull()][Microsoft.Win32.RegistryValueKind]$Kind
+    )
+
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+    if ($null -eq $key) { throw "Cannot open the current user's Environment registry key for update." }
+    try {
+        if ($Exists) {
+            $key.SetValue("Path", $Value, $Kind)
+        } else {
+            $key.DeleteValue("Path", $false)
+        }
+    } finally {
+        $key.Dispose()
+    }
+}
+
 $Work = Join-Path ([System.IO.Path]::GetTempPath()) ("netclaw-install-smoke-" + [Guid]::NewGuid().ToString('N'))
 $Serve = Join-Path $Work "serve"
 $BinDir = Join-Path $Work "bin"
-$OriginalUserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+$OriginalUserPath = Get-UserPathRegistryState
 $OriginalProcessPath = $env:PATH
 New-Item -ItemType Directory -Path $Serve, $BinDir -Force | Out-Null
 
@@ -123,9 +165,18 @@ try {
     # 6. Real install of the stand-in archives
     Write-Host ""
     Write-Host "=== real install ==="
+
+    $invalidOut = & pwsh -NoProfile -File $InstallPs1 `
+        -InstallDir (Join-Path $Work "invalid;path") -DryRun 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0 -and $invalidOut -match "cannot contain semicolons") {
+        Pass "PATH: unrepresentable Windows install directory rejected"
+    } else {
+        Fail "PATH: Windows install directory containing ';' was accepted"
+    }
+
     $installDir = Join-Path $Work "installed"
     $existingUserEntry = Join-Path $Work "existing-user-bin"
-    [Environment]::SetEnvironmentVariable("PATH", $existingUserEntry, "User")
+    Set-UserPathRegistryState $true $existingUserEntry ([Microsoft.Win32.RegistryValueKind]::String)
     $installOut = & $InstallPs1 -InstallDir $installDir *>&1 | Out-String
     Write-Host ($installOut.TrimEnd())
     foreach ($name in @("netclaw", "netclawd")) {
@@ -141,7 +192,8 @@ try {
     # current process's inherited Machine PATH entries.
     Write-Host ""
     Write-Host "=== PATH automation ==="
-    $persistedEntries = @([Environment]::GetEnvironmentVariable("PATH", "User") -split ';')
+    $persistedPath = Get-UserPathRegistryState
+    $persistedEntries = @($persistedPath.Value -split ';')
     if ($persistedEntries[0] -eq $installDir `
         -and $persistedEntries -contains $existingUserEntry `
         -and @($persistedEntries | Where-Object { $_ -eq $installDir }).Count -eq 1) {
@@ -164,11 +216,12 @@ try {
     # A persisted entry must still repair a stale current process, and a
     # trailing separator must not create a duplicate User PATH entry.
     $env:PATH = $OriginalProcessPath
-    $userPathBeforeRepeat = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $userPathBeforeRepeat = Get-UserPathRegistryState
     & $InstallPs1 -InstallDir "$installDir\" *>&1 | Out-Null
-    $userPathAfterRepeat = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $userPathAfterRepeat = Get-UserPathRegistryState
     $repeatProcessEntries = @($env:PATH -split ';' | Where-Object { $_ })
-    if ($userPathAfterRepeat -eq $userPathBeforeRepeat `
+    if ($userPathAfterRepeat.Value -eq $userPathBeforeRepeat.Value `
+        -and $userPathAfterRepeat.Kind -eq $userPathBeforeRepeat.Kind `
         -and $repeatProcessEntries[0] -eq $installDir `
         -and @($repeatProcessEntries | Where-Object { $_ -eq $installDir }).Count -eq 1) {
         Pass "PATH: repeat install is idempotent and repairs current process"
@@ -176,11 +229,32 @@ try {
         Fail "PATH: repeat install changed User PATH or duplicated process entry"
     }
 
+    $env:NETCLAW_SMOKE_INSTALL_DIR = $installDir
+    $expandedUserPath = "%NETCLAW_SMOKE_INSTALL_DIR%;$existingUserEntry"
+    Set-UserPathRegistryState $true $expandedUserPath ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    $env:PATH = $OriginalProcessPath
+    & $InstallPs1 -InstallDir $installDir *>&1 | Out-Null
+    $expandedUserPathAfter = Get-UserPathRegistryState
+    if ($expandedUserPathAfter.Value -eq $expandedUserPath `
+        -and $expandedUserPathAfter.Kind -eq [Microsoft.Win32.RegistryValueKind]::ExpandString) {
+        Pass "PATH: expandable User entry keeps its raw text and REG_EXPAND_SZ type"
+    } else {
+        Fail "PATH: expandable User entry or its registry type was rewritten"
+    }
+
+    $env:PATH = ""
+    & $InstallPs1 -InstallDir $installDir *>&1 | Out-Null
+    if ($env:PATH -eq $installDir) {
+        Pass "PATH: empty process PATH does not create an empty entry"
+    } else {
+        Fail "PATH: empty process PATH produced unexpected contents"
+    }
+
     # 7c. Test -SkipShell flag
     Write-Host ""
     Write-Host "=== -SkipShell flag ==="
-    $skipDir = Join-Path $Work "skip-install"
-    $skipUserPathBefore = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $skipDir = Join-Path $Work "skip-install's"
+    $skipUserPathBefore = Get-UserPathRegistryState
     $skipProcessPathBefore = $env:PATH
     $skipOut = & pwsh -NoProfile -File $InstallPs1 -InstallDir $skipDir -SkipShell 2>&1 | Out-String
     if ($LASTEXITCODE -eq 0) {
@@ -193,10 +267,13 @@ try {
     } else {
         Fail "-SkipShell: missing 'skipped' message"
     }
-    if ([Environment]::GetEnvironmentVariable("PATH", "User") -eq $skipUserPathBefore `
+    $skipUserPathAfter = Get-UserPathRegistryState
+    if ($skipUserPathAfter.Value -eq $skipUserPathBefore.Value `
+        -and $skipUserPathAfter.Kind -eq $skipUserPathBefore.Kind `
         -and $env:PATH -eq $skipProcessPathBefore `
+        -and $skipOut -match [regex]::Escape("Add this directory to your User PATH") `
         -and $skipOut -match [regex]::Escape($skipDir)) {
-        Pass "-SkipShell: PATH is unchanged and manual command contains resolved install directory"
+        Pass "-SkipShell: PATH is unchanged and manual guidance handles a literal install directory"
     } else {
         Fail "-SkipShell: changed PATH or printed an unusable manual command"
     }
@@ -294,10 +371,11 @@ try {
 }
 finally {
     if ($ServerProc -and -not $ServerProc.HasExited) { $ServerProc.Kill() }
-    [Environment]::SetEnvironmentVariable("PATH", $OriginalUserPath, "User")
+    Set-UserPathRegistryState $OriginalUserPath.Exists $OriginalUserPath.Value $OriginalUserPath.Kind
     $env:PATH = $OriginalProcessPath
     $env:MANIFEST_URL = $null
     $env:NETCLAW_CONFIG_DIR = $null
+    $env:NETCLAW_SMOKE_INSTALL_DIR = $null
     Remove-Item -Path $Work -Recurse -Force -ErrorAction SilentlyContinue
 }
 

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -138,20 +138,82 @@ try {
         }
     }
 
-    # 7. Verify PATH instruction uses User scope correctly (issue #1072)
-    # The printed instruction must NOT use $env:PATH (which merges Machine+User
-    # and corrupts the User PATH when written back). It must read User scope.
+    # 7. Verify PATH automation output
+    # The installer now auto-modifies PATH. Verify the output reflects this.
     Write-Host ""
-    Write-Host "=== PATH instruction check ==="
-    if ($installOut -match '\$env:PATH') {
-        Fail "PATH instruction: uses `$env:PATH (corrupts User PATH by merging Machine entries)"
+    Write-Host "=== PATH automation output ==="
+    if ($installOut -match 'netclaw is (already )?on your PATH') {
+        Pass "PATH output: indicates netclaw is on PATH"
     } else {
-        Pass "PATH instruction: does not use `$env:PATH"
+        Fail "PATH output: missing PATH confirmation message"
     }
-    if ($installOut -match "GetEnvironmentVariable\('PATH',\s*'User'\)") {
-        Pass "PATH instruction: reads from User scope"
+    # The -SkipShell path still prints instructions — verify they use User scope
+    if ($installOut -match '\$env:PATH') {
+        Fail "PATH output: uses `$env:PATH (corrupts User PATH by merging Machine entries)"
     } else {
-        Fail "PATH instruction: should read from User scope with GetEnvironmentVariable('PATH', 'User')"
+        Pass "PATH output: does not use `$env:PATH"
+    }
+
+    # 7b. Verify PATH is actually modified (not just printed)
+    # We can't hermetically test SetEnvironmentVariable("User") since it touches the registry,
+    # but we CAN test the decision logic with fake PATH values.
+    Write-Host ""
+    Write-Host "=== PATH automation logic ==="
+
+    # Test: duplicate detection — directory not yet in PATH
+    $fakePath1 = "C:\existing\path;C:\another\path"
+    $testDir = "C:\Users\test\.netclaw\bin"
+    $testDirNorm = $testDir.TrimEnd('\')
+    $entries1 = ($fakePath1 -split ';' | ForEach-Object { $_.TrimEnd('\') })
+    if ($entries1 -notcontains $testDirNorm) {
+        Pass "PATH logic: new entry not in PATH (would be added)"
+    } else {
+        Fail "PATH logic: false negative — new entry detected as present"
+    }
+
+    # Test: duplicate detection — directory already in PATH
+    $fakePath2 = "$testDir;C:\existing\path"
+    $entries2 = ($fakePath2 -split ';' | ForEach-Object { $_.TrimEnd('\') })
+    if ($entries2 -contains $testDirNorm) {
+        Pass "PATH logic: existing entry detected (would skip)"
+    } else {
+        Fail "PATH logic: false negative — existing entry not detected"
+    }
+
+    # Test: trailing backslash normalization
+    $fakePath3 = "C:\Users\test\.netclaw\bin`;C:\existing"
+    $entries3 = ($fakePath3 -split ';' | ForEach-Object { $_.TrimEnd('\') })
+    if ($entries3 -contains $testDirNorm) {
+        Pass "PATH logic: trailing backslash normalized"
+    } else {
+        Fail "PATH logic: trailing backslash not normalized"
+    }
+
+    # Test: empty User PATH (null)
+    $fakePath4 = $null
+    $entries4 = if ([string]::IsNullOrEmpty($fakePath4)) { @() } else {
+        $fakePath4 -split ';' | ForEach-Object { $_.TrimEnd('\') }
+    }
+    if ($entries4.Count -eq 0) {
+        Pass "PATH logic: null User PATH treated as empty"
+    } else {
+        Fail "PATH logic: null User PATH not handled"
+    }
+
+    # 7c. Test -SkipShell flag
+    Write-Host ""
+    Write-Host "=== -SkipShell flag ==="
+    $skipDir = Join-Path $Work "skip-install"
+    $skipOut = & pwsh -NoProfile -File $InstallPs1 -InstallDir $skipDir -SkipShell 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0) {
+        Pass "-SkipShell: install completes without error"
+    } else {
+        Fail "-SkipShell: install failed (exit=$LASTEXITCODE)"
+    }
+    if ($skipOut -match "PATH modification skipped") {
+        Pass "-SkipShell: output mentions PATH modification skipped"
+    } else {
+        Fail "-SkipShell: missing 'skipped' message"
     }
 
     # 8. Release channel resolution (dry-run)

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -6,10 +6,17 @@
 # download -> checksum -> extract -> install path, plus -DryRun.
 #
 # Usage:    pwsh -File scripts/smoke/install-smoke.ps1
-# Requires: PowerShell 7+, python (for the local HTTP server).
+#           powershell.exe -File scripts/smoke/install-smoke.ps1
+# Requires: PowerShell 5.1+ and python (for the local HTTP server).
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+$PowerShellExecutable = if ($PSVersionTable.PSEdition -eq "Desktop") {
+    (Get-Command powershell.exe).Source
+} else {
+    (Get-Command pwsh).Source
+}
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot ".." "..")).Path
 $InstallPs1 = Join-Path $RepoRoot "scripts" "install.ps1"
@@ -51,8 +58,8 @@ function Set-UserPathRegistryState {
         [AllowNull()][Microsoft.Win32.RegistryValueKind]$Kind
     )
 
-    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
-    if ($null -eq $key) { throw "Cannot open the current user's Environment registry key for update." }
+    $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey("Environment")
+    if ($null -eq $key) { throw "Cannot create or open the current user's Environment registry key for update." }
     try {
         if ($Exists) {
             $key.SetValue("Path", $Value, $Kind)
@@ -147,7 +154,7 @@ try {
     # 5. Dry-run check - resolves assets, installs nothing
     Write-Host "=== dry run ==="
     $dryDir = Join-Path $Work "dryrun-none"
-    $dryOut = & pwsh -NoProfile -File $InstallPs1 -InstallDir $dryDir -DryRun 2>&1 | Out-String
+    $dryOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $dryDir -DryRun 2>&1 | Out-String
     Write-Host ($dryOut.TrimEnd())
     if ($LASTEXITCODE -eq 0 `
         -and $dryOut -match 'DRY RUN: would install netclaw ' `
@@ -166,7 +173,7 @@ try {
     Write-Host ""
     Write-Host "=== real install ==="
 
-    $invalidOut = & pwsh -NoProfile -File $InstallPs1 `
+    $invalidOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 `
         -InstallDir (Join-Path $Work "invalid;path") -DryRun 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0 -and $invalidOut -match "cannot contain semicolons") {
         Pass "PATH: unrepresentable Windows install directory rejected"
@@ -242,6 +249,36 @@ try {
         Fail "PATH: expandable User entry or its registry type was rewritten"
     }
 
+    $literalPercentInstall = Join-Path $Work "%NETCLAW_LITERAL%\bin"
+    Set-UserPathRegistryState $true $existingUserEntry ([Microsoft.Win32.RegistryValueKind]::String)
+    $literalPercentOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 `
+        -InstallDir $literalPercentInstall 2>&1 | Out-String
+    $literalPercentState = Get-UserPathRegistryState
+    if ($LASTEXITCODE -eq 0 `
+        -and $literalPercentState.Kind -eq [Microsoft.Win32.RegistryValueKind]::String `
+        -and @($literalPercentState.Value -split ';')[0] -eq $literalPercentInstall) {
+        Pass "PATH: literal percent is preserved in a non-expanding User PATH"
+    } else {
+        Fail "PATH: literal percent was not preserved in a non-expanding User PATH"
+        Write-Host ($literalPercentOut.TrimEnd())
+    }
+
+    $expandablePath = "%SystemRoot%\System32"
+    $unsafePercentInstall = Join-Path $Work "%TEMP%\netclaw"
+    Set-UserPathRegistryState $true $expandablePath ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    $expandableStateBefore = Get-UserPathRegistryState
+    $unsafePercentOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 `
+        -InstallDir $unsafePercentInstall 2>&1 | Out-String
+    $expandableStateAfter = Get-UserPathRegistryState
+    if ($LASTEXITCODE -ne 0 `
+        -and $unsafePercentOut -match "cannot be safely added to an expandable User PATH" `
+        -and $expandableStateAfter.Value -eq $expandableStateBefore.Value `
+        -and $expandableStateAfter.Kind -eq $expandableStateBefore.Kind) {
+        Pass "PATH: literal percent is rejected before mutating an expandable User PATH"
+    } else {
+        Fail "PATH: literal percent corrupted or changed an expandable User PATH"
+    }
+
     $env:PATH = ""
     & $InstallPs1 -InstallDir $installDir *>&1 | Out-Null
     if ($env:PATH -eq $installDir) {
@@ -257,7 +294,7 @@ try {
     $skipDir = Join-Path $Work "skip-install's"
     $skipUserPathBefore = Get-UserPathRegistryState
     $skipProcessPathBefore = $env:PATH
-    $skipOut = & pwsh -NoProfile -File $InstallPs1 -InstallDir $skipDir -SkipShell 2>&1 | Out-String
+    $skipOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $skipDir -SkipShell 2>&1 | Out-String
     if ($LASTEXITCODE -eq 0) {
         Pass "-SkipShell: install completes without error"
     } else {
@@ -285,7 +322,7 @@ try {
     $shouldNotExist = Join-Path $Work "should-not-exist"
 
     function Assert-Resolves([string]$desc, [string]$want, [string[]]$extraArgs) {
-        $out = & pwsh -NoProfile -File $InstallPs1 -InstallDir $shouldNotExist -DryRun @extraArgs 2>&1 | Out-String
+        $out = & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $shouldNotExist -DryRun @extraArgs 2>&1 | Out-String
         $pattern = "(?m)^\s+Version:\s+$([regex]::Escape($want))\s*$"
         if ($LASTEXITCODE -eq 0 -and $out -match $pattern) {
             Pass "channel: $desc -> $want"
@@ -301,7 +338,7 @@ try {
     Assert-Resolves "-Version pin overrides -Channel"     $BetaVersion @("-Channel", "stable", "-Version", $BetaVersion)
 
     # An unknown channel must be rejected by the ValidateSet, not silently default.
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $shouldNotExist -DryRun -Channel bogus 2>&1 | Out-Null
+    & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $shouldNotExist -DryRun -Channel bogus 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Pass "channel: unknown value rejected"
     } else {
@@ -315,7 +352,7 @@ try {
     $freshDir = Join-Path $Work "fresh-beta"
     $freshConfigDir = Join-Path $Work "fresh-beta-config"
     $env:NETCLAW_CONFIG_DIR = $freshConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $freshDir -Channel beta -SkipShell 2>&1 | Out-Null
+    & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $freshDir -Channel beta -SkipShell 2>&1 | Out-Null
     $freshConfig = Join-Path $freshConfigDir "netclaw.json"
     if ((Test-Path $freshConfig)) {
         $c = Get-Content -Raw $freshConfig | ConvertFrom-Json
@@ -334,7 +371,7 @@ try {
     New-Item -ItemType Directory -Path $existConfigDir -Force | Out-Null
     '{"configVersion":1,"Daemon":{"ExposureMode":"local"}}' | Set-Content -Path (Join-Path $existConfigDir "netclaw.json") -Encoding UTF8
     $env:NETCLAW_CONFIG_DIR = $existConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $existDir -Channel beta -SkipShell 2>&1 | Out-Null
+    & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $existDir -Channel beta -SkipShell 2>&1 | Out-Null
     $c = Get-Content -Raw (Join-Path $existConfigDir "netclaw.json") | ConvertFrom-Json
     if ($c.Daemon.UpdateChannel -eq "beta" -and $c.Daemon.ExposureMode -eq "local") {
         Pass "config: -Channel beta patches existing config, preserves other Daemon keys"
@@ -348,7 +385,7 @@ try {
     New-Item -ItemType Directory -Path $noflagConfigDir -Force | Out-Null
     '{"configVersion":1,"Daemon":{"UpdateChannel":"beta"}}' | Set-Content -Path (Join-Path $noflagConfigDir "netclaw.json") -Encoding UTF8
     $env:NETCLAW_CONFIG_DIR = $noflagConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $noflagDir -SkipShell 2>&1 | Out-Null
+    & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $noflagDir -SkipShell 2>&1 | Out-Null
     $c = Get-Content -Raw (Join-Path $noflagConfigDir "netclaw.json") | ConvertFrom-Json
     if ($c.Daemon.UpdateChannel -eq "beta") {
         Pass "config: plain upgrade preserves existing beta channel"
@@ -362,7 +399,7 @@ try {
     New-Item -ItemType Directory -Path $downConfigDir -Force | Out-Null
     '{"configVersion":1,"Daemon":{"UpdateChannel":"beta"}}' | Set-Content -Path (Join-Path $downConfigDir "netclaw.json") -Encoding UTF8
     $env:NETCLAW_CONFIG_DIR = $downConfigDir
-    & pwsh -NoProfile -File $InstallPs1 -InstallDir $downDir -Channel stable -SkipShell 2>&1 | Out-Null
+    & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $downDir -Channel stable -SkipShell 2>&1 | Out-Null
     $c = Get-Content -Raw (Join-Path $downConfigDir "netclaw.json") | ConvertFrom-Json
     if ($c.Daemon.UpdateChannel -eq "stable") {
         Pass "config: -Channel stable overwrites existing beta"
@@ -388,6 +425,7 @@ if ($script:Fail -gt 0) {
 }
 Write-Host "install smoke (ps1): PASSED"
 # Exit explicitly on the result, not on $LASTEXITCODE — the channel checks above run
-# `pwsh -Channel bogus` (which exits non-zero by design), and without this the script
+# a child PowerShell `-Channel bogus` invocation (which exits non-zero by design),
+# and without this the script
 # would fall off the end and inherit that non-zero code despite all assertions passing.
 exit 0

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -29,6 +29,21 @@ $script:Fail = 0
 function Pass([string]$m) { Write-Host "PASS: $m"; $script:Pass++ }
 function Fail([string]$m) { Write-Host "FAIL: $m"; $script:Fail++ }
 
+function Invoke-CapturedPowerShell {
+    param([string[]]$Arguments)
+
+    # Windows PowerShell 5.1 promotes a native child's stderr to an error record.
+    # Rejection tests need to inspect that output and exit code without aborting.
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = & $PowerShellExecutable @Arguments 2>&1 | Out-String
+        [PSCustomObject]@{ Output = $output; ExitCode = $LASTEXITCODE }
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+}
+
 function Get-UserPathRegistryState {
     $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
     if ($null -eq $key) { throw "Cannot open the current user's Environment registry key." }
@@ -175,9 +190,10 @@ try {
     Write-Host ""
     Write-Host "=== real install ==="
 
-    $invalidOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 `
-        -InstallDir (Join-Path $Work "invalid;path") -DryRun 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0 -and $invalidOut -match "cannot contain semicolons") {
+    $invalidResult = Invoke-CapturedPowerShell -Arguments @(
+        "-NoProfile", "-File", $InstallPs1,
+        "-InstallDir", (Join-Path $Work "invalid;path"), "-DryRun")
+    if ($invalidResult.ExitCode -ne 0 -and $invalidResult.Output -match "cannot contain semicolons") {
         Pass "PATH: unrepresentable Windows install directory rejected"
     } else {
         Fail "PATH: Windows install directory containing ';' was accepted"
@@ -269,11 +285,11 @@ try {
     $unsafePercentInstall = Join-Path $Work "%TEMP%\netclaw"
     Set-UserPathRegistryState $true $expandablePath ([Microsoft.Win32.RegistryValueKind]::ExpandString)
     $expandableStateBefore = Get-UserPathRegistryState
-    $unsafePercentOut = & $PowerShellExecutable -NoProfile -File $InstallPs1 `
-        -InstallDir $unsafePercentInstall 2>&1 | Out-String
+    $unsafePercentResult = Invoke-CapturedPowerShell -Arguments @(
+        "-NoProfile", "-File", $InstallPs1, "-InstallDir", $unsafePercentInstall)
     $expandableStateAfter = Get-UserPathRegistryState
-    if ($LASTEXITCODE -ne 0 `
-        -and $unsafePercentOut -match "cannot be safely added to an expandable User PATH" `
+    if ($unsafePercentResult.ExitCode -ne 0 `
+        -and $unsafePercentResult.Output -match "cannot be safely added to an expandable User PATH" `
         -and $expandableStateAfter.Value -eq $expandableStateBefore.Value `
         -and $expandableStateAfter.Kind -eq $expandableStateBefore.Kind) {
         Pass "PATH: literal percent is rejected before mutating an expandable User PATH"
@@ -340,8 +356,10 @@ try {
     Assert-Resolves "-Version pin overrides -Channel"     $BetaVersion @("-Channel", "stable", "-Version", $BetaVersion)
 
     # An unknown channel must be rejected by the ValidateSet, not silently default.
-    & $PowerShellExecutable -NoProfile -File $InstallPs1 -InstallDir $shouldNotExist -DryRun -Channel bogus 2>&1 | Out-Null
-    if ($LASTEXITCODE -ne 0) {
+    $invalidChannelResult = Invoke-CapturedPowerShell -Arguments @(
+        "-NoProfile", "-File", $InstallPs1, "-InstallDir", $shouldNotExist,
+        "-DryRun", "-Channel", "bogus")
+    if ($invalidChannelResult.ExitCode -ne 0) {
         Pass "channel: unknown value rejected"
     } else {
         Fail "channel: unknown value should fail (exit=$LASTEXITCODE)"
@@ -426,8 +444,6 @@ if ($script:Fail -gt 0) {
     exit 1
 }
 Write-Host "install smoke (ps1): PASSED"
-# Exit explicitly on the result, not on $LASTEXITCODE — the channel checks above run
-# a child PowerShell `-Channel bogus` invocation (which exits non-zero by design),
-# and without this the script
-# would fall off the end and inherit that non-zero code despite all assertions passing.
+# Deliberate rejection checks run child processes that exit nonzero, so return
+# the assertion result explicitly instead of inheriting a child's exit code.
 exit 0

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -18,8 +18,8 @@ $PowerShellExecutable = if ($PSVersionTable.PSEdition -eq "Desktop") {
     (Get-Command pwsh).Source
 }
 
-$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot ".." "..")).Path
-$InstallPs1 = Join-Path $RepoRoot "scripts" "install.ps1"
+$RepoRoot = (Resolve-Path (Join-Path (Join-Path $PSScriptRoot "..") "..")).Path
+$InstallPs1 = Join-Path (Join-Path $RepoRoot "scripts") "install.ps1"
 $Version = "0.0.0"            # stable -> manifest.latest
 $BetaVersion = "0.0.1-beta1"  # prerelease -> manifest.latestPrerelease
 $Rid = "win-x64"

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -125,7 +125,9 @@ try {
         latestPrerelease = $BetaVersion
         releases         = @($betaEntry, $stableEntry)
     }
-    $manifest | ConvertTo-Json -Depth 8 | Set-Content -Path (Join-Path $Serve "manifest.json") -Encoding utf8
+    # The fixture is ASCII-only. Windows PowerShell 5.1 writes a BOM for
+    # -Encoding UTF8 while PowerShell 7 does not, so use an identical encoding.
+    $manifest | ConvertTo-Json -Depth 8 | Set-Content -Path (Join-Path $Serve "manifest.json") -Encoding ascii
 
     # 4. Serve the manifest + archives from localhost
     $python = Get-Command python3 -ErrorAction SilentlyContinue

--- a/scripts/smoke/install-smoke.ps1
+++ b/scripts/smoke/install-smoke.ps1
@@ -249,6 +249,7 @@ try {
     } else {
         Fail "PATH: empty process PATH produced unexpected contents"
     }
+    $env:PATH = $OriginalProcessPath
 
     # 7c. Test -SkipShell flag
     Write-Host ""

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -177,11 +177,16 @@ else
 fi
 
 # ── 6. Mechanical check: a real install on the host's native RID ─────────────
+# Uses a temp HOME so shell integration writes to the temp dir, not the
+# CI runner's real profile — and we can verify the RC was modified.
 echo ""
 echo "=== real install (host RID, stand-in archive) ==="
-INSTALL_DIR="$WORK/installed"
+INSTALL_HOME="$WORK/installed-home"
+INSTALL_DIR="$INSTALL_HOME/.netclaw/bin"
+mkdir -p "$INSTALL_HOME"
 set +e
-install_out=$(MANIFEST_URL="$BASE_URL/manifest.json" INSTALL_DIR="$INSTALL_DIR" \
+install_out=$(HOME="$INSTALL_HOME" \
+              MANIFEST_URL="$BASE_URL/manifest.json" INSTALL_DIR="$INSTALL_DIR" \
               bash "$INSTALL_SH" 2>&1)
 install_rc=$?
 set -e
@@ -200,6 +205,26 @@ for name in netclaw netclawd; do
     fail "install: $name missing, not executable, or did not run"
   fi
 done
+
+# Verify shell integration actually ran
+INSTALL_ENV="$INSTALL_HOME/.netclaw/env"
+if [ -f "$INSTALL_ENV" ]; then
+  pass "real install: env script created"
+else
+  fail "real install: env script not found at $INSTALL_ENV"
+fi
+
+# The RC file depends on $SHELL — check whichever one was created
+RC_MODIFIED=false
+for rc in "$INSTALL_HOME/.bashrc" "$INSTALL_HOME/.zshrc" "$INSTALL_HOME/.profile" "$INSTALL_HOME/.config/fish/conf.d/netclaw.fish"; do
+  if [ -f "$rc" ] && grep -qxF ". \"$INSTALL_ENV\"" "$rc" 2>/dev/null; then
+    pass "real install: $(basename $rc) sources env script"
+    RC_MODIFIED=true
+  fi
+done
+if [ "$RC_MODIFIED" = false ]; then
+  fail "real install: no RC file sources env script (SHELL=$SHELL)"
+fi
 
 # ── 7. Release channel resolution (dry-run) ──────────────────────────────────
 echo ""

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -111,6 +111,26 @@ rm -f "$MANIFEST_DEST"
 bash "$MANIFEST_GEN" "$VERSION"      "$WORK/checksums-$VERSION"      "$BASE_URL" >/dev/null
 bash "$MANIFEST_GEN" "$BETA_VERSION" "$WORK/checksums-$BETA_VERSION" "$BASE_URL" >/dev/null
 cp "$MANIFEST_DEST" "$SERVE/manifest.json"
+python3 - "$SERVE/manifest.json" "$SERVE/manifest-rid-first.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    manifest = json.load(source)
+for release in manifest["releases"]:
+    release["assets"] = [
+        {
+            "rid": asset["rid"],
+            "component": asset["component"],
+            "url": asset["url"],
+            "sha256": asset["sha256"],
+            "sizeBytes": asset["sizeBytes"],
+        }
+        for asset in release["assets"]
+    ]
+with open(sys.argv[2], "w", encoding="utf-8") as destination:
+    json.dump(manifest, destination)
+PY
 
 # ── 4. Serve the manifest + archives from localhost ──────────────────────────
 python3 -m http.server "$PORT" --bind 127.0.0.1 --directory "$SERVE" >/dev/null 2>&1 &
@@ -169,6 +189,32 @@ check_detect "macOS x86_64 + Rosetta -> osx-arm64" Darwin x86_64 1 'DRY RUN: wou
 check_detect "Intel Mac rejected"               Darwin x86_64  0 'Apple Silicon'    1
 check_detect "unsupported OS rejected"          freebsd x86_64 0 'Unsupported OS'   1
 
+# Exercise the grep parser with a valid manifest whose asset fields are in the
+# reverse order. A private mirror need not preserve the generator's JSON order.
+NO_JQ_BIN="$WORK/no-jq-bin"
+mkdir -p "$NO_JQ_BIN"
+for cmd in bash curl cut grep head mktemp rm sed sha256sum shasum tar tr uname; do
+  command_path=$(command -v "$cmd" 2>/dev/null || true)
+  if [ -n "$command_path" ]; then
+    ln -s "$command_path" "$NO_JQ_BIN/$cmd"
+  fi
+done
+set +e
+no_jq_out=$(PATH="$NO_JQ_BIN" \
+  MANIFEST_URL="$BASE_URL/manifest-rid-first.json" \
+  INSTALL_DIR="$WORK/no-jq-install" \
+  /bin/bash "$INSTALL_SH" --dry-run 2>&1)
+no_jq_rc=$?
+set -e
+if [ "$no_jq_rc" -eq 0 ] \
+    && echo "$no_jq_out" | grep -q 'DRY RUN: would install netclaw ' \
+    && echo "$no_jq_out" | grep -q 'DRY RUN: would install netclawd '; then
+  pass "manifest: jq-less parser accepts rid-before-component assets"
+else
+  fail "manifest: jq-less rid-before-component parse failed (exit=$no_jq_rc)"
+  echo "$no_jq_out" | indent
+fi
+
 # Dry run must not create the install directory.
 if [ -d "$WORK/should-not-exist" ]; then
   fail "dry-run: created an install directory (should install nothing)"
@@ -217,8 +263,8 @@ fi
 # The RC file depends on $SHELL — check whichever one was created
 RC_MODIFIED=false
 for rc in "$INSTALL_HOME/.bashrc" "$INSTALL_HOME/.zshrc" "$INSTALL_HOME/.profile" "$INSTALL_HOME/.config/fish/conf.d/netclaw.fish"; do
-  if [ -f "$rc" ] && grep -qxF ". \"$INSTALL_ENV\"" "$rc" 2>/dev/null; then
-    pass "real install: $(basename $rc) sources env script"
+  if [ -f "$rc" ] && grep -qxF ". '$INSTALL_ENV'" "$rc" 2>/dev/null; then
+    pass "real install: $(basename "$rc") sources env script"
     RC_MODIFIED=true
   fi
 done
@@ -281,7 +327,7 @@ set +e
 fresh_out=$(MANIFEST_URL="$BASE_URL/manifest.json" \
             INSTALL_DIR="$FRESH_DIR" \
             CONFIG_DIR="$FRESH_CONFIG_DIR" \
-            bash "$INSTALL_SH" --channel beta 2>&1)
+            bash "$INSTALL_SH" --channel beta --skip-shell 2>&1)
 fresh_rc=$?
 set -e
 if [ "$fresh_rc" -eq 0 ] && [ -f "$FRESH_CONFIG_DIR/netclaw.json" ]; then
@@ -309,7 +355,7 @@ set +e
 exist_out=$(MANIFEST_URL="$BASE_URL/manifest.json" \
             INSTALL_DIR="$EXIST_DIR" \
             CONFIG_DIR="$EXIST_CONFIG_DIR" \
-            bash "$INSTALL_SH" --channel beta 2>&1)
+            bash "$INSTALL_SH" --channel beta --skip-shell 2>&1)
 exist_rc=$?
 set -e
 if [ "$exist_rc" -eq 0 ] && command -v jq >/dev/null 2>&1; then
@@ -322,6 +368,7 @@ if [ "$exist_rc" -eq 0 ] && command -v jq >/dev/null 2>&1; then
   fi
 else
   fail "config: --channel beta on existing config (exit=$exist_rc)"
+  echo "$exist_out" | indent
 fi
 
 # 8c. Plain upgrade (no --channel) leaves existing beta config alone
@@ -333,7 +380,7 @@ set +e
 noflag_out=$(MANIFEST_URL="$BASE_URL/manifest.json" \
              INSTALL_DIR="$NOFLAG_DIR" \
              CONFIG_DIR="$NOFLAG_CONFIG_DIR" \
-             bash "$INSTALL_SH" 2>&1)
+             bash "$INSTALL_SH" --skip-shell 2>&1)
 noflag_rc=$?
 set -e
 if [ "$noflag_rc" -eq 0 ] && command -v jq >/dev/null 2>&1; then
@@ -345,6 +392,7 @@ if [ "$noflag_rc" -eq 0 ] && command -v jq >/dev/null 2>&1; then
   fi
 else
   fail "config: plain upgrade (exit=$noflag_rc)"
+  echo "$noflag_out" | indent
 fi
 
 # 8d. --channel stable on existing beta overwrites to stable
@@ -356,7 +404,7 @@ set +e
 down_out=$(MANIFEST_URL="$BASE_URL/manifest.json" \
            INSTALL_DIR="$DOWNGRADE_DIR" \
            CONFIG_DIR="$DOWNGRADE_CONFIG_DIR" \
-           bash "$INSTALL_SH" --channel stable 2>&1)
+           bash "$INSTALL_SH" --channel stable --skip-shell 2>&1)
 down_rc=$?
 set -e
 if [ "$down_rc" -eq 0 ] && command -v jq >/dev/null 2>&1; then
@@ -368,330 +416,128 @@ if [ "$down_rc" -eq 0 ] && command -v jq >/dev/null 2>&1; then
   fi
 else
   fail "config: --channel stable on existing beta (exit=$down_rc)"
+  echo "$down_out" | indent
 fi
 
 # ── 9. Shell integration (PATH automation) ───────────────────────────────────
-# Tests that install.sh correctly modifies shell RC files for bash, zsh, and fish.
-# Uses fake SHELL values and temp home directories to isolate each case.
 echo ""
 echo "=== shell integration ==="
 
-# shell_integration_test <desc> <shell_name> <rc_relpath>
-#   desc:        test description
-#   shell_name:  basename of the fake SHELL (bash, zsh, fish, unknown)
-#   rc_relpath:  path relative to temp HOME where the RC file should be created
-shell_integration_test() {
-  local desc="$1" shell_name="$2" rc_rel="$3"
-  local temp_home="$WORK/shell-int-$desc"
-  local install_dir="$temp_home/.netclaw/bin"
-  local rc_file="$temp_home/$rc_rel"
-  local env_file="$temp_home/.netclaw/env"
-
-  # Pre-seed a minimal RC file so the installer has something to append to
-  mkdir -p "$(dirname "$rc_file")"
-  printf '# existing config\n' > "$rc_file"
-
-  # Run install WITHOUT --skip-shell
-  set +e
-  local out rc
-  out=$(SHELL="/bin/$shell_name" \
-        HOME="$temp_home" \
-        MANIFEST_URL="$BASE_URL/manifest.json" \
-        INSTALL_DIR="$install_dir" \
-        CONFIG_DIR="$temp_home/.netclaw/config" \
-        bash "$INSTALL_SH" 2>&1)
-  rc=$?
-  set +e
-
-  if [ "$rc" -ne 0 ]; then
-    fail "$desc: install failed (exit=$rc)"
-    echo "$out" | indent
-    return
-  fi
-
-  # Verify env script was created
-  if [ -f "$env_file" ]; then
-    pass "$desc: env script created at .netclaw/env"
+assert_path_once() {
+  local desc="$1" observed_path="$2" install_dir="$3"
+  local count
+  count=$(printf '%s' "$observed_path" | tr ':' '\n' | grep -cxF "$install_dir" || true)
+  if [ "$count" -eq 1 ]; then
+    pass "$desc: install directory appears exactly once on PATH"
   else
-    fail "$desc: env script not found at .netclaw/env"
-  fi
-
-  # Verify env script is executable
-  if [ -x "$env_file" ]; then
-    pass "$desc: env script is executable"
-  else
-    fail "$desc: env script is not executable"
-  fi
-
-  # Verify env script contains the colon-affixed PATH guard (rustup pattern)
-  if grep -qF 'case ":${PATH}:"' "$env_file" 2>/dev/null; then
-    pass "$desc: env script contains colon-affixed PATH guard"
-  else
-    fail "$desc: env script missing colon-affixed PATH guard"
-  fi
-
-  # Verify env script contains the install dir in the PATH export
-  if grep -qF "export PATH=\"$install_dir:" "$env_file" 2>/dev/null; then
-    pass "$desc: env script exports correct install dir"
-  else
-    fail "$desc: env script does not export correct install dir"
-  fi
-
-  # Verify RC file was modified with the source line
-  local src_count
-  src_count=$(grep -cxF ". \"$env_file\"" "$rc_file" 2>/dev/null || true)
-  if [ "$src_count" -eq 1 ]; then
-    pass "$desc: $rc_rel contains exactly 1 source line"
-  else
-    fail "$desc: $rc_rel contains $src_count source lines (expected 1)"
-  fi
-
-  # Verify RC file contains the marker comment
-  if grep -qF "# netclaw shell setup" "$rc_file" 2>/dev/null; then
-    pass "$desc: $rc_rel contains marker comment"
-  else
-    fail "$desc: $rc_rel missing marker comment"
-  fi
-
-  # Verify the RC file is syntactically valid (bash -n)
-  set +e
-  bash -n "$rc_file" 2>"$WORK/syntax_err_$desc"
-  local syntax_rc=$?
-  set +e
-  if [ "$syntax_rc" -eq 0 ]; then
-    pass "$desc: $rc_rel passes bash -n syntax check"
-  else
-    fail "$desc: $rc_rel has syntax errors"
-    cat "$WORK/syntax_err_$desc" | indent
-  fi
-
-  # Verify PATH is correct after sourcing the env script
-  set +e
-  local eval_path
-  eval_path=$(bash -c "source '$env_file'; echo \$PATH" 2>/dev/null)
-  set +e
-  if echo "$eval_path" | tr ':' '\n' | grep -qxF "$install_dir"; then
-    pass "$desc: PATH contains install dir after sourcing env"
-  else
-    fail "$desc: PATH does not contain install dir after sourcing env"
-  fi
-
-  # Test duplicate prevention: run install again
-  set +e
-  out2=$(SHELL="/bin/$shell_name" \
-         HOME="$temp_home" \
-         MANIFEST_URL="$BASE_URL/manifest.json" \
-         INSTALL_DIR="$install_dir" \
-         CONFIG_DIR="$temp_home/.netclaw/config" \
-         bash "$INSTALL_SH" 2>&1)
-  rc2=$?
-  set +e
-
-  if [ "$rc2" -eq 0 ]; then
-    local dup_count
-    dup_count=$(grep -cxF ". \"$env_file\"" "$rc_file" 2>/dev/null || true)
-    if [ "$dup_count" -eq 1 ]; then
-      pass "$desc: no duplicate source line after second install"
-    else
-      fail "$desc: $dup_count source lines after second install (expected 1)"
-    fi
-
-    # Verify the "already sources" message appears
-    if echo "$out2" | grep -qF "already sources netclaw"; then
-      pass "$desc: outputs 'already sources netclaw' on re-install"
-    else
-      fail "$desc: missing 'already sources netclaw' message on re-install"
-    fi
-  else
-    fail "$desc: second install failed (exit=$rc2)"
+    fail "$desc: install directory appears $count times on PATH"
   fi
 }
 
-# Test bash on Linux — should modify ~/.bashrc
-# Test bash — RC file depends on host OS: .bashrc on Linux, .profile on macOS
-BASH_RC=$(uname -s | grep -q Darwin && echo ".profile" || echo ".bashrc")
-shell_integration_test "bash-$(uname)" "bash" "$BASH_RC"
+run_unix_installer() {
+  local shell_path="$1" home="$2" install_dir="$3"
+  shift 3
+  SHELL="$shell_path" HOME="$home" \
+    MANIFEST_URL="$BASE_URL/manifest.json" INSTALL_DIR="$install_dir" \
+    CONFIG_DIR="$home/.netclaw/config" \
+    bash "$INSTALL_SH" "$@"
+}
 
-# Test zsh — should modify ~/.zshrc
-shell_integration_test "zsh" "zsh" ".zshrc"
+# Bash: run the generated startup path through Bash itself, then repeat the
+# install to prove both profile mutation and PATH evaluation are idempotent.
+BASH_HOME="$WORK/shell-bash"
+BASH_INSTALL="$BASH_HOME/netclaw install's/bin"
+mkdir -p "$BASH_HOME"
+if [ "$(uname -s)" = "Darwin" ]; then
+  BASH_RC="$BASH_HOME/.bash_profile"
+  printf '# existing bash profile' > "$BASH_RC"
+  printf '# profile must remain untouched\n' > "$BASH_HOME/.profile"
+else
+  BASH_RC="$BASH_HOME/.bashrc"
+  printf '# existing bash rc' > "$BASH_RC"
+fi
 
-# Test fish — should modify ~/.config/fish/conf.d/netclaw.fish
-# Test fish — unset XDG_CONFIG_HOME so it falls back to $HOME/.config
-# (CI runners may have XDG_CONFIG_HOME set to a path outside our temp HOME)
-FISH_HOME="$WORK/shell-int-fish"
-FISH_INSTALL="$FISH_HOME/.netclaw/bin"
-FISH_RC="$FISH_HOME/.config/fish/conf.d/netclaw.fish"
-FISH_ENV="$FISH_HOME/.netclaw/env"
-set +e
-fish_out=$(env -u XDG_CONFIG_HOME \
-           SHELL="/bin/fish" \
-           HOME="$FISH_HOME" \
-           MANIFEST_URL="$BASE_URL/manifest.json" \
-           INSTALL_DIR="$FISH_INSTALL" \
-           CONFIG_DIR="$FISH_HOME/.netclaw/config" \
-           bash "$INSTALL_SH" 2>&1)
-fish_rc=$?
-set +e
-if [ "$fish_rc" -ne 0 ]; then
-  fail "fish: install failed (exit=$fish_rc)"
-  echo "$fish_out" | indent
-else
-  pass "fish: install completes"
-fi
-if [ -f "$FISH_ENV" ]; then
-  pass "fish: env script created"
-else
-  fail "fish: env script not found"
-fi
-fish_src_count=$(grep -cxF ". \"$FISH_ENV\"" "$FISH_RC" 2>/dev/null || true)
-if [ "$fish_src_count" -eq 1 ]; then
-  pass "fish: conf.d/netclaw.fish contains exactly 1 source line"
-else
-  fail "fish: conf.d/netclaw.fish contains $fish_src_count source lines (expected 1)"
-fi
-if grep -qF "# netclaw shell setup" "$FISH_RC" 2>/dev/null; then
-  pass "fish: conf.d/netclaw.fish contains marker comment"
-else
-  fail "fish: conf.d/netclaw.fish missing marker comment"
-fi
-# Verify PATH works after sourcing
-set +e
-eval_path=$(bash -c "source '$FISH_ENV'; echo \$PATH" 2>/dev/null)
-set +e
-if echo "$eval_path" | tr ':' '\n' | grep -qxF "$FISH_INSTALL"; then
-  pass "fish: PATH contains install dir after sourcing env"
-else
-  fail "fish: PATH does not contain install dir after sourcing env"
-fi
-# Test duplicate prevention: run install again
-set +e
-fish_out2=$(env -u XDG_CONFIG_HOME \
-            SHELL="/bin/fish" \
-            HOME="$FISH_HOME" \
-            MANIFEST_URL="$BASE_URL/manifest.json" \
-            INSTALL_DIR="$FISH_INSTALL" \
-            CONFIG_DIR="$FISH_HOME/.netclaw/config" \
-            bash "$INSTALL_SH" 2>&1)
-fish_rc2=$?
-set +e
-if [ "$fish_rc2" -eq 0 ]; then
-  dup_count=$(grep -cxF ". \"$FISH_ENV\"" "$FISH_RC" 2>/dev/null || true)
-  if [ "$dup_count" -eq 1 ]; then
-    pass "fish: no duplicate source line after second install"
+if run_unix_installer "$(command -v bash)" "$BASH_HOME" "$BASH_INSTALL" >/dev/null \
+    && run_unix_installer "$(command -v bash)" "$BASH_HOME" "$BASH_INSTALL" >/dev/null; then
+  bash_path=$(PATH="/usr/bin:/bin" HOME="$BASH_HOME" \
+    bash --noprofile --rcfile "$BASH_RC" -i -c 'printf "%s" "$PATH"' 2>/dev/null)
+  assert_path_once "bash" "$bash_path" "$BASH_INSTALL"
+  source_count=$(grep -cF "$BASH_HOME/.netclaw/env" "$BASH_RC" || true)
+  if [ "$source_count" -eq 1 ]; then
+    pass "bash: profile source line is idempotent"
   else
-    fail "fish: $dup_count source lines after second install (expected 1)"
+    fail "bash: profile contains $source_count netclaw source lines"
   fi
-  if echo "$fish_out2" | grep -qF "already sources netclaw"; then
-    pass "fish: outputs 'already sources netclaw' on re-install"
+  if [ "$(uname -s)" = "Darwin" ] && ! grep -qF netclaw "$BASH_HOME/.profile"; then
+    pass "bash-macos: existing .bash_profile wins over .profile"
   fi
 else
-  fail "fish: second install failed (exit=$fish_rc2)"
+  fail "bash: installer failed"
 fi
 
-# Test --skip-shell — should NOT modify any RC file
-echo ""
-echo "  shell-int --skip-shell:"
-SKIP_HOME="$WORK/shell-int-skip"
-SKIP_INSTALL="$SKIP_HOME/.netclaw/bin"
-SKIP_RC="$SKIP_HOME/.bashrc"
-mkdir -p "$SKIP_HOME"
-printf '# skip test\n' > "$SKIP_RC"
-set +e
-skip_out=$(SHELL="/bin/bash" \
-           HOME="$SKIP_HOME" \
-           MANIFEST_URL="$BASE_URL/manifest.json" \
-           INSTALL_DIR="$SKIP_INSTALL" \
-           CONFIG_DIR="$SKIP_HOME/.netclaw/config" \
-           bash "$INSTALL_SH" --skip-shell 2>&1)
-skip_rc=$?
-set +e
-if [ "$skip_rc" -eq 0 ]; then
-  pass "--skip-shell: install completes without error"
-else
-  fail "--skip-shell: install failed (exit=$skip_rc)"
-fi
-# Verify the RC file was NOT modified (no source line added)
-skip_lines=$(grep -cF ". \"$SKIP_HOME/.netclaw/env\"" "$SKIP_RC" 2>/dev/null || true)
-if [ "${skip_lines:-0}" -eq 0 ]; then
-  pass "--skip-shell: .bashrc was not modified"
-else
-  fail "--skip-shell: .bashrc was modified (found $skip_lines source lines)"
-fi
-# Verify no env script was created
-if [ ! -f "$SKIP_HOME/.netclaw/env" ]; then
-  pass "--skip-shell: env script was not created"
-else
-  fail "--skip-shell: env script was created"
-fi
-# Verify the output mentions "skipped"
-if echo "$skip_out" | grep -qi "shell integration skipped"; then
-  pass "--skip-shell: output mentions shell integration skipped"
-else
-  fail "--skip-shell: missing 'skipped' message in output"
-fi
-
-# Test unknown shell — should not crash, should print manual instructions
-echo ""
-echo "  shell-int unknown shell:"
-UNKNOWN_HOME="$WORK/shell-int-unknown"
-UNKNOWN_INSTALL="$UNKNOWN_HOME/.netclaw/bin"
-set +e
-unknown_out=$(SHELL="/bin/unknownshell" \
-              HOME="$UNKNOWN_HOME" \
-              MANIFEST_URL="$BASE_URL/manifest.json" \
-              INSTALL_DIR="$UNKNOWN_INSTALL" \
-              CONFIG_DIR="$UNKNOWN_HOME/.netclaw/config" \
-              bash "$INSTALL_SH" 2>&1)
-unknown_rc=$?
-set +e
-if [ "$unknown_rc" -eq 0 ]; then
-  pass "unknown shell: install completes without error"
-else
-  fail "unknown shell: install failed (exit=$unknown_rc)"
-fi
-if echo "$unknown_out" | grep -qi "not supported for automatic PATH setup"; then
-  pass "unknown shell: prints unsupported shell message"
-else
-  fail "unknown shell: missing unsupported shell message"
-fi
-
-# Test ZDOTDIR — zsh should respect ZDOTDIR for RC location
-echo ""
-echo "  shell-int ZDOTDIR:"
-ZDOT_HOME="$WORK/shell-int-zdotdir"
-ZDOT_DIR="$ZDOT_HOME/custom-zdotdir"
-ZDOT_INSTALL="$ZDOT_HOME/.netclaw/bin"
-ZDOT_RC="$ZDOT_DIR/.zshrc"
-mkdir -p "$ZDOT_DIR"
-printf '# zdotdir config\n' > "$ZDOT_RC"
-set +e
-zdot_out=$(SHELL="/bin/zsh" \
-           HOME="$ZDOT_HOME" \
-           ZDOTDIR="$ZDOT_DIR" \
-           MANIFEST_URL="$BASE_URL/manifest.json" \
-           INSTALL_DIR="$ZDOT_INSTALL" \
-           CONFIG_DIR="$ZDOT_HOME/.netclaw/config" \
-           bash "$INSTALL_SH" 2>&1)
-zdot_rc=$?
-set +e
-if [ "$zdot_rc" -eq 0 ]; then
-  # Check the ZDOTDIR rc file was modified, NOT ~/.zshrc
-  if grep -qxF '. "'"$ZDOT_HOME/.netclaw/env"'"' "$ZDOT_RC" 2>/dev/null; then
-    pass "ZDOTDIR: source line added to \$ZDOTDIR/.zshrc"
+# Zsh: CI installs zsh on Linux and macOS provides it. Explicitly source the
+# selected ZDOTDIR file under zsh so a Bash-compatible false positive cannot pass.
+if command -v zsh >/dev/null 2>&1; then
+  ZSH_HOME="$WORK/shell-zsh"
+  ZDOT_DIR="$ZSH_HOME/custom-zdotdir"
+  ZSH_INSTALL="$ZSH_HOME/netclaw install's/bin"
+  mkdir -p "$ZDOT_DIR"
+  printf '# existing zsh config\n' > "$ZDOT_DIR/.zshrc"
+  if ZDOTDIR="$ZDOT_DIR" run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null \
+      && ZDOTDIR="$ZDOT_DIR" run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null; then
+    zsh_path=$(PATH="/usr/bin:/bin" ZDOTDIR="$ZDOT_DIR" \
+      zsh -f -c 'source "$ZDOTDIR/.zshrc"; print -rn -- "$PATH"')
+    assert_path_once "zsh" "$zsh_path" "$ZSH_INSTALL"
+    if [ ! -e "$ZSH_HOME/.zshrc" ]; then
+      pass "zsh: ZDOTDIR is authoritative"
+    else
+      fail "zsh: installer touched ~/.zshrc despite ZDOTDIR"
+    fi
   else
-    fail "ZDOTDIR: source line not found in \$ZDOTDIR/.zshrc"
-    cat "$ZDOT_RC" | indent
-  fi
-  # Verify ~/.zshrc was NOT created or modified
-  if [ ! -f "$ZDOT_HOME/.zshrc" ]; then
-    pass "ZDOTDIR: ~/.zshrc was not touched"
-  else
-    fail "ZDOTDIR: ~/.zshrc was created (should not exist)"
+    fail "zsh: installer failed"
   fi
 else
-  fail "ZDOTDIR: install failed (exit=$zdot_rc)"
-  echo "$zdot_out" | indent
+  echo "SKIP: zsh executable not available"
 fi
+
+# Fish owns a native conf.d file. Execute that file with fish, not Bash.
+if command -v fish >/dev/null 2>&1; then
+  FISH_HOME="$WORK/shell-fish"
+  FISH_INSTALL="$FISH_HOME/netclaw install's/bin"
+  FISH_RC="$FISH_HOME/.config/fish/conf.d/netclaw.fish"
+  if XDG_CONFIG_HOME="$FISH_HOME/.config" \
+      run_unix_installer "$(command -v fish)" "$FISH_HOME" "$FISH_INSTALL" >/dev/null \
+      && XDG_CONFIG_HOME="$FISH_HOME/.config" \
+      run_unix_installer "$(command -v fish)" "$FISH_HOME" "$FISH_INSTALL" >/dev/null; then
+    fish_path=$(PATH="/usr/bin:/bin" fish --no-config -c \
+      "source '$FISH_RC'; string join : -- \$PATH")
+    assert_path_once "fish" "$fish_path" "$FISH_INSTALL"
+  else
+    fail "fish: installer failed"
+  fi
+else
+  echo "SKIP: fish executable not available"
+fi
+
+# Opt-out and unsupported shells must leave shell files alone and print a
+# self-contained command instead of referring to an env file that was not made.
+for mode in skip unknown; do
+  MANUAL_HOME="$WORK/shell-$mode"
+  MANUAL_INSTALL="$MANUAL_HOME/netclaw install's/bin"
+  mkdir -p "$MANUAL_HOME"
+  if [ "$mode" = "skip" ]; then
+    manual_out=$(run_unix_installer "$(command -v bash)" "$MANUAL_HOME" "$MANUAL_INSTALL" --skip-shell)
+  else
+    manual_out=$(run_unix_installer /bin/unknownshell "$MANUAL_HOME" "$MANUAL_INSTALL")
+  fi
+  manual_command=$(printf '%s\n' "$manual_out" | sed -n 's/^  \{0,4\}\(export PATH=.*\)$/\1/p' | head -1)
+  if [ -n "$manual_command" ] && [ ! -e "$MANUAL_HOME/.netclaw/env" ]; then
+    manual_path=$(PATH="/usr/bin:/bin" bash -c "$manual_command; printf '%s' \"\$PATH\"")
+    assert_path_once "$mode" "$manual_path" "$MANUAL_INSTALL"
+  else
+    fail "$mode: missing usable manual PATH command or created shell files"
+  fi
+done
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -345,6 +345,257 @@ else
   fail "config: --channel stable on existing beta (exit=$down_rc)"
 fi
 
+# ── 9. Shell integration (PATH automation) ───────────────────────────────────
+# Tests that install.sh correctly modifies shell RC files for bash, zsh, and fish.
+# Uses fake SHELL values and temp home directories to isolate each case.
+echo ""
+echo "=== shell integration ==="
+
+# shell_integration_test <desc> <shell_name> <rc_relpath>
+#   desc:        test description
+#   shell_name:  basename of the fake SHELL (bash, zsh, fish, unknown)
+#   rc_relpath:  path relative to temp HOME where the RC file should be created
+shell_integration_test() {
+  local desc="$1" shell_name="$2" rc_rel="$3"
+  local temp_home="$WORK/shell-int-$desc"
+  local install_dir="$temp_home/.netclaw/bin"
+  local rc_file="$temp_home/$rc_rel"
+  local env_file="$temp_home/.netclaw/env"
+
+  # Pre-seed a minimal RC file so the installer has something to append to
+  mkdir -p "$(dirname "$rc_file")"
+  printf '# existing config\n' > "$rc_file"
+
+  # Run install WITHOUT --skip-shell
+  set +e
+  local out rc
+  out=$(SHELL="/bin/$shell_name" \
+        HOME="$temp_home" \
+        MANIFEST_URL="$BASE_URL/manifest.json" \
+        INSTALL_DIR="$install_dir" \
+        CONFIG_DIR="$temp_home/.netclaw/config" \
+        bash "$INSTALL_SH" 2>&1)
+  rc=$?
+  set +e
+
+  if [ "$rc" -ne 0 ]; then
+    fail "$desc: install failed (exit=$rc)"
+    echo "$out" | indent
+    return
+  fi
+
+  # Verify env script was created
+  if [ -f "$env_file" ]; then
+    pass "$desc: env script created at .netclaw/env"
+  else
+    fail "$desc: env script not found at .netclaw/env"
+  fi
+
+  # Verify env script is executable
+  if [ -x "$env_file" ]; then
+    pass "$desc: env script is executable"
+  else
+    fail "$desc: env script is not executable"
+  fi
+
+  # Verify env script contains the colon-affixed PATH guard (rustup pattern)
+  if grep -qF 'case ":${PATH}:"' "$env_file" 2>/dev/null; then
+    pass "$desc: env script contains colon-affixed PATH guard"
+  else
+    fail "$desc: env script missing colon-affixed PATH guard"
+  fi
+
+  # Verify env script contains the install dir in the PATH export
+  if grep -qF "export PATH=\"$install_dir:" "$env_file" 2>/dev/null; then
+    pass "$desc: env script exports correct install dir"
+  else
+    fail "$desc: env script does not export correct install dir"
+  fi
+
+  # Verify RC file was modified with the source line
+  local src_count
+  src_count=$(grep -cxF ". \"$env_file\"" "$rc_file" 2>/dev/null || true)
+  if [ "$src_count" -eq 1 ]; then
+    pass "$desc: $rc_rel contains exactly 1 source line"
+  else
+    fail "$desc: $rc_rel contains $src_count source lines (expected 1)"
+  fi
+
+  # Verify RC file contains the marker comment
+  if grep -qF "# netclaw shell setup" "$rc_file" 2>/dev/null; then
+    pass "$desc: $rc_rel contains marker comment"
+  else
+    fail "$desc: $rc_rel missing marker comment"
+  fi
+
+  # Verify the RC file is syntactically valid (bash -n)
+  set +e
+  bash -n "$rc_file" 2>"$WORK/syntax_err_$desc"
+  local syntax_rc=$?
+  set +e
+  if [ "$syntax_rc" -eq 0 ]; then
+    pass "$desc: $rc_rel passes bash -n syntax check"
+  else
+    fail "$desc: $rc_rel has syntax errors"
+    cat "$WORK/syntax_err_$desc" | indent
+  fi
+
+  # Verify PATH is correct after sourcing the env script
+  set +e
+  local eval_path
+  eval_path=$(bash -c "source '$env_file'; echo \$PATH" 2>/dev/null)
+  set +e
+  if echo "$eval_path" | tr ':' '\n' | grep -qxF "$install_dir"; then
+    pass "$desc: PATH contains install dir after sourcing env"
+  else
+    fail "$desc: PATH does not contain install dir after sourcing env"
+  fi
+
+  # Test duplicate prevention: run install again
+  set +e
+  out2=$(SHELL="/bin/$shell_name" \
+         HOME="$temp_home" \
+         MANIFEST_URL="$BASE_URL/manifest.json" \
+         INSTALL_DIR="$install_dir" \
+         CONFIG_DIR="$temp_home/.netclaw/config" \
+         bash "$INSTALL_SH" 2>&1)
+  rc2=$?
+  set +e
+
+  if [ "$rc2" -eq 0 ]; then
+    local dup_count
+    dup_count=$(grep -cxF ". \"$env_file\"" "$rc_file" 2>/dev/null || true)
+    if [ "$dup_count" -eq 1 ]; then
+      pass "$desc: no duplicate source line after second install"
+    else
+      fail "$desc: $dup_count source lines after second install (expected 1)"
+    fi
+
+    # Verify the "already sources" message appears
+    if echo "$out2" | grep -qF "already sources netclaw"; then
+      pass "$desc: outputs 'already sources netclaw' on re-install"
+    else
+      fail "$desc: missing 'already sources netclaw' message on re-install"
+    fi
+  else
+    fail "$desc: second install failed (exit=$rc2)"
+  fi
+}
+
+# Test bash on Linux — should modify ~/.bashrc
+shell_integration_test "bash-linux" "bash" ".bashrc"
+
+# Test zsh — should modify ~/.zshrc
+shell_integration_test "zsh" "zsh" ".zshrc"
+
+# Test fish — should modify ~/.config/fish/conf.d/netclaw.fish
+shell_integration_test "fish" "fish" ".config/fish/conf.d/netclaw.fish"
+
+# Test --skip-shell — should NOT modify any RC file
+echo ""
+echo "  shell-int --skip-shell:"
+SKIP_HOME="$WORK/shell-int-skip"
+SKIP_INSTALL="$SKIP_HOME/.netclaw/bin"
+SKIP_RC="$SKIP_HOME/.bashrc"
+mkdir -p "$SKIP_HOME"
+printf '# skip test\n' > "$SKIP_RC"
+set +e
+skip_out=$(SHELL="/bin/bash" \
+           HOME="$SKIP_HOME" \
+           MANIFEST_URL="$BASE_URL/manifest.json" \
+           INSTALL_DIR="$SKIP_INSTALL" \
+           CONFIG_DIR="$SKIP_HOME/.netclaw/config" \
+           bash "$INSTALL_SH" --skip-shell 2>&1)
+skip_rc=$?
+set +e
+if [ "$skip_rc" -eq 0 ]; then
+  pass "--skip-shell: install completes without error"
+else
+  fail "--skip-shell: install failed (exit=$skip_rc)"
+fi
+# Verify the RC file was NOT modified (no source line added)
+skip_lines=$(grep -cF ". \"$SKIP_HOME/.netclaw/env\"" "$SKIP_RC" 2>/dev/null || true)
+if [ "${skip_lines:-0}" -eq 0 ]; then
+  pass "--skip-shell: .bashrc was not modified"
+else
+  fail "--skip-shell: .bashrc was modified (found $skip_lines source lines)"
+fi
+# Verify no env script was created
+if [ ! -f "$SKIP_HOME/.netclaw/env" ]; then
+  pass "--skip-shell: env script was not created"
+else
+  fail "--skip-shell: env script was created"
+fi
+# Verify the output mentions "skipped"
+if echo "$skip_out" | grep -qi "shell integration skipped"; then
+  pass "--skip-shell: output mentions shell integration skipped"
+else
+  fail "--skip-shell: missing 'skipped' message in output"
+fi
+
+# Test unknown shell — should not crash, should print manual instructions
+echo ""
+echo "  shell-int unknown shell:"
+UNKNOWN_HOME="$WORK/shell-int-unknown"
+UNKNOWN_INSTALL="$UNKNOWN_HOME/.netclaw/bin"
+set +e
+unknown_out=$(SHELL="/bin/unknownshell" \
+              HOME="$UNKNOWN_HOME" \
+              MANIFEST_URL="$BASE_URL/manifest.json" \
+              INSTALL_DIR="$UNKNOWN_INSTALL" \
+              CONFIG_DIR="$UNKNOWN_HOME/.netclaw/config" \
+              bash "$INSTALL_SH" 2>&1)
+unknown_rc=$?
+set +e
+if [ "$unknown_rc" -eq 0 ]; then
+  pass "unknown shell: install completes without error"
+else
+  fail "unknown shell: install failed (exit=$unknown_rc)"
+fi
+if echo "$unknown_out" | grep -qi "not supported for automatic PATH setup"; then
+  pass "unknown shell: prints unsupported shell message"
+else
+  fail "unknown shell: missing unsupported shell message"
+fi
+
+# Test ZDOTDIR — zsh should respect ZDOTDIR for RC location
+echo ""
+echo "  shell-int ZDOTDIR:"
+ZDOT_HOME="$WORK/shell-int-zdotdir"
+ZDOT_DIR="$ZDOT_HOME/custom-zdotdir"
+ZDOT_INSTALL="$ZDOT_HOME/.netclaw/bin"
+ZDOT_RC="$ZDOT_DIR/.zshrc"
+mkdir -p "$ZDOT_DIR"
+printf '# zdotdir config\n' > "$ZDOT_RC"
+set +e
+zdot_out=$(SHELL="/bin/zsh" \
+           HOME="$ZDOT_HOME" \
+           ZDOTDIR="$ZDOT_DIR" \
+           MANIFEST_URL="$BASE_URL/manifest.json" \
+           INSTALL_DIR="$ZDOT_INSTALL" \
+           CONFIG_DIR="$ZDOT_HOME/.netclaw/config" \
+           bash "$INSTALL_SH" 2>&1)
+zdot_rc=$?
+set +e
+if [ "$zdot_rc" -eq 0 ]; then
+  # Check the ZDOTDIR rc file was modified, NOT ~/.zshrc
+  if grep -qxF '. "'"$ZDOT_HOME/.netclaw/env"'"' "$ZDOT_RC" 2>/dev/null; then
+    pass "ZDOTDIR: source line added to \$ZDOTDIR/.zshrc"
+  else
+    fail "ZDOTDIR: source line not found in \$ZDOTDIR/.zshrc"
+    cat "$ZDOT_RC" | indent
+  fi
+  # Verify ~/.zshrc was NOT created or modified
+  if [ ! -f "$ZDOT_HOME/.zshrc" ]; then
+    pass "ZDOTDIR: ~/.zshrc was not touched"
+  else
+    fail "ZDOTDIR: ~/.zshrc was created (should not exist)"
+  fi
+else
+  fail "ZDOTDIR: install failed (exit=$zdot_rc)"
+  echo "$zdot_out" | indent
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -508,13 +508,85 @@ shell_integration_test() {
 }
 
 # Test bash on Linux — should modify ~/.bashrc
-shell_integration_test "bash-linux" "bash" ".bashrc"
+# Test bash — RC file depends on host OS: .bashrc on Linux, .profile on macOS
+BASH_RC=$(uname -s | grep -q Darwin && echo ".profile" || echo ".bashrc")
+shell_integration_test "bash-$(uname)" "bash" "$BASH_RC"
 
 # Test zsh — should modify ~/.zshrc
 shell_integration_test "zsh" "zsh" ".zshrc"
 
 # Test fish — should modify ~/.config/fish/conf.d/netclaw.fish
-shell_integration_test "fish" "fish" ".config/fish/conf.d/netclaw.fish"
+# Test fish — unset XDG_CONFIG_HOME so it falls back to $HOME/.config
+# (CI runners may have XDG_CONFIG_HOME set to a path outside our temp HOME)
+FISH_HOME="$WORK/shell-int-fish"
+FISH_INSTALL="$FISH_HOME/.netclaw/bin"
+FISH_RC="$FISH_HOME/.config/fish/conf.d/netclaw.fish"
+FISH_ENV="$FISH_HOME/.netclaw/env"
+set +e
+fish_out=$(env -u XDG_CONFIG_HOME \
+           SHELL="/bin/fish" \
+           HOME="$FISH_HOME" \
+           MANIFEST_URL="$BASE_URL/manifest.json" \
+           INSTALL_DIR="$FISH_INSTALL" \
+           CONFIG_DIR="$FISH_HOME/.netclaw/config" \
+           bash "$INSTALL_SH" 2>&1)
+fish_rc=$?
+set +e
+if [ "$fish_rc" -ne 0 ]; then
+  fail "fish: install failed (exit=$fish_rc)"
+  echo "$fish_out" | indent
+else
+  pass "fish: install completes"
+fi
+if [ -f "$FISH_ENV" ]; then
+  pass "fish: env script created"
+else
+  fail "fish: env script not found"
+fi
+fish_src_count=$(grep -cxF ". \"$FISH_ENV\"" "$FISH_RC" 2>/dev/null || true)
+if [ "$fish_src_count" -eq 1 ]; then
+  pass "fish: conf.d/netclaw.fish contains exactly 1 source line"
+else
+  fail "fish: conf.d/netclaw.fish contains $fish_src_count source lines (expected 1)"
+fi
+if grep -qF "# netclaw shell setup" "$FISH_RC" 2>/dev/null; then
+  pass "fish: conf.d/netclaw.fish contains marker comment"
+else
+  fail "fish: conf.d/netclaw.fish missing marker comment"
+fi
+# Verify PATH works after sourcing
+set +e
+eval_path=$(bash -c "source '$FISH_ENV'; echo \$PATH" 2>/dev/null)
+set +e
+if echo "$eval_path" | tr ':' '\n' | grep -qxF "$FISH_INSTALL"; then
+  pass "fish: PATH contains install dir after sourcing env"
+else
+  fail "fish: PATH does not contain install dir after sourcing env"
+fi
+# Test duplicate prevention: run install again
+set +e
+fish_out2=$(env -u XDG_CONFIG_HOME \
+            SHELL="/bin/fish" \
+            HOME="$FISH_HOME" \
+            MANIFEST_URL="$BASE_URL/manifest.json" \
+            INSTALL_DIR="$FISH_INSTALL" \
+            CONFIG_DIR="$FISH_HOME/.netclaw/config" \
+            bash "$INSTALL_SH" 2>&1)
+fish_rc2=$?
+set +e
+if [ "$fish_rc2" -eq 0 ]; then
+  dup_count=$(grep -cxF ". \"$FISH_ENV\"" "$FISH_RC" 2>/dev/null || true)
+  if [ "$dup_count" -eq 1 ]; then
+    pass "fish: no duplicate source line after second install"
+  else
+    fail "fish: $dup_count source lines after second install (expected 1)"
+  fi
+  if echo "$fish_out2" | grep -qF "already sources netclaw"; then
+    pass "fish: outputs 'already sources netclaw' on re-install"
+  fi
+else
+  fail "fish: second install failed (exit=$fish_rc2)"
+fi
 
 # Test --skip-shell — should NOT modify any RC file
 echo ""

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -189,6 +189,18 @@ check_detect "macOS x86_64 + Rosetta -> osx-arm64" Darwin x86_64 1 'DRY RUN: wou
 check_detect "Intel Mac rejected"               Darwin x86_64  0 'Apple Silicon'    1
 check_detect "unsupported OS rejected"          freebsd x86_64 0 'Unsupported OS'   1
 
+set +e
+invalid_path_out=$(INSTALL_DIR="$WORK/invalid:path" \
+  MANIFEST_URL="$BASE_URL/manifest.json" \
+  bash "$INSTALL_SH" --dry-run 2>&1)
+invalid_path_rc=$?
+set -e
+if [ "$invalid_path_rc" -ne 0 ] && echo "$invalid_path_out" | grep -q "cannot contain ':'"; then
+  pass "PATH: unrepresentable Unix install directory rejected"
+else
+  fail "PATH: Unix install directory containing ':' was accepted"
+fi
+
 # Exercise the dependency-free parser with a valid manifest whose asset fields
 # are in reverse order. A private mirror need not preserve JSON property order.
 NO_JQ_BIN="$WORK/no-jq-bin"
@@ -462,6 +474,13 @@ if run_unix_installer "$(command -v bash)" "$BASH_HOME" "$BASH_INSTALL" >/dev/nu
   bash_path=$(PATH="/usr/bin:/bin" HOME="$BASH_HOME" \
     bash --noprofile --rcfile "$BASH_RC" -i -c 'printf "%s" "$PATH"' 2>/dev/null)
   assert_path_once "bash" "$bash_path" "$BASH_INSTALL"
+  bash_empty_path=$(PATH="" HOME="$BASH_HOME" \
+    /bin/bash --noprofile --rcfile "$BASH_RC" -i -c 'printf "%s" "$PATH"' 2>/dev/null)
+  if [ "$bash_empty_path" = "$BASH_INSTALL" ]; then
+    pass "bash: empty PATH does not introduce a current-directory entry"
+  else
+    fail "bash: empty PATH produced '$bash_empty_path'"
+  fi
   source_count=$(grep -cF "$BASH_HOME/.netclaw/env" "$BASH_RC" || true)
   if [ "$source_count" -eq 1 ]; then
     pass "bash: profile source line is idempotent"
@@ -534,6 +553,12 @@ for mode in skip unknown; do
   if [ -n "$manual_command" ] && [ ! -e "$MANUAL_HOME/.netclaw/env" ]; then
     manual_path=$(PATH="/usr/bin:/bin" bash -c "$manual_command; printf '%s' \"\$PATH\"")
     assert_path_once "$mode" "$manual_path" "$MANUAL_INSTALL"
+    manual_empty_path=$(PATH="" /bin/bash -c "$manual_command; printf '%s' \"\$PATH\"")
+    if [ "$manual_empty_path" = "$MANUAL_INSTALL" ]; then
+      pass "$mode: manual command preserves an empty PATH without adding current directory"
+    else
+      fail "$mode: manual command produced '$manual_empty_path' from an empty PATH"
+    fi
   else
     fail "$mode: missing usable manual PATH command or created shell files"
   fi

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -189,11 +189,11 @@ check_detect "macOS x86_64 + Rosetta -> osx-arm64" Darwin x86_64 1 'DRY RUN: wou
 check_detect "Intel Mac rejected"               Darwin x86_64  0 'Apple Silicon'    1
 check_detect "unsupported OS rejected"          freebsd x86_64 0 'Unsupported OS'   1
 
-# Exercise the grep parser with a valid manifest whose asset fields are in the
-# reverse order. A private mirror need not preserve the generator's JSON order.
+# Exercise the dependency-free parser with a valid manifest whose asset fields
+# are in reverse order. A private mirror need not preserve JSON property order.
 NO_JQ_BIN="$WORK/no-jq-bin"
 mkdir -p "$NO_JQ_BIN"
-for cmd in bash curl cut grep head mktemp rm sed sha256sum shasum tar tr uname; do
+for cmd in awk bash curl cut grep head mktemp rm sed sha256sum shasum tar tr uname; do
   command_path=$(command -v "$cmd" 2>/dev/null || true)
   if [ -n "$command_path" ]; then
     ln -s "$command_path" "$NO_JQ_BIN/$cmd"
@@ -207,11 +207,11 @@ no_jq_out=$(PATH="$NO_JQ_BIN" \
 no_jq_rc=$?
 set -e
 if [ "$no_jq_rc" -eq 0 ] \
-    && echo "$no_jq_out" | grep -q 'DRY RUN: would install netclaw ' \
-    && echo "$no_jq_out" | grep -q 'DRY RUN: would install netclawd '; then
-  pass "manifest: jq-less parser accepts rid-before-component assets"
+    && echo "$no_jq_out" | grep -q "DRY RUN: would install netclaw .*/$VERSION/" \
+    && echo "$no_jq_out" | grep -q "DRY RUN: would install netclawd .*/$VERSION/"; then
+  pass "manifest: jq-less parser selects stable assets with reordered fields"
 else
-  fail "manifest: jq-less rid-before-component parse failed (exit=$no_jq_rc)"
+  fail "manifest: jq-less reordered-field parse failed (exit=$no_jq_rc)"
   echo "$no_jq_out" | indent
 fi
 

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -201,6 +201,28 @@ else
   fail "PATH: Unix install directory containing ':' was accepted"
 fi
 
+PHYSICAL_INSTALL="$WORK/physical:install"
+SYMLINK_INSTALL="$WORK/safe-install-link"
+SYMLINK_HOME="$WORK/symlink-home"
+mkdir -p "$PHYSICAL_INSTALL" "$SYMLINK_HOME"
+ln -s "$PHYSICAL_INSTALL" "$SYMLINK_INSTALL"
+set +e
+symlink_path_out=$(HOME="$SYMLINK_HOME" SHELL="$(command -v bash)" \
+  INSTALL_DIR="$SYMLINK_INSTALL" MANIFEST_URL="$BASE_URL/manifest.json" \
+  bash "$INSTALL_SH" cli 2>&1)
+symlink_path_rc=$?
+set -e
+if [ "$symlink_path_rc" -ne 0 ] \
+    && echo "$symlink_path_out" | grep -q "cannot contain ':'" \
+    && [ ! -e "$SYMLINK_HOME/.netclaw/env" ] \
+    && [ ! -e "$SYMLINK_HOME/.bashrc" ] \
+    && [ ! -e "$PHYSICAL_INSTALL/netclaw" ]; then
+  pass "PATH: physical install path is validated before install or shell mutation"
+else
+  fail "PATH: unrepresentable symlink target was installed or persisted"
+  echo "$symlink_path_out" | indent
+fi
+
 # Exercise the dependency-free parser with a valid manifest whose asset fields
 # are in reverse order. A private mirror need not preserve JSON property order.
 NO_JQ_BIN="$WORK/no-jq-bin"
@@ -495,22 +517,23 @@ else
   fail "bash: installer failed"
 fi
 
-# Zsh: CI installs zsh on Linux and macOS provides it. Explicitly source the
-# selected ZDOTDIR file under zsh so a Bash-compatible false positive cannot pass.
+# Zsh: resolve a non-exported ZDOTDIR from .zshenv, then execute the selected
+# startup file under zsh so a Bash-compatible false positive cannot pass.
 if command -v zsh >/dev/null 2>&1; then
   ZSH_HOME="$WORK/shell-zsh"
   ZDOT_DIR="$ZSH_HOME/custom-zdotdir"
   ZSH_INSTALL="$ZSH_HOME/netclaw install's/bin"
   mkdir -p "$ZDOT_DIR"
+  printf "ZDOTDIR='%s'\n" "$ZDOT_DIR" > "$ZSH_HOME/.zshenv"
   printf '# existing zsh config\n' > "$ZDOT_DIR/.zshrc"
-  if ZDOTDIR="$ZDOT_DIR" run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null \
-      && ZDOTDIR="$ZDOT_DIR" run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null; then
+  if (unset ZDOTDIR; run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null) \
+      && (unset ZDOTDIR; run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null); then
     ZSH_INSTALL_PHYSICAL=$(cd "$ZSH_INSTALL" && pwd -P)
     zsh_path=$(PATH="/usr/bin:/bin" ZDOTDIR="$ZDOT_DIR" \
       zsh -f -c 'source "$ZDOTDIR/.zshrc"; print -rn -- "$PATH"')
     assert_path_once "zsh" "$zsh_path" "$ZSH_INSTALL_PHYSICAL"
     if [ ! -e "$ZSH_HOME/.zshrc" ]; then
-      pass "zsh: ZDOTDIR is authoritative"
+      pass "zsh: non-exported ZDOTDIR is authoritative"
     else
       fail "zsh: installer touched ~/.zshrc despite ZDOTDIR"
     fi
@@ -541,32 +564,40 @@ else
   echo "SKIP: fish executable not available"
 fi
 
-# Opt-out and unsupported shells must leave shell files alone and print a
-# self-contained command instead of referring to an env file that was not made.
-for mode in skip unknown; do
-  MANUAL_HOME="$WORK/shell-$mode"
-  MANUAL_INSTALL="$MANUAL_HOME/netclaw install's/bin"
-  mkdir -p "$MANUAL_HOME"
-  if [ "$mode" = "skip" ]; then
-    manual_out=$(run_unix_installer "$(command -v bash)" "$MANUAL_HOME" "$MANUAL_INSTALL" --skip-shell)
+# Opt-out under a supported shell must print a self-contained command instead
+# of referring to an env file that was not made.
+MANUAL_HOME="$WORK/shell-skip"
+MANUAL_INSTALL="$MANUAL_HOME/netclaw install's/bin"
+mkdir -p "$MANUAL_HOME"
+manual_out=$(run_unix_installer "$(command -v bash)" "$MANUAL_HOME" "$MANUAL_INSTALL" --skip-shell)
+manual_command=$(printf '%s\n' "$manual_out" | sed -n 's/^  \{0,4\}\(export PATH=.*\)$/\1/p' | head -1)
+if [ -n "$manual_command" ] && [ ! -e "$MANUAL_HOME/.netclaw/env" ]; then
+  MANUAL_INSTALL_PHYSICAL=$(cd "$MANUAL_INSTALL" && pwd -P)
+  manual_path=$(PATH="/usr/bin:/bin" bash -c "$manual_command; printf '%s' \"\$PATH\"")
+  assert_path_once "skip" "$manual_path" "$MANUAL_INSTALL_PHYSICAL"
+  manual_empty_path=$(PATH="" /bin/bash -c "$manual_command; printf '%s' \"\$PATH\"")
+  if [ "$manual_empty_path" = "$MANUAL_INSTALL_PHYSICAL" ]; then
+    pass "skip: manual command preserves an empty PATH without adding current directory"
   else
-    manual_out=$(run_unix_installer /bin/unknownshell "$MANUAL_HOME" "$MANUAL_INSTALL")
+    fail "skip: manual command produced '$manual_empty_path' from an empty PATH"
   fi
-  manual_command=$(printf '%s\n' "$manual_out" | sed -n 's/^  \{0,4\}\(export PATH=.*\)$/\1/p' | head -1)
-  if [ -n "$manual_command" ] && [ ! -e "$MANUAL_HOME/.netclaw/env" ]; then
-    MANUAL_INSTALL_PHYSICAL=$(cd "$MANUAL_INSTALL" && pwd -P)
-    manual_path=$(PATH="/usr/bin:/bin" bash -c "$manual_command; printf '%s' \"\$PATH\"")
-    assert_path_once "$mode" "$manual_path" "$MANUAL_INSTALL_PHYSICAL"
-    manual_empty_path=$(PATH="" /bin/bash -c "$manual_command; printf '%s' \"\$PATH\"")
-    if [ "$manual_empty_path" = "$MANUAL_INSTALL_PHYSICAL" ]; then
-      pass "$mode: manual command preserves an empty PATH without adding current directory"
-    else
-      fail "$mode: manual command produced '$manual_empty_path' from an empty PATH"
-    fi
-  else
-    fail "$mode: missing usable manual PATH command or created shell files"
-  fi
-done
+else
+  fail "skip: missing usable manual PATH command or created shell files"
+fi
+
+# Unsupported shells get shell-neutral guidance; emitting Bash syntax for an
+# arbitrary shell would make the suggested command actively misleading.
+UNKNOWN_HOME="$WORK/shell-unknown"
+UNKNOWN_INSTALL="$UNKNOWN_HOME/netclaw install's/bin"
+unknown_out=$(run_unix_installer /bin/unknownshell "$UNKNOWN_HOME" "$UNKNOWN_INSTALL")
+UNKNOWN_INSTALL_PHYSICAL=$(cd "$UNKNOWN_INSTALL" && pwd -P)
+if echo "$unknown_out" | grep -qF "$UNKNOWN_INSTALL_PHYSICAL" \
+    && ! echo "$unknown_out" | grep -q 'export PATH=' \
+    && [ ! -e "$UNKNOWN_HOME/.netclaw/env" ]; then
+  pass "unknown: guidance is shell-neutral and no shell files are created"
+else
+  fail "unknown: guidance is shell-specific or shell files were created"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/smoke/install-smoke.sh
+++ b/scripts/smoke/install-smoke.sh
@@ -471,12 +471,13 @@ fi
 
 if run_unix_installer "$(command -v bash)" "$BASH_HOME" "$BASH_INSTALL" >/dev/null \
     && run_unix_installer "$(command -v bash)" "$BASH_HOME" "$BASH_INSTALL" >/dev/null; then
+  BASH_INSTALL_PHYSICAL=$(cd "$BASH_INSTALL" && pwd -P)
   bash_path=$(PATH="/usr/bin:/bin" HOME="$BASH_HOME" \
     bash --noprofile --rcfile "$BASH_RC" -i -c 'printf "%s" "$PATH"' 2>/dev/null)
-  assert_path_once "bash" "$bash_path" "$BASH_INSTALL"
+  assert_path_once "bash" "$bash_path" "$BASH_INSTALL_PHYSICAL"
   bash_empty_path=$(PATH="" HOME="$BASH_HOME" \
     /bin/bash --noprofile --rcfile "$BASH_RC" -i -c 'printf "%s" "$PATH"' 2>/dev/null)
-  if [ "$bash_empty_path" = "$BASH_INSTALL" ]; then
+  if [ "$bash_empty_path" = "$BASH_INSTALL_PHYSICAL" ]; then
     pass "bash: empty PATH does not introduce a current-directory entry"
   else
     fail "bash: empty PATH produced '$bash_empty_path'"
@@ -504,9 +505,10 @@ if command -v zsh >/dev/null 2>&1; then
   printf '# existing zsh config\n' > "$ZDOT_DIR/.zshrc"
   if ZDOTDIR="$ZDOT_DIR" run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null \
       && ZDOTDIR="$ZDOT_DIR" run_unix_installer "$(command -v zsh)" "$ZSH_HOME" "$ZSH_INSTALL" >/dev/null; then
+    ZSH_INSTALL_PHYSICAL=$(cd "$ZSH_INSTALL" && pwd -P)
     zsh_path=$(PATH="/usr/bin:/bin" ZDOTDIR="$ZDOT_DIR" \
       zsh -f -c 'source "$ZDOTDIR/.zshrc"; print -rn -- "$PATH"')
-    assert_path_once "zsh" "$zsh_path" "$ZSH_INSTALL"
+    assert_path_once "zsh" "$zsh_path" "$ZSH_INSTALL_PHYSICAL"
     if [ ! -e "$ZSH_HOME/.zshrc" ]; then
       pass "zsh: ZDOTDIR is authoritative"
     else
@@ -528,9 +530,10 @@ if command -v fish >/dev/null 2>&1; then
       run_unix_installer "$(command -v fish)" "$FISH_HOME" "$FISH_INSTALL" >/dev/null \
       && XDG_CONFIG_HOME="$FISH_HOME/.config" \
       run_unix_installer "$(command -v fish)" "$FISH_HOME" "$FISH_INSTALL" >/dev/null; then
+    FISH_INSTALL_PHYSICAL=$(cd "$FISH_INSTALL" && pwd -P)
     fish_path=$(PATH="/usr/bin:/bin" fish --no-config -c \
       "source '$FISH_RC'; string join : -- \$PATH")
-    assert_path_once "fish" "$fish_path" "$FISH_INSTALL"
+    assert_path_once "fish" "$fish_path" "$FISH_INSTALL_PHYSICAL"
   else
     fail "fish: installer failed"
   fi
@@ -551,10 +554,11 @@ for mode in skip unknown; do
   fi
   manual_command=$(printf '%s\n' "$manual_out" | sed -n 's/^  \{0,4\}\(export PATH=.*\)$/\1/p' | head -1)
   if [ -n "$manual_command" ] && [ ! -e "$MANUAL_HOME/.netclaw/env" ]; then
+    MANUAL_INSTALL_PHYSICAL=$(cd "$MANUAL_INSTALL" && pwd -P)
     manual_path=$(PATH="/usr/bin:/bin" bash -c "$manual_command; printf '%s' \"\$PATH\"")
-    assert_path_once "$mode" "$manual_path" "$MANUAL_INSTALL"
+    assert_path_once "$mode" "$manual_path" "$MANUAL_INSTALL_PHYSICAL"
     manual_empty_path=$(PATH="" /bin/bash -c "$manual_command; printf '%s' \"\$PATH\"")
-    if [ "$manual_empty_path" = "$MANUAL_INSTALL" ]; then
+    if [ "$manual_empty_path" = "$MANUAL_INSTALL_PHYSICAL" ]; then
       pass "$mode: manual command preserves an empty PATH without adding current directory"
     else
       fail "$mode: manual command produced '$manual_empty_path' from an empty PATH"


### PR DESCRIPTION
## Summary

Automatically make installed Netclaw binaries available on PATH while preserving an explicit opt-out:

- Unix: create `~/.netclaw/env` and source it from the detected bash or zsh startup file; write a native fish `conf.d` snippet.
- Windows: persist the normalized install directory in the User PATH and update the current installer process without rewriting inherited Machine PATH entries.
- Support `--skip-shell` and `-SkipShell` for callers that do not want installer-managed PATH integration.
- Document the default behavior and opt-out commands.

## Refactoring applied

This revision removes the mock-heavy shell-command tests and narrows the implementation around observable behavior:

- Shell paths are quoted safely, including spaces and apostrophes.
- Repeated installs are idempotent.
- macOS bash startup precedence and zsh's effective `ZDOTDIR` are respected.
- Unknown Unix shells are not modified and receive shell-neutral guidance.
- Windows User, Machine-inherited, and current-process PATH values remain separate.
- A stale Windows process PATH is repaired even when the User PATH already contains Netclaw.
- The dependency-free manifest parser uses portable POSIX tools, accepts reordered JSON fields, and selects assets from the requested release.

## Independent adversarial hardening

A separate agent reviewed the implementation specifically for shell and PATH mutation hazards. Every actionable finding was fixed:

- Unix validates the physical path after symlink resolution and before copying binaries or modifying shell files, so a safe-looking symlink cannot introduce `:`, CR, or LF into persisted PATH data.
- zsh is queried after it reads `.zshenv`, so a non-exported `ZDOTDIR` is honored; unsafe or ambiguous results decline automatic mutation.
- Unsupported shells receive the literal directory and shell-neutral instructions rather than a Bash command that may be invalid.
- Windows PowerShell 5.1 no longer calls the modern-only `Path.TrimEndingDirectorySeparator` API; CI executes the complete smoke suite under both Windows PowerShell 5.1 and PowerShell 7.
- A literal `%NAME%` install path is preserved under `REG_SZ` and explicitly rejected before mutation under `REG_EXPAND_SZ`, where Windows would expand and corrupt it.
- The per-user `HKCU\\Environment` key is opened or created without elevation; the installer never modifies `HKLM` or the machine PATH.
- Existing raw User PATH text, `REG_SZ`/`REG_EXPAND_SZ` type, `%VAR%` references, inherited process entries, and empty-PATH semantics remain preserved.

## Validation

- All 32 current GitHub checks pass on head `4da4e50a7`.
- Unix installer smoke: 30/30 locally; Ubuntu and macOS CI additionally execute zsh/fish and physical-path coverage.
- Windows installer smoke: 24/24 under PowerShell 7 and 24/24 under stock Windows PowerShell 5.1, on both push and pull-request triggers.
- Full .NET suite: 6,013 passed locally with 14 opt-in integration tests skipped; all six Ubuntu/macOS/Windows CI test jobs pass.
- Native smoke passes on Linux and macOS for both trigger sets; screenshot regression and native publishing pass.
- `shellcheck scripts/install.sh scripts/smoke/install-smoke.sh`
- PowerShell parser validation
- `dotnet slopwatch analyze`: 0 issues
- `pwsh -File ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`

Website documentation follow-up: netclaw-dev/netclaw-website#89.
