### PR TITLE
fix(slack): render <@user>, <@subteam^group> and <#channel> mentions as rich-text elements

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -454,7 +454,31 @@ public class SlackBlockConverterTests
         var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
 
         var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
-        Assert.Equal("subteam^S0123ABC", group.UserGroupId);
+        Assert.Equal("S0123ABC", group.UserGroupId);
+    }
+
+    [Fact]
+    public void UserGroupMention_WithLabel_ProducesRichTextUserGroup()
+    {
+        var blocks = SlackBlockConverter.Convert("Heads up <@subteam^S0123ABC|@eng-team>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
+        Assert.Equal("S0123ABC", group.UserGroupId);
+    }
+
+    [Fact]
+    public void UserGroupMention_DocumentedBangForm_ProducesRichTextUserGroup()
+    {
+        var blocks = SlackBlockConverter.Convert("Heads up <!subteam^S0123ABC>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
+        Assert.Equal("S0123ABC", group.UserGroupId);
     }
 
     [Fact]
@@ -467,6 +491,18 @@ public class SlackBlockConverterTests
 
         var channel = Assert.Single(section.Elements.OfType<RichTextChannel>());
         Assert.Equal("C0AM51E342X", channel.ChannelId);
+    }
+
+    [Fact]
+    public void ChannelMention_PrivateChannel_ProducesRichTextChannel()
+    {
+        var blocks = SlackBlockConverter.Convert("See <#G0AM51E342X|private>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var channel = Assert.Single(section.Elements.OfType<RichTextChannel>());
+        Assert.Equal("G0AM51E342X", channel.ChannelId);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SlackBlockConverterTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -415,5 +415,70 @@ public class SlackBlockConverterTests
             .FirstOrDefault(e => e.Style is { Bold: true, Italic: true });
         Assert.NotNull(styled);
         Assert.Equal("bold and italic", styled.Text);
+    }
+
+    [Fact]
+    public void UserMention_ProducesRichTextUser()
+    {
+        var blocks = SlackBlockConverter.Convert("Ping <@U01SU57E553> when ready");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var user = Assert.Single(section.Elements.OfType<RichTextUser>());
+        Assert.Equal("U01SU57E553", user.UserId);
+
+        var texts = section.Elements.OfType<RichTextText>().ToList();
+        Assert.Equal("Ping ", texts[0].Text);
+        Assert.Equal(" when ready", texts[1].Text);
+    }
+
+    [Fact]
+    public void UserMention_WithLabel_ProducesRichTextUser()
+    {
+        var blocks = SlackBlockConverter.Convert("Thanks <@U01SU57E553|david>!");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var user = Assert.Single(section.Elements.OfType<RichTextUser>());
+        Assert.Equal("U01SU57E553", user.UserId);
+    }
+
+    [Fact]
+    public void UserGroupMention_ProducesRichTextUserGroup()
+    {
+        var blocks = SlackBlockConverter.Convert("Heads up <@subteam^S0123ABC>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var group = Assert.Single(section.Elements.OfType<RichTextUserGroup>());
+        Assert.Equal("subteam^S0123ABC", group.UserGroupId);
+    }
+
+    [Fact]
+    public void ChannelMention_ProducesRichTextChannel()
+    {
+        var blocks = SlackBlockConverter.Convert("Posted in <#C0AM51E342X> already");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var channel = Assert.Single(section.Elements.OfType<RichTextChannel>());
+        Assert.Equal("C0AM51E342X", channel.ChannelId);
+    }
+
+    [Fact]
+    public void UserMention_InListItem_ProducesRichTextUser()
+    {
+        var blocks = SlackBlockConverter.Convert("- David: approve <@U01SU57E553>");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var list = Assert.Single(rtb.Elements.OfType<RichTextList>());
+        var item = list.Elements[0];
+
+        var user = Assert.Single(item.Elements.OfType<RichTextUser>());
+        Assert.Equal("U01SU57E553", user.UserId);
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SlackBlockConverter.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -277,6 +277,20 @@ public static partial class SlackBlockConverter
                 : new RichTextLink { Url = url };
         });
 
+        // Slack-native mentions passed through by the agent: <@U...>
+        // user, <@subteam^S...> user group, <#C...> channel. Without
+        // explicit rich-text elements the Block Kit surface renders
+        // the syntax as literal text (the mrkdwn Text fallback handles
+        // them natively, but blocks win on every modern client).
+        TryMatch(UserMentionRegex(), text, ref best, (m) =>
+            new RichTextUser { UserId = m.Groups[1].Value });
+
+        TryMatch(UserGroupMentionRegex(), text, ref best, (m) =>
+            new RichTextUserGroup { UserGroupId = m.Groups[1].Value });
+
+        TryMatch(ChannelMentionRegex(), text, ref best, (m) =>
+            new RichTextChannel { ChannelId = m.Groups[1].Value });
+
         if (best.Element is null)
             return (0, 0, null, null);
 
@@ -357,4 +371,17 @@ public static partial class SlackBlockConverter
     // Ordered list prefix: 1. or 2. etc.
     [GeneratedRegex(@"^\d+\.\s")]
     private static partial Regex OrderedListPrefix();
+
+    // Slack user mention: <@U0123ABC> or <@W0123ABC>, optionally with a
+    // fallback label (<@U0123ABC|david>).
+    [GeneratedRegex(@"<@([UW][0-9A-Z]+)(?:\|[^>]+)?>")]
+    private static partial Regex UserMentionRegex();
+
+    // Slack user-group mention: <@subteam^S0123ABC>.
+    [GeneratedRegex(@"<@(subteam\^[S0-9A-Z]+)>")]
+    private static partial Regex UserGroupMentionRegex();
+
+    // Slack channel mention: <#C0123ABC>, optionally with a label.
+    [GeneratedRegex(@"<#(C[0-9A-Z]+)(?:\|[^>]+)?>")]
+    private static partial Regex ChannelMentionRegex();
 }

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -377,11 +377,16 @@ public static partial class SlackBlockConverter
     [GeneratedRegex(@"<@([UW][0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex UserMentionRegex();
 
-    // Slack user-group mention: <@subteam^S0123ABC>.
-    [GeneratedRegex(@"<@(subteam\^[S0-9A-Z]+)>")]
+    // Slack user-group mention: <!subteam^S0123ABC> (the form Slack
+    // documents and emits) or <@subteam^S0123ABC> (agent-style),
+    // optionally with a fallback label (<!subteam^S0123ABC|@eng-team>).
+    // Captures the bare group ID only — Slack's usergroup_id does not
+    // include the subteam^ prefix.
+    [GeneratedRegex(@"<[!@]subteam\^([0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex UserGroupMentionRegex();
 
-    // Slack channel mention: <#C0123ABC>, optionally with a label.
-    [GeneratedRegex(@"<#(C[0-9A-Z]+)(?:\|[^>]+)?>")]
+    // Slack channel mention: <#C0123ABC> or <#G0123ABC> (private channels
+    // and group DMs), optionally with a label.
+    [GeneratedRegex(@"<#([CGD][0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex ChannelMentionRegex();
 }


### PR DESCRIPTION
Supersedes #1759 by @CumpsD — this branch contains the author's original commit (`b5fe6276`) unchanged, plus follow-up fixes on top. All credit for the feature goes to @CumpsD.

**Original feature (by @CumpsD):** renders Slack user, user-group, and channel mentions as Block Kit rich-text elements instead of literal text.

**Follow-up fixes (from review of #1759):**
- `usergroup_id` now carries the bare group ID (`S0123ABC`) — the `subteam^` prefix was being baked into the field, which Slack won't resolve ([usergroup element docs](https://docs.slack.dev/reference/block-kit/block-elements/usergroup-element/))
- User-group regex now also matches the labeled form (`<@subteam^S123|@eng-team>`) and the documented bang form `<!subteam^S123>` ([formatting docs](https://docs.slack.dev/messaging/formatting-message-text/))
- Channel regex now covers `G`/`D`-prefixed conversation IDs (private channels, group DMs), not just `C`

**Tests:** 5 new tests in `SlackBlockConverterTests` (user, labeled user, user-group, labeled user-group, bang-form user-group, channel, private channel, in-list-item). All 33 SlackBlockConverter tests pass locally.