### PR TITLE
fix(approvals): drop quoted free-text operands from stored approval patterns (#1406)

### DIFF
--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -364,6 +364,93 @@ public sealed class ShellApprovalMatcherTests
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_single_line_quoted_free_text_terminates_pattern_at_flag()
+    {
+        // Issue #1406: a single-line quoted commit message is call-specific
+        // free text, not approvable intent. The stored pattern stops at the
+        // flag so a later commit with a different message still matches.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("git commit -m \"fix the bug\""));
+
+        Assert.Single(patterns);
+        Assert.Equal("git commit -m", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_single_line_quoted_body_drops_from_pattern()
+    {
+        // Issue #1406: the ticket body is a single-line quoted operand with
+        // internal whitespace, so it drops before it inflates the pattern.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("freshdesk ticket reply --message \"Single line body\""));
+
+        Assert.Single(patterns);
+        Assert.Equal("freshdesk ticket reply --message", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_single_word_quoted_arg_is_kept()
+    {
+        // A single-word quoted arg has no internal whitespace, so it stays in
+        // the pattern and normalizes the same as its unquoted form — the drop
+        // rule targets only multi-word quoted free text.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("git commit -m \"fix\""));
+
+        Assert.Single(patterns);
+        Assert.Equal("git commit -m fix", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractPatterns_quoted_glob_without_internal_whitespace_is_kept()
+    {
+        // `"*.cs"` is quoted but has no internal whitespace, so the drop rule
+        // leaves it in the pattern — only whitespace-bearing free text drops.
+        var patterns = _matcher.ExtractPatterns(new ToolName("shell_execute"),
+            Args("find . -name \"*.cs\"", "/srv/project"));
+
+        Assert.Single(patterns);
+        Assert.Contains("-name", patterns[0]);
+        Assert.Contains("*.cs", patterns[0]);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractCandidates_quoted_path_with_space_keeps_directory_scope()
+    {
+        // Security: the drop rule shapes only the stored pattern. A quoted
+        // path with a space is authorization state — ExtractCandidates still
+        // scopes the candidate to the file's parent directory.
+        var candidates = _matcher.ExtractCandidates(new ToolName("shell_execute"),
+            Args("cat \"my file.txt\"", "/srv/project"));
+
+        Assert.Contains(candidates, c => c.Verb == "cat" && c.Directory == "/srv/project");
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void ExtractCandidates_quoted_free_text_before_path_keeps_path_scope()
+    {
+        // The quoted search pattern `"foo bar"` is free text and never becomes
+        // a scope, while the trailing path operand still scopes the candidate.
+        var candidates = _matcher.ExtractCandidates(new ToolName("shell_execute"),
+            Args("grep \"foo bar\" ./notes.txt", "/srv/project"));
+
+        Assert.Contains(candidates, c => c.Verb == "grep" && c.Directory == "/srv/project");
+        Assert.DoesNotContain(candidates, c => c.Directory is not null && c.Directory.Contains("foo"));
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
+    public void FormatForDisplay_single_line_quoted_free_text_shows_full_command()
+    {
+        // The drop rule is pattern-only: a single-line command has no line
+        // break, so the operator still sees the full message verbatim in the
+        // approval prompt. Only the stored pattern omits the body.
+        var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),
+            Args("git commit -m \"fix the bug\""));
+
+        Assert.Equal("git commit -m \"fix the bug\"", display);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only — matcher routes through BashParser on POSIX")]
     public void FormatForDisplay_carriage_return_arg_is_summarized()
     {
         var display = _matcher.FormatForDisplay(new ToolName("shell_execute"),

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -511,12 +511,14 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     /// Rebuilds one clause's user-facing text from its parsed parts: verb
     /// chain, positional/flag args, and redirects. Synthetic cd-attribution
     /// args are dropped — they carry an inherited cwd, not a token the user
-    /// typed. Call-specific value arguments (issue #1331, generalized to
-    /// digit-bearing tokens — see <see cref="IsCallSpecificValueToken"/>)
-    /// are also excluded since they vary between invocations of the same
-    /// verb chain. Once a value token is encountered, the greedy walk
-    /// terminates — subsequent args (wrapped subcommands like <c>curl</c>
-    /// after <c>timeout 30</c>) are outside the approval intent.
+    /// typed. Call-specific value arguments are also excluded since they vary
+    /// between invocations of the same verb chain: digit-bearing tokens
+    /// (issue #1331, see <see cref="IsCallSpecificValueToken"/>), multi-line
+    /// quoted strings (issue #1402, see <see cref="ContainsLineBreak"/>), and
+    /// single-line quoted free text (issue #1406, see
+    /// <see cref="IsQuotedFreeTextArg"/>). Once such a token is encountered,
+    /// the greedy walk terminates — subsequent args (wrapped subcommands like
+    /// <c>curl</c> after <c>timeout 30</c>) are outside the approval intent.
     /// The result is fed back through
     /// <see cref="ShellTokenizer.NormalizeApprovalUnit"/> for path
     /// normalization, so this only needs to emit a clean token sequence.
@@ -547,6 +549,16 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             // pattern's display. Like the digit rule above, hitting one
             // terminates the walk.
             if (ContainsLineBreak(arg.Raw))
+                break;
+
+            // Issue #1406: a single-line quoted operand whose text holds
+            // internal whitespace (a commit message, a ticket body, an inline
+            // note) is call-specific free text. Every unique value would
+            // otherwise become a new stored pattern that re-prompts. Same
+            // termination mechanism as the digit (#1331) and multi-line
+            // (#1402) rules. A path arg is exempt so a quoted path with a
+            // space keeps its directory scope (see IsQuotedFreeTextArg).
+            if (IsQuotedFreeTextArg(arg))
                 break;
 
             if (sb.Length > 0)
@@ -616,6 +628,58 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         foreach (var c in token)
         {
             if (char.IsAsciiDigit(c))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when <paramref name="arg"/> is a quote-wrapped operand whose text
+    /// holds internal whitespace and is not a path (issue #1406). Such an
+    /// operand is call-specific free text — a commit message, a ticket body,
+    /// an inline note — that varies between invocations of the same verb
+    /// chain, so it must not enter the stored approval pattern. Like the
+    /// digit-bearing (#1331) and multi-line (#1402) rules, hitting one
+    /// terminates the reconstruction walk.
+    /// <para>
+    /// The rule is deliberately narrow so it never widens a grant:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Only a single matching quote pair qualifies. An unquoted token
+    /// cannot hold internal whitespace — the shell splits it into separate
+    /// args — so a single-word quoted arg (<c>git commit -m "fix"</c>) has no
+    /// internal whitespace, stays in the pattern, and normalizes the same as
+    /// its unquoted form.</item>
+    /// <item>A path arg is exempt. Its directory is authorization state that
+    /// <see cref="ExtractCandidatesViaBashAnalysis"/> resolves separately from
+    /// the same parsed <c>Arg</c>, so a quoted path with a space
+    /// (<c>cat "my file.txt"</c>) keeps its scope. Only a value operand, never
+    /// a path, drops here.</item>
+    /// </list>
+    /// This rule only shapes the stored/display pattern. It does not touch the
+    /// gate candidate or the live authorization decision, which re-parse each
+    /// command and scope every path arg through the zone gate.
+    /// </summary>
+    private static bool IsQuotedFreeTextArg(ShellSyntaxTree.Arg arg)
+    {
+        if (arg.IsPath)
+            return false;
+
+        var raw = arg.Raw;
+
+        // A single matching quote pair around at least one inner character.
+        // The shortest droppable form is quote + whitespace + quote (length 3).
+        if (raw.Length < 3)
+            return false;
+
+        var quote = raw[0];
+        if (quote is not ('"' or '\'') || raw[^1] != quote)
+            return false;
+
+        for (var i = 1; i < raw.Length - 1; i++)
+        {
+            if (char.IsWhiteSpace(raw[i]))
                 return true;
         }
 


### PR DESCRIPTION
## Problem

A single-line quoted operand flowed verbatim into the stored shell approval
pattern. Every unique value became a new pattern. The gate re-prompted for each
one. Two examples:

- `git commit -m "fix the bug"` kept `fix the bug` in the pattern, so every
  commit message re-prompted.
- `freshdesk ticket reply --message "Single line body"` kept the body.

The existing termination rules did not fire. `IsCallSpecificValueToken` needs a
digit in the token. The #1402 rule needs an embedded line break.

## The fix (predicate 1)

The change adds one rule to `ReconstructClauseText`. A quote-wrapped arg whose
decoded text holds internal whitespace is call-specific free text. The rule
drops it from the normalized pattern. It runs beside the digit (#1331) and
multi-line (#1402) rules. The composition is `digit OR multi-line OR
whitespace-quoted`.

Predicate 1 is the conservative choice. A single-word quoted arg has no
internal whitespace, so the pattern keeps it. `git commit -m "fix"` still keeps
`fix`, and a quoted and an unquoted single token normalize the same way. Only a
multi-word quoted value operand drops.

## Security reasoning

- **Pattern-only.** The change shapes the stored pattern and the approve-retry
  key only. It does not change the live authorization decision. That decision
  re-parses each command and scopes every path arg through the zone gate.
  `FormatForDisplay` still shows the full command to the operator, because a
  single-line command has no line break and takes the verbatim fast path.
- **Path args keep their scope.** The drop applies to value tokens only. The
  parser marks a real path `IsPath`, and the rule exempts it. A quoted path
  with a space (`cat "my file.txt"`) keeps its directory scope, which
  `ExtractCandidates` resolves from the same parsed arg. A quoted search
  pattern (`grep "foo bar" ./notes.txt`) drops, and the trailing path still
  scopes the candidate.
- **Wrappers are unaffected.** The analyzer expands `bash -c` and `sh -c`
  command strings into inner clauses before this walk, so the rule never hides
  an inner command from the gate. Prefix wrappers such as `env` and `timeout`
  keep their existing termination behavior.

## Tests

New cases in `ShellApprovalMatcherTests`:

- `git commit -m "fix the bug"` normalizes to `git commit -m`.
- `freshdesk ticket reply --message "Single line body"` drops the body.
- `git commit -m "fix"` keeps `fix` (single-word quoted).
- `find . -name "*.cs"` keeps the glob (no internal whitespace).
- `cat "my file.txt"` keeps its directory scope in `ExtractCandidates`.
- `grep "foo bar" ./notes.txt` keeps the path scope and ignores the free text.
- `FormatForDisplay` shows the full command for a single-line message.

No existing test needed a normalization update. `git commit -m fix` and
`bash -c "git push --force"` stay unchanged, because neither carries a
multi-word quoted value operand.

### Validation

- `dotnet test src/Netclaw.Security.Tests` — 678 passed, 0 failed, 0 skipped.
- Downstream approval and compaction tests in `Netclaw.Actors.Tests` — 437
  passed, 0 failed.
- `dotnet slopwatch analyze` — 0 issues.
- `Add-FileHeaders.ps1 -Verify` — all files have headers.

## Spec follow-up

The `openspec/specs/tool-approval-gates/spec.md` "Shell command pattern
matching" requirement defines call-specific classification as one
morphological rule (digit-bearing). This change adds the quoted-free-text
rule. Reconcile the spec through `/opsx-sync`. Do not hand-edit it.
