### PR TITLE
Make MCP tool-level auth failures visible, and unblock netclaw mcp auth

### DIFF
--- a/src/Netclaw.Actors/Tools/McpToolResultFormatter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolResultFormatter.cs
@@ -48,6 +48,22 @@ public static class McpToolResultFormatter
         return result?.ToString() ?? string.Empty;
     }
 
+    /// <summary>
+    /// Reports whether the MCP server flagged this result as a failure, and yields the
+    /// server's own detail. A tool-level failure arrives as an ordinary successful
+    /// response, so no exception reaches the transport layer and nothing downstream can
+    /// tell it apart from a normal result without this signal.
+    /// </summary>
+    public static bool TryGetErrorDetail(object? result, out string detail)
+    {
+        detail = string.Empty;
+        if (result is not JsonElement element || !IsCallToolResult(element) || !IsError(element))
+            return false;
+
+        detail = ExtractDetail(element);
+        return true;
+    }
+
     private static bool IsCallToolResult(JsonElement element)
         => element.ValueKind == JsonValueKind.Object
            && (element.TryGetProperty("content", out _) || element.TryGetProperty("isError", out _));

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -334,6 +334,10 @@ internal static class McpCommand
         var startResult = await startResponse.Content.ReadFromJsonAsync<JsonElement>();
         var authUrl = startResult.GetProperty("authorizationUrl").GetString()!;
         var flowState = startResult.GetProperty("state").GetString()!;
+        // Wait until the deadline the daemon reports rather than assume the flow lifetime.
+        // A client that gives up first tells the operator the attempt timed out while the
+        // daemon is still ready to accept their callback.
+        var deadline = startResult.GetProperty("expiresAt").GetDateTimeOffset();
 
         // 2. Open browser (detect headless first)
         var canOpenBrowser = BrowserDetection.CanOpenBrowser();
@@ -369,7 +373,8 @@ internal static class McpCommand
 
         // 3. Start polling + listen for paste concurrently
         writer.Write("Waiting for authorization");
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var remaining = deadline - DateTimeOffset.UtcNow;
+        using var cts = new CancellationTokenSource(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
         var pollTask = PollMcpOAuthStatusAsync(daemonApi, flowState, writer, cts.Token);
         var pasteTask = ReadPasteRedirectAsync(daemonApi, writer, cts.Token);
 

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -337,7 +337,14 @@ internal static class McpCommand
         // Wait until the deadline the daemon reports rather than assume the flow lifetime.
         // A client that gives up first tells the operator the attempt timed out while the
         // daemon is still ready to accept their callback.
-        var deadline = startResult.GetProperty("expiresAt").GetDateTimeOffset();
+        // A daemon older than this CLI does not report the deadline. The CLI and the
+        // daemon swap separately during an upgrade, so a newer CLI against an older
+        // daemon is a normal window rather than a broken install, and crashing here
+        // would take out `netclaw mcp auth` for the length of it. Fall back to the
+        // lifetime that daemon enforces.
+        var deadline = startResult.TryGetProperty("expiresAt", out var expiresAt)
+            ? expiresAt.GetDateTimeOffset()
+            : DateTimeOffset.UtcNow.AddMinutes(5);
 
         // 2. Open browser (detect headless first)
         var canOpenBrowser = BrowserDetection.CanOpenBrowser();

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -279,6 +279,9 @@ public sealed class OAuthFlowCoordinator : IDisposable
             var startResult = await startResponse.Content.ReadFromJsonAsync<JsonElement>(ct);
             var authUrl = startResult.GetProperty("authorizationUrl").GetString()!;
             var flowState = startResult.GetProperty("state").GetString()!;
+            // The daemon owns the flow deadline; polling past it, or stopping before it,
+            // both misreport the outcome to the operator.
+            var deadline = startResult.GetProperty("expiresAt").GetDateTimeOffset();
 
             // Step 2: Try to open browser (detect headless first)
             VerificationUri = authUrl;
@@ -300,7 +303,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
             }
 
             // Step 3: Poll daemon for completion
-            var pollTimeout = TimeSpan.FromMinutes(5);
+            var pollTimeout = deadline - DateTimeOffset.UtcNow;
             var pollInterval = TimeSpan.FromSeconds(2);
             var elapsed = TimeSpan.Zero;
 

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -280,8 +280,11 @@ public sealed class OAuthFlowCoordinator : IDisposable
             var authUrl = startResult.GetProperty("authorizationUrl").GetString()!;
             var flowState = startResult.GetProperty("state").GetString()!;
             // The daemon owns the flow deadline; polling past it, or stopping before it,
-            // both misreport the outcome to the operator.
-            var deadline = startResult.GetProperty("expiresAt").GetDateTimeOffset();
+            // both misreport the outcome to the operator. A daemon older than this CLI
+            // does not report it, which is a normal window during a staged upgrade.
+            var deadline = startResult.TryGetProperty("expiresAt", out var expiresAt)
+                ? expiresAt.GetDateTimeOffset()
+                : DateTimeOffset.UtcNow.AddMinutes(5);
 
             // Step 2: Try to open browser (detect headless first)
             VerificationUri = authUrl;

--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
@@ -120,6 +120,59 @@ public sealed class McpClientManagerLifecycleTests
     }
 
     [Fact]
+    public async Task ToolLevelAuthFailure_MovesServerOutOfConnected()
+    {
+        var runtime = new ControlledMcpClientRuntime();
+        runtime.Enqueue(new ClientPlan("run")
+        {
+            // An expired credential reaches the agent as an ordinary successful response
+            // carrying isError, not as a transport 401. The transport stays healthy, so
+            // without reclassification the server keeps reporting Connected while every
+            // call fails, and the operator is never told to reauthorize.
+            Invoke = (_, _) => Task.FromResult<object?>(JsonDocument.Parse(
+                """{"content":[{"type":"text","text":"Unauthorized: token expired"}],"isError":true}""")
+                .RootElement.Clone()),
+        });
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(
+            McpConnectionState.Connected,
+            harness.Manager.GetServerStatuses()[ServerName].State);
+
+        await InvokeAsync(harness.Manager, TestContext.Current.CancellationToken);
+
+        var status = harness.Manager.GetServerStatuses()[ServerName];
+        Assert.Equal(McpConnectionState.AuthFailed, status.State);
+        Assert.Contains($"netclaw mcp auth {ServerName.Value}", status.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ToolLevelFailureDetail_ReachesTheDaemonLog()
+    {
+        var runtime = new ControlledMcpClientRuntime();
+        runtime.Enqueue(new ClientPlan("run")
+        {
+            Invoke = (_, _) => Task.FromResult<object?>(JsonDocument.Parse(
+                """{"content":[{"type":"text","text":"database_not_found: no such data source"}],"isError":true}""")
+                .RootElement.Clone()),
+        });
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        await InvokeAsync(harness.Manager, TestContext.Current.CancellationToken);
+
+        // The detail reaches the model either way. Logging it is what gives an operator
+        // something to debug from, instead of only the result length.
+        Assert.Contains(
+            harness.Logger.Entries,
+            entry => entry.Contains("database_not_found: no such data source", StringComparison.Ordinal));
+        // A non-auth failure must not change connection state.
+        Assert.Equal(
+            McpConnectionState.Connected,
+            harness.Manager.GetServerStatuses()[ServerName].State);
+    }
+
+    [Fact]
     public async Task CancellationAndApplicationErrors_DoNotReconnectOrDisposeHealthyClient()
     {
         var invocationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -419,6 +472,7 @@ public sealed class McpClientManagerLifecycleTests
                 NullLogger<McpOAuthCredentialStore>.Instance);
             _flowBroker = new McpOAuthFlowBroker(timeProvider, CancellationToken.None);
             Registry = new ToolRegistry();
+            Logger = new RecordingLogger<McpClientManager>();
             Manager = new McpClientManager(
                 new Dictionary<string, McpServerEntry>
                 {
@@ -438,13 +492,15 @@ public sealed class McpClientManagerLifecycleTests
                 notificationSink,
                 timeProvider,
                 runtime,
-                NullLogger<McpClientManager>.Instance,
+                Logger,
                 new SessionConfig());
         }
 
         public McpClientManager Manager { get; }
 
         public ToolRegistry Registry { get; }
+
+        public RecordingLogger<McpClientManager> Logger { get; }
 
         public void MarkStopFailureObserved() => _stopFailureObserved = true;
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Concurrent;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
@@ -144,6 +145,40 @@ public sealed class McpClientManagerLifecycleTests
         var status = harness.Manager.GetServerStatuses()[ServerName];
         Assert.Equal(McpConnectionState.AuthFailed, status.State);
         Assert.Contains($"netclaw mcp auth {ServerName.Value}", status.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InvocationAgainstAnAuthFailedServer_NamesTheRemedy()
+    {
+        var runtime = new ControlledMcpClientRuntime();
+        runtime.Enqueue(new ClientPlan("run")
+        {
+            Invoke = (_, _) => Task.FromResult<object?>(JsonDocument.Parse(
+                """{"content":[{"type":"text","text":"Unauthorized: token expired"}],"isError":true}""")
+                .RootElement.Clone()),
+        });
+        // The reconnect that follows must fail the way a dead credential does. A failure
+        // the manager cannot read as an auth problem would reclassify the server as
+        // Unreachable, and the remedy branch would correctly not apply.
+        runtime.Enqueue(new ClientPlan("run")
+        {
+            Initialize = _ => Task.FromException(
+                new HttpRequestException("Unauthorized", null, HttpStatusCode.Unauthorized)),
+        });
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+        await InvokeAsync(harness.Manager, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            McpConnectionState.AuthFailed,
+            harness.Manager.GetServerStatuses()[ServerName].State);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InvokeAsync(harness.Manager, TestContext.Current.CancellationToken));
+
+        // This text is what the agent repeats to the operator. "unavailable" would send
+        // them looking for a broken server rather than a credential to renew.
+        Assert.Contains($"netclaw mcp auth {ServerName.Value}", error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("unavailable", error.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Mcp/McpOAuthTestDoubles.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpOAuthTestDoubles.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Daemon.Mcp;
 
@@ -28,5 +29,37 @@ internal static class McpOAuthTestDoubles
             CancellationToken cancellationToken)
             => throw new InvalidOperationException(
                 $"This test's MCP OAuth registrar was not expected to issue requests (attempted {request.RequestUri}).");
+    }
+}
+
+/// <summary>
+/// Captures both the exceptions and the rendered messages a component logs, so a test can
+/// assert on diagnostics that never surface through a return value.
+/// </summary>
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    public Exception? LastException { get; private set; }
+
+    public List<Exception> Exceptions { get; } = [];
+
+    public List<string> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(formatter(state, exception));
+        if (exception is not null)
+        {
+            LastException = exception;
+            Exceptions.Add(exception);
+        }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -82,6 +82,60 @@ public sealed class McpSdkOAuthFlowIntegrationTests
     }
 
     [Fact]
+    public async Task ExplicitAuthorizationGivesTheOperatorTimeToFinishInTheBrowser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var server = await FakeOAuthMcpServer.StartAsync(ct);
+        using var directory = new DisposableTempDir();
+        await using var harness = CreateManagerHarness(server, directory.Path);
+
+        await harness.Manager.StartAuthorizationAsync(harness.ServerName, ct);
+
+        // The SDK ships a 5 second server/discover probe and a 60 second initialization
+        // budget. Both are machine-scale. A server that answers the probe with 401 sends the
+        // SDK into the callback handler, which cannot return until the operator finishes in
+        // a browser; the probe timeout then cancels that wait and the SDK calls the handler
+        // again for the same flow, ending the authorization the operator was still doing.
+        var options = harness.Runtime.LastClientOptions;
+        Assert.NotNull(options);
+        Assert.Equal(McpOAuthFlowBroker.FlowLifetime, options!.DiscoverProbeTimeout);
+        Assert.Equal(McpOAuthFlowBroker.FlowLifetime, options.InitializationTimeout);
+    }
+
+    [Fact]
+    public async Task BackgroundReconnectKeepsTheSdkDefaultConnectTimeouts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var server = await FakeOAuthMcpServer.StartAsync(ct);
+        server.AcceptBearer("startup-access");
+        using var directory = new DisposableTempDir();
+        var paths = new NetclawPaths(directory.Path);
+        paths.EnsureDirectoriesExist();
+        var canonical = McpOAuthCredentialStore.CanonicalizeResource(server.McpEndpoint.ToString());
+        File.WriteAllText(paths.SecretsPath, $$"""
+            {
+              "McpOAuthTokens": {
+                "fake-oauth": {
+                  "AccessToken": "startup-access",
+                  "ClientId": "startup-client",
+                  "ResourceIdentity": "{{canonical}}"
+                }
+              }
+            }
+            """);
+        await using var harness = CreateManagerHarness(server, directory.Path);
+
+        await harness.Manager.StartAsync(ct);
+
+        // Nobody is waiting on a background reconnect: its handler returns immediately, so
+        // stretching these would only delay a genuinely unreachable server.
+        var options = harness.Runtime.LastClientOptions;
+        Assert.NotNull(options);
+        Assert.NotEqual(McpOAuthFlowBroker.FlowLifetime, options!.DiscoverProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(60), options.InitializationTimeout);
+    }
+
+    [Fact]
     public async Task ConcurrentManagerStartsShareCandidateUrlCredentialWriteAndGeneration()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -745,6 +799,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
         public HttpClientTransportOptions? LastHttpOptions { get; private set; }
 
+        public McpClientOptions? LastClientOptions { get; private set; }
+
         public InitializationBarrier? InitializationBarrier { get; set; }
 
         public void FailNextToolListing() => Interlocked.Exchange(ref _failNextToolListing, 1);
@@ -761,6 +817,7 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _createCount);
+            LastClientOptions = options;
             return McpClient.CreateAsync(transport, options, cancellationToken: cancellationToken);
         }
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -734,31 +734,6 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         }
     }
 
-    private sealed class RecordingLogger<T> : ILogger<T>
-    {
-        public Exception? LastException { get; private set; }
-
-        public List<Exception> Exceptions { get; } = [];
-
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            if (exception is not null)
-            {
-                LastException = exception;
-                Exceptions.Add(exception);
-            }
-        }
-    }
-
     private sealed class FakeServerMcpRuntime(
         FakeOAuthMcpServer server,
         bool failToolListing) : IMcpClientRuntime

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -205,7 +205,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             _ = RunExplicitAuthorizationAsync(lifecycle, entry, started.Flow);
 
         var request = await started.Flow.WaitForAuthorizationRequestAsync(requestCancellation);
-        return new McpOAuthStartResponse(request.Url.ToString(), request.State);
+        return new McpOAuthStartResponse(request.Url.ToString(), request.State, started.Flow.ExpiresAt);
     }
 
     public async Task<string> InvokeAsync(

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -776,17 +776,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             }
 
             var transport = CreateTransport(name, entry, oauthCache, authorizationFlow);
-            var client = await _clientRuntime.CreateAsync(transport, new McpClientOptions
-            {
-                ClientInfo = new()
-                {
-                    Name = "netclaw",
-                    Title = "Netclaw",
-                    Version = BuildInfo.Version,
-                    WebsiteUrl = "https://netclaw.dev",
-                    Description = "Open-source autonomous operations agent built on Akka.NET",
-                },
-            }, ct);
+            var client = await _clientRuntime.CreateAsync(transport, BuildClientOptions(authorizationFlow), ct);
             return new McpClientCandidate(client, oauthCache);
         }
         catch
@@ -795,6 +785,44 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 _credentialStore.Discard(oauthCache);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Builds the client options, stretching both connect timeouts when an operator is
+    /// waiting at a browser.
+    /// <para>
+    /// The SDK defaults are machine-scale: a 5 second <c>server/discover</c> probe and a
+    /// 60 second initialization budget. A server that answers the probe with 401 sends the
+    /// SDK into the authorization callback handler, which cannot return until the operator
+    /// finishes. The probe timeout then cancels that wait, the SDK falls back to the
+    /// <c>initialize</c> handshake, and it calls the handler a second time for the same
+    /// flow — which the single-owner guard rejects, ending the authorization the operator
+    /// was still working through. Both timeouts therefore match the flow lifetime while a
+    /// flow exists. A background reconnect keeps the defaults, because its handler returns
+    /// immediately and nothing waits.
+    /// </para>
+    /// </summary>
+    private static McpClientOptions BuildClientOptions(McpOAuthFlow? authorizationFlow)
+    {
+        var options = new McpClientOptions
+        {
+            ClientInfo = new()
+            {
+                Name = "netclaw",
+                Title = "Netclaw",
+                Version = BuildInfo.Version,
+                WebsiteUrl = "https://netclaw.dev",
+                Description = "Open-source autonomous operations agent built on Akka.NET",
+            },
+        };
+
+        if (authorizationFlow is not null)
+        {
+            options.InitializationTimeout = McpOAuthFlowBroker.FlowLifetime;
+            options.DiscoverProbeTimeout = McpOAuthFlowBroker.FlowLifetime;
+        }
+
+        return options;
     }
 
     private IClientTransport CreateTransport(

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -719,10 +719,26 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             "authentication_failed");
     }
 
-    private static InvalidOperationException CreateUnavailableException(
+    /// <summary>
+    /// Explains why a tool could not run. This message is what the agent reports, so a
+    /// server that is only waiting on authorization must name that remedy: "unavailable"
+    /// reads as a broken server and sends the operator looking for the wrong problem.
+    /// </summary>
+    private InvalidOperationException CreateUnavailableException(
         McpServerName serverName,
         ToolName toolName)
-        => new($"MCP server '{serverName.Value}' is unavailable or tool '{toolName.Value}' is not registered.");
+    {
+        var state = _servers.TryGetValue(serverName, out var lifecycle)
+            ? lifecycle.Snapshot?.Status.State
+            : null;
+
+        return state is McpConnectionState.AuthFailed or McpConnectionState.AwaitingAuth
+            ? new InvalidOperationException(
+                $"MCP server '{serverName.Value}' requires authorization. " +
+                $"Run: netclaw mcp auth {serverName.Value}")
+            : new InvalidOperationException(
+                $"MCP server '{serverName.Value}' is unavailable or tool '{toolName.Value}' is not registered.");
+    }
 
     private async Task<McpClientCandidate> CreateClientAsync(
         McpServerName name,

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -15,6 +15,7 @@ using ModelContextProtocol.Authentication;
 using ModelContextProtocol.Client;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Mcp;
@@ -242,6 +243,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 throw CreateUnavailableException(serverName, toolName);
 
             return await InvokeFunctionAsync(
+                serverName,
                 function,
                 $"{serverName.Value}/{toolName.Value}",
                 arguments,
@@ -647,6 +649,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     }
 
     private async Task<string> InvokeFunctionAsync(
+        McpServerName serverName,
         AIFunction function,
         string qualifiedToolName,
         IDictionary<string, object?>? arguments,
@@ -656,7 +659,64 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             ? new AIFunctionArguments(arguments)
             : null;
         var result = await _clientRuntime.InvokeAsync(function, aiArgs, ct);
+
+        if (McpToolResultFormatter.TryGetErrorDetail(result, out var detail))
+            ReportToolFailure(serverName, qualifiedToolName, detail);
+
         return McpToolResultFormatter.Format(result, qualifiedToolName);
+    }
+
+    /// <summary>
+    /// Records a failure the MCP server reported inside an otherwise successful response.
+    /// The detail reaches the model but no exception reaches the transport layer, so
+    /// without this the daemon log keeps only the result length and an operator has
+    /// nothing to debug from.
+    /// </summary>
+    private void ReportToolFailure(McpServerName serverName, string qualifiedToolName, string detail)
+    {
+        // Redact before logging: an MCP error body can echo the arguments it rejected, and
+        // daemon logs leave the box when OTLP export is enabled.
+        _logger.LogWarning(
+            "MCP tool '{Tool}' reported a failure: {Detail}",
+            qualifiedToolName,
+            SecretOutputRedactor.Redact(detail));
+
+        if (!IsAuthFailureMessage(detail))
+            return;
+
+        MarkToolAuthFailure(serverName);
+    }
+
+    /// <summary>
+    /// Moves a server out of <see cref="McpConnectionState.Connected"/> when its
+    /// credential is rejected at call time. The transport stays healthy in this case, so
+    /// status would otherwise report a working server while every invocation fails, and
+    /// the one state that needs operator action would be the one state never shown.
+    /// </summary>
+    private void MarkToolAuthFailure(McpServerName serverName)
+    {
+        if (!_servers.TryGetValue(serverName, out var lifecycle))
+            return;
+
+        var current = lifecycle.Snapshot;
+        if (current is null || current.Status.State is McpConnectionState.AuthFailed)
+            return;
+
+        var status = new McpServerStatus(
+            serverName,
+            McpConnectionState.AuthFailed,
+            current.Status.ToolCount,
+            $"Authentication rejected by server. Run: netclaw mcp auth {serverName.Value}",
+            _timeProvider.GetUtcNow());
+        lifecycle.Publish(current with { Status = status });
+
+        _logger.LogWarning(
+            "MCP server '{Name}' rejected an authenticated tool call; reauthorization is required",
+            serverName.Value);
+        EmitAuthAlert(
+            serverName,
+            $"MCP server '{serverName.Value}' authentication failed. Run: netclaw mcp auth {serverName.Value}",
+            "authentication_failed");
     }
 
     private static InvalidOperationException CreateUnavailableException(
@@ -955,16 +1015,25 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         if (ex is HttpRequestException { StatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden })
             return true;
 
-        if (ex.Message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("forbidden", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("AuthorizationCallbackHandler", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("authorization code", StringComparison.OrdinalIgnoreCase))
+        if (IsAuthFailureMessage(ex.Message))
             return true;
 
         return ex.InnerException is not null && IsAuthFailure(ex.InnerException);
     }
+
+    /// <summary>
+    /// Recognizes an authentication rejection from message text alone. A tool-level
+    /// failure carries no exception and no HTTP status, so the wording is all there is.
+    /// </summary>
+    private static bool IsAuthFailureMessage(string message)
+        => message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("forbidden", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("invalid_token", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("token expired", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("AuthorizationCallbackHandler", StringComparison.OrdinalIgnoreCase)
+           || message.Contains("authorization code", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Identifies a stored client registration the authorization server will never accept

--- a/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Mcp/McpEndpointRouteBuilderExtensions.cs
@@ -19,8 +19,13 @@ public sealed record McpOAuthCallbackQuery(
     // RFC 9207 issuer identifier. The MCP SDK validates it; the daemon only relays it.
     [FromQuery(Name = "iss")] string? Iss);
 
-/// <summary>Authorization URL and opaque state returned when an MCP OAuth flow starts.</summary>
-public sealed record McpOAuthStartResponse(string AuthorizationUrl, string State);
+/// <summary>
+/// Authorization URL and state returned when an MCP OAuth flow starts, with the deadline the
+/// daemon will enforce. Clients wait until <paramref name="ExpiresAt"/> rather than assume a
+/// lifetime, so a client that stops early can never report a timeout for a flow the daemon
+/// still considers live.
+/// </summary>
+public sealed record McpOAuthStartResponse(string AuthorizationUrl, string State, DateTimeOffset ExpiresAt);
 
 /// <summary>Connection status for a single MCP server.</summary>
 public sealed record McpServerStatusDto(


### PR DESCRIPTION
Follow-up to #1714. Four defects found by running the SDK 2.0 migration against live MCP servers, plus one compatibility fix.

An MCP server can report a failure inside a **successful** response, with `isError: true`. No exception reaches the transport layer, and that single fact caused three separate problems.

## An expired credential was invisible

The daemon recorded only the length of the result. The server's own detail went to the model and never reached disk, so an operator whose agent said "Notion is auth-failing" had nothing to check. `McpToolResultFormatter` already extracted that detail; nothing logged it.

The detail is now logged at warning level, redacted first — an MCP error body can echo the arguments it rejected, and daemon logs leave the box when the OTLP exporter is on.

## Status reported a healthy server while every call failed

A rejected credential arrives as a tool-level failure, not an HTTP 401. The transport stays healthy, so the server kept reporting `Connected` while every invocation failed. The one state that needs an operator action was the one state that status never showed.

A tool-level failure whose text reads as an authentication rejection now moves the server to `AuthFailed`, names `netclaw mcp auth <name>`, and raises the same operational alert a transport failure raises. The message match is shared with the exception path so both recognize the same wording.

## The invocation error did not name the remedy

A call against a server awaiting authorization threw `MCP server '<name>' is unavailable or tool '<tool>' is not registered`. That text is what the agent repeats to the operator, and it reads as a broken server. It now names `netclaw mcp auth <name>` when the server state is `AuthFailed` or `AwaitingAuth`, and keeps the original wording for every other cause.

## `netclaw mcp auth` failed five seconds after printing the URL

This one is a regression from #1714 and it blocked reauthorization completely.

SDK 2.0 probes `server/discover` before falling back to the `initialize` handshake, and bounds that probe at **five seconds**. A server that answers the probe with 401 sends the SDK into the authorization callback handler, which cannot return until the operator finishes in a browser. The probe timeout cancels that wait, the SDK falls back to `initialize`, gets a second 401, and calls the handler again for the same flow. The single-owner guard rejects the second call and the whole attempt dies.

The guard is correct and stays. Each call to `InitiateAuthorizationCodeFlowAsync` mints a fresh `state`, so a second call cannot reuse the URL the operator already has on screen. The fix is to stop the probe expiring while a person works: both connect timeouts now match the flow lifetime **when a flow exists**. A background reconnect keeps the SDK defaults, because its handler returns immediately and nothing waits.

Release 1.4.1 had no discovery probe, so one 401 produced one handler call.

## Flow deadline

The CLI and the TUI each waited a hardcoded five minutes while the daemon enforced its own deadline. They agreed by coincidence. `McpOAuthStartResponse` now carries the flow's `ExpiresAt` and both clients wait until that moment.

Sharing the `FlowLifetime` constant was the other option and it is worse: the constant is internal to the daemon, and the CLI is an HTTP client of the daemon rather than a reference to it. A per-flow deadline also survives a lifetime that later varies by server.

The clients tolerate a daemon that does not send the field. The CLI and the daemon swap separately during an upgrade, so a newer CLI against an older daemon is a normal window rather than a broken install.

## Validation

- 6084 tests pass, 0 fail.
- Every new test was verified in both directions: each fails when its fix is reverted.
- `dotnet slopwatch analyze`, the copyright header check, and `git diff --check` are clean.
- Live on Linux against real Notion and TextForge servers. `netclaw mcp auth notion` now completes, and the resulting record carries `AuthorizationServer` and `TokenEndpointAuthMethod`, so it refreshes without another authorization.
