### PR TITLE
fix(ci): pin Verify snapshot files to LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,11 @@
 * text=auto
 *.csv -text
 
+# Verify snapshot files must stay LF on every platform. Windows checkout
+# otherwise produces CRLF and Verify throws VerifiedLineEndingException.
+*.verified.* text eol=lf working-tree-encoding=UTF-8
+*.received.* text eol=lf working-tree-encoding=UTF-8
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #


### PR DESCRIPTION
## Problem

Windows CI fails intermittently with Verify `VerifiedLineEndingException` on snapshot tests (e.g. `SessionMemoryObserverActorTests.Distillation*_matches_approved_snapshot`, `ShellApprovalDispositionMatrixTests`). Root cause: the repo's `.gitattributes` only has `* text=auto`, so `*.verified.*` files are checked out with CRLF on Windows. Verify requires LF.

## Fix

Pin snapshot files to LF with `working-tree-encoding=UTF-8` in `.gitattributes`:

```
*.verified.* text eol=lf working-tree-encoding=UTF-8
*.received.* text eol=lf working-tree-encoding=UTF-8
```

Committed blobs already use LF; the renormalize pass is a no-op on Linux. This makes Windows checkouts match, killing the whole CRLF snapshot class of flakes.

## Tests

No code change. Verify snapshot tests now run with LF on all platforms.