### PR TITLE
fix(approvals): stop treating fd-dup redirects (2>&1) as dynamic syntax

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
@@ -486,6 +486,21 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Require([], isMessy: true, approvalChecks: 0)),
         Case(
+            "fd-dup-redirect-safe-verb-allows",
+            Bash("git status 2>&1"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
+            "fd-dup-redirect-safe-pipeline-allows",
+            Bash("git log --oneline -5 2>&1 | tail -20"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
+            "fd-dup-redirect-mutating-no-grant-prompts-not-messy",
+            Bash("git push origin dev 2>&1 | tail -2"),
+            Approvals.None,
+            ExpectedApproval.Require(["git push origin dev", "tail"], isMessy: false)),
+        Case(
             "background-list-prompts-for-mutating-tail",
             Bash("git status & git push"),
             Approvals.None,

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
@@ -496,10 +496,25 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
         Case(
+            "fd-close-redirect-safe-verb-allows",
+            Bash("git status 2>&-"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
+            "fd-move-redirect-safe-verb-allows",
+            Bash("git status 2>&1-"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
             "fd-dup-redirect-mutating-no-grant-prompts-not-messy",
             Bash("git push origin dev 2>&1 | tail -2"),
             Approvals.None,
             ExpectedApproval.Require(["git push origin dev", "tail"], isMessy: false)),
+        Case(
+            "dynamic-fd-redirect-fails-closed",
+            Bash("git status 2>&$FD"),
+            Approvals.None,
+            ExpectedApproval.Require([], isMessy: true, approvalChecks: 0)),
         Case(
             "background-list-prompts-for-mutating-tail",
             Bash("git status & git push"),

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
@@ -1,4 +1,4 @@
-# Fresh Personal approval matrix
+﻿# Fresh Personal approval matrix
 
 `Tools.ShellMode`: `HostAllowed`
 
@@ -62,6 +62,9 @@
 | command-substitution-fails-closed | Personal | Project | Interactive | echo $(git push) | none | RequiresApproval | approval required | none | Yes |
 | dynamic-path-fails-closed | Personal | Project | Interactive | cat "$FILE" | none | RequiresApproval | approval required | none | Yes |
 | dynamic-redirect-fails-closed | Personal | Project | Interactive | git status > "$OUTPUT" | none | RequiresApproval | approval required | none | Yes |
+| fd-dup-redirect-safe-verb-allows | Personal | Project | Interactive | git status 2>&1 | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| fd-dup-redirect-safe-pipeline-allows | Personal | Project | Interactive | git log --oneline -5 2>&1 \| tail -20 | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| fd-dup-redirect-mutating-no-grant-prompts-not-messy | Personal | Project | Interactive | git push origin dev 2>&1 \| tail -2 | none | RequiresApproval | approval required | git push origin dev, tail | No |
 | background-list-prompts-for-mutating-tail | Personal | Project | Interactive | git status & git push | none | RequiresApproval | approval required | none | Yes |
 | unbalanced-quote-fails-closed | Personal | Project | Interactive | git push "unterminated | none | RequiresApproval | approval required | none | Yes |
 | multiline-argument-prompts | Personal | Project | Interactive | gh issue comment 123 --body "first line\nsecond line" | none | RequiresApproval | approval required | gh issue comment | No |

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
@@ -64,7 +64,10 @@
 | dynamic-redirect-fails-closed | Personal | Project | Interactive | git status > "$OUTPUT" | none | RequiresApproval | approval required | none | Yes |
 | fd-dup-redirect-safe-verb-allows | Personal | Project | Interactive | git status 2>&1 | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | fd-dup-redirect-safe-pipeline-allows | Personal | Project | Interactive | git log --oneline -5 2>&1 \| tail -20 | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| fd-close-redirect-safe-verb-allows | Personal | Project | Interactive | git status 2>&- | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| fd-move-redirect-safe-verb-allows | Personal | Project | Interactive | git status 2>&1- | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | fd-dup-redirect-mutating-no-grant-prompts-not-messy | Personal | Project | Interactive | git push origin dev 2>&1 \| tail -2 | none | RequiresApproval | approval required | git push origin dev, tail | No |
+| dynamic-fd-redirect-fails-closed | Personal | Project | Interactive | git status 2>&$FD | none | RequiresApproval | approval required | none | Yes |
 | background-list-prompts-for-mutating-tail | Personal | Project | Interactive | git status & git push | none | RequiresApproval | approval required | none | Yes |
 | unbalanced-quote-fails-closed | Personal | Project | Interactive | git push "unterminated | none | RequiresApproval | approval required | none | Yes |
 | multiline-argument-prompts | Personal | Project | Interactive | gh issue comment 123 --body "first line\nsecond line" | none | RequiresApproval | approval required | gh issue comment | No |

--- a/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
@@ -36,6 +36,31 @@ public sealed class ShellCommandAnalysisTests
         Assert.True(analysis.HasDynamicSyntax);
     }
 
+    [Theory]
+    [InlineData("git status 2>&1")]
+    [InlineData("git status 2>&123")]
+    [InlineData("git status 2>&1-")]
+    [InlineData("git status 2>&-")]
+    public void Static_file_descriptor_redirect_is_not_dynamic(string command)
+    {
+        var analysis = _analyzer.Analyze(command);
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.False(analysis.HasDynamicSyntax);
+    }
+
+    [Theory]
+    [InlineData("git status 2>&$FD")]
+    [InlineData("git status >&$FD")]
+    [InlineData("git status 2>&${FD}")]
+    public void Dynamic_file_descriptor_redirect_stays_dynamic(string command)
+    {
+        var analysis = _analyzer.Analyze(command);
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.True(analysis.HasDynamicSyntax);
+    }
+
     [Fact]
     public void Background_list_fails_closed_when_parser_omits_its_tail()
     {

--- a/src/Netclaw.Security/ShellCommandAnalysis.cs
+++ b/src/Netclaw.Security/ShellCommandAnalysis.cs
@@ -190,5 +190,29 @@ internal sealed record ShellCommandAnalysis(
         // Treating it as dynamic fails the whole command closed to an approval
         // prompt for every `2>&1`-shaped command, even fully safe ones.
         || clause.Redirects.Any(static redirect =>
-            redirect.IsDynamicSkip && !redirect.Target.StartsWith('&')));
+            redirect.IsDynamicSkip
+            && !IsStaticFileDescriptor(redirect.Target)));
+
+    /// <summary>
+    /// Returns true only for the static file-descriptor targets that
+    /// ShellSyntaxTree 0.2 recognizes: &amp;N, &amp;N-, and &amp;-.
+    /// </summary>
+    private static bool IsStaticFileDescriptor(string target)
+    {
+        if (target == "&-")
+            return true;
+
+        if (target.Length < 2 || target[0] != '&')
+            return false;
+
+        var index = 1;
+        while (index < target.Length && char.IsAsciiDigit(target[index]))
+            index++;
+
+        if (index == 1)
+            return false;
+
+        return index == target.Length
+               || index == target.Length - 1 && target[index] == '-';
+    }
 }

--- a/src/Netclaw.Security/ShellCommandAnalysis.cs
+++ b/src/Netclaw.Security/ShellCommandAnalysis.cs
@@ -183,5 +183,12 @@ internal sealed record ShellCommandAnalysis(
         // A glob in a directory segment can hide traversal or a symlink.
         // Only a leaf glob has a fixed directory scope.
         || clause.Args.Any(ShellGlobPath.HasUnresolvedDescendantScope)
-        || clause.Redirects.Any(static redirect => redirect.IsDynamicSkip));
+        // An fd-dup target (&1, &2, &-) is a static file-descriptor number,
+        // not a dynamic token: ShellSyntaxTree marks it IsDynamicSkip to mean
+        // "do not path-resolve", but it carries no unresolved syntax and no
+        // filesystem scope (ResolveRedirectDirectory skips &-prefixed targets).
+        // Treating it as dynamic fails the whole command closed to an approval
+        // prompt for every `2>&1`-shaped command, even fully safe ones.
+        || clause.Redirects.Any(static redirect =>
+            redirect.IsDynamicSkip && !redirect.Target.StartsWith('&')));
 }


### PR DESCRIPTION
## Problem

Since 0.25.3, any shell command with a static file-descriptor redirect can trigger an approval prompt. Examples include `2>&1`, `>&1`, and `1>&2`.

ShellSyntaxTree marks static descriptor targets as `IsDynamicSkip=true` to prevent path resolution. Netclaw interpreted that flag as unresolved dynamic syntax and failed the complete command closed.

## Fix

Netclaw now exempts only the static descriptor forms that ShellSyntaxTree 0.2 recognizes:

- `&N` duplicates descriptor N.
- `&N-` moves descriptor N.
- `&-` closes the descriptor.

The check does not exempt every target that starts with `&`. Dynamic forms such as `2>&$FD` and `>&$FD` remain unresolved and fail closed.

This change is a Netclaw 0.25.4 workaround. ShellSyntaxTree 0.3 should expose explicit redirect operations and target classifications.

## Validation

The change adds these approval cases:

- `git status 2>&1` allows as a safe verb.
- `git log --oneline -5 2>&1 | tail -20` allows as a safe pipeline.
- `git status 2>&-` allows with a static descriptor close.
- `git status 2>&1-` allows with a static descriptor move.
- `git push origin dev 2>&1 | tail -2` prompts without a messy classification.
- `git status 2>&$FD` remains messy and fails closed.
- `git status > "$OUTPUT"` remains messy and fails closed.

Local validation:

- `ShellCommandAnalysisTests`: 12 passed.
- `Netclaw.Security.Tests`: 653 passed.
- `ShellApprovalDispositionMatrixTests`: 114 passed.
- Header verification passed.
- Slopwatch found zero issues.

The production corpus attributed 18 of 45 approval prompts to the static `2>&1` signature.