### PR TITLE
test: verify callers preserve capability overrides

### DIFF
--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -479,6 +479,33 @@ public sealed class ModelCommandTests : IDisposable
         Assert.Equal(65536, main.GetProperty("ContextWindow").GetInt32());
     }
 
+    [Theory]
+    [InlineData("ContextWindow", "65536")]
+    [InlineData("InputModalities", "Text, Image")]
+    [InlineData("OutputModalities", "Text, Audio")]
+    public async Task Set_SameModelWithoutCapabilityOptions_PreservesStoredCapability(
+        string propertyName,
+        string expectedValue)
+    {
+        WriteConfig(WithMainEntry(new Dictionary<string, object>
+        {
+            ["Provider"] = "my-ollama",
+            ["ModelId"] = "qwen3:30b",
+            ["ContextWindow"] = 65536,
+            ["InputModalities"] = "Text, Image",
+            ["OutputModalities"] = "Text, Audio"
+        }));
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b"],
+            _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+        using var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var main = ReadActiveModel(config, "Main");
+        Assert.Equal(expectedValue, main.GetProperty(propertyName).ToString());
+    }
+
     [Fact]
     public async Task Set_ClearContextWindow_RemovesStoredClamp()
     {

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -212,6 +212,50 @@ public sealed class ModelManagerViewModelTests : IDisposable
         Assert.False(main.TryGetProperty("OutputModalities", out _));
     }
 
+    [Theory]
+    [InlineData("ContextWindow", "65536")]
+    [InlineData("InputModalities", "Text, Image")]
+    [InlineData("OutputModalities", "Text, Audio")]
+    public async Task ConfirmAssignment_SameModelWithoutCapabilityControls_PreservesStoredCapability(
+        string propertyName,
+        string expectedValue)
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            },
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "model-a",
+                    ["ContextWindow"] = 65536,
+                    ["InputModalities"] = "Text, Image",
+                    ["OutputModalities"] = "Text, Audio"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+        vm.StartAssignment("Main");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        vm.SelectModel("model-a");
+        vm.ConfirmAssignment();
+
+        using var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var main = ReadActiveModel(config, "Main");
+        Assert.Equal(expectedValue, main.GetProperty(propertyName).ToString());
+    }
+
     [Fact]
     public async Task StartAssignment_WhenProbeThrows_ReportsFailureAndStopsProbing()
     {

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -270,6 +270,62 @@ public sealed class ProviderStepViewModelTests : IDisposable
         Assert.False(main.ContainsKey("OutputModalities"));
     }
 
+    [Theory]
+    [InlineData("ContextWindow", "65536")]
+    [InlineData("InputModalities", "Text, Image")]
+    [InlineData("OutputModalities", "Text, Audio")]
+    public void ContributeConfig_SameModelWithoutCapabilityControls_PreservesStoredCapability(
+        string propertyName,
+        string expectedValue)
+    {
+        File.WriteAllText(_context.Paths.NetclawConfigPath, System.Text.Json.JsonSerializer.Serialize(
+            new Dictionary<string, object>
+            {
+                ["configVersion"] = 1,
+                ["Providers"] = new Dictionary<string, object>
+                {
+                    ["openai"] = new Dictionary<string, object>
+                    {
+                        ["Type"] = "openai",
+                        ["AuthMethod"] = "OAuthDevice"
+                    }
+                },
+                ["Models"] = new Dictionary<string, object>
+                {
+                    ["Main"] = new Dictionary<string, object>
+                    {
+                        ["Provider"] = "openai",
+                        ["ModelId"] = "gpt-new-codex",
+                        ["ContextWindow"] = 65536,
+                        ["InputModalities"] = "Text, Image",
+                        ["OutputModalities"] = "Text, Audio"
+                    }
+                }
+            }));
+
+        using var step = new ProviderStepViewModel(_registry, _fakeProbe);
+        step.SelectedProviderType = "OpenAI";
+        step.SelectedAuthMethod = AuthMethod.OAuthDevice;
+        step.SelectedModelId = "gpt-new-codex";
+        step.DiscoveredModels.Add(new DiscoveredModel
+        {
+            ModelId = new Netclaw.Configuration.ModelId("gpt-new-codex"),
+            ContextWindowTokens = 512000,
+            InputModalities = ModelModality.Text,
+            OutputModalities = ModelModality.Text,
+        });
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        var config = builder.BuildConfigDictionary();
+        var models = (Dictionary<string, object>)config["Models"];
+        var roles = (Dictionary<string, object>)models["Roles"];
+        var definitions = (Dictionary<string, object>)models["Definitions"];
+        var main = (Dictionary<string, object>)definitions[(string)roles["Main"]];
+        Assert.Equal(expectedValue, main[propertyName].ToString());
+    }
+
     [Fact]
     public void GitHubCopilotPublicHost_ContributeConfig_EmitsNoVendorOptions()
     {


### PR DESCRIPTION
## Summary

PR #1761 fixed model capability ownership. This follow-up tests each public caller at its boundary.

Each theory starts with stored operator overrides. The caller then selects the same model without capability controls. The test proves that the stored value remains.

The theories cover:

- `netclaw model set`
- the TUI model manager
- the init wizard

Each theory covers:

- `ContextWindow`
- `InputModalities`
- `OutputModalities`

A future `Unset` to `Clear` regression will remove a seeded property. The related theory case will fail.

## Validation

- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --no-build`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`