### PR TITLE
fix(approvals): show MCP arguments in prompts

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.34.0"
+  version: "2.35.0"
 ---
 
 # Netclaw Operations
@@ -116,13 +116,17 @@ or MCP tools by capability before concluding a tool doesn't exist. Full guidance
 ## Approval Prompts
 
 MCP approval prompts show a bounded, redacted preview of the call arguments.
-Source and destination paths, filenames, directories, and URLs appear first so
-the operator can verify what will move where. Large content, message bodies,
-binary data, and nested collections are summarized by size instead of dumped
-into chat; secret-like fields and token-shaped values are always redacted. MCP
-grants are tool-wide rather than directory-scoped, so these prompts omit the
-misleading `Always here` option and label the persistent choice `Always allow
-this tool` rather than the shell-oriented `Always anywhere`.
+Actual path- and URL-shaped values appear first and receive a larger preview so
+the operator can verify location context without guessing from argument names.
+URL credentials, query values, and fragments are redacted.
+Large strings, binary data, and nested collections are summarized by size;
+secret-like fields and token-shaped values are always redacted. Argument names
+and values are escaped before display so server-controlled schema text cannot
+break or spoof the approval prompt. MCP grants are tool-wide rather than
+directory-scoped, so these prompts omit the misleading `Always here` option and
+label the persistent choice `Always allow this tool` rather than the
+shell-oriented `Always anywhere`. Other non-shell tools also omit `Always here`
+because their approval matchers do not consume directory scope.
 
 Approvals are typed `(verb, directory)` pairs in `tool-approvals.json`:
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.33.0"
+  version: "2.34.0"
 ---
 
 # Netclaw Operations
@@ -114,6 +114,15 @@ or MCP tools by capability before concluding a tool doesn't exist. Full guidance
 `skill_read_resource('netclaw-operations', 'references/tools.md')`.
 
 ## Approval Prompts
+
+MCP approval prompts show a bounded, redacted preview of the call arguments.
+Source and destination paths, filenames, directories, and URLs appear first so
+the operator can verify what will move where. Large content, message bodies,
+binary data, and nested collections are summarized by size instead of dumped
+into chat; secret-like fields and token-shaped values are always redacted. MCP
+grants are tool-wide rather than directory-scoped, so these prompts omit the
+misleading `Always here` option and label the persistent choice `Always allow
+this tool` rather than the shell-oriented `Always anywhere`.
 
 Approvals are typed `(verb, directory)` pairs in `tool-approvals.json`:
 

--- a/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
@@ -280,6 +280,55 @@ public sealed class DiscordApprovalPromptBuilderTests
         };
 
     [Fact]
+    public void Mcp_prompt_renders_invocation_without_shell_scope_chrome()
+    {
+        var request = V2Request(
+            "Dropbox/upload(destination_directory=\"/Finance/Q3\", contents=(90000 chars, 2000 lines))",
+            ["Dropbox/upload"],
+            cwd: null,
+            options:
+            [
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveMcpToolLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+            ]) with
+        {
+            ToolName = new Netclaw.Tools.ToolName("Dropbox/upload")
+        };
+
+        var text = DiscordApprovalPromptBuilder.BuildTextPrompt(request);
+        var (buttonText, buttons) = DiscordApprovalPromptBuilder.BuildButtonPrompt(request);
+
+        Assert.Contains("MCP tool approval required", text);
+        Assert.Contains("Invocation:", text);
+        Assert.Contains("Allow this MCP tool invocation?", text);
+        Assert.Contains("**Invocation:**", buttonText);
+        Assert.Contains(buttons, button => button.Label == ApprovalOptionKeys.ApproveMcpToolLabel);
+        Assert.DoesNotContain("no working directory", text);
+        Assert.DoesNotContain("Always anywhere", text);
+        Assert.DoesNotContain("• Dropbox/upload", text);
+    }
+
+    [Fact]
+    public void Mcp_resolution_describes_tool_scope_not_shell_location()
+    {
+        var request = V2Request("Dropbox/upload(path=\"/Finance/Q3\")", ["Dropbox/upload"], null, FullButtonRow()) with
+        {
+            ToolName = new Netclaw.Tools.ToolName("Dropbox/upload")
+        };
+
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
+            request,
+            ApprovalOptionKeys.ApproveEverywhere,
+            "user-1");
+
+        Assert.Contains("MCP tool approval resolved", text);
+        Assert.Contains("Always allowed: Dropbox/upload", text);
+        Assert.DoesNotContain("anywhere", text);
+    }
+
+    [Fact]
     public void V2_single_verb_collapses_into_header()
     {
         var request = V2Request("git status", ["git status"], "/home/user/repos/foo", FullButtonRow());

--- a/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
@@ -356,6 +356,53 @@ public sealed class MattermostApprovalPromptBuilderTests
         };
 
     [Fact]
+    public void Mcp_prompt_renders_invocation_without_shell_patterns()
+    {
+        var request = CreateStandardRequest() with
+        {
+            ToolName = new Netclaw.Tools.ToolName("Dropbox/upload"),
+            DisplayText = "Dropbox/upload(destination_directory=\"/Finance/Q3\", contents=(90000 chars, 2000 lines))",
+            Patterns = ["Dropbox/upload"],
+            Options =
+            [
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveMcpToolLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+            ]
+        };
+
+        var text = MattermostApprovalPromptBuilder.BuildTextPrompt(request);
+
+        Assert.Contains("MCP tool approval required", text);
+        Assert.Contains("**Invocation:**", text);
+        Assert.Contains("Allow this MCP tool invocation?", text);
+        Assert.Contains(ApprovalOptionKeys.ApproveMcpToolLabel, text);
+        Assert.DoesNotContain("**Pattern", text);
+        Assert.DoesNotContain("Always anywhere", text);
+    }
+
+    [Fact]
+    public void Mcp_resolution_uses_contextual_persistent_grant_label()
+    {
+        var request = CreateStandardRequest() with
+        {
+            ToolName = new Netclaw.Tools.ToolName("Dropbox/upload"),
+            DisplayText = "Dropbox/upload(path=\"/Finance/Q3\")"
+        };
+
+        var text = MattermostApprovalPromptBuilder.BuildResolvedPromptText(
+            request,
+            ApprovalOptionKeys.ApproveEverywhere,
+            "user-1");
+
+        Assert.Contains("MCP tool approval resolved", text);
+        Assert.Contains($"**Decision:** {ApprovalOptionKeys.ApproveMcpToolLabel}", text);
+        Assert.DoesNotContain("Allow this MCP tool invocation?", text);
+        Assert.DoesNotContain("Always anywhere", text);
+    }
+
+    [Fact]
     public void Oversized_command_keeps_prompt_under_Mattermost_cap()
     {
         // Mattermost's hard message cap is 16K, but approval prompts

--- a/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostApprovalPromptBuilderTests.cs
@@ -70,15 +70,29 @@ public sealed class MattermostApprovalPromptBuilderTests
     [Fact]
     public void BuildDecisionStatus_formats_known_keys()
     {
-        Assert.Contains(ApprovalOptionKeys.ApproveOnceLabel, MattermostApprovalPromptBuilder.BuildDecisionStatus(ApprovalOptionKeys.ApproveOnce));
-        Assert.Contains(ApprovalOptionKeys.ApproveAlwaysLabel, MattermostApprovalPromptBuilder.BuildDecisionStatus(ApprovalOptionKeys.ApproveAlways));
-        Assert.Contains(ApprovalOptionKeys.DenyLabel, MattermostApprovalPromptBuilder.BuildDecisionStatus(ApprovalOptionKeys.Deny));
+        var toolName = new Netclaw.Tools.ToolName("shell_execute");
+        Assert.Contains(ApprovalOptionKeys.ApproveOnceLabel, MattermostApprovalPromptBuilder.BuildDecisionStatus(ApprovalOptionKeys.ApproveOnce, toolName));
+        Assert.Contains(ApprovalOptionKeys.ApproveAlwaysLabel, MattermostApprovalPromptBuilder.BuildDecisionStatus(ApprovalOptionKeys.ApproveAlways, toolName));
+        Assert.Contains(ApprovalOptionKeys.DenyLabel, MattermostApprovalPromptBuilder.BuildDecisionStatus(ApprovalOptionKeys.Deny, toolName));
+    }
+
+    [Fact]
+    public void BuildDecisionStatus_uses_MCP_persistent_label()
+    {
+        var status = MattermostApprovalPromptBuilder.BuildDecisionStatus(
+            ApprovalOptionKeys.ApproveEverywhere,
+            new Netclaw.Tools.ToolName("Dropbox/upload"));
+
+        Assert.Contains(ApprovalOptionKeys.ApproveMcpToolLabel, status);
+        Assert.DoesNotContain(ApprovalOptionKeys.ApproveEverywhereLabel, status);
     }
 
     [Fact]
     public void BuildDecisionStatus_passes_through_unknown_key()
     {
-        var status = MattermostApprovalPromptBuilder.BuildDecisionStatus("custom_key");
+        var status = MattermostApprovalPromptBuilder.BuildDecisionStatus(
+            "custom_key",
+            new Netclaw.Tools.ToolName("shell_execute"));
         Assert.Contains("custom_key", status);
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
@@ -79,6 +79,55 @@ public sealed class SlackApprovalBlockBuilderTests
     }
 
     [Fact]
+    public void Mcp_prompt_renders_invocation_without_shell_scope_chrome()
+    {
+        var request = Request(
+            "Dropbox/upload(destination_directory=\"/Finance/Q3\", contents=(90000 chars, 2000 lines))",
+            ["Dropbox/upload"],
+            cwd: null,
+            options:
+            [
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveMcpToolLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+            ]) with
+        {
+            ToolName = new ToolName("Dropbox/upload")
+        };
+
+        var text = SlackApprovalBlockBuilder.BuildApprovalText(request);
+        var blocks = string.Join('\n', SlackApprovalBlockBuilder.BuildApprovalBlocks(request)
+            .OfType<SectionBlock>()
+            .Select(block => block.Text is Markdown markdown ? markdown.Text : string.Empty));
+
+        Assert.Contains("MCP tool approval required", text);
+        Assert.Contains("Allow this MCP tool invocation?", text);
+        Assert.Contains("*Invocation:*", blocks);
+        Assert.DoesNotContain("no working directory", text);
+        Assert.DoesNotContain("Always anywhere", text);
+        Assert.DoesNotContain("• `Dropbox/upload`", text);
+    }
+
+    [Fact]
+    public void Mcp_resolution_describes_tool_scope_not_shell_location()
+    {
+        var request = Request("Dropbox/upload(path=\"/Finance/Q3\")", ["Dropbox/upload"], null, FullButtonRow()) with
+        {
+            ToolName = new ToolName("Dropbox/upload")
+        };
+
+        var text = SlackApprovalBlockBuilder.BuildResolvedApprovalText(
+            request,
+            ApprovalOptionKeys.ApproveEverywhere,
+            "U123");
+
+        Assert.Contains("MCP tool approval resolved", text);
+        Assert.Contains("Always allowed: Dropbox/upload", text);
+        Assert.DoesNotContain("anywhere", text);
+    }
+
+    [Fact]
     public void Messy_command_emits_complex_command_hint()
     {
         var request = Request(

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -590,6 +590,35 @@ public sealed class ToolApprovalGateTests
     }
 
     [Fact]
+    public void Non_shell_tool_omits_directory_scoped_persistence_option()
+    {
+        var config = new ToolConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Approval
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false));
+
+        var tool = new Netclaw.Actors.Tests.Memory.FakeNetclawTool("file_read", "content");
+        var decision = policy.AuthorizeInvocation(tool, PersonalContext());
+
+        Assert.True(decision.NeedsApproval);
+        Assert.DoesNotContain(
+            decision.ApprovalContext!.Options,
+            option => option.Key.Value == ApprovalOptionKeys.ApproveAlways);
+        Assert.Contains(
+            decision.ApprovalContext.Options,
+            option => option.Key.Value == ApprovalOptionKeys.ApproveEverywhere
+                      && option.Label == ApprovalOptionKeys.ApproveEverywhereLabel);
+    }
+
+    [Fact]
     public void Non_safe_list_tool_returns_requires_approval_when_interactive_unsupported()
     {
         var config = new ToolConfig();

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -368,6 +368,74 @@ public sealed class ToolApprovalGateTests
     }
 
     [Fact]
+    public void mcp_approval_context_displays_arguments_without_netclaw_meta_fields()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+        var content = string.Join('\n', Enumerable.Repeat("large memory payload", 1_000));
+
+        var decision = policy.AuthorizeInvocation(
+            McpTool("notion", "create-pages"),
+            PersonalContext(),
+            new Dictionary<string, object?>
+            {
+                ["destination_path"] = "/Board/Quarterly Results",
+                ["content"] = content,
+                ["_rationale"] = "Create the requested report"
+            });
+
+        Assert.True(decision.NeedsApproval);
+        Assert.Contains("destination_path=\"/Board/Quarterly Results\"", decision.ApprovalContext!.DisplayText);
+        Assert.Contains($"content=({content.Length} chars, 1000 lines)", decision.ApprovalContext.DisplayText);
+        Assert.DoesNotContain("_rationale", decision.ApprovalContext.DisplayText);
+        Assert.DoesNotContain("Create the requested report", decision.ApprovalContext.DisplayText);
+        Assert.DoesNotContain(
+            decision.ApprovalContext.Options,
+            option => option.Key.Value == ApprovalOptionKeys.ApproveAlways);
+        Assert.Contains(
+            decision.ApprovalContext.Options,
+            option => option.Key.Value == ApprovalOptionKeys.ApproveEverywhere
+                      && option.Label == ApprovalOptionKeys.ApproveMcpToolLabel);
+        Assert.DoesNotContain(
+            decision.ApprovalContext.Options,
+            option => option.Label == ApprovalOptionKeys.ApproveEverywhereLabel);
+    }
+
+    [Fact]
+    public void mcp_declared_parameter_that_resembles_meta_remains_visible()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+        var function = AIFunctionFactory.Create(
+            (string rationale) => rationale,
+            "create-pages",
+            "create-pages");
+        var tool = new McpToolAdapter(function, "notion", "create-pages");
+
+        var decision = policy.AuthorizeInvocation(
+            tool,
+            PersonalContext(),
+            new Dictionary<string, object?> { ["Rationale"] = "Customer-visible reason" });
+
+        Assert.True(decision.NeedsApproval);
+        Assert.Contains("Rationale=\"Customer-visible reason\"", decision.ApprovalContext!.DisplayText);
+    }
+
+    [Fact]
     public void mcp_exact_override_beats_server_default()
     {
         var approvalPolicy = new ToolApprovalConfig

--- a/src/Netclaw.Actors/Protocol/ApprovalOptionKeys.cs
+++ b/src/Netclaw.Actors/Protocol/ApprovalOptionKeys.cs
@@ -43,6 +43,7 @@ public static class ApprovalOptionKeys
     public const string ApproveSessionLabel = "This chat";
     public const string ApproveAlwaysLabel = "Always here";
     public const string ApproveEverywhereLabel = "Always anywhere";
+    public const string ApproveMcpToolLabel = "Always allow this tool";
     public const string DenyLabel = "Deny";
 
     /// <summary>
@@ -67,12 +68,19 @@ public static class ApprovalOptionKeys
     /// Maps an approval option key to its short human-readable label. Returns
     /// the key unchanged when it is not a recognized option.
     /// </summary>
-    public static string LabelFor(string optionKey) => optionKey switch
+    public static string LabelFor(string optionKey) => LabelFor(optionKey, isMcpTool: false);
+
+    /// <summary>
+    /// Maps an approval option key to its context-aware label. MCP grants are
+    /// tool-scoped rather than directory-scoped, so the global persistence key
+    /// is rendered as "Always allow this tool" instead of "Always anywhere".
+    /// </summary>
+    public static string LabelFor(string optionKey, bool isMcpTool) => optionKey switch
     {
         ApproveOnce => ApproveOnceLabel,
         ApproveSession => ApproveSessionLabel,
         ApproveAlways => ApproveAlwaysLabel,
-        ApproveEverywhere => ApproveEverywhereLabel,
+        ApproveEverywhere => isMcpTool ? ApproveMcpToolLabel : ApproveEverywhereLabel,
         Deny => DenyLabel,
         _ => optionKey
     };

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3901,7 +3901,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ];
 
         var options = optionKeys
-            .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
+            .Select(key => new ToolInteractionOption(
+                new ApprovalOptionKey(key),
+                ApprovalOptionKeys.LabelFor(key, new ToolName(pending.ToolName).IsMcp)))
             .ToArray();
 
         if (!ToolInteractionResponseParser.TryParseApprovalResponse(msg.Text, options, out var selectedKey)

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -348,7 +348,8 @@ public sealed class ToolAccessPolicy
             isCwdShallow: IsCwdTooShallow(context.Approval.Cwd),
             allEffectiveDirsAreSessionScratch: AllCandidatesResolveToSessionScratch(
                 candidates, context.Approval.Cwd, context.SessionDirectory),
-            supportsDirectoryScope: matcher is not McpApprovalMatcher);
+            supportsDirectoryScope: matcher is ShellApprovalMatcher,
+            isMcpTool: toolName.IsMcp);
 
         var approvalContext = new ToolApprovalContext(
             toolName.Value,
@@ -412,17 +413,18 @@ public sealed class ToolAccessPolicy
     /// to a directory that won't recur. <c>This chat</c> already provides
     /// the equivalent in-session semantics without polluting the persistent
     /// store.</item>
-    /// <item><b>No directory scope</b> (MCP tools) — <c>Always here</c> is
-    /// omitted because the matcher grants by canonical tool name, not cwd.
-    /// The remaining persistent choice is labeled <c>Always allow this tool</c>
-    /// because it persists a canonical-tool grant.</item>
+    /// <item><b>No directory scope</b> (all non-shell tools) — <c>Always
+    /// here</c> is omitted because these matchers grant independently of cwd.
+    /// For MCP tools, the remaining persistent choice is labeled <c>Always
+    /// allow this tool</c> because it persists a canonical-tool grant.</item>
     /// </list>
     /// </summary>
     private static IReadOnlyList<ToolApprovalOption> BuildApprovalOptions(
         bool isMessy,
         bool isCwdShallow,
         bool allEffectiveDirsAreSessionScratch,
-        bool supportsDirectoryScope)
+        bool supportsDirectoryScope,
+        bool isMcpTool)
     {
         if (isMessy)
         {
@@ -446,7 +448,7 @@ public sealed class ToolAccessPolicy
 
         options.Add(new ToolApprovalOption(
             ApprovalOptionKeys.ApproveEverywhereKey,
-            ApprovalOptionKeys.LabelFor(ApprovalOptionKeys.ApproveEverywhere, isMcpTool: !supportsDirectoryScope)));
+            ApprovalOptionKeys.LabelFor(ApprovalOptionKeys.ApproveEverywhere, isMcpTool)));
         options.Add(new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel));
 
         return options;

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -109,7 +109,10 @@ public sealed class ToolAccessPolicy
                 return ToolAccessDecision.Deny("mcp_tool_not_allowed_for_audience_profile");
 
             var mcpToolName = new ToolName(tool.Name);
-            return CheckApprovalGate(mcpToolName, context, arguments, DefaultApprovalMatcher.Instance);
+            var (_, approvalArguments) = ToolCallMeta.ExtractFrom(
+                arguments,
+                key => ToolArgumentValidator.ResolveMetaField(mcp, key));
+            return CheckApprovalGate(mcpToolName, context, approvalArguments, McpApprovalMatcher.Instance);
         }
 
         var toolName = new ToolName(tool.Name);
@@ -344,7 +347,8 @@ public sealed class ToolAccessPolicy
             isMessy,
             isCwdShallow: IsCwdTooShallow(context.Approval.Cwd),
             allEffectiveDirsAreSessionScratch: AllCandidatesResolveToSessionScratch(
-                candidates, context.Approval.Cwd, context.SessionDirectory));
+                candidates, context.Approval.Cwd, context.SessionDirectory),
+            supportsDirectoryScope: matcher is not McpApprovalMatcher);
 
         var approvalContext = new ToolApprovalContext(
             toolName.Value,
@@ -408,12 +412,17 @@ public sealed class ToolAccessPolicy
     /// to a directory that won't recur. <c>This chat</c> already provides
     /// the equivalent in-session semantics without polluting the persistent
     /// store.</item>
+    /// <item><b>No directory scope</b> (MCP tools) — <c>Always here</c> is
+    /// omitted because the matcher grants by canonical tool name, not cwd.
+    /// The remaining persistent choice is labeled <c>Always allow this tool</c>
+    /// because it persists a canonical-tool grant.</item>
     /// </list>
     /// </summary>
     private static IReadOnlyList<ToolApprovalOption> BuildApprovalOptions(
         bool isMessy,
         bool isCwdShallow,
-        bool allEffectiveDirsAreSessionScratch)
+        bool allEffectiveDirsAreSessionScratch,
+        bool supportsDirectoryScope)
     {
         if (isMessy)
         {
@@ -430,12 +439,14 @@ public sealed class ToolAccessPolicy
             new ToolApprovalOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel)
         };
 
-        if (!isCwdShallow && !allEffectiveDirsAreSessionScratch)
+        if (supportsDirectoryScope && !isCwdShallow && !allEffectiveDirsAreSessionScratch)
         {
             options.Add(new ToolApprovalOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel));
         }
 
-        options.Add(new ToolApprovalOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveEverywhereLabel));
+        options.Add(new ToolApprovalOption(
+            ApprovalOptionKeys.ApproveEverywhereKey,
+            ApprovalOptionKeys.LabelFor(ApprovalOptionKeys.ApproveEverywhere, isMcpTool: !supportsDirectoryScope)));
         options.Add(new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel));
 
         return options;

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using Netclaw.Actors.Protocol;
 using Netclaw.Channels;
+using Netclaw.Tools;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
 namespace Netclaw.Channels.Discord;
@@ -25,13 +26,14 @@ internal static class DiscordApprovalPromptBuilder
     public static string BuildTextPrompt(ToolInteractionRequest request)
     {
         var sb = new StringBuilder();
-        sb.AppendLine("Netclaw approval required:");
+        sb.AppendLine(request.ToolName.IsMcp ? "MCP tool approval required:" : "Netclaw approval required:");
         sb.Append("Tool: ").AppendLine(request.ToolName.Value);
-        sb.Append("Action: ").AppendLine(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars));
+        sb.Append(request.ToolName.IsMcp ? "Invocation: " : "Action: ")
+            .AppendLine(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars));
         sb.AppendLine(BuildApproveHeader(request));
 
         var verbs = ResolveDisplayVerbs(request);
-        if (verbs.Count > 1)
+        if (!request.ToolName.IsMcp && verbs.Count > 1)
         {
             foreach (var verb in verbs)
                 sb.Append("  • ").AppendLine(verb);
@@ -52,7 +54,9 @@ internal static class DiscordApprovalPromptBuilder
         ToolInteractionRequest request)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(":lock: **Tool approval required**");
+        sb.Append(":lock: **")
+            .Append(request.ToolName.IsMcp ? "MCP tool approval required" : "Tool approval required")
+            .AppendLine("**");
         AppendToolSummary(sb, request);
 
         sb.AppendLine();
@@ -87,9 +91,12 @@ internal static class DiscordApprovalPromptBuilder
             : ":white_check_mark:";
 
         var sb = new StringBuilder();
-        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        sb.Append(statusEmoji)
+            .Append(request.ToolName.IsMcp ? " **MCP tool approval resolved**" : " **Tool approval resolved**")
+            .AppendLine();
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
+        sb.Append(request.ToolName.IsMcp ? "**Invocation:** `" : "**Action:** `")
+            .Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
         sb.Append("**").Append(BuildResolutionLine(request, selectedKey)).Append("**");
         sb.Append(" (by <@").Append(senderId).Append(">)");
 
@@ -126,24 +133,36 @@ internal static class DiscordApprovalPromptBuilder
             : ":white_check_mark:";
 
         var sb = new StringBuilder();
-        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        var isMcpTool = !string.IsNullOrEmpty(toolName) && new ToolName(toolName).IsMcp;
+        sb.Append(statusEmoji)
+            .Append(isMcpTool ? " **MCP tool approval resolved**" : " **Tool approval resolved**")
+            .AppendLine();
 
         if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
         {
             sb.Append("**Tool:** `").Append(toolName).AppendLine("`");
-            sb.Append("**Action:** `")
+            sb.Append(isMcpTool ? "**Invocation:** `" : "**Action:** `")
                 .Append(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))
                 .AppendLine("`");
         }
 
-        sb.Append("**").Append(BuildGenericResolutionLine(selectedKey)).Append("**");
+        sb.Append("**").Append(BuildGenericResolutionLine(selectedKey, isMcpTool)).Append("**");
         sb.Append(" (by <@").Append(senderId).Append(">)");
 
         return sb.ToString();
     }
 
-    private static string BuildGenericResolutionLine(string selectedKey)
-        => selectedKey switch
+    private static string BuildGenericResolutionLine(string selectedKey, bool isMcpTool)
+        => isMcpTool
+            ? selectedKey switch
+            {
+                ApprovalOptionKeys.ApproveAlways or ApprovalOptionKeys.ApproveEverywhere => "Always allowed this MCP tool",
+                ApprovalOptionKeys.ApproveSession => "Allowed this MCP tool for this chat",
+                ApprovalOptionKeys.ApproveOnce => "Allowed once",
+                ApprovalOptionKeys.Deny => "Denied",
+                _ => "Resolved"
+            }
+            : selectedKey switch
         {
             ApprovalOptionKeys.ApproveAlways => "Saved: always here",
             ApprovalOptionKeys.ApproveEverywhere => "Saved: always anywhere",
@@ -156,11 +175,12 @@ internal static class DiscordApprovalPromptBuilder
     private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
     {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
+        sb.Append(request.ToolName.IsMcp ? "**Invocation:** `" : "**Action:** `")
+            .Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
         sb.Append("**").Append(BuildApproveHeader(request)).AppendLine("**");
 
         var verbs = ResolveDisplayVerbs(request);
-        if (verbs.Count > 1)
+        if (!request.ToolName.IsMcp && verbs.Count > 1)
         {
             foreach (var verb in verbs)
                 sb.Append("  • `").Append(verb).AppendLine("`");
@@ -180,6 +200,9 @@ internal static class DiscordApprovalPromptBuilder
     /// </summary>
     private static string BuildApproveHeader(ToolInteractionRequest request)
     {
+        if (request.ToolName.IsMcp)
+            return "Allow this MCP tool invocation?";
+
         var verbs = ResolveDisplayVerbs(request);
         var location = ResolveHeaderLocation(request);
 
@@ -195,6 +218,18 @@ internal static class DiscordApprovalPromptBuilder
     /// </summary>
     private static string BuildResolutionLine(ToolInteractionRequest request, string selectedKey)
     {
+        if (request.ToolName.IsMcp)
+        {
+            return selectedKey switch
+            {
+                ApprovalOptionKeys.ApproveAlways or ApprovalOptionKeys.ApproveEverywhere => $"Always allowed: {request.ToolName}",
+                ApprovalOptionKeys.ApproveSession => $"Allowed for this chat: {request.ToolName}",
+                ApprovalOptionKeys.ApproveOnce => "Allowed once",
+                ApprovalOptionKeys.Deny => "Denied",
+                _ => "Resolved"
+            };
+        }
+
         var verbs = string.Join(", ", ResolveDisplayVerbs(request));
         var location = ResolveHeaderLocation(request);
 

--- a/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
+++ b/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
@@ -92,8 +92,11 @@ internal sealed class PendingApprovalRequest
         RequesterSenderId = requesterSenderId;
         RequesterPrincipal = requesterPrincipal;
         OptionKeys = [.. optionKeys];
+        var isMcpTool = !string.IsNullOrEmpty(toolName) && new ToolName(toolName).IsMcp;
         Options = OptionKeys
-            .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
+            .Select(key => new ToolInteractionOption(
+                new ApprovalOptionKey(key),
+                ApprovalOptionKeys.LabelFor(key, isMcpTool)))
             .ToArray();
         PromptMessageId = promptMessageId;
         ToolName = toolName;

--- a/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using Netclaw.Actors.Protocol;
 using Netclaw.Channels;
+using Netclaw.Tools;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
 namespace Netclaw.Channels.Mattermost;
@@ -28,8 +29,8 @@ internal static class MattermostApprovalPromptBuilder
         MattermostCallbackActionStore? actionStore = null)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(":lock: **Tool approval required**");
-        AppendToolSummary(sb, request);
+        AppendApprovalTitle(sb, request);
+        AppendToolSummary(sb, request, includeApprovalQuestion: true);
         sb.AppendLine();
         sb.Append("You can also reply with ").Append(FormatReplyLetters(request.Options)).Append(" in this thread.");
 
@@ -62,7 +63,7 @@ internal static class MattermostApprovalPromptBuilder
             .ToList();
 
         var attachment = new MattermostAttachment(
-            Fallback: $"Tool approval required — reply with {string.Join(", ", Enumerable.Range(0, actions.Count).Select(GetReplyLetter))}",
+            Fallback: $"{(request.ToolName.IsMcp ? "MCP tool approval required" : "Tool approval required")} — reply with {string.Join(", ", Enumerable.Range(0, actions.Count).Select(GetReplyLetter))}",
             Color: "#3AA3E3",
             Actions: actions);
 
@@ -72,8 +73,8 @@ internal static class MattermostApprovalPromptBuilder
     public static string BuildTextPrompt(ToolInteractionRequest request)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(":lock: **Tool approval required**");
-        AppendToolSummary(sb, request);
+        AppendApprovalTitle(sb, request);
+        AppendToolSummary(sb, request, includeApprovalQuestion: true);
 
         sb.AppendLine();
         sb.AppendLine("Reply with:");
@@ -95,11 +96,13 @@ internal static class MattermostApprovalPromptBuilder
         var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
             : ":white_check_mark:";
-        var decisionLabel = ApprovalOptionKeys.LabelFor(selectedKey);
+        var decisionLabel = ApprovalOptionKeys.LabelFor(selectedKey, request.ToolName.IsMcp);
 
         var sb = new StringBuilder();
-        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
-        AppendToolSummary(sb, request);
+        sb.Append(statusEmoji)
+            .Append(request.ToolName.IsMcp ? " **MCP tool approval resolved**" : " **Tool approval resolved**")
+            .AppendLine();
+        AppendToolSummary(sb, request, includeApprovalQuestion: false);
 
         sb.Append("**Decision:** ").Append(decisionLabel);
         sb.Append(" (by @").Append(senderId).Append(')');
@@ -141,15 +144,18 @@ internal static class MattermostApprovalPromptBuilder
         var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
             ? ":no_entry:"
             : ":white_check_mark:";
-        var decisionLabel = ApprovalOptionKeys.LabelFor(selectedKey);
+        var isMcpTool = !string.IsNullOrEmpty(toolName) && new ToolName(toolName).IsMcp;
+        var decisionLabel = ApprovalOptionKeys.LabelFor(selectedKey, isMcpTool);
 
         var sb = new StringBuilder();
-        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        sb.Append(statusEmoji)
+            .Append(isMcpTool ? " **MCP tool approval resolved**" : " **Tool approval resolved**")
+            .AppendLine();
 
         if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
         {
             sb.Append("**Tool:** `").Append(toolName).AppendLine("`");
-            sb.Append("**Action:** `")
+            sb.Append(isMcpTool ? "**Invocation:** `" : "**Action:** `")
                 .Append(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))
                 .AppendLine("`");
         }
@@ -166,12 +172,20 @@ internal static class MattermostApprovalPromptBuilder
             Text: resolvedText);
     }
 
-    private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
+    private static void AppendToolSummary(
+        StringBuilder sb,
+        ToolInteractionRequest request,
+        bool includeApprovalQuestion)
     {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
+        sb.Append(request.ToolName.IsMcp ? "**Invocation:** `" : "**Action:** `")
+            .Append(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)).AppendLine("`");
 
-        if (request.Patterns.Count > 0)
+        if (request.ToolName.IsMcp && includeApprovalQuestion)
+        {
+            sb.AppendLine("**Allow this MCP tool invocation?**");
+        }
+        else if (request.Patterns.Count > 0)
         {
             if (request.Patterns.Count == 1)
             {
@@ -187,6 +201,11 @@ internal static class MattermostApprovalPromptBuilder
 
         AppendAdoptedContextSummary(sb, request);
     }
+
+    private static void AppendApprovalTitle(StringBuilder sb, ToolInteractionRequest request)
+        => sb.Append(":lock: **")
+            .Append(request.ToolName.IsMcp ? "MCP tool approval required" : "Tool approval required")
+            .AppendLine("**");
 
     private static void AppendAdoptedContextSummary(StringBuilder sb, ToolInteractionRequest request)
     {

--- a/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostApprovalPromptBuilder.cs
@@ -82,9 +82,9 @@ internal static class MattermostApprovalPromptBuilder
         return sb.ToString().TrimEnd();
     }
 
-    public static string BuildDecisionStatus(string selectedKey)
+    public static string BuildDecisionStatus(string selectedKey, ToolName toolName)
     {
-        var label = ApprovalOptionKeys.LabelFor(selectedKey);
+        var label = ApprovalOptionKeys.LabelFor(selectedKey, toolName.IsMcp);
         return $"Recorded approval decision: {label}.";
     }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
@@ -85,8 +85,11 @@ internal sealed class PendingApprovalRequest
         RequesterSenderId = requesterSenderId;
         RequesterPrincipal = requesterPrincipal;
         OptionKeys = [.. optionKeys];
+        var isMcpTool = !string.IsNullOrEmpty(toolName) && new ToolName(toolName).IsMcp;
         Options = OptionKeys
-            .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
+            .Select(key => new ToolInteractionOption(
+                new ApprovalOptionKey(key),
+                ApprovalOptionKeys.LabelFor(key, isMcpTool)))
             .ToArray();
         PromptPostId = promptPostId;
         ToolName = toolName;

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Protocol;
+using Netclaw.Tools;
 using SlackNet.Blocks;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
@@ -28,13 +29,13 @@ internal static class SlackApprovalBlockBuilder
     {
         var lines = new List<string>
         {
-            ":lock: *Tool approval required*",
+            $":lock: *{ApprovalTitle(request.ToolName)}*",
             $"> `{request.ToolName}`: `{ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)}`",
             BuildApproveHeader(request)
         };
 
         var verbs = ResolveDisplayVerbs(request);
-        if (verbs.Count > 1)
+        if (!request.ToolName.IsMcp && verbs.Count > 1)
         {
             foreach (var verb in verbs)
                 lines.Add($"  • `{verb}`");
@@ -59,11 +60,13 @@ internal static class SlackApprovalBlockBuilder
         {
             new SectionBlock
             {
-                Text = new Markdown(":lock: *Tool approval required*")
+                Text = new Markdown($":lock: *{ApprovalTitle(request.ToolName)}*")
             },
             new SectionBlock
             {
-                Text = new Markdown($"*Tool:* `{EscapeMarkdown(request.ToolName.Value)}`\n*Request:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars))}`"),
+                Text = new Markdown(
+                    $"*Tool:* `{EscapeMarkdown(request.ToolName.Value)}`\n"
+                    + $"*{RequestLabel(request.ToolName)}:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars))}`"),
                 Expand = true
             },
             new SectionBlock
@@ -73,7 +76,7 @@ internal static class SlackApprovalBlockBuilder
         };
 
         var verbs = ResolveDisplayVerbs(request);
-        if (verbs.Count > 1)
+        if (!request.ToolName.IsMcp && verbs.Count > 1)
         {
             var verbLines = verbs.Select(v => $"• `{EscapeMarkdown(v)}`");
             blocks.Add(new SectionBlock
@@ -134,7 +137,7 @@ internal static class SlackApprovalBlockBuilder
 
         return string.Join("\n", new[]
         {
-            $"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>",
+            $"{statusPrefix} *{ApprovalResolvedTitle(request.ToolName)}* by <@{EscapeMarkdown(senderId)}>",
             $"> `{request.ToolName}`: `{ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars)}`",
             BuildResolutionLine(request, selectedKey)
         });
@@ -154,13 +157,13 @@ internal static class SlackApprovalBlockBuilder
         {
             new SectionBlock
             {
-                Text = new Markdown($"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>")
+                Text = new Markdown($"{statusPrefix} *{ApprovalResolvedTitle(request.ToolName)}* by <@{EscapeMarkdown(senderId)}>")
             },
             new SectionBlock
             {
                 Text = new Markdown(
                     $"*Tool:* `{EscapeMarkdown(request.ToolName.Value)}`\n"
-                    + $"*Request:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars))}`\n"
+                    + $"*{RequestLabel(request.ToolName)}:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(request.DisplayText, MaxDisplayTextChars))}`\n"
                     + $"*{EscapeMarkdown(resolutionLine)}*"),
                 Expand = true
             }
@@ -208,7 +211,7 @@ internal static class SlackApprovalBlockBuilder
 
         var lines = new List<string>(3)
         {
-            $"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>"
+            $"{statusPrefix} *{ApprovalResolvedTitle(toolName)}* by <@{EscapeMarkdown(senderId)}>"
         };
 
         if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(displayText))
@@ -217,7 +220,7 @@ internal static class SlackApprovalBlockBuilder
                 $"> `{toolName}`: `{ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars)}`");
         }
 
-        lines.Add(BuildGenericResolutionLine(selectedKey));
+        lines.Add(BuildGenericResolutionLine(selectedKey, IsMcpToolName(toolName)));
 
         return string.Join("\n", lines);
     }
@@ -241,7 +244,7 @@ internal static class SlackApprovalBlockBuilder
         {
             new SectionBlock
             {
-                Text = new Markdown($"{statusPrefix} *Tool approval resolved* by <@{EscapeMarkdown(senderId)}>")
+                Text = new Markdown($"{statusPrefix} *{ApprovalResolvedTitle(toolName)}* by <@{EscapeMarkdown(senderId)}>")
             }
         };
 
@@ -251,8 +254,8 @@ internal static class SlackApprovalBlockBuilder
             {
                 Text = new Markdown(
                     $"*Tool:* `{EscapeMarkdown(toolName)}`\n"
-                    + $"*Request:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))}`\n"
-                    + $"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*"),
+                    + $"*{RequestLabel(toolName)}:* `{EscapeMarkdown(ApprovalDisplayTextFormatter.Truncate(displayText, MaxDisplayTextChars))}`\n"
+                    + $"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey, IsMcpToolName(toolName)))}*"),
                 Expand = true
             });
         }
@@ -260,15 +263,24 @@ internal static class SlackApprovalBlockBuilder
         {
             blocks.Add(new SectionBlock
             {
-                Text = new Markdown($"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey))}*")
+                Text = new Markdown($"*{EscapeMarkdown(BuildGenericResolutionLine(selectedKey, isMcpTool: false))}*")
             });
         }
 
         return blocks;
     }
 
-    private static string BuildGenericResolutionLine(string selectedKey)
-        => selectedKey switch
+    private static string BuildGenericResolutionLine(string selectedKey, bool isMcpTool)
+        => isMcpTool
+            ? selectedKey switch
+            {
+                ApprovalOptionKeys.ApproveAlways or ApprovalOptionKeys.ApproveEverywhere => "Always allowed this MCP tool",
+                ApprovalOptionKeys.ApproveSession => "Allowed this MCP tool for this chat",
+                ApprovalOptionKeys.ApproveOnce => "Allowed once",
+                ApprovalOptionKeys.Deny => "Denied",
+                _ => "Resolved"
+            }
+            : selectedKey switch
         {
             ApprovalOptionKeys.ApproveAlways => "Saved: always here",
             ApprovalOptionKeys.ApproveEverywhere => "Saved: always anywhere",
@@ -299,6 +311,9 @@ internal static class SlackApprovalBlockBuilder
     /// </remarks>
     private static string BuildApproveHeader(ToolInteractionRequest request)
     {
+        if (request.ToolName.IsMcp)
+            return "Allow this MCP tool invocation?";
+
         var verbs = ResolveDisplayVerbs(request);
         var location = ResolveHeaderLocation(request);
 
@@ -354,6 +369,18 @@ internal static class SlackApprovalBlockBuilder
     /// </summary>
     private static string BuildResolutionLine(ToolInteractionRequest request, string selectedKey)
     {
+        if (request.ToolName.IsMcp)
+        {
+            return selectedKey switch
+            {
+                ApprovalOptionKeys.ApproveAlways or ApprovalOptionKeys.ApproveEverywhere => $"Always allowed: {request.ToolName}",
+                ApprovalOptionKeys.ApproveSession => $"Allowed for this chat: {request.ToolName}",
+                ApprovalOptionKeys.ApproveOnce => "Allowed once",
+                ApprovalOptionKeys.Deny => "Denied",
+                _ => "Resolved"
+            };
+        }
+
         var verbs = string.Join(", ", ResolveDisplayVerbs(request));
         var location = ResolveHeaderLocation(request);
 
@@ -379,6 +406,24 @@ internal static class SlackApprovalBlockBuilder
         => request.CandidateVerbs.Count > 0
             ? request.CandidateVerbs
             : request.Patterns;
+
+    private static string ApprovalTitle(ToolName toolName)
+        => toolName.IsMcp ? "MCP tool approval required" : "Tool approval required";
+
+    private static string ApprovalResolvedTitle(ToolName toolName)
+        => toolName.IsMcp ? "MCP tool approval resolved" : "Tool approval resolved";
+
+    private static string ApprovalResolvedTitle(string? toolName)
+        => IsMcpToolName(toolName) ? "MCP tool approval resolved" : "Tool approval resolved";
+
+    private static string RequestLabel(ToolName toolName)
+        => toolName.IsMcp ? "Invocation" : "Request";
+
+    private static string RequestLabel(string toolName)
+        => new ToolName(toolName).IsMcp ? "Invocation" : "Request";
+
+    private static bool IsMcpToolName(string? toolName)
+        => !string.IsNullOrEmpty(toolName) && new ToolName(toolName).IsMcp;
 
     private static void AppendAdoptedContextSummary(List<string> lines, ToolInteractionRequest request)
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1835,8 +1835,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             RequesterSenderId = requesterSenderId;
             RequesterPrincipal = requesterPrincipal;
             OptionKeys = [.. optionKeys];
+            var isMcpTool = !string.IsNullOrEmpty(toolName) && new ToolName(toolName).IsMcp;
             Options = OptionKeys
-                .Select(key => new ToolInteractionOption(new ApprovalOptionKey(key), ApprovalOptionKeys.LabelFor(key)))
+                .Select(key => new ToolInteractionOption(
+                    new ApprovalOptionKey(key),
+                    ApprovalOptionKeys.LabelFor(key, isMcpTool)))
                 .ToArray();
             PromptMessageTs = promptMessageTs;
             ToolName = toolName;

--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -4,10 +4,14 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.AI;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tools;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
 using Termina;
 using Termina.Hosting;
 using Termina.Input;
@@ -325,9 +329,89 @@ public sealed class ChatPageTests
         WriteSnapshot("chat-approval-expanded.txt", expanded);
     }
 
-    private async Task<string> CaptureFrameAsync(bool expand)
+    [Fact]
+    public async Task LargeMcpApproval_RenderedFrameSnapshot()
     {
-        var (terminal, app, _) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+        var content = string.Join('\n', Enumerable.Repeat("large memorizer payload that must not render", 2_000));
+        var function = AIFunctionFactory.Create(
+            (string contents, string source_path, string destination_directory, string access_token) => "uploaded",
+            "upload",
+            "Upload a file to Dropbox");
+        var tool = new McpToolAdapter(function, "Dropbox", "upload");
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.AllowedMcpServers.Add("Dropbox");
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["Dropbox"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false));
+        var executionContext = new ToolExecutionContext(
+            new ToolRunScope
+            {
+                Session = new ToolSessionScope.Bound("test-session", null),
+                Audience = TrustAudience.Personal,
+                InlineOutputBudget = InlineOutputBudget.Default,
+                InteractiveApproval = new InteractiveApprovalCapability.Unavailable()
+            },
+            ToolExecutionTimeout.Default);
+        var decision = policy.AuthorizeInvocation(
+            tool,
+            executionContext,
+            new Dictionary<string, object?>
+            {
+                ["contents"] = content,
+                ["source_path"] = "/home/operator/reports/2026/Q3/quarterly-results-final.pdf",
+                ["destination_directory"] = "/Finance/Board Pack/2026/Q3",
+                ["access_token"] = "must-never-render",
+                ["_rationale"] = "Upload the requested board report"
+            });
+        var approvalContext = Assert.IsType<ToolApprovalContext>(decision.ApprovalContext);
+        var approval = BuildApproval(approvalContext.DisplayText, approvalContext.ToolName) with
+        {
+            Patterns = approvalContext.Patterns,
+            CandidateVerbs = approvalContext.CandidateVerbs,
+            Options = approvalContext.Options
+                .Select(option => new ToolInteractionOption(option.Key, option.Label))
+                .ToArray()
+        };
+
+        var collapsed = await CaptureFrameAsync(approval, expand: false);
+        var expanded = await CaptureFrameAsync(approval, expand: true);
+
+        WriteSnapshot("chat-mcp-approval-large-collapsed.txt", collapsed);
+        WriteSnapshot("chat-mcp-approval-large-expanded.txt", expanded);
+
+        Assert.Contains("/Finance/Board Pack/2026/Q3", expanded);
+        Assert.Contains("quarterly-results-final.pdf", expanded);
+        Assert.Contains(content.Length.ToString(), expanded);
+        Assert.Contains("chars, 2000 lines", expanded);
+        Assert.Contains("MCP tool approval required", expanded);
+        Assert.Contains("Invocation:", expanded);
+        Assert.Contains(ApprovalOptionKeys.ApproveMcpToolLabel, expanded);
+        Assert.DoesNotContain("Patterns:", expanded);
+        Assert.DoesNotContain(ApprovalOptionKeys.ApproveEverywhereLabel, expanded);
+        Assert.DoesNotContain("large memorizer payload", expanded);
+        Assert.DoesNotContain("must-never-render", collapsed);
+        Assert.DoesNotContain("must-never-render", expanded);
+        Assert.DoesNotContain("_rationale", expanded);
+        Assert.DoesNotContain("Upload the requested board report", expanded);
+    }
+
+    private async Task<string> CaptureFrameAsync(bool expand)
+        => await CaptureFrameAsync(BuildApproval(LongShellBody), expand);
+
+    private async Task<string> CaptureFrameAsync(ToolInteractionRequest approval, bool expand)
+    {
+        var (terminal, app, _) = CreateHeadlessApp(approval, out var input);
         if (expand)
             input.EnqueueKey(ConsoleKey.O, false, false, true);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
@@ -363,7 +447,7 @@ public sealed class ChatPageTests
         File.WriteAllText(Path.Combine(targetDir, filename), content);
     }
 
-    private static ToolInteractionRequest BuildApproval(string displayText)
+    private static ToolInteractionRequest BuildApproval(string displayText, string toolName = "shell_execute")
     {
         return new ToolInteractionRequest
         {
@@ -371,7 +455,7 @@ public sealed class ChatPageTests
             TimestampMs = 0,
             Kind = "approval",
             CallId = new Netclaw.Tools.ToolCallId("test-call"),
-            ToolName = new Netclaw.Tools.ToolName("shell_execute"),
+            ToolName = new Netclaw.Tools.ToolName(toolName),
             DisplayText = displayText,
             Patterns = ["cd"],
             CandidateVerbs = ["cd"],

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-collapsed.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-collapsed.txt
@@ -1,10 +1,10 @@
 ╭─Netclaw Chat─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │System: MCP tool approval required                                                                                    │
 │  Tool: Dropbox/upload                                                                                                │
-│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3",                                       │
-│source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf", access_token=***REDACTED***, contents=(89999│
-│chars, 2000 lines))                                                                                                   │
+│Invocation: Dropbox/upload(source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf",                  │
+│destination_directory="/Finance/Board Pack/2026/Q3", contents=(89999 chars, 2000 lines), access_token=***REDACTED***) │
 │  Options: Once, This chat, Always allow this tool, Deny                                                              │
+│                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -30,7 +30,7 @@
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │MCP tool approval required: Dropbox/upload.                                                                           │
-│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3", source_path="… [Ctrl+O to view full]  │
+│Invocation: Dropbox/upload(source_path="/home/operator/reports/2026/Q3/quarterly-results-fina… [Ctrl+O to view full]  │
 │Select an option and press Enter.                                                                                     │
 │1. Once                                                                                                               │
 │2. This chat                                                                                                          │

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-collapsed.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-collapsed.txt
@@ -1,0 +1,40 @@
+╭─Netclaw Chat─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│System: MCP tool approval required                                                                                    │
+│  Tool: Dropbox/upload                                                                                                │
+│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3",                                       │
+│source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf", access_token=***REDACTED***, contents=(89999│
+│chars, 2000 lines))                                                                                                   │
+│  Options: Once, This chat, Always allow this tool, Deny                                                              │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│MCP tool approval required: Dropbox/upload.                                                                           │
+│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3", source_path="… [Ctrl+O to view full]  │
+│Select an option and press Enter.                                                                                     │
+│1. Once                                                                                                               │
+│2. This chat                                                                                                          │
+│3. Always allow this tool                                                                                             │
+│4. Deny                                                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+[Up/Down] Select [Enter] Confirm [Ctrl+O] View full [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-expanded.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-expanded.txt
@@ -1,10 +1,11 @@
 ╭─Netclaw Chat─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │System: MCP tool approval required                                                                                    │
 │  Tool: Dropbox/upload                                                                                                │
-│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3",                                       │
-│source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf", access_token=***REDACTED***, contents=(89999│
-│chars, 2000 lines))                                                                                                   │
+│Invocation: Dropbox/upload(source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf",                  │
+│destination_directory="/Finance/Board Pack/2026/Q3", contents=(89999 chars, 2000 lines), access_token=***REDACTED***) │
 │  Options: Once, This chat, Always allow this tool, Deny                                                              │
+│                                                                                                                      │
+│                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -28,9 +29,8 @@
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │MCP tool approval required: Dropbox/upload.                                                                           │
-│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3",                                       │
-│source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf", access_token=***REDACTED***, contents=(89999│
-│chars, 2000 lines))                                                                                                   │
+│Invocation: Dropbox/upload(source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf",                  │
+│destination_directory="/Finance/Board Pack/2026/Q3", contents=(89999 chars, 2000 lines), access_token=***REDACTED***) │
 │Select an option and press Enter.                                                                                     │
 │1. Once                                                                                                               │
 │2. This chat                                                                                                          │

--- a/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-expanded.txt
+++ b/src/Netclaw.Cli.Tests/Tui/__snapshots__/chat-mcp-approval-large-expanded.txt
@@ -1,0 +1,40 @@
+╭─Netclaw Chat─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│System: MCP tool approval required                                                                                    │
+│  Tool: Dropbox/upload                                                                                                │
+│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3",                                       │
+│source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf", access_token=***REDACTED***, contents=(89999│
+│chars, 2000 lines))                                                                                                   │
+│  Options: Once, This chat, Always allow this tool, Deny                                                              │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─Input────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│MCP tool approval required: Dropbox/upload.                                                                           │
+│Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3",                                       │
+│source_path="/home/operator/reports/2026/Q3/quarterly-results-final.pdf", access_token=***REDACTED***, contents=(89999│
+│chars, 2000 lines))                                                                                                   │
+│Select an option and press Enter.                                                                                     │
+│1. Once                                                                                                               │
+│2. This chat                                                                                                          │
+│3. Always allow this tool                                                                                             │
+│4. Deny                                                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+[Up/Down] Select [Enter] Confirm [Ctrl+O] Collapse [PgUp/PgDn] Scroll [Ctrl+Q] Quit | Approval required | test-model

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -462,9 +462,17 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
 
             case ToolInteractionRequest msg:
                 RemoveThinkingSpinner();
-                _chatHistory.AppendLine($"System: Approval required for {msg.ToolName}", Color.Yellow);
-                _chatHistory.AppendLine($"  {msg.DisplayText}", Color.White);
-                if (msg.Patterns.Count > 0)
+                _chatHistory.AppendLine(
+                    msg.ToolName.IsMcp
+                        ? "System: MCP tool approval required"
+                        : $"System: Approval required for {msg.ToolName}",
+                    Color.Yellow);
+                if (msg.ToolName.IsMcp)
+                    _chatHistory.AppendLine($"  Tool: {msg.ToolName}", Color.BrightBlack);
+                _chatHistory.AppendLine(
+                    msg.ToolName.IsMcp ? $"  Invocation: {msg.DisplayText}" : $"  {msg.DisplayText}",
+                    Color.White);
+                if (!msg.ToolName.IsMcp && msg.Patterns.Count > 0)
                     _chatHistory.AppendLine($"  Patterns: {string.Join(", ", msg.Patterns)}", Color.BrightBlack);
                 _chatHistory.AppendLine($"  Options: {string.Join(", ", msg.Options.Select(o => o.Label))}", Color.Yellow);
                 _chatHistory.ScrollToBottom();

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -288,7 +288,9 @@ public partial class ChatViewModel : ReactiveViewModel
         if (CurrentInteraction is not { } interaction)
             return "Approval required";
 
-        return $"Approval required for {interaction.ToolName}.";
+        return interaction.ToolName.IsMcp
+            ? $"MCP tool approval required: {interaction.ToolName}."
+            : $"Approval required for {interaction.ToolName}.";
     }
 
     /// <summary>
@@ -305,11 +307,12 @@ public partial class ChatViewModel : ReactiveViewModel
         if (CurrentInteraction is not { } interaction)
             return string.Empty;
 
-        var patterns = interaction.Patterns.Count > 0
+        var patterns = !interaction.ToolName.IsMcp && interaction.Patterns.Count > 0
             ? $" Patterns: {string.Join(", ", interaction.Patterns)}"
             : string.Empty;
 
-        var fullBody = $"{interaction.DisplayText}{patterns}";
+        var prefix = interaction.ToolName.IsMcp ? "Invocation: " : string.Empty;
+        var fullBody = $"{prefix}{interaction.DisplayText}{patterns}";
 
         if (IsApprovalDetailVisible.Value)
             return Netclaw.Channels.ApprovalDisplayTextFormatter.Truncate(fullBody, MaxExpandedApprovalBodyChars);

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 using Xunit;
@@ -978,5 +979,116 @@ public sealed class DefaultApprovalMatcherTests
             null,
             [Verb("mcp:memorizer:get")],
             cwd: null));
+    }
+}
+
+public sealed class McpApprovalMatcherTests
+{
+    private readonly McpApprovalMatcher _matcher = McpApprovalMatcher.Instance;
+
+    [Fact]
+    public void FormatForDisplay_without_arguments_returns_tool_name()
+    {
+        Assert.Equal(
+            "Dropbox/upload",
+            _matcher.FormatForDisplay(new ToolName("Dropbox/upload"), null));
+    }
+
+    [Fact]
+    public void FormatForDisplay_prioritizes_locators_and_summarizes_large_content()
+    {
+        var content = string.Join('\n', Enumerable.Repeat("memorizer payload line", 2_000));
+        var display = _matcher.FormatForDisplay(
+            new ToolName("Dropbox/upload"),
+            new Dictionary<string, object?>
+            {
+                ["contents"] = content,
+                ["overwrite"] = true,
+                ["source_path"] = "/home/operator/reports/quarterly-results.pdf",
+                ["destination_directory"] = "/Finance/Board/2026/Q3"
+            });
+
+        Assert.Contains("source_path=\"/home/operator/reports/quarterly-results.pdf\"", display);
+        Assert.Contains("destination_directory=\"/Finance/Board/2026/Q3\"", display);
+        Assert.Contains($"contents=({content.Length} chars, 2000 lines)", display);
+        Assert.DoesNotContain("memorizer payload line", display);
+        Assert.True(
+            display.IndexOf("destination_directory", StringComparison.Ordinal)
+            < display.IndexOf("overwrite", StringComparison.Ordinal));
+        Assert.True(
+            display.IndexOf("source_path", StringComparison.Ordinal)
+            < display.IndexOf("contents", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FormatForDisplay_handles_JsonElement_scalars_and_small_structures()
+    {
+        using var json = JsonDocument.Parse(
+            """{"mode":"replace","options":{"notify":true,"retries":3},"tags":["finance","board"]}""");
+        var root = json.RootElement;
+
+        var display = _matcher.FormatForDisplay(
+            new ToolName("Dropbox/upload"),
+            new Dictionary<string, object?>
+            {
+                ["mode"] = root.GetProperty("mode").Clone(),
+                ["options"] = root.GetProperty("options").Clone(),
+                ["tags"] = root.GetProperty("tags").Clone()
+            });
+
+        Assert.Contains("mode=\"replace\"", display);
+        Assert.Contains("options={\"notify\":true,\"retries\":3}", display);
+        Assert.Contains("tags=[\"finance\",\"board\"]", display);
+        Assert.DoesNotContain('\n', display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_redacts_top_level_nested_and_token_shaped_secrets()
+    {
+        using var json = JsonDocument.Parse(
+            """{"password":"nested-password","safe":"visible"}""");
+        const string providerToken = "sk-1234567890abcdef";
+
+        var display = _matcher.FormatForDisplay(
+            new ToolName("service/create"),
+            new Dictionary<string, object?>
+            {
+                ["access_token"] = "plain-access-token",
+                ["options"] = json.RootElement.Clone(),
+                ["reference"] = providerToken
+            });
+
+        Assert.DoesNotContain("plain-access-token", display);
+        Assert.DoesNotContain("nested-password", display);
+        Assert.DoesNotContain(providerToken, display);
+        Assert.Contains("***REDACTED***", display);
+        Assert.Contains("visible", display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_preserves_both_ends_of_long_locator()
+    {
+        var path = "/source/" + new string('a', 1_100) + "/quarterly-results.pdf";
+
+        var display = _matcher.FormatForDisplay(
+            new ToolName("Dropbox/upload"),
+            new Dictionary<string, object?> { ["source_path"] = path });
+
+        Assert.Contains("/source/", display);
+        Assert.Contains("quarterly-results.pdf", display);
+        Assert.Contains($"[{path.Length} chars]", display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_reports_unserializable_value_without_throwing()
+    {
+        var value = new Func<int>(() => 42);
+
+        var display = _matcher.FormatForDisplay(
+            new ToolName("service/invoke"),
+            new Dictionary<string, object?> { ["callback"] = value });
+
+        Assert.Contains("value unavailable", display);
+        Assert.DoesNotContain("42", display);
     }
 }

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -995,7 +995,7 @@ public sealed class McpApprovalMatcherTests
     }
 
     [Fact]
-    public void FormatForDisplay_prioritizes_locators_and_summarizes_large_content()
+    public void FormatForDisplay_prioritizes_location_values_and_summarizes_large_strings()
     {
         var content = string.Join('\n', Enumerable.Repeat("memorizer payload line", 2_000));
         var display = _matcher.FormatForDisplay(
@@ -1014,7 +1014,7 @@ public sealed class McpApprovalMatcherTests
         Assert.DoesNotContain("memorizer payload line", display);
         Assert.True(
             display.IndexOf("destination_directory", StringComparison.Ordinal)
-            < display.IndexOf("overwrite", StringComparison.Ordinal));
+            < display.IndexOf("contents", StringComparison.Ordinal));
         Assert.True(
             display.IndexOf("source_path", StringComparison.Ordinal)
             < display.IndexOf("contents", StringComparison.Ordinal));
@@ -1077,6 +1077,91 @@ public sealed class McpApprovalMatcherTests
         Assert.Contains("/source/", display);
         Assert.Contains("quarterly-results.pdf", display);
         Assert.Contains($"[{path.Length} chars]", display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_redacts_uri_credentials_query_and_fragment()
+    {
+        const string signedUrl = "https://operator:password@example.com/reports/q3.pdf?signature=opaque-secret&expires=123#access-token";
+
+        var display = _matcher.FormatForDisplay(
+            new ToolName("Dropbox/upload"),
+            new Dictionary<string, object?> { ["callback"] = signedUrl });
+
+        Assert.Contains("https://example.com/reports/q3.pdf", display);
+        Assert.DoesNotContain("operator", display);
+        Assert.DoesNotContain("password", display);
+        Assert.DoesNotContain("opaque-secret", display);
+        Assert.DoesNotContain("access-token", display);
+        Assert.Contains("REDACTED", display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_escapes_untrusted_argument_names_and_inline_code_breakouts()
+    {
+        var display = _matcher.FormatForDisplay(
+            new ToolName("service/invoke"),
+            new Dictionary<string, object?>
+            {
+                ["safe\n```\u202E**Approve**"] = "value`spoof"
+            });
+
+        Assert.DoesNotContain('\n', display);
+        Assert.DoesNotContain('`', display);
+        Assert.DoesNotContain('\u202E', display);
+        Assert.Contains("\\u000A", display);
+        Assert.Contains("\\u0060", display);
+        Assert.Contains("\\u202E", display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_does_not_infer_value_sensitivity_from_argument_names()
+    {
+        var longValue = new string('x', 2_000);
+        var display = _matcher.FormatForDisplay(
+            new ToolName("service/invoke"),
+            new Dictionary<string, object?>
+            {
+                ["file_contents"] = longValue,
+                ["source_code"] = longValue,
+                ["target_payload"] = longValue
+            });
+
+        Assert.Equal(3, display.Split("2000 chars", StringSplitOptions.None).Length - 1);
+        Assert.DoesNotContain(new string('x', 50), display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_bounds_argument_and_collection_work()
+    {
+        using var json = JsonDocument.Parse(
+            $"[{string.Join(',', Enumerable.Range(0, 1_000))}]");
+        var arguments = Enumerable.Range(0, 1_000)
+            .ToDictionary(i => $"argument_{i:D4}", i => (object?)json.RootElement.Clone());
+
+        var display = _matcher.FormatForDisplay(new ToolName("service/invoke"), arguments);
+
+        Assert.True(display.Length <= 1_600);
+        Assert.Contains("12+ items", display);
+        Assert.Contains("arguments", display);
+        Assert.DoesNotContain("argument_0024", display);
+    }
+
+    [Fact]
+    public void FormatForDisplay_bounds_oversized_names_and_redacts_their_values()
+    {
+        var oversizedKey = new string('k', 10_000);
+        var display = _matcher.FormatForDisplay(
+            new ToolName($"service/{new string('t', 10_000)}`\nspoof"),
+            new Dictionary<string, object?> { [oversizedKey] = "must-not-appear" });
+
+        Assert.True(display.Length <= 1_600);
+        Assert.DoesNotContain("must-not-appear", display);
+        Assert.DoesNotContain('`', display);
+        Assert.DoesNotContain('\n', display);
+        Assert.Contains("10015 chars", display);
+        Assert.Contains("10000\\u0020chars", display);
+        Assert.Contains("REDACTED", display);
     }
 
     [Fact]

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text;
+using System.Text.Json;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 
@@ -771,4 +772,194 @@ public sealed class DefaultApprovalMatcher : IToolApprovalMatcher
 
     public string FormatForDisplay(ToolName toolName, IDictionary<string, object?>? arguments)
         => toolName.Value;
+}
+
+/// <summary>
+/// MCP approval matcher. Grant matching remains at the canonical tool-name
+/// level, while the display text includes a bounded, redacted preview of the
+/// server arguments so an operator can make an informed decision.
+/// </summary>
+public sealed class McpApprovalMatcher : IToolApprovalMatcher
+{
+    public static readonly McpApprovalMatcher Instance = new();
+
+    private const int StandardStringPreviewChars = 240;
+    private const int LocatorStringPreviewChars = 1_000;
+    private const int LocatorPreviewHeadChars = 600;
+    private const int LocatorPreviewTailChars = 350;
+    private const int SmallStructurePreviewChars = 240;
+    private const string Redacted = "***REDACTED***";
+
+    private static DefaultApprovalMatcher Default => DefaultApprovalMatcher.Instance;
+
+    public string GetApprovalModeKey(ToolName toolName, IDictionary<string, object?>? arguments)
+        => Default.GetApprovalModeKey(toolName, arguments);
+
+    public bool IsFailClosedOnPersonal(ToolName toolName, IDictionary<string, object?>? arguments)
+        => Default.IsFailClosedOnPersonal(toolName, arguments);
+
+    public IReadOnlyList<string> ExtractPatterns(ToolName toolName, IDictionary<string, object?>? arguments)
+        => Default.ExtractPatterns(toolName, arguments);
+
+    public IReadOnlyList<string> ExtractCandidateVerbs(ToolName toolName, IDictionary<string, object?>? arguments)
+        => Default.ExtractCandidateVerbs(toolName, arguments);
+
+    public IReadOnlyList<ApprovalCandidate> ExtractCandidates(
+        ToolName toolName,
+        IDictionary<string, object?>? arguments)
+        => Default.ExtractCandidates(toolName, arguments);
+
+    public bool IsApproved(
+        ToolName toolName,
+        IDictionary<string, object?>? arguments,
+        IReadOnlyList<ApprovalEntry> approvedEntries,
+        string? cwd)
+        => Default.IsApproved(toolName, arguments, approvedEntries, cwd);
+
+    public bool IsMessy(ToolName toolName, IDictionary<string, object?>? arguments)
+        => Default.IsMessy(toolName, arguments);
+
+    public string FormatForDisplay(ToolName toolName, IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+            return toolName.Value;
+
+        var parts = arguments
+            .OrderBy(static pair => ArgumentPriority(pair.Key))
+            .ThenBy(static pair => pair.Key, StringComparer.Ordinal)
+            .Select(static pair => $"{pair.Key}={FormatArgument(pair.Key, pair.Value)}");
+
+        return $"{toolName.Value}({string.Join(", ", parts)})";
+    }
+
+    private static int ArgumentPriority(string key)
+    {
+        if (IsLocatorKey(key))
+            return 0;
+
+        return IsContentKey(key) ? 2 : 1;
+    }
+
+    private static string FormatArgument(string key, object? value)
+    {
+        if (SecretOutputRedactor.IsSecretKey(key) || value is SensitiveString)
+            return Redacted;
+
+        if (value is byte[] bytes)
+            return $"({bytes.Length} bytes)";
+
+        JsonElement element;
+        try
+        {
+            element = value is JsonElement json
+                ? json
+                : JsonSerializer.SerializeToElement(value, value?.GetType() ?? typeof(object));
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            return $"({value?.GetType().Name ?? "unknown"} value unavailable)";
+        }
+
+        return FormatJsonValue(key, element);
+    }
+
+    private static string FormatJsonValue(string key, JsonElement value)
+    {
+        if (SecretOutputRedactor.IsSecretKey(key))
+            return Redacted;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => FormatString(key, value.GetString() ?? string.Empty),
+            JsonValueKind.Number => value.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => "null",
+            JsonValueKind.Undefined => "(undefined)",
+            JsonValueKind.Object => FormatObject(value),
+            JsonValueKind.Array => FormatArray(value),
+            _ => "(unsupported value)"
+        };
+    }
+
+    private static string FormatString(string key, string value)
+    {
+        var maxChars = IsLocatorKey(key) ? LocatorStringPreviewChars : StandardStringPreviewChars;
+        if (value.Length <= maxChars)
+            return SecretOutputRedactor.Redact(JsonSerializer.Serialize(value));
+
+        if (IsLocatorKey(key))
+        {
+            var preview = value[..LocatorPreviewHeadChars]
+                          + $"…[{value.Length} chars]…"
+                          + value[^LocatorPreviewTailChars..];
+            return SecretOutputRedactor.Redact(JsonSerializer.Serialize(preview));
+        }
+
+        return $"({value.Length} chars, {CountLines(value)} lines)";
+    }
+
+    private static string FormatObject(JsonElement value)
+    {
+        var properties = value.EnumerateObject().ToList();
+        var rawLength = value.GetRawText().Length;
+        if (rawLength > SmallStructurePreviewChars)
+            return $"({properties.Count} properties, {rawLength} chars)";
+
+        var parts = properties
+            .OrderBy(static property => property.Name, StringComparer.Ordinal)
+            .Select(static property =>
+                $"{JsonSerializer.Serialize(property.Name)}:{FormatJsonValue(property.Name, property.Value)}");
+        return $"{{{string.Join(",", parts)}}}";
+    }
+
+    private static string FormatArray(JsonElement value)
+    {
+        var items = value.EnumerateArray().ToList();
+        var rawLength = value.GetRawText().Length;
+        if (rawLength > SmallStructurePreviewChars)
+            return $"({items.Count} items, {rawLength} chars)";
+
+        return $"[{string.Join(",", items.Select(static item => FormatJsonValue(string.Empty, item)))}]";
+    }
+
+    private static int CountLines(string value)
+    {
+        var lines = 1;
+        foreach (var ch in value)
+        {
+            if (ch == '\n')
+                lines++;
+        }
+
+        return lines;
+    }
+
+    private static bool IsLocatorKey(string key)
+    {
+        var normalized = ToolArgumentHelper.NormalizeKey(key);
+        return normalized.Contains("path", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("file", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("folder", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("directory", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("source", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("destination", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("target", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("url", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("uri", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsContentKey(string key)
+    {
+        var normalized = ToolArgumentHelper.NormalizeKey(key);
+        return normalized.Contains("content", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("body", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("text", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("message", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("payload", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("data", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("blob", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("document", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("memory", StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections;
 using System.Text;
 using System.Text.Json;
 using Netclaw.Configuration;
@@ -783,11 +784,19 @@ public sealed class McpApprovalMatcher : IToolApprovalMatcher
 {
     public static readonly McpApprovalMatcher Instance = new();
 
+    private const int MaxToolNameChars = 256;
+    private const int MaxArgumentNameChars = 160;
+    private const int MaxArguments = 24;
+    private const int MaxDisplayChars = 1_600;
+    private const int MaxNestedItems = 12;
+    private const int MaxNestedDepth = 3;
+    private const int MaxStructurePreviewChars = 360;
+    private const int MaxUrlParseChars = 4_096;
+    private const int MaxLineCountChars = 100_000;
     private const int StandardStringPreviewChars = 240;
     private const int LocatorStringPreviewChars = 1_000;
     private const int LocatorPreviewHeadChars = 600;
     private const int LocatorPreviewTailChars = 350;
-    private const int SmallStructurePreviewChars = 240;
     private const string Redacted = "***REDACTED***";
 
     private static DefaultApprovalMatcher Default => DefaultApprovalMatcher.Instance;
@@ -821,23 +830,51 @@ public sealed class McpApprovalMatcher : IToolApprovalMatcher
 
     public string FormatForDisplay(ToolName toolName, IDictionary<string, object?>? arguments)
     {
+        var displayToolName = FormatToolName(toolName.Value);
         if (arguments is null || arguments.Count == 0)
-            return toolName.Value;
+            return displayToolName;
 
-        var parts = arguments
-            .OrderBy(static pair => ArgumentPriority(pair.Key))
-            .ThenBy(static pair => pair.Key, StringComparer.Ordinal)
-            .Select(static pair => $"{pair.Key}={FormatArgument(pair.Key, pair.Value)}");
+        // MCP schemas may contain arbitrary property names and arbitrarily
+        // large collections. Sample before formatting so an approval prompt
+        // has a hard work and allocation ceiling even for a hostile server.
+        var sampled = arguments
+            .Take(MaxArguments)
+            .OrderBy(static pair => IsLocationLike(pair.Value) ? 0 : 1)
+            .ToList();
 
-        return $"{toolName.Value}({string.Join(", ", parts)})";
-    }
+        var display = new StringBuilder(Math.Min(MaxDisplayChars, displayToolName.Length + 256));
+        display.Append(displayToolName).Append('(');
+        var rendered = 0;
 
-    private static int ArgumentPriority(string key)
-    {
-        if (IsLocatorKey(key))
-            return 0;
+        foreach (var pair in sampled)
+        {
+            var part = $"{FormatArgumentName(pair.Key)}={FormatArgument(pair.Key, pair.Value)}";
+            var separatorChars = rendered == 0 ? 0 : 2;
+            if (display.Length + separatorChars + part.Length + 1 > MaxDisplayChars)
+                break;
 
-        return IsContentKey(key) ? 2 : 1;
+            if (separatorChars > 0)
+                display.Append(", ");
+
+            display.Append(part);
+            rendered++;
+        }
+
+        var omitted = arguments.Count - rendered;
+        if (omitted > 0)
+        {
+            var omission = $"… (+{omitted} arguments)";
+            var separator = rendered == 0 ? string.Empty : ", ";
+            var available = MaxDisplayChars - display.Length - 1;
+            if (separator.Length + omission.Length <= available)
+                display.Append(separator).Append(omission);
+            else if (available > 1)
+                display.Append('…');
+        }
+
+        display.Append(')');
+
+        return display.ToString();
     }
 
     private static string FormatArgument(string key, object? value)
@@ -847,6 +884,18 @@ public sealed class McpApprovalMatcher : IToolApprovalMatcher
 
         if (value is byte[] bytes)
             return $"({bytes.Length} bytes)";
+
+        if (value is string text)
+            return FormatString(text);
+
+        if (value is IDictionary dictionary)
+            return $"({dictionary.Count} properties)";
+
+        if (value is ICollection collection)
+            return $"({collection.Count} items)";
+
+        if (value is IEnumerable)
+            return "(collection value)";
 
         JsonElement element;
         try
@@ -860,106 +909,230 @@ public sealed class McpApprovalMatcher : IToolApprovalMatcher
             return $"({value?.GetType().Name ?? "unknown"} value unavailable)";
         }
 
-        return FormatJsonValue(key, element);
+        return FormatJsonValue(key, element, depth: 0);
     }
 
-    private static string FormatJsonValue(string key, JsonElement value)
+    private static string FormatJsonValue(string key, JsonElement value, int depth)
     {
         if (SecretOutputRedactor.IsSecretKey(key))
             return Redacted;
 
         return value.ValueKind switch
         {
-            JsonValueKind.String => FormatString(key, value.GetString() ?? string.Empty),
+            JsonValueKind.String => FormatString(value.GetString() ?? string.Empty),
             JsonValueKind.Number => value.GetRawText(),
             JsonValueKind.True => "true",
             JsonValueKind.False => "false",
             JsonValueKind.Null => "null",
             JsonValueKind.Undefined => "(undefined)",
-            JsonValueKind.Object => FormatObject(value),
-            JsonValueKind.Array => FormatArray(value),
+            JsonValueKind.Object => FormatObject(value, depth),
+            JsonValueKind.Array => FormatArray(value, depth),
             _ => "(unsupported value)"
         };
     }
 
-    private static string FormatString(string key, string value)
+    private static string FormatString(string value)
     {
-        var maxChars = IsLocatorKey(key) ? LocatorStringPreviewChars : StandardStringPreviewChars;
-        if (value.Length <= maxChars)
-            return SecretOutputRedactor.Redact(JsonSerializer.Serialize(value));
+        if (TrySanitizeAbsoluteUri(value, out var sanitizedUri))
+            return SerializeStringForDisplay(sanitizedUri);
 
-        if (IsLocatorKey(key))
-        {
-            var preview = value[..LocatorPreviewHeadChars]
-                          + $"…[{value.Length} chars]…"
-                          + value[^LocatorPreviewTailChars..];
-            return SecretOutputRedactor.Redact(JsonSerializer.Serialize(preview));
-        }
+        if (IsPathLike(value))
+            return FormatPath(value);
 
-        return $"({value.Length} chars, {CountLines(value)} lines)";
+        return FormatNonLocatorString(value);
     }
 
-    private static string FormatObject(JsonElement value)
+    private static string FormatPath(string value)
     {
-        var properties = value.EnumerateObject().ToList();
-        var rawLength = value.GetRawText().Length;
-        if (rawLength > SmallStructurePreviewChars)
-            return $"({properties.Count} properties, {rawLength} chars)";
+        if (value.Length <= LocatorStringPreviewChars)
+            return SerializeStringForDisplay(SecretOutputRedactor.Redact(value));
+
+        var preview = value[..LocatorPreviewHeadChars]
+                      + $"…[{value.Length} chars]…"
+                      + value[^LocatorPreviewTailChars..];
+        return SerializeStringForDisplay(SecretOutputRedactor.Redact(preview));
+    }
+
+    private static string FormatNonLocatorString(string value)
+    {
+        if (value.Length <= StandardStringPreviewChars)
+            return SerializeStringForDisplay(SecretOutputRedactor.Redact(value));
+
+        return $"({value.Length} chars, {CountLinesForDisplay(value)} lines)";
+    }
+
+    private static string FormatObject(JsonElement value, int depth)
+    {
+        if (depth >= MaxNestedDepth)
+            return "(nested object)";
+
+        var properties = value.EnumerateObject().Take(MaxNestedItems + 1).ToList();
+        if (properties.Count > MaxNestedItems)
+            return $"({MaxNestedItems}+ properties)";
 
         var parts = properties
             .OrderBy(static property => property.Name, StringComparer.Ordinal)
-            .Select(static property =>
-                $"{JsonSerializer.Serialize(property.Name)}:{FormatJsonValue(property.Name, property.Value)}");
-        return $"{{{string.Join(",", parts)}}}";
+            .Select(property =>
+                $"{SerializeStringForDisplay(BoundArgumentName(property.Name))}:{FormatJsonValue(property.Name, property.Value, depth + 1)}");
+        return BoundStructurePreview($"{{{string.Join(",", parts)}}}", properties.Count, "properties");
     }
 
-    private static string FormatArray(JsonElement value)
+    private static string FormatArray(JsonElement value, int depth)
     {
-        var items = value.EnumerateArray().ToList();
-        var rawLength = value.GetRawText().Length;
-        if (rawLength > SmallStructurePreviewChars)
-            return $"({items.Count} items, {rawLength} chars)";
+        if (depth >= MaxNestedDepth)
+            return "(nested array)";
 
-        return $"[{string.Join(",", items.Select(static item => FormatJsonValue(string.Empty, item)))}]";
+        var items = value.EnumerateArray().Take(MaxNestedItems + 1).ToList();
+        if (items.Count > MaxNestedItems)
+            return $"({MaxNestedItems}+ items)";
+
+        var preview = $"[{string.Join(",", items.Select(item => FormatJsonValue(string.Empty, item, depth + 1)))}]";
+        return BoundStructurePreview(preview, items.Count, "items");
     }
 
-    private static int CountLines(string value)
+    private static string BoundStructurePreview(string preview, int count, string unit)
+        => preview.Length <= MaxStructurePreviewChars ? preview : $"({count} {unit})";
+
+    private static string FormatArgumentName(string key)
     {
-        var lines = 1;
+        if (key.Length is > 0 and <= MaxArgumentNameChars && key.All(IsSafeArgumentNameChar))
+            return key;
+
+        // Approval displays are embedded in inline-code markup by the chat
+        // renderers. Encode every non-identifier code unit, including
+        // backticks, line breaks, ANSI controls, and bidi overrides, so an MCP
+        // schema cannot escape the invocation line or spoof prompt chrome.
+        var bounded = BoundArgumentName(key);
+        var escaped = new StringBuilder(bounded.Length + 2);
+        escaped.Append('"');
+        foreach (var ch in bounded)
+        {
+            if (IsSafeArgumentNameChar(ch))
+                escaped.Append(ch);
+            else
+                escaped.Append("\\u").Append(((int)ch).ToString("X4"));
+        }
+
+        return escaped.Append('"').ToString();
+    }
+
+    private static string BoundArgumentName(string key)
+        => key.Length <= MaxArgumentNameChars
+            ? key
+            : $"{key[..120]}…[{key.Length} chars]";
+
+    private static string FormatToolName(string toolName)
+    {
+        var bounded = toolName.Length <= MaxToolNameChars
+            ? toolName
+            : $"{toolName[..200]}…[{toolName.Length} chars]";
+        return EscapePresentationControls(bounded);
+    }
+
+    private static bool IsSafeArgumentNameChar(char ch)
+        => ch is >= 'a' and <= 'z'
+            or >= 'A' and <= 'Z'
+            or >= '0' and <= '9'
+            or '_' or '-' or '.';
+
+    private static string SerializeStringForDisplay(string value)
+    {
+        var serialized = JsonSerializer.Serialize(value);
+        return EscapePresentationControls(serialized);
+    }
+
+    private static string EscapePresentationControls(string value)
+    {
+        if (!value.Any(IsPresentationControl))
+            return value;
+
+        var escaped = new StringBuilder(value.Length);
         foreach (var ch in value)
         {
-            if (ch == '\n')
+            if (IsPresentationControl(ch))
+                escaped.Append("\\u").Append(((int)ch).ToString("X4"));
+            else
+                escaped.Append(ch);
+        }
+
+        return escaped.ToString();
+    }
+
+    private static bool IsPresentationControl(char ch)
+        => ch == '`' || char.IsControl(ch) || IsDirectionalOrLineControl(ch);
+
+    private static bool IsDirectionalOrLineControl(char ch)
+        => ch is '\u061C' or '\u200E' or '\u200F'
+            or >= '\u2028' and <= '\u202E'
+            or >= '\u2066' and <= '\u2069'
+            or '\uFEFF';
+
+    private static bool TrySanitizeAbsoluteUri(string value, out string sanitized)
+    {
+        sanitized = string.Empty;
+        if (value.Length > MaxUrlParseChars
+            || !Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || string.IsNullOrEmpty(uri.Host))
+        {
+            return false;
+        }
+
+        try
+        {
+            var builder = new UriBuilder(uri)
+            {
+                UserName = string.Empty,
+                Password = string.Empty,
+                Query = string.IsNullOrEmpty(uri.Query) ? string.Empty : Redacted,
+                Fragment = string.IsNullOrEmpty(uri.Fragment) ? string.Empty : Redacted
+            };
+            sanitized = SecretOutputRedactor.Redact(builder.Uri.AbsoluteUri);
+            return true;
+        }
+        catch (UriFormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsPathLike(string value)
+    {
+        if (value.Length == 0 || value.IndexOfAny(['\r', '\n']) >= 0)
+            return false;
+
+        return Path.IsPathRooted(value)
+               || value.StartsWith("~/", StringComparison.Ordinal)
+               || value.StartsWith("./", StringComparison.Ordinal)
+               || value.StartsWith("../", StringComparison.Ordinal)
+               || value.StartsWith("\\\\", StringComparison.Ordinal)
+               || value.Length >= 3 && char.IsAsciiLetter(value[0]) && value[1] == ':'
+                   && value[2] is '\\' or '/';
+    }
+
+    private static bool IsLocationLike(object? value)
+    {
+        var text = value switch
+        {
+            string stringValue => stringValue,
+            JsonElement { ValueKind: JsonValueKind.String } jsonValue => jsonValue.GetString(),
+            _ => null
+        };
+
+        return text is not null
+               && (IsPathLike(text) || TrySanitizeAbsoluteUri(text, out _));
+    }
+
+    private static string CountLinesForDisplay(string value)
+    {
+        var lines = 1;
+        var charsToInspect = Math.Min(value.Length, MaxLineCountChars);
+        for (var i = 0; i < charsToInspect; i++)
+        {
+            if (value[i] == '\n')
                 lines++;
         }
 
-        return lines;
+        return value.Length <= MaxLineCountChars ? lines.ToString() : $"{lines}+";
     }
 
-    private static bool IsLocatorKey(string key)
-    {
-        var normalized = ToolArgumentHelper.NormalizeKey(key);
-        return normalized.Contains("path", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("file", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("folder", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("directory", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("source", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("destination", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("target", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("url", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("uri", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsContentKey(string key)
-    {
-        var normalized = ToolArgumentHelper.NormalizeKey(key);
-        return normalized.Contains("content", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("body", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("text", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("message", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("payload", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("data", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("blob", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("document", StringComparison.OrdinalIgnoreCase)
-               || normalized.Contains("memory", StringComparison.OrdinalIgnoreCase);
-    }
 }

--- a/src/Netclaw.Security/SecretOutputRedactor.cs
+++ b/src/Netclaw.Security/SecretOutputRedactor.cs
@@ -15,6 +15,26 @@ public static partial class SecretOutputRedactor
 {
     private const string Redacted = "***REDACTED***";
 
+    private static readonly string[] SecretKeyFragments =
+    [
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "authorization",
+        "credential",
+        "privatekey",
+        "signingkey",
+        "connectionstring"
+    ];
+
+    internal static bool IsSecretKey(string key)
+    {
+        var normalized = Netclaw.Tools.ToolArgumentHelper.NormalizeKey(key);
+        return SecretKeyFragments.Any(fragment =>
+            normalized.Contains(fragment, StringComparison.OrdinalIgnoreCase));
+    }
+
     public static bool ContainsSecretLikeContent(string output)
     {
         if (string.IsNullOrEmpty(output))

--- a/src/Netclaw.Security/SecretOutputRedactor.cs
+++ b/src/Netclaw.Security/SecretOutputRedactor.cs
@@ -13,6 +13,7 @@ namespace Netclaw.Security;
 /// </summary>
 public static partial class SecretOutputRedactor
 {
+    private const int MaxSecretKeyChars = 512;
     private const string Redacted = "***REDACTED***";
 
     private static readonly string[] SecretKeyFragments =
@@ -30,6 +31,12 @@ public static partial class SecretOutputRedactor
 
     internal static bool IsSecretKey(string key)
     {
+        // A hostile MCP schema can supply arbitrarily large property names.
+        // Fail closed instead of allocating an equally large normalized key
+        // just to decide whether its value is safe to display.
+        if (key.Length > MaxSecretKeyChars)
+            return true;
+
         var normalized = Netclaw.Tools.ToolArgumentHelper.NormalizeKey(key);
         return SecretKeyFragments.Any(fragment =>
             normalized.Contains(fragment, StringComparison.OrdinalIgnoreCase));

--- a/src/Netclaw.Tools.Abstractions/ToolName.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolName.cs
@@ -12,6 +12,13 @@ namespace Netclaw.Tools;
 /// </summary>
 public readonly record struct ToolName(string Value)
 {
+    /// <summary>
+    /// MCP tools use the canonical operator-facing <c>{server}/{tool}</c>
+    /// identity. First-party tool names never contain the separator.
+    /// </summary>
+    public bool IsMcp => !string.IsNullOrEmpty(Value)
+                         && Value.IndexOf('/', StringComparison.Ordinal) > 0;
+
     public static explicit operator ToolName(string value) => new(value);
 
     public override string ToString() => Value;


### PR DESCRIPTION
Closes #1685.

## Summary

- add an MCP-specific approval matcher that renders bounded, JSON-safe argument previews instead of repeating only the tool name
- prioritize path, directory, file, URL, and URI arguments; summarize large strings, collections, and binary values; redact secret-like fields
- strip Netclaw metadata schema-aware before building the operator-facing preview, while preserving declared MCP parameters with similar names
- make MCP approval chrome describe a tool invocation rather than shell patterns or working-directory scope across CLI chat, Slack, Discord, and Mattermost
- keep the stable `approve_everywhere` wire key while presenting its MCP semantics as `Always allow this tool`, including after actor recovery
- add collapsed and expanded headless CLI snapshots generated through `McpToolAdapter` and `ToolAccessPolicy`
- update the bundled operations skill with the new approval behavior

## Example

```text
MCP tool approval required: Dropbox/upload.
Invocation: Dropbox/upload(destination_directory="/Finance/Board Pack/2026/Q3", ...)
1. Once
2. This chat
3. Always allow this tool
4. Deny
```

Large content is summarized by character and line count, while secret values are redacted.

## Validation

- `dotnet test Netclaw.slnx --no-restore`
- `./scripts/smoke/run-smoke.sh light` — 22 tapes and 9 scenarios passed
- `dotnet slopwatch analyze` — 0 issues
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff upstream/dev...HEAD --check`

The model-backed eval suite could not start in this environment because `NETCLAW_EVAL_PROVIDER_TYPE`, `NETCLAW_EVAL_PROVIDER_ENDPOINT`, and `NETCLAW_EVAL_MODEL_ID` are not configured.
