### PR TITLE
fix(tui): escape during approval prompt denies instead of quitting

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -234,13 +234,16 @@ public sealed class ChatPageTests
     }
 
     [Fact]
-    public async Task Escape_WithNoPendingInteraction_StillQuits()
+    public async Task Escape_WithNoPendingInteraction_IsNoOp_CtrlQQuits()
     {
-        // Bare Escape with no approval prompt keeps the historical behavior:
-        // it quits the app. Only the approval-prompt case routes to deny.
+        // Escape is a pure cancel key everywhere — idle it's a no-op, never
+        // a quit. Ctrl+Q is the only quit affordance (#1757). Enqueue Escape
+        // first, then Ctrl+Q; the lifecycle log proves Escape didn't shut
+        // down and only the explicit Ctrl+Q did.
         var (terminal, app, vm) = CreateHeadlessApp(seed: null, out var input);
 
-        input.EnqueueKey(ConsoleKey.Escape);
+        input.EnqueueKey(ConsoleKey.Escape); // idle: no-op
+        input.EnqueueKey(ConsoleKey.Q, false, false, true); // quit
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await app.RunAsync(cts.Token);

--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -175,6 +175,65 @@ public sealed class ChatPageTests
     }
 
     [Fact]
+    public async Task Escape_WithPendingInteraction_DeniesInsteadOfQuitting()
+    {
+        // Regression for #1757: pressing Escape during an approval prompt used
+        // to call RequestAppShutdown() and tear down the whole session. It must
+        // now act as a deny on the pending interaction — the session stays
+        // alive and the deny key is what gets submitted to the daemon.
+        // The ordered event list proves the sequence: Escape submits deny,
+        // and only the explicit Ctrl+Q afterwards shuts the app down.
+        var (terminal, app, vm) = CreateHeadlessApp(BuildApproval(LongShellBody), out var input);
+
+        input.EnqueueKey(ConsoleKey.Escape); // deny the approval
+        input.EnqueueKey(ConsoleKey.Q, false, false, true); // then quit cleanly
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(new[] { "submit:deny", "shutdown" }, vm.LifecycleEvents);
+    }
+
+    [Fact]
+    public async Task Escape_WithNoPendingInteraction_StillQuits()
+    {
+        // Bare Escape with no approval prompt keeps the historical behavior:
+        // it quits the app. Only the approval-prompt case routes to deny.
+        var (terminal, app, vm) = CreateHeadlessApp(seed: null, out var input);
+
+        input.EnqueueKey(ConsoleKey.Escape);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(new[] { "shutdown" }, vm.LifecycleEvents);
+    }
+
+    [Fact]
+    public async Task DenyPendingInteraction_NoDenyOption_DoesNotSubmit()
+    {
+        // If an approval interaction somehow lacks a deny option, denying must
+        // be a no-op rather than submitting an unrelated option — and Escape
+        // must still not quit the session.
+        var noDenyOptions = new[]
+        {
+            new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+            new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel)
+        };
+        var (terminal, app, vm) = CreateHeadlessApp(
+            BuildApproval(LongShellBody), out var input, options: noDenyOptions);
+
+        input.EnqueueKey(ConsoleKey.Escape); // attempt deny
+        input.EnqueueKey(ConsoleKey.Q, false, false, true); // then quit cleanly
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Null(vm.LastSubmittedInteractionKey);
+        Assert.Equal(new[] { "shutdown" }, vm.LifecycleEvents);
+    }
+
+    [Fact]
     public void NewInteraction_ResetsCollapsedState()
     {
         // This case operates directly on the ViewModel — the goal is to
@@ -516,6 +575,28 @@ public sealed class ChatPageTests
     {
         private readonly ToolInteractionRequest? _seed;
 
+        /// <summary>
+        /// Set when the page routes Escape to app shutdown (the pre-#1757
+        /// buggy path). Tests assert this stays false while an approval prompt
+        /// is pending.
+        /// </summary>
+        public bool ShutdownRequested => LifecycleEvents.Contains("shutdown");
+
+        /// <summary>
+        /// Ordered record of ViewModel lifecycle events, in the order they
+        /// happened. Lets tests prove that Escape submitted a deny BEFORE the
+        /// explicit Ctrl+Q quit — the flag alone can't distinguish which key
+        /// requested shutdown.
+        /// </summary>
+        public List<string> LifecycleEvents { get; } = new();
+
+        /// <summary>
+        /// Captures the option key submitted to the daemon. Headless tests
+        /// cannot reach a live daemon, so the submission seam records the key
+        /// the ViewModel resolved and simulates a successful response.
+        /// </summary>
+        public string? LastSubmittedInteractionKey { get; private set; }
+
         public TestChatViewModel(ToolInteractionRequest? seed)
             : base(
                 // 127.0.0.1:1 is never dialed: InitializeSessionAsync is
@@ -538,6 +619,19 @@ public sealed class ChatPageTests
             base.OnActivated();
             if (_seed is not null)
                 SeedPendingInteractionForTesting(_seed);
+        }
+
+        public override void RequestAppShutdown()
+        {
+            LifecycleEvents.Add("shutdown");
+            base.RequestAppShutdown();
+        }
+
+        protected override Task SubmitInteractionSelectionAsync(string selectedKey)
+        {
+            LastSubmittedInteractionKey = selectedKey;
+            LifecycleEvents.Add($"submit:{selectedKey}");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ChatPageTests.cs
@@ -191,7 +191,46 @@ public sealed class ChatPageTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await app.RunAsync(cts.Token);
 
-        Assert.Equal(new[] { "submit:deny", "shutdown" }, vm.LifecycleEvents);
+        Assert.Equal(new[] { "deny:called", "submit:deny", "shutdown" }, vm.LifecycleEvents);
+    }
+
+    [Fact]
+    public async Task Escape_WithPendingInteractionAndStaleGenerating_Denies()
+    {
+        // The reorder fix: a pending approval prompt must win over the
+        // generation-cancel branch even when IsGenerating still reads true
+        // (stale flag race — the daemon output handler clears it on arrival,
+        // but the UI thread can observe the pre-clear value). Pre-fix, Escape
+        // took the IsGenerating arm, swallowed the key, and only quit after a
+        // second Escape; the prompt was never denied.
+        var (terminal, app, vm) = CreateHeadlessApp(
+            BuildApproval(LongShellBody), out var input, startGenerating: true);
+
+        input.EnqueueKey(ConsoleKey.Escape); // deny the approval
+        input.EnqueueKey(ConsoleKey.Q, false, false, true); // then quit cleanly
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(new[] { "deny:called", "submit:deny", "shutdown" }, vm.LifecycleEvents);
+    }
+
+    [Fact]
+    public async Task Escape_WhileGenerating_ShowsStatusInsteadOfQuitting()
+    {
+        // Escape during generation can't cancel the turn yet (separate TODO),
+        // but it must NOT quit the app silently and must NOT eat the key
+        // without feedback — the user gets a status message instead.
+        var (terminal, app, vm) = CreateHeadlessApp(seed: null, out var input, startGenerating: true);
+
+        input.EnqueueKey(ConsoleKey.Escape); // no-op + status message
+        input.EnqueueKey(ConsoleKey.Q, false, false, true); // quit cleanly
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(new[] { "shutdown" }, vm.LifecycleEvents);
+        Assert.Contains("cancel", vm.StatusMessage.Value, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -230,7 +269,11 @@ public sealed class ChatPageTests
         await app.RunAsync(cts.Token);
 
         Assert.Null(vm.LastSubmittedInteractionKey);
-        Assert.Equal(new[] { "shutdown" }, vm.LifecycleEvents);
+        // The "deny:called" marker proves Escape routed to the deny path even
+        // though the interaction carried no deny option — the no-op branch
+        // ran, and nothing bogus was submitted. Without the marker this test
+        // would pass vacuously even if the page never called deny at all.
+        Assert.Equal(new[] { "deny:called", "shutdown" }, vm.LifecycleEvents);
     }
 
     [Fact]
@@ -530,7 +573,8 @@ public sealed class ChatPageTests
     private static (VirtualTerminal Terminal, TerminaApplication App, TestChatViewModel Vm)
         CreateHeadlessApp(ToolInteractionRequest? seed, out VirtualInputSource input,
             int width = 120, int height = 40,
-            IReadOnlyList<ToolInteractionOption>? options = null)
+            IReadOnlyList<ToolInteractionOption>? options = null,
+            bool startGenerating = false)
     {
         var terminal = new VirtualTerminal(width, height);
         var virtualInput = new VirtualInputSource();
@@ -553,7 +597,7 @@ public sealed class ChatPageTests
                         : options is null
                             ? seed
                             : seed with { Options = options };
-                    capturedVm = new TestChatViewModel(effectiveSeed);
+                    capturedVm = new TestChatViewModel(effectiveSeed, startGenerating);
                     return capturedVm;
                 });
         });
@@ -574,6 +618,7 @@ public sealed class ChatPageTests
     private sealed class TestChatViewModel : ChatViewModel
     {
         private readonly ToolInteractionRequest? _seed;
+        private readonly bool _startGenerating;
 
         /// <summary>
         /// Set when the page routes Escape to app shutdown (the pre-#1757
@@ -597,7 +642,7 @@ public sealed class ChatPageTests
         /// </summary>
         public string? LastSubmittedInteractionKey { get; private set; }
 
-        public TestChatViewModel(ToolInteractionRequest? seed)
+        public TestChatViewModel(ToolInteractionRequest? seed, bool startGenerating = false)
             : base(
                 // 127.0.0.1:1 is never dialed: InitializeSessionAsync is
                 // overridden to no-op, so the underlying HubConnection stays
@@ -610,6 +655,7 @@ public sealed class ChatPageTests
                 new NetclawPaths())
         {
             _seed = seed;
+            _startGenerating = startGenerating;
         }
 
         protected override Task InitializeSessionAsync() => Task.CompletedTask;
@@ -619,12 +665,23 @@ public sealed class ChatPageTests
             base.OnActivated();
             if (_seed is not null)
                 SeedPendingInteractionForTesting(_seed);
+            // Simulate the stale-flag race: IsGenerating can still read true
+            // right after an interaction lands (the daemon output handler
+            // clears it, but the UI thread can observe the pre-clear value).
+            if (_startGenerating)
+                IsGenerating.Value = true;
         }
 
         public override void RequestAppShutdown()
         {
             LifecycleEvents.Add("shutdown");
             base.RequestAppShutdown();
+        }
+
+        internal override Task DenyPendingInteractionAsync()
+        {
+            LifecycleEvents.Add("deny:called");
+            return base.DenyPendingInteractionAsync();
         }
 
         protected override Task SubmitInteractionSelectionAsync(string selectedKey)

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -298,10 +298,10 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
             return;
         }
 
-        // Escape: cancel or quit. With an approval prompt up, Escape denies
-        // the pending interaction (Termina's default "cancel" semantics, and
-        // the convention every other NetClaw page follows) instead of tearing
-        // down the whole session (#1757). Bare Escape only quits when idle.
+        // Escape is a cancel key everywhere — never quits. With an approval
+        // prompt up it denies the pending interaction (#1757); while
+        // generating it shows a status message (cancel not supported yet);
+        // idle it's a no-op. Ctrl+Q is the only quit affordance.
         if (keyInfo.Key == ConsoleKey.Escape)
         {
             // A pending approval prompt always takes precedence. IsGenerating
@@ -323,10 +323,7 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 ViewModel.StatusMessage.Value = "Cancel generation is not supported yet.";
                 ViewModel.RequestRedraw();
             }
-            else
-            {
-                ViewModel.RequestAppShutdown();
-            }
+            // else: idle — no-op. The status bar advertises [Ctrl+Q] Quit.
 
             return;
         }

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -298,12 +298,19 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
             return;
         }
 
-        // Escape: cancel or quit
+        // Escape: cancel or quit. With an approval prompt up, Escape denies
+        // the pending interaction (Termina's default "cancel" semantics, and
+        // the convention every other NetClaw page follows) instead of tearing
+        // down the whole session (#1757). Bare Escape only quits when idle.
         if (keyInfo.Key == ConsoleKey.Escape)
         {
             if (ViewModel.IsGenerating.Value)
             {
                 // TODO: cancel generation when supported
+            }
+            else if (ViewModel.HasPendingInteraction)
+            {
+                _ = ViewModel.DenyPendingInteractionAsync();
             }
             else
             {

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -304,13 +304,24 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         // down the whole session (#1757). Bare Escape only quits when idle.
         if (keyInfo.Key == ConsoleKey.Escape)
         {
-            if (ViewModel.IsGenerating.Value)
+            // A pending approval prompt always takes precedence. IsGenerating
+            // is cleared when a ToolInteractionRequest arrives, but the UI
+            // thread can observe a stale value, so the prompt check must come
+            // first — otherwise Escape gets swallowed by the generation-cancel
+            // TODO branch and the user has to press it again.
+            if (ViewModel.HasPendingInteraction)
             {
-                // TODO: cancel generation when supported
-            }
-            else if (ViewModel.HasPendingInteraction)
-            {
+                // Fire-and-forget is safe: SubmitInteractionSelectionAsync
+                // catches daemon exceptions internally and re-presents the
+                // prompt (or shows a reconnect status) on failure.
                 _ = ViewModel.DenyPendingInteractionAsync();
+            }
+            else if (ViewModel.IsGenerating.Value)
+            {
+                // TODO: cancel generation when supported (#1757 follow-up).
+                // For now, tell the user instead of silently eating the key.
+                ViewModel.StatusMessage.Value = "Cancel generation is not supported yet.";
+                ViewModel.RequestRedraw();
             }
             else
             {

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -214,7 +214,7 @@ public partial class ChatViewModel : ReactiveViewModel
         }
     }
 
-    public void RequestAppShutdown()
+    public virtual void RequestAppShutdown()
     {
         Shutdown();
     }
@@ -276,6 +276,27 @@ public partial class ChatViewModel : ReactiveViewModel
             return Task.CompletedTask;
 
         return SubmitInteractionSelectionAsync(option.Key.Value);
+    }
+
+    /// <summary>
+    /// Denies the current pending approval interaction, if one exists.
+    /// Maps to the first-class <see cref="ApprovalOptionKeys.Deny"/> wire key,
+    /// so the session records a hard refusal of this call only (no ban on the
+    /// verb for future invocations). Called by the TUI when the user presses
+    /// Escape while an approval prompt is up — Escape means "cancel the
+    /// dialog", not "quit the app" (#1757).
+    /// </summary>
+    public virtual Task DenyPendingInteractionAsync()
+    {
+        if (CurrentInteraction is null)
+            return Task.CompletedTask;
+
+        var denyOption = CurrentInteraction.Options.FirstOrDefault(candidate =>
+            string.Equals(candidate.Key.Value, ApprovalOptionKeys.Deny, StringComparison.Ordinal));
+        if (denyOption is null)
+            return Task.CompletedTask;
+
+        return SubmitInteractionSelectionAsync(denyOption.Key.Value);
     }
 
     /// <summary>
@@ -513,7 +534,7 @@ public partial class ChatViewModel : ReactiveViewModel
         RequestRedraw();
     }
 
-    private async Task SubmitInteractionSelectionAsync(string selectedKey)
+    protected virtual async Task SubmitInteractionSelectionAsync(string selectedKey)
     {
         if (CurrentInteraction is null)
             return;

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -38,6 +38,15 @@ public partial class ChatViewModel : ReactiveViewModel
     private readonly Subject<SessionOutput> _outputSubject = new();
     private readonly Queue<string> _pendingMessages = new();
     private readonly Queue<ToolInteractionRequest> _pendingInteractions = new();
+
+    /// <summary>
+    /// True while an interaction response is in flight to the daemon. Guards
+    /// against duplicate submissions (e.g. Escape + Enter pressed back to
+    /// back) so only one <see cref="ToolInteractionResponse"/> is sent per
+    /// interaction. Released on success (interaction dequeued) and on failure
+    /// (prompt re-presented for retry) alike.
+    /// </summary>
+    private bool _isSubmittingInteraction;
     private IDisposable? _daemonOutputSubscription;
     private IDisposable? _daemonConnectionSubscription;
     // Per-session USAGE log writer. Mirrors HeadlessChannel's writer so the
@@ -286,7 +295,7 @@ public partial class ChatViewModel : ReactiveViewModel
     /// Escape while an approval prompt is up — Escape means "cancel the
     /// dialog", not "quit the app" (#1757).
     /// </summary>
-    public virtual Task DenyPendingInteractionAsync()
+    internal virtual Task DenyPendingInteractionAsync()
     {
         if (CurrentInteraction is null)
             return Task.CompletedTask;
@@ -539,6 +548,9 @@ public partial class ChatViewModel : ReactiveViewModel
         if (CurrentInteraction is null)
             return;
 
+        if (_isSubmittingInteraction)
+            return;
+
         if (!_sessionReady || !_daemonClient.IsConnected)
         {
             StatusMessage.Value = "Approval required. Reconnecting...";
@@ -551,6 +563,7 @@ public partial class ChatViewModel : ReactiveViewModel
 
         try
         {
+            _isSubmittingInteraction = true;
             await _daemonClient.EnsureSessionAsync(DaemonClient.TuiChannelType);
             await _daemonClient.RespondToInteractionAsync(pending.CallId.Value, selectedKey);
 
@@ -569,6 +582,10 @@ public partial class ChatViewModel : ReactiveViewModel
             StatusMessage.Value = $"Approval response failed ({ex.Message}). Reconnecting...";
             RequestRedraw();
             _ = ConnectUntilReadyAsync();
+        }
+        finally
+        {
+            _isSubmittingInteraction = false;
         }
     }
 


### PR DESCRIPTION
Fixes #1757.

## Problem
Pressing Escape while an approval prompt is up in `netclaw chat` calls `RequestAppShutdown()` and tears down the whole session. The pending interaction dies with the process — neither approved nor denied.

## Fix
In `ChatPage.HandleKeyPress`, when `HasPendingInteraction` is true, Escape now routes to the first-class `Deny` option instead of quitting:

- `ChatViewModel.DenyPendingInteractionAsync()` resolves the `ApprovalOptionKeys.Deny` option and submits it through the existing interaction-response path.
- Bare Escape (no prompt, not generating) still quits, preserving the historical behavior.
- Generation-cancel remains a separate TODO (unchanged).

This matches Termina's default "cancel" semantics and the convention every other NetClaw page follows (Escape = back/cancel, never quit).

## Tests
- `Escape_WithPendingInteraction_DeniesInsteadOfQuitting` — proves Escape submits `deny` and only the explicit Ctrl+Q shuts down (ordered event log).
- `Escape_WithNoPendingInteraction_StillQuits` — bare Escape keeps quitting.
- `DenyPendingInteraction_NoDenyOption_DoesNotSubmit` — a prompt without a deny option is a safe no-op, no quit, no bogus submit.

Full `Netclaw.Cli.Tests` suite: 1286/1286 passing. Build: 0 warnings, 0 errors.