### PR TITLE
Deflake obsolete shell timeout override test

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -62,22 +62,6 @@ public class ShellToolTests
     }
 
     [Fact]
-    public async Task Requested_timeout_overrides_default_timeout()
-    {
-        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
-        var args = ToolInput.Create("Command", "sleep 1");
-        var context = TestToolExecutionContext.CreateBound("test/thread", Path.GetTempPath(), new TestToolExecutionContextOptions
-        {
-            Audience = TrustAudience.Personal,
-            ExecutionTimeout = new ToolExecutionTimeout(TimeSpan.FromSeconds(5))
-        });
-
-        var result = await tool.ExecuteAsync(args, context, CancellationToken.None);
-
-        Assert.Contains("Exit code: 0", result);
-    }
-
-    [Fact]
     public async Task Caller_cancellation_kills_child_process_tree_and_returns_gracefully()
     {
         // Reproduces the session-pipeline path: ShellTool's own timeout is long,


### PR DESCRIPTION
## Summary

- remove Requested_timeout_overrides_default_timeout, a stale positive wall-clock timing test
- keep Timeout_kills_long_running_process as the ShellTool deadline-enforcement integration test
- rely on the existing deterministic high/low timeout-selection pipeline tests for the override contract
- make no production-code or timeout-margin changes

## Why this was flaky

The test originally compared a one-second ToolConfig default with a longer per-call request. Timeout ownership later moved into SessionToolExecutionPipeline and ToolConfig.ShellTimeoutSeconds was removed, but the test remained as sleep 1 under a directly supplied five-second context deadline.

On Windows, cmd.exe must resolve and start an external sleep.exe. Under full-suite contention, child startup, antivirus scanning, and scheduling can consume the wall-clock budget. Increasing the margin would only reduce the probability.

Both the Akka.NET and .NET concurrency specialist reviews independently recommended deleting the obsolete test. It contains no Akka test semantics; Akka hosts only contribute ambient CI load that exposes the race.

Failure observed in PR #1686 Windows validation:
https://github.com/netclaw-dev/netclaw/actions/runs/29609025771/job/87979045155

## Validation

- focused ShellTool and timeout-selection tests: 35/35 passed
- focused stress loop: 20 runs, 700/700 test executions passed
- full Netclaw.Actors.Tests suite: 2,635/2,635 passed
- dotnet slopwatch analyze: 0 issues
- copyright header verification passed
- git diff --check passed