### PR TITLE
Release 0.25.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,14 +8,11 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.25.0</VersionPrefix>
+    <VersionPrefix>0.25.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <PackageReleaseNotes>- Preserve Git working context across sessions and subagents — A bounded, audience-aware Git working-context snapshot stays current in the system prompt, and coding subagents inherit recent-file/project context (#1630)
-- User-written AGENTS.md for application-specific agent guidance — Operators can author ~/.netclaw/identity/AGENTS.md, layered after Netclaw's embedded operating core and inherited by sub-agents (#1622)
-- Memory curation no longer overwrites existing documents on collision — Create-decision collisions now append new content instead of silently overwriting the existing document (#1637)
-- STDIO MCP server arguments no longer rewritten — The daemon now preserves configured STDIO MCP server arguments, and uses one daemon-owned client per configured MCP server (#1636)
-- Logical skill access and authoritative inventory refresh — Skill loading now resolves through logical skill_load/skill_read_resource access with native &gt; managed-feed &gt; external precedence (#1634)
-- Bump SkillServer to stable — Netclaw.SkillClient 0.4.0-beta.4 → 0.4.0 (#1638)</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      Bug Fixes: MCP OAuth lifecycle hardened to prevent credential loss on upgrade; MCP tool-level auth failures now visible; MCP permissions focus/save fixed in TUI; TUI approval revocation targets highlighted item. Internal: Migrate to MCP SDK 2.0.0; GitHub Copilot GHE model routing. Dependencies: Anthropic 12.39.0, Mattermost.NET 5.0.7, SkillClient 0.4.1, OpenTelemetry 1.17.0, OllamaSharp 5.4.27, SkiaSharp 4.150.1, SourceLink 10.0.301, Akka updated.
+    </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # NetClaw Release Notes
 
+## 0.25.1 (2026-07-31)
+
+### Bug Fixes
+- **MCP OAuth lifecycle hardened** — Takes back client registration from the MCP SDK to prevent credential loss on upgrade; fixes `token_endpoint_auth_method` hardcoding issue with RFC 7591 ([#1708](https://github.com/netclaw-dev/netclaw/pull/1708))
+- **MCP tool-level auth failures now visible** — Daemon logs MCP `isError: true` responses at warning level, fixes `netclaw mcp auth` fallback for older daemons during upgrades ([#1720](https://github.com/netclaw-dev/netclaw/pull/1720))
+- **MCP permissions focus and save interaction fixed in TUI** ([#1694](https://github.com/netclaw-dev/netclaw/pull/1694))
+- **Revoke the highlighted approval in TUI** — Approval revocation now targets the currently highlighted item ([#1721](https://github.com/netclaw-dev/netclaw/pull/1721))
+
+### Internal Improvements
+- **Migrate to ModelContextProtocol SDK 2.0.0** — Brings in thread-safe token cache and updated OAuth flow ([#1714](https://github.com/netclaw-dev/netclaw/pull/1714))
+- **GitHub Copilot GHE: route models through advertised responses endpoint** with model catalog support ([#1707](https://github.com/netclaw-dev/netclaw/pull/1707))
+
+### Dependency Updates
+- **Bump Anthropic SDK** — 12.35.1 → 12.39.0
+- **Bump Mattermost.NET** — 5.0.3 → 5.0.7
+- **Bump Netclaw.SkillClient** — 0.4.0 → 0.4.1
+- **Bump OpenTelemetry** — 1.16.0 → 1.17.0
+- **Bump OllamaSharp** — 5.4.25 → 5.4.27
+- **Bump SkiaSharp.NativeAssets.Linux** — 4.148.0 → 4.150.1
+- **Bump Microsoft.SourceLink.GitHub** — 10.0.300 → 10.0.301
+- **Bump Akka** — Akka.Cluster.Sharding and Akka.Persistence updated
+
 ## 0.25.0 (2026-07-18)
 
 This stable release concludes the 0.25.0 beta cycle (five beta releases from 0.25.0-beta.1 through beta.5) and adds a round of final polish focused on installation, CLI reliability, and daemon shutdown robustness.


### PR DESCRIPTION
Patch release with MCP OAuth lifecycle hardening, MCP tool-level auth visibility, TUI fixes, and MCP SDK 2.0.0 migration.

See [RELEASE_NOTES.md](https://github.com/netclaw-dev/netclaw/blob/release/v0.25.1/RELEASE_NOTES.md) for full details.