### PR TITLE
fix(ci): dispatch website rebuild directly from release pipeline

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -569,3 +569,30 @@ jobs:
     needs: publish-binary-manifest
     uses: ./.github/workflows/publish_skills.yml
     secrets: inherit
+
+  # ────────────────────────────────────────────────────────────────────
+  # Job 7: Trigger netclaw.dev website rebuild
+  # ────────────────────────────────────────────────────────────────────
+  # The website rebuilds at deploy time by fetching the GitHub Releases API,
+  # so it needs the release to be created but has no dependency on binary
+  # publishing or skills. Dispatches directly (rather than reacting to a
+  # release:published event) because GITHUB_TOKEN-authored releases cannot
+  # trigger downstream workflows.
+  rebuild-website:
+    name: Trigger netclaw.dev rebuild
+    needs: create-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Dispatch website deploy workflow
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::WEBSITE_DISPATCH_TOKEN secret is not set on this repository." >&2
+            exit 1
+          fi
+          gh workflow run deploy.yml \
+            --repo netclaw-dev/netclaw-website \
+            --ref dev
+          echo "Dispatched deploy.yml on netclaw-dev/netclaw-website@dev."

--- a/.github/workflows/website-rebuild.yml
+++ b/.github/workflows/website-rebuild.yml
@@ -1,15 +1,14 @@
-# Fires netclaw-website's deploy workflow whenever a release is published
-# here. The receiving workflow rebuilds the site (re-fetching the GitHub
-# Releases API at build time) so /changelog stays in sync.
+# Manual fallback to dispatch netclaw-website's deploy workflow.
+# The automated path lives in publish_release_binaries.yml (rebuild-website job)
+# which dispatches directly after create-release because GITHUB_TOKEN-authored
+# releases cannot trigger downstream workflow events.
 #
 # Auth: WEBSITE_DISPATCH_TOKEN repository secret, a fine-grained PAT with
 # Actions: read+write on netclaw-dev/netclaw-website. See
 # ops/auto-rebuild-on-release/README.md in netclaw-website for setup.
-name: Trigger netclaw.dev rebuild
+name: Trigger netclaw.dev rebuild (manual)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

The `website-rebuild.yml` workflow listened for `release: published` events, but these never fired because the `create-release` job in `publish_release_binaries.yml` creates releases using `GITHUB_TOKEN`. GitHub blocks `GITHUB_TOKEN`-authored events from triggering downstream workflows as an infinite-loop guard.

Only two runs of `website-rebuild.yml` ever succeeded — both manual `workflow_dispatch` triggers.

## Fix

- **`publish_release_binaries.yml`**: Added `rebuild-website` job (Job 7) that dispatches `deploy.yml` on `netclaw-dev/netclaw-website` using `WEBSITE_DISPATCH_TOKEN`. It depends only on `create-release`, so it fires as soon as the GitHub Release exists — in parallel with binary builds.
- **`website-rebuild.yml`**: Stripped to `workflow_dispatch` only. Kept as a manual fallback if the automated job ever fails and needs a retrigger.