### PR TITLE
fix(slack): render <@user>, <@subteam^group> and <#channel> mentions as rich-text elements

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SlackBlockConverterTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -415,5 +415,70 @@ public class SlackBlockConverterTests
             .FirstOrDefault(e => e.Style is { Bold: true, Italic: true });
         Assert.NotNull(styled);
         Assert.Equal("bold and italic", styled.Text);
+    }
+
+    [Fact]
+    public void UserMention_ProducesRichTextUser()
+    {
+        var blocks = SlackBlockConverter.Convert("Ping <@U01SU57E553> when ready");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var user = Assert.Single(section.Elements.OfType<RichTextUser>());
+        Assert.Equal("U01SU57E553", user.UserId);
+
+        var texts = section.Elements.OfType<RichTextText>().ToList();
+        Assert.Equal("Ping ", texts[0].Text);
+        Assert.Equal(" when ready", texts[1].Text);
+    }
+
+    [Fact]
+    public void UserMention_WithLabel_ProducesRichTextUser()
+    {
+        var blocks = SlackBlockConverter.Convert("Thanks <@U01SU57E553|david>!");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var user = Assert.Single(section.Elements.OfType<RichTextUser>());
+        Assert.Equal("U01SU57E553", user.UserId);
+    }
+
+    [Fact]
+    public void UserGroupMention_ProducesRichTextUserGroup()
+    {
+        var blocks = SlackBlockConverter.Convert("Heads up <@subteam^S0123ABC>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
+        Assert.Equal("subteam^S0123ABC", group.UserGroupId);
+    }
+
+    [Fact]
+    public void ChannelMention_ProducesRichTextChannel()
+    {
+        var blocks = SlackBlockConverter.Convert("Posted in <#C0AM51E342X> already");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var channel = Assert.Single(section.Elements.OfType<RichTextChannel>());
+        Assert.Equal("C0AM51E342X", channel.ChannelId);
+    }
+
+    [Fact]
+    public void UserMention_InListItem_ProducesRichTextUser()
+    {
+        var blocks = SlackBlockConverter.Convert("- David: approve <@U01SU57E553>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var list = Assert.Single(rtb.Elements.OfType<RichTextList>());
+        var item = list.Elements[0];
+
+        var user = Assert.Single(item.Elements.OfType<RichTextUser>());
+        Assert.Equal("U01SU57E553", user.UserId);
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="SlackBlockConverterTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -454,7 +454,31 @@ public class SlackBlockConverterTests
         var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
 
         var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
-        Assert.Equal("subteam^S0123ABC", group.UserGroupId);
+        Assert.Equal("S0123ABC", group.UserGroupId);
+    }
+
+    [Fact]
+    public void UserGroupMention_WithLabel_ProducesRichTextUserGroup()
+    {
+        var blocks = SlackBlockConverter.Convert("Escalate to <@subteam^S0123ABC|oncall> now");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
+        Assert.Equal("S0123ABC", group.UserGroupId);
+    }
+
+    [Fact]
+    public void PrivateChannelMention_ProducesRichTextChannel()
+    {
+        var blocks = SlackBlockConverter.Convert("Also in <#G0123ABC|private-ops>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var channel = Assert.Single(section.Elements.OfType<RichTextChannel>());
+        Assert.Equal("G0123ABC", channel.ChannelId);
     }
 
     [Fact]

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SlackBlockConverter.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -277,6 +277,20 @@ public static partial class SlackBlockConverter
                 : new RichTextLink { Url = url };
         });
 
+        // Slack-native mentions passed through by the agent: <@U...>
+        // user, <@subteam^S...> user group, <#C...> channel. Without
+        // explicit rich-text elements the Block Kit surface renders
+        // the syntax as literal text (the mrkdwn Text fallback handles
+        // them natively, but blocks win on every modern client).
+        TryMatch(UserMentionRegex(), text, ref best, (m) =>
+            new RichTextUser { UserId = m.Groups[1].Value });
+
+        TryMatch(UserGroupMentionRegex(), text, ref best, (m) =>
+            new RichTextUserGroup { UserGroupId = m.Groups[1].Value });
+
+        TryMatch(ChannelMentionRegex(), text, ref best, (m) =>
+            new RichTextChannel { ChannelId = m.Groups[1].Value });
+
         if (best.Element is null)
             return (0, 0, null, null);
 
@@ -357,4 +371,17 @@ public static partial class SlackBlockConverter
     // Ordered list prefix: 1. or 2. etc.
     [GeneratedRegex(@"^\d+\.\s")]
     private static partial Regex OrderedListPrefix();
+
+    // Slack user mention: <@U0123ABC> or <@W0123ABC>, optionally with a
+    // fallback label (<@U0123ABC|david>).
+    [GeneratedRegex(@"<@([UW][0-9A-Z]+)(?:\|[^>]+)?>")]
+    private static partial Regex UserMentionRegex();
+
+    // Slack user-group mention: <@subteam^S0123ABC>.
+    [GeneratedRegex(@"<@(subteam\^[S0-9A-Z]+)>")]
+    private static partial Regex UserGroupMentionRegex();
+
+    // Slack channel mention: <#C0123ABC>, optionally with a label.
+    [GeneratedRegex(@"<#(C[0-9A-Z]+)(?:\|[^>]+)?>")]
+    private static partial Regex ChannelMentionRegex();
 }

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="SlackBlockConverter.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -377,11 +377,15 @@ public static partial class SlackBlockConverter
     [GeneratedRegex(@"<@([UW][0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex UserMentionRegex();
 
-    // Slack user-group mention: <@subteam^S0123ABC>.
-    [GeneratedRegex(@"<@(subteam\^[S0-9A-Z]+)>")]
+    // Slack user-group mention: <@subteam^S0123ABC>, optionally with a
+    // label (<@subteam^S0123ABC|oncall>). Captures the bare group ID —
+    // the rich-text usergroup element takes the ID as returned by
+    // usergroups.list, without the subteam^ prefix.
+    [GeneratedRegex(@"<@subteam\^([S0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex UserGroupMentionRegex();
 
     // Slack channel mention: <#C0123ABC>, optionally with a label.
-    [GeneratedRegex(@"<#(C[0-9A-Z]+)(?:\|[^>]+)?>")]
+    // C = public channel, G = private channel/group DM, D = DM.
+    [GeneratedRegex(@"<#([CGD][0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex ChannelMentionRegex();
 }


### PR DESCRIPTION
The Block Kit converter parses bold/italic/code/links but passed Slack-native mention syntax (`<@U...>`, `<@subteam^S...>`, `<#C...>`) through as literal text: rich_text blocks render their own elements and ignore the mrkdwn `Text` fallback on modern clients, so agents had no way to mention users in outbound Slack messages.

Add mention patterns to the inline parser emitting `RichTextUser`, `RichTextUserGroup` and `RichTextChannel` (all present in SlackNet 0.17.x), including the labeled forms (`<@U123|name>`, `<#C123|general>`). Covers paragraphs, list items and quotes via the shared `ParseInlineElements`.

Adds 5 converter tests: user, labeled user, user group, channel, and user mention inside a bullet list item. All 30 `SlackBlockConverterTests` pass locally.