### PR TITLE
Use the reminder actor clock in the expiry test

### DIFF
--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -855,7 +855,7 @@ public class ReminderManagerActorTests : TestKit
     public async Task Expired_reminder_disabled_on_fire_without_executing()
     {
         var manager = await GetManagerAsync();
-        var now = TimeProvider.System.GetUtcNow();
+        var now = _timeProvider.GetUtcNow();
 
         // Drain PreStart reconcile
         await manager.Ask<ReminderManagerActor.ReconcileCompleted>(


### PR DESCRIPTION
## Summary

- Use the reminder actor's `FakeTimeProvider` in the expiry test.
- Remove the comparison between a frozen actor clock and the system clock.

## Cause

PR #1766 exposed this race in the macOS CI job.

The test created `ExpiresAt` from `TimeProvider.System`. The actor compared that value against its injected `FakeTimeProvider`.

Clock drift could place the test expiry after the actor's frozen time. The actor then started an execution instead of disabling the reminder.

The fix derives the test time from the same fake clock. It does not increase a timeout or add a delay.

## Validation

- The focused test passed 20 consecutive runs.
- All 2,759 Netclaw.Actors tests passed.
- The full solution test run passed. Opt-in integration tests skipped as configured.
- `dotnet slopwatch analyze` passed with zero issues.
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` passed.
- `git diff --check` passed.
