### PR TITLE
Release 0.25.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <VersionPrefix>0.25.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      Bug fixes: MCP tool catalog changes on connected servers are detected and refreshed automatically; MCP permissions tool-grid scroll position preserved when editing rows; static fd-dup redirects (2>&1) no longer treated as dynamic shell syntax. 
+      Bug fixes: MCP tool catalog changes on connected servers are detected and refreshed automatically; MCP permissions tool-grid scroll position preserved when editing rows; static fd-dup redirects (2&amp;>1) no longer treated as dynamic shell syntax. 
     </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,10 +8,10 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.25.3</VersionPrefix>
+    <VersionPrefix>0.25.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      Features: Tool execution reports pre-execution authorization decisions with reasons. Bug fixes: Escape is no-op at TUI root (Ctrl+Q quits) and denies pending approvals; Slack user/group/channel mentions render as rich text; runtime model capabilities no longer persisted to config; incompatible session history degrades gracefully; doctor shell approval fallback aligned; shell approvals fail closed, regex timeout race removed, Bash approval gaps fixed, every parsed shell path checked against approval scope. Dependencies: ShellSyntaxTree 0.2.0-beta.1, SkiaSharp 4.151.0, CsCheck 4.8.0.
+      Bug fixes: MCP tool catalog changes on connected servers are detected and refreshed automatically; MCP permissions tool-grid scroll position preserved when editing rows; static fd-dup redirects (2>&1) no longer treated as dynamic shell syntax. 
     </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # NetClaw Release Notes
 
+## 0.25.4 (2026-08-06)
+
+### Bug Fixes
+- **MCP: live tool catalog refresh** — The daemon now re-lists healthy MCP servers' tool catalogs on a throttled cadence, so servers that add, remove, rename, or edit tools mid-session become visible to the model without a disconnect + reconnect ([#1771](https://github.com/netclaw-dev/netclaw/pull/1771))
+- **MCP permissions: scroll position preserved** — Editing tool-grid rows with the left/right keys no longer jumps the scroll position back to the top ([#1775](https://github.com/netclaw-dev/netclaw/pull/1775))
+- **Shell approvals: static fd-dup redirects allowed** — `2>&1` and similar static file-descriptor duplications are no longer classified as dynamic shell syntax, so safe commands like `git status 2>&1` skip the approval prompt ([#1776](https://github.com/netclaw-dev/netclaw/pull/1776))
+
 ## 0.25.3 (2026-08-05)
 
 ### Features


### PR DESCRIPTION
## Summary

Update release notes and version metadata for 0.25.4.

Includes bug fixes for MCP live catalog refresh, MCP permissions scroll preservation, and shell approval handling for static fd-dup redirects.

## Changes
- Updated `Directory.Build.props` to `0.25.4`
- Added 0.25.4 section to `RELEASE_NOTES.md`