### PR TITLE
fix(mcp): detect live tool catalog changes on connected servers

### DIFF
--- a/src/Netclaw.Cli.Tests/Mcp/McpOAuthEndToEndTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpOAuthEndToEndTests.cs
@@ -135,6 +135,19 @@ public sealed class McpOAuthEndToEndTests : IDisposable
             return new McpClientInitialization(tools.Cast<AIFunction>().ToList());
         }
 
+        public ValueTask<IReadOnlyList<AIFunction>> ListToolsAsync(
+            McpClient client,
+            CancellationToken cancellationToken)
+            => ListToolsCoreAsync(client, cancellationToken);
+
+        private async ValueTask<IReadOnlyList<AIFunction>> ListToolsCoreAsync(
+            McpClient client,
+            CancellationToken cancellationToken)
+        {
+            var tools = await client.ListToolsAsync(cancellationToken: cancellationToken);
+            return tools.Cast<AIFunction>().ToList();
+        }
+
         public ValueTask<object?> InvokeAsync(
             AIFunction function,
             AIFunctionArguments? arguments,

--- a/src/Netclaw.Daemon.Tests/Mcp/McpCatalogRefreshTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpCatalogRefreshTests.cs
@@ -1,0 +1,215 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpCatalogRefreshTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Daemon.Mcp;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+public sealed class McpCatalogRefreshTests
+{
+    private static readonly McpServerName ServerName = new("test");
+    private static readonly DateTimeOffset InitialTime = DateTimeOffset.Parse("2026-07-22T12:00:00Z");
+
+    [Fact]
+    public async Task CatalogChange_RepublishesSnapshotAndGeneration()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("old_tool"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        // Connect marked the catalog fresh; the throttle must elapse before a refresh.
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        plan.ToolNames = ["old_tool", "new_tool"];
+        Assert.True(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+
+        var snapshot = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(2, snapshot.Generation);
+        Assert.Equal(2, snapshot.ToolFunctions.Count);
+        Assert.Equal(2, snapshot.Status.ToolCount);
+        Assert.Equal(1, plan.RefreshCount);
+        Assert.Equal(1, runtime.CreateCount); // no reconnect
+        AssertPublishedTools(harness, "new_tool", "old_tool");
+    }
+
+    [Fact]
+    public async Task NoCatalogChange_DoesNotBumpGeneration()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("stable_tool"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+
+        var snapshot = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(1, snapshot.Generation);
+        Assert.Equal(1, plan.RefreshCount);
+        Assert.Equal(1, runtime.CreateCount);
+        AssertPublishedTools(harness, "stable_tool");
+    }
+
+    [Fact]
+    public async Task RefreshIsThrottledWithinInterval()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("tool_a"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        // First refresh immediately after connect is throttled (connect marked it fresh).
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        plan.ToolNames = ["tool_a", "tool_b"];
+        Assert.True(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+
+        // Second refresh within the interval is throttled even though the catalog changed.
+        plan.ToolNames = ["tool_a", "tool_b", "tool_c"];
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+
+        var snapshot = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(2, snapshot.Generation);
+        Assert.Equal(1, plan.RefreshCount); // only the middle call actually re-listed
+    }
+
+    [Fact]
+    public async Task FailedRefresh_KeepsLastGoodCatalogAndGeneration()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("old_tool"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        plan.ListFailure = new InvalidOperationException("server blew up");
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+        Assert.Equal(1, plan.RefreshCount); // prove the failure path actually ran
+
+        var snapshot = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(1, snapshot.Generation);
+        Assert.Equal("old_tool", Assert.Single(snapshot.ToolFunctions).Key);
+        Assert.Equal(McpConnectionState.Connected, snapshot.Status.State);
+        AssertPublishedTools(harness, "old_tool");
+    }
+
+    [Fact]
+    public async Task FailedRefresh_RollsBackThrottleSoNextTickRetries()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("tool_a"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        plan.ListFailure = new InvalidOperationException("transient");
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+        Assert.Equal(1, plan.RefreshCount);
+
+        // The claim was rolled back, so a 30s advance allows an immediate retry rather
+        // than forcing a 5-minute wait. Catalog is unchanged, so no generation bump.
+        plan.ListFailure = null;
+        time.Advance(TimeSpan.FromSeconds(30));
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+        Assert.Equal(2, plan.RefreshCount);
+        Assert.Equal(1, harness.Manager.GetSnapshot(ServerName)?.Generation);
+    }
+
+    [Fact]
+    public async Task EmptyCatalogRefresh_KeepsLastGoodTools()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("tool_a", "tool_b"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        plan.ToolNames = []; // server now reports no tools
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+
+        var snapshot = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(1, snapshot.Generation);
+        Assert.Equal(2, snapshot.ToolFunctions.Count);
+        Assert.Equal(McpConnectionState.Connected, snapshot.Status.State);
+        AssertPublishedTools(harness, "tool_a", "tool_b");
+    }
+
+    [Fact]
+    public async Task RefreshOnUnknownServer_IsNoOp()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("tool_a"));
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(new McpServerName("missing"), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Fingerprint_IgnoresToolOrder()
+    {
+        var a = AIFunctionFactory.Create(() => "unused", name: "tool_a", description: "desc");
+        var b = AIFunctionFactory.Create(() => "unused", name: "tool_b", description: "desc");
+
+        Assert.Equal(
+            McpClientManager.ComputeCatalogFingerprint([a, b]),
+            McpClientManager.ComputeCatalogFingerprint([b, a]));
+    }
+
+    [Fact]
+    public void Fingerprint_ChangesOnDescriptionOrToolAdd()
+    {
+        var baseline = AIFunctionFactory.Create(() => "unused", name: "tool", description: "desc");
+        var newDescription = AIFunctionFactory.Create(() => "unused", name: "tool", description: "changed");
+        var addedTool = AIFunctionFactory.Create(() => "unused", name: "other", description: "desc");
+
+        var baselineHash = McpClientManager.ComputeCatalogFingerprint([baseline]);
+        Assert.NotEqual(baselineHash, McpClientManager.ComputeCatalogFingerprint([newDescription]));
+        Assert.NotEqual(baselineHash, McpClientManager.ComputeCatalogFingerprint([baseline, addedTool]));
+    }
+
+    [Fact]
+    public void CanonicalSchema_IgnoresKeyOrderAndWhitespace()
+    {
+        var a = JsonDocument.Parse("""{"z":1,"a":{"y":true,"b":"x"}}""").RootElement;
+        var b = JsonDocument.Parse(""" { "a": { "b": "x", "y": true }, "z": 1 } """).RootElement;
+
+        Assert.Equal(McpClientManager.CanonicalSchema(a), McpClientManager.CanonicalSchema(b));
+    }
+
+    [Fact]
+    public void CanonicalSchema_ChangesOnSchemaEdit()
+    {
+        var a = JsonDocument.Parse("""{"type":"object","properties":{"a":{"type":"number"}}}""").RootElement;
+        var b = JsonDocument.Parse("""{"type":"object","properties":{"a":{"type":"string"}}}""").RootElement;
+
+        Assert.NotEqual(McpClientManager.CanonicalSchema(a), McpClientManager.CanonicalSchema(b));
+    }
+
+    private static void AssertPublishedTools(McpClientManagerLifecycleTests.ManagerHarness harness, params string[] expected)
+    {
+        Assert.Equal(expected, harness.Manager.GetToolNames(ServerName));
+        Assert.Equal(expected.Length, harness.Manager.GetServerStatuses()[ServerName].ToolCount);
+    }
+
+    private static McpClientManagerLifecycleTests.ManagerHarness CreateHarness(McpClientManagerLifecycleTests.ControlledMcpClientRuntime runtime)
+        => new(runtime, new FakeTimeProvider(InitialTime));
+
+    private static McpClientManagerLifecycleTests.ManagerHarness CreateHarness(
+        McpClientManagerLifecycleTests.ControlledMcpClientRuntime runtime,
+        FakeTimeProvider time)
+        => new(runtime, time);
+}

--- a/src/Netclaw.Daemon.Tests/Mcp/McpCatalogRefreshTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpCatalogRefreshTests.cs
@@ -148,6 +148,40 @@ public sealed class McpCatalogRefreshTests
     }
 
     [Fact]
+    public async Task EmptyCatalogRefresh_RollsBackThrottleSoNextTickRetries()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new McpClientManagerLifecycleTests.ClientPlan("tool_a", "tool_b"));
+        var time = new FakeTimeProvider(InitialTime);
+        await using var harness = CreateHarness(runtime, time);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        time.Advance(McpClientManager.CatalogRefreshInterval);
+        plan.ToolNames = []; // server now reports no tools
+        Assert.False(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+        Assert.Equal(1, plan.RefreshCount);
+
+        // The last-good, previously non-empty catalog stays published.
+        var snapshotAfterEmpty = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(1, snapshotAfterEmpty.Generation);
+        Assert.Equal(2, snapshotAfterEmpty.ToolFunctions.Count);
+        AssertPublishedTools(harness, "tool_a", "tool_b");
+
+        // The claim was rolled back, so a 30s advance allows an immediate retry rather
+        // than forcing a 5-minute wait. The server recovers with a changed catalog, so
+        // the re-list runs and the snapshot generation bumps.
+        plan.ToolNames = ["tool_a", "tool_b", "tool_c"];
+        time.Advance(TimeSpan.FromSeconds(30));
+        Assert.True(await harness.Manager.TryRefreshCatalogAsync(ServerName, TestContext.Current.CancellationToken));
+        Assert.Equal(2, plan.RefreshCount);
+
+        var snapshotAfterRecovery = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
+        Assert.Equal(2, snapshotAfterRecovery.Generation);
+        Assert.Equal(3, snapshotAfterRecovery.ToolFunctions.Count);
+        AssertPublishedTools(harness, "tool_a", "tool_b", "tool_c");
+    }
+
+    [Fact]
     public async Task RefreshOnUnknownServer_IsNoOp()
     {
         var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();

--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
@@ -487,11 +487,18 @@ public sealed class McpClientManagerLifecycleTests
         IOperationalNotificationSink notificationSink)
         => new(runtime, timeProvider, notificationSink);
 
-    private sealed class ManagerHarness : IAsyncDisposable
+    internal sealed class ManagerHarness : IAsyncDisposable
     {
         private readonly McpOAuthFlowBroker _flowBroker;
         private bool _stopFailureObserved;
         private bool _managerDisposed;
+
+        public ManagerHarness(
+            ControlledMcpClientRuntime runtime,
+            FakeTimeProvider timeProvider)
+            : this(runtime, timeProvider, NullNotificationSink.Instance)
+        {
+        }
 
         public ManagerHarness(
             ControlledMcpClientRuntime runtime,
@@ -555,7 +562,7 @@ public sealed class McpClientManagerLifecycleTests
         }
     }
 
-    private sealed class ControlledMcpClientRuntime : IMcpClientRuntime
+    internal sealed class ControlledMcpClientRuntime : IMcpClientRuntime
     {
         private readonly ConcurrentQueue<ClientPlan> _plans = new();
         private readonly ConcurrentDictionary<McpClient, ClientPlan> _clients = new();
@@ -598,6 +605,23 @@ public sealed class McpClientManagerLifecycleTests
             if (plan.Initialize is not null)
                 await plan.Initialize(cancellationToken);
 
+            var functions = BuildFunctions(plan);
+            return new McpClientInitialization(functions.Values.ToList());
+        }
+
+        public ValueTask<IReadOnlyList<AIFunction>> ListToolsAsync(
+            McpClient client,
+            CancellationToken cancellationToken)
+        {
+            var plan = _clients[client];
+            Interlocked.Increment(ref plan.RefreshCountStorage);
+            if (plan.ListFailure is not null)
+                return ValueTask.FromException<IReadOnlyList<AIFunction>>(plan.ListFailure);
+            return ValueTask.FromResult<IReadOnlyList<AIFunction>>(BuildFunctions(plan).Values.ToList());
+        }
+
+        private IReadOnlyDictionary<string, AIFunction> BuildFunctions(ClientPlan plan)
+        {
             var functions = new Dictionary<string, AIFunction>(StringComparer.OrdinalIgnoreCase);
             foreach (var name in plan.ToolNames)
             {
@@ -606,7 +630,7 @@ public sealed class McpClientManagerLifecycleTests
                 _functions[function] = plan;
             }
 
-            return new McpClientInitialization(functions.Values.ToList());
+            return functions;
         }
 
         public async ValueTask<object?> InvokeAsync(
@@ -632,15 +656,17 @@ public sealed class McpClientManagerLifecycleTests
         }
     }
 
-    private sealed class ClientPlan(params string[] toolNames)
+    internal sealed class ClientPlan(params string[] toolNames)
     {
-        public string[] ToolNames { get; } = toolNames;
+        public string[] ToolNames { get; set; } = toolNames;
 
         public Func<CancellationToken, Task>? Initialize { get; init; }
 
         public Func<int, CancellationToken, Task<object?>>? Invoke { get; init; }
 
         public Exception? DisposeFailure { get; init; }
+
+        public Exception? ListFailure { get; set; }
 
         public TaskCompletionSource Created { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -654,9 +680,13 @@ public sealed class McpClientManagerLifecycleTests
 
         public int DisposeCountStorage;
 
+        public int RefreshCountStorage;
+
         public int InvocationCount => Volatile.Read(ref InvocationCountStorage);
 
         public int DisposeCount => Volatile.Read(ref DisposeCountStorage);
+
+        public int RefreshCount => Volatile.Read(ref RefreshCountStorage);
     }
 
     private sealed class RecordingNotificationSink : IOperationalNotificationSink

--- a/src/Netclaw.Daemon.Tests/Mcp/McpReconnectionServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpReconnectionServiceTests.cs
@@ -33,6 +33,8 @@ public sealed class McpReconnectionServiceTests
         await service.CheckAndReconnectAsync(CancellationToken.None);
 
         Assert.Equal(0, _reconnectable.ReconnectCallCount);
+        // Only the Connected server gets a catalog refresh; AwaitingAuth/AuthFailed/Disabled do not.
+        Assert.Equal(1, _reconnectable.RefreshCallCount);
     }
 
     [Fact]
@@ -181,8 +183,11 @@ public sealed class McpReconnectionServiceTests
     {
         private readonly Dictionary<McpServerName, McpServerStatus> _statuses = new();
         private int _reconnectCallCount;
+        private int _refreshCallCount;
 
         public int ReconnectCallCount => Volatile.Read(ref _reconnectCallCount);
+
+        public int RefreshCallCount => Volatile.Read(ref _refreshCallCount);
 
         public Func<McpServerName, CancellationToken, Task<bool>>? OnReconnect { get; set; }
 
@@ -203,6 +208,12 @@ public sealed class McpReconnectionServiceTests
             if (OnReconnect is not null)
                 return await OnReconnect(serverName, ct);
             return false;
+        }
+
+        public Task<bool> TryRefreshCatalogAsync(McpServerName serverName, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _refreshCallCount);
+            return Task.FromResult(true);
         }
     }
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -837,6 +837,19 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             return new McpClientInitialization(tools.Cast<AIFunction>().ToList());
         }
 
+        public ValueTask<IReadOnlyList<AIFunction>> ListToolsAsync(
+            McpClient client,
+            CancellationToken cancellationToken)
+            => ListToolsCoreAsync(client, cancellationToken);
+
+        private async ValueTask<IReadOnlyList<AIFunction>> ListToolsCoreAsync(
+            McpClient client,
+            CancellationToken cancellationToken)
+        {
+            var tools = await client.ListToolsAsync(cancellationToken: cancellationToken);
+            return tools.Cast<AIFunction>().ToList();
+        }
+
         public ValueTask<object?> InvokeAsync(
             AIFunction function,
             AIFunctionArguments? arguments,

--- a/src/Netclaw.Daemon/Mcp/IMcpReconnectable.cs
+++ b/src/Netclaw.Daemon/Mcp/IMcpReconnectable.cs
@@ -12,4 +12,11 @@ internal interface IMcpReconnectable
     IReadOnlyDictionary<McpServerName, McpServerStatus> GetServerStatuses();
 
     Task<bool> TryReconnectAsync(McpServerName serverName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Re-lists a healthy server's tool catalog on its live client. Throttled by the
+    /// implementer; returns false when the server is not connected, refreshed too
+    /// recently, or the catalog is unchanged.
+    /// </summary>
+    Task<bool> TryRefreshCatalogAsync(McpServerName serverName, CancellationToken ct = default);
 }

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -3,16 +3,22 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Net;
 using System.Runtime.ExceptionServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Authentication;
 using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -41,6 +47,20 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     private bool _stopping;
     private bool _disposed;
     private Task? _stopTask;
+
+    /// <summary>
+    /// Minimum time between catalog refresh polls on a healthy connection. The
+    /// reconnection service ticks every 30 seconds; this throttle keeps the
+    /// re-list RPC quiet on stable servers while still converging within a few
+    /// minutes of a live catalog change.
+    /// </summary>
+    internal static readonly TimeSpan CatalogRefreshInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Bounds a single catalog re-list so a server that stops answering cannot stall
+    /// the poll loop, block a reconnect on the per-server gate, or delay shutdown.
+    /// </summary>
+    internal static readonly TimeSpan CatalogRefreshTimeout = TimeSpan.FromSeconds(15);
 
     public McpClientManager(
         Dictionary<string, McpServerEntry> serverEntries,
@@ -174,6 +194,151 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             return false;
 
         return await ReconnectAsync(lifecycle, entry, observed, ct, null);
+    }
+
+    /// <summary>
+    /// Re-lists a connected server's tools on the live client and republishes the
+    /// snapshot when the catalog changed. Throttled to <see cref="CatalogRefreshInterval"/>
+    /// per server. A failed refresh never empties the catalog: the last good snapshot
+    /// and generation stay published until a later refresh succeeds, and transport-level
+    /// failures are left to the invocation path and the reconnection service to handle.
+    /// </summary>
+    public async Task<bool> TryRefreshCatalogAsync(McpServerName serverName, CancellationToken ct = default)
+    {
+        if (IsStopping
+            || !_serverEntries.TryGetValue(serverName.Value, out var entry)
+            || !entry.Enabled)
+            return false;
+
+        if (!_servers.TryGetValue(serverName, out var lifecycle)
+            || lifecycle.Snapshot is not { IsConnected: true })
+            return false;
+
+        using var candidateCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            ct, _lifetimeCancellation.Token);
+        candidateCancellation.CancelAfter(CatalogRefreshTimeout);
+        try
+        {
+            await lifecycle.Gate.WaitAsync(candidateCancellation.Token);
+        }
+        catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (IsStopping)
+                return false;
+
+            var snapshot = lifecycle.Snapshot;
+            if (snapshot is not { IsConnected: true })
+                return false;
+
+            if (_flowBroker.TryGetActive(snapshot.Name, out _))
+                return false;
+
+            if (!lifecycle.TryClaimCatalogRefresh(
+                    _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+                    (long)CatalogRefreshInterval.TotalMilliseconds,
+                    out var previousRefreshMs))
+            {
+                return false;
+            }
+
+            return await RefreshCatalogCoreAsync(
+                lifecycle, entry, snapshot, previousRefreshMs, candidateCancellation.Token);
+        }
+        finally
+        {
+            lifecycle.Gate.Release();
+        }
+    }
+
+    private async Task<bool> RefreshCatalogCoreAsync(
+        McpServerLifecycle lifecycle,
+        McpServerEntry entry,
+        McpServerSnapshot current,
+        long previousRefreshMs,
+        CancellationToken ct)
+    {
+        try
+        {
+            var tools = await _clientRuntime.ListToolsAsync(current.Client!, ct);
+            var functions = CreateFunctionMap(tools);
+
+            // A server that was serving tools now reports none. Publishing an empty
+            // catalog would wipe the model-visible index, and the server is still
+            // Connected so the invocation path can't rescue it either. Treat it as
+            // transient: keep the last good snapshot, retry on the next poll window.
+            if (functions.Count == 0 && current.ToolFunctions.Count > 0)
+            {
+                _logger.LogWarning(
+                    "MCP server '{Name}' catalog refresh returned no tools; keeping {ToolCount} existing tool(s)",
+                    current.Name.Value,
+                    current.ToolFunctions.Count);
+                return false;
+            }
+
+            var fingerprint = ComputeCatalogFingerprint(functions.Values);
+            if (string.Equals(fingerprint, current.CatalogFingerprint, StringComparison.Ordinal))
+                return false;
+
+            var publishedTools = ToolRegistrationExtensions.PrepareMcpTools(
+                current.Name.Value,
+                tools,
+                entry.GrantCategory,
+                this,
+                _maxToolDescriptionChars,
+                _maxToolSchemaWarnChars,
+                _logger);
+            LogToolDrift(current.Name, tools);
+
+            McpServerSnapshot replacement;
+            lock (_shutdownSync)
+            {
+                if (_stopping)
+                    return false;
+
+                replacement = current with
+                {
+                    ToolFunctions = functions,
+                    Generation = checked(current.Generation + 1),
+                    Status = new McpServerStatus(
+                        current.Name,
+                        McpConnectionState.Connected,
+                        functions.Count,
+                        null,
+                        current.Status.LastErrorAt),
+                    CatalogFingerprint = fingerprint,
+                };
+                // Connection first, tools second — same ordering as the connect path.
+                lifecycle.Publish(replacement);
+                _toolRegistry.PublishMcpServerTools(current.Name.Value, publishedTools);
+            }
+
+            _logger.LogInformation(
+                "MCP server '{Name}' catalog refreshed as generation {Generation} ({ToolCount} tools)",
+                current.Name.Value,
+                replacement.Generation,
+                functions.Count);
+            return true;
+        }
+        catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)
+        {
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // Invariant: a failed refresh must never empty the catalog. Roll back the
+            // throttle claim so the next 30s tick retries instead of waiting 5 minutes.
+            lifecycle.RollbackCatalogRefreshClaim(previousRefreshMs);
+            _logger.LogWarning(ex,
+                "MCP server '{Name}' catalog refresh failed; keeping generation {Generation} unchanged",
+                current.Name.Value,
+                current.Generation);
+            return false;
+        }
     }
 
     internal async Task<McpOAuthStartResponse> StartAuthorizationAsync(
@@ -388,6 +553,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             var initialization = await _clientRuntime.InitializeAsync(candidate, ct);
             var tools = initialization.Tools;
             var functions = CreateFunctionMap(tools);
+            var catalogFingerprint = ComputeCatalogFingerprint(functions.Values);
             var publishedTools = ToolRegistrationExtensions.PrepareMcpTools(
                 current.Name.Value,
                 tools,
@@ -430,11 +596,14 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                     candidate,
                     functions,
                     checked(current.Generation + 1),
-                    connectedStatus);
+                    connectedStatus,
+                    catalogFingerprint);
                 // Connection first, tools second. A tool the model can see is then always
                 // dispatchable, because dispatch resolves it from this snapshot.
                 lifecycle.Publish(replacement);
                 _toolRegistry.PublishMcpServerTools(current.Name.Value, publishedTools);
+                // The connect path just listed the catalog; skip the next poll window.
+                lifecycle.MarkCatalogRefreshed(_timeProvider.GetUtcNow().ToUnixTimeMilliseconds());
                 candidate = null;
                 oauthCache = null;
             }
@@ -1202,6 +1371,61 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         return new ReadOnlyDictionary<string, AIFunction>(map);
     }
 
+    /// <summary>
+    /// Computes a content checksum over the model-visible surface of a server's tool
+    /// catalog: name, description, input schema, and return schema of every tool.
+    /// Order-independent (tools are sorted by name) and schema-canonical (object keys
+    /// sorted, whitespace normalized), so a server reordering either is not mistaken
+    /// for a change. Equal fingerprints mean the catalog is unchanged; any add, remove,
+    /// rename, or schema edit changes the checksum.
+    /// </summary>
+    internal static string ComputeCatalogFingerprint(IEnumerable<AIFunction> tools)
+    {
+        using var stream = new MemoryStream();
+        foreach (var tool in tools.OrderBy(t => t.Name, StringComparer.Ordinal))
+        {
+            WriteField(stream, tool.Name);
+            WriteField(stream, tool.Description ?? string.Empty);
+            WriteField(stream, CanonicalSchema(tool.JsonSchema));
+            WriteField(stream, tool.ReturnJsonSchema is { } returnSchema ? CanonicalSchema(returnSchema) : string.Empty);
+        }
+
+        return Convert.ToHexString(SHA256.HashData(stream.ToArray()));
+    }
+
+    /// <summary>Canonicalizes a schema (sorted object keys, normalized whitespace) so
+    /// semantically identical schemas hash the same. Exposed for tests.</summary>
+    internal static string CanonicalSchema(JsonElement schema)
+    {
+        if (schema.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            return string.Empty;
+
+        return CanonicalNode(schema)?.ToJsonString() ?? string.Empty;
+    }
+
+    private static JsonNode? CanonicalNode(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Object => new JsonObject(element.EnumerateObject()
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .Select(property => new KeyValuePair<string, JsonNode?>(property.Name, CanonicalNode(property.Value)))),
+        JsonValueKind.Array => new JsonArray(element.EnumerateArray().Select(CanonicalNode).ToArray()),
+        JsonValueKind.String => JsonValue.Create(element.GetString()),
+        JsonValueKind.Number => JsonValue.Create(element),
+        JsonValueKind.True => JsonValue.Create(true),
+        JsonValueKind.False => JsonValue.Create(false),
+        JsonValueKind.Null => null,
+        _ => JsonValue.Create(element.GetRawText()),
+    };
+
+    private static void WriteField(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(length, bytes.Length);
+        stream.Write(length);
+        stream.Write(bytes);
+    }
+
     private void LogToolDrift(McpServerName serverName, IReadOnlyList<AIFunction> discoveredTools)
     {
         var profiles = _toolConfig.AudienceProfiles;
@@ -1288,6 +1512,11 @@ internal interface IMcpClientRuntime
         McpClient client,
         CancellationToken cancellationToken);
 
+    /// <summary>Re-lists a connected client's tools from the server (no reconnect).</summary>
+    ValueTask<IReadOnlyList<AIFunction>> ListToolsAsync(
+        McpClient client,
+        CancellationToken cancellationToken);
+
     ValueTask<object?> InvokeAsync(
         AIFunction function,
         AIFunctionArguments? arguments,
@@ -1308,8 +1537,16 @@ internal sealed class McpClientRuntime : IMcpClientRuntime
         McpClient client,
         CancellationToken cancellationToken)
     {
+        var tools = await ListToolsAsync(client, cancellationToken);
+        return new McpClientInitialization(tools);
+    }
+
+    public async ValueTask<IReadOnlyList<AIFunction>> ListToolsAsync(
+        McpClient client,
+        CancellationToken cancellationToken)
+    {
         var tools = await client.ListToolsAsync(cancellationToken: cancellationToken);
-        return new McpClientInitialization(tools.Cast<AIFunction>().ToList());
+        return tools.Cast<AIFunction>().ToList();
     }
 
     public ValueTask<object?> InvokeAsync(
@@ -1331,12 +1568,35 @@ internal sealed record McpClientCandidate(
 internal sealed class McpServerLifecycle(McpServerSnapshot initialSnapshot)
 {
     private McpServerSnapshot? _snapshot = initialSnapshot;
+    private long _lastCatalogRefreshMs;
 
     public SemaphoreSlim Gate { get; } = new(1, 1);
 
     public McpServerSnapshot? Snapshot => Volatile.Read(ref _snapshot);
 
     public void Publish(McpServerSnapshot? snapshot) => Volatile.Write(ref _snapshot, snapshot);
+
+    /// <summary>
+    /// Claims the next catalog refresh slot when <paramref name="minIntervalMs"/> has
+    /// elapsed since the last refresh or connect. Callers hold <see cref="Gate"/>, so a
+    /// plain field is sufficient. Outputs the previous claim so a failed attempt can roll
+    /// back and retry sooner than the full interval.
+    /// </summary>
+    public bool TryClaimCatalogRefresh(long nowMs, long minIntervalMs, out long previousMs)
+    {
+        previousMs = _lastCatalogRefreshMs;
+        if (nowMs - previousMs < minIntervalMs)
+            return false;
+
+        _lastCatalogRefreshMs = nowMs;
+        return true;
+    }
+
+    /// <summary>Restores the claim timestamp after a failed refresh so the next tick retries.</summary>
+    public void RollbackCatalogRefreshClaim(long previousMs) => _lastCatalogRefreshMs = previousMs;
+
+    /// <summary>Records a successful catalog refresh (or connect) so the poll throttle starts from now.</summary>
+    public void MarkCatalogRefreshed(long nowMs) => _lastCatalogRefreshMs = nowMs;
 }
 
 internal sealed record McpServerSnapshot(
@@ -1344,7 +1604,8 @@ internal sealed record McpServerSnapshot(
     McpClient? Client,
     IReadOnlyDictionary<string, AIFunction> ToolFunctions,
     long Generation,
-    McpServerStatus Status)
+    McpServerStatus Status,
+    string CatalogFingerprint = "")
 {
     private static readonly IReadOnlyDictionary<string, AIFunction> EmptyFunctions =
         new ReadOnlyDictionary<string, AIFunction>(new Dictionary<string, AIFunction>());

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -273,6 +273,9 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             // transient: keep the last good snapshot, retry on the next poll window.
             if (functions.Count == 0 && current.ToolFunctions.Count > 0)
             {
+                // Roll back the throttle claim so the next 30s tick retries instead of
+                // waiting 5 minutes, matching the failed-refresh path below.
+                lifecycle.RollbackCatalogRefreshClaim(previousRefreshMs);
                 _logger.LogWarning(
                     "MCP server '{Name}' catalog refresh returned no tools; keeping {ToolCount} existing tool(s)",
                     current.Name.Value,

--- a/src/Netclaw.Daemon/Mcp/McpReconnectionService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpReconnectionService.cs
@@ -58,6 +58,12 @@ internal sealed class McpReconnectionService : BackgroundService
             if (status.State is not McpConnectionState.Unreachable)
             {
                 _backoff.TryRemove(serverName, out _);
+
+                // Healthy connections get a throttled catalog refresh so live tool
+                // changes surface without a reconnect. The manager owns the cadence.
+                if (status.State is McpConnectionState.Connected)
+                    await TryRefreshCatalogAsync(serverName, ct);
+
                 continue;
             }
 
@@ -133,6 +139,26 @@ internal sealed class McpReconnectionService : BackgroundService
             {
                 ["serverName"] = serverName.Value,
             }));
+    }
+
+    private async Task TryRefreshCatalogAsync(McpServerName serverName, CancellationToken ct)
+    {
+        try
+        {
+            await _mcpReconnectable.TryRefreshCatalogAsync(serverName, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A refresh failure is not a connection failure — the manager keeps the
+            // last good catalog and the next tick retries. Log and move on.
+            _logger.LogDebug(ex,
+                "MCP server '{Name}' catalog refresh threw an exception",
+                serverName.Value);
+        }
     }
 
     internal readonly record struct BackoffState(int FailureCount, long LastAttemptMs);


### PR DESCRIPTION
## What

Closes #1769. The daemon enumerated an MCP server's tool catalog exactly once per client lifetime — inside `McpClientRuntime.InitializeAsync`, only reached at connect/reconnect. A server that added, removed, renamed, or edited tools mid-session stayed invisible to the model until a disconnect + reconnect.

This reuses the reconnection service's existing 30s health tick to also re-list **healthy** servers' catalogs on the **live client** (no client rebuild, no OAuth re-run), throttled to once per 5 minutes per server.

## How

- **`McpClientManager.TryRefreshCatalogAsync(serverName, ct)`** — re-lists tools via a new `IMcpClientRuntime.ListToolsAsync` seam, computes a SHA-256 content fingerprint over the sorted, schema-canonicalized tool surface (name, description, input schema, return schema), and republishes `McpServerSnapshot` with `Generation + 1` + a `ToolRegistry` update **only when the fingerprint changed**. Same "connection first, tools second" publish ordering as the connect path.
- **`McpReconnectionService`** — the 30s tick's connected branch calls `TryRefreshCatalogAsync`. Cadence/throttle lives in the manager (`McpServerLifecycle.TryClaimCatalogRefresh`), so the service stays dumb.
- **`IMcpReconnectable.TryRefreshCatalogAsync`** — new interface method so the service can reach the refresh through its existing abstraction.

## Safety invariants

- **A failed refresh never empties the catalog.** Last-good snapshot + generation stay published; the throttle claim is rolled back so the next 30s tick retries (no 5-minute blackout after a transient error).
- **A refresh that returns zero tools from a previously non-empty server is treated as transient** — the wipe is refused, last-good tools stay, retry on next window.
- **Per-refresh 15s timeout** (`CatalogRefreshTimeout`) — one hung server cannot stall the poll loop, block a reconnect on the per-server gate, or delay daemon shutdown.
- **No-change short-circuit** — the fingerprint is order- and key-order-stable, so a server reordering its catalog or schema keys does not churn the index.

## Design notes

- Poll-only by design: nothing in the fleet sends `notifications/tools/list_changed`, so the notification path was deliberately omitted (fewest moving parts). The refresh mechanism is the exact seam prompts/resources support will hang off later.
- The connect path marks the catalog fresh, so no redundant re-list ~35s after startup.
- Shadow catalog disk files remain startup-only — consistent with existing reconnect behavior, not a regression.

## Tests

New `McpCatalogRefreshTests` (10 tests): change republishes generation; no-change doesn't bump; throttle within interval; failed refresh keeps last good; **failed refresh rolls back throttle so next tick retries**; **empty catalog keeps last good**; unknown server no-op; fingerprint order-stability; fingerprint changes on description/tool-add; canonical schema ignores key order/whitespace.

All 144 MCP tests in `Netclaw.Daemon.Tests` pass. Full diff reviewed by three adversarial sub-agents (concurrency, security, simplification) — their findings (throttle leak, unbounded gate hold, empty-catalog wipe, schema churn, dead code) are all addressed in this commit.