### PR TITLE
Migrate to ModelContextProtocol 2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,11 @@
     <SlackNetVersion>0.17.10</SlackNetVersion>
     <DiscordNetVersion>3.20.1</DiscordNetVersion>
     <MattermostNetVersion>5.0.3</MattermostNetVersion>
-    <MicrosoftExtensionsAIVersion>10.8.0</MicrosoftExtensionsAIVersion>
+    <MicrosoftExtensionsAIVersion>10.8.3</MicrosoftExtensionsAIVersion>
+    <!-- Microsoft.Extensions.TimeProvider.Testing ships on the dotnet/extensions minor
+         cadence and has no 10.8.x patch, so it cannot share MicrosoftExtensionsAIVersion
+         once the AI packages move to a patch release. -->
+    <MicrosoftExtensionsTimeProviderTestingVersion>10.8.0</MicrosoftExtensionsTimeProviderTestingVersion>
     <OpenAIVersion>2.12.0</OpenAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.10</MicrosoftAspNetCoreVersion>
     <SkiaSharpVersion>4.148.0</SkiaSharpVersion>
@@ -20,7 +24,7 @@
          that trips NU1902 under our TreatWarningsAsErrors policy. -->
     <AspireHostingVersion>13.4.6</AspireHostingVersion>
     <CommunityToolkitAspireVersion>13.4.0</CommunityToolkitAspireVersion>
-    <ModelContextProtocolVersion>1.4.1</ModelContextProtocolVersion>
+    <ModelContextProtocolVersion>2.0.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
@@ -44,7 +48,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsAIVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsTimeProviderTestingVersion)" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="$(ModelContextProtocolVersion)" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="$(ModelContextProtocolVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreVersion)" />

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -59,6 +59,18 @@ When a tape fails, `smoke-logs/tapes/<name>/` collects: a debug GIF of the
 last frame, the combined tape file, daemon logs, and the produced
 `NETCLAW_HOME`. CI uploads the `smoke-logs` directory as a job artefact.
 
+**Rerun this workflow in full, never with `--failed`.** The binary artefact
+name ends with the attempt number
+(`netclaw-native-binaries-linux-x64-<run-id>-1`). A partial rerun becomes
+attempt 2 and looks for `...-2`, which the publish job never produced, so
+`Download binary artifact` fails before a tape runs. Use
+`gh run rerun <run-id>`, not `gh run rerun --failed <run-id>`.
+
+The job installs Ollama from its release-pinned installer before it runs a
+tape. A `curl: (35) Recv failure` at that step is a network failure that
+reaches no test code. Confirm the failure is inside a tape before you
+investigate the change under review.
+
 **Authoring conventions are in `tests/smoke/tapes/README.md`**
 — the short version: `Wait+Screen /pattern/` only (no `Sleep`), 1400×800
 default surface, no `Screenshot` directives in flow tapes, pair every

--- a/openspec/changes/simplify-mcp-oauth-lifecycle/design.md
+++ b/openspec/changes/simplify-mcp-oauth-lifecycle/design.md
@@ -89,7 +89,7 @@ cannot delegate: client lifecycle and durable local state.
 
 **Decision:** Authorization-server selection, PKCE, authorization-code exchange,
 bearer injection, and refresh delegate entirely to the SDK via
-`ClientOAuthOptions`, `ITokenCache`, and `AuthorizationRedirectDelegate`.
+`ClientOAuthOptions`, `ITokenCache`, and `AuthorizationCallbackHandler`.
 `McpOAuthService`'s protocol code — authorization-URL construction, code
 exchange, refresh redemption, `GetValidTokenAsync`, and the metadata cache — is
 deleted.
@@ -111,7 +111,7 @@ registering with the same method the SDK will later select, and seeds
 
 **Rationale:** One protocol implementation cannot drift from itself. 1.4.1
 already exposes every hook the interactive and non-interactive flows need, and
-the redirect delegate explicitly supports custom UI, so the manual stack can go
+the authorization callback handler explicitly supports custom UI, so the manual stack can go
 now — before the pending upstream fixes ship. This is a net-negative-LOC change
 that shrinks the attack and defect surface.
 
@@ -329,10 +329,11 @@ URL, and a task the HTTP callback completes with the code) and
 supplying `ITokenCache` adapters). The broker performs no discovery, DCR, PKCE,
 exchange, or refresh. On `POST /api/mcp/oauth/start/{name}`, the manager opens a
 pending broker flow and starts an unpublished candidate whose
-`AuthorizationRedirectDelegate` is owned by that flow; the SDK generates the
-authorization URL, the broker returns it through the existing
-`McpOAuthStartResponse`, and `GET /api/mcp/oauth/callback` validates the exact
-pending state and completes the flow. The callback request is never made the
+`AuthorizationCallbackHandler` is owned by that flow; the SDK generates the
+authorization URL and the `state` inside it, the broker indexes the flow by that
+state and returns the URL through the existing `McpOAuthStartResponse`, and
+`GET /api/mcp/oauth/callback` routes on that state and relays `code`, `state`,
+and `iss` to the SDK, which validates them. The callback request is never made the
 candidate's lifetime owner, so closing the tab cannot cancel a running exchange.
 The start request does not own the candidate either: the manager supplies a
 daemon-owned cancellation token bounded by flow expiry and shutdown. A second
@@ -351,7 +352,7 @@ They may continue using a healthy published generation, or report
 the authorization flow.
 The redirect URI is
 `http://127.0.0.1:{DaemonConfig.Port}/api/mcp/oauth/callback`, never derived
-from a request `Host` header. For normal startup the redirect delegate is
+from a request `Host` header. For normal startup the authorization callback handler is
 non-interactive and returns no code, so startup never unexpectedly opens a
 browser or blocks.
 
@@ -360,24 +361,27 @@ simultaneously protocol client, cache, state machine, and persistence layer. The
 simplicity metric is fewer authorities and state machines, not fewer classes.
 Deriving the port from config fixes defect 7 for any non-default local port.
 
-**Decompiled 1.4.1 contract (verified against the shipped assembly):**
+**SDK 2.0.0 contract (verified against the shipped source):**
 
-- `AuthorizationRedirectDelegate` returns the authorization code as a string;
-  the SDK invokes it only after discovery, DCR, and PKCE, with the fully built
-  authorization URI and the `ClientOAuthOptions.RedirectUri`. A null or empty
-  return throws `McpException` — loud, non-blocking, and safe for the
-  non-interactive startup variant, which maps that failure to `AwaitingAuth`.
-- The SDK neither generates nor validates the OAuth `state` parameter. The
-  broker injects its opaque state via
-  `ClientOAuthOptions.AdditionalAuthorizationParameters["state"]` (the SDK's
-  URL builder reserves only `client_id`, `redirect_uri`, `response_type`,
-  `code_challenge`, `code_challenge_method`, `resource`, and `scope`), and
-  Netclaw owns state validation and CSRF protection end-to-end.
+- `AuthorizationCallbackHandler` returns an `AuthorizationResult` carrying the
+  authorization code, the `state`, and the RFC 9207 `iss`. The SDK invokes it
+  only after discovery, DCR, and PKCE, with the fully built authorization URI
+  and the `ClientOAuthOptions.RedirectUri`. A null return throws `McpException`
+  — loud, non-blocking, and safe for the non-interactive startup variant, which
+  maps that failure to `AwaitingAuth`. `AuthorizationRedirectDelegate` is
+  obsolete (diagnostic MCP9007) and skips state and issuer validation.
+- The SDK generates and validates the OAuth `state` parameter, and validates
+  `iss` per RFC 9207. The broker reads the state out of the SDK-built
+  authorization URL only to index the flow, so the browser callback can reach
+  it, and relays `code`, `state`, and `iss` back unchanged. The broker MUST NOT
+  send its own `state` through
+  `ClientOAuthOptions.AdditionalAuthorizationParameters`: the SDK's URL builder
+  merges those entries with `Dictionary.Add`, which throws on the duplicate key.
 - The provider contains no synchronization, and the transport's POST and
   GET/SSE paths can challenge concurrently through one provider instance. The
-  broker therefore elects the first redirect-delegate invocation as the flow
+  broker therefore elects the first callback-handler invocation as the flow
   owner. It alone publishes the authorization URL, waits for the callback code,
-  and returns that code to its SDK invocation. Concurrent delegates observe the
+  and returns that code to its SDK invocation. Concurrent handler invocations observe the
   same flow as authorization-in-progress and do not prompt, but they fail their
   request with a classified in-progress result rather than reusing the owner's
   code with a different PKCE verifier.
@@ -445,7 +449,7 @@ blank error into an operator instruction.
   fake-server OAuth integration tests plus the existing provider reproduction
   cases; report standards/SDK defects upstream instead of re-forking the
   protocol inside Netclaw.
-- **[Risk]** The SDK redirect-delegate interactive flow is unexercised in this
+- **[Risk]** The SDK authorization-callback-handler interactive flow is unexercised in this
   codebase — today `BuildOAuthOptions` sets the delegate to return `null`,
   deliberately suppressing the SDK browser path. → **Mitigation:**
   decompilation of the shipped 1.4.1 assembly has verified the static contract
@@ -497,7 +501,7 @@ release; the split exists for review isolation and rollback clarity.
    OAuth protocol behavior changes. Update netclaw-dev/netclaw#1696 with the
    local lifecycle completion; do not close it.
 2. **PR 2 — SDK-owned OAuth, durable boundary, diagnostics.** Replace the manual
-   OAuth stack with the SDK redirect-delegate flow; add `McpOAuthFlowBroker` and
+   OAuth stack with the SDK authorization-callback-handler flow; add `McpOAuthFlowBroker` and
    `McpOAuthCredentialStore`; delete discovery/DCR/PKCE/exchange/refresh and the
    metadata-cache runtime dependency; add transactional `secrets.json` mutation
    and migrate callers; bind credentials to the configured resource identity;

--- a/openspec/changes/simplify-mcp-oauth-lifecycle/proposal.md
+++ b/openspec/changes/simplify-mcp-oauth-lifecycle/proposal.md
@@ -34,7 +34,7 @@ parts: one owner per concern, not a more complete second OAuth implementation.
   degradation).
 - **OAuth ownership**: PKCE, authorization-code exchange, refresh, and bearer
   injection delegate to the MCP C# SDK (ModelContextProtocol.Core 1.4.1
-  `ClientOAuthOptions`, `ITokenCache`, `AuthorizationRedirectDelegate`).
+  `ClientOAuthOptions`, `ITokenCache`, `AuthorizationCallbackHandler`).
   Netclaw's manual protocol implementation in `McpOAuthService` and the
   `mcp-oauth-metadata.json` runtime dependency are **removed**. Existing
   metadata files are ignored, not deleted.
@@ -55,7 +55,7 @@ parts: one owner per concern, not a more complete second OAuth implementation.
   handoff only: opaque one-time state, bounded flow lifetime via
   `TimeProvider`) and `McpOAuthCredentialStore` (durable per-server token
   sets plus the DCR-issued client ID; supplies SDK `ITokenCache` adapters).
-  One SDK redirect delegate owns each flow's PKCE/code exchange; concurrent
+  One SDK authorization callback handler owns each flow's PKCE/code exchange; concurrent
   delegates observe authorization in progress but never reuse its code.
 - **Durable credentials**: active token state changes only after durable
   persistence succeeds; persistence failure fails the connection visibly. A token

--- a/openspec/changes/simplify-mcp-oauth-lifecycle/specs/mcp-oauth/spec.md
+++ b/openspec/changes/simplify-mcp-oauth-lifecycle/specs/mcp-oauth/spec.md
@@ -70,13 +70,16 @@ operator-facing error naming `OAuthClientId` as the remedy.
 
 Explicit authorization (`netclaw mcp auth <name>`) SHALL retain its existing
 CLI and HTTP surface. The daemon SHALL broker the SDK-generated authorization
-URL to the operator and complete the SDK's redirect delegate from the local
-callback endpoint. Flow state values SHALL be cryptographically opaque,
-one-time, bound to a single server and flow, and SHALL expire after a bounded
-lifetime of five minutes measured via `TimeProvider`. Netclaw SHALL validate
-the callback state itself — the SDK neither generates nor validates the OAuth
-state parameter. The first redirect-delegate invocation for a flow SHALL own
-the authorization URL, callback code, and PKCE exchange. Concurrent delegate
+URL to the operator and complete the SDK's authorization callback handler from
+the local callback endpoint. A flow SHALL be one-time, bound to a single server,
+and SHALL expire after a bounded lifetime of five minutes measured via
+`TimeProvider`. The SDK owns the OAuth `state` value: it generates the value,
+puts it in the authorization URL, and validates the value that returns. The
+daemon SHALL read that value out of the authorization URL only to index the flow,
+so the browser callback can reach it. The daemon SHALL relay `code`, `state`,
+and the RFC 9207 `iss` parameter to the SDK without a change, and SHALL validate
+none of them. The first callback-handler invocation for a flow SHALL own the
+authorization URL, callback code, and PKCE exchange. Concurrent handler
 invocations SHALL observe that authorization is already in progress and SHALL
 NOT receive or reuse the owner's authorization code. At most one
 interactive flow SHALL be active per server; concurrent start requests SHALL
@@ -90,7 +93,7 @@ existing five-minute CLI and TUI polling timeout.
 - **GIVEN** a configured HTTP MCP server requiring OAuth
 - **WHEN** the operator starts explicit authorization
 - **THEN** the daemon creates a pending flow and an unpublished candidate connection
-- **AND** the SDK performs discovery, registration if needed, and PKCE, and supplies the authorization URL through its redirect delegate
+- **AND** the SDK performs discovery, registration if needed, and PKCE, and supplies the authorization URL through its authorization callback handler
 - **AND** the CLI receives that URL through the existing start response and polls the existing status endpoint
 - **AND** the callback completes the flow, the SDK exchanges the code, and the candidate is published only after initialization (including tool listing) succeeds
 - **AND** polling reports `Completed` only after that publication succeeds
@@ -138,7 +141,7 @@ existing five-minute CLI and TUI polling timeout.
 #### Scenario: Concurrent challenges reuse one pending flow
 
 - **GIVEN** a pending interactive flow for a server
-- **WHEN** the SDK invokes the redirect delegate concurrently from parallel transport requests
+- **WHEN** the SDK invokes the authorization callback handler concurrently from parallel transport requests
 - **THEN** one invocation owns the authorization URL and callback code
 - **AND** every other invocation observes authorization in progress without prompting
 - **AND** no authorization code is returned to more than one SDK invocation
@@ -257,7 +260,7 @@ NOT derive the callback host from an incoming request's Host header.
 
 The system SHALL create every configured HTTP MCP transport without an
 operator-configured `Authorization` header with SDK OAuth support whose
-non-interactive redirect delegate returns no authorization code. A configured
+non-interactive authorization callback handler returns no authorization result. A configured
 `Authorization` header SHALL suppress SDK OAuth so the SDK cannot replace it
 after a challenge. OAuth support SHALL remain dormant for unauthenticated
 servers, and all operator-provided headers SHALL remain authoritative. When interactive authorization is required, the

--- a/openspec/changes/simplify-mcp-oauth-lifecycle/tasks.md
+++ b/openspec/changes/simplify-mcp-oauth-lifecycle/tasks.md
@@ -41,7 +41,7 @@ never `Thread.Sleep` or `Task.Delay` in orchestration.
 
 - [x] 5.1 Update netclaw-dev/netclaw#1696 with the local lifecycle completion. Do not close it — the upstream SDK fixes are still pending.
 
-## 6. PR 2 — Spike: prove the SDK redirect-delegate flow
+## 6. PR 2 — Spike: prove the SDK authorization-callback-handler flow
 
 - [x] 6.1 Stand up a fake OAuth MCP server harness exposing discovery metadata, a DCR endpoint, an authorization endpoint, and a token endpoint, usable from integration tests. Done when a test can drive each endpoint.
 - [x] 6.2 Prove the SDK redirect-delegate flow end-to-end against the fake server — discovery, DCR, PKCE, authorization-URL delivery via `AuthorizationRedirectDelegate`, callback completion, code exchange, and `ITokenCache` store — BEFORE any manual OAuth code is deleted. Done when a green integration test drives the full SDK path and de-risks the previously unexercised redirect delegate.

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -477,7 +477,7 @@ public sealed class McpCommandTests : IDisposable
     {
         var lines = new Queue<string?>([
             "not-a-url",
-            "http://127.0.0.1:5199/api/mcp/oauth/callback?code=auth-code&state=flow-state"
+            "http://127.0.0.1:5199/api/mcp/oauth/callback?code=auth-code&state=flow-state&iss=https%3A%2F%2Fauth.example"
         ]);
 
         var submissions = 0;
@@ -486,11 +486,14 @@ public sealed class McpCommandTests : IDisposable
         var result = await McpCommand.ReadPasteRedirectAsync(
             output,
             _ => Task.FromResult(lines.Dequeue()),
-            (code, state, _) =>
+            (code, state, iss, _) =>
             {
                 submissions++;
                 Assert.Equal("auth-code", code);
                 Assert.Equal("flow-state", state);
+                // The MCP SDK validates iss per RFC 9207. Dropping it here makes every
+                // headless authorization fail against a server that advertises it.
+                Assert.Equal("https://auth.example", iss);
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             },
             CancellationToken.None);
@@ -514,7 +517,7 @@ public sealed class McpCommandTests : IDisposable
         var result = await McpCommand.ReadPasteRedirectAsync(
             output,
             _ => Task.FromResult(lines.Dequeue()),
-            (code, _, _) =>
+            (code, _, _, _) =>
             {
                 submissions++;
                 var status = code == "bad-code"

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -241,12 +241,20 @@ public sealed class DaemonApi
             $"{_endpoint}/api/mcp/oauth/status-by-state/{Uri.EscapeDataString(state)}", cts.Token);
     }
 
-    public async Task<HttpResponseMessage> McpOAuthCallbackAsync(string code, string state, CancellationToken ct = default)
+    public async Task<HttpResponseMessage> McpOAuthCallbackAsync(
+        string code,
+        string state,
+        string? iss,
+        CancellationToken ct = default)
     {
         using var cts = CreateTimeoutCts(LongTimeout, ct);
         var client = CreateHttpClient();
-        return await client.GetAsync(
-            $"{_endpoint}/api/mcp/oauth/callback?code={Uri.EscapeDataString(code)}&state={Uri.EscapeDataString(state)}", cts.Token);
+        // The MCP SDK validates iss per RFC 9207 and rejects the response when an advertising
+        // server sent one and it does not arrive, so the paste path must carry it too.
+        var query = $"code={Uri.EscapeDataString(code)}&state={Uri.EscapeDataString(state)}";
+        if (!string.IsNullOrEmpty(iss))
+            query += $"&iss={Uri.EscapeDataString(iss)}";
+        return await client.GetAsync($"{_endpoint}/api/mcp/oauth/callback?{query}", cts.Token);
     }
 
     public async Task<JsonElement> GetMcpServerStatusesAsync(CancellationToken ct = default)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -456,14 +456,14 @@ internal static class McpCommand
         return await ReadPasteRedirectAsync(
             writer,
             token => Task.Run(Console.ReadLine, token),
-            (code, state, token) => daemonApi.McpOAuthCallbackAsync(code, state, token),
+            (code, state, iss, token) => daemonApi.McpOAuthCallbackAsync(code, state, iss, token),
             ct);
     }
 
     internal static async Task<bool> ReadPasteRedirectAsync(
         TextWriter writer,
         Func<CancellationToken, Task<string?>> readLineAsync,
-        Func<string, string, CancellationToken, Task<HttpResponseMessage>> submitRedirectAsync,
+        Func<string, string, string?, CancellationToken, Task<HttpResponseMessage>> submitRedirectAsync,
         CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
@@ -485,7 +485,7 @@ internal static class McpCommand
             if (string.IsNullOrWhiteSpace(line))
                 continue;
 
-            if (!OAuthRedirectParser.TryParse(line, out var code, out var state, out var error))
+            if (!OAuthRedirectParser.TryParse(line, out var code, out var state, out var iss, out var error))
             {
                 writer.WriteLine($"Invalid redirect URL: {error}");
                 continue;
@@ -493,7 +493,7 @@ internal static class McpCommand
 
             try
             {
-                using var response = await submitRedirectAsync(code, state, ct);
+                using var response = await submitRedirectAsync(code, state, iss, ct);
                 if (response.IsSuccessStatusCode)
                     return true;
 

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -31,7 +31,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
     private CancellationTokenSource? _cts;
 
     // Set during flow start to route SubmitRedirectUrlAsync to the correct callback
-    private Func<string, string, Task<HttpResponseMessage>>? _activeCallbackFunc;
+    private Func<string, string, string?, Task<HttpResponseMessage>>? _activeCallbackFunc;
 
     // ── Observable state ──────────────────────────────────────────────
 
@@ -78,7 +78,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
         Cancel();
         _cts = new CancellationTokenSource();
         _activeCallbackFunc = _daemonApi is not null
-            ? (code, state) => _daemonApi.ProviderOAuthCallbackAsync(code, state)
+            ? (code, state, _) => _daemonApi.ProviderOAuthCallbackAsync(code, state)
             : null;
         Completion = RunBrowserFlowAsync(providerType, onSuccess, _cts.Token);
         return _cts.Token;
@@ -94,7 +94,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
         Cancel();
         _cts = new CancellationTokenSource();
         _activeCallbackFunc = _daemonApi is not null
-            ? (code, state) => _daemonApi.McpOAuthCallbackAsync(code, state)
+            ? (code, state, iss) => _daemonApi.McpOAuthCallbackAsync(code, state, iss)
             : null;
         Completion = RunMcpBrowserFlowAsync(serverName, onSuccess, _cts.Token);
         return _cts.Token;
@@ -121,7 +121,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
     /// </summary>
     public async Task SubmitRedirectUrlAsync(string? pastedUrl)
     {
-        if (!OAuthRedirectParser.TryParse(pastedUrl, out var code, out var state, out var error))
+        if (!OAuthRedirectParser.TryParse(pastedUrl, out var code, out var state, out var iss, out var error))
         {
             ErrorMessage = error;
             _requestRedraw();
@@ -137,7 +137,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
 
         try
         {
-            var response = await _activeCallbackFunc(code, state);
+            var response = await _activeCallbackFunc(code, state, iss);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/Netclaw.Configuration/McpOAuthTokenSet.cs
+++ b/src/Netclaw.Configuration/McpOAuthTokenSet.cs
@@ -41,6 +41,15 @@ public sealed class McpOAuthTokenSet
     public bool DynamicClientRegistration { get; set; }
 
     /// <summary>
+    /// Issuer of the authorization server that issued this client registration. The MCP SDK
+    /// binds a registration to one issuer and will not reuse it against another.
+    /// </summary>
+    public string? AuthorizationServer { get; set; }
+
+    /// <summary>Token endpoint authentication method this client registered with.</summary>
+    public string? TokenEndpointAuthMethod { get; set; }
+
+    /// <summary>
     /// Legacy resource field. It is retained for deserialization only and is not
     /// accepted as the security binding for cached credentials.
     /// </summary>

--- a/src/Netclaw.Daemon.Tests/Mcp/McpEndpointRouteBuilderExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpEndpointRouteBuilderExtensionsTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.Authentication;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
@@ -235,6 +236,10 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
         var ct = TestContext.Current.CancellationToken;
         using var broker = new McpOAuthFlowBroker(TimeProvider.System, CancellationToken.None);
         var flow = broker.StartOrJoin(new McpServerName("failed-server")).Flow;
+        // Look-up by state needs a state, and only the SDK can supply one. Drive the
+        // callback handler far enough to publish the authorization URL it built.
+        _ = InvokeCallbackHandler(flow, new Uri("https://auth.example.com/authorize?state=failed-state"), ct);
+        await flow.WaitForAuthorizationRequestAsync(ct);
         broker.Fail(flow, new McpErrorResponse(
             "MCP OAuth dynamic client registration failed: HTTP 403 Forbidden.",
             "dynamic client registration",
@@ -275,11 +280,9 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
 
         using var broker = new McpOAuthFlowBroker(TimeProvider.System, CancellationToken.None);
         var pending = broker.StartOrJoin(new McpServerName("test-mcp")).Flow;
-        var expectedUrl = new Uri("https://auth.example.com/authorize?client_id=test-client");
-        var owner = pending.HandleAuthorizationRedirectAsync(
-            expectedUrl,
-            new Uri("http://127.0.0.1:5199/api/mcp/oauth/callback"),
-            ct);
+        var expectedUrl = new Uri("https://auth.example.com/authorize?client_id=test-client&state=sdk-state");
+        var owner = InvokeCallbackHandler(pending, expectedUrl, ct);
+        await pending.WaitForAuthorizationRequestAsync(ct);
         await using var app = await CreateAppAsync(
             spoofLoopback: true,
             mcpServers: servers,
@@ -293,7 +296,7 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
         Assert.True(body.TryGetProperty("authorizationUrl", out var urlProp));
         Assert.True(body.TryGetProperty("state", out var stateProp));
         Assert.False(string.IsNullOrWhiteSpace(urlProp.GetString()));
-        Assert.False(string.IsNullOrWhiteSpace(stateProp.GetString()));
+        Assert.Equal("sdk-state", stateProp.GetString());
         Assert.Equal(expectedUrl.ToString(), urlProp.GetString());
         broker.Fail(pending, new McpErrorResponse("test cleanup"));
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await owner);
@@ -316,10 +319,11 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
 
         using var broker = new McpOAuthFlowBroker(TimeProvider.System, CancellationToken.None);
         var flow = broker.StartOrJoin(new McpServerName("test-mcp")).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(
-            new Uri("https://auth.example.com/authorize"),
-            new Uri("http://127.0.0.1:5199/api/mcp/oauth/callback"),
+        var owner = InvokeCallbackHandler(
+            flow,
+            new Uri("https://auth.example.com/authorize?state=happy-path"),
             ct);
+        await flow.WaitForAuthorizationRequestAsync(ct);
         await using var app = await CreateAppAsync(
             spoofLoopback: true,
             mcpServers: servers,
@@ -328,8 +332,12 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
 
         // Complete via callback — no Authorization header (AllowAnonymous)
         var callback = client.GetAsync(
-            $"/api/mcp/oauth/callback?code=test-code&state={flow.State}", ct);
-        Assert.Equal("test-code", await owner);
+            $"/api/mcp/oauth/callback?code=test-code&state={flow.State}&iss=https%3A%2F%2Fauth.example.com", ct);
+        var result = await owner;
+        Assert.Equal("test-code", result?.Code);
+        // The SDK validates both against what it generated, so both must survive the round trip.
+        Assert.Equal("happy-path", result?.State);
+        Assert.Equal("https://auth.example.com", result?.Iss);
         broker.BeginCommit(flow);
         broker.Complete(flow);
         var callbackResponse = await callback;
@@ -345,14 +353,15 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
         var ct = TestContext.Current.CancellationToken;
         using var broker = new McpOAuthFlowBroker(TimeProvider.System, CancellationToken.None);
         var flow = broker.StartOrJoin(new McpServerName("test-mcp")).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(
-            new Uri("https://auth.example.com/authorize"),
-            new Uri("http://127.0.0.1:5199/api/mcp/oauth/callback"),
+        var owner = InvokeCallbackHandler(
+            flow,
+            new Uri("https://auth.example.com/authorize?state=failure-path"),
             ct);
+        await flow.WaitForAuthorizationRequestAsync(ct);
         await using var app = await CreateAppAsync(spoofLoopback: true, flowBroker: broker);
         var callback = app.GetTestClient().GetAsync(
             $"/api/mcp/oauth/callback?code=sensitive-code&state={flow.State}", ct);
-        Assert.Equal("sensitive-code", await owner);
+        Assert.Equal("sensitive-code", (await owner)?.Code);
         broker.Fail(flow, new McpErrorResponse(
             "MCP OAuth authorization code exchange failed: HTTP 403 Forbidden.",
             "authorization code exchange",
@@ -365,7 +374,18 @@ public sealed class McpEndpointRouteBuilderExtensionsTests : IDisposable
         Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
         Assert.Contains("authorization code exchange failed", html, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("sensitive-code", html, StringComparison.Ordinal);
-        Assert.DoesNotContain(flow.State, html, StringComparison.Ordinal);
+        Assert.DoesNotContain("failure-path", html, StringComparison.Ordinal);
     }
 
+    private static Task<AuthorizationResult?> InvokeCallbackHandler(
+        McpOAuthFlow flow,
+        Uri authorizationUri,
+        CancellationToken cancellationToken)
+        => flow.HandleAuthorizationCallbackAsync(
+            new AuthorizationCallbackContext
+            {
+                AuthorizationUri = authorizationUri,
+                RedirectUri = new Uri("http://127.0.0.1:5199/api/mcp/oauth/callback"),
+            },
+            cancellationToken);
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/McpOAuthFlowBrokerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpOAuthFlowBrokerTests.cs
@@ -43,13 +43,24 @@ public sealed class McpOAuthFlowBrokerTests
     [Fact]
     public async Task AuthorizationUrlWithoutStateFailsTheFlowInsteadOfHanging()
     {
-        using var broker = CreateBroker();
+        // A virtual clock is what makes this test meaningful: the expiry timer never fires,
+        // so the waiting caller can only be released by the failure path under test. On the
+        // system clock the five-minute expiry releases it anyway and the assertion passes
+        // whether or not the flow fails promptly.
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 22, 12, 0, 0, TimeSpan.Zero));
+        using var broker = new McpOAuthFlowBroker(time, CancellationToken.None);
         var flow = broker.StartOrJoin(ServerName).Flow;
+        var waitingStart = flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
 
         var handler = InvokeCallbackHandler(flow, new Uri("https://auth.example/authorize?client_id=one"));
 
         await Assert.ThrowsAsync<McpOAuthOperationException>(async () => await handler);
         Assert.Null(flow.State);
+        await Assert.ThrowsAsync<McpOAuthOperationException>(
+            async () => await waitingStart.WaitAsync(
+                TimeSpan.FromSeconds(30),
+                TestContext.Current.CancellationToken));
+        Assert.Equal(McpOAuthFlowStatus.Failed, broker.GetLatestStatus(ServerName).Status);
     }
 
     [Fact]
@@ -73,19 +84,22 @@ public sealed class McpOAuthFlowBrokerTests
     }
 
     [Fact]
-    public void StatelessTerminalFlowIsRetiredByPruning()
+    public void StatelessTerminalFlowIsDisposedWhenReplaced()
     {
-        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 22, 12, 0, 0, TimeSpan.Zero));
-        using var broker = new McpOAuthFlowBroker(time, CancellationToken.None);
+        using var daemonCancellation = new CancellationTokenSource();
+        using var broker = new McpOAuthFlowBroker(TimeProvider.System, daemonCancellation.Token);
         var abandoned = broker.StartOrJoin(ServerName).Flow;
         broker.Fail(abandoned, new McpErrorResponse("discovery failed", "authorization start"));
 
-        // A flow with no state was never indexed by state, so only the per-server sweep can
-        // reach it. Without that sweep its timer and token source leak.
-        time.Advance(McpOAuthFlowBroker.FlowLifetime * 2);
+        // Retrying immediately is the normal reaction to a failed authorization, so the
+        // replacement must reclaim the old flow. It was never indexed by state, so nothing
+        // else can reach it, and Cancel alone does not release its registration on the daemon
+        // shutdown token — only Dispose does.
+        var replacement = broker.StartOrJoin(ServerName);
 
-        Assert.Equal(McpOAuthFlowStatus.NotStarted, broker.GetLatestStatus(ServerName).Status);
-        Assert.NotSame(abandoned, broker.StartOrJoin(ServerName).Flow);
+        Assert.True(replacement.Created);
+        Assert.NotSame(abandoned, replacement.Flow);
+        Assert.True(abandoned.IsDisposed);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Mcp/McpOAuthFlowBrokerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpOAuthFlowBrokerTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.Time.Testing;
+using ModelContextProtocol.Authentication;
 using Netclaw.Daemon.Mcp;
 using Netclaw.Tools;
 using Xunit;
@@ -13,11 +14,10 @@ namespace Netclaw.Daemon.Tests.Mcp;
 public sealed class McpOAuthFlowBrokerTests
 {
     private static readonly McpServerName ServerName = new("oauth-server");
-    private static readonly Uri AuthorizationUrl = new("https://auth.example/authorize?client_id=one");
     private static readonly Uri RedirectUri = new("http://127.0.0.1:7331/api/mcp/oauth/callback");
 
     [Fact]
-    public void ConcurrentStartsForOneServerShareOpaqueFlow()
+    public async Task ConcurrentStartsForOneServerShareFlowAndSdkState()
     {
         using var broker = CreateBroker();
 
@@ -27,44 +27,116 @@ public sealed class McpOAuthFlowBrokerTests
         Assert.True(first.Created);
         Assert.False(second.Created);
         Assert.Same(first.Flow, second.Flow);
-        Assert.Equal(43, first.Flow.State.Length);
-        Assert.DoesNotContain(ServerName.Value, first.Flow.State, StringComparison.Ordinal);
+
+        // The MCP SDK owns `state` from 2.0 onward, so a flow has none until the SDK
+        // hands over the authorization URL it built.
+        Assert.Null(first.Flow.State);
+
+        _ = InvokeCallbackHandler(first.Flow, AuthorizationUrl("sdk-state"));
+        var request = await first.Flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("sdk-state", request.State);
+        Assert.Equal("sdk-state", first.Flow.State);
+        Assert.Same(first.Flow, broker.GetForCallback("sdk-state"));
     }
 
     [Fact]
-    public async Task FirstDelegateOwnsUrlAndCodeFollowersFailWithoutCodeReuse()
+    public async Task AuthorizationUrlWithoutStateFailsTheFlowInsteadOfHanging()
     {
         using var broker = CreateBroker();
         var flow = broker.StartOrJoin(ServerName).Flow;
 
-        var owner = flow.HandleAuthorizationRedirectAsync(
-            AuthorizationUrl,
-            RedirectUri,
-            CancellationToken.None);
-        var follower = flow.HandleAuthorizationRedirectAsync(
-            new Uri("https://auth.example/authorize?client_id=two"),
-            RedirectUri,
-            CancellationToken.None);
+        var handler = InvokeCallbackHandler(flow, new Uri("https://auth.example/authorize?client_id=one"));
 
-        Assert.Equal(AuthorizationUrl, await flow.WaitForAuthorizationUrlAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<McpOAuthOperationException>(async () => await handler);
+        Assert.Null(flow.State);
+    }
+
+    [Fact]
+    public async Task FailureBeforeTheAuthorizationUrlSurfacesToTheWaitingStartRequest()
+    {
+        using var broker = CreateBroker();
+        var flow = broker.StartOrJoin(ServerName).Flow;
+        var waiting = flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
+
+        // Registration and discovery run before the SDK builds an authorization URL, so a
+        // failure there leaves the flow with no state. `netclaw mcp auth` must still get the
+        // structured reason instead of waiting for a URL that will never arrive.
+        broker.Fail(flow, new McpErrorResponse(
+            "MCP OAuth dynamic client registration failed: HTTP 403 Forbidden.",
+            "dynamic client registration",
+            403));
+
+        var error = await Assert.ThrowsAsync<McpOAuthOperationException>(async () => await waiting);
+        Assert.Equal(403, error.Error.Status);
+        Assert.Null(flow.State);
+    }
+
+    [Fact]
+    public void StatelessTerminalFlowIsRetiredByPruning()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 22, 12, 0, 0, TimeSpan.Zero));
+        using var broker = new McpOAuthFlowBroker(time, CancellationToken.None);
+        var abandoned = broker.StartOrJoin(ServerName).Flow;
+        broker.Fail(abandoned, new McpErrorResponse("discovery failed", "authorization start"));
+
+        // A flow with no state was never indexed by state, so only the per-server sweep can
+        // reach it. Without that sweep its timer and token source leak.
+        time.Advance(McpOAuthFlowBroker.FlowLifetime * 2);
+
+        Assert.Equal(McpOAuthFlowStatus.NotStarted, broker.GetLatestStatus(ServerName).Status);
+        Assert.NotSame(abandoned, broker.StartOrJoin(ServerName).Flow);
+    }
+
+    [Fact]
+    public async Task CallbackParametersReturnToTheSdkUnmodified()
+    {
+        using var broker = CreateBroker();
+        var flow = broker.StartOrJoin(ServerName).Flow;
+        var handler = InvokeCallbackHandler(flow, AuthorizationUrl("round-trip"));
+        await flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
+
+        // The SDK compares state against the value it generated and validates iss per
+        // RFC 9207, so the daemon must relay both without touching them.
+        broker.GetForCallback("round-trip")
+            .DeliverAuthorizationResponse("the-code", "round-trip", "https://auth.example");
+
+        var result = await handler;
+        Assert.Equal("the-code", result?.Code);
+        Assert.Equal("round-trip", result?.State);
+        Assert.Equal("https://auth.example", result?.Iss);
+    }
+
+    [Fact]
+    public async Task FirstHandlerOwnsUrlAndCodeFollowersFailWithoutCodeReuse()
+    {
+        using var broker = CreateBroker();
+        var flow = broker.StartOrJoin(ServerName).Flow;
+
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("owner"));
+        var follower = InvokeCallbackHandler(flow, AuthorizationUrl("follower"));
+
+        var request = await flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(AuthorizationUrl("owner"), request.Url);
         await Assert.ThrowsAsync<McpOAuthAuthorizationInProgressException>(async () => await follower);
-        broker.GetForCallback(flow.State).DeliverCode("owner-code");
-        Assert.Equal("owner-code", await owner);
+
+        broker.GetForCallback("owner").DeliverAuthorizationResponse("owner-code", "owner", null);
+        Assert.Equal("owner-code", (await owner)?.Code);
         broker.BeginCommit(flow);
         broker.Complete(flow);
-        Assert.Equal(McpOAuthFlowStatus.Completed, broker.GetStatusByState(flow.State).Status);
+        Assert.Equal(McpOAuthFlowStatus.Completed, broker.GetStatusByState("owner").Status);
     }
 
     [Fact]
-    public void MissingOrMismatchedStateDoesNotAffectPendingFlow()
+    public async Task MissingOrMismatchedStateDoesNotAffectPendingFlow()
     {
         using var broker = CreateBroker();
-        var flow = broker.StartOrJoin(ServerName).Flow;
+        var flow = await StartFlowWithStateAsync(broker, "pending-state");
 
         Assert.Throws<McpOAuthCallbackException>(() => broker.GetForCallback("wrong-state"));
 
-        Assert.Same(flow, broker.GetForCallback(flow.State));
-        Assert.Equal(McpOAuthFlowStatus.Pending, broker.GetStatusByState(flow.State).Status);
+        Assert.Same(flow, broker.GetForCallback("pending-state"));
+        Assert.Equal(McpOAuthFlowStatus.Pending, broker.GetStatusByState("pending-state").Status);
     }
 
     [Fact]
@@ -72,12 +144,13 @@ public sealed class McpOAuthFlowBrokerTests
     {
         using var broker = CreateBroker();
         var flow = broker.StartOrJoin(ServerName).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("one-time"));
 
-        flow.DeliverCode("one-time-code");
-        Assert.Equal("one-time-code", await owner);
+        flow.DeliverAuthorizationResponse("one-time-code", "one-time", null);
+        Assert.Equal("one-time-code", (await owner)?.Code);
 
-        Assert.Throws<McpOAuthCallbackException>(() => flow.DeliverCode("reused-code"));
+        Assert.Throws<McpOAuthCallbackException>(
+            () => flow.DeliverAuthorizationResponse("reused-code", "one-time", null));
     }
 
     [Fact]
@@ -86,15 +159,16 @@ public sealed class McpOAuthFlowBrokerTests
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 22, 12, 0, 0, TimeSpan.Zero));
         using var broker = new McpOAuthFlowBroker(time, CancellationToken.None);
         var flow = broker.StartOrJoin(ServerName).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("expiring"));
+        await flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
 
         time.Advance(McpOAuthFlowBroker.FlowLifetime);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await owner);
-        var terminal = broker.GetStatusByState(flow.State);
+        var terminal = broker.GetStatusByState("expiring");
         Assert.Equal(McpOAuthFlowStatus.Failed, terminal.Status);
         Assert.Contains("expired", terminal.Error?.Error, StringComparison.OrdinalIgnoreCase);
-        Assert.Throws<McpOAuthCallbackException>(() => broker.GetForCallback(flow.State));
+        Assert.Throws<McpOAuthCallbackException>(() => broker.GetForCallback("expiring"));
     }
 
     [Fact]
@@ -103,14 +177,14 @@ public sealed class McpOAuthFlowBrokerTests
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 22, 12, 0, 0, TimeSpan.Zero));
         using var broker = new McpOAuthFlowBroker(time, CancellationToken.None);
         var flow = broker.StartOrJoin(ServerName).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
-        flow.DeliverCode("burned-code");
-        Assert.Equal("burned-code", await owner);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("burned"));
+        flow.DeliverAuthorizationResponse("burned-code", "burned", null);
+        Assert.Equal("burned-code", (await owner)?.Code);
 
         time.Advance(McpOAuthFlowBroker.FlowLifetime);
 
         Assert.Throws<McpOAuthOperationException>(() => broker.BeginCommit(flow));
-        Assert.Equal(McpOAuthFlowStatus.Failed, broker.GetStatusByState(flow.State).Status);
+        Assert.Equal(McpOAuthFlowStatus.Failed, broker.GetStatusByState("burned").Status);
     }
 
     [Fact]
@@ -119,16 +193,16 @@ public sealed class McpOAuthFlowBrokerTests
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 22, 12, 0, 0, TimeSpan.Zero));
         using var broker = new McpOAuthFlowBroker(time, CancellationToken.None);
         var flow = broker.StartOrJoin(ServerName).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
-        flow.DeliverCode("commit-code");
-        Assert.Equal("commit-code", await owner);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("commit"));
+        flow.DeliverAuthorizationResponse("commit-code", "commit", null);
+        Assert.Equal("commit-code", (await owner)?.Code);
         time.Advance(McpOAuthFlowBroker.FlowLifetime - TimeSpan.FromTicks(1));
 
         broker.BeginCommit(flow);
         time.Advance(TimeSpan.FromTicks(1));
         broker.Complete(flow);
 
-        Assert.Equal(McpOAuthFlowStatus.Completed, broker.GetStatusByState(flow.State).Status);
+        Assert.Equal(McpOAuthFlowStatus.Completed, broker.GetStatusByState("commit").Status);
     }
 
     [Fact]
@@ -137,15 +211,16 @@ public sealed class McpOAuthFlowBrokerTests
         using var broker = CreateBroker();
         var flow = broker.StartOrJoin(ServerName).Flow;
         using var requestCancellation = new CancellationTokenSource();
-        var request = flow.WaitForAuthorizationUrlAsync(requestCancellation.Token);
-        requestCancellation.Cancel();
+        var request = flow.WaitForAuthorizationRequestAsync(requestCancellation.Token);
+        await requestCancellation.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await request);
 
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
-        Assert.Equal(AuthorizationUrl, await flow.WaitForAuthorizationUrlAsync(CancellationToken.None));
-        flow.DeliverCode("still-running");
-        Assert.Equal("still-running", await owner);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("still-running"));
+        var published = await flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(AuthorizationUrl("still-running"), published.Url);
+        flow.DeliverAuthorizationResponse("still-running-code", "still-running", null);
+        Assert.Equal("still-running-code", (await owner)?.Code);
     }
 
     [Fact]
@@ -153,18 +228,18 @@ public sealed class McpOAuthFlowBrokerTests
     {
         using var broker = CreateBroker();
         var flow = broker.StartOrJoin(ServerName).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
-        flow.DeliverCode("delivered");
-        Assert.Equal("delivered", await owner);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("delivered"));
+        flow.DeliverAuthorizationResponse("delivered-code", "delivered", null);
+        Assert.Equal("delivered-code", (await owner)?.Code);
         using var requestCancellation = new CancellationTokenSource();
         var callbackWait = flow.WaitForTerminalAsync(requestCancellation.Token);
-        requestCancellation.Cancel();
+        await requestCancellation.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await callbackWait);
 
         broker.BeginCommit(flow);
         broker.Complete(flow);
-        Assert.Equal(McpOAuthFlowStatus.Completed, broker.GetStatusByState(flow.State).Status);
+        Assert.Equal(McpOAuthFlowStatus.Completed, broker.GetStatusByState("delivered").Status);
     }
 
     [Fact]
@@ -173,27 +248,47 @@ public sealed class McpOAuthFlowBrokerTests
         using var daemonCancellation = new CancellationTokenSource();
         using var broker = new McpOAuthFlowBroker(TimeProvider.System, daemonCancellation.Token);
         var flow = broker.StartOrJoin(ServerName).Flow;
-        var owner = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
-        var follower = flow.HandleAuthorizationRedirectAsync(AuthorizationUrl, RedirectUri, CancellationToken.None);
+        var owner = InvokeCallbackHandler(flow, AuthorizationUrl("cancelled"));
+        var follower = InvokeCallbackHandler(flow, AuthorizationUrl("cancelled"));
 
-        daemonCancellation.Cancel();
+        await daemonCancellation.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await owner);
         await Assert.ThrowsAsync<McpOAuthAuthorizationInProgressException>(async () => await follower);
     }
 
     [Fact]
-    public void TerminalFlowAllowsNewAttemptWithNewStateWhileKeepingOldStatus()
+    public async Task TerminalFlowAllowsNewAttemptWithNewStateWhileKeepingOldStatus()
     {
         using var broker = CreateBroker();
-        var oldFlow = broker.StartOrJoin(ServerName).Flow;
+        var oldFlow = await StartFlowWithStateAsync(broker, "old-state");
         broker.Fail(oldFlow, new McpErrorResponse("DCR failed: HTTP 403 Forbidden.", "dynamic client registration", 403));
 
         var next = broker.StartOrJoin(ServerName);
 
         Assert.True(next.Created);
-        Assert.NotEqual(oldFlow.State, next.Flow.State);
-        Assert.Equal(403, broker.GetStatusByState(oldFlow.State).Error?.Status);
+        Assert.NotSame(oldFlow, next.Flow);
+        Assert.Equal(403, broker.GetStatusByState("old-state").Error?.Status);
+    }
+
+    private static Uri AuthorizationUrl(string state)
+        => new($"https://auth.example/authorize?client_id=one&state={state}");
+
+    private static Task<AuthorizationResult?> InvokeCallbackHandler(McpOAuthFlow flow, Uri authorizationUri)
+        => flow.HandleAuthorizationCallbackAsync(
+            new AuthorizationCallbackContext
+            {
+                AuthorizationUri = authorizationUri,
+                RedirectUri = RedirectUri,
+            },
+            CancellationToken.None);
+
+    private static async Task<McpOAuthFlow> StartFlowWithStateAsync(McpOAuthFlowBroker broker, string state)
+    {
+        var flow = broker.StartOrJoin(ServerName).Flow;
+        _ = InvokeCallbackHandler(flow, AuthorizationUrl(state));
+        await flow.WaitForAuthorizationRequestAsync(TestContext.Current.CancellationToken);
+        return flow;
     }
 
     private static McpOAuthFlowBroker CreateBroker()

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -414,6 +414,46 @@ public sealed class McpSdkOAuthFlowIntegrationTests
     }
 
     [Fact]
+    public async Task LegacyCredentialsWithoutAnIssuerRequireOneReauthorizationAtExpiry()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var server = await FakeOAuthMcpServer.StartAsync(ct);
+        server.AcceptRefreshToken("legacy-refresh", "legacy-client");
+        using var directory = new DisposableTempDir();
+        var paths = new NetclawPaths(directory.Path);
+        paths.EnsureDirectoriesExist();
+        var canonical = McpOAuthCredentialStore.CanonicalizeResource(server.McpEndpoint.ToString());
+
+        // The shape every install written before SDK 2.0 carries at the moment its access
+        // token lapses: a refresh token the authorization server would honour, but no
+        // AuthorizationServer. Release 1.4.1 refreshed this silently. SDK 2.0 gates refresh on
+        // the stored issuer, and Netclaw deliberately does not fill that value from what the
+        // resource server advertises — a repointed server could then satisfy the SDK's own
+        // issuer binding with a value of its choosing. One reauthorization is the trade.
+        File.WriteAllText(paths.SecretsPath, $$"""
+            {
+              "McpOAuthTokens": {
+                "fake-oauth": {
+                  "AccessToken": "expired-legacy-access",
+                  "RefreshToken": "legacy-refresh",
+                  "ClientId": "legacy-client",
+                  "ExpiresAt": "2020-01-01T00:00:00+00:00",
+                  "ResourceIdentity": "{{canonical}}"
+                }
+              }
+            }
+            """);
+        await using var harness = CreateManagerHarness(server, directory.Path);
+
+        await harness.Manager.StartAsync(ct);
+
+        Assert.Equal(0, server.RefreshGrantCount);
+        var status = harness.Manager.GetServerStatuses()[harness.ServerName];
+        Assert.Equal(McpConnectionState.AuthFailed, status.State);
+        Assert.Contains("netclaw mcp auth fake-oauth", status.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task LegacyUnboundCredentialsReportAwaitingAuthWithoutBeingStamped()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -832,6 +872,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
         public void AcceptBearer(string token) => _state.AcceptBearer(token);
 
+        public void AcceptRefreshToken(string token, string clientId) => _state.AcceptRefreshToken(token, clientId);
+
         public void FailNextTokenExchange() => _state.FailNextTokenExchange();
 
         public void RevokeAccessToken(string token) => _state.RevokeAccessToken(token);
@@ -1246,6 +1288,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         }
 
         public void AcceptBearer(string token) => _acceptedAccessTokens[token] = 0;
+
+        public void AcceptRefreshToken(string token, string clientId) => _refreshTokens[token] = clientId;
 
         public void RejectClient(string clientId) => _rejectedClients[clientId] = 0;
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -286,6 +286,38 @@ public sealed class McpSdkOAuthFlowIntegrationTests
     }
 
     [Fact]
+    public async Task StoredCredentialsRefreshAfterRestartWithoutReauthorization()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var server = await FakeOAuthMcpServer.StartAsync(ct);
+        using var directory = new DisposableTempDir();
+        await using (var first = CreateManagerHarness(server, directory.Path))
+        {
+            await CompleteManagerAuthorizationAsync(server, first, ct);
+        }
+
+        await using var restarted = CreateManagerHarness(server, directory.Path);
+        await restarted.Manager.StartAsync(ct);
+        Assert.Equal(McpConnectionState.Connected, restarted.Manager.GetServerStatuses()[restarted.ServerName].State);
+
+        // SDK 2.0 only redeems a refresh token when the stored container reports the same
+        // client registration the provider holds — client id, secret, issuer, and token
+        // endpoint auth method. Drop the access token so the resource server answers 401 and
+        // the SDK must take that path.
+        var issuedAccessToken = server.TokenRequests[^1].IssuedAccessToken;
+        server.RevokeAccessToken(issuedAccessToken);
+        var authorizationsBefore = server.AuthorizationRequests.Count;
+
+        await restarted.Manager.TryReconnectAsync(restarted.ServerName, ct);
+
+        Assert.Equal(1, server.RefreshGrantCount);
+        Assert.Equal(McpConnectionState.Connected, restarted.Manager.GetServerStatuses()[restarted.ServerName].State);
+        // A refresh that silently falls through to interactive authorization is the failure
+        // this test exists to catch, so no new authorization request may appear.
+        Assert.Equal(authorizationsBefore, server.AuthorizationRequests.Count);
+    }
+
+    [Fact]
     public async Task RejectedClientIdentityIsDiscardedSoTheNextAuthorizationRegistersAfresh()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -379,6 +411,47 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         Assert.Equal(
             McpOAuthCredentialStore.CanonicalizeResource(server.McpEndpoint.ToString()),
             harness.Credentials.GetActiveForTests(harness.ServerName)?.ResourceIdentity);
+    }
+
+    [Fact]
+    public async Task LegacyCredentialsWithoutAnIssuerStillRefresh()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var server = await FakeOAuthMcpServer.StartAsync(ct);
+        server.AcceptBearer("legacy-access");
+        server.AcceptRefreshToken("legacy-refresh", "legacy-client");
+        using var directory = new DisposableTempDir();
+        var paths = new NetclawPaths(directory.Path);
+        paths.EnsureDirectoriesExist();
+
+        // Exactly the shape an install written before SDK 2.0 carries: no AuthorizationServer.
+        // SDK 2.0 refuses to refresh without one, so this is the upgrade path that would
+        // otherwise force every operator to authorize again.
+        File.WriteAllText(paths.SecretsPath, $$"""
+            {
+              "McpOAuthTokens": {
+                "fake-oauth": {
+                  "AccessToken": "legacy-access",
+                  "RefreshToken": "legacy-refresh",
+                  "ClientId": "legacy-client",
+                  "McpServerUrl": "{{server.McpEndpoint}}"
+                }
+              }
+            }
+            """);
+        await using var harness = CreateManagerHarness(server, directory.Path);
+        await harness.Manager.StartAsync(ct);
+        Assert.Equal(McpConnectionState.Connected, harness.Manager.GetServerStatuses()[harness.ServerName].State);
+
+        server.RevokeAccessToken("legacy-access");
+        var authorizationsBefore = server.AuthorizationRequests.Count;
+
+        await harness.Manager.TryReconnectAsync(harness.ServerName, ct);
+
+        Assert.Equal(1, server.RefreshGrantCount);
+        Assert.Equal(McpConnectionState.Connected, harness.Manager.GetServerStatuses()[harness.ServerName].State);
+        Assert.Equal(authorizationsBefore, server.AuthorizationRequests.Count);
+        Assert.Empty(server.DynamicClientRegistrations);
     }
 
     [Fact]
@@ -800,7 +873,13 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
         public void AcceptBearer(string token) => _state.AcceptBearer(token);
 
+        public void AcceptRefreshToken(string token, string clientId) => _state.AcceptRefreshToken(token, clientId);
+
         public void FailNextTokenExchange() => _state.FailNextTokenExchange();
+
+        public void RevokeAccessToken(string token) => _state.RevokeAccessToken(token);
+
+        public int RefreshGrantCount => _state.RefreshGrantCount;
 
         public static async Task<FakeOAuthMcpServer> StartAsync(
             CancellationToken ct,
@@ -920,6 +999,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         private readonly ConcurrentDictionary<string, RegisteredClient> _clients = new(StringComparer.Ordinal);
         private readonly ConcurrentDictionary<string, AuthorizationCodeRecord> _authorizationCodes = new(StringComparer.Ordinal);
         private readonly ConcurrentDictionary<string, byte> _acceptedAccessTokens = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, string> _refreshTokens = new(StringComparer.Ordinal);
+        private int _refreshGrantCount;
         private readonly ConcurrentDictionary<string, byte> _rejectedClients = new(StringComparer.Ordinal);
         private readonly ConcurrentQueue<DynamicClientRegistrationObservation> _registrations = new();
         private readonly ConcurrentQueue<AuthorizationObservation> _authorizations = new();
@@ -1098,8 +1179,10 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         {
             var form = await context.Request.ReadFormAsync(context.RequestAborted);
             var grantType = form["grant_type"].ToString();
+            if (string.Equals(grantType, "refresh_token", StringComparison.Ordinal))
+                return HandleRefreshGrant(form);
             if (!string.Equals(grantType, "authorization_code", StringComparison.Ordinal))
-                return Results.BadRequest("Only authorization_code is supported by the fake server.");
+                return Results.BadRequest($"Unsupported grant_type '{grantType}'.");
 
             var code = form["code"].ToString();
             if (!_authorizationCodes.TryGetValue(code, out var authorizationCode))
@@ -1148,6 +1231,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
                 return Results.StatusCode(StatusCodes.Status500InternalServerError);
 
             _acceptedAccessTokens[issuedAccessToken] = 0;
+            _refreshTokens[issuedRefreshToken] = clientId;
             return Results.Json(new
             {
                 access_token = issuedAccessToken,
@@ -1157,6 +1241,40 @@ public sealed class McpSdkOAuthFlowIntegrationTests
                 scope = authorizationCode.Scope,
             });
         }
+
+        /// <summary>
+        /// Redeems a refresh token the way a rotating-token authorization server does: the old
+        /// refresh token is consumed and a new pair is issued.
+        /// </summary>
+        private IResult HandleRefreshGrant(IFormCollection form)
+        {
+            var presented = form["refresh_token"].ToString();
+            if (!_refreshTokens.TryRemove(presented, out var clientId))
+                return Results.BadRequest(new { error = "invalid_grant" });
+
+            var requestedClientId = form["client_id"].ToString();
+            if (!string.Equals(requestedClientId, clientId, StringComparison.Ordinal))
+                return Results.BadRequest(new { error = "invalid_client" });
+
+            var issuedAccessToken = $"access-{Interlocked.Increment(ref _tokenSequence)}";
+            var issuedRefreshToken = $"refresh-{_tokenSequence}";
+            _refreshTokens[issuedRefreshToken] = clientId;
+            _acceptedAccessTokens[issuedAccessToken] = 0;
+            Interlocked.Increment(ref _refreshGrantCount);
+
+            return Results.Json(new
+            {
+                access_token = issuedAccessToken,
+                refresh_token = issuedRefreshToken,
+                token_type = "Bearer",
+                expires_in = 3600,
+            });
+        }
+
+        /// <summary>Stops accepting an access token, which makes the resource server answer 401.</summary>
+        public void RevokeAccessToken(string token) => _acceptedAccessTokens.TryRemove(token, out _);
+
+        public int RefreshGrantCount => Volatile.Read(ref _refreshGrantCount);
 
         public bool TryAcceptBearer(string authorizationHeader)
         {
@@ -1169,6 +1287,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         }
 
         public void AcceptBearer(string token) => _acceptedAccessTokens[token] = 0;
+
+        public void AcceptRefreshToken(string token, string clientId) => _refreshTokens[token] = clientId;
 
         public void RejectClient(string clientId) => _rejectedClients[clientId] = 0;
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -414,47 +414,6 @@ public sealed class McpSdkOAuthFlowIntegrationTests
     }
 
     [Fact]
-    public async Task LegacyCredentialsWithoutAnIssuerStillRefresh()
-    {
-        var ct = TestContext.Current.CancellationToken;
-        await using var server = await FakeOAuthMcpServer.StartAsync(ct);
-        server.AcceptBearer("legacy-access");
-        server.AcceptRefreshToken("legacy-refresh", "legacy-client");
-        using var directory = new DisposableTempDir();
-        var paths = new NetclawPaths(directory.Path);
-        paths.EnsureDirectoriesExist();
-
-        // Exactly the shape an install written before SDK 2.0 carries: no AuthorizationServer.
-        // SDK 2.0 refuses to refresh without one, so this is the upgrade path that would
-        // otherwise force every operator to authorize again.
-        File.WriteAllText(paths.SecretsPath, $$"""
-            {
-              "McpOAuthTokens": {
-                "fake-oauth": {
-                  "AccessToken": "legacy-access",
-                  "RefreshToken": "legacy-refresh",
-                  "ClientId": "legacy-client",
-                  "McpServerUrl": "{{server.McpEndpoint}}"
-                }
-              }
-            }
-            """);
-        await using var harness = CreateManagerHarness(server, directory.Path);
-        await harness.Manager.StartAsync(ct);
-        Assert.Equal(McpConnectionState.Connected, harness.Manager.GetServerStatuses()[harness.ServerName].State);
-
-        server.RevokeAccessToken("legacy-access");
-        var authorizationsBefore = server.AuthorizationRequests.Count;
-
-        await harness.Manager.TryReconnectAsync(harness.ServerName, ct);
-
-        Assert.Equal(1, server.RefreshGrantCount);
-        Assert.Equal(McpConnectionState.Connected, harness.Manager.GetServerStatuses()[harness.ServerName].State);
-        Assert.Equal(authorizationsBefore, server.AuthorizationRequests.Count);
-        Assert.Empty(server.DynamicClientRegistrations);
-    }
-
-    [Fact]
     public async Task LegacyUnboundCredentialsReportAwaitingAuthWithoutBeingStamped()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -873,8 +832,6 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
         public void AcceptBearer(string token) => _state.AcceptBearer(token);
 
-        public void AcceptRefreshToken(string token, string clientId) => _state.AcceptRefreshToken(token, clientId);
-
         public void FailNextTokenExchange() => _state.FailNextTokenExchange();
 
         public void RevokeAccessToken(string token) => _state.RevokeAccessToken(token);
@@ -1204,8 +1161,9 @@ public sealed class McpSdkOAuthFlowIntegrationTests
                 authorizationCode.CodeChallenge,
                 ComputeCodeChallenge(codeVerifier),
                 StringComparison.Ordinal);
-            var issuedAccessToken = $"access-{Interlocked.Increment(ref _tokenSequence)}";
-            var issuedRefreshToken = $"refresh-{_tokenSequence}";
+            var sequence = Interlocked.Increment(ref _tokenSequence);
+            var issuedAccessToken = $"access-{sequence}";
+            var issuedRefreshToken = $"refresh-{sequence}";
 
             var observation = new TokenRequestObservation(
                 ClientId: clientId,
@@ -1256,8 +1214,9 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             if (!string.Equals(requestedClientId, clientId, StringComparison.Ordinal))
                 return Results.BadRequest(new { error = "invalid_client" });
 
-            var issuedAccessToken = $"access-{Interlocked.Increment(ref _tokenSequence)}";
-            var issuedRefreshToken = $"refresh-{_tokenSequence}";
+            var sequence = Interlocked.Increment(ref _tokenSequence);
+            var issuedAccessToken = $"access-{sequence}";
+            var issuedRefreshToken = $"refresh-{sequence}";
             _refreshTokens[issuedRefreshToken] = clientId;
             _acceptedAccessTokens[issuedAccessToken] = 0;
             Interlocked.Increment(ref _refreshGrantCount);
@@ -1287,8 +1246,6 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         }
 
         public void AcceptBearer(string token) => _acceptedAccessTokens[token] = 0;
-
-        public void AcceptRefreshToken(string token, string clientId) => _refreshTokens[token] = clientId;
 
         public void RejectClient(string clientId) => _rejectedClients[clientId] = 0;
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -51,7 +51,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             new Uri("http://127.0.0.1:7331/api/mcp/oauth/callback"),
             ct);
         var flow = harness.Broker.GetForCallback(started.State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
 
         var terminal = await flow.WaitForTerminalAsync(ct);
 
@@ -101,7 +101,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             RedirectUri,
             ct);
         var flow = harness.Broker.GetForCallback(starts[0].State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
         Assert.Equal(McpOAuthFlowStatus.Completed, (await flow.WaitForTerminalAsync(ct)).Status);
 
         Assert.Single(server.DynamicClientRegistrations);
@@ -123,7 +123,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             RedirectUri,
             ct);
         var firstFlow = harness.Broker.GetForCallback(firstStart.State);
-        firstFlow.DeliverCode(firstAuthorization.Code);
+        firstFlow.DeliverAuthorizationResponse(firstAuthorization.Code, firstAuthorization.State, null);
         Assert.Equal(
             McpOAuthFlowStatus.Failed,
             (await firstFlow.WaitForTerminalAsync(ct)).Status);
@@ -134,7 +134,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             RedirectUri,
             ct);
         var secondFlow = harness.Broker.GetForCallback(secondStart.State);
-        secondFlow.DeliverCode(secondAuthorization.Code);
+        secondFlow.DeliverAuthorizationResponse(secondAuthorization.Code, secondAuthorization.State, null);
         Assert.Equal(
             McpOAuthFlowStatus.Completed,
             (await secondFlow.WaitForTerminalAsync(ct)).Status);
@@ -167,7 +167,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
         var authorization = await server.AuthorizeAsync(new Uri(started.AuthorizationUrl), RedirectUri, ct);
         var flow = harness.Broker.GetForCallback(started.State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
         Assert.Equal(McpOAuthFlowStatus.Completed, (await flow.WaitForTerminalAsync(ct)).Status);
     }
 
@@ -184,7 +184,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         var started = await harness.Manager.StartAuthorizationAsync(harness.ServerName, ct);
         var authorization = await server.AuthorizeAsync(new Uri(started.AuthorizationUrl), RedirectUri, ct);
         var flow = harness.Broker.GetForCallback(started.State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
         await barrier.Reached.Task.WaitAsync(ct);
         Assert.Null(harness.Credentials.GetActiveForTests(harness.ServerName));
 
@@ -209,7 +209,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         var started = await harness.Manager.StartAuthorizationAsync(harness.ServerName, ct);
         var authorization = await server.AuthorizeAsync(new Uri(started.AuthorizationUrl), RedirectUri, ct);
         var flow = harness.Broker.GetForCallback(started.State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
         var terminal = await flow.WaitForTerminalAsync(ct);
 
         var retained = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(harness.ServerName));
@@ -236,7 +236,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         var started = await harness.Manager.StartAuthorizationAsync(harness.ServerName, ct);
         var authorization = await server.AuthorizeAsync(new Uri(started.AuthorizationUrl), RedirectUri, ct);
         var flow = harness.Broker.GetForCallback(started.State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
         await barrier.Reached.Task.WaitAsync(ct);
         try
         {
@@ -302,7 +302,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         var rejectedStart = await harness.Manager.StartAuthorizationAsync(harness.ServerName, ct);
         var rejectedAuthorization = await server.AuthorizeAsync(new Uri(rejectedStart.AuthorizationUrl), RedirectUri, ct);
         var rejectedFlow = harness.Broker.GetForCallback(rejectedStart.State);
-        rejectedFlow.DeliverCode(rejectedAuthorization.Code);
+        rejectedFlow.DeliverAuthorizationResponse(rejectedAuthorization.Code, rejectedAuthorization.State, null);
 
         Assert.Equal(McpOAuthFlowStatus.Failed, (await rejectedFlow.WaitForTerminalAsync(ct)).Status);
 
@@ -317,7 +317,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         var replacementAuthorization = await server.AuthorizeAsync(
             new Uri(replacementStart.AuthorizationUrl), RedirectUri, ct);
         var replacementFlow = harness.Broker.GetForCallback(replacementStart.State);
-        replacementFlow.DeliverCode(replacementAuthorization.Code);
+        replacementFlow.DeliverAuthorizationResponse(replacementAuthorization.Code, replacementAuthorization.State, null);
 
         Assert.Equal(McpOAuthFlowStatus.Completed, (await replacementFlow.WaitForTerminalAsync(ct)).Status);
         Assert.Equal("client-2", harness.Credentials.GetActiveForTests(harness.ServerName)?.ClientId);
@@ -583,7 +583,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         var started = await harness.Manager.StartAuthorizationAsync(harness.ServerName, ct);
         var authorization = await server.AuthorizeAsync(new Uri(started.AuthorizationUrl), RedirectUri, ct);
         var flow = harness.Broker.GetForCallback(started.State);
-        flow.DeliverCode(authorization.Code);
+        flow.DeliverAuthorizationResponse(authorization.Code, authorization.State, null);
         Assert.Equal(McpOAuthFlowStatus.Completed, (await flow.WaitForTerminalAsync(ct)).Status);
     }
 

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -203,8 +203,8 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         if (started.Created)
             _ = RunExplicitAuthorizationAsync(lifecycle, entry, started.Flow);
 
-        var authorizationUrl = await started.Flow.WaitForAuthorizationUrlAsync(requestCancellation);
-        return new McpOAuthStartResponse(authorizationUrl.ToString(), started.Flow.State);
+        var request = await started.Flow.WaitForAuthorizationRequestAsync(requestCancellation);
+        return new McpOAuthStartResponse(request.Url.ToString(), request.State);
     }
 
     public async Task<string> InvokeAsync(
@@ -775,12 +775,13 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             ClientSecret = entry.OAuthClientId is null ? identity.ClientSecret : null,
             Scopes = ParseScopes(entry.OAuthScope),
             TokenCache = cache,
-            AuthorizationRedirectDelegate = authorizationFlow is null
-                ? static (_, _, _) => Task.FromResult<string?>(null)
-                : authorizationFlow.HandleAuthorizationRedirectAsync,
-            AdditionalAuthorizationParameters = authorizationFlow is null
-                ? new Dictionary<string, string>()
-                : new Dictionary<string, string> { ["state"] = authorizationFlow.State },
+
+            // A background reconnect has no flow and therefore no operator at a browser.
+            // Returning null makes the SDK fail the connection instead of blocking on a
+            // redirect nobody will complete.
+            AuthorizationCallbackHandler = authorizationFlow is null
+                ? static (_, _) => Task.FromResult<AuthorizationResult?>(null)
+                : authorizationFlow.HandleAuthorizationCallbackAsync,
 
             // DynamicClientRegistration is deliberately left unset. McpOAuthClientRegistrar
             // owns registration because the SDK hard-codes client_secret_post and cannot
@@ -958,8 +959,11 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             || ex.Message.Contains("forbidden", StringComparison.OrdinalIgnoreCase)
             || ex.Message.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase)
             || ex.Message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("AuthorizationRedirectDelegate", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("authorization code", StringComparison.OrdinalIgnoreCase))
+            || ex.Message.Contains("AuthorizationCallbackHandler", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("authorization code", StringComparison.OrdinalIgnoreCase)
+            // The SDK validates the returned state and the RFC 9207 issuer from 2.0 onward.
+            // Both rejections mean the operator must authorize again.
+            || ex.Message.Contains("authorization response", StringComparison.OrdinalIgnoreCase))
             return true;
 
         return ex.InnerException is not null && IsAuthFailure(ex.InnerException);

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -776,16 +776,6 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             Scopes = ParseScopes(entry.OAuthScope),
             TokenCache = cache,
 
-            // Same choice the SDK's default selector makes; the point is the side effect.
-            // The SDK selects the issuer before it reads the token cache, so this hands a
-            // pre-2.0 credential the issuer it needs to refresh.
-            AuthServerSelector = servers =>
-            {
-                var selected = servers.FirstOrDefault();
-                cache.ObservedAuthorizationServer = selected?.OriginalString;
-                return selected;
-            },
-
             // A background reconnect has no flow and therefore no operator at a browser.
             // Returning null makes the SDK fail the connection instead of blocking on a
             // redirect nobody will complete.
@@ -970,17 +960,23 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             || ex.Message.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase)
             || ex.Message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
             || ex.Message.Contains("AuthorizationCallbackHandler", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("authorization code", StringComparison.OrdinalIgnoreCase)
-            // The SDK validates the returned state and the RFC 9207 issuer from 2.0 onward.
-            // Both rejections mean the operator must authorize again.
-            || ex.Message.Contains("authorization response", StringComparison.OrdinalIgnoreCase))
+            || ex.Message.Contains("authorization code", StringComparison.OrdinalIgnoreCase))
             return true;
 
         return ex.InnerException is not null && IsAuthFailure(ex.InnerException);
     }
 
+    /// <summary>
+    /// Identifies a stored client registration the authorization server will never accept
+    /// again. The caller only acts on this when the client id came from dynamic registration,
+    /// so an operator-pinned OAuthClientId is never discarded behind their back.
+    /// </summary>
     private static bool IsInvalidClientFailure(Exception ex)
         => ex.Message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
+           // A registration is bound to the issuer that granted it. When the resource server
+           // moves to a new issuer, SDK 2.0 refuses to reuse the old one and offers no remedy
+           // of its own, so the stale identity has to go or every retry repeats the failure.
+           || ex.Message.Contains("authorization server changed", StringComparison.OrdinalIgnoreCase)
            || ex.InnerException is not null && IsInvalidClientFailure(ex.InnerException);
 
     internal static McpErrorResponse CreateSafeOAuthError(Exception ex, string fallbackOperation)

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -776,6 +776,16 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             Scopes = ParseScopes(entry.OAuthScope),
             TokenCache = cache,
 
+            // Same choice the SDK's default selector makes; the point is the side effect.
+            // The SDK selects the issuer before it reads the token cache, so this hands a
+            // pre-2.0 credential the issuer it needs to refresh.
+            AuthServerSelector = servers =>
+            {
+                var selected = servers.FirstOrDefault();
+                cache.ObservedAuthorizationServer = selected?.OriginalString;
+                return selected;
+            },
+
             // A background reconnect has no flow and therefore no operator at a browser.
             // Returning null makes the SDK fail the connection instead of blocking on a
             // redirect nobody will complete.

--- a/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
@@ -15,7 +15,9 @@ namespace Netclaw.Daemon.Mcp;
 /// <summary>Query string for the MCP OAuth browser callback.</summary>
 public sealed record McpOAuthCallbackQuery(
     [FromQuery(Name = "code")] string? Code,
-    [FromQuery(Name = "state")] string? State);
+    [FromQuery(Name = "state")] string? State,
+    // RFC 9207 issuer identifier. The MCP SDK validates it; the daemon only relays it.
+    [FromQuery(Name = "iss")] string? Iss);
 
 /// <summary>Authorization URL and opaque state returned when an MCP OAuth flow starts.</summary>
 public sealed record McpOAuthStartResponse(string AuthorizationUrl, string State);
@@ -107,7 +109,7 @@ public static class McpEndpointRouteBuilderExtensions
             try
             {
                 var flow = flowBroker.GetForCallback(query.State);
-                flow.DeliverCode(query.Code);
+                flow.DeliverAuthorizationResponse(query.Code, query.State, query.Iss);
                 var terminal = await flow.WaitForTerminalAsync(requestCancellation);
                 if (terminal.Status is McpOAuthFlowStatus.Failed)
                 {

--- a/src/Netclaw.Daemon/Mcp/McpOAuthClientRegistrar.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthClientRegistrar.cs
@@ -129,12 +129,7 @@ internal sealed class McpOAuthClientRegistrar(
             authMethod,
             issuer);
 
-        return new McpOAuthClientIdentity(
-            clientId,
-            clientSecret,
-            DynamicClientRegistration: true,
-            issuer,
-            authMethod);
+        return new McpOAuthClientIdentity(clientId, clientSecret, DynamicClientRegistration: true);
     }
 
     private async Task<(string Issuer, string? RegistrationEndpoint, IReadOnlyList<string> AuthMethods)?>

--- a/src/Netclaw.Daemon/Mcp/McpOAuthClientRegistrar.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthClientRegistrar.cs
@@ -129,7 +129,12 @@ internal sealed class McpOAuthClientRegistrar(
             authMethod,
             issuer);
 
-        return new McpOAuthClientIdentity(clientId, clientSecret, DynamicClientRegistration: true);
+        return new McpOAuthClientIdentity(
+            clientId,
+            clientSecret,
+            DynamicClientRegistration: true,
+            issuer,
+            authMethod);
     }
 
     private async Task<(string Issuer, string? RegistrationEndpoint, IReadOnlyList<string> AuthMethods)?>

--- a/src/Netclaw.Daemon/Mcp/McpOAuthCredentialStore.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthCredentialStore.cs
@@ -17,10 +17,18 @@ namespace Netclaw.Daemon.Mcp;
 
 internal sealed class McpOAuthRetiredCredentialWriterException(string message) : InvalidOperationException(message);
 
+/// <summary>
+/// A client registration as the MCP SDK understands it. From SDK 2.0 the SDK compares all
+/// four values against the ones it holds before it will redeem a refresh token
+/// (<c>CachedTokensMatchClientCredentials</c>), so a missing issuer or auth method silently
+/// disables refresh and forces the operator to authorize again at every token expiry.
+/// </summary>
 internal sealed record McpOAuthClientIdentity(
     string? ClientId,
     string? ClientSecret,
-    bool DynamicClientRegistration);
+    bool DynamicClientRegistration,
+    string? AuthorizationServer = null,
+    string? TokenEndpointAuthMethod = null);
 
 /// <summary>
 /// Per-connection SDK token cache. Unpublished candidates keep tokens local;
@@ -65,6 +73,14 @@ internal sealed class McpOAuthTokenCache : ITokenCache
     internal bool Published { get; set; }
 
     internal bool Retired { get; set; }
+
+    /// <summary>
+    /// The authorization server the SDK selected on this connection. Credentials stored
+    /// before this field existed carry no issuer, and SDK 2.0 will not redeem their refresh
+    /// token without one. The SDK selects the issuer before it reads this cache, so recording
+    /// it here fills the gap without a second discovery request.
+    /// </summary>
+    internal string? ObservedAuthorizationServer { get; set; }
 
     public ValueTask<TokenContainer?> GetTokensAsync(CancellationToken cancellationToken)
         => new(_store.ReadTokens(this, cancellationToken));
@@ -138,12 +154,22 @@ internal sealed class McpOAuthCredentialStore
             McpOAuthClientIdentity identity;
             if (!string.IsNullOrWhiteSpace(configuredClientId))
             {
-                identity = new McpOAuthClientIdentity(configuredClientId, null, false);
+                identity = new McpOAuthClientIdentity(
+                    configuredClientId,
+                    null,
+                    false,
+                    active?.AuthorizationServer,
+                    active?.TokenEndpointAuthMethod);
             }
             else
             {
                 identity = active is { DynamicClientRegistration: true, ClientId: not null }
-                    ? new McpOAuthClientIdentity(active.ClientId, active.ClientSecret?.Value, true)
+                    ? new McpOAuthClientIdentity(
+                        active.ClientId,
+                        active.ClientSecret?.Value,
+                        true,
+                        active.AuthorizationServer,
+                        active.TokenEndpointAuthMethod)
                     : new McpOAuthClientIdentity(null, null, false);
             }
 
@@ -293,7 +319,7 @@ internal sealed class McpOAuthCredentialStore
         {
             if (!IsBound(cache.Credentials, cache.CanonicalResource))
                 return null;
-            return ToTokenContainer(cache.Credentials!);
+            return ToTokenContainer(cache.Credentials!, cache.ObservedAuthorizationServer);
         }
     }
 
@@ -374,6 +400,11 @@ internal sealed class McpOAuthCredentialStore
             ClientSecret = identity.ClientSecret is null ? null : new SensitiveString(identity.ClientSecret),
             DynamicClientRegistration = identity.DynamicClientRegistration,
             ResourceIdentity = canonicalResource,
+
+            // Prefer what the SDK just reported; fall back to the identity we registered
+            // with. The SDK omits these on a container it did not build itself.
+            AuthorizationServer = tokens.AuthorizationServer ?? identity.AuthorizationServer,
+            TokenEndpointAuthMethod = tokens.TokenEndpointAuthMethod ?? identity.TokenEndpointAuthMethod,
         };
         replacement.RefreshToken = tokens.RefreshToken is not null
             ? new SensitiveString(tokens.RefreshToken)
@@ -389,7 +420,7 @@ internal sealed class McpOAuthCredentialStore
            && string.Equals(current.ClientId, replacement.ClientId, StringComparison.Ordinal)
            && current.DynamicClientRegistration == replacement.DynamicClientRegistration;
 
-    private TokenContainer ToTokenContainer(McpOAuthTokenSet credentials)
+    private TokenContainer ToTokenContainer(McpOAuthTokenSet credentials, string? observedAuthorizationServer)
     {
         // Records written before ObtainedAt existed deserialize it as 0001-01-01. Anchoring
         // the lifetime at "now" keeps ExpiresAt authoritative; measuring from the default
@@ -409,6 +440,14 @@ internal sealed class McpOAuthCredentialStore
             ExpiresIn = expiresIn,
             ObtainedAt = obtainedAt,
             Scope = credentials.Scope,
+
+            // SDK 2.0 refuses to redeem the refresh token unless the container reports the
+            // same registration the provider holds. Omitting any of these four makes every
+            // refresh fall through to interactive authorization.
+            ClientId = credentials.ClientId,
+            ClientSecret = credentials.ClientSecret?.Value,
+            AuthorizationServer = credentials.AuthorizationServer ?? observedAuthorizationServer,
+            TokenEndpointAuthMethod = credentials.TokenEndpointAuthMethod,
         };
     }
 

--- a/src/Netclaw.Daemon/Mcp/McpOAuthCredentialStore.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthCredentialStore.cs
@@ -17,18 +17,10 @@ namespace Netclaw.Daemon.Mcp;
 
 internal sealed class McpOAuthRetiredCredentialWriterException(string message) : InvalidOperationException(message);
 
-/// <summary>
-/// A client registration as the MCP SDK understands it. From SDK 2.0 the SDK compares all
-/// four values against the ones it holds before it will redeem a refresh token
-/// (<c>CachedTokensMatchClientCredentials</c>), so a missing issuer or auth method silently
-/// disables refresh and forces the operator to authorize again at every token expiry.
-/// </summary>
 internal sealed record McpOAuthClientIdentity(
     string? ClientId,
     string? ClientSecret,
-    bool DynamicClientRegistration,
-    string? AuthorizationServer = null,
-    string? TokenEndpointAuthMethod = null);
+    bool DynamicClientRegistration);
 
 /// <summary>
 /// Per-connection SDK token cache. Unpublished candidates keep tokens local;
@@ -73,14 +65,6 @@ internal sealed class McpOAuthTokenCache : ITokenCache
     internal bool Published { get; set; }
 
     internal bool Retired { get; set; }
-
-    /// <summary>
-    /// The authorization server the SDK selected on this connection. Credentials stored
-    /// before this field existed carry no issuer, and SDK 2.0 will not redeem their refresh
-    /// token without one. The SDK selects the issuer before it reads this cache, so recording
-    /// it here fills the gap without a second discovery request.
-    /// </summary>
-    internal string? ObservedAuthorizationServer { get; set; }
 
     public ValueTask<TokenContainer?> GetTokensAsync(CancellationToken cancellationToken)
         => new(_store.ReadTokens(this, cancellationToken));
@@ -154,22 +138,12 @@ internal sealed class McpOAuthCredentialStore
             McpOAuthClientIdentity identity;
             if (!string.IsNullOrWhiteSpace(configuredClientId))
             {
-                identity = new McpOAuthClientIdentity(
-                    configuredClientId,
-                    null,
-                    false,
-                    active?.AuthorizationServer,
-                    active?.TokenEndpointAuthMethod);
+                identity = new McpOAuthClientIdentity(configuredClientId, null, false);
             }
             else
             {
                 identity = active is { DynamicClientRegistration: true, ClientId: not null }
-                    ? new McpOAuthClientIdentity(
-                        active.ClientId,
-                        active.ClientSecret?.Value,
-                        true,
-                        active.AuthorizationServer,
-                        active.TokenEndpointAuthMethod)
+                    ? new McpOAuthClientIdentity(active.ClientId, active.ClientSecret?.Value, true)
                     : new McpOAuthClientIdentity(null, null, false);
             }
 
@@ -319,7 +293,7 @@ internal sealed class McpOAuthCredentialStore
         {
             if (!IsBound(cache.Credentials, cache.CanonicalResource))
                 return null;
-            return ToTokenContainer(cache.Credentials!, cache.ObservedAuthorizationServer);
+            return ToTokenContainer(cache.Credentials!, cache.Identity);
         }
     }
 
@@ -403,8 +377,8 @@ internal sealed class McpOAuthCredentialStore
 
             // Prefer what the SDK just reported; fall back to the identity we registered
             // with. The SDK omits these on a container it did not build itself.
-            AuthorizationServer = tokens.AuthorizationServer ?? identity.AuthorizationServer,
-            TokenEndpointAuthMethod = tokens.TokenEndpointAuthMethod ?? identity.TokenEndpointAuthMethod,
+            AuthorizationServer = tokens.AuthorizationServer,
+            TokenEndpointAuthMethod = tokens.TokenEndpointAuthMethod,
         };
         replacement.RefreshToken = tokens.RefreshToken is not null
             ? new SensitiveString(tokens.RefreshToken)
@@ -414,13 +388,18 @@ internal sealed class McpOAuthCredentialStore
         return replacement;
     }
 
+    /// <summary>
+    /// A refresh token belongs to the issuer that minted it. Carrying one onto a record bound
+    /// to a different authorization server would send it to a server that never issued it.
+    /// </summary>
     private static bool CanRetainRefreshToken(McpOAuthTokenSet? current, McpOAuthTokenSet replacement)
         => current?.RefreshToken is not null
            && string.Equals(current.ResourceIdentity, replacement.ResourceIdentity, StringComparison.Ordinal)
            && string.Equals(current.ClientId, replacement.ClientId, StringComparison.Ordinal)
+           && string.Equals(current.AuthorizationServer, replacement.AuthorizationServer, StringComparison.Ordinal)
            && current.DynamicClientRegistration == replacement.DynamicClientRegistration;
 
-    private TokenContainer ToTokenContainer(McpOAuthTokenSet credentials, string? observedAuthorizationServer)
+    private TokenContainer ToTokenContainer(McpOAuthTokenSet credentials, McpOAuthClientIdentity identity)
     {
         // Records written before ObtainedAt existed deserialize it as 0001-01-01. Anchoring
         // the lifetime at "now" keeps ExpiresAt authoritative; measuring from the default
@@ -443,10 +422,12 @@ internal sealed class McpOAuthCredentialStore
 
             // SDK 2.0 refuses to redeem the refresh token unless the container reports the
             // same registration the provider holds. Omitting any of these four makes every
-            // refresh fall through to interactive authorization.
-            ClientId = credentials.ClientId,
-            ClientSecret = credentials.ClientSecret?.Value,
-            AuthorizationServer = credentials.AuthorizationServer ?? observedAuthorizationServer,
+            // refresh fall through to interactive authorization. The client id and secret
+            // come from the identity the provider was built with, not from disk: a pinned
+            // OAuthClientId suppresses the stored secret, and the two must agree.
+            ClientId = identity.ClientId,
+            ClientSecret = identity.ClientSecret,
+            AuthorizationServer = credentials.AuthorizationServer,
             TokenEndpointAuthMethod = credentials.TokenEndpointAuthMethod,
         };
     }

--- a/src/Netclaw.Daemon/Mcp/McpOAuthFlowBroker.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthFlowBroker.cs
@@ -3,7 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Security.Cryptography;
+using System.Web;
+using ModelContextProtocol.Authentication;
 using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Mcp;
@@ -42,16 +43,14 @@ internal sealed class McpOAuthFlowBroker : IDisposable
             if (_latestByServer.TryGetValue(serverName, out var active) && !active.IsTerminal)
                 return new McpOAuthFlowStart(active, false);
 
-            var state = CreateOpaqueState();
             var flow = new McpOAuthFlow(
                 serverName,
-                state,
                 _timeProvider.GetUtcNow().Add(FlowLifetime),
                 _timeProvider,
                 _daemonCancellation,
-                OnFlowExpired);
+                OnFlowExpired,
+                OnStateDiscovered);
             _latestByServer[serverName] = flow;
-            _byState[state] = flow;
             return new McpOAuthFlowStart(flow, true);
         }
     }
@@ -155,7 +154,9 @@ internal sealed class McpOAuthFlowBroker : IDisposable
             if (_disposed)
                 return;
             _disposed = true;
-            flows = _byState.Values.ToList();
+            // Union both indexes: a flow that never reached its authorization URL appears
+            // only in _latestByServer.
+            flows = _byState.Values.Concat(_latestByServer.Values).Distinct().ToList();
             _latestByServer.Clear();
             _byState.Clear();
         }
@@ -165,6 +166,18 @@ internal sealed class McpOAuthFlowBroker : IDisposable
             flow.Fail(new McpErrorResponse("The daemon stopped the authorization flow.", "daemon shutdown"));
             flow.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Indexes a flow under the <c>state</c> value the MCP SDK generated for it. The browser
+    /// callback carries only that value, so a flow cannot be routed to before the SDK builds
+    /// its authorization URL. The flow registers here before it publishes that URL, so an
+    /// operator can never be redirected to a callback the broker cannot resolve.
+    /// </summary>
+    private void OnStateDiscovered(McpOAuthFlow flow, string state)
+    {
+        lock (_sync)
+            _byState[state] = flow;
     }
 
     private void OnFlowExpired(McpOAuthFlow flow)
@@ -193,26 +206,32 @@ internal sealed class McpOAuthFlowBroker : IDisposable
                 _latestByServer.Remove(flow.ServerName);
             flow.Dispose();
         }
-    }
 
-    private static string CreateOpaqueState()
-    {
-        var bytes = RandomNumberGenerator.GetBytes(32);
-        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        // A flow that failed before the SDK built its authorization URL has no state key, so
+        // the loop above cannot reach it. Retire it here or its timer and token source leak.
+        foreach (var (serverName, flow) in _latestByServer.ToArray())
+        {
+            if (flow.State is not null || !flow.IsTerminal || flow.ExpiresAt > cutoff)
+                continue;
+
+            _latestByServer.Remove(serverName);
+            flow.Dispose();
+        }
     }
 }
 
 internal sealed class McpOAuthFlow : IDisposable
 {
     private readonly object _sync = new();
-    private readonly TaskCompletionSource<Uri> _authorizationUrl =
+    private readonly TaskCompletionSource<(Uri Url, string State)> _authorizationRequest =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly TaskCompletionSource<string> _authorizationCode =
+    private readonly TaskCompletionSource<AuthorizationResult> _authorizationResponse =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource<McpOAuthFlowTerminal> _terminal =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _lifetimeCancellation;
     private readonly ITimer _expiryTimer;
+    private readonly Action<McpOAuthFlow, string> _stateDiscovered;
     private int _delegateOwner;
     private bool _codeDelivered;
     private bool _commitClaimed;
@@ -220,15 +239,15 @@ internal sealed class McpOAuthFlow : IDisposable
 
     public McpOAuthFlow(
         McpServerName serverName,
-        string state,
         DateTimeOffset expiresAt,
         TimeProvider timeProvider,
         CancellationToken daemonCancellation,
-        Action<McpOAuthFlow> expired)
+        Action<McpOAuthFlow> expired,
+        Action<McpOAuthFlow, string> stateDiscovered)
     {
         ServerName = serverName;
-        State = state;
         ExpiresAt = expiresAt;
+        _stateDiscovered = stateDiscovered;
         _lifetimeCancellation = CancellationTokenSource.CreateLinkedTokenSource(daemonCancellation);
         _expiryTimer = timeProvider.CreateTimer(
             static state =>
@@ -243,7 +262,11 @@ internal sealed class McpOAuthFlow : IDisposable
 
     public McpServerName ServerName { get; }
 
-    public string State { get; }
+    /// <summary>
+    /// The <c>state</c> value the MCP SDK generated for this flow. Null until the SDK builds
+    /// the authorization URL.
+    /// </summary>
+    public string? State { get; private set; }
 
     public DateTimeOffset ExpiresAt { get; }
 
@@ -260,28 +283,32 @@ internal sealed class McpOAuthFlow : IDisposable
         }
     }
 
-    public Task<Uri> WaitForAuthorizationUrlAsync(CancellationToken requestCancellation)
-        => _authorizationUrl.Task.WaitAsync(requestCancellation);
+    public Task<(Uri Url, string State)> WaitForAuthorizationRequestAsync(CancellationToken requestCancellation)
+        => _authorizationRequest.Task.WaitAsync(requestCancellation);
 
     public Task<McpOAuthFlowTerminal> WaitForTerminalAsync(CancellationToken requestCancellation)
         => _terminal.Task.WaitAsync(requestCancellation);
 
-    public async Task<string?> HandleAuthorizationRedirectAsync(
-        Uri authorizationUri,
-        Uri redirectUri,
+    public async Task<AuthorizationResult?> HandleAuthorizationCallbackAsync(
+        AuthorizationCallbackContext context,
         CancellationToken sdkCancellation)
     {
         if (Interlocked.CompareExchange(ref _delegateOwner, 1, 0) != 0)
             throw new McpOAuthAuthorizationInProgressException(ServerName);
 
-        _authorizationUrl.TrySetResult(authorizationUri);
+        PublishAuthorizationRequest(context.AuthorizationUri);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
             sdkCancellation,
             _lifetimeCancellation.Token);
-        return await _authorizationCode.Task.WaitAsync(cancellation.Token);
+        return await _authorizationResponse.Task.WaitAsync(cancellation.Token);
     }
 
-    public void DeliverCode(string code)
+    /// <summary>
+    /// Hands the browser's callback parameters back to the MCP SDK. The SDK compares
+    /// <paramref name="state"/> against the value it generated and validates
+    /// <paramref name="iss"/> per RFC 9207, so both travel through unmodified.
+    /// </summary>
+    public void DeliverAuthorizationResponse(string code, string? state, string? iss)
     {
         lock (_sync)
         {
@@ -290,7 +317,31 @@ internal sealed class McpOAuthFlow : IDisposable
             _codeDelivered = true;
         }
 
-        _authorizationCode.TrySetResult(code);
+        _authorizationResponse.TrySetResult(new AuthorizationResult
+        {
+            Code = code,
+            State = state,
+            Iss = iss,
+        });
+    }
+
+    private void PublishAuthorizationRequest(Uri authorizationUri)
+    {
+        var state = HttpUtility.ParseQueryString(authorizationUri.Query)["state"];
+        if (string.IsNullOrEmpty(state))
+        {
+            throw new McpOAuthOperationException(new McpErrorResponse(
+                "The MCP SDK produced an authorization URL with no state parameter.",
+                "authorization start"));
+        }
+
+        lock (_sync)
+            State = state;
+
+        // Index before publishing the URL: the operator cannot reach the callback until the
+        // URL is observable, so this ordering makes an unroutable callback impossible.
+        _stateDiscovered(this, state);
+        _authorizationRequest.TrySetResult((authorizationUri, state));
     }
 
     public bool TryBeginCommit(DateTimeOffset now)
@@ -340,8 +391,8 @@ internal sealed class McpOAuthFlow : IDisposable
             _terminal.TrySetResult(terminal);
         }
 
-        _authorizationUrl.TrySetException(new McpOAuthOperationException(error));
-        _authorizationCode.TrySetCanceled(_lifetimeCancellation.Token);
+        _authorizationRequest.TrySetException(new McpOAuthOperationException(error));
+        _authorizationResponse.TrySetCanceled(_lifetimeCancellation.Token);
         EndLifetime();
     }
 

--- a/src/Netclaw.Daemon/Mcp/McpOAuthFlowBroker.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthFlowBroker.cs
@@ -40,8 +40,18 @@ internal sealed class McpOAuthFlowBroker : IDisposable
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             PruneTombstones();
-            if (_latestByServer.TryGetValue(serverName, out var active) && !active.IsTerminal)
-                return new McpOAuthFlowStart(active, false);
+            if (_latestByServer.TryGetValue(serverName, out var active))
+            {
+                if (!active.IsTerminal)
+                    return new McpOAuthFlowStart(active, false);
+
+                // A flow that failed before the SDK built its authorization URL never reached
+                // _byState, so the state-keyed sweep below cannot reclaim it. Once it is
+                // replaced here nothing can reach it at all, and its timer and its token
+                // source registration on the daemon shutdown token would leak.
+                if (active.State is null)
+                    active.Dispose();
+            }
 
             var flow = new McpOAuthFlow(
                 serverName,
@@ -177,7 +187,13 @@ internal sealed class McpOAuthFlowBroker : IDisposable
     private void OnStateDiscovered(McpOAuthFlow flow, string state)
     {
         lock (_sync)
+        {
+            // The SDK calls this from a task that outlives the broker. Dispose() clears both
+            // indexes and fails every flow; re-inserting here would answer the operator's
+            // callback with "already used" instead of the shutdown reason.
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _byState[state] = flow;
+        }
     }
 
     private void OnFlowExpired(McpOAuthFlow flow)
@@ -204,17 +220,6 @@ internal sealed class McpOAuthFlowBroker : IDisposable
             if (_latestByServer.TryGetValue(flow.ServerName, out var latest)
                 && ReferenceEquals(latest, flow))
                 _latestByServer.Remove(flow.ServerName);
-            flow.Dispose();
-        }
-
-        // A flow that failed before the SDK built its authorization URL has no state key, so
-        // the loop above cannot reach it. Retire it here or its timer and token source leak.
-        foreach (var (serverName, flow) in _latestByServer.ToArray())
-        {
-            if (flow.State is not null || !flow.IsTerminal || flow.ExpiresAt > cutoff)
-                continue;
-
-            _latestByServer.Remove(serverName);
             flow.Dispose();
         }
     }
@@ -330,9 +335,14 @@ internal sealed class McpOAuthFlow : IDisposable
         var state = HttpUtility.ParseQueryString(authorizationUri.Query)["state"];
         if (string.IsNullOrEmpty(state))
         {
-            throw new McpOAuthOperationException(new McpErrorResponse(
+            var error = new McpErrorResponse(
                 "The MCP SDK produced an authorization URL with no state parameter.",
-                "authorization start"));
+                "authorization start");
+            // Fail before throwing. The caller waiting in StartAuthorizationAsync observes
+            // _authorizationRequest, and an exception that only unwinds the SDK's task would
+            // leave that caller blocked for the full flow lifetime.
+            Fail(error);
+            throw new McpOAuthOperationException(error);
         }
 
         lock (_sync)
@@ -396,8 +406,12 @@ internal sealed class McpOAuthFlow : IDisposable
         EndLifetime();
     }
 
+    /// <summary>Observable so a test can prove the broker reclaims a retired flow.</summary>
+    public bool IsDisposed { get; private set; }
+
     public void Dispose()
     {
+        IsDisposed = true;
         _expiryTimer.Dispose();
         _lifetimeCancellation.Dispose();
     }

--- a/src/Netclaw.Providers/OAuth/OAuthRedirectParser.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthRedirectParser.cs
@@ -12,17 +12,29 @@ namespace Netclaw.Providers.OAuth;
 public static class OAuthRedirectParser
 {
     /// <summary>
-    /// Try to extract <c>code</c> and <c>state</c> query parameters from a pasted redirect URL.
+    /// Try to extract <c>code</c>, <c>state</c>, and <c>iss</c> query parameters from a pasted
+    /// redirect URL.
     /// </summary>
     /// <param name="input">The pasted URL string.</param>
     /// <param name="code">The extracted authorization code.</param>
     /// <param name="state">The extracted state parameter.</param>
+    /// <param name="iss">
+    /// The RFC 9207 issuer identifier, or null when the authorization server sent none. An
+    /// authorization server that advertises iss support rejects a response without it, so this
+    /// value must reach the consumer that validates it.
+    /// </param>
     /// <param name="error">A user-friendly error message if parsing fails.</param>
     /// <returns>True if both code and state were successfully extracted.</returns>
-    public static bool TryParse(string? input, out string code, out string state, out string? error)
+    public static bool TryParse(
+        string? input,
+        out string code,
+        out string state,
+        out string? iss,
+        out string? error)
     {
         code = "";
         state = "";
+        iss = null;
         error = null;
 
         if (string.IsNullOrWhiteSpace(input))
@@ -56,6 +68,7 @@ public static class OAuthRedirectParser
 
         code = codeValue;
         state = stateValue;
+        iss = query["iss"];
         return true;
     }
 }


### PR DESCRIPTION
Upgrades `ModelContextProtocol.Core` from 1.4.1 to 2.0.0, which shipped on 2026-07-28.

Release 2.0.0 contains the thread-safe token cache from [csharp-sdk#1595](https://github.com/modelcontextprotocol/csharp-sdk/issues/1595) — the upstream fix #1696 waits for, verified present at the `v2.0.0` tag as `SemaphoreSlim _tokenAcquisitionLock`. No 1.x backport exists, so the 2.x migration is the only path.

## The migration

**The SDK owns the OAuth `state` from 2.0 onward.** It generates the value, puts it in the authorization URL, and rejects a callback that returns a different one. `McpOAuthFlowBroker` no longer mints its own state; it reads the SDK's value back out of the authorization URL to index the flow, then relays `code`, `state`, and the RFC 9207 `iss` back untouched. The SDK validates all three, which adds issuer validation the old path skipped.

`AuthorizationRedirectDelegate` is obsolete (`MCP9007`, a build error here) and is replaced by `ClientOAuthOptions.AuthorizationCallbackHandler`.

**One break the compiler cannot see.** `BuildAuthorizationUrl` merges `AdditionalAuthorizationParameters` with `Dictionary.Add`, which throws on a duplicate key. The daemon sent its own `state` through that dictionary, so every authorization attempt would have failed at run time. Removed.

**`McpOAuthClientRegistrar` stays.** Release 2.0.0 still hard-codes `token_endpoint_auth_method` to `client_secret_post` in its registration body (`ClientOAuthProvider.cs:937`), so a public-client-only server still rejects the SDK. Upstream PR #1615 covers the token request only.

## Refresh would have died silently

SDK 2.0 added `CachedTokensMatchClientCredentials`, which gates **both** refresh paths on four values matching: client id, client secret, authorization server, and token endpoint auth method. The token container reported none of them, so the SDK never redeemed a refresh token — it fell through to interactive authorization, which a background reconnect cannot complete. Every OAuth MCP server would have reached `AwaitingAuth` at its first token expiry. Release 1.4.1 had no such gate, so this arrives with the upgrade.

The credential record now persists the authorization server and the token endpoint auth method, and the container reports all four. The client id and secret come from the identity the provider was built with, not from disk — a pinned `OAuthClientId` suppresses the stored secret, and the two must agree.

## Upgrade impact

**A credential written before 2.0 carries no issuer and cannot refresh. Each affected MCP server needs one `netclaw mcp auth <name>`, after which its record is complete and refreshes normally.**

An earlier revision of this branch avoided that by filling the missing issuer from the value the protected resource advertises at connect time. That defeats the binding it appears to satisfy: a resource server that repoints to a different issuer supplies the value the SDK then compares against, so the SDK would send the stored client secret and refresh token to an authorization server that never issued them. The fill is removed. One recoverable reauthorization is the correct trade.

## Other defects found and fixed

- The CLI paste-redirect path sent only `code` and `state`. Against a server that advertises RFC 9207 `iss`, the SDK rejected every pasted redirect, and the consumed flow made each retry report the state as already used — unauthorizable from a headless host. `OAuthRedirectParser`, `DaemonApi`, the TUI coordinator, and `netclaw mcp auth` now relay `iss`.
- A refresh token stayed on a record after the issuer changed. The retention test now compares the issuer.
- The SDK's issuer-change rejection was unclassified, so nothing cleared the stale registration and every retry repeated the failure. It is classified now, and only a dynamically registered client is cleared.
- A flow that failed before the SDK built an authorization URL leaked its timer and its registration on the daemon shutdown token when an operator retried inside the flow lifetime.
- An authorization URL without a state now fails the flow before it throws; the waiting start request was left to wait out the full lifetime.
- `OnStateDiscovered` refuses to write to a disposed broker.

## Dependencies

`Microsoft.Extensions.AI` moves to 10.8.3 because the SDK requires that floor. `Microsoft.Extensions.TimeProvider.Testing` gets its own version property — it ships on the `dotnet/extensions` minor cadence and has no 10.8.x patch.

## Specs

The `simplify-mcp-oauth-lifecycle` delta spec required Netclaw-generated opaque state and Netclaw-side state validation, which `/opsx-sync` would have copied into the standing spec. The requirement, its scenarios, and the design document now record SDK-owned state and the `iss` relay.

## Validation

- 6078 tests pass, 0 fail.
- `dotnet slopwatch analyze`, the copyright header check, `git diff --check`, and `openspec validate` are clean.
- Every new regression test was verified in both directions: each fails when its fix is reverted.
- Live binary swap on Linux. All four MCP servers reconnected with identical tool counts and no reauthorization; zero `[ERR]`/`[FTL]` in the daemon log.

## Issues

Closes #1696.
