### PR TITLE
feat(github-copilot(GHE)): route models through advertised responses endpoint

### DIFF
--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotDescriptorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotDescriptorTests.cs
@@ -83,6 +83,32 @@ public sealed class GitHubCopilotDescriptorTests
     }
 
     [Fact]
+    public void ParseCopilotModelCapabilities_RetainsHttpEndpointsWithoutConfusingWebSocketResponses()
+    {
+        var capabilities = GitHubCopilotDescriptor.ParseCopilotModelCapabilities(
+            """
+            { "data": [
+              { "id": "responses-only", "capabilities": { "type": "chat" }, "supported_endpoints": ["/responses", "ws:/responses"] },
+              { "id": "chat-only", "capabilities": { "type": "chat" }, "supported_endpoints": ["/chat/completions"] },
+              { "id": "dual", "capabilities": { "type": "chat" }, "supported_endpoints": ["/responses", "/chat/completions"] },
+              { "id": "not-chat", "capabilities": { "type": "embeddings" }, "supported_endpoints": ["/responses"] },
+              { "id": "hidden", "capabilities": { "type": "chat" }, "model_picker_enabled": false, "supported_endpoints": ["/responses"] }
+            ] }
+            """);
+
+        Assert.Equal(3, capabilities.Count);
+        var responsesOnly = Assert.Single(capabilities, capability => capability.ModelId == "responses-only");
+        Assert.True(responsesOnly.SupportsResponses);
+        Assert.False(responsesOnly.SupportsChatCompletions);
+        Assert.Contains("ws:/responses", responsesOnly.SupportedEndpoints);
+        Assert.Equal(GitHubCopilotApiKind.Responses, responsesOnly.PreferredApi);
+        Assert.Equal(GitHubCopilotApiKind.ChatCompletions,
+            Assert.Single(capabilities, capability => capability.ModelId == "chat-only").PreferredApi);
+        Assert.Equal(GitHubCopilotApiKind.Responses,
+            Assert.Single(capabilities, capability => capability.ModelId == "dual").PreferredApi);
+    }
+
+    [Fact]
     public async Task Probe_FallsBackToCuratedListWhenModelsEndpointFails()
     {
         var handler = new FakeHttpMessageHandler(request =>

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotModelCatalogTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotModelCatalogTests.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="GitHubCopilotModelCatalogTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+using Netclaw.Providers.GitHubCopilot;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers.GitHubCopilot;
+
+public sealed class GitHubCopilotModelCatalogTests
+{
+    [Fact]
+    public void Catalog_UsesEndpointAndCaseInsensitiveModelLookup()
+    {
+        var catalog = new GitHubCopilotModelCatalog();
+        var capability = new GitHubCopilotModelCapability(
+            "GPT-5.5", true, false, ["/responses"]);
+
+        catalog.Store(new Uri("https://api.tenant.ghe.com"), [capability]);
+
+        Assert.Same(capability,
+            catalog.Find(new Uri("https://api.tenant.ghe.com/"), "gpt-5.5"));
+        Assert.Null(catalog.Find(new Uri("https://api.githubcopilot.com"), "gpt-5.5"));
+    }
+
+    [Fact]
+    public async Task LazyClient_InitializesExactlyOnceForConcurrentFirstRequests()
+    {
+        var initializeCount = 0;
+        var client = new GitHubCopilotCapabilityResolvingChatClient(() =>
+        {
+            Interlocked.Increment(ref initializeCount);
+            return Task.FromResult<IChatClient>(new TestChatClient());
+        });
+
+        await Task.WhenAll(
+            client.GetResponseAsync([new ChatMessage(ChatRole.User, "one")],
+                cancellationToken: TestContext.Current.CancellationToken),
+            client.GetResponseAsync([new ChatMessage(ChatRole.User, "two")],
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(1, initializeCount);
+    }
+
+    private sealed class TestChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse());
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
@@ -45,8 +45,29 @@ public sealed class GitHubCopilotProviderPluginTests
     private static GitHubCopilotProviderPlugin NewPlugin()
     {
         var exchanger = NewExchanger();
-        var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
+        var descriptor = DescriptorWithModels(exchanger, "/chat/completions");
         return new GitHubCopilotProviderPlugin(descriptor, exchanger);
+    }
+
+    private static GitHubCopilotDescriptor DescriptorWithModels(
+        CopilotTokenExchanger exchanger, params string[] endpoints)
+    {
+        var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(new
+            {
+                data = new[]
+                {
+                    new
+                    {
+                        id = "gpt-4o",
+                        capabilities = new { type = "chat" },
+                        supported_endpoints = endpoints,
+                    },
+                },
+            }), Encoding.UTF8, "application/json"),
+        });
+        return new GitHubCopilotDescriptor(new HttpClient(handler), exchanger);
     }
 
     [Fact]
@@ -119,7 +140,7 @@ public sealed class GitHubCopilotProviderPluginTests
         });
 
         var exchanger = ExchangerReturning("copilot-real", apiBase: "https://api.githubcopilot.com");
-        var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
+        var descriptor = DescriptorWithModels(exchanger, "/chat/completions");
         var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
         {
             TransportOverride = new HttpClientPipelineTransport(new HttpClient(captureHandler)),
@@ -161,7 +182,7 @@ public sealed class GitHubCopilotProviderPluginTests
         });
 
         var exchanger = ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com");
-        var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
+        var descriptor = DescriptorWithModels(exchanger, "/chat/completions");
         var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
         {
             TransportOverride = new HttpClientPipelineTransport(new HttpClient(captureHandler)),
@@ -202,7 +223,7 @@ public sealed class GitHubCopilotProviderPluginTests
         });
 
         var exchanger = ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com");
-        var descriptor = new GitHubCopilotDescriptor(new HttpClient(), exchanger);
+        var descriptor = DescriptorWithModels(exchanger, "/chat/completions");
         var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
         {
             TransportOverride = new HttpClientPipelineTransport(new HttpClient(captureHandler)),
@@ -226,6 +247,78 @@ public sealed class GitHubCopilotProviderPluginTests
         Assert.Equal("copilot-proxy.example.com", sentUri!.Host);
     }
 
+    [Fact]
+    public async Task CreateChatClient_ResponsesOnlyModel_UsesResponsesAtTokenHostWithCopilotHeaders()
+    {
+        Uri? sentUri = null;
+        HttpRequestMessage? sentRequest = null;
+        var captureHandler = new FakeHttpMessageHandler(req =>
+        {
+            sentUri = req.RequestUri;
+            sentRequest = req;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(MinimalResponseJson, Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var exchanger = ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com");
+        var descriptor = DescriptorWithModels(exchanger, "/responses", "ws:/responses");
+        var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
+        {
+            TransportOverride = new HttpClientPipelineTransport(new HttpClient(captureHandler)),
+        };
+        var entry = new ProviderEntry
+        {
+            Type = "github-copilot", AuthMethod = AuthMethod.OAuthDevice,
+            OAuthAccessToken = new SensitiveString("oauth-1"),
+        };
+
+        var client = plugin.CreateChatClient(
+            entry, new ModelReference { Provider = "my-copilot", ModelId = "gpt-4o" });
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(sentUri);
+        Assert.Equal("api.tenant.ghe.com", sentUri!.Host);
+        Assert.Equal("/responses", sentUri.AbsolutePath);
+        Assert.Equal("Bearer copilot-ghe", sentRequest!.Headers.Authorization!.ToString());
+        Assert.Equal("vscode-chat", sentRequest.Headers.GetValues("copilot-integration-id").Single());
+        Assert.True(sentRequest.Headers.Contains("editor-version"));
+        Assert.Equal("conversation-agent", sentRequest.Headers.GetValues("openai-intent").Single());
+        Assert.Equal(NetclawUserAgent.Value, sentRequest.Headers.UserAgent.ToString());
+    }
+
+    [Fact]
+    public async Task CreateChatClient_ModelWithoutHttpEndpoint_FailsBeforeInference()
+    {
+        var inferenceCalls = 0;
+        var exchanger = ExchangerReturning("copilot-ghe", apiBase: "https://api.tenant.ghe.com");
+        var descriptor = DescriptorWithModels(exchanger, "ws:/responses");
+        var plugin = new GitHubCopilotProviderPlugin(descriptor, exchanger)
+        {
+            TransportOverride = new HttpClientPipelineTransport(new HttpClient(
+                new FakeHttpMessageHandler(_ =>
+                {
+                    Interlocked.Increment(ref inferenceCalls);
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }))),
+        };
+        var entry = new ProviderEntry
+        {
+            Type = "github-copilot", AuthMethod = AuthMethod.OAuthDevice,
+            OAuthAccessToken = new SensitiveString("oauth-1"),
+        };
+        var client = plugin.CreateChatClient(
+            entry, new ModelReference { Provider = "my-copilot", ModelId = "gpt-4o" });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hi")], cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("does not advertise a supported HTTP inference endpoint", error.Message);
+        Assert.Equal(0, inferenceCalls);
+    }
+
     private const string MinimalChatCompletionJson =
         """
         {
@@ -241,6 +334,26 @@ public sealed class GitHubCopilotProviderPluginTests
             }
           ],
           "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+        }
+        """;
+
+    private const string MinimalResponseJson =
+        """
+        {
+          "id": "resp-test",
+          "object": "response",
+          "created_at": 0,
+          "status": "completed",
+          "model": "gpt-4o",
+          "output": [
+            {
+              "id": "msg-test",
+              "type": "message",
+              "status": "completed",
+              "role": "assistant",
+              "content": [ { "type": "output_text", "text": "ok", "annotations": [] } ]
+            }
+          ]
         }
         """;
 }

--- a/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/GitHubCopilot/GitHubCopilotProviderPluginTests.cs
@@ -286,7 +286,9 @@ public sealed class GitHubCopilotProviderPluginTests
         Assert.Equal("vscode-chat", sentRequest.Headers.GetValues("copilot-integration-id").Single());
         Assert.True(sentRequest.Headers.Contains("editor-version"));
         Assert.Equal("conversation-agent", sentRequest.Headers.GetValues("openai-intent").Single());
-        Assert.Equal(NetclawUserAgent.Value, sentRequest.Headers.UserAgent.ToString());
+        var userAgent = sentRequest.Headers.UserAgent.ToString();
+        Assert.StartsWith(NetclawUserAgent.Value, userAgent);
+        Assert.Equal(1, userAgent.Split(NetclawUserAgent.Value, StringSplitOptions.None).Length - 1);
     }
 
     [Fact]

--- a/src/Netclaw.Providers/GitHubCopilot/CopilotRequestPolicy.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/CopilotRequestPolicy.cs
@@ -128,5 +128,6 @@ internal sealed class CopilotRequestPolicy(
         headers.Set("copilot-integration-id", "vscode-chat");
         headers.Set("editor-version", "Netclaw/1.0");
         headers.Set("openai-intent", "conversation-agent");
+        headers.Set("user-agent", NetclawUserAgent.Value);
     }
 }

--- a/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotDescriptor.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotDescriptor.cs
@@ -18,6 +18,7 @@ namespace Netclaw.Providers.GitHubCopilot;
 public sealed class GitHubCopilotDescriptor(
     HttpClient httpClient, CopilotTokenExchanger tokenExchanger) : IProviderDescriptor
 {
+    private readonly GitHubCopilotModelCatalog _modelCatalog = new();
 
     // The public Copilot API host. Standard/individual tokens are valid here;
     // org and GHE-data-residency tokens are valid only at the host reported in
@@ -93,66 +94,8 @@ public sealed class GitHubCopilotDescriptor(
                 []);
         }
 
-        CopilotToken copilot;
-        try
-        {
-            copilot = await tokenExchanger.GetTokenAsync(entry, ct);
-        }
-        catch (CopilotAuthExpiredException)
-        {
-            return new ProviderProbeResult(false,
-                "GitHub Copilot authorization expired. Re-authenticate by running "
-                + "'netclaw provider remove <name>' then "
-                + "'netclaw provider add <name> github-copilot --auth oauth-device'.",
-                []);
-        }
-        catch (HttpRequestException ex)
-        {
-            return new ProviderProbeResult(false,
-                $"GitHub Copilot token exchange failed: {ex.Message}",
-                []);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return new ProviderProbeResult(false,
-                $"GitHub Copilot token exchange failed: {ex.Message}",
-                []);
-        }
-
-        // Probe /models at the host the token is valid at (endpoints.api). For
-        // GHE data residency this is the tenant host, not api.githubcopilot.com;
-        // probing the wrong host is what let a broken GHE provider report healthy
-        // at setup (issue #1550). A deliberate custom endpoint override wins. If
-        // we are meant to follow the token's host but the exchange reported none,
-        // surface that — never silently probe a guessed default host.
-        string probeEndpoint;
-        if (HasCustomEndpointOverride(entry.Endpoint))
-        {
-            probeEndpoint = entry.Endpoint!;
-        }
-        else if (copilot.ApiBase is { } apiBase)
-        {
-            probeEndpoint = apiBase.ToString();
-        }
-        else
-        {
-            return new ProviderProbeResult(false,
-                "GitHub Copilot token exchange did not return an API host "
-                + "(endpoints.api); cannot determine where to reach the Copilot API. "
-                + "Re-authenticate the provider, or set an explicit endpoint to "
-                + "override the host.",
-                []);
-        }
-
-        var modelsResult = await ProbeHelpers.ExecuteProbeAsync(
-            httpClient,
-            "GitHub Copilot",
-            DefaultEndpoint,
-            ModelListingPath,
-            probeEndpoint,
-            ApplyCopilotRequestHeaders(copilot.Token.Value),
-            ParseCopilotModels,
-            ct);
+        var discovery = await DiscoverModelCatalogAsync(entry, ct).ConfigureAwait(false);
+        var modelsResult = discovery.Result;
 
         if (!modelsResult.Success)
         {
@@ -172,6 +115,85 @@ public sealed class GitHubCopilotDescriptor(
         return modelsResult;
     }
 
+    internal async Task<GitHubCopilotModelCapability> ResolveModelCapabilityAsync(
+        ProviderEntry entry, string modelId)
+    {
+        var discovery = await DiscoverModelCatalogAsync(entry, CancellationToken.None).ConfigureAwait(false);
+        if (!discovery.Result.Success || discovery.ApiEndpoint is null)
+        {
+            throw new InvalidOperationException(
+                $"GitHub Copilot model capability discovery failed: {discovery.Result.ErrorMessage}");
+        }
+
+        var capability = _modelCatalog.Find(discovery.ApiEndpoint, modelId);
+        if (capability is not null)
+            return capability;
+
+        var availableModels = discovery.Capabilities
+            .Select(capability => capability.ModelId)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .Select(id => $"- {id}");
+        throw new InvalidOperationException(
+            $"GitHub Copilot model '{modelId}' is not available to the authenticated account.\n\n"
+            + "Available models:\n" + string.Join('\n', availableModels));
+    }
+
+    private async Task<ModelCatalogDiscovery> DiscoverModelCatalogAsync(
+        ProviderEntry entry, CancellationToken ct)
+    {
+        CopilotToken copilot;
+        try
+        {
+            copilot = await tokenExchanger.GetTokenAsync(entry, ct).ConfigureAwait(false);
+        }
+        catch (CopilotAuthExpiredException)
+        {
+            return ModelCatalogDiscovery.Fail(
+                "GitHub Copilot authorization expired. Re-authenticate by running "
+                + "'netclaw provider remove <name>' then "
+                + "'netclaw provider add <name> github-copilot --auth oauth-device'.");
+        }
+        catch (HttpRequestException ex)
+        {
+            return ModelCatalogDiscovery.Fail($"GitHub Copilot token exchange failed: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ModelCatalogDiscovery.Fail($"GitHub Copilot token exchange failed: {ex.Message}");
+        }
+
+        Uri? apiEndpoint = HasCustomEndpointOverride(entry.Endpoint)
+            ? new Uri(entry.Endpoint!)
+            : copilot.ApiBase;
+        if (apiEndpoint is null)
+        {
+            return ModelCatalogDiscovery.Fail(
+                "GitHub Copilot token exchange did not return an API host "
+                + "(endpoints.api); cannot determine where to reach the Copilot API. "
+                + "Re-authenticate the provider, or set an explicit endpoint to override the host.");
+        }
+
+        IReadOnlyList<GitHubCopilotModelCapability>? capabilities = null;
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient,
+            "GitHub Copilot",
+            DefaultEndpoint,
+            ModelListingPath,
+            apiEndpoint.ToString(),
+            ApplyCopilotRequestHeaders(copilot.Token.Value),
+            json =>
+            {
+                capabilities = ParseCopilotModelCapabilities(json);
+                return ProjectProbeResult(capabilities);
+            },
+            ct).ConfigureAwait(false);
+
+        if (result.Success && capabilities is not null)
+            _modelCatalog.Store(apiEndpoint, capabilities);
+
+        return new ModelCatalogDiscovery(result, apiEndpoint, capabilities ?? []);
+    }
+
     private static Action<HttpRequestMessage> ApplyCopilotRequestHeaders(string copilotToken) =>
         request =>
         {
@@ -181,12 +203,17 @@ public sealed class GitHubCopilotDescriptor(
             request.Headers.TryAddWithoutValidation("openai-intent", "conversation-agent");
         };
 
-    // Filters the Copilot /models payload to chat-capable entries the
-    // server marks as picker-eligible. Falls back to the curated list when
-    // every entry is filtered out so callers never see a zero-model success.
+    // One parser feeds both the picker projection and the provider-local runtime
+    // catalog. capabilities.type filters non-chat models but is not treated as
+    // proof that /chat/completions is supported.
     internal static ProviderProbeResult ParseCopilotModels(string json)
     {
-        var models = new List<DiscoveredModel>();
+        return ProjectProbeResult(ParseCopilotModelCapabilities(json));
+    }
+
+    internal static IReadOnlyList<GitHubCopilotModelCapability> ParseCopilotModelCapabilities(string json)
+    {
+        var models = new List<GitHubCopilotModelCapability>();
         using var doc = JsonDocument.Parse(json);
 
         if (doc.RootElement.TryGetProperty("data", out var data)
@@ -213,15 +240,45 @@ public sealed class GitHubCopilotDescriptor(
                     continue;
                 }
 
-                models.Add(new DiscoveredModel { ModelId = new(id) });
+                var endpoints = entry.TryGetProperty("supported_endpoints", out var endpointsProp)
+                    && endpointsProp.ValueKind == JsonValueKind.Array
+                    ? endpointsProp.EnumerateArray()
+                        .Where(endpoint => endpoint.ValueKind == JsonValueKind.String)
+                        .Select(endpoint => endpoint.GetString())
+                        .Where(endpoint => !string.IsNullOrWhiteSpace(endpoint))
+                        .Select(endpoint => endpoint!)
+                        .ToArray()
+                    : [];
+
+                models.Add(new GitHubCopilotModelCapability(
+                    id,
+                    endpoints.Any(endpoint => string.Equals(endpoint, "/responses", StringComparison.OrdinalIgnoreCase)),
+                    endpoints.Any(endpoint => string.Equals(endpoint, "/chat/completions", StringComparison.OrdinalIgnoreCase)),
+                    endpoints));
             }
         }
 
+        return models;
+    }
+
+    private static ProviderProbeResult ProjectProbeResult(
+        IReadOnlyList<GitHubCopilotModelCapability> models)
+    {
         return models.Count == 0
             ? new ProviderProbeResult(true,
                 "GitHub Copilot /models returned no chat-capable entries; "
                 + "using curated fallback.",
                 CuratedModels)
-            : new ProviderProbeResult(true, null, models);
+            : new ProviderProbeResult(true, null,
+                models.Select(model => new DiscoveredModel { ModelId = new(model.ModelId) }).ToArray());
+    }
+
+    private sealed record ModelCatalogDiscovery(
+        ProviderProbeResult Result,
+        Uri? ApiEndpoint,
+        IReadOnlyList<GitHubCopilotModelCapability> Capabilities)
+    {
+        public static ModelCatalogDiscovery Fail(string error) =>
+            new(new ProviderProbeResult(false, error, []), null, []);
     }
 }

--- a/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotModelCatalog.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotModelCatalog.cs
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+// <copyright file="GitHubCopilotModelCatalog.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Providers.GitHubCopilot;
+
+internal enum GitHubCopilotApiKind
+{
+    Responses,
+    ChatCompletions,
+}
+
+/// <summary>Provider-local endpoint capability advertised by GitHub Copilot /models.</summary>
+internal sealed record GitHubCopilotModelCapability(
+    string ModelId,
+    bool SupportsResponses,
+    bool SupportsChatCompletions,
+    IReadOnlyList<string> SupportedEndpoints)
+{
+    public GitHubCopilotApiKind? PreferredApi => SupportsResponses
+        ? GitHubCopilotApiKind.Responses
+        : SupportsChatCompletions ? GitHubCopilotApiKind.ChatCompletions : null;
+}
+
+/// <summary>
+/// Caches authenticated Copilot model capabilities by the effective API endpoint
+/// and the canonical server model id. Tokens are intentionally never retained.
+/// </summary>
+internal sealed class GitHubCopilotModelCatalog
+{
+    private readonly ConcurrentDictionary<GitHubCopilotCatalogKey, GitHubCopilotModelCapability> _entries = new();
+
+    public void Store(Uri apiEndpoint, IEnumerable<GitHubCopilotModelCapability> capabilities)
+    {
+        var endpoint = NormalizeEndpoint(apiEndpoint);
+        foreach (var capability in capabilities)
+            _entries[new GitHubCopilotCatalogKey(endpoint, NormalizeModelId(capability.ModelId))] = capability;
+    }
+
+    public GitHubCopilotModelCapability? Find(Uri apiEndpoint, string modelId)
+    {
+        var endpoint = NormalizeEndpoint(apiEndpoint);
+        return _entries.TryGetValue(
+            new GitHubCopilotCatalogKey(endpoint, NormalizeModelId(modelId)), out var capability)
+            ? capability
+            : null;
+    }
+
+    private static string NormalizeEndpoint(Uri endpoint) => endpoint.AbsoluteUri.TrimEnd('/');
+    private static string NormalizeModelId(string modelId) => modelId.ToUpperInvariant();
+
+    private readonly record struct GitHubCopilotCatalogKey(string Endpoint, string ModelId);
+}
+
+/// <summary>Minimal lazy delegate that selects the Copilot API exactly once.</summary>
+internal sealed class GitHubCopilotCapabilityResolvingChatClient(
+    Func<Task<IChatClient>> initialize) : IChatClient
+{
+    private readonly object _initializationLock = new();
+    private Task<IChatClient>? _innerTask;
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var inner = await GetInnerAsync(cancellationToken).ConfigureAwait(false);
+        return await inner.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var inner = await GetInnerAsync(cancellationToken).ConfigureAwait(false);
+        await foreach (var update in inner.GetStreamingResponseAsync(messages, options, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            yield return update;
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) =>
+        _innerTask is { IsCompletedSuccessfully: true }
+            ? _innerTask.Result.GetService(serviceType, serviceKey)
+            : null;
+
+    public void Dispose()
+    {
+        if (_innerTask is { IsCompletedSuccessfully: true })
+            _innerTask.Result.Dispose();
+    }
+
+    private Task<IChatClient> GetInnerAsync(CancellationToken cancellationToken)
+    {
+        Task<IChatClient> task;
+        lock (_initializationLock)
+            task = _innerTask ??= initialize();
+
+        return task.WaitAsync(cancellationToken);
+    }
+}

--- a/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotProviderPlugin.cs
+++ b/src/Netclaw.Providers/GitHubCopilot/GitHubCopilotProviderPlugin.cs
@@ -8,6 +8,7 @@ using System.ClientModel.Primitives;
 using Microsoft.Extensions.AI;
 using Netclaw.Configuration;
 using OpenAI;
+using OpenAI.Responses;
 
 namespace Netclaw.Providers.GitHubCopilot;
 
@@ -32,36 +33,59 @@ public sealed class GitHubCopilotProviderPlugin(
 
     public override IChatClient CreateChatClient(ProviderEntry entry, ModelReference model)
     {
+        return new GitHubCopilotCapabilityResolvingChatClient(async () =>
+        {
+            var capability = await Descriptor.ResolveModelCapabilityAsync(entry, model.ModelId)
+                .ConfigureAwait(false);
+            return CreateSdkClient(entry, model.Provider, capability);
+        });
+    }
+
+    private IChatClient CreateSdkClient(
+        ProviderEntry entry, string? providerName, GitHubCopilotModelCapability capability)
+    {
         var endpoint = string.IsNullOrWhiteSpace(entry.Endpoint)
             ? Descriptor.DefaultEndpoint
             : entry.Endpoint.TrimEnd('/');
-
-        var options = new OpenAIClientOptions
-        {
-            Endpoint = new Uri(endpoint),
-        };
-
-        if (TransportOverride is not null)
-            options.Transport = TransportOverride;
-
-        // The SDK owns the Authorization header: its key-credential auth policy
-        // runs after any policy we register and writes "Bearer {key}" from this
-        // credential at send time. So we hand it a mutable credential and let
-        // CopilotRequestPolicy refresh its value (to a fresh short-lived Copilot
-        // token) on every call. The "placeholder" is overwritten before the
-        // first request goes out.
         var credential = new ApiKeyCredential("placeholder");
         var oauth = GitHubCopilotDescriptor.CreateOAuthAuth(entry);
-
-        // When the operator left the endpoint on the public default, let the chat
-        // host follow the token's endpoints.api (required for GHE data residency,
-        // issue #1550). A deliberate custom endpoint (e.g. a proxy) is respected.
         var followTokenHost = !GitHubCopilotDescriptor.HasCustomEndpointOverride(entry.Endpoint);
-        options.AddPolicy(
-            new CopilotRequestPolicy(tokenExchanger, entry, credential, followTokenHost, model.Provider, oauth),
-            PipelinePosition.PerCall);
 
-        var client = new OpenAIClient(credential, options);
-        return client.GetChatClient(model.ModelId).AsIChatClient();
+        if (capability.PreferredApi is null)
+        {
+            var advertised = capability.SupportedEndpoints.Count == 0
+                ? "(none)"
+                : string.Join(", ", capability.SupportedEndpoints);
+            throw new InvalidOperationException(
+                $"GitHub Copilot model '{capability.ModelId}' does not advertise a supported HTTP inference endpoint. "
+                + $"Advertised endpoints: {advertised}.");
+        }
+
+        return capability.PreferredApi == GitHubCopilotApiKind.Responses
+            ? CreateResponsesClient()
+            : CreateChatCompletionsClient();
+
+        IChatClient CreateResponsesClient()
+        {
+            var options = new ResponsesClientOptions { Endpoint = new Uri(endpoint) };
+            if (TransportOverride is not null)
+                options.Transport = TransportOverride;
+            options.AddPolicy(CreateRequestPolicy(), PipelinePosition.PerCall);
+            return new ResponsesClient(credential, options).AsIChatClient(capability.ModelId);
+        }
+
+        IChatClient CreateChatCompletionsClient()
+        {
+            var options = new OpenAIClientOptions { Endpoint = new Uri(endpoint) };
+            if (TransportOverride is not null)
+                options.Transport = TransportOverride;
+            options.AddPolicy(CreateRequestPolicy(), PipelinePosition.PerCall);
+            return new OpenAIClient(credential, options)
+                .GetChatClient(capability.ModelId)
+                .AsIChatClient();
+        }
+
+        CopilotRequestPolicy CreateRequestPolicy() =>
+            new(tokenExchanger, entry, credential, followTokenHost, providerName, oauth);
     }
 }


### PR DESCRIPTION
Fixes #1706

## Summary

GitHub Copilot currently routes every model through `/chat/completions`, including models whose authenticated `/models` metadata advertises only `/responses`.

This change adds provider-local endpoint capability discovery and selects the correct API:

- `/responses` → `ResponsesClient`
- `/chat/completions` only → existing `ChatClient`
- both → prefer `/responses`
- neither → fail before inference

No model-name or version allowlists are used.

## Scope

Changes are limited to the GitHub Copilot provider and focused tests.

This PR does not change shared model contracts, configuration, daemon startup, generic routing, retry/failover behavior, authentication, token exchange, or other providers.

## Validation

Live validation against GitHub Enterprise Copilot passed:

- `gpt-5.5`
- `gpt-5.4-mini`
- `gpt-5.3-codex`
- `mai-code-1-flash-picker`

For each model:

- GHE token exchange returned HTTP 200
- tenant `/models` discovery returned HTTP 200
- inference completed successfully
- `unsupported_api_for_model` was absent
- fallback was not invoked

Existing `gpt-5.4` compatibility remains intact.

## Build validation

- Full solution build: 30 succeeded, 0 failed
- Linux x64 CLI and daemon publish: passed
- Container build and deployment: passed
- Published daemon SHA256 matched the daemon packaged in the container

Test evidence: 
<img width="1912" height="990" alt="image" src="https://github.com/user-attachments/assets/83224cb7-31c4-47f8-9103-d79405fe4357" />

token exchange → HTTP 200
/models → HTTP 200
LLM streaming call completed
no failover

## Live GHE validation evidence

Test environment:

- GitHub Enterprise OAuth device authentication
- Tenant-specific Copilot API host returned through `endpoints.api`
- Fresh Linux x64 self-contained Netclaw daemon from commit `206fad03`
- Deployed container image digest: `sha256:32c8484f1629fe4d5353cafa8b7d4f72e31ff1cc1d58b8c061196fed0ceca0f3`
- Published daemon and image-contained daemon SHA256: `14848BA5753D10AB6010C5D526199370D1BC27D2052DD3724A2EA0E93426323B`

### Before the fix

| Main model | Advertised endpoint | Previous result |
|---|---|---|
| `gpt-5.5` | `/responses` | HTTP 400 `unsupported_api_for_model`; incorrectly sent to `/chat/completions`; fallback invoked |
| `gpt-5.4-mini` | `/responses` | HTTP 400 `unsupported_api_for_model`; incorrectly sent to `/chat/completions` |
| `gpt-5.3-codex` | `/responses` | HTTP 400 `unsupported_api_for_model`; incorrectly sent to `/chat/completions` |
| `mai-code-1-flash-picker` | Responses-capable model returned by authenticated discovery | HTTP 400 `unsupported_api_for_model`; incorrectly sent to `/chat/completions`; fallback invoked |

Representative failure:

    model "gpt-5.5" is not accessible via the /chat/completions endpoint

### After the fix

| Main model | Token exchange | Authenticated `/models` | Inference | `unsupported_api_for_model` | Fallback invoked | Result |
|---|---:|---:|---:|---:|---:|---:|
| `gpt-5.5` | HTTP 200 | HTTP 200 | Completed; input 10,543 / output 19 | No | No | PASS |
| `gpt-5.4-mini` | HTTP 200 | HTTP 200 | Completed; input 10,551 / output 86 | No | No | PASS |
| `gpt-5.3-codex` | HTTP 200 | HTTP 200 | Completed; input 10,546 / output 23 | No | No | PASS |
| `mai-code-1-flash-picker` | HTTP 200 | HTTP 200 | Completed; input 10,553 / output 104 | No | No | PASS |

### Sanitized log evidence

`gpt-5.5`:

    Copilot token exchange: HTTP 200
    GET https://copilot-api.<tenant>.ghe.com/models: HTTP 200
    LLM streaming call completed in 2127ms (input: 10543, output: 19)
    No unsupported_api_for_model error
    No "failing over to next candidate" event

`gpt-5.4-mini`:

    Copilot token exchange: HTTP 200
    GET https://copilot-api.<tenant>.ghe.com/models: HTTP 200
    LLM streaming call completed in 2285ms (input: 10551, output: 86)
    No unsupported_api_for_model error
    No "failing over to next candidate" event

`gpt-5.3-codex`:

    Copilot token exchange: HTTP 200
    GET https://copilot-api.<tenant>.ghe.com/models: HTTP 200
    LLM streaming call completed in 3035ms (input: 10546, output: 23)
    No unsupported_api_for_model error
    No "failing over to next candidate" event

`mai-code-1-flash-picker`:

    Copilot token exchange: HTTP 200
    GET https://copilot-api.<tenant>.ghe.com/models: HTTP 200
    LLM streaming call completed in 2884ms (input: 10553, output: 104)
    No unsupported_api_for_model error
    No "failing over to next candidate" event

### Result

The live GHE tests demonstrate that endpoint-capability discovery is active and that previously failing Responses-only models now complete inference without falling back to the known `/chat/completions`-compatible GPT-5.4 model.

