### PR TITLE
Clean up terminal jobs and successful one-shot reminders

### DIFF
--- a/docs/runbooks/background-jobs.md
+++ b/docs/runbooks/background-jobs.md
@@ -82,6 +82,19 @@ is notified** with the log path so the agent can relaunch. Notification volume
 is bounded by design: passivated sessions have no live jobs, so only sessions
 that were warm at crash time appear here.
 
+### Terminal artifact retention
+
+The manager retains each terminal definition and its output directory for 24
+hours after completion. The policy applies to `Completed`, `Failed`,
+`Cancelled`, `TimedOut`, `Lost`, and `Reaped` jobs.
+
+The manager starts an hourly cleanup sweep after startup reconciliation. The
+sweep deletes the output directory before it deletes the definition. A file
+error keeps the definition and lets the next sweep retry the cleanup.
+
+A terminal definition without `CompletedAtMs` is corrupt. The sweep reports
+the problem and retains its artifacts instead of inferring a deletion time.
+
 ## Monitoring
 
 ### Active jobs in context
@@ -110,6 +123,9 @@ check_background_job(JobId: "abc123", Cancel: true)  # cancel
 Returns: status, elapsed time, rationale, exit code (if finished), and the
 live output tail (last 2000 chars, read from the streaming log). Only
 accessible from the same session/audience/boundary that submitted the job.
+
+The tool can query a terminal job during its 24-hour retention window. After
+that window, the tool reports that it cannot find the job.
 
 This tool is only available when shell execution is granted (same `shell` grant
 category as `shell_execute`).

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.42.0"
+  version: "2.43.0"
 ---
 
 # Netclaw Operations
@@ -104,6 +104,7 @@ view inline plus a pointer to the full output — not the whole thing:
   `shell_execute` to get around it — that just spills again.
 - **`background_job`** output goes to `~/.netclaw/jobs/{id}/output.log` (bounded);
   `check_background_job` returns a tail, and you can `file_read`/`grep` the log for the rest.
+  Netclaw deletes a terminal job's definition and logs 24 hours after completion.
 
 Reading a targeted range or grepping is always cheaper than re-running a command or
 re-reading a whole file. Secret-bearing values are redacted from all tool output.

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.43.0"
+  version: "2.44.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -254,6 +254,8 @@ Lifecycle:
   notification with the log path — relaunch if still needed.
 - Process exit (success or failure) delivers a result turn with exit code,
   output tail, and log path — even if the session was passivated mid-flight.
+- Netclaw retains every terminal job definition and its logs for 24 hours after
+  completion. The hourly cleanup sweep then deletes both artifact types.
 
 Monitoring a running job (e.g. waiting for a dev server to come up):
 
@@ -282,7 +284,8 @@ Rules:
   model server that takes minutes to respond) should run as background jobs.
 - The user must approve the command before it starts running in the background.
 - Maximum 5 concurrent background jobs; overflow queues FIFO.
-- Job definitions persist to `~/.netclaw/jobs/{id}.json`.
+- Job definitions persist to `~/.netclaw/jobs/{id}.json` until 24 hours after
+  the job reaches a terminal state.
 
 `check_background_job` is only available when shell execution is granted (same
 `shell` grant category). It validates that the requesting session matches the

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -70,6 +70,7 @@ A one-shot reminder stays enabled while an occurrence can retry. After a
 successful acknowledgement, Netclaw deletes its definition and history. A poison
 one-shot becomes disabled with a `Failed` outcome. Its definition and history
 remain available until an operator uses the permanent delete command.
+Startup reconciliation also removes completed one-shots from prior versions.
 
 Each attempt has a 20-minute inactivity limit and a one-hour absolute limit.
 The durable acknowledgement lease is 70 minutes. A daemon crash therefore lets

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -66,10 +66,10 @@ A known execution or delivery failure starts the Akka.Reminders retry policy.
 The retry uses bounded backoff and the same durable occurrence identity. A
 successful attempt resets the consecutive failure count.
 
-A one-shot reminder stays enabled while an occurrence can retry. A successful
-one-shot becomes disabled with a `Completed` outcome. A poison one-shot becomes
-disabled with a `Failed` outcome. Both definitions and their history remain
-available until an operator uses the permanent delete command.
+A one-shot reminder stays enabled while an occurrence can retry. After a
+successful acknowledgement, Netclaw deletes its definition and history. A poison
+one-shot becomes disabled with a `Failed` outcome. Its definition and history
+remain available until an operator uses the permanent delete command.
 
 Each attempt has a 20-minute inactivity limit and a one-hour absolute limit.
 The durable acknowledgement lease is 70 minutes. A daemon crash therefore lets

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
@@ -98,6 +98,59 @@ public sealed class BackgroundJobDefinitionStoreTests : IDisposable
     }
 
     /// <summary>
+    /// Terminal-job cleanup: <see cref="BackgroundJobDefinitionStore.DeleteJobArtifacts"/>
+    /// removes BOTH the definition file and the job's output-log directory, so the
+    /// store cannot grow without bound after a job's retention window elapses.
+    /// </summary>
+    [Fact]
+    public void DeleteJobArtifacts_removes_definition_and_output_directory()
+    {
+        var store = new BackgroundJobDefinitionStore(_paths);
+        var jobId = new BackgroundJobId("cleanup-job-001");
+
+        store.Save(new BackgroundJobDefinition
+        {
+            Id = jobId,
+            Command = "dotnet test",
+            SessionId = new Netclaw.Actors.Protocol.SessionId("C0ABC/1712000000.000001"),
+            Rationale = "Run the test suite.",
+            Status = BackgroundJobStatus.Completed,
+            TimeoutSeconds = 300,
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            OriginChannelType = Netclaw.Actors.Channels.ChannelType.Slack
+        });
+
+        // Simulate a real job's output log on disk.
+        var outputLogPath = store.GetOutputLogPath(jobId);
+        File.WriteAllText(outputLogPath, "build output");
+
+        Assert.NotNull(store.Get(jobId));
+        Assert.True(File.Exists(outputLogPath));
+
+        var removed = store.DeleteJobArtifacts(jobId);
+
+        Assert.True(removed);
+        Assert.Null(store.Get(jobId));
+        Assert.False(File.Exists(outputLogPath));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(outputLogPath)));
+    }
+
+    /// <summary>
+    /// Idempotent cleanup: deleting artifacts for an already-removed job reports
+    /// false and does not throw.
+    /// </summary>
+    [Fact]
+    public void DeleteJobArtifacts_missing_job_returns_false_without_throwing()
+    {
+        var store = new BackgroundJobDefinitionStore(_paths);
+
+        var removed = store.DeleteJobArtifacts(new BackgroundJobId("never-existed"));
+
+        Assert.False(removed);
+    }
+
+    /// <summary>
     /// Byte-equality gate for issue #994 Pass 7b. Wrapping <c>BackgroundJobDefinition.Id</c>
     /// in <see cref="BackgroundJobId"/> and <c>SessionId</c> in
     /// <see cref="Netclaw.Actors.Protocol.SessionId"/> MUST NOT change the on-disk JSON:

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
@@ -151,6 +151,69 @@ public sealed class BackgroundJobDefinitionStoreTests : IDisposable
     }
 
     /// <summary>
+    /// Traversal guard (adversarial review, HIGH): Uri.EscapeDataString does not
+    /// escape dots, so a dot-only id must NOT resolve to the jobs directory's
+    /// parent and delete it recursively. The store rejects such ids at
+    /// deserialization, and DeleteJobArtifacts contains the delete to the jobs
+    /// directory as belt-and-braces.
+    /// </summary>
+    [Fact]
+    public void DeleteJobArtifacts_dot_only_id_cannot_escape_jobs_directory()
+    {
+        var store = new BackgroundJobDefinitionStore(_paths);
+        var jobsDir = _paths.JobsDirectory;
+        var parentDir = Path.GetDirectoryName(jobsDir.TrimEnd(Path.DirectorySeparatorChar))!;
+        var sentinel = Path.Combine(parentDir, "sentinel-file.txt");
+        File.WriteAllText(sentinel, "do not delete");
+
+        // ".." would resolve to the parent of the jobs directory.
+        var removed = store.DeleteJobArtifacts(new BackgroundJobId(".."));
+
+        // The delete must be refused (nothing removed) — the parent survives.
+        Assert.False(removed);
+        Assert.True(File.Exists(sentinel));
+        Assert.True(Directory.Exists(jobsDir));
+
+        File.Delete(sentinel);
+    }
+
+    /// <summary>
+    /// Traversal guard (adversarial review, HIGH): a persisted definition whose
+    /// id is "." or ".." must be rejected at load — it never appears in
+    /// List(), so the sweep can never act on it.
+    /// </summary>
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void Definition_with_dot_only_id_is_rejected_at_load(string unsafeId)
+    {
+        var logger = new CapturingJobLogger<BackgroundJobDefinitionStore>();
+        var store = new BackgroundJobDefinitionStore(_paths, logger);
+
+        // File name mirrors what GetPath would produce for this id:
+        // Uri.EscapeDataString leaves dots unescaped, so the file is "..json".
+        var filePath = Path.Combine(_paths.JobsDirectory, $"{Uri.EscapeDataString(unsafeId)}.json");
+        File.WriteAllText(filePath, $$"""
+            {
+              "id": "{{unsafeId}}",
+              "command": "echo pwn",
+              "sessionId": "C0TEST/1712000000.000001",
+              "rationale": "test",
+              "status": "Completed",
+              "timeoutSeconds": 600,
+              "startedAtMs": 0,
+              "completedAtMs": 0,
+              "audience": "Personal",
+              "boundary": "Personal"
+            }
+            """);
+
+        Assert.Empty(store.List());
+        Assert.Null(store.Get(new BackgroundJobId(unsafeId)));
+        Assert.Contains(logger.Errors, e => e.Contains("unsafe id"));
+    }
+
+    /// <summary>
     /// Byte-equality gate for issue #994 Pass 7b. Wrapping <c>BackgroundJobDefinition.Id</c>
     /// in <see cref="BackgroundJobId"/> and <c>SessionId</c> in
     /// <see cref="Netclaw.Actors.Protocol.SessionId"/> MUST NOT change the on-disk JSON:

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
@@ -150,6 +150,42 @@ public sealed class BackgroundJobDefinitionStoreTests : IDisposable
         Assert.False(removed);
     }
 
+    [Fact]
+    public void DeleteJobArtifacts_keeps_definition_when_output_cleanup_fails_then_retries()
+    {
+        var store = new BackgroundJobDefinitionStore(_paths);
+        var jobId = new BackgroundJobId("cleanup-retry-001");
+        store.Save(new BackgroundJobDefinition
+        {
+            Id = jobId,
+            Command = "dotnet test",
+            SessionId = new Netclaw.Actors.Protocol.SessionId("C0ABC/1712000000.000001"),
+            Rationale = "Run the test suite.",
+            Status = BackgroundJobStatus.Completed,
+            TimeoutSeconds = 300,
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            OriginChannelType = Netclaw.Actors.Channels.ChannelType.Slack
+        });
+
+        var outputLogPath = store.GetOutputLogPathOnly(jobId);
+        var outputDirectory = Path.GetDirectoryName(outputLogPath)!;
+        File.WriteAllText(outputDirectory, "path collision");
+
+        var error = Assert.Throws<IOException>(() => store.DeleteJobArtifacts(jobId));
+
+        Assert.Contains("is not a directory", error.Message);
+        Assert.NotNull(store.Get(jobId));
+        Assert.True(File.Exists(outputDirectory));
+
+        File.Delete(outputDirectory);
+        File.WriteAllText(store.GetOutputLogPath(jobId), "build output");
+
+        Assert.True(store.DeleteJobArtifacts(jobId));
+        Assert.Null(store.Get(jobId));
+        Assert.False(Directory.Exists(outputDirectory));
+    }
+
     /// <summary>
     /// Traversal guard (adversarial review, HIGH): Uri.EscapeDataString does not
     /// escape dots, so a dot-only id must NOT resolve to the jobs directory's
@@ -211,6 +247,39 @@ public sealed class BackgroundJobDefinitionStoreTests : IDisposable
         Assert.Empty(store.List());
         Assert.Null(store.Get(new BackgroundJobId(unsafeId)));
         Assert.Contains(logger.Errors, e => e.Contains("unsafe id"));
+    }
+
+    [Fact]
+    public void Definition_with_id_that_does_not_match_file_name_is_rejected_at_load()
+    {
+        var logger = new CapturingJobLogger<BackgroundJobDefinitionStore>();
+        var store = new BackgroundJobDefinitionStore(_paths, logger);
+        var victimId = new BackgroundJobId("victim-job");
+        store.Save(new BackgroundJobDefinition
+        {
+            Id = victimId,
+            Command = "dotnet test",
+            SessionId = new Netclaw.Actors.Protocol.SessionId("C0ABC/1712000000.000001"),
+            Rationale = "Run the test suite.",
+            Status = BackgroundJobStatus.Completed,
+            StartedAtMs = 1,
+            CompletedAtMs = 2,
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            OriginChannelType = Netclaw.Actors.Channels.ChannelType.Slack
+        });
+
+        var victimPath = Path.Combine(_paths.JobsDirectory, $"{Uri.EscapeDataString(victimId.Value)}.json");
+        var aliasPath = Path.Combine(_paths.JobsDirectory, "stale-alias.json");
+        File.Copy(victimPath, aliasPath);
+
+        var loaded = store.List();
+
+        var definition = Assert.Single(loaded);
+        Assert.Equal(victimId, definition.Id);
+        Assert.Null(store.Get(new BackgroundJobId("stale-alias")));
+        Assert.Contains(logger.Errors, error =>
+            error.Contains("does not match its canonical file name", StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -49,6 +49,16 @@ public class BackgroundJobManagerActorTests : TestKit
 
     private IActorRef GetManager() => ActorRegistry.For(Sys).Get<BackgroundJobManagerActorKey>();
 
+    private async Task<BackgroundJobManagerHealthResponse> RunTerminalSweepAsync(IActorRef manager)
+    {
+        // Both messages use the same sender, so the health response is a strict
+        // mailbox barrier after the sweep.
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance, TestActor);
+        manager.Tell(GetBackgroundJobManagerHealth.Instance, TestActor);
+        return await ExpectMsgAsync<BackgroundJobManagerHealthResponse>(
+            TimeSpan.FromSeconds(30), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
     private BackgroundJobDefinition MakeTerminalDefinition(string jobId, BackgroundJobStatus status, long completedAtMs) => new()
     {
         Id = new BackgroundJobId(jobId),
@@ -324,7 +334,8 @@ public class BackgroundJobManagerActorTests : TestKit
 
     [Fact]
     public async Task StartupReconciliation_EmitsAlert_ForLegacyJobMissingTrustFields()
-    {        var paths = new NetclawPaths(_dir.Path);
+    {
+        var paths = new NetclawPaths(_dir.Path);
         paths.EnsureDirectoriesExist();
 
         const string jobId = "legacy-job-alert";
@@ -390,13 +401,7 @@ public class BackgroundJobManagerActorTests : TestKit
 
         _store.Save(MakeTerminalDefinition("sweep-past", BackgroundJobStatus.Completed, pastWindowMs));
 
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
-        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        await RunTerminalSweepAsync(manager);
 
         Assert.Null(_store.Get(new BackgroundJobId("sweep-past")));
     }
@@ -409,10 +414,7 @@ public class BackgroundJobManagerActorTests : TestKit
 
         _store.Save(MakeTerminalDefinition("sweep-recent", BackgroundJobStatus.Completed, recentMs));
 
-        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        await RunTerminalSweepAsync(manager);
 
         Assert.NotNull(_store.Get(new BackgroundJobId("sweep-recent")));
     }
@@ -431,10 +433,7 @@ public class BackgroundJobManagerActorTests : TestKit
         _store.Save(MakeTerminalDefinition("sweep-running", BackgroundJobStatus.Running, pastWindowMs));
         _store.Save(MakeTerminalDefinition("sweep-pending", BackgroundJobStatus.Pending, pastWindowMs));
 
-        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        await RunTerminalSweepAsync(manager);
 
         Assert.NotNull(_store.Get(new BackgroundJobId("sweep-running")));
         Assert.NotNull(_store.Get(new BackgroundJobId("sweep-pending")));
@@ -455,10 +454,7 @@ public class BackgroundJobManagerActorTests : TestKit
 
         _store.Save(MakeTerminalDefinition("sweep-log", BackgroundJobStatus.Failed, pastWindowMs));
 
-        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        await RunTerminalSweepAsync(manager);
 
         Assert.Null(_store.Get(jobId));
         Assert.False(File.Exists(outputLogPath));
@@ -466,11 +462,60 @@ public class BackgroundJobManagerActorTests : TestKit
     }
 
     [Fact]
-    public async Task TerminalSweep_SweepsTerminalJobWithNullCompletedAtMs_UsingStartedAtFallback()
+    public async Task TerminalSweep_CleanupFailureDoesNotRestartManagerAndLaterSweepRetries()
     {
-        // Adversarial review, MED: a terminal-status definition with null
-        // CompletedAtMs must still be swept once its StartedAtMs is past the
-        // window — otherwise it leaks forever (the exact bug this PR fixes).
+        var manager = GetManager();
+        var pastWindowMs = TimeProvider.System.GetUtcNow()
+            .Subtract(BackgroundJobManagerActor.TerminalJobRetentionWindow)
+            .Subtract(TimeSpan.FromMinutes(1))
+            .ToUnixTimeMilliseconds();
+        var blocked = MakeTerminalDefinition("sweep-blocked", BackgroundJobStatus.Failed, pastWindowMs);
+        var removable = MakeTerminalDefinition("sweep-removable", BackgroundJobStatus.Completed, pastWindowMs);
+        _store.Save(blocked);
+        _store.Save(removable);
+
+        var blockedOutputPath = _store.GetOutputLogPathOnly(blocked.Id);
+        var blockedOutputDirectory = Path.GetDirectoryName(blockedOutputPath)!;
+        File.WriteAllText(blockedOutputDirectory, "path collision");
+        File.WriteAllText(_store.GetOutputLogPath(removable.Id), "completed output");
+
+        var active = await manager.Ask<BackgroundJobStarted>(
+            MakeStartCommand("sleep 60"),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            var health = await RunTerminalSweepAsync(manager);
+
+            Assert.Equal(1, health.ActiveJobCount);
+            Assert.NotNull(_store.Get(blocked.Id));
+            Assert.Null(_store.Get(removable.Id));
+
+            File.Delete(blockedOutputDirectory);
+            await RunTerminalSweepAsync(manager);
+
+            Assert.Null(_store.Get(blocked.Id));
+        }
+        finally
+        {
+            if (File.Exists(blockedOutputDirectory))
+                File.Delete(blockedOutputDirectory);
+
+            await manager.Ask<BackgroundJobCancelResponse>(
+                new CancelBackgroundJob(
+                    active.JobId,
+                    new SessionId("test/thread"),
+                    TrustAudience.Personal,
+                    TrustBoundary.Personal),
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task TerminalSweep_KeepsTerminalJobWithMissingCompletionTime()
+    {
         var manager = GetManager();
         var pastWindowMs = TimeProvider.System.GetUtcNow()
             .Subtract(BackgroundJobManagerActor.TerminalJobRetentionWindow)
@@ -480,32 +525,12 @@ public class BackgroundJobManagerActorTests : TestKit
         var def = MakeTerminalDefinition("sweep-null-completed", BackgroundJobStatus.Failed, pastWindowMs);
         def = def with { CompletedAtMs = null };
         _store.Save(def);
+        var outputLogPath = _store.GetOutputLogPath(def.Id);
+        File.WriteAllText(outputLogPath, "diagnostic output");
 
-        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        await RunTerminalSweepAsync(manager);
 
-        Assert.Null(_store.Get(new BackgroundJobId("sweep-null-completed")));
-    }
-
-    [Fact]
-    public async Task TerminalSweep_KeepsTerminalJobWithNullCompletedAtMs_WhenStartedAtRecent()
-    {
-        // A terminal job with null CompletedAtMs but a RECENT StartedAtMs must
-        // survive the sweep — the StartedAt fallback must not over-delete.
-        var manager = GetManager();
-        var recentMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds();
-
-        var def = MakeTerminalDefinition("sweep-null-recent", BackgroundJobStatus.Failed, recentMs);
-        def = def with { CompletedAtMs = null };
-        _store.Save(def);
-
-        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
-        await manager.Ask<BackgroundJobManagerHealthResponse>(
-            GetBackgroundJobManagerHealth.Instance,
-            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
-
-        Assert.NotNull(_store.Get(new BackgroundJobId("sweep-null-recent")));
+        Assert.NotNull(_store.Get(def.Id));
+        Assert.True(File.Exists(outputLogPath));
     }
 }

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -464,4 +464,48 @@ public class BackgroundJobManagerActorTests : TestKit
         Assert.False(File.Exists(outputLogPath));
         Assert.False(Directory.Exists(Path.GetDirectoryName(outputLogPath)));
     }
+
+    [Fact]
+    public async Task TerminalSweep_SweepsTerminalJobWithNullCompletedAtMs_UsingStartedAtFallback()
+    {
+        // Adversarial review, MED: a terminal-status definition with null
+        // CompletedAtMs must still be swept once its StartedAtMs is past the
+        // window — otherwise it leaks forever (the exact bug this PR fixes).
+        var manager = GetManager();
+        var pastWindowMs = TimeProvider.System.GetUtcNow()
+            .Subtract(BackgroundJobManagerActor.TerminalJobRetentionWindow)
+            .Subtract(TimeSpan.FromMinutes(1))
+            .ToUnixTimeMilliseconds();
+
+        var def = MakeTerminalDefinition("sweep-null-completed", BackgroundJobStatus.Failed, pastWindowMs);
+        def = def with { CompletedAtMs = null };
+        _store.Save(def);
+
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.Null(_store.Get(new BackgroundJobId("sweep-null-completed")));
+    }
+
+    [Fact]
+    public async Task TerminalSweep_KeepsTerminalJobWithNullCompletedAtMs_WhenStartedAtRecent()
+    {
+        // A terminal job with null CompletedAtMs but a RECENT StartedAtMs must
+        // survive the sweep — the StartedAt fallback must not over-delete.
+        var manager = GetManager();
+        var recentMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds();
+
+        var def = MakeTerminalDefinition("sweep-null-recent", BackgroundJobStatus.Failed, recentMs);
+        def = def with { CompletedAtMs = null };
+        _store.Save(def);
+
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(_store.Get(new BackgroundJobId("sweep-null-recent")));
+    }
 }

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -49,6 +49,21 @@ public class BackgroundJobManagerActorTests : TestKit
 
     private IActorRef GetManager() => ActorRegistry.For(Sys).Get<BackgroundJobManagerActorKey>();
 
+    private BackgroundJobDefinition MakeTerminalDefinition(string jobId, BackgroundJobStatus status, long completedAtMs) => new()
+    {
+        Id = new BackgroundJobId(jobId),
+        Command = "echo hello",
+        SessionId = new SessionId("test/thread"),
+        Rationale = "test run",
+        Status = status,
+        StartedAtMs = completedAtMs - 60_000,
+        CompletedAtMs = completedAtMs,
+        TimeoutSeconds = 60,
+        Audience = TrustAudience.Personal,
+        Boundary = TrustBoundary.Personal,
+        OriginChannelType = ChannelType.Tui
+    };
+
     private StartBackgroundJob MakeStartCommand(string command = "echo hello") => new()
     {
         Command = command,
@@ -309,8 +324,7 @@ public class BackgroundJobManagerActorTests : TestKit
 
     [Fact]
     public async Task StartupReconciliation_EmitsAlert_ForLegacyJobMissingTrustFields()
-    {
-        var paths = new NetclawPaths(_dir.Path);
+    {        var paths = new NetclawPaths(_dir.Path);
         paths.EnsureDirectoriesExist();
 
         const string jobId = "legacy-job-alert";
@@ -363,5 +377,91 @@ public class BackgroundJobManagerActorTests : TestKit
             lock (_sync)
                 _alerts.Add(alert);
         }
+    }
+
+    [Fact]
+    public async Task TerminalSweep_DeletesJobPastRetentionWindow()
+    {
+        var manager = GetManager();
+        var pastWindowMs = TimeProvider.System.GetUtcNow()
+            .Subtract(BackgroundJobManagerActor.TerminalJobRetentionWindow)
+            .Subtract(TimeSpan.FromMinutes(1))
+            .ToUnixTimeMilliseconds();
+
+        _store.Save(MakeTerminalDefinition("sweep-past", BackgroundJobStatus.Completed, pastWindowMs));
+
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.Null(_store.Get(new BackgroundJobId("sweep-past")));
+    }
+
+    [Fact]
+    public async Task TerminalSweep_KeepsJobWithinRetentionWindow()
+    {
+        var manager = GetManager();
+        var recentMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds();
+
+        _store.Save(MakeTerminalDefinition("sweep-recent", BackgroundJobStatus.Completed, recentMs));
+
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(_store.Get(new BackgroundJobId("sweep-recent")));
+    }
+
+    [Fact]
+    public async Task TerminalSweep_DoesNotTouchNonTerminalJobs()
+    {
+        var manager = GetManager();
+        var pastWindowMs = TimeProvider.System.GetUtcNow()
+            .Subtract(BackgroundJobManagerActor.TerminalJobRetentionWindow)
+            .Subtract(TimeSpan.FromMinutes(1))
+            .ToUnixTimeMilliseconds();
+
+        // A Running job with a stale CompletedAtMs must never be swept — the
+        // status guard is independent of the timestamp.
+        _store.Save(MakeTerminalDefinition("sweep-running", BackgroundJobStatus.Running, pastWindowMs));
+        _store.Save(MakeTerminalDefinition("sweep-pending", BackgroundJobStatus.Pending, pastWindowMs));
+
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(_store.Get(new BackgroundJobId("sweep-running")));
+        Assert.NotNull(_store.Get(new BackgroundJobId("sweep-pending")));
+    }
+
+    [Fact]
+    public async Task TerminalSweep_DeletesOutputLogWithDefinition()
+    {
+        var manager = GetManager();
+        var pastWindowMs = TimeProvider.System.GetUtcNow()
+            .Subtract(BackgroundJobManagerActor.TerminalJobRetentionWindow)
+            .Subtract(TimeSpan.FromMinutes(1))
+            .ToUnixTimeMilliseconds();
+        var jobId = new BackgroundJobId("sweep-log");
+
+        var outputLogPath = _store.GetOutputLogPath(jobId);
+        File.WriteAllText(outputLogPath, "some output");
+
+        _store.Save(MakeTerminalDefinition("sweep-log", BackgroundJobStatus.Failed, pastWindowMs));
+
+        manager.Tell(BackgroundJobManagerActor.SweepTerminalJobs.Instance);
+        await manager.Ask<BackgroundJobManagerHealthResponse>(
+            GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.Null(_store.Get(jobId));
+        Assert.False(File.Exists(outputLogPath));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(outputLogPath)));
     }
 }

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -321,7 +321,7 @@ public class ReminderManagerActorTests : TestKit
     }
 
     [Fact]
-    public async Task Reconcile_retains_past_oneshot_without_durable_outcome()
+    public async Task Reconcile_deletes_completed_oneshot_and_retains_ambiguous_or_failed_oneshots()
     {
         var manager = await GetManagerAsync();
         var now = TimeProvider.System.GetUtcNow();
@@ -361,6 +361,23 @@ public class ReminderManagerActorTests : TestKit
         await historyStore.AppendAsync(
             zombie.Id,
             new HistoryRecord(now.AddMinutes(-30), false, 100, "session-1", "recovery failed"));
+        var completed = zombie with
+        {
+            Id = new ReminderId("completed-old"),
+            Enabled = false,
+            TerminalOutcome = ReminderTerminalOutcome.Completed
+        };
+        var failed = zombie with
+        {
+            Id = new ReminderId("failed-old"),
+            Enabled = false,
+            ConsecutiveFailures = ReminderManagerActor.FailurePauseThreshold,
+            TerminalOutcome = ReminderTerminalOutcome.Failed
+        };
+        _definitionStore.Save(completed);
+        _definitionStore.Save(failed);
+        await historyStore.AppendAsync(completed.Id, new HistoryRecord(now, true, 100, "session-1", null));
+        await historyStore.AppendAsync(failed.Id, new HistoryRecord(now, false, 100, "session-1", "failed"));
 
         // Confirm it shows up as scheduled
         var healthBefore = await manager.Ask<ReminderHealthResponse>(
@@ -379,6 +396,10 @@ public class ReminderManagerActorTests : TestKit
         Assert.True(afterReconcile!.Enabled);
         Assert.Null(afterReconcile.TerminalOutcome);
         Assert.Single(await historyStore.ReadAsync(zombie.Id, 10));
+        Assert.Null(_definitionStore.Get(completed.Id));
+        Assert.Empty(await historyStore.ReadAsync(completed.Id, 10));
+        Assert.NotNull(_definitionStore.Get(failed.Id));
+        Assert.Single(await historyStore.ReadAsync(failed.Id, 10));
     }
 
     [Theory]

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -1238,7 +1238,7 @@ public class ReminderManagerActorTests : TestKit
     }
 
     [Fact]
-    public async Task Successful_retry_resets_failure_count_and_soft_deletes_oneshot()
+    public async Task Successful_retry_deletes_oneshot_definition_and_history()
     {
         var manager = await GetManagerAsync();
         var gatewayProbe = CreateTestProbe("retry-success-gateway");
@@ -1271,17 +1271,9 @@ public class ReminderManagerActorTests : TestKit
 
         await AwaitAssertAsync(async () =>
         {
-            var stored = _definitionStore.Get(definition.Id);
-            Assert.NotNull(stored);
-            Assert.False(stored!.Enabled);
-            Assert.Equal(0, stored.ConsecutiveFailures);
-            Assert.Equal(ReminderTerminalOutcome.Completed, stored.TerminalOutcome);
-
-            var status = await manager.Ask<ReminderStatusResponse>(
-                new GetReminderStatusQuery(definition.Id),
-                TimeSpan.FromSeconds(3),
-                TestContext.Current.CancellationToken);
-            Assert.Equal("Delivered", status.Occurrence?.CompletionStatus);
+            Assert.Null(_definitionStore.Get(definition.Id));
+            var historyStore = new ReminderHistoryStore(new NetclawPaths(_basePath));
+            Assert.Empty(await historyStore.ReadAsync(definition.Id, 10));
         }, duration: TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
     }
 

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -54,7 +54,44 @@ public sealed class BackgroundJobDefinitionStore
             return null;
         }
 
-        return JsonSerializer.Deserialize<BackgroundJobDefinition>(text, JsonOptions);
+        var definition = JsonSerializer.Deserialize<BackgroundJobDefinition>(text, JsonOptions);
+        if (definition is null)
+            return null;
+
+        // Reject ids that resolve to special directory entries ("." / "..") —
+        // Uri.EscapeDataString does NOT escape dots, so such an id would make
+        // DeleteJobArtifacts target the jobs directory itself or its parent
+        // (see DeleteJobArtifacts containment check). The manager only ever
+        // generates 12-hex ids; anything else on disk is corrupt or hostile.
+        if (!IsSafeJobId(definition.Id.Value))
+        {
+            _logger.LogError(
+                "Background job document {Path} has an unsafe id '{JobId}'. The job will not be loaded.",
+                path, definition.Id.Value);
+            return null;
+        }
+
+        return definition;
+    }
+
+    /// <summary>
+    /// True when the id is a plain file-name token that cannot traverse out of
+    /// the jobs directory. Dots pass through <c>Uri.EscapeDataString</c>
+    /// unescaped, so "." / ".." (and any id containing a path separator) are
+    /// rejected outright.
+    /// </summary>
+    private static bool IsSafeJobId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return false;
+
+        if (id is "." or "..")
+            return false;
+
+        if (id.IndexOfAny(['/', '\\']) >= 0)
+            return false;
+
+        return true;
     }
 
     /// <summary>
@@ -168,10 +205,22 @@ public sealed class BackgroundJobDefinitionStore
             // what the execution actor wrote.
             var outputLogPath = GetOutputLogPathOnly(id);
             var outputDir = Path.GetDirectoryName(outputLogPath);
-            if (outputDir is not null && Directory.Exists(outputDir))
+            if (outputDir is not null)
             {
-                Directory.Delete(outputDir, recursive: true);
-                removed = true;
+                // Containment guard: Uri.EscapeDataString does not escape dots,
+                // so an id like ".." would otherwise resolve to the jobs
+                // directory's parent and Directory.Delete(recursive) would wipe
+                // it. Never touch anything outside the jobs directory.
+                var root = Path.GetFullPath(_directory);
+                var fullDir = Path.GetFullPath(outputDir);
+                var prefix = root.EndsWith(Path.DirectorySeparatorChar)
+                    ? root
+                    : root + Path.DirectorySeparatorChar;
+                if (fullDir.StartsWith(prefix, StringComparison.Ordinal) && Directory.Exists(fullDir))
+                {
+                    Directory.Delete(fullDir, recursive: true);
+                    removed = true;
+                }
             }
 
             return removed;

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -71,6 +71,17 @@ public sealed class BackgroundJobDefinitionStore
             return null;
         }
 
+        var expectedFileName = $"{Uri.EscapeDataString(definition.Id.Value)}.json";
+        var actualFileName = Path.GetFileName(path);
+        if (!string.Equals(actualFileName, expectedFileName, StringComparison.Ordinal))
+        {
+            _logger.LogError(
+                "Background job document {Path} has id '{JobId}', which does not match its canonical file name {ExpectedFileName}. "
+                + "The job will not be loaded.",
+                path, definition.Id.Value, expectedFileName);
+            return null;
+        }
+
         return definition;
     }
 
@@ -193,13 +204,6 @@ public sealed class BackgroundJobDefinitionStore
         {
             var removed = false;
 
-            var path = GetPath(id);
-            if (File.Exists(path))
-            {
-                File.Delete(path);
-                removed = true;
-            }
-
             // Reuse the canonical output-log path (same encoding as
             // GetOutputLogPathOnly) so the artifact directory matches exactly
             // what the execution actor wrote.
@@ -216,11 +220,27 @@ public sealed class BackgroundJobDefinitionStore
                 var prefix = root.EndsWith(Path.DirectorySeparatorChar)
                     ? root
                     : root + Path.DirectorySeparatorChar;
-                if (fullDir.StartsWith(prefix, StringComparison.Ordinal) && Directory.Exists(fullDir))
+                if (!fullDir.StartsWith(prefix, StringComparison.Ordinal))
+                    return false;
+
+                if (File.Exists(fullDir))
+                    throw new IOException($"Background job artifact path '{fullDir}' is not a directory.");
+
+                if (Directory.Exists(fullDir))
                 {
                     Directory.Delete(fullDir, recursive: true);
                     removed = true;
                 }
+            }
+
+            // Keep the definition until every output artifact is gone. A later
+            // sweep can retry if the directory delete fails because of a lock,
+            // permissions, or another transient filesystem error.
+            var path = GetPath(id);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+                removed = true;
             }
 
             return removed;

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="BackgroundJobDefinitionStore.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -142,6 +142,35 @@ public sealed class BackgroundJobDefinitionStore
 
             File.Delete(path);
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Deletes the job definition file AND its output-log directory. Used by
+    /// terminal-job cleanup once a job's retention window has elapsed. Returns
+    /// true when anything was removed.
+    /// </summary>
+    public bool DeleteJobArtifacts(BackgroundJobId id)
+    {
+        lock (_sync)
+        {
+            var removed = false;
+
+            var path = GetPath(id);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+                removed = true;
+            }
+
+            var outputDir = Path.Combine(_directory, Uri.EscapeDataString(id.Value));
+            if (Directory.Exists(outputDir))
+            {
+                Directory.Delete(outputDir, recursive: true);
+                removed = true;
+            }
+
+            return removed;
         }
     }
 

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -163,8 +163,12 @@ public sealed class BackgroundJobDefinitionStore
                 removed = true;
             }
 
-            var outputDir = Path.Combine(_directory, Uri.EscapeDataString(id.Value));
-            if (Directory.Exists(outputDir))
+            // Reuse the canonical output-log path (same encoding as
+            // GetOutputLogPathOnly) so the artifact directory matches exactly
+            // what the execution actor wrote.
+            var outputLogPath = GetOutputLogPathOnly(id);
+            var outputDir = Path.GetDirectoryName(outputLogPath);
+            if (outputDir is not null && Directory.Exists(outputDir))
             {
                 Directory.Delete(outputDir, recursive: true);
                 removed = true;

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="BackgroundJobManagerActor.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -26,6 +26,22 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     internal const int MaxConcurrentJobs = 5;
     internal const int MaxOutputTailChars = 2000;
 
+    /// <summary>
+    /// How long a terminal job's definition and output log are retained after
+    /// completion before the cleanup sweep deletes them. The delivered result
+    /// message references the full output-log path, so the grace period must be
+    /// long enough for the owning session to poll <c>check_background_job</c> or
+    /// read the log after delivery. See <see cref="SweepTerminalJobs"/>.
+    /// </summary>
+    internal static TimeSpan TerminalJobRetentionWindow = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Cadence of the periodic terminal-job cleanup sweep. The sweep also runs
+    /// once during startup reconciliation, so a daemon restart immediately
+    /// purges anything past the retention window.
+    /// </summary>
+    internal static TimeSpan TerminalSweepInterval = TimeSpan.FromHours(1);
+
     // Capture ceiling for a job's output log: the execution actor drains each
     // stream to this bound (head+tail) so a chatty long-running job can't buffer
     // its full output in memory and OOM the daemon. The log holds a head+tail view
@@ -45,6 +61,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     private readonly HashSet<string> _activeJobIds = [];
     private readonly Queue<string> _deferredQueue = new();
     private readonly Dictionary<string, BackgroundJobDefinition> _definitions = [];
+    private ICancelable? _sweepCancelable;
 
     public BackgroundJobManagerActor(
         BackgroundJobDefinitionStore store,
@@ -62,6 +79,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         Receive<QueryBackgroundJob>(HandleQuery);
         Receive<KillJobsForSession>(HandleKillJobsForSession);
         Receive<GetBackgroundJobManagerHealth>(_ => HandleGetHealth());
+        Receive<SweepTerminalJobs>(_ => HandleSweepTerminalJobs());
     }
 
     protected override void PreStart()
@@ -72,6 +90,22 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         // (macOS CI): ActorOf returns before PreStart executes, allowing external
         // messages to queue ahead of the Reconcile message.
         HandleReconcile();
+
+        // Periodic cleanup for terminal jobs past their retention window. The
+        // startup reconcile also sweeps, so a restart purges immediately; this
+        // timer keeps the store from growing during a long-lived daemon run.
+        _sweepCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
+            TerminalSweepInterval,
+            TerminalSweepInterval,
+            Self,
+            SweepTerminalJobs.Instance,
+            Self);
+    }
+
+    protected override void PostStop()
+    {
+        _sweepCancelable?.Cancel();
+        _sweepCancelable = null;
     }
 
     private async Task HandleStartAsync(StartBackgroundJob cmd)
@@ -322,7 +356,64 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
 
         if (reconciled > 0)
             _log.Info("Background job startup reconciliation: marked {0} orphaned job(s) as lost", reconciled);
+
+        // Startup sweep: purge terminal jobs whose retention window has elapsed,
+        // in the same pass as the orphan reconciliation.
+        HandleSweepTerminalJobs();
     }
+
+    /// <summary>
+    /// Deletes definitions (and output logs) for terminal jobs whose
+    /// <c>CompletedAtMs</c> is older than <see cref="TerminalJobRetentionWindow"/>.
+    /// Active jobs are never touched. Terminal jobs stay queryable via
+    /// <c>check_background_job</c> during the window — the delivered result
+    /// message references the output-log path, and a slow polling session may
+    /// still read it — then get swept so the store cannot grow without bound.
+    /// </summary>
+    private void HandleSweepTerminalJobs()
+    {
+        var swept = 0;
+        var cutoffMs = _timeProvider.GetUtcNow()
+            .Subtract(TerminalJobRetentionWindow)
+            .ToUnixTimeMilliseconds();
+
+        foreach (var def in _store.List())
+        {
+            if (!IsTerminalStatus(def.Status))
+                continue;
+
+            // Belt-and-braces: never sweep a job this actor still considers
+            // active, even if the on-disk snapshot is stale.
+            if (_activeJobIds.Contains(def.Id.Value))
+                continue;
+
+            if (def.CompletedAtMs is null || def.CompletedAtMs.Value > cutoffMs)
+                continue;
+
+            if (_store.DeleteJobArtifacts(def.Id))
+            {
+                _definitions.Remove(def.Id.Value);
+                swept++;
+                _log.Info(
+                    "Swept terminal background job {JobId} (status={Status}, completed_at={CompletedAtMs}) past retention window",
+                    def.Id, def.Status, def.CompletedAtMs);
+            }
+        }
+
+        if (swept > 0)
+            _log.Info("Background job terminal sweep: deleted {0} job(s) past the retention window", swept);
+    }
+
+    private static bool IsTerminalStatus(BackgroundJobStatus status) => status switch
+    {
+        BackgroundJobStatus.Completed or
+        BackgroundJobStatus.Failed or
+        BackgroundJobStatus.Cancelled or
+        BackgroundJobStatus.TimedOut or
+        BackgroundJobStatus.Lost or
+        BackgroundJobStatus.Reaped => true,
+        _ => false
+    };
 
     private void NotifyLostJob(BackgroundJobDefinition lost, long nowMs)
     {
@@ -497,4 +588,11 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
                output + filePath;
     }
 
+    /// <summary>
+    /// Internal self-message: periodic terminal-job cleanup sweep.
+    /// </summary>
+    internal sealed record SweepTerminalJobs : INoSerializationVerificationNeeded
+    {
+        public static readonly SweepTerminalJobs Instance = new();
+    }
 }

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -21,7 +21,7 @@ namespace Netclaw.Actors.Jobs;
 /// Infrastructure singleton that manages background job lifecycle independently
 /// of any session. Follows the same pattern as <c>ReminderManagerActor</c>.
 /// </summary>
-public sealed class BackgroundJobManagerActor : ReceiveActor
+public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
 {
     internal const int MaxConcurrentJobs = 5;
     internal const int MaxOutputTailChars = 2000;
@@ -61,7 +61,17 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     private readonly HashSet<string> _activeJobIds = [];
     private readonly Queue<string> _deferredQueue = new();
     private readonly Dictionary<string, BackgroundJobDefinition> _definitions = [];
-    private ICancelable? _sweepCancelable;
+
+    /// <summary>
+    /// Timer identity for the periodic terminal-job sweep.
+    /// </summary>
+    private static readonly object TerminalSweepTimerKey = new();
+
+    /// <summary>
+    /// Timer scheduler injected by Akka for <see cref="IWithTimers"/>. Timers
+    /// are canceled automatically when the actor stops.
+    /// </summary>
+    public ITimerScheduler Timers { get; set; } = null!;
 
     public BackgroundJobManagerActor(
         BackgroundJobDefinitionStore store,
@@ -94,18 +104,8 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         // Periodic cleanup for terminal jobs past their retention window. The
         // startup reconcile also sweeps, so a restart purges immediately; this
         // timer keeps the store from growing during a long-lived daemon run.
-        _sweepCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
-            TerminalSweepInterval,
-            TerminalSweepInterval,
-            Self,
-            SweepTerminalJobs.Instance,
-            Self);
-    }
-
-    protected override void PostStop()
-    {
-        _sweepCancelable?.Cancel();
-        _sweepCancelable = null;
+        // IWithTimers cancels the timer automatically when the actor stops.
+        Timers.StartPeriodicTimer(TerminalSweepTimerKey, SweepTerminalJobs.Instance, TerminalSweepInterval);
     }
 
     private async Task HandleStartAsync(StartBackgroundJob cmd)

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -33,14 +33,14 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
     /// long enough for the owning session to poll <c>check_background_job</c> or
     /// read the log after delivery. See <see cref="SweepTerminalJobs"/>.
     /// </summary>
-    internal static TimeSpan TerminalJobRetentionWindow = TimeSpan.FromHours(24);
+    internal static readonly TimeSpan TerminalJobRetentionWindow = TimeSpan.FromHours(24);
 
     /// <summary>
     /// Cadence of the periodic terminal-job cleanup sweep. The sweep also runs
     /// once during startup reconciliation, so a daemon restart immediately
     /// purges anything past the retention window.
     /// </summary>
-    internal static TimeSpan TerminalSweepInterval = TimeSpan.FromHours(1);
+    internal static readonly TimeSpan TerminalSweepInterval = TimeSpan.FromHours(1);
 
     // Capture ceiling for a job's output log: the execution actor drains each
     // stream to this bound (head+tail) so a chatty long-running job can't buffer

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -387,7 +387,13 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
             if (_activeJobIds.Contains(def.Id.Value))
                 continue;
 
-            if (def.CompletedAtMs is null || def.CompletedAtMs.Value > cutoffMs)
+            // Terminal jobs always carry CompletedAtMs from the manager's own
+            // transitions, but a corrupt/legacy file can have terminal status
+            // with a null completion time — fall back to StartedAtMs so that
+            // class still gets swept instead of leaking forever. StartedAtMs is
+            // always present (set at submission), so the fallback is total.
+            var completedAtMs = def.CompletedAtMs ?? def.StartedAtMs;
+            if (completedAtMs > cutoffMs)
                 continue;
 
             if (_store.DeleteJobArtifacts(def.Id))

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -387,22 +387,39 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
             if (_activeJobIds.Contains(def.Id.Value))
                 continue;
 
-            // Terminal jobs always carry CompletedAtMs from the manager's own
-            // transitions, but a corrupt/legacy file can have terminal status
-            // with a null completion time — fall back to StartedAtMs so that
-            // class still gets swept instead of leaking forever. StartedAtMs is
-            // always present (set at submission), so the fallback is total.
-            var completedAtMs = def.CompletedAtMs ?? def.StartedAtMs;
+            // Every manager-owned terminal transition writes CompletedAtMs. A
+            // missing value is corrupt state, so do not infer a completion time
+            // and risk deletion before the full retention window has elapsed.
+            if (def.CompletedAtMs is not { } completedAtMs)
+            {
+                _log.Warning(
+                    "Cannot sweep terminal background job {JobId} with status {Status}: completion timestamp is missing",
+                    def.Id, def.Status);
+                continue;
+            }
+
             if (completedAtMs > cutoffMs)
                 continue;
 
-            if (_store.DeleteJobArtifacts(def.Id))
+            try
             {
-                _definitions.Remove(def.Id.Value);
-                swept++;
-                _log.Info(
-                    "Swept terminal background job {JobId} (status={Status}, completed_at={CompletedAtMs}) past retention window",
-                    def.Id, def.Status, def.CompletedAtMs);
+                if (_store.DeleteJobArtifacts(def.Id))
+                {
+                    _definitions.Remove(def.Id.Value);
+                    swept++;
+                    _log.Info(
+                        "Swept terminal background job {JobId} (status={Status}, completed_at={CompletedAtMs}) past retention window",
+                        def.Id, def.Status, def.CompletedAtMs);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Keep the definition so the next periodic sweep can retry the
+                // cleanup. One filesystem failure must not stop the manager or
+                // prevent cleanup of other terminal jobs.
+                _log.Warning(
+                    "Failed to sweep terminal background job {JobId}; cleanup will retry: {Error}",
+                    def.Id, ex.Message);
             }
         }
 

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -872,22 +872,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         }
 
         if (definition is { Schedule.Type: ReminderScheduleType.OneShot })
-        {
-            try
-            {
-                _definitionStore.Save(definition with
-                {
-                    Enabled = false,
-                    ConsecutiveFailures = 0,
-                    TerminalOutcome = ReminderTerminalOutcome.Completed,
-                    UpdatedAtMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds()
-                });
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to save completed state for one-shot reminder '{0}'", outcome.Id.Value);
-            }
-        }
+            await DeleteReminderInternalAsync(outcome.Id);
 
         _log.Info("Reminder '{0}' execution completed successfully", outcome.Id.Value);
     }

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -443,7 +443,6 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     /// </summary>
     private async Task DeleteReminderInternalAsync(ReminderId id)
     {
-        _definitionStore.Delete(id);
         await CancelScheduleOnlyAsync(id);
         _skipCounts.Remove(id);
 
@@ -454,7 +453,11 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         catch (Exception ex)
         {
             _log.Warning(ex, "Failed to delete history for reminder '{0}'", id.Value);
+            throw;
         }
+
+        // Delete the definition last so reconciliation can retry a partial cleanup.
+        _definitionStore.Delete(id);
     }
 
     private async Task<ReminderStateResponse> EnableReminderInternalAsync(ReminderId id)

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -1043,6 +1043,17 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             var definitions = _definitionStore.List();
             var definitionsById = definitions.ToDictionary(d => d.Id.Value, StringComparer.Ordinal);
 
+            var deletedCompletedOneShots = 0;
+            foreach (var definition in definitions.Where(d =>
+                         !d.Enabled &&
+                         d.Schedule.Type == ReminderScheduleType.OneShot &&
+                         d.TerminalOutcome == ReminderTerminalOutcome.Completed))
+            {
+                await DeleteReminderInternalAsync(definition.Id);
+                definitionsById.Remove(definition.Id.Value);
+                deletedCompletedOneShots++;
+            }
+
             var cancelledOrphans = 0;
             foreach (var (id, _) in scheduled)
             {
@@ -1099,6 +1110,13 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                 if (outcome is null)
                     continue;
 
+                if (outcome == ReminderTerminalOutcome.Completed)
+                {
+                    await DeleteReminderInternalAsync(definition.Id);
+                    deletedCompletedOneShots++;
+                    continue;
+                }
+
                 var terminalDefinition = definition with
                 {
                     Enabled = false,
@@ -1120,13 +1138,15 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                 disabledExpired++;
             }
 
-            if (cancelledOrphans > 0 || restoredSchedules > 0 || softDeletedOneShots > 0 || disabledExpired > 0)
+            if (cancelledOrphans > 0 || restoredSchedules > 0 || softDeletedOneShots > 0
+                || disabledExpired > 0 || deletedCompletedOneShots > 0)
             {
-                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}, soft_deleted_oneshots={2}, disabled_expired={3}",
+                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}, soft_deleted_oneshots={2}, disabled_expired={3}, deleted_completed_oneshots={4}",
                     cancelledOrphans,
                     restoredSchedules,
                     softDeletedOneShots,
-                    disabledExpired);
+                    disabledExpired,
+                    deletedCompletedOneShots);
             }
 
             // Only ack external callers — skip Self.Tell from PreStart


### PR DESCRIPTION
## Summary

- Delete terminal background job definitions and output logs after a 24-hour grace period.
- Run the terminal job sweep during startup reconciliation and once each hour.
- Delete a successful one-shot reminder definition and history after its acknowledgement succeeds.
- Remove completed one-shot definitions and histories from prior versions during startup reconciliation.
- Keep failed or ambiguous one-shot reminders visible for retry and diagnosis.

## Scope

This change does not alter reminder storage, scheduler payloads, session ownership, delivery routes, or retry settlement.

Existing active reminders and background jobs keep their current paths.

The failed one-shot retention window remains separate work in #1820.

## Validation

- `Netclaw.Actors.Tests`: 2,921 passed.
- The focused cleanup and failure-retention tests passed.
- Slopwatch found zero issues.
- The file header check passed.
- `git diff --check` passed.

The eval suite did not run.

Addresses #1820.