### PR TITLE
chore: remove xunit.v3.mtp-off prerelease workaround

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,7 +88,6 @@
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.v3.mtp-off" Version="4.0.0-pre.128" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="CsCheck" Version="4.7.0" />

--- a/samples/Netclaw.Demo.AppHost.IntegrationTests/Netclaw.Demo.AppHost.IntegrationTests.csproj
+++ b/samples/Netclaw.Demo.AppHost.IntegrationTests/Netclaw.Demo.AppHost.IntegrationTests.csproj
@@ -11,11 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <!-- xUnit 3.2.2 can append its foreground-thread diagnostic to the assembly-info
-         JSON consumed by the VS adapter, making discovery fail nondeterministically.
-         The protocol fix shipped in 4.0.0-pre.116; pre.128 is the first fixed build
-         published to NuGet. Keep prerelease consumption local until xUnit 4 is stable. -->
-    <PackageReference Include="xunit.v3.mtp-off" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <!-- Promote the transitive MessagePack (via Aspire/StreamJsonRpc) to the patched
          2.5.301 to clear NuGetAudit GHSA-hv8m-jj95-wg3x. See Directory.Packages.props. -->


### PR DESCRIPTION
## Changes
- Removed `xunit.v3.mtp-off` 4.0.0-pre.128 from `Directory.Packages.props`
- Swapped `Demo.AppHost.IntegrationTests` to `xunit.v3` 3.2.2, matching every other test project
- The `mtp-off` package was a surgical workaround for an MTP discovery race in xUnit 3.2.2 (commit 84b94df7). No other project uses it, and the build passes cleanly without it.

Closes #1740.