### PR TITLE
Upgrade to Termina 0.16.1 and preserve TUI state

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.2.0" />
-    <PackageVersion Include="Termina" Version="0.15.1" />
+    <PackageVersion Include="Termina" Version="0.16.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.2.0" />
-    <PackageVersion Include="Termina" Version="0.16.0" />
+    <PackageVersion Include="Termina" Version="0.16.1" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
@@ -233,6 +233,53 @@ public sealed class McpToolPermissionsViewModelTests : IDisposable
     }
 
     [Fact]
+    public void ToggleServerAccess_FirstEnableReplacesAStoredPartialGrantSet()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Team": {
+                    "McpServersMode": "Allowlist",
+                    "AllowedMcpServers": [],
+                    "McpServerToolGrants": {
+                      "notion": ["search"]
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        var vm = CreateVm();
+        var tools = new[] { "create-pages", "search", "list-databases" };
+        vm.InitializeForTests(new McpServerName("notion"), tools);
+        vm.SetSelectedAudienceForTests(TrustAudience.Team);
+
+        Assert.False(vm.IsServerAllowedForSelectedAudience());
+
+        vm.ToggleServerAccess();
+
+        Assert.True(vm.IsServerAllowedForSelectedAudience());
+        foreach (var tool in tools)
+            Assert.True(vm.IsToolGranted(new ToolName(tool)));
+
+        vm.ToggleServerAccess();
+
+        Assert.False(vm.IsServerAllowedForSelectedAudience());
+        foreach (var tool in tools)
+            Assert.False(vm.IsToolGranted(new ToolName(tool)));
+
+        vm.ToggleServerAccess();
+
+        Assert.True(vm.IsServerAllowedForSelectedAudience());
+        foreach (var tool in tools)
+            Assert.True(vm.IsToolGranted(new ToolName(tool)));
+    }
+
+    [Fact]
     public void ToggleServerAccess_DisablingClearsGrantedTools()
     {
         var vm = CreateVm();

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -19,7 +19,7 @@ namespace Netclaw.Cli.Mcp;
 public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsViewModel>
 {
     private SelectionListNode<string>? _serverList;
-    private DynamicLayoutNode? _contentNode;
+    private KeyedDynamicLayoutNode<(ToolPermissionsState State, int Revision)>? _contentNode;
     private DynamicLayoutNode? _footerNode;
     private DynamicLayoutNode? _gridHeaderRowsNode;
     private DynamicLayoutNode? _toolRowsNode;
@@ -68,23 +68,26 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
     private LayoutNode BuildContent()
     {
-        _contentNode = new DynamicLayoutNode(() =>
-        {
-            _serverList = null;
-            _toolScrollNode = null;
-            _gridHeaderRowsNode = null;
-            _toolRowsNode = null;
-            _stepSubs.Clear();
-
-            return ViewModel.CurrentState.Value switch
+        _contentNode = new KeyedDynamicLayoutNode<(ToolPermissionsState State, int Revision)>(
+            GetContentKey,
+            _ =>
             {
-                ToolPermissionsState.Loading => BuildLoading(),
-                ToolPermissionsState.ServerList => BuildServerList(),
-                ToolPermissionsState.ToolGrid => BuildToolGrid(),
-                ToolPermissionsState.Saving => BuildLoading(),
-                _ => Layouts.Empty()
-            };
-        });
+                _serverList = null;
+                _toolScrollNode = null;
+                _gridHeaderRowsNode = null;
+                _toolRowsNode = null;
+                _stepSubs.Clear();
+
+                return ViewModel.CurrentState.Value switch
+                {
+                    ToolPermissionsState.Loading => BuildLoading(),
+                    ToolPermissionsState.ServerList => BuildServerList(),
+                    ToolPermissionsState.ToolGrid => BuildToolGrid(),
+                    ToolPermissionsState.Saving => BuildLoading(),
+                    _ => Layouts.Empty()
+                };
+            },
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
 
         // ToolGrid updates invalidate only the header and rows, so the scroll container persists and keeps its scroll position.
         ViewModel.StateVersion
@@ -104,6 +107,15 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             .DisposeWith(Subscriptions);
 
         return _contentNode.Fill();
+    }
+
+    private (ToolPermissionsState State, int Revision) GetContentKey()
+    {
+        var state = ViewModel.CurrentState.Value;
+        var revision = state is ToolPermissionsState.Loading or ToolPermissionsState.Saving
+            ? ViewModel.StateVersion.Value
+            : 0;
+        return (state, revision);
     }
 
     private ILayoutNode BuildLoading()

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -648,8 +648,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
                 _pendingGrants[SelectedServer] = serverGrants;
             }
 
-            if (!serverGrants.ContainsKey(audienceName))
-                serverGrants[audienceName] = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
+            serverGrants[audienceName] = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
         }
         else if (_pendingGrants.TryGetValue(SelectedServer, out var existingGrants))
         {

--- a/src/Netclaw.Cli/Tui/ModelManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerPage.cs
@@ -28,7 +28,7 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
 
     private IFocusable? _lastFocusedList;
     private TextInputNode? _lastFocusedInput;
-    private DynamicLayoutNode? _contentNode;
+    private KeyedDynamicLayoutNode<ModelManagerContent>? _contentNode;
     private readonly CompositeDisposable _stepSubs = [];
 
     protected override void OnBound()
@@ -57,27 +57,47 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
 
     private LayoutNode BuildContent()
     {
-        _contentNode = new DynamicLayoutNode(() =>
-        {
-            _lastFocusedList = null;
-            _lastFocusedInput = null;
-            _stepSubs.Clear();
-
-            return ViewModel.CurrentState.Value switch
+        _contentNode = new KeyedDynamicLayoutNode<ModelManagerContent>(
+            GetContentKey,
+            _ =>
             {
-                ModelManagerState.RoleOverview => BuildRoleOverview(),
-                ModelManagerState.SelectProvider => BuildProviderSelection(),
-                ModelManagerState.DiscoverModels => BuildDiscoverModels(),
-                ModelManagerState.ConfirmAssignment => BuildConfirmAssignment(),
-                _ => Layouts.Empty()
-            };
-        });
+                _lastFocusedList = null;
+                _lastFocusedInput = null;
+                _stepSubs.Clear();
+
+                return ViewModel.CurrentState.Value switch
+                {
+                    ModelManagerState.RoleOverview => BuildRoleOverview(),
+                    ModelManagerState.SelectProvider => BuildProviderSelection(),
+                    ModelManagerState.DiscoverModels => BuildDiscoverModels(),
+                    ModelManagerState.ConfirmAssignment => BuildConfirmAssignment(),
+                    _ => Layouts.Empty()
+                };
+            },
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
 
         ViewModel.StateVersion
             .Subscribe(_ => _contentNode.Invalidate())
             .DisposeWith(Subscriptions);
 
         return _contentNode;
+    }
+
+    private ModelManagerContent GetContentKey()
+    {
+        if (ViewModel.CurrentState.Value != ModelManagerState.DiscoverModels)
+            return (ModelManagerContent)ViewModel.CurrentState.Value;
+
+        if (ViewModel.IsProbing.Value)
+            return ModelManagerContent.DiscoverProbing;
+        if (ViewModel.ProbeResult.Value is { Success: false })
+            return ModelManagerContent.DiscoverFailed;
+        if (ViewModel.ManualModelEntry)
+            return ModelManagerContent.DiscoverManualEntry;
+        if (ViewModel.ProbeResult.Value is not null && ViewModel.DiscoveredModels.Count == 0)
+            return ModelManagerContent.DiscoverEmpty;
+
+        return ModelManagerContent.DiscoverList;
     }
 
     private LayoutNode BuildStatusBar()
@@ -118,14 +138,15 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
     private ILayoutNode BuildRoleOverview()
     {
         var models = ViewModel.Models;
-        var items = new List<string>
-        {
-            FormatRoleItem("Main", models?.Main),
-            FormatRoleItem("Fallback", models?.Fallback),
-            FormatRoleItem("Compaction", models?.Compaction)
-        };
+        var items = new[] { "Main", "Fallback", "Compaction" };
 
-        _roleList = Layouts.SelectionList(items)
+        _roleList = Layouts.SelectionList(items, role => FormatRoleItem(role, role switch
+        {
+            "Main" => ViewModel.Models?.Main,
+            "Fallback" => ViewModel.Models?.Fallback,
+            "Compaction" => ViewModel.Models?.Compaction,
+            _ => null
+        }))
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -137,8 +158,7 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
             {
                 if (selected.Count > 0)
                 {
-                    var role = selected[0].Split(' ', 2)[0].Trim();
-                    ViewModel.StartAssignment(role);
+                    ViewModel.StartAssignment(selected[0]);
                 }
             })
             .DisposeWith(_stepSubs);
@@ -384,8 +404,7 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
                         var selectedItems = _roleList.SelectedItems;
                         if (selectedItems.Count > 0)
                         {
-                            var role = selectedItems[0].Split(' ', 2)[0].Trim();
-                            ViewModel.ClearRole(role);
+                            ViewModel.ClearRole(selectedItems[0]);
                         }
                     }
                     return;
@@ -404,6 +423,18 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
         }
 
         RouteInputToActiveComponent(keyInfo);
+    }
+
+    private enum ModelManagerContent
+    {
+        RoleOverview = ModelManagerState.RoleOverview,
+        SelectProvider = ModelManagerState.SelectProvider,
+        ConfirmAssignment = ModelManagerState.ConfirmAssignment,
+        DiscoverProbing,
+        DiscoverFailed,
+        DiscoverEmpty,
+        DiscoverManualEntry,
+        DiscoverList
     }
 
     private void RouteInputToActiveComponent(ConsoleKeyInfo keyInfo)

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -45,7 +45,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
     private IFocusable? _lastFocusedList;
     private TextInputNode? _lastFocusedInput;
-    private DynamicLayoutNode? _contentNode;
+    private KeyedDynamicLayoutNode<(ProviderManagerState State, int Revision)>? _contentNode;
     private readonly CompositeDisposable _stepSubs = [];
 
     protected override void OnBound()
@@ -73,34 +73,37 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
     private LayoutNode BuildContent()
     {
-        _contentNode = new DynamicLayoutNode(() =>
-        {
-            _lastFocusedList = null;
-            _lastFocusedInput = null;
-            _stepSubs.Clear();
-
-            return ViewModel.CurrentState.Value switch
+        _contentNode = new KeyedDynamicLayoutNode<(ProviderManagerState State, int Revision)>(
+            GetContentKey,
+            _ =>
             {
-                ProviderManagerState.Loading => BuildLoadingView(),
-                ProviderManagerState.List => BuildProviderListView(),
-                ProviderManagerState.AddSelectType => BuildAddSelectTypeView(),
-                ProviderManagerState.AddName => BuildAddNameView(),
-                ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
-                ProviderManagerState.AddGitHubCopilotAuthHost => BuildGitHubCopilotAuthHostView(),
-                ProviderManagerState.AddGitHubCopilotEnterpriseHost => BuildGitHubCopilotEnterpriseHostView(),
-                ProviderManagerState.AddGitHubCopilotEnterpriseApiBase => BuildGitHubCopilotEnterpriseApiBaseView(),
-                ProviderManagerState.AddCredentials => BuildCredentialsView(),
-                ProviderManagerState.AddOAuthDeviceFlow => BuildOAuthDeviceFlowView(),
-                ProviderManagerState.AddBrowserOAuthFlow => BuildBrowserOAuthFlowView(),
-                ProviderManagerState.AddValidating => BuildValidatingView(),
-                ProviderManagerState.AddComplete => BuildAddCompleteView(),
-                ProviderManagerState.Details => BuildDetailsView(),
-                ProviderManagerState.RenameProvider => BuildRenameView(),
-                ProviderManagerState.FixCredentials => BuildFixCredentialsView(),
-                ProviderManagerState.RemoveConfirm => BuildRemoveConfirmView(),
-                _ => Layouts.Empty()
-            };
-        });
+                _lastFocusedList = null;
+                _lastFocusedInput = null;
+                _stepSubs.Clear();
+
+                return ViewModel.CurrentState.Value switch
+                {
+                    ProviderManagerState.Loading => BuildLoadingView(),
+                    ProviderManagerState.List => BuildProviderListView(),
+                    ProviderManagerState.AddSelectType => BuildAddSelectTypeView(),
+                    ProviderManagerState.AddName => BuildAddNameView(),
+                    ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
+                    ProviderManagerState.AddGitHubCopilotAuthHost => BuildGitHubCopilotAuthHostView(),
+                    ProviderManagerState.AddGitHubCopilotEnterpriseHost => BuildGitHubCopilotEnterpriseHostView(),
+                    ProviderManagerState.AddGitHubCopilotEnterpriseApiBase => BuildGitHubCopilotEnterpriseApiBaseView(),
+                    ProviderManagerState.AddCredentials => BuildCredentialsView(),
+                    ProviderManagerState.AddOAuthDeviceFlow => BuildOAuthDeviceFlowView(),
+                    ProviderManagerState.AddBrowserOAuthFlow => BuildBrowserOAuthFlowView(),
+                    ProviderManagerState.AddValidating => BuildValidatingView(),
+                    ProviderManagerState.AddComplete => BuildAddCompleteView(),
+                    ProviderManagerState.Details => BuildDetailsView(),
+                    ProviderManagerState.RenameProvider => BuildRenameView(),
+                    ProviderManagerState.FixCredentials => BuildFixCredentialsView(),
+                    ProviderManagerState.RemoveConfirm => BuildRemoveConfirmView(),
+                    _ => Layouts.Empty()
+                };
+            },
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
 
         ViewModel.StateVersion
             .Subscribe(_ => _contentNode.Invalidate())
@@ -111,6 +114,17 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         // no per-surface tick subscription required.
 
         return _contentNode;
+    }
+
+    private (ProviderManagerState State, int Revision) GetContentKey()
+    {
+        var state = ViewModel.CurrentState.Value;
+        var revision = state is ProviderManagerState.Loading
+            or ProviderManagerState.AddValidating
+            or ProviderManagerState.Details
+            ? ViewModel.StateVersion.Value
+            : 0;
+        return (state, revision);
     }
 
     private LayoutNode BuildStatusBar()


### PR DESCRIPTION
## Summary

- Update Termina from 0.16.0 to 0.16.1.
- Use keyed dynamic layouts for provider, model, and MCP workflows.
- Preserve stateful controls while each logical screen remains active.
- Replace owned controls after a screen transition.
- Keep model role values separate from their display text.
- Select all discovered tools when a user enables MCP server access.
- Replace an old empty or partial grant set on the first enable action.
- Clear effective tool access when a user disables MCP server access.

## Validation

- The solution build passed with zero warnings and zero errors.
- All 16 MCP permission view-model tests passed.
- The native smoke harness passed all 23 tapes and 9 scenarios.
- Slopwatch found zero issues.
- The file header check passed.
- The diff check passed.

Fixes #1823