### PR TITLE
fix(sessions): seed the immediate-retry approval bypass for every approved scope

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -137,6 +137,52 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     }
 
     [Fact]
+    public async Task Approved_always_seeds_the_immediate_retry_bypass_so_a_partially_covered_command_still_runs()
+    {
+        // Regression for the "approved command still throws" trigger. A piped
+        // command's standalone verbs (e.g. base64, head) have no path argument, so
+        // "Always here" cannot persist a directory-scoped grant for them — by
+        // design. The user's click must still run THIS call once, via the one-time
+        // bypass. The bug: the pipeline seeded that bypass only for ApprovedOnce, so
+        // ApprovedSession/ApprovedAlways re-hit the gate on retry and failed the
+        // turn. This fake re-requires approval until the retry carries the bypass.
+        var executor = new BypassRequiredOnRetryExecutor();
+        var approvalChannel = new ApprovalChannel();
+        var probe = CreateTestProbe("approved-always-bypass-probe");
+        var approvalRequestTcs = new TaskCompletionSource<ToolInteractionRequest>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionId = new SessionId("D1/approved-always-bypass");
+
+        var toolCalls = new List<FunctionCallContent>
+        {
+            new("call-1", "shell_execute", new Dictionary<string, object?>
+            {
+                ["command"] = "gh api foo/bar 2>/dev/null | base64 -d | head"
+            })
+        };
+
+        var pipelineTask = new SessionToolPipelineTestFixture(executor, toolCalls, sessionId, probe.Ref)
+            .WithTurnContext(InteractiveTurnContext(sessionId))
+            .WithApprovals(
+                approvalChannel,
+                request => approvalRequestTcs.TrySetResult(request.Request),
+                Timeout.InfiniteTimeSpan)
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var approvalRequest = await approvalRequestTcs.Task.WaitAsync(
+            TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        approvalChannel.Complete(approvalRequest.CallId, ApprovalDecision.ApprovedAlways);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(completed.ToolResults);
+        Assert.Equal("ran-with-bypass", result.Content);
+    }
+
+    [Fact]
     public async Task Source_less_approval_required_turn_fails_closed_without_prompt()
     {
         var executor = new ApprovalThenSuccessExecutor();
@@ -795,6 +841,43 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
             ct.ThrowIfCancellationRequested();
             return Task.FromResult("approved-and-ran");
+        }
+    }
+
+    private sealed class BypassRequiredOnRetryExecutor : IToolExecutor
+    {
+        private static readonly string[] Patterns = ["gh api", "base64", "head"];
+
+        public Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<string> ExecuteAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
+        {
+            // Stand in for the real gate on a command whose persisted grant does not
+            // cover every candidate verb: authorization keeps requiring approval
+            // until the immediate retry carries the one-time bypass for these
+            // patterns. That bypass is what the pipeline must seed for every
+            // approved scope, not just ApprovedOnce.
+            var approval = context?.Approval;
+            if (approval is not null
+                && string.Equals(approval.OneTimeApprovedToolName, toolCall.Name, StringComparison.Ordinal)
+                && Patterns.All(approval.OneTimeApprovedPatterns.Contains))
+            {
+                return Task.FromResult("ran-with-bypass");
+            }
+
+            throw new ToolApprovalRequiredException(new ToolApprovalContext(
+                ToolName: toolCall.Name,
+                DisplayText: "gh api foo/bar | base64 -d | head",
+                Patterns: Patterns,
+                CandidateVerbs: Patterns,
+                Options:
+                [
+                    new ToolApprovalOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolApprovalOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                    new ToolApprovalOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                    new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
+                ]));
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -139,13 +139,12 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     [Fact]
     public async Task Approved_always_seeds_the_immediate_retry_bypass_so_a_partially_covered_command_still_runs()
     {
-        // Regression for the "approved command still throws" trigger. A piped
-        // command's standalone verbs (e.g. base64, head) have no path argument, so
-        // "Always here" cannot persist a directory-scoped grant for them — by
-        // design. The user's click must still run THIS call once, via the one-time
-        // bypass. The bug: the pipeline seeded that bypass only for ApprovedOnce, so
-        // ApprovedSession/ApprovedAlways re-hit the gate on retry and failed the
-        // turn. This fake re-requires approval until the retry carries the bypass.
+        // Regression for the "approved command still throws" trigger
+        // (https://github.com/netclaw-dev/netclaw/issues/1802): the pipeline seeded
+        // the one-time retry bypass only for ApprovedOnce, so a command approved
+        // with ApprovedSession/ApprovedAlways whose durable grant does not cover
+        // every verb re-hit the gate on retry and failed the turn. This fake
+        // re-requires approval until the immediate retry carries the bypass.
         var executor = new BypassRequiredOnRetryExecutor();
         var approvalChannel = new ApprovalChannel();
         var probe = CreateTestProbe("approved-always-bypass-probe");

--- a/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
+++ b/src/Netclaw.Actors/Sessions/IApprovalChannel.cs
@@ -44,6 +44,26 @@ public enum ApprovalDecision
 }
 
 /// <summary>
+/// Extensions over <see cref="ApprovalDecision"/>.
+/// </summary>
+public static class ApprovalDecisionExtensions
+{
+    /// <summary>
+    /// True when the decision grants execution (any approve scope) rather than
+    /// Denied or TimedOut. Every "the user approved" branch — the live pipeline
+    /// retry, the cold re-drive plan, and the sub-agent loop — must classify the
+    /// approve scopes identically, so route them through this one predicate
+    /// instead of duplicating the scope list (a missed site reintroduces the
+    /// "approved command still fails" bug for the new scope).
+    /// </summary>
+    public static bool IsApprovalGrant(this ApprovalDecision decision)
+        => decision is ApprovalDecision.ApprovedOnce
+            or ApprovalDecision.ApprovedSession
+            or ApprovalDecision.ApprovedAlways
+            or ApprovalDecision.ApprovedEverywhere;
+}
+
+/// <summary>
 /// Bridge between the tool execution pipeline (thread pool) and the session actor
 /// (mailbox). Allows tool tasks to block awaiting user approval while the actor
 /// remains responsive to incoming messages.

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -4315,10 +4315,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (!_resolvedToolApprovals.TryGetValue(call.CallId.Value, out var resolved))
                 continue;
 
-            if (resolved.Decision is ApprovalDecision.ApprovedOnce
-                or ApprovalDecision.ApprovedSession
-                or ApprovalDecision.ApprovedAlways
-                or ApprovalDecision.ApprovedEverywhere)
+            if (resolved.Decision.IsApprovalGrant())
             {
                 // Pre-seed the one-time bypass for the just-approved call so the
                 // re-drive runs it once even when its durable grant (if any) does

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -4324,6 +4324,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 // ApprovedOnce has no durable grant at all; broader scopes still
                 // record their durable grant separately. This only authorizes the
                 // immediate re-drive, matching the live pipeline and the sub-agent.
+                // See https://github.com/netclaw-dev/netclaw/issues/1802.
                 preSeed[call.CallId.Value] = resolved.Pending.Patterns;
             }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -4315,10 +4315,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (!_resolvedToolApprovals.TryGetValue(call.CallId.Value, out var resolved))
                 continue;
 
-            if (resolved.Decision == ApprovalDecision.ApprovedOnce)
+            if (resolved.Decision is ApprovalDecision.ApprovedOnce
+                or ApprovalDecision.ApprovedSession
+                or ApprovalDecision.ApprovedAlways
+                or ApprovalDecision.ApprovedEverywhere)
             {
-                // ApprovedOnce has no persisted grant. Pre-seed only this call
-                // so the re-drive skips the gate once without broadening approval.
+                // Pre-seed the one-time bypass for the just-approved call so the
+                // re-drive runs it once even when its durable grant (if any) does
+                // not cover every candidate verb — e.g. a piped command's standalone
+                // verbs (base64, head) are never persisted directory-scoped.
+                // ApprovedOnce has no durable grant at all; broader scopes still
+                // record their durable grant separately. This only authorizes the
+                // immediate re-drive, matching the live pipeline and the sub-agent.
                 preSeed[call.CallId.Value] = resolved.Pending.Patterns;
             }
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -565,10 +565,7 @@ internal sealed class SessionToolExecutionPipeline
 
             sw.Stop();
 
-            if (decision is ApprovalDecision.ApprovedOnce
-                or ApprovalDecision.ApprovedSession
-                or ApprovalDecision.ApprovedAlways
-                or ApprovalDecision.ApprovedEverywhere)
+            if (decision.IsApprovalGrant())
             {
                 // Retry execution now that approval is granted. Seed the one-time
                 // bypass for the just-approved call regardless of scope. Broader

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -568,7 +568,8 @@ internal sealed class SessionToolExecutionPipeline
             if (decision.IsApprovalGrant())
             {
                 // Retry execution now that approval is granted. Seed the one-time
-                // bypass for the just-approved call regardless of scope. Broader
+                // bypass for the just-approved call regardless of scope
+                // (https://github.com/netclaw-dev/netclaw/issues/1802). Broader
                 // scopes (session/always) DO get a durable grant recorded by the
                 // session actor, but that grant can legitimately not cover every
                 // candidate: a piped command's standalone verbs (base64, head) have

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -570,13 +570,18 @@ internal sealed class SessionToolExecutionPipeline
                 or ApprovalDecision.ApprovedAlways
                 or ApprovalDecision.ApprovedEverywhere)
             {
-                // Retry execution now that approval is granted
-                // (Approve-once is retried through transient context state; broader scopes
-                // are also recorded by the session actor into the shared approval service.)
-                if (decision == ApprovalDecision.ApprovedOnce)
-                {
-                    context.Approval.SeedOneTimeApproval(tc.Name, ctx.Patterns);
-                }
+                // Retry execution now that approval is granted. Seed the one-time
+                // bypass for the just-approved call regardless of scope. Broader
+                // scopes (session/always) DO get a durable grant recorded by the
+                // session actor, but that grant can legitimately not cover every
+                // candidate: a piped command's standalone verbs (base64, head) have
+                // no path argument and so are never persisted directory-scoped
+                // (by design). Without the transient bypass, the immediate retry
+                // re-hits the gate and fails a call the user just approved. This
+                // matches the sub-agent loop (SubAgentActor), which seeds for every
+                // approved scope. The bypass is per-call, pattern-scoped, and
+                // cleared after the attempt, so it cannot leak to any other call.
+                context.Approval.SeedOneTimeApproval(tc.Name, ctx.Patterns);
 
                 sw = Stopwatch.StartNew();
                 if (meta is { Background: true }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -1190,10 +1190,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         self.Tell(SubAgentApprovalWaitCompleted.Instance);
                     }
 
-                    if (decision is ParentApprovalDecision.ApprovedOnce
-                        or ParentApprovalDecision.ApprovedSession
-                        or ParentApprovalDecision.ApprovedAlways
-                        or ParentApprovalDecision.ApprovedEverywhere)
+                    if (decision.IsApprovalGrant())
                     {
                         // The immediate retry needs a transient grant even for session/always
                         // approvals because the sub-agent's scope ID differs from the parent

--- a/src/Netclaw.Tools.Abstractions/IParentApprovalBridge.cs
+++ b/src/Netclaw.Tools.Abstractions/IParentApprovalBridge.cs
@@ -40,6 +40,23 @@ public enum ParentApprovalDecision
 }
 
 /// <summary>
+/// Extensions over <see cref="ParentApprovalDecision"/>.
+/// </summary>
+public static class ParentApprovalDecisionExtensions
+{
+    /// <summary>
+    /// True when the sub-agent's parent decision grants execution (any approve
+    /// scope). Mirrors <c>ApprovalDecision.IsApprovalGrant</c> so the sub-agent
+    /// loop classifies approve scopes identically to the parent session paths.
+    /// </summary>
+    public static bool IsApprovalGrant(this ParentApprovalDecision decision)
+        => decision is ParentApprovalDecision.ApprovedOnce
+            or ParentApprovalDecision.ApprovedSession
+            or ParentApprovalDecision.ApprovedAlways
+            or ParentApprovalDecision.ApprovedEverywhere;
+}
+
+/// <summary>
 /// Thrown when a sub-agent needs parent approval but the parent session cannot
 /// safely emit an approval prompt with complete authority context.
 /// </summary>


### PR DESCRIPTION
Closes #1802

## The bug

A shell command the user **approved** could still fail with "I encountered an error executing a tool." This is the *trigger* behind the self-hosted/DeepSeek approval failures (the history-wedge amplifier was fixed separately in #1796).

## Confirmed mechanism (not theorized)

For a piped command like `gh api … 2>/dev/null | base64 -d | head`, the approval gate extracts these candidates:

```
gh api | <cwd>-ish   ;   base64 | (no directory)   ;   head | (no directory)
```

The standalone pipeline verbs `base64` / `head` have **no path argument**, so:

- **`Always here`** (persistent, directory-scoped) cannot persist a grant for them — their directory defaults to `cwd`, and when `cwd` is the session scratch dir the dead-on-arrival guard drops them. This is **by design** (you can't fold `curl`/`gh`/`base64` to a directory).
- **`This chat`** (session-scoped) records them **verb-only**, so it works.

The one-time bypass that lets the *just-approved* call run this once was seeded **only for `ApprovedOnce`** (`SessionToolExecutionPipeline.cs`). So `ApprovedSession` / `ApprovedAlways` re-hit the gate on retry, the uncovered verbs read as unapproved, and the turn failed — for a command the user had just approved. In a parallel batch approved call-by-call this looked like one sibling running (session, verb-only match) and the other throwing (persistent grant didn't cover the standalone verbs), with **no `approval_near_miss`** logged (nothing was persisted to compare) — exactly what the production logs showed.

## The fix

Seed the one-time bypass for the just-approved call **regardless of scope**, in both the live pipeline and the cold re-drive plan (`LlmSessionActor.BuildApprovalRedrivePlan`). This matches the **sub-agent loop** (`SubAgentActor`), which already seeds for every approved scope and documents why. The bypass is per-call, pattern-scoped, and cleared after the attempt, so it only authorizes the immediate retry the user approved; broader scopes still record their durable grant separately for future calls. It does **not** change what "Always here" persists (standalone verbs remaining non-persistable is intentional).

## Reproduction & tests

A pipeline regression test drives `ApprovedAlways` against an executor that requires the bypass on retry (standing in for a command whose durable grant doesn't cover every verb): **`ToolExecutionFailed` before, runs after**. Full Sessions + Tools suites stay green (1331 passed), including the existing `ApprovedOnce` / `ApprovedSession` / `ApprovedAlways` pipeline tests, the shell-approval matrix, and all sub-agent tests.
