### PR TITLE
Store session automation artifacts with their sessions

### DIFF
--- a/docs/runbooks/background-jobs.md
+++ b/docs/runbooks/background-jobs.md
@@ -128,9 +128,9 @@ category as `shell_execute`).
 Existing jobs can remain under `~/.netclaw/jobs/`. Netclaw reads and updates
 these jobs at their current paths. Netclaw does not move them automatically.
 
-The generic file tools cannot change a direct session `jobs/{id}.json`
-definition. Use the background job tools for job state changes. The output log
-files remain readable and writable inside the session file scope.
+The generic file tools cannot change files in a session `jobs/` directory. Use
+the background job tools for job state changes. The output log files remain
+readable inside the session file scope.
 
 ## Configuration
 

--- a/docs/runbooks/background-jobs.md
+++ b/docs/runbooks/background-jobs.md
@@ -35,7 +35,7 @@ The `BackgroundJobManagerActor` manages job lifecycle:
 - **Process isolation**: each job runs as a child `BackgroundJobExecutionActor`
   that spawns the shell process with stdin closed.
 - **Streaming output capture**: stdout/stderr stream line-by-line to
-  `~/.netclaw/jobs/{id}/output.log` *while the process runs* (stderr lines
+  `~/.netclaw/sessions/{session-key}/jobs/{id}/output.log` *while the process runs* (stderr lines
   prefixed `[stderr]`). Each line is secret-redacted at write time. The log is
   bounded by single-slot rotation: when `output.log` crosses ~5 MB it moves to
   `output.1.log` (replacing any earlier rotation), so a job holds at most
@@ -43,7 +43,7 @@ The `BackgroundJobManagerActor` manages job lifecycle:
 - **Timeout**: a kill timer is armed **only** when the agent passes a positive
   `_timeout_seconds`. Omitted means no timer — the job runs until it exits or
   is reaped.
-- **Definitions**: persisted to `~/.netclaw/jobs/{id}.json` for crash recovery.
+- **Definitions**: persisted to `~/.netclaw/sessions/{session-key}/jobs/{id}.json` for crash recovery.
 
 ### Termination
 
@@ -75,9 +75,10 @@ job process outlives the daemon.
 
 ### Startup reconciliation
 
-On daemon restart, the manager scans `~/.netclaw/jobs/` for definitions with
-status `Running` or `Pending`. These are orphaned processes lost during the
-restart — marked `Lost` with a completion timestamp, **and the owning session
+On daemon restart, the manager scans each session job directory. It also scans
+`~/.netclaw/jobs/` for existing definitions. Running or pending definitions are
+orphaned processes. The manager marks them `Lost` with a completion timestamp.
+The owning session
 is notified** with the log path so the agent can relaunch. Notification volume
 is bounded by design: passivated sessions have no live jobs, so only sessions
 that were warm at crash time appear here.
@@ -117,12 +118,15 @@ category as `shell_execute`).
 ## Filesystem layout
 
 ```
-~/.netclaw/jobs/
+~/.netclaw/sessions/{session-key}/jobs/
 ├── abc123.json           # job definition (status, command, session, timing)
 └── abc123/
     ├── output.log        # live streamed stdout + stderr (most recent)
     └── output.1.log      # rotated predecessor (present only after rotation)
 ```
+
+Existing jobs can remain under `~/.netclaw/jobs/`. Netclaw reads and updates
+these jobs at their current paths. Netclaw does not move them automatically.
 
 ## Configuration
 
@@ -140,7 +144,7 @@ approval policy and audience ACL as regular shell execution.
 
 | Symptom | Check |
 |---------|-------|
-| Job stuck as "running" | Check `~/.netclaw/jobs/{id}.json` status; daemon may have restarted (jobs become Lost) |
+| Job stuck as "running" | Check the session `jobs/{id}.json` status. Existing jobs can remain under `~/.netclaw/jobs/`. |
 | No result delivered | Check daemon logs for gateway resolution failure; verify channel type matches a registered gateway |
 | Job definition shows Lost | Normal after daemon restart — the owning session was notified; the pre-crash log remains readable |
 | Job definition shows Reaped | Normal after the owning session went idle — the agent resubmits if still needed |

--- a/docs/runbooks/background-jobs.md
+++ b/docs/runbooks/background-jobs.md
@@ -128,6 +128,10 @@ category as `shell_execute`).
 Existing jobs can remain under `~/.netclaw/jobs/`. Netclaw reads and updates
 these jobs at their current paths. Netclaw does not move them automatically.
 
+The generic file tools cannot change a direct session `jobs/{id}.json`
+definition. Use the background job tools for job state changes. The output log
+files remain readable and writable inside the session file scope.
+
 ## Configuration
 
 The `_timeout_seconds` metadata field on the tool call arms a per-job kill

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.43.0"
+  version: "2.44.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.42.0"
+  version: "2.43.0"
 ---
 
 # Netclaw Operations
@@ -102,7 +102,7 @@ view inline plus a pointer to the full output — not the whole thing:
   specific range with `StartLine`/`Limit` or `grep` (`StartLine` is a 1-based line
   number — line 1 is the first line). Don't `cat` a huge file through
   `shell_execute` to get around it — that just spills again.
-- **`background_job`** output goes to `~/.netclaw/jobs/{id}/output.log` (bounded);
+- **`background_job`** output goes to `{session}/jobs/{id}/output.log` (bounded);
   `check_background_job` returns a tail, and you can `file_read`/`grep` the log for the rest.
 
 Reading a targeted range or grepping is always cheaper than re-running a command or

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -107,6 +107,11 @@ audience is always allowed.
 Other scheduling tools: `list_reminders`, `cancel_reminder`,
 `get_reminder_history`.
 
+Do not edit a session reminder or job definition JSON file with a generic file
+tool. Netclaw reserves those files because they contain the durable trust and
+ownership envelope. Use the reminder and background job tools instead. The
+history and output log files remain available to file tools.
+
 ## Proactive channel messaging
 
 To start a brand-new conversation on a chat channel — a `delivery_kind=channel`

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -107,10 +107,10 @@ audience is always allowed.
 Other scheduling tools: `list_reminders`, `cancel_reminder`,
 `get_reminder_history`.
 
-Do not edit a session reminder or job definition JSON file with a generic file
-tool. Netclaw reserves those files because they contain the durable trust and
-ownership envelope. Use the reminder and background job tools instead. The
-history and output log files remain available to file tools.
+Do not edit files in a session reminder or job directory with a generic file
+tool. Netclaw reserves those subsystem-owned artifacts. Use the reminder and
+background job tools instead. Definitions, history, and output logs remain
+readable through file tools.
 
 ## Proactive channel messaging
 

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -257,8 +257,8 @@ Lifecycle:
 
 Monitoring a running job (e.g. waiting for a dev server to come up):
 
-- `file_read`/`grep` the output log — it streams live (secret-redacted,
-  rotation-bounded) at `~/.netclaw/jobs/{id}/output.log`.
+- `file_read`/`grep` the output log. It streams live at
+  `{session}/jobs/{id}/output.log` with secret redaction and bounded rotation.
 - `check_background_job(JobId: "id")` — status, elapsed time, live output tail
 - Probe the service directly (e.g. curl the port) once the log shows it started.
 - `check_background_job(JobId: "id", Cancel: true)` — cancel a running job.
@@ -282,7 +282,8 @@ Rules:
   model server that takes minutes to respond) should run as background jobs.
 - The user must approve the command before it starts running in the background.
 - Maximum 5 concurrent background jobs; overflow queues FIFO.
-- Job definitions persist to `~/.netclaw/jobs/{id}.json`.
+- New job definitions persist to `{session}/jobs/{id}.json`.
+- Existing definitions under `~/.netclaw/jobs/` stay there. Netclaw reads and updates them in place.
 
 `check_background_job` is only available when shell execution is granted (same
 `shell` grant category). It validates that the requesting session matches the

--- a/openspec/changes/session-owned-automation-artifacts/.openspec.yaml
+++ b/openspec/changes/session-owned-automation-artifacts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/session-owned-automation-artifacts/design.md
+++ b/openspec/changes/session-owned-automation-artifacts/design.md
@@ -15,7 +15,7 @@ The reminder and job managers are daemon singletons. They coordinate concurrent 
 - Put session-owned reminder and job files under the source session directory.
 - Keep daemon-owned reminder files under the daemon schedule directory.
 - Keep the current actors, messages, scheduler payload, and tool contracts.
-- Preserve all compatible files during the path migration.
+- Preserve all current files at their present paths.
 - Let a future session-retention process remove session artifacts as one unit.
 
 **Non-Goals:**
@@ -57,11 +57,11 @@ This decision avoids one manager per session. It also avoids a new actor protoco
 
 Alternative: Move execution managers below each session actor. This adds actor lifecycle changes and splits the global concurrency limit.
 
-### Store indexes preserve the current ID-only contracts
+### Fixed-directory scans preserve the current ID-only contracts
 
-Each store will maintain an in-memory map from its globally unique ID to a canonical file path. Startup scans will rebuild each map.
+Each store will scan only the daemon directory and the fixed artifact directory under each session.
 
-The reminder store will scan the daemon reminder directory and each fixed session reminder directory. The job store will scan each fixed session job directory.
+The stores will not add an index, a new service, or a new persistence record.
 
 `ReminderPayload` will continue to contain only `ReminderId`. Manager commands will also keep their current ID-only forms.
 
@@ -75,27 +75,21 @@ Alternative: Add `SessionId` to all reminder messages. This gives stronger type 
 
 A caller will provide typed ownership data, not an arbitrary file path. The store will derive the full path from `SessionId` and the artifact ID.
 
-The store will require the result to remain under the exact source session directory. It will reject path traversal and symbolic-link escapes.
+The store will require the result to remain under the exact source session directory. It will reject a path traversal attempt.
 
 A loaded definition must name the same session as its containing session directory. The store will reject a mismatch and log the reason.
 
 The current audience and boundary checks will remain unchanged. A path under another trusted root will not satisfy the session-owner check.
 
-### Startup performs a convergent legacy migration
+### Current artifacts stay at their present paths
 
-The reminder store will inspect each legacy global definition. It will move only a `CurrentSession` definition with a valid `Delivery.SessionId`.
+The stores will read both the daemon directories and the fixed session subdirectories. They will not move files during startup.
 
-The store will move the history file before the definition file. The definition move will act as the migration commit point.
+An update will write to the path that already owns the definition. This rule keeps active reminders and background job records stable.
 
-The job store will inspect each legacy global job definition. It will move the output directory before the definition file.
+Only a new `CurrentSession` reminder or background job will use a session directory. `Channel` and `None` reminders will use the daemon directory.
 
-Each move will use a temporary path and an atomic rename within the destination file system. A restart will resume an incomplete migration.
-
-The migration will never overwrite a destination artifact. A conflict or invalid owner will produce an error and preserve the source data.
-
-The stores will continue to read a valid legacy source after a migration error. This compatibility path will be explicit and observable.
-
-No scheduler replacement is necessary. The persisted reminder payload still resolves through the ID index after the definition moves.
+No scheduler replacement is necessary. The persisted reminder payload still resolves by its current reminder ID.
 
 ### Future session retention must respect live session automation
 
@@ -107,22 +101,16 @@ Background jobs do not need a retention pin. The current passivation contract re
 
 ## Risks / Trade-offs
 
-- **A startup scan can cost more with many sessions.** The stores scan only fixed `reminders/` and `jobs/` subdirectories.
-- **An interrupted migration can split related files.** The definition file acts as the commit point, and the next startup resumes the move.
+- **A lookup can cost more with many sessions.** The stores scan only fixed `reminders/` and `jobs/` subdirectories.
 - **A duplicate ID can make ownership ambiguous.** The stores retain global ID uniqueness and fail on duplicate definitions.
 - **A direct file edit can bypass a tool confirmation.** Store validation still rejects invalid schema, owner, audience, and boundary data.
 - **A future janitor can delete an active reminder.** The later retention change must define a live-reminder policy before file removal.
 
 ## Migration Plan
 
-1. Start the daemon with the new owner-aware stores.
-2. Scan the current daemon directories and the fixed session artifact directories.
-3. Move valid legacy session-owned artifacts to their canonical session paths.
-4. Build the ID indexes from the canonical and compatible legacy files.
-5. Run the current reminder and job reconciliation paths without protocol changes.
-6. Log each migration failure and keep its source files intact.
+No file migration occurs. The new stores read current daemon paths and new session paths.
 
-Rollback can use the prior binary after operators move session artifacts back to the legacy directories. The JSON formats do not change.
+Rollback can use the prior binary for all existing files. New session-owned files require the new binary.
 
 ## Open Questions
 

--- a/openspec/changes/session-owned-automation-artifacts/design.md
+++ b/openspec/changes/session-owned-automation-artifacts/design.md
@@ -1,0 +1,129 @@
+## Context
+
+Netclaw stores reminder files under `~/.netclaw/schedules/reminders/`. It stores background job files under `~/.netclaw/jobs/`.
+
+`CurrentSession` reminders return to one source session. Every background job also records one source `SessionId` and returns there.
+
+The session directory provides the canonical file root for session artifacts. The file policy also treats that directory as a trusted root.
+
+The reminder and job managers are daemon singletons. They coordinate concurrent work across sessions and must remain singletons.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Put session-owned reminder and job files under the source session directory.
+- Keep daemon-owned reminder files under the daemon schedule directory.
+- Keep the current actors, messages, scheduler payload, and tool contracts.
+- Preserve all compatible files during the path migration.
+- Let a future session-retention process remove session artifacts as one unit.
+
+**Non-Goals:**
+
+- Implement the future 30-day session-retention process.
+- Move manager actor ownership into each session actor.
+- Change reminder execution, delivery, retry, or settlement behavior.
+- Change background process execution, passivation, or delivery behavior.
+- Permit duplicate reminder or job IDs across sessions.
+- Add a new configuration value or storage service.
+- Add a background-job-specific artifact retention timer.
+
+## Decisions
+
+### The session directory is the physical ownership boundary
+
+Netclaw will use these canonical paths:
+
+```text
+~/.netclaw/sessions/{session-key}/reminders/{reminder-id}.json
+~/.netclaw/sessions/{session-key}/reminders/{reminder-id}.history.jsonl
+~/.netclaw/sessions/{session-key}/jobs/{job-id}.json
+~/.netclaw/sessions/{session-key}/jobs/{job-id}/output.log
+```
+
+`CurrentSession` reminder files will use the session paths. All background job files will use the session paths.
+
+`Channel` and `None` reminder files will remain under `~/.netclaw/schedules/reminders/`. Those reminders create new sessions and have daemon scope.
+
+The implementation will reuse `NetclawPaths.SessionsDirectory` and `SessionDirectoryHelper`. It will not add a parallel path configuration.
+
+Alternative: Keep the global directories and add a separate artifact purge. This duplicates session ownership and requires two retention mechanisms.
+
+### Manager actors remain global coordinators
+
+The current singleton managers will retain concurrency control, reconciliation, and delivery coordination. Physical file ownership will not change actor ownership.
+
+This decision avoids one manager per session. It also avoids a new actor protocol for cross-session capacity control.
+
+Alternative: Move execution managers below each session actor. This adds actor lifecycle changes and splits the global concurrency limit.
+
+### Store indexes preserve the current ID-only contracts
+
+Each store will maintain an in-memory map from its globally unique ID to a canonical file path. Startup scans will rebuild each map.
+
+The reminder store will scan the daemon reminder directory and each fixed session reminder directory. The job store will scan each fixed session job directory.
+
+`ReminderPayload` will continue to contain only `ReminderId`. Manager commands will also keep their current ID-only forms.
+
+This decision avoids an Akka.Reminders payload migration. It also avoids changes to protobuf messages, CLI routes, tools, and actor commands.
+
+Alternative: Persist an absolute definition path in `ReminderPayload`. That path can become stale after a home-directory move or data restore.
+
+Alternative: Add `SessionId` to all reminder messages. This gives stronger type context but adds unnecessary protocol changes for the current global ID model.
+
+### The stores derive and validate every session path
+
+A caller will provide typed ownership data, not an arbitrary file path. The store will derive the full path from `SessionId` and the artifact ID.
+
+The store will require the result to remain under the exact source session directory. It will reject path traversal and symbolic-link escapes.
+
+A loaded definition must name the same session as its containing session directory. The store will reject a mismatch and log the reason.
+
+The current audience and boundary checks will remain unchanged. A path under another trusted root will not satisfy the session-owner check.
+
+### Startup performs a convergent legacy migration
+
+The reminder store will inspect each legacy global definition. It will move only a `CurrentSession` definition with a valid `Delivery.SessionId`.
+
+The store will move the history file before the definition file. The definition move will act as the migration commit point.
+
+The job store will inspect each legacy global job definition. It will move the output directory before the definition file.
+
+Each move will use a temporary path and an atomic rename within the destination file system. A restart will resume an incomplete migration.
+
+The migration will never overwrite a destination artifact. A conflict or invalid owner will produce an error and preserve the source data.
+
+The stores will continue to read a valid legacy source after a migration error. This compatibility path will be explicit and observable.
+
+No scheduler replacement is necessary. The persisted reminder payload still resolves through the ID index after the definition moves.
+
+### Future session retention must respect live session automation
+
+This change does not add session retention. A later retention design must not silently delete a session with an enabled `CurrentSession` reminder.
+
+That design can pin the session or cancel its reminders before removal. The future OpenSpec change must select and test one policy.
+
+Background jobs do not need a retention pin. The current passivation contract reaps them before the session becomes inactive.
+
+## Risks / Trade-offs
+
+- **A startup scan can cost more with many sessions.** The stores scan only fixed `reminders/` and `jobs/` subdirectories.
+- **An interrupted migration can split related files.** The definition file acts as the commit point, and the next startup resumes the move.
+- **A duplicate ID can make ownership ambiguous.** The stores retain global ID uniqueness and fail on duplicate definitions.
+- **A direct file edit can bypass a tool confirmation.** Store validation still rejects invalid schema, owner, audience, and boundary data.
+- **A future janitor can delete an active reminder.** The later retention change must define a live-reminder policy before file removal.
+
+## Migration Plan
+
+1. Start the daemon with the new owner-aware stores.
+2. Scan the current daemon directories and the fixed session artifact directories.
+3. Move valid legacy session-owned artifacts to their canonical session paths.
+4. Build the ID indexes from the canonical and compatible legacy files.
+5. Run the current reminder and job reconciliation paths without protocol changes.
+6. Log each migration failure and keep its source files intact.
+
+Rollback can use the prior binary after operators move session artifacts back to the legacy directories. The JSON formats do not change.
+
+## Open Questions
+
+None.

--- a/openspec/changes/session-owned-automation-artifacts/design.md
+++ b/openspec/changes/session-owned-automation-artifacts/design.md
@@ -43,7 +43,16 @@ Netclaw will use these canonical paths:
 
 `CurrentSession` reminder files will use the session paths. All background job files will use the session paths.
 
-`Channel` and `None` reminder files will remain under `~/.netclaw/schedules/reminders/`. Those reminders create new sessions and have daemon scope.
+The reminder delivery kind defines its physical owner:
+
+| Reminder behavior | Delivery kind | Physical owner | Definition directory |
+|---|---|---|---|
+| Return to the source session | `CurrentSession` | The source session | `~/.netclaw/sessions/{session-key}/reminders/` |
+| Create a new session | `Channel` or `None` | The daemon | `~/.netclaw/schedules/reminders/` |
+
+A reminder that creates a new session will remain in the daemon reminder directory. Its definition and history will not use the creator session directory.
+
+This change moves only new `CurrentSession` reminder files. It does not move daemon-scoped reminder files.
 
 The implementation will reuse `NetclawPaths.SessionsDirectory` and `SessionDirectoryHelper`. It will not add a parallel path configuration.
 

--- a/openspec/changes/session-owned-automation-artifacts/design.md
+++ b/openspec/changes/session-owned-automation-artifacts/design.md
@@ -81,6 +81,12 @@ A loaded definition must name the same session as its containing session directo
 
 The current audience and boundary checks will remain unchanged. A path under another trusted root will not satisfy the session-owner check.
 
+The stores will reject a session path that contains a symbolic link or reparse point. They will reuse `PathUtility.ContainsSymlinkSegment`.
+
+The generic write policy will reserve only the direct reminder and job definition files. The agent can still read the definitions and write logs or history.
+
+This rule protects the stored trust envelope from a generic file edit. The reminder and job tools remain the supported mutation surfaces.
+
 ### Current artifacts stay at their present paths
 
 The stores will read both the daemon directories and the fixed session subdirectories. They will not move files during startup.
@@ -90,6 +96,10 @@ An update will write to the path that already owns the definition. This rule kee
 Only a new `CurrentSession` reminder or background job will use a session directory. `Channel` and `None` reminders will use the daemon directory.
 
 No scheduler replacement is necessary. The persisted reminder payload still resolves by its current reminder ID.
+
+The stores will count only valid definitions when they detect duplicate IDs. A corrupt or owner-mismatched candidate will not hide a valid legacy definition.
+
+A reminder update will validate its storage owner before it changes the scheduler. An invalid owner transition will leave the prior definition and schedule unchanged.
 
 ### Future session retention must respect live session automation
 
@@ -103,7 +113,7 @@ Background jobs do not need a retention pin. The current passivation contract re
 
 - **A lookup can cost more with many sessions.** The stores scan only fixed `reminders/` and `jobs/` subdirectories.
 - **A duplicate ID can make ownership ambiguous.** The stores retain global ID uniqueness and fail on duplicate definitions.
-- **A direct file edit can bypass a tool confirmation.** Store validation still rejects invalid schema, owner, audience, and boundary data.
+- **A direct file edit can change a trust field.** The generic write policy reserves definition JSON files while it leaves other session artifacts writable.
 - **A future janitor can delete an active reminder.** The later retention change must define a live-reminder policy before file removal.
 
 ## Migration Plan

--- a/openspec/changes/session-owned-automation-artifacts/design.md
+++ b/openspec/changes/session-owned-automation-artifacts/design.md
@@ -83,7 +83,7 @@ The current audience and boundary checks will remain unchanged. A path under ano
 
 The stores will reject a session path that contains a symbolic link or reparse point. They will reuse `PathUtility.ContainsSymlinkSegment`.
 
-The generic write policy will reserve only the direct reminder and job definition files. The agent can still read the definitions and write logs or history.
+The generic write policy will reserve the reminder and job artifact subtrees. The agent can still read definitions, history, and logs.
 
 This rule protects the stored trust envelope from a generic file edit. The reminder and job tools remain the supported mutation surfaces.
 
@@ -113,7 +113,7 @@ Background jobs do not need a retention pin. The current passivation contract re
 
 - **A lookup can cost more with many sessions.** The stores scan only fixed `reminders/` and `jobs/` subdirectories.
 - **A duplicate ID can make ownership ambiguous.** The stores retain global ID uniqueness and fail on duplicate definitions.
-- **A direct file edit can change a trust field.** The generic write policy reserves definition JSON files while it leaves other session artifacts writable.
+- **A direct file edit can change a subsystem-owned record.** The generic write policy reserves session automation artifacts from generic writes.
 - **A future janitor can delete an active reminder.** The later retention change must define a live-reminder policy before file removal.
 
 ## Migration Plan

--- a/openspec/changes/session-owned-automation-artifacts/proposal.md
+++ b/openspec/changes/session-owned-automation-artifacts/proposal.md
@@ -9,8 +9,8 @@ PRD-008 requires durable scheduled work, but Netclaw stores session-owned automa
 - Keep `Channel` and `None` reminder definitions and history in the daemon-wide reminder directory.
 - Keep the current reminder manager, background job manager, execution actors, delivery routes, and trust derivation.
 - Persist logical session ownership and derive a validated absolute artifact path before file access.
-- Restrict each session-owned path to the exact source session directory and reject path or symbolic-link escapes.
-- Move compatible legacy session-owned artifacts from the daemon-wide directories during startup reconciliation.
+- Restrict each session-owned path to the exact source session directory and reject path traversal.
+- Read current session-owned artifacts from their present daemon-wide locations without an automatic move.
 - Use the future session-retention process instead of a background-job-specific artifact timer.
 - Leave the planned session-retention process outside this change.
 
@@ -29,8 +29,8 @@ None.
 
 ## Impact
 
-- **In scope:** PRD-008 storage, reminder lookup, reminder reconciliation, background job lookup, startup migration, and path-containment tests.
+- **In scope:** PRD-008 storage, reminder lookup, reminder reconciliation, background job lookup, dual-location reads, and path tests.
 - **Out of scope:** The planned 30-day session-retention process, a job-specific retention timer, actor ownership changes, scheduler replacement, and delivery-route changes.
 - **Security:** The daemon derives paths from typed session identity. It does not accept an arbitrary path as reminder or job authority.
 - **Operations:** Session removal can later remove these artifacts with the other session files. Daemon-scoped reminders remain independent of session retention.
-- **Compatibility:** Startup reconciliation moves compatible legacy artifacts. Existing reminder schedules remain valid across the storage migration.
+- **Compatibility:** Current files remain in place. ID-only scheduler payloads and current reminder schedules remain valid.

--- a/openspec/changes/session-owned-automation-artifacts/proposal.md
+++ b/openspec/changes/session-owned-automation-artifacts/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+PRD-008 requires durable scheduled work, but Netclaw stores session-owned automation artifacts in daemon-wide directories. This layout prevents a future session-retention process from deleting all artifacts for one session as a unit.
+
+## What Changes
+
+- Store `CurrentSession` reminder definitions and history under the source session directory.
+- Store background job definitions and output logs under the source session directory.
+- Keep `Channel` and `None` reminder definitions and history in the daemon-wide reminder directory.
+- Keep the current reminder manager, background job manager, execution actors, delivery routes, and trust derivation.
+- Persist logical session ownership and derive a validated absolute artifact path before file access.
+- Restrict each session-owned path to the exact source session directory and reject path or symbolic-link escapes.
+- Move compatible legacy session-owned artifacts from the daemon-wide directories during startup reconciliation.
+- Use the future session-retention process instead of a background-job-specific artifact timer.
+- Leave the planned session-retention process outside this change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `netclaw-session`: Define the session directory as the lifecycle boundary for session-owned automation artifacts.
+- `netclaw-scheduling`: Route `CurrentSession` reminder storage by session owner while daemon-scoped reminders retain global storage.
+- `reminder-execution-history`: Store reminder history beside the reminder definition under the same ownership boundary.
+- `background-job-execution`: Store each job definition and output log under its source session directory without replacing the singleton execution manager.
+
+## Impact
+
+- **In scope:** PRD-008 storage, reminder lookup, reminder reconciliation, background job lookup, startup migration, and path-containment tests.
+- **Out of scope:** The planned 30-day session-retention process, a job-specific retention timer, actor ownership changes, scheduler replacement, and delivery-route changes.
+- **Security:** The daemon derives paths from typed session identity. It does not accept an arbitrary path as reminder or job authority.
+- **Operations:** Session removal can later remove these artifacts with the other session files. Daemon-scoped reminders remain independent of session retention.
+- **Compatibility:** Startup reconciliation moves compatible legacy artifacts. Existing reminder schedules remain valid across the storage migration.

--- a/openspec/changes/session-owned-automation-artifacts/specs/background-job-execution/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/background-job-execution/spec.md
@@ -68,6 +68,14 @@ The manager SHALL deliver the lost result and output path to the source session 
 - **THEN** the store rejects the ambiguous duplicate
 - **AND** it logs both paths
 
+#### Scenario: Invalid candidate does not shadow a valid job
+
+- **GIVEN** one valid job claims an ID
+- **AND** a corrupt or owner-mismatched file uses the same encoded file name in another scope
+- **WHEN** the store resolves the job ID
+- **THEN** the store returns the valid job
+- **AND** it logs the rejected candidate
+
 ### Requirement: Background job execution
 
 The system SHALL create one `BackgroundJobExecutionActor` child for each job. The daemon manager SHALL remain the parent actor.

--- a/openspec/changes/session-owned-automation-artifacts/specs/background-job-execution/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/background-job-execution/spec.md
@@ -4,11 +4,13 @@
 
 The system SHALL provide one `BackgroundJobManagerActor` as a daemon infrastructure actor. The manager SHALL coordinate jobs across all sessions.
 
-The source session SHALL own each job definition and output directory. The manager SHALL persist them under:
+The source session SHALL own each new job definition and output directory. The manager SHALL persist them under:
 
 `~/.netclaw/sessions/{session-key}/jobs/`
 
-The manager SHALL enforce the current global concurrency limit and FIFO queue. File ownership SHALL NOT create one manager or one capacity limit per session.
+The store SHALL also read existing jobs under `~/.netclaw/jobs/`. It SHALL preserve their definition and output paths during reads and updates.
+
+The manager SHALL enforce the current global concurrency limit and FIFO queue. File ownership SHALL NOT create one manager or capacity limit per session.
 
 Job persistence SHALL NOT guarantee process continuity across a daemon restart. Startup reconciliation SHALL mark an orphaned job as lost.
 
@@ -19,6 +21,7 @@ The manager SHALL deliver the lost result and output path to the source session 
 - **WHEN** the Netclaw daemon starts
 - **THEN** one `BackgroundJobManagerActor` is registered
 - **AND** it scans each fixed session job directory
+- **AND** it scans the existing daemon job directory
 - **AND** it runs the current best-effort reconciliation
 
 #### Scenario: Concurrency limit remains global
@@ -44,12 +47,26 @@ The manager SHALL deliver the lost result and output path to the source session 
 - **AND** it does not guarantee that the prior process resumes
 - **AND** it notifies the source session when the agent must start a new job
 
-#### Scenario: Manager lookup uses session ownership
+#### Scenario: New manager lookup uses session ownership
 
 - **GIVEN** a job command contains the job ID and source `SessionId`
 - **WHEN** the manager reads or updates the job
 - **THEN** the store resolves the canonical path under that exact session directory
 - **AND** another trusted root does not satisfy the owner check
+
+#### Scenario: Existing job stays at its current path
+
+- **GIVEN** a valid job definition and output exist under `~/.netclaw/jobs/`
+- **WHEN** the store starts, reads, or updates that job
+- **THEN** both artifacts remain under `~/.netclaw/jobs/`
+- **AND** the manager resolves the job with its stored ID and `SessionId`
+
+#### Scenario: Duplicate job ID fails loud
+
+- **GIVEN** the same job ID exists in the daemon and a session job directory
+- **WHEN** the store resolves that ID
+- **THEN** the store rejects the ambiguous duplicate
+- **AND** it logs both paths
 
 ### Requirement: Background job execution
 
@@ -131,47 +148,3 @@ An explicit timeout SHALL kill the full process tree. The completion result SHAL
 - **THEN** the completion uses a trusted turn
 - **AND** that trust equals the approved synchronous shell result trust
 - **AND** the stored audience and boundary do not become broader
-
-## ADDED Requirements
-
-### Requirement: Legacy background job artifact migration
-
-On startup, the job store SHALL inspect legacy definitions under `~/.netclaw/jobs/`. It SHALL derive each destination from the stored `SessionId`.
-
-The store SHALL move the job output directory before it moves the definition file. The definition move SHALL act as the migration commit point.
-
-The store SHALL NOT overwrite a destination artifact. A conflict or invalid owner SHALL produce an error and preserve the source data.
-
-The store SHALL continue to resolve a valid legacy job after a migration error. This compatibility path SHALL produce an operator-visible log entry.
-
-#### Scenario: Legacy job moves to its source session
-
-- **GIVEN** a valid legacy job definition contains a valid `SessionId`
-- **AND** no destination artifact exists
-- **WHEN** startup migration runs
-- **THEN** the output directory moves to the canonical session job directory when present
-- **AND** the definition moves to the same session job directory
-- **AND** the job keeps its current ID and status
-
-#### Scenario: Migration conflict preserves legacy job
-
-- **GIVEN** a legacy job and its destination path both exist
-- **WHEN** startup migration runs
-- **THEN** the migration does not overwrite either artifact
-- **AND** the store logs the conflict
-- **AND** the manager can still inspect the source job through the explicit compatibility path
-
-#### Scenario: Restart resumes an interrupted job migration
-
-- **GIVEN** a prior migration moved the output directory but did not move the definition
-- **WHEN** the daemon restarts
-- **THEN** the migration accepts the matching destination output directory
-- **AND** it completes the definition move without output loss
-
-#### Scenario: Invalid session owner fails loud
-
-- **GIVEN** a legacy job definition has an invalid or absent `SessionId`
-- **WHEN** startup migration runs
-- **THEN** the store does not move the job
-- **AND** it logs the path and validation error
-- **AND** the manager does not execute the job under a substituted session

--- a/openspec/changes/session-owned-automation-artifacts/specs/background-job-execution/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/background-job-execution/spec.md
@@ -1,0 +1,177 @@
+## MODIFIED Requirements
+
+### Requirement: Background job manager lifecycle
+
+The system SHALL provide one `BackgroundJobManagerActor` as a daemon infrastructure actor. The manager SHALL coordinate jobs across all sessions.
+
+The source session SHALL own each job definition and output directory. The manager SHALL persist them under:
+
+`~/.netclaw/sessions/{session-key}/jobs/`
+
+The manager SHALL enforce the current global concurrency limit and FIFO queue. File ownership SHALL NOT create one manager or one capacity limit per session.
+
+Job persistence SHALL NOT guarantee process continuity across a daemon restart. Startup reconciliation SHALL mark an orphaned job as lost.
+
+The manager SHALL deliver the lost result and output path to the source session through the standard trusted route.
+
+#### Scenario: Manager registered at startup
+
+- **WHEN** the Netclaw daemon starts
+- **THEN** one `BackgroundJobManagerActor` is registered
+- **AND** it scans each fixed session job directory
+- **AND** it runs the current best-effort reconciliation
+
+#### Scenario: Concurrency limit remains global
+
+- **GIVEN** the global concurrency limit has five active jobs across multiple sessions
+- **WHEN** another session submits a job
+- **THEN** the manager places that job in the FIFO queue
+- **AND** it starts the job after global capacity becomes available
+
+#### Scenario: Orphaned process cleanup on restart
+
+- **GIVEN** a session-owned job definition exists but its process does not run
+- **WHEN** the manager reconciles after a daemon restart
+- **THEN** the manager marks the job as lost with reason "process lost during restart"
+- **AND** it delivers a `Lost` result and the session-owned output path to the source session
+- **AND** the output written before the restart remains available
+
+#### Scenario: In-flight job can require a new launch after restart
+
+- **GIVEN** a background job ran before the daemon stopped
+- **WHEN** the daemon starts and reconciliation runs
+- **THEN** the manager performs the current best-effort reconciliation
+- **AND** it does not guarantee that the prior process resumes
+- **AND** it notifies the source session when the agent must start a new job
+
+#### Scenario: Manager lookup uses session ownership
+
+- **GIVEN** a job command contains the job ID and source `SessionId`
+- **WHEN** the manager reads or updates the job
+- **THEN** the store resolves the canonical path under that exact session directory
+- **AND** another trusted root does not satisfy the owner check
+
+### Requirement: Background job execution
+
+The system SHALL create one `BackgroundJobExecutionActor` child for each job. The daemon manager SHALL remain the parent actor.
+
+The execution actor SHALL start a detached process and close its standard input. It SHALL not require process exit before it exposes output.
+
+The actor SHALL write redacted standard output and standard error to:
+
+`~/.netclaw/sessions/{session-key}/jobs/{jobId}/output.log`
+
+The actor SHALL keep the current bounded rotation policy. The current log and at most one prior log SHALL remain on disk.
+
+On process exit, the actor SHALL deliver the result to the source session through `DeliverTrustedSessionTurn`.
+
+This route SHALL preserve parity with the approved synchronous shell result. It SHALL not grant more trust than the source tool execution.
+
+An explicit timeout SHALL kill the full process tree. The completion result SHALL read its output tail from the session-owned log.
+
+#### Scenario: Process started and monitored
+
+- **GIVEN** the manager accepts a `StartBackgroundJob` command
+- **WHEN** the execution actor starts
+- **THEN** the actor starts the process with standard input closed
+- **AND** it streams redacted output to the source session job directory
+- **AND** the manager returns the job ID and session-owned output path
+
+#### Scenario: Output is observable while the process runs
+
+- **GIVEN** a background job has produced output
+- **WHEN** the source session uses `check_background_job`, `file_read`, or `grep`
+- **THEN** the current output is present in the session-owned log
+- **AND** each line passed through secret redaction before the write
+
+#### Scenario: Log rotation bounds disk usage
+
+- **GIVEN** a background job output exceeds the rotation threshold
+- **WHEN** the threshold is crossed
+- **THEN** the current log replaces the single prior-log slot
+- **AND** output continues in a new current log
+- **AND** the job output remains size-bounded
+
+#### Scenario: Process completes successfully
+
+- **GIVEN** a background job process exits with code 0
+- **WHEN** the execution actor detects the exit
+- **THEN** it reads the output tail from the session-owned log
+- **AND** it delivers the exit code, output path, output tail, and rationale to the source session
+- **AND** it marks the job definition as completed
+
+#### Scenario: Process fails
+
+- **GIVEN** a background job process exits with a nonzero code
+- **WHEN** the execution actor detects the exit
+- **THEN** it delivers the failure, output, output path, and rationale to the source session
+- **AND** it marks the job definition as failed
+
+#### Scenario: Process reaches its timeout
+
+- **GIVEN** a background job has an explicit positive `_timeout_seconds`
+- **AND** the process exceeds that value
+- **WHEN** the timeout fires
+- **THEN** the actor kills the full process tree
+- **AND** it delivers the timeout error to the source session
+- **AND** it marks the job definition as timed out
+
+#### Scenario: Job result reaches a passivated session
+
+- **GIVEN** a background job completes during or after source session passivation
+- **WHEN** the result arrives through `DeliverTrustedSessionTurn`
+- **THEN** the source session recovers from its Akka Persistence journal
+- **AND** it processes the result turn
+- **AND** job-ID deduplication prevents a duplicate result after a reap race
+
+#### Scenario: Trusted delivery preserves synchronous shell parity
+
+- **GIVEN** an approved `shell_execute` call started a background job
+- **WHEN** the job completes
+- **THEN** the completion uses a trusted turn
+- **AND** that trust equals the approved synchronous shell result trust
+- **AND** the stored audience and boundary do not become broader
+
+## ADDED Requirements
+
+### Requirement: Legacy background job artifact migration
+
+On startup, the job store SHALL inspect legacy definitions under `~/.netclaw/jobs/`. It SHALL derive each destination from the stored `SessionId`.
+
+The store SHALL move the job output directory before it moves the definition file. The definition move SHALL act as the migration commit point.
+
+The store SHALL NOT overwrite a destination artifact. A conflict or invalid owner SHALL produce an error and preserve the source data.
+
+The store SHALL continue to resolve a valid legacy job after a migration error. This compatibility path SHALL produce an operator-visible log entry.
+
+#### Scenario: Legacy job moves to its source session
+
+- **GIVEN** a valid legacy job definition contains a valid `SessionId`
+- **AND** no destination artifact exists
+- **WHEN** startup migration runs
+- **THEN** the output directory moves to the canonical session job directory when present
+- **AND** the definition moves to the same session job directory
+- **AND** the job keeps its current ID and status
+
+#### Scenario: Migration conflict preserves legacy job
+
+- **GIVEN** a legacy job and its destination path both exist
+- **WHEN** startup migration runs
+- **THEN** the migration does not overwrite either artifact
+- **AND** the store logs the conflict
+- **AND** the manager can still inspect the source job through the explicit compatibility path
+
+#### Scenario: Restart resumes an interrupted job migration
+
+- **GIVEN** a prior migration moved the output directory but did not move the definition
+- **WHEN** the daemon restarts
+- **THEN** the migration accepts the matching destination output directory
+- **AND** it completes the definition move without output loss
+
+#### Scenario: Invalid session owner fails loud
+
+- **GIVEN** a legacy job definition has an invalid or absent `SessionId`
+- **WHEN** startup migration runs
+- **THEN** the store does not move the job
+- **AND** it logs the path and validation error
+- **AND** the manager does not execute the job under a substituted session

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-scheduling/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-scheduling/spec.md
@@ -4,15 +4,19 @@
 
 The system SHALL persist each reminder definition as a JSON file. It SHALL preserve the definition and its schedule across process restarts.
 
-A `CurrentSession` definition SHALL use this path:
+A new `CurrentSession` definition SHALL use this path:
 
 `~/.netclaw/sessions/{session-key}/reminders/{reminderId}.json`
 
-A `Channel` or `None` definition SHALL use this path:
+A new `Channel` or `None` definition SHALL use this path:
 
 `~/.netclaw/schedules/reminders/{reminderId}.json`
 
-The reminder store SHALL keep reminder IDs unique across both ownership scopes. It SHALL map each ID to one validated canonical path.
+The store SHALL read definitions from the daemon directory and each fixed session reminder directory.
+
+The store SHALL preserve the current path for each existing definition. It SHALL NOT move a definition during startup or update.
+
+The reminder store SHALL keep reminder IDs unique across both ownership scopes. It SHALL reject an ID that exists in more than one directory.
 
 The Akka.Reminders payload SHALL remain an ID-only pointer. The manager SHALL resolve that ID through the reminder store before execution.
 
@@ -22,7 +26,7 @@ On startup, the system SHALL load all valid definitions and reconcile all active
 
 - **GIVEN** valid reminder definitions exist in daemon and session reminder directories
 - **WHEN** the Netclaw process restarts
-- **THEN** the reminder store rebuilds its ID-to-path index
+- **THEN** the reminder store finds the definitions through fixed-directory scans
 - **AND** the manager reconciles all active schedules
 - **AND** paused reminders remain paused
 
@@ -39,68 +43,40 @@ On startup, the system SHALL load all valid definitions and reconcile all active
 - **WHEN** the manager confirms the new reminder
 - **THEN** the definition already exists under the daemon reminder directory
 
-#### Scenario: Scheduler payload remains stable after a definition move
+#### Scenario: Existing current-session reminder stays at its current path
 
-- **GIVEN** an Akka.Reminders occurrence contains a `ReminderPayload` with one reminder ID
-- **AND** the definition moved from the legacy directory to its session directory
-- **WHEN** the occurrence fires
-- **THEN** the manager resolves the same ID through the rebuilt store index
-- **AND** no scheduler payload migration is necessary
+- **GIVEN** a valid `CurrentSession` definition exists in the daemon reminder directory
+- **WHEN** the store starts, reads, or updates that reminder
+- **THEN** the definition remains in the daemon reminder directory
+- **AND** the manager resolves its existing ID-only scheduler payload
+- **AND** the current schedule remains active
+
+#### Scenario: Existing daemon-scoped reminder stays at its current path
+
+- **GIVEN** a valid `Channel` or `None` definition exists in the daemon reminder directory
+- **WHEN** the store starts, reads, or updates that reminder
+- **THEN** the definition remains in the daemon reminder directory
+- **AND** no session-owned copy is created
 
 #### Scenario: Duplicate reminder ID fails loud
 
 - **GIVEN** two definition files claim the same reminder ID
-- **WHEN** the reminder store builds its index
+- **WHEN** the reminder store resolves that ID
 - **THEN** the store rejects the ambiguous duplicate
 - **AND** it logs both paths
 - **AND** the manager does not schedule the duplicate
+
+#### Scenario: Session owner mismatch fails loud
+
+- **GIVEN** a session reminder file names a different `Delivery.SessionId`
+- **WHEN** the reminder store reads the file
+- **THEN** the store rejects the definition
+- **AND** it logs the file path and owner mismatch
 
 #### Scenario: Corrupt reminder definition does not run
 
 - **GIVEN** a reminder definition contains invalid JSON or an invalid schema
 - **WHEN** the reminder store loads the file
-- **THEN** the store excludes the definition from its index
+- **THEN** the store excludes the definition
 - **AND** the manager does not schedule it
 - **AND** the current invalid-definition policy reports or removes the file
-
-## ADDED Requirements
-
-### Requirement: Legacy current-session reminder migration
-
-On startup, the reminder store SHALL inspect legacy definitions in the daemon reminder directory. It SHALL move each valid `CurrentSession` definition to its canonical session directory.
-
-The store SHALL move a matching history file before it moves the definition. The definition move SHALL act as the migration commit point.
-
-The store SHALL NOT overwrite a destination file. A conflict or invalid `Delivery.SessionId` SHALL produce an error and preserve the source files.
-
-The store SHALL continue to resolve a valid source definition after a migration error. This compatibility path SHALL produce an operator-visible log entry.
-
-#### Scenario: Legacy current-session reminder moves to its session
-
-- **GIVEN** a valid legacy `CurrentSession` definition exists in the daemon reminder directory
-- **AND** no destination artifact exists
-- **WHEN** startup migration runs
-- **THEN** the history file moves to the source session reminder directory when present
-- **AND** the definition moves to the same directory
-- **AND** the reminder keeps its current ID and schedule
-
-#### Scenario: Daemon-scoped reminder does not move
-
-- **GIVEN** a valid legacy definition has `Delivery.Kind = Channel` or `Delivery.Kind = None`
-- **WHEN** startup migration runs
-- **THEN** the definition and history remain in the daemon reminder directory
-
-#### Scenario: Migration conflict preserves source data
-
-- **GIVEN** a legacy definition and its destination path both exist
-- **WHEN** startup migration runs
-- **THEN** the migration does not overwrite either file
-- **AND** the store logs the conflict
-- **AND** the source definition remains available through the explicit compatibility path
-
-#### Scenario: Restart resumes an interrupted migration
-
-- **GIVEN** a prior migration moved the history but did not move the definition
-- **WHEN** the daemon restarts
-- **THEN** the migration accepts the matching destination history
-- **AND** it completes the definition move without duplicate history records

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-scheduling/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-scheduling/spec.md
@@ -1,0 +1,106 @@
+## MODIFIED Requirements
+
+### Requirement: Schedule persistence
+
+The system SHALL persist each reminder definition as a JSON file. It SHALL preserve the definition and its schedule across process restarts.
+
+A `CurrentSession` definition SHALL use this path:
+
+`~/.netclaw/sessions/{session-key}/reminders/{reminderId}.json`
+
+A `Channel` or `None` definition SHALL use this path:
+
+`~/.netclaw/schedules/reminders/{reminderId}.json`
+
+The reminder store SHALL keep reminder IDs unique across both ownership scopes. It SHALL map each ID to one validated canonical path.
+
+The Akka.Reminders payload SHALL remain an ID-only pointer. The manager SHALL resolve that ID through the reminder store before execution.
+
+On startup, the system SHALL load all valid definitions and reconcile all active schedules. A paused definition SHALL remain paused.
+
+#### Scenario: Reminders survive process restart
+
+- **GIVEN** valid reminder definitions exist in daemon and session reminder directories
+- **WHEN** the Netclaw process restarts
+- **THEN** the reminder store rebuilds its ID-to-path index
+- **AND** the manager reconciles all active schedules
+- **AND** paused reminders remain paused
+
+#### Scenario: New current-session reminder is durable before confirmation
+
+- **GIVEN** a session creates a `CurrentSession` reminder
+- **WHEN** the manager confirms the new reminder
+- **THEN** the definition already exists under the source session directory
+- **AND** its stored `Delivery.SessionId` matches that directory
+
+#### Scenario: New daemon-scoped reminder is durable before confirmation
+
+- **GIVEN** a session creates a `Channel` or `None` reminder
+- **WHEN** the manager confirms the new reminder
+- **THEN** the definition already exists under the daemon reminder directory
+
+#### Scenario: Scheduler payload remains stable after a definition move
+
+- **GIVEN** an Akka.Reminders occurrence contains a `ReminderPayload` with one reminder ID
+- **AND** the definition moved from the legacy directory to its session directory
+- **WHEN** the occurrence fires
+- **THEN** the manager resolves the same ID through the rebuilt store index
+- **AND** no scheduler payload migration is necessary
+
+#### Scenario: Duplicate reminder ID fails loud
+
+- **GIVEN** two definition files claim the same reminder ID
+- **WHEN** the reminder store builds its index
+- **THEN** the store rejects the ambiguous duplicate
+- **AND** it logs both paths
+- **AND** the manager does not schedule the duplicate
+
+#### Scenario: Corrupt reminder definition does not run
+
+- **GIVEN** a reminder definition contains invalid JSON or an invalid schema
+- **WHEN** the reminder store loads the file
+- **THEN** the store excludes the definition from its index
+- **AND** the manager does not schedule it
+- **AND** the current invalid-definition policy reports or removes the file
+
+## ADDED Requirements
+
+### Requirement: Legacy current-session reminder migration
+
+On startup, the reminder store SHALL inspect legacy definitions in the daemon reminder directory. It SHALL move each valid `CurrentSession` definition to its canonical session directory.
+
+The store SHALL move a matching history file before it moves the definition. The definition move SHALL act as the migration commit point.
+
+The store SHALL NOT overwrite a destination file. A conflict or invalid `Delivery.SessionId` SHALL produce an error and preserve the source files.
+
+The store SHALL continue to resolve a valid source definition after a migration error. This compatibility path SHALL produce an operator-visible log entry.
+
+#### Scenario: Legacy current-session reminder moves to its session
+
+- **GIVEN** a valid legacy `CurrentSession` definition exists in the daemon reminder directory
+- **AND** no destination artifact exists
+- **WHEN** startup migration runs
+- **THEN** the history file moves to the source session reminder directory when present
+- **AND** the definition moves to the same directory
+- **AND** the reminder keeps its current ID and schedule
+
+#### Scenario: Daemon-scoped reminder does not move
+
+- **GIVEN** a valid legacy definition has `Delivery.Kind = Channel` or `Delivery.Kind = None`
+- **WHEN** startup migration runs
+- **THEN** the definition and history remain in the daemon reminder directory
+
+#### Scenario: Migration conflict preserves source data
+
+- **GIVEN** a legacy definition and its destination path both exist
+- **WHEN** startup migration runs
+- **THEN** the migration does not overwrite either file
+- **AND** the store logs the conflict
+- **AND** the source definition remains available through the explicit compatibility path
+
+#### Scenario: Restart resumes an interrupted migration
+
+- **GIVEN** a prior migration moved the history but did not move the definition
+- **WHEN** the daemon restarts
+- **THEN** the migration accepts the matching destination history
+- **AND** it completes the definition move without duplicate history records

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-scheduling/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-scheduling/spec.md
@@ -66,6 +66,21 @@ On startup, the system SHALL load all valid definitions and reconcile all active
 - **AND** it logs both paths
 - **AND** the manager does not schedule the duplicate
 
+#### Scenario: Invalid candidate does not shadow a valid reminder
+
+- **GIVEN** one valid reminder claims an ID
+- **AND** a corrupt or owner-mismatched file uses the same encoded file name in another scope
+- **WHEN** the store resolves the reminder ID
+- **THEN** the store returns the valid reminder
+- **AND** it applies the current invalid-file policy to the invalid candidate
+
+#### Scenario: Invalid owner transition keeps the current schedule
+
+- **GIVEN** an enabled reminder definition is stored in a session directory
+- **WHEN** an update changes its session owner or daemon ownership scope
+- **THEN** the manager rejects the update before a scheduler mutation
+- **AND** the current definition and schedule remain active
+
 #### Scenario: Session owner mismatch fails loud
 
 - **GIVEN** a session reminder file names a different `Delivery.SessionId`

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
@@ -10,23 +10,23 @@ The boundary SHALL NOT include `Channel` or `None` reminder files. Those reminde
 
 The system SHALL derive each artifact path from the typed `SessionId`. It SHALL NOT accept an arbitrary file path as ownership authority.
 
-#### Scenario: Current-session reminder uses the session boundary
+#### Scenario: New current-session reminder uses the session boundary
 
-- **GIVEN** a reminder has `Delivery.Kind = CurrentSession`
+- **GIVEN** a new reminder has `Delivery.Kind = CurrentSession`
 - **AND** its delivery contains a valid `SessionId`
 - **WHEN** the reminder store saves the definition
 - **THEN** the definition is stored under that session directory
 - **AND** its history uses the same reminder subdirectory
 
-#### Scenario: Background job uses the session boundary
+#### Scenario: New background job uses the session boundary
 
-- **GIVEN** a session starts a background job
+- **GIVEN** a session starts a new background job
 - **WHEN** the job store saves its definition and output
 - **THEN** both artifacts are stored under that session directory
 
-#### Scenario: Daemon-scoped reminder stays outside the session boundary
+#### Scenario: New daemon-scoped reminder stays outside the session boundary
 
-- **GIVEN** a reminder has `Delivery.Kind = Channel` or `Delivery.Kind = None`
+- **GIVEN** a new reminder has `Delivery.Kind = Channel` or `Delivery.Kind = None`
 - **WHEN** the reminder store saves the definition
 - **THEN** the definition and history remain in the daemon reminder directory
 
@@ -36,10 +36,3 @@ The system SHALL derive each artifact path from the typed `SessionId`. It SHALL 
 - **AND** the path is outside the exact source session directory
 - **WHEN** the store validates a session-owned artifact path
 - **THEN** the store rejects the path
-
-#### Scenario: Session artifact path contains a symbolic-link escape
-
-- **GIVEN** a candidate artifact path contains a symbolic-link segment
-- **AND** that segment resolves outside the source session directory
-- **WHEN** the store validates the path
-- **THEN** the store rejects the path and logs the reason

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
@@ -36,3 +36,17 @@ The system SHALL derive each artifact path from the typed `SessionId`. It SHALL 
 - **AND** the path is outside the exact source session directory
 - **WHEN** the store validates a session-owned artifact path
 - **THEN** the store rejects the path
+
+#### Scenario: Session artifact path contains a symbolic link
+
+- **GIVEN** a session reminder or job path contains a symbolic link or reparse point
+- **WHEN** a store reads, writes, deletes, or enumerates that path
+- **THEN** the store rejects the path
+- **AND** it does not access the link target
+
+#### Scenario: Generic file write targets a definition
+
+- **GIVEN** an agent can write other files in its session directory
+- **WHEN** it uses a generic file or safe shell path to write a direct `reminders/*.json` or `jobs/*.json` definition
+- **THEN** the file access policy rejects the write
+- **AND** reminder history and job output paths remain writable

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Session directory owns session automation artifacts
+
+The system SHALL use the canonical session directory as the lifecycle boundary for session-owned automation files.
+
+The boundary SHALL include `CurrentSession` reminder definitions, their history files, background job definitions, and background job output logs.
+
+The boundary SHALL NOT include `Channel` or `None` reminder files. Those reminders have daemon scope because they create new sessions.
+
+The system SHALL derive each artifact path from the typed `SessionId`. It SHALL NOT accept an arbitrary file path as ownership authority.
+
+#### Scenario: Current-session reminder uses the session boundary
+
+- **GIVEN** a reminder has `Delivery.Kind = CurrentSession`
+- **AND** its delivery contains a valid `SessionId`
+- **WHEN** the reminder store saves the definition
+- **THEN** the definition is stored under that session directory
+- **AND** its history uses the same reminder subdirectory
+
+#### Scenario: Background job uses the session boundary
+
+- **GIVEN** a session starts a background job
+- **WHEN** the job store saves its definition and output
+- **THEN** both artifacts are stored under that session directory
+
+#### Scenario: Daemon-scoped reminder stays outside the session boundary
+
+- **GIVEN** a reminder has `Delivery.Kind = Channel` or `Delivery.Kind = None`
+- **WHEN** the reminder store saves the definition
+- **THEN** the definition and history remain in the daemon reminder directory
+
+#### Scenario: Trusted root does not replace exact owner validation
+
+- **GIVEN** a candidate artifact path is under a trusted project or global root
+- **AND** the path is outside the exact source session directory
+- **WHEN** the store validates a session-owned artifact path
+- **THEN** the store rejects the path
+
+#### Scenario: Session artifact path contains a symbolic-link escape
+
+- **GIVEN** a candidate artifact path contains a symbolic-link segment
+- **AND** that segment resolves outside the source session directory
+- **WHEN** the store validates the path
+- **THEN** the store rejects the path and logs the reason

--- a/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/netclaw-session/spec.md
@@ -47,6 +47,6 @@ The system SHALL derive each artifact path from the typed `SessionId`. It SHALL 
 #### Scenario: Generic file write targets a definition
 
 - **GIVEN** an agent can write other files in its session directory
-- **WHEN** it uses a generic file or safe shell path to write a direct `reminders/*.json` or `jobs/*.json` definition
+- **WHEN** it uses a generic file or safe shell path to write under the session `reminders/` or `jobs/` directory
 - **THEN** the file access policy rejects the write
-- **AND** reminder history and job output paths remain writable
+- **AND** reminder definitions, history, and job output paths remain readable

--- a/openspec/changes/session-owned-automation-artifacts/specs/reminder-execution-history/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/reminder-execution-history/spec.md
@@ -1,0 +1,69 @@
+## MODIFIED Requirements
+
+### Requirement: Execution record written per run
+
+On completion of each reminder execution, the system SHALL append one structured record to the history path for that reminder owner.
+
+A `CurrentSession` reminder SHALL use this path:
+
+`~/.netclaw/sessions/{session-key}/reminders/{reminderId}.history.jsonl`
+
+A `Channel` or `None` reminder SHALL use this path:
+
+`~/.netclaw/schedules/reminders/{reminderId}.history.jsonl`
+
+The record SHALL contain `firedAt`, `success`, `durationMs`, `sessionId`, and `errorMessage`. A write failure SHALL not change the execution result.
+
+#### Scenario: Successful execution recorded
+
+- **WHEN** a reminder execution completes successfully
+- **THEN** the store appends a record with `success: true`, elapsed `durationMs`, and the execution session ID
+- **AND** the manager receives the successful execution result
+
+#### Scenario: Failed execution recorded
+
+- **WHEN** a reminder execution fails or reaches its timeout
+- **THEN** the store appends a record with `success: false` and a non-null `errorMessage`
+
+#### Scenario: History follows current-session ownership
+
+- **GIVEN** a reminder has `Delivery.Kind = CurrentSession`
+- **WHEN** the store appends its execution record
+- **THEN** the history file is beside the definition in the source session reminder directory
+
+#### Scenario: History follows daemon ownership
+
+- **GIVEN** a reminder has `Delivery.Kind = Channel` or `Delivery.Kind = None`
+- **WHEN** the store appends its execution record
+- **THEN** the history file is beside the definition in the daemon reminder directory
+
+#### Scenario: History write failure does not block manager
+
+- **WHEN** a history file write fails
+- **THEN** the system logs a warning with the reminder ID and error detail
+- **AND** the manager still receives the completion or failure result
+- **AND** the history failure does not change the reminder failure counter
+
+### Requirement: History file lifecycle
+
+The history file SHALL be created beside the definition on the first reminder execution. It SHALL use the same daemon or session ownership scope.
+
+When a reminder is deleted, the system SHALL delete its definition and history from that scope. An absent history file SHALL produce an empty result.
+
+#### Scenario: History file absent before first execution
+
+- **GIVEN** a reminder has never run
+- **WHEN** a history read is requested
+- **THEN** the store returns an empty list without an error
+
+#### Scenario: Current-session history deleted with reminder
+
+- **GIVEN** a `CurrentSession` reminder has a history file
+- **WHEN** the reminder is deleted
+- **THEN** the definition and history are removed from the source session reminder directory
+
+#### Scenario: Daemon-scoped history deleted with reminder
+
+- **GIVEN** a `Channel` or `None` reminder has a history file
+- **WHEN** the reminder is deleted
+- **THEN** the definition and history are removed from the daemon reminder directory

--- a/openspec/changes/session-owned-automation-artifacts/specs/reminder-execution-history/spec.md
+++ b/openspec/changes/session-owned-automation-artifacts/specs/reminder-execution-history/spec.md
@@ -4,13 +4,15 @@
 
 On completion of each reminder execution, the system SHALL append one structured record to the history path for that reminder owner.
 
-A `CurrentSession` reminder SHALL use this path:
+A new `CurrentSession` reminder SHALL use this path:
 
 `~/.netclaw/sessions/{session-key}/reminders/{reminderId}.history.jsonl`
 
-A `Channel` or `None` reminder SHALL use this path:
+A new `Channel` or `None` reminder SHALL use this path:
 
 `~/.netclaw/schedules/reminders/{reminderId}.history.jsonl`
+
+The history file SHALL stay beside its definition. An existing daemon-owned history file SHALL remain at its current path.
 
 The record SHALL contain `firedAt`, `success`, `durationMs`, `sessionId`, and `errorMessage`. A write failure SHALL not change the execution result.
 
@@ -25,11 +27,18 @@ The record SHALL contain `firedAt`, `success`, `durationMs`, `sessionId`, and `e
 - **WHEN** a reminder execution fails or reaches its timeout
 - **THEN** the store appends a record with `success: false` and a non-null `errorMessage`
 
-#### Scenario: History follows current-session ownership
+#### Scenario: New history follows current-session ownership
 
 - **GIVEN** a reminder has `Delivery.Kind = CurrentSession`
 - **WHEN** the store appends its execution record
 - **THEN** the history file is beside the definition in the source session reminder directory
+
+#### Scenario: Existing current-session history stays at its current path
+
+- **GIVEN** a `CurrentSession` reminder definition exists in the daemon reminder directory
+- **WHEN** the store appends or reads its execution history
+- **THEN** the history file stays beside that daemon-owned definition
+- **AND** the store does not create a session-owned copy
 
 #### Scenario: History follows daemon ownership
 

--- a/openspec/changes/session-owned-automation-artifacts/tasks.md
+++ b/openspec/changes/session-owned-automation-artifacts/tasks.md
@@ -33,7 +33,7 @@
 
 ## 6. Adversarial Review Hardening
 
-- [x] 6.1 Reserve session reminder and job definition JSON files from generic writes.
+- [x] 6.1 Reserve session reminder and job artifacts from generic writes.
 - [x] 6.2 Reject session artifact paths that contain a symbolic link or reparse point.
 - [x] 6.3 Count only valid definitions when duplicate IDs are resolved.
 - [x] 6.4 Validate reminder storage ownership before a scheduler mutation.

--- a/openspec/changes/session-owned-automation-artifacts/tasks.md
+++ b/openspec/changes/session-owned-automation-artifacts/tasks.md
@@ -1,0 +1,35 @@
+## 1. Canonical Session Paths
+
+- [ ] 1.1 Extend `SessionDirectoryHelper` with fixed reminder and job subdirectory paths. Reuse `NetclawPaths.SessionsDirectory`.
+- [ ] 1.2 Add path tests for session containment, encoded artifact IDs, duplicate IDs, and symbolic-link escapes.
+
+## 2. Current-Session Reminder Storage
+
+- [ ] 2.1 Make `ReminderDefinitionStore` index daemon and session definitions by the current global reminder ID.
+- [ ] 2.2 Route `CurrentSession` definitions through their stored `Delivery.SessionId`. Keep `Channel` and `None` definitions in the daemon directory.
+- [ ] 2.3 Make `ReminderHistoryStore` use the indexed definition owner for read, append, and delete operations.
+- [ ] 2.4 Add the convergent legacy migration for current-session definitions and history. Preserve source data after a conflict or invalid owner.
+- [ ] 2.5 Add store and manager tests for restart lookup, daemon/session routing, migration restart, conflicts, corrupt files, and owner mismatch.
+- [ ] 2.6 Assert that `ReminderPayload`, reminder manager commands, retry settlement, and delivery routes remain unchanged.
+
+## 3. Background Job Storage
+
+- [ ] 3.1 Make `BackgroundJobDefinitionStore` derive definition and output paths from the required source `SessionId`.
+- [ ] 3.2 Update job manager calls to supply the source session for reads, writes, deletes, status checks, and output access.
+- [ ] 3.3 Add the convergent legacy migration for job definitions and output directories. Preserve source data after a conflict or invalid owner.
+- [ ] 3.4 Add store and manager tests for session routing, restart reconciliation, migration restart, conflicts, owner mismatch, and log access.
+- [ ] 3.5 Assert that the singleton manager, global capacity limit, FIFO queue, passivation reap, and trusted delivery behavior remain unchanged.
+
+## 4. Operations Guidance
+
+- [ ] 4.1 Update `docs/runbooks/background-jobs.md` with the session-owned paths and legacy migration behavior.
+- [ ] 4.2 Update the `netclaw-operations` skill and its scheduling reference. Increase the skill metadata version.
+- [ ] 4.3 Update source documentation that names the legacy reminder or job paths.
+
+## 5. Validation
+
+- [ ] 5.1 Run the focused reminder, background job, path-policy, serialization, and daemon endpoint tests.
+- [ ] 5.2 Run the affected project test suites and record all environment-dependent skips.
+- [ ] 5.3 Run `./evals/run-evals.sh` because the operational system skill changes.
+- [ ] 5.4 Run `dotnet slopwatch analyze` and `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`.
+- [ ] 5.5 Run strict OpenSpec validation and `git diff --check`.

--- a/openspec/changes/session-owned-automation-artifacts/tasks.md
+++ b/openspec/changes/session-owned-automation-artifacts/tasks.md
@@ -30,6 +30,5 @@
 
 - [ ] 5.1 Run the focused reminder, background job, path-policy, serialization, and daemon endpoint tests.
 - [ ] 5.2 Run the affected project test suites and record all environment-dependent skips.
-- [ ] 5.3 Run `./evals/run-evals.sh` because the operational system skill changes.
-- [ ] 5.4 Run `dotnet slopwatch analyze` and `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`.
-- [ ] 5.5 Run strict OpenSpec validation and `git diff --check`.
+- [ ] 5.3 Run `dotnet slopwatch analyze` and `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`.
+- [ ] 5.4 Run strict OpenSpec validation and `git diff --check`.

--- a/openspec/changes/session-owned-automation-artifacts/tasks.md
+++ b/openspec/changes/session-owned-automation-artifacts/tasks.md
@@ -1,34 +1,32 @@
 ## 1. Canonical Session Paths
 
-- [ ] 1.1 Extend `SessionDirectoryHelper` with fixed reminder and job subdirectory paths. Reuse `NetclawPaths.SessionsDirectory`.
-- [ ] 1.2 Add path tests for session containment, encoded artifact IDs, duplicate IDs, and symbolic-link escapes.
+- [x] 1.1 Extend `SessionDirectoryHelper` with fixed reminder and job subdirectory paths. Reuse `NetclawPaths.SessionsDirectory`.
+- [x] 1.2 Add path tests for session containment and encoded artifact IDs.
 
 ## 2. Current-Session Reminder Storage
 
-- [ ] 2.1 Make `ReminderDefinitionStore` index daemon and session definitions by the current global reminder ID.
-- [ ] 2.2 Route `CurrentSession` definitions through their stored `Delivery.SessionId`. Keep `Channel` and `None` definitions in the daemon directory.
-- [ ] 2.3 Make `ReminderHistoryStore` use the indexed definition owner for read, append, and delete operations.
-- [ ] 2.4 Add the convergent legacy migration for current-session definitions and history. Preserve source data after a conflict or invalid owner.
-- [ ] 2.5 Add store and manager tests for restart lookup, daemon/session routing, migration restart, conflicts, corrupt files, and owner mismatch.
-- [ ] 2.6 Assert that `ReminderPayload`, reminder manager commands, retry settlement, and delivery routes remain unchanged.
+- [x] 2.1 Make `ReminderDefinitionStore` scan daemon and session definitions by the current global reminder ID.
+- [x] 2.2 Route `CurrentSession` definitions through their stored `Delivery.SessionId`. Keep `Channel` and `None` definitions in the daemon directory.
+- [x] 2.3 Make `ReminderHistoryStore` use the actual definition directory for read, append, and delete operations.
+- [x] 2.4 Add store and manager tests for restart lookup, daemon/session routing, legacy path retention, conflicts, corrupt files, and owner mismatch.
+- [x] 2.5 Assert that `ReminderPayload`, reminder manager commands, retry settlement, and delivery routes remain unchanged.
 
 ## 3. Background Job Storage
 
-- [ ] 3.1 Make `BackgroundJobDefinitionStore` derive definition and output paths from the required source `SessionId`.
-- [ ] 3.2 Update job manager calls to supply the source session for reads, writes, deletes, status checks, and output access.
-- [ ] 3.3 Add the convergent legacy migration for job definitions and output directories. Preserve source data after a conflict or invalid owner.
-- [ ] 3.4 Add store and manager tests for session routing, restart reconciliation, migration restart, conflicts, owner mismatch, and log access.
-- [ ] 3.5 Assert that the singleton manager, global capacity limit, FIFO queue, passivation reap, and trusted delivery behavior remain unchanged.
+- [x] 3.1 Make `BackgroundJobDefinitionStore` derive definition and output paths from the required source `SessionId`.
+- [x] 3.2 Update job manager calls to supply the source session for reads, writes, deletes, status checks, and output access.
+- [x] 3.3 Add store and manager tests for session routing, restart reconciliation, legacy path retention, conflicts, owner mismatch, and log access.
+- [x] 3.4 Assert that the singleton manager, global capacity limit, FIFO queue, passivation reap, and trusted delivery behavior remain unchanged.
 
 ## 4. Operations Guidance
 
-- [ ] 4.1 Update `docs/runbooks/background-jobs.md` with the session-owned paths and legacy migration behavior.
-- [ ] 4.2 Update the `netclaw-operations` skill and its scheduling reference. Increase the skill metadata version.
-- [ ] 4.3 Update source documentation that names the legacy reminder or job paths.
+- [x] 4.1 Update `docs/runbooks/background-jobs.md` with session-owned paths and legacy path compatibility.
+- [x] 4.2 Update the `netclaw-operations` skill and its scheduling reference. Increase the skill metadata version.
+- [x] 4.3 Update source documentation that names the legacy reminder or job paths.
 
 ## 5. Validation
 
-- [ ] 5.1 Run the focused reminder, background job, path-policy, serialization, and daemon endpoint tests.
-- [ ] 5.2 Run the affected project test suites and record all environment-dependent skips.
-- [ ] 5.3 Run `dotnet slopwatch analyze` and `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`.
-- [ ] 5.4 Run strict OpenSpec validation and `git diff --check`.
+- [x] 5.1 Run the focused reminder, background job, path-policy, serialization, and daemon endpoint tests.
+- [x] 5.2 Run the affected project test suites and record all environment-dependent skips.
+- [x] 5.3 Run `dotnet slopwatch analyze` and `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`.
+- [x] 5.4 Run strict OpenSpec validation and `git diff --check`.

--- a/openspec/changes/session-owned-automation-artifacts/tasks.md
+++ b/openspec/changes/session-owned-automation-artifacts/tasks.md
@@ -30,3 +30,12 @@
 - [x] 5.2 Run the affected project test suites and record all environment-dependent skips.
 - [x] 5.3 Run `dotnet slopwatch analyze` and `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`.
 - [x] 5.4 Run strict OpenSpec validation and `git diff --check`.
+
+## 6. Adversarial Review Hardening
+
+- [x] 6.1 Reserve session reminder and job definition JSON files from generic writes.
+- [x] 6.2 Reject session artifact paths that contain a symbolic link or reparse point.
+- [x] 6.3 Count only valid definitions when duplicate IDs are resolved.
+- [x] 6.4 Validate reminder storage ownership before a scheduler mutation.
+- [x] 6.5 Add focused regression tests and update operations guidance.
+- [x] 6.6 Run the focused suites, quality gates, strict OpenSpec validation, and `git diff --check`.

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Jobs;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Xunit;
 
@@ -139,6 +140,113 @@ public sealed class BackgroundJobDefinitionStoreTests : IDisposable
         Assert.NotNull(loaded);
         Assert.Equal(new BackgroundJobId("job-byte-eq"), loaded!.Id);
         Assert.Equal(new Netclaw.Actors.Protocol.SessionId("C0ABC/1712000000.000001"), loaded.SessionId);
+    }
+
+    [Fact]
+    public void New_job_definition_and_output_use_source_session_directory()
+    {
+        var store = new BackgroundJobDefinitionStore(_paths);
+        var definition = CreateDefinition("session-job", "C0ABC/1712000000.000001");
+
+        store.Save(definition);
+        var outputPath = store.GetOutputLogPath(definition.Id, definition.SessionId);
+
+        var sessionDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            definition.SessionId,
+            _paths.SessionsDirectory);
+        Assert.True(File.Exists(Path.Combine(sessionDirectory, "session-job.json")));
+        Assert.Equal(Path.Combine(sessionDirectory, "session-job", "output.log"), outputPath);
+        Assert.True(Directory.Exists(Path.GetDirectoryName(outputPath)));
+        Assert.False(File.Exists(Path.Combine(_paths.JobsDirectory, "session-job.json")));
+    }
+
+    [Fact]
+    public void Existing_job_definition_and_output_stay_in_daemon_directory_after_update()
+    {
+        var definition = CreateDefinition("existing-job", "C0ABC/1712000000.000001");
+        var daemonPath = Path.Combine(_paths.JobsDirectory, "existing-job.json");
+        WriteDefinition(daemonPath, definition);
+        var daemonOutputPath = Path.Combine(_paths.JobsDirectory, "existing-job", "output.log");
+        Directory.CreateDirectory(Path.GetDirectoryName(daemonOutputPath)!);
+        File.WriteAllText(daemonOutputPath, "existing output");
+
+        var store = new BackgroundJobDefinitionStore(_paths);
+        store.Save(definition with { Status = BackgroundJobStatus.Completed, ExitCode = 0 });
+
+        var sessionDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            definition.SessionId,
+            _paths.SessionsDirectory);
+        Assert.True(File.Exists(daemonPath));
+        Assert.Equal(daemonOutputPath, store.GetOutputLogPathOnly(definition.Id, definition.SessionId));
+        Assert.Equal("existing output", File.ReadAllText(daemonOutputPath));
+        Assert.False(File.Exists(Path.Combine(sessionDirectory, "existing-job.json")));
+        Assert.Equal(BackgroundJobStatus.Completed, new BackgroundJobDefinitionStore(_paths).Get(definition.Id)!.Status);
+    }
+
+    [Fact]
+    public void Duplicate_id_across_daemon_and_session_directories_is_rejected()
+    {
+        var definition = CreateDefinition("duplicate-job", "C0ABC/1712000000.000001");
+        var daemonPath = Path.Combine(_paths.JobsDirectory, "duplicate-job.json");
+        WriteDefinition(daemonPath, definition);
+        var sessionDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            definition.SessionId,
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(sessionDirectory);
+        WriteDefinition(Path.Combine(sessionDirectory, "duplicate-job.json"), definition);
+        var logger = new CapturingJobLogger<BackgroundJobDefinitionStore>();
+
+        var store = new BackgroundJobDefinitionStore(_paths, logger);
+
+        Assert.Null(store.Get(definition.Id));
+        Assert.Empty(store.List());
+        Assert.Contains(logger.Errors, message =>
+            message.Contains(daemonPath, StringComparison.Ordinal)
+            && message.Contains(sessionDirectory, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Session_directory_owner_mismatch_is_rejected()
+    {
+        var definition = CreateDefinition("owner-mismatch", "C0ABC/1712000000.000001");
+        var wrongDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            new SessionId("C0OTHER/1712000000.000002"),
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(wrongDirectory);
+        var wrongPath = Path.Combine(wrongDirectory, "owner-mismatch.json");
+        WriteDefinition(wrongPath, definition);
+        var logger = new CapturingJobLogger<BackgroundJobDefinitionStore>();
+
+        var store = new BackgroundJobDefinitionStore(_paths, logger);
+
+        Assert.Null(store.Get(definition.Id));
+        Assert.Empty(store.List());
+        Assert.Contains(logger.Errors, message =>
+            message.Contains(wrongPath, StringComparison.Ordinal)
+            && message.Contains("owner", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static BackgroundJobDefinition CreateDefinition(string id, string sessionId) => new()
+    {
+        Id = new BackgroundJobId(id),
+        Command = "dotnet test",
+        SessionId = new SessionId(sessionId),
+        Rationale = "Run the test suite.",
+        Status = BackgroundJobStatus.Pending,
+        TimeoutSeconds = 300,
+        StartedAtMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+        Audience = TrustAudience.Personal,
+        Boundary = TrustBoundary.Personal
+    };
+
+    private static void WriteDefinition(string path, BackgroundJobDefinition definition)
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(definition, options));
     }
 
     public void Dispose()

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobDefinitionStoreTests.cs
@@ -205,6 +205,68 @@ public sealed class BackgroundJobDefinitionStoreTests : IDisposable
             && message.Contains(sessionDirectory, StringComparison.Ordinal));
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Invalid_session_candidate_does_not_shadow_valid_daemon_definition(bool corruptCandidate)
+    {
+        var definition = CreateDefinition("invalid-candidate", "C0ABC/1712000000.000001");
+        WriteDefinition(Path.Combine(_paths.JobsDirectory, "invalid-candidate.json"), definition);
+        var sessionDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            corruptCandidate
+                ? definition.SessionId
+                : new SessionId("C0OTHER/1712000000.000002"),
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(sessionDirectory);
+        var candidatePath = Path.Combine(sessionDirectory, "invalid-candidate.json");
+        if (corruptCandidate)
+            File.WriteAllText(candidatePath, "not json");
+        else
+            WriteDefinition(candidatePath, definition);
+
+        var loaded = new BackgroundJobDefinitionStore(_paths).Get(definition.Id);
+
+        Assert.Equal(definition, loaded);
+    }
+
+    [Fact]
+    public void Session_job_directory_symlink_is_rejected_before_write()
+    {
+        var definition = CreateDefinition("linked-job", "C0ABC/1712000000.000001");
+        var jobDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            definition.SessionId,
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(Path.GetDirectoryName(jobDirectory)!);
+        var externalDirectory = Path.Combine(_basePath, "external-jobs");
+        Directory.CreateDirectory(externalDirectory);
+        Directory.CreateSymbolicLink(jobDirectory, externalDirectory);
+        var store = new BackgroundJobDefinitionStore(_paths);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => store.Save(definition));
+
+        Assert.Contains("symbolic link", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(externalDirectory, "linked-job.json")));
+    }
+
+    [Fact]
+    public void Session_job_output_directory_symlink_is_rejected_before_access()
+    {
+        var definition = CreateDefinition("linked-output", "C0ABC/1712000000.000001");
+        var store = new BackgroundJobDefinitionStore(_paths);
+        store.Save(definition);
+        var jobDirectory = SessionDirectoryHelper.GetSessionJobsDirectory(
+            definition.SessionId,
+            _paths.SessionsDirectory);
+        var externalDirectory = Path.Combine(_basePath, "external-output");
+        Directory.CreateDirectory(externalDirectory);
+        Directory.CreateSymbolicLink(Path.Combine(jobDirectory, definition.Id.Value), externalDirectory);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            store.GetOutputLogPathOnly(definition.Id, definition.SessionId));
+
+        Assert.Contains("symbolic link", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void Session_directory_owner_mismatch_is_rejected()
     {

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobExecutionActorTests.cs
@@ -55,7 +55,7 @@ public class BackgroundJobExecutionActorTests : TestKit
 
     private IActorRef SpawnExecution(BackgroundJobDefinition definition, IActorRef probe)
     {
-        var outputPath = _store.GetOutputLogPath(definition.Id);
+        var outputPath = _store.GetOutputLogPath(definition.Id, definition.SessionId);
         var props = Props.Create(() => new BackgroundJobExecutionActor(definition, outputPath, TimeProvider.System));
         return Sys.ActorOf(ForwardingParent.Props(props, probe), $"exec-{definition.Id}");
     }
@@ -124,7 +124,7 @@ public class BackgroundJobExecutionActorTests : TestKit
         var definition = MakeDefinition(command);
         var probe = CreateTestProbe("parent");
         var actor = SpawnExecution(definition, probe);
-        var outputPath = _store.GetOutputLogPath(definition.Id);
+        var outputPath = _store.GetOutputLogPath(definition.Id, definition.SessionId);
 
         await AwaitAssertAsync(() =>
             {

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -243,7 +243,7 @@ public class BackgroundJobManagerActorTests : TestKit
             Boundary = TrustBoundary.Personal,
             OriginChannelType = ChannelType.Tui
         });
-        var logPath = _store.GetOutputLogPath(orphanId);
+        var logPath = _store.GetOutputLogPath(orphanId, sessionId);
         await File.WriteAllTextAsync(
             logPath, "Server running on http://127.0.0.1:4000/\n",
             TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Protocol/SessionDirectoryHelperTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SessionDirectoryHelperTests.cs
@@ -16,20 +16,6 @@ public sealed class SessionDirectoryHelperTests : IDisposable
     public void Dispose() => _directory.Dispose();
 
     [Fact]
-    public void Automation_directories_use_the_canonical_session_directory()
-    {
-        var sessionId = new SessionId("C123/1712000000.000001");
-        var sessionDirectory = SessionDirectoryHelper.GetSessionDirectory(sessionId, _directory.Path);
-
-        Assert.Equal(
-            Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory),
-            SessionDirectoryHelper.GetSessionRemindersDirectory(sessionId, _directory.Path));
-        Assert.Equal(
-            Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory),
-            SessionDirectoryHelper.GetSessionJobsDirectory(sessionId, _directory.Path));
-    }
-
-    [Fact]
     public void Automation_directory_rejects_an_empty_session_id()
     {
         var exception = Assert.Throws<ArgumentException>(() =>

--- a/src/Netclaw.Actors.Tests/Protocol/SessionDirectoryHelperTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SessionDirectoryHelperTests.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionDirectoryHelperTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Protocol;
+
+public sealed class SessionDirectoryHelperTests : IDisposable
+{
+    private readonly DisposableTempDir _directory = new();
+
+    public void Dispose() => _directory.Dispose();
+
+    [Fact]
+    public void Automation_directories_use_the_canonical_session_directory()
+    {
+        var sessionId = new SessionId("C123/1712000000.000001");
+        var sessionDirectory = SessionDirectoryHelper.GetSessionDirectory(sessionId, _directory.Path);
+
+        Assert.Equal(
+            Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory),
+            SessionDirectoryHelper.GetSessionRemindersDirectory(sessionId, _directory.Path));
+        Assert.Equal(
+            Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory),
+            SessionDirectoryHelper.GetSessionJobsDirectory(sessionId, _directory.Path));
+    }
+
+    [Fact]
+    public void Automation_directory_rejects_an_empty_session_id()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            SessionDirectoryHelper.GetSessionJobsDirectory(new SessionId(" "), _directory.Path));
+
+        Assert.Equal("sessionId", exception.ParamName);
+    }
+
+}

--- a/src/Netclaw.Actors.Tests/Reminders/GetReminderHistoryToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/GetReminderHistoryToolTests.cs
@@ -13,6 +13,7 @@ namespace Netclaw.Actors.Tests.Reminders;
 public class GetReminderHistoryToolTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
+    private readonly ReminderDefinitionStore _definitionStore;
     private readonly ReminderHistoryStore _store;
     private readonly GetReminderHistoryTool _tool;
 
@@ -20,7 +21,8 @@ public class GetReminderHistoryToolTests : IDisposable
     {
         var paths = new NetclawPaths(_dir.Path);
         Directory.CreateDirectory(paths.RemindersDirectory);
-        _store = new ReminderHistoryStore(paths);
+        _definitionStore = new ReminderDefinitionStore(paths);
+        _store = new ReminderHistoryStore(_definitionStore);
         _tool = new GetReminderHistoryTool(_store, new SchedulingConfig());
     }
 
@@ -43,6 +45,7 @@ public class GetReminderHistoryToolTests : IDisposable
     public async Task Returns_formatted_history_for_existing_reminder()
     {
         var id = new ReminderId("daily-summary");
+        SaveDefinition(id);
         await _store.AppendAsync(id, new HistoryRecord(
             FiredAt: DateTimeOffset.UtcNow,
             Success: true,
@@ -63,6 +66,7 @@ public class GetReminderHistoryToolTests : IDisposable
     public async Task Last_param_is_capped_at_100()
     {
         var id = new ReminderId("busy-job");
+        SaveDefinition(id);
         // Store uses max 500, so add 150 records normally
         for (var i = 0; i < 150; i++)
             await _store.AppendAsync(id, new HistoryRecord(
@@ -85,6 +89,7 @@ public class GetReminderHistoryToolTests : IDisposable
     public async Task Error_message_included_for_failed_run()
     {
         var id = new ReminderId("failing-job");
+        SaveDefinition(id);
         await _store.AppendAsync(id, new HistoryRecord(
             FiredAt: DateTimeOffset.UtcNow,
             Success: false,
@@ -97,5 +102,22 @@ public class GetReminderHistoryToolTests : IDisposable
 
         Assert.Contains("False", result);
         Assert.Contains("Notification tool returned an unspecified error.", result);
+    }
+
+    private void SaveDefinition(ReminderId id)
+    {
+        var now = TimeProvider.System.GetUtcNow();
+        _definitionStore.Save(new ReminderDefinition
+        {
+            Id = id,
+            Title = id.Value,
+            Instructions = "Run the test reminder.",
+            Delivery = new ReminderDelivery { Kind = DeliveryKind.None },
+            Schedule = new ReminderSchedule { Type = ReminderScheduleType.OneShot, FireAt = now.AddHours(1) },
+            Audience = TrustAudience.Personal,
+            Boundary = TrustBoundary.Personal,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
     }
 }

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
 using Xunit;
@@ -291,6 +292,153 @@ public sealed class ReminderDefinitionStoreTests : IDisposable
         // explicit containment check in GetPath would throw if that invariant
         // ever regressed.
         Assert.False(store.Exists(new ReminderId(maliciousId)));
+    }
+
+    [Fact]
+    public void New_current_session_reminder_uses_session_directory()
+    {
+        var store = new ReminderDefinitionStore(_paths);
+        var definition = CreateDefinition(
+            "session-owned",
+            DeliveryKind.CurrentSession,
+            "C0ABC/1712000000.000001");
+
+        store.Save(definition);
+
+        var sessionDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(definition.Delivery.SessionId!),
+            _paths.SessionsDirectory);
+        var sessionPath = Path.Combine(sessionDirectory, "session-owned.json");
+        var daemonPath = Path.Combine(_paths.RemindersDirectory, "session-owned.json");
+        Assert.True(File.Exists(sessionPath));
+        Assert.False(File.Exists(daemonPath));
+        Assert.Equal(definition, new ReminderDefinitionStore(_paths).Get(definition.Id));
+    }
+
+    [Fact]
+    public void Existing_current_session_reminder_stays_in_daemon_directory_after_update()
+    {
+        var definition = CreateDefinition(
+            "existing-current-session",
+            DeliveryKind.CurrentSession,
+            "C0ABC/1712000000.000001");
+        var daemonPath = Path.Combine(_paths.RemindersDirectory, "existing-current-session.json");
+        WriteDefinition(daemonPath, definition);
+
+        var store = new ReminderDefinitionStore(_paths);
+        var updated = definition with { Title = "Updated title" };
+        store.Save(updated);
+
+        var sessionPath = Path.Combine(
+            SessionDirectoryHelper.GetSessionRemindersDirectory(
+                new SessionId(definition.Delivery.SessionId!),
+                _paths.SessionsDirectory),
+            "existing-current-session.json");
+        Assert.True(File.Exists(daemonPath));
+        Assert.False(File.Exists(sessionPath));
+        Assert.Equal("Updated title", new ReminderDefinitionStore(_paths).Get(definition.Id)!.Title);
+    }
+
+    [Theory]
+    [InlineData(DeliveryKind.Channel)]
+    [InlineData(DeliveryKind.None)]
+    public void New_daemon_scoped_reminder_uses_daemon_directory(DeliveryKind deliveryKind)
+    {
+        var store = new ReminderDefinitionStore(_paths);
+        var definition = CreateDefinition($"daemon-{deliveryKind}", deliveryKind);
+
+        store.Save(definition);
+
+        var daemonPath = Path.Combine(
+            _paths.RemindersDirectory,
+            $"{Uri.EscapeDataString(definition.Id.Value)}.json");
+        Assert.True(File.Exists(daemonPath));
+        Assert.Equal(definition, new ReminderDefinitionStore(_paths).Get(definition.Id));
+    }
+
+    [Fact]
+    public void Duplicate_id_across_daemon_and_session_directories_is_rejected()
+    {
+        var definition = CreateDefinition(
+            "duplicate-reminder",
+            DeliveryKind.CurrentSession,
+            "C0ABC/1712000000.000001");
+        var daemonPath = Path.Combine(_paths.RemindersDirectory, "duplicate-reminder.json");
+        WriteDefinition(daemonPath, definition);
+        var sessionDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(definition.Delivery.SessionId!),
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(sessionDirectory);
+        WriteDefinition(Path.Combine(sessionDirectory, "duplicate-reminder.json"), definition);
+        var logger = new CapturingLogger<ReminderDefinitionStore>();
+
+        var store = new ReminderDefinitionStore(_paths, logger);
+
+        Assert.Null(store.Get(definition.Id));
+        Assert.Empty(store.List());
+        Assert.Contains(logger.Errors, message =>
+            message.Contains(daemonPath, StringComparison.Ordinal)
+            && message.Contains(sessionDirectory, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Session_directory_owner_mismatch_is_rejected()
+    {
+        var definition = CreateDefinition(
+            "owner-mismatch",
+            DeliveryKind.CurrentSession,
+            "C0ABC/1712000000.000001");
+        var wrongDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId("C0OTHER/1712000000.000002"),
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(wrongDirectory);
+        var wrongPath = Path.Combine(wrongDirectory, "owner-mismatch.json");
+        WriteDefinition(wrongPath, definition);
+        var logger = new CapturingLogger<ReminderDefinitionStore>();
+
+        var store = new ReminderDefinitionStore(_paths, logger);
+
+        Assert.Null(store.Get(definition.Id));
+        Assert.Empty(store.List());
+        Assert.Contains(logger.Errors, message =>
+            message.Contains(wrongPath, StringComparison.Ordinal)
+            && message.Contains("owner", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ReminderDefinition CreateDefinition(
+        string id,
+        DeliveryKind deliveryKind,
+        string? sessionId = null)
+    {
+        var now = TimeProvider.System.GetUtcNow();
+        return new ReminderDefinition
+        {
+            Id = new ReminderId(id),
+            Title = id,
+            Instructions = "Check status.",
+            Delivery = new ReminderDelivery { Kind = deliveryKind, SessionId = sessionId },
+            Schedule = new ReminderSchedule
+            {
+                Type = ReminderScheduleType.OneShot,
+                FireAt = now.AddHours(1)
+            },
+            Audience = TrustAudience.Personal,
+            Boundary = TrustBoundary.Personal,
+            Enabled = true,
+            CreatedBy = "test",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+    }
+
+    private static void WriteDefinition(string path, ReminderDefinition definition)
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(definition, options));
     }
 
     public void Dispose()

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
@@ -360,25 +360,32 @@ public sealed class ReminderDefinitionStoreTests : IDisposable
     public void Duplicate_id_across_daemon_and_session_directories_is_rejected()
     {
         var definition = CreateDefinition(
-            "duplicate-reminder",
+            "duplicate-reminder\r\n[INF] forged",
             DeliveryKind.CurrentSession,
             "C0ABC/1712000000.000001");
-        var daemonPath = Path.Combine(_paths.RemindersDirectory, "duplicate-reminder.json");
+        var fileName = $"{Uri.EscapeDataString(definition.Id.Value)}.json";
+        var daemonPath = Path.Combine(_paths.RemindersDirectory, fileName);
         WriteDefinition(daemonPath, definition);
         var sessionDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
             new SessionId(definition.Delivery.SessionId!),
             _paths.SessionsDirectory);
         Directory.CreateDirectory(sessionDirectory);
-        WriteDefinition(Path.Combine(sessionDirectory, "duplicate-reminder.json"), definition);
+        WriteDefinition(Path.Combine(sessionDirectory, fileName), definition);
         var logger = new CapturingLogger<ReminderDefinitionStore>();
 
         var store = new ReminderDefinitionStore(_paths, logger);
 
         Assert.Null(store.Get(definition.Id));
         Assert.Empty(store.List());
-        Assert.Contains(logger.Errors, message =>
-            message.Contains(daemonPath, StringComparison.Ordinal)
-            && message.Contains(sessionDirectory, StringComparison.Ordinal));
+        Assert.NotEmpty(logger.Errors);
+        Assert.All(logger.Errors, message =>
+        {
+            Assert.DoesNotContain('\r', message);
+            Assert.DoesNotContain('\n', message);
+            Assert.Contains("\\r\\n", message, StringComparison.Ordinal);
+            Assert.Contains(daemonPath, message, StringComparison.Ordinal);
+            Assert.Contains(sessionDirectory, message, StringComparison.Ordinal);
+        });
     }
 
     [Theory]

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ReminderDefinitionStoreTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -379,6 +379,58 @@ public sealed class ReminderDefinitionStoreTests : IDisposable
         Assert.Contains(logger.Errors, message =>
             message.Contains(daemonPath, StringComparison.Ordinal)
             && message.Contains(sessionDirectory, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Invalid_session_candidate_does_not_shadow_valid_daemon_definition(bool corruptCandidate)
+    {
+        var definition = CreateDefinition(
+            "invalid-candidate",
+            DeliveryKind.CurrentSession,
+            "C0ABC/1712000000.000001");
+        var daemonPath = Path.Combine(_paths.RemindersDirectory, "invalid-candidate.json");
+        WriteDefinition(daemonPath, definition);
+        var sessionDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(corruptCandidate
+                ? definition.Delivery.SessionId!
+                : "C0OTHER/1712000000.000002"),
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(sessionDirectory);
+        var candidatePath = Path.Combine(sessionDirectory, "invalid-candidate.json");
+        var store = new ReminderDefinitionStore(_paths);
+        if (corruptCandidate)
+            File.WriteAllText(candidatePath, "not json");
+        else
+            WriteDefinition(candidatePath, definition);
+
+        var loaded = store.Get(definition.Id);
+
+        Assert.Equal(definition, loaded);
+        Assert.Equal(!corruptCandidate, File.Exists(candidatePath));
+    }
+
+    [Fact]
+    public void Session_reminder_directory_symlink_is_rejected_before_write()
+    {
+        var definition = CreateDefinition(
+            "linked-reminder",
+            DeliveryKind.CurrentSession,
+            "C0ABC/1712000000.000001");
+        var reminderDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(definition.Delivery.SessionId!),
+            _paths.SessionsDirectory);
+        Directory.CreateDirectory(Path.GetDirectoryName(reminderDirectory)!);
+        var externalDirectory = Path.Combine(_basePath, "external-reminders");
+        Directory.CreateDirectory(externalDirectory);
+        Directory.CreateSymbolicLink(reminderDirectory, externalDirectory);
+        var store = new ReminderDefinitionStore(_paths);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => store.Save(definition));
+
+        Assert.Contains("symbolic link", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(externalDirectory, "linked-reminder.json")));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderDefinitionStoreTests.cs
@@ -283,15 +283,15 @@ public sealed class ReminderDefinitionStoreTests : IDisposable
     [InlineData("..\\..\\windows\\system32\\config")]
     [InlineData("/etc/passwd")]
     [InlineData("C:\\Windows\\System32")]
-    public void Exists_with_traversal_id_does_not_escape_reminders_directory(string maliciousId)
+    public void Get_with_traversal_id_does_not_escape_reminders_directory(string maliciousId)
     {
         var store = new ReminderDefinitionStore(_paths);
 
         // Uri.EscapeDataString neutralizes path separators, so the canonical
-        // path stays inside _basePath and Exists() simply returns false. The
+        // path stays inside _basePath and Get() simply returns null. The
         // explicit containment check in GetPath would throw if that invariant
         // ever regressed.
-        Assert.False(store.Exists(new ReminderId(maliciousId)));
+        Assert.Null(store.Get(new ReminderId(maliciousId)));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -30,7 +30,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     {
         var paths = new NetclawPaths(_dir.Path);
         Directory.CreateDirectory(paths.RemindersDirectory);
-        _historyStore = new ReminderHistoryStore(paths);
+        _historyStore = new ReminderHistoryStore(new ReminderDefinitionStore(paths));
     }
 
     void IDisposable.Dispose()
@@ -411,6 +411,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             bool acceptCompletion = true,
             bool reportChild = false)
         {
+            historyStore.DefinitionStore.Save(definition);
             var executionId = Guid.NewGuid();
             var envelope = new Akka.Reminders.ReminderEnvelope<ReminderPayload>(
                 new Akka.Reminders.ReminderEntity(ReminderManagerActor.ShardRegionName, ReminderManagerActor.EntityId),

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderHistoryStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderHistoryStoreTests.cs
@@ -3,6 +3,9 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
@@ -13,14 +16,18 @@ namespace Netclaw.Actors.Tests.Reminders;
 public class ReminderHistoryStoreTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+    private readonly ReminderDefinitionStore _definitionStore;
     private readonly ReminderHistoryStore _store;
     private static readonly ReminderId TestId = new("test-reminder");
 
     public ReminderHistoryStoreTests()
     {
-        var paths = new NetclawPaths(_dir.Path);
-        Directory.CreateDirectory(paths.RemindersDirectory);
-        _store = new ReminderHistoryStore(paths);
+        _paths = new NetclawPaths(_dir.Path);
+        Directory.CreateDirectory(_paths.RemindersDirectory);
+        _definitionStore = new ReminderDefinitionStore(_paths);
+        _definitionStore.Save(CreateDefinition(TestId));
+        _store = new ReminderHistoryStore(_definitionStore);
     }
 
     public void Dispose()
@@ -91,6 +98,60 @@ public class ReminderHistoryStoreTests : IDisposable
         Assert.Equal("session-4", records[2].SessionId);
     }
 
+    [Fact]
+    public async Task New_current_session_history_is_beside_its_session_definition()
+    {
+        var id = new ReminderId("session-history");
+        var definition = CreateDefinition(id) with
+        {
+            Delivery = new ReminderDelivery
+            {
+                Kind = DeliveryKind.CurrentSession,
+                SessionId = "C0ABC/1712000000.000001"
+            }
+        };
+        _definitionStore.Save(definition);
+
+        await _store.AppendAsync(id, MakeRecord(true));
+
+        var directory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(definition.Delivery.SessionId!),
+            _paths.SessionsDirectory);
+        Assert.True(File.Exists(Path.Combine(directory, "session-history.json")));
+        Assert.True(File.Exists(Path.Combine(directory, "session-history.history.jsonl")));
+        Assert.False(File.Exists(Path.Combine(_paths.RemindersDirectory, "session-history.history.jsonl")));
+    }
+
+    [Fact]
+    public async Task Existing_current_session_history_stays_beside_its_daemon_definition()
+    {
+        var id = new ReminderId("existing-session-history");
+        var definition = CreateDefinition(id) with
+        {
+            Delivery = new ReminderDelivery
+            {
+                Kind = DeliveryKind.CurrentSession,
+                SessionId = "C0ABC/1712000000.000001"
+            }
+        };
+        var definitionPath = Path.Combine(_paths.RemindersDirectory, "existing-session-history.json");
+        WriteDefinition(definitionPath, definition);
+        var store = new ReminderHistoryStore(new ReminderDefinitionStore(_paths));
+
+        await store.AppendAsync(id, MakeRecord(true));
+
+        var daemonHistoryPath = Path.Combine(
+            _paths.RemindersDirectory,
+            "existing-session-history.history.jsonl");
+        var sessionDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(definition.Delivery.SessionId!),
+            _paths.SessionsDirectory);
+        Assert.True(File.Exists(definitionPath));
+        Assert.True(File.Exists(daemonHistoryPath));
+        Assert.False(File.Exists(Path.Combine(sessionDirectory, "existing-session-history.history.jsonl")));
+        Assert.Single(await store.ReadAsync(id, 10));
+    }
+
     private static HistoryRecord MakeRecord(bool success, string? sessionId = null) =>
         new(
             FiredAt: DateTimeOffset.UtcNow,
@@ -98,4 +159,31 @@ public class ReminderHistoryStoreTests : IDisposable
             DurationMs: 1234,
             SessionId: sessionId ?? "reminder/test-reminder/1234567890",
             ErrorMessage: success ? null : "test error");
+
+    private static ReminderDefinition CreateDefinition(ReminderId id)
+    {
+        var now = TimeProvider.System.GetUtcNow();
+        return new ReminderDefinition
+        {
+            Id = id,
+            Title = id.Value,
+            Instructions = "Run the test reminder.",
+            Delivery = new ReminderDelivery { Kind = DeliveryKind.None },
+            Schedule = new ReminderSchedule { Type = ReminderScheduleType.OneShot, FireAt = now.AddHours(1) },
+            Audience = TrustAudience.Personal,
+            Boundary = TrustBoundary.Personal,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+    }
+
+    private static void WriteDefinition(string path, ReminderDefinition definition)
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(definition, options));
+    }
 }

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderHistoryStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderHistoryStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ReminderHistoryStoreTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -98,10 +98,12 @@ public class ReminderHistoryStoreTests : IDisposable
         Assert.Equal("session-4", records[2].SessionId);
     }
 
-    [Fact]
-    public async Task New_current_session_history_is_beside_its_session_definition()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Current_session_history_stays_beside_its_definition(bool legacyDaemonPath)
     {
-        var id = new ReminderId("session-history");
+        var id = new ReminderId(legacyDaemonPath ? "legacy-session-history" : "session-history");
         var definition = CreateDefinition(id) with
         {
             Delivery = new ReminderDelivery
@@ -110,45 +112,28 @@ public class ReminderHistoryStoreTests : IDisposable
                 SessionId = "C0ABC/1712000000.000001"
             }
         };
-        _definitionStore.Save(definition);
-
-        await _store.AppendAsync(id, MakeRecord(true));
-
-        var directory = SessionDirectoryHelper.GetSessionRemindersDirectory(
-            new SessionId(definition.Delivery.SessionId!),
-            _paths.SessionsDirectory);
-        Assert.True(File.Exists(Path.Combine(directory, "session-history.json")));
-        Assert.True(File.Exists(Path.Combine(directory, "session-history.history.jsonl")));
-        Assert.False(File.Exists(Path.Combine(_paths.RemindersDirectory, "session-history.history.jsonl")));
-    }
-
-    [Fact]
-    public async Task Existing_current_session_history_stays_beside_its_daemon_definition()
-    {
-        var id = new ReminderId("existing-session-history");
-        var definition = CreateDefinition(id) with
+        ReminderHistoryStore store;
+        if (legacyDaemonPath)
         {
-            Delivery = new ReminderDelivery
-            {
-                Kind = DeliveryKind.CurrentSession,
-                SessionId = "C0ABC/1712000000.000001"
-            }
-        };
-        var definitionPath = Path.Combine(_paths.RemindersDirectory, "existing-session-history.json");
-        WriteDefinition(definitionPath, definition);
-        var store = new ReminderHistoryStore(new ReminderDefinitionStore(_paths));
+            WriteDefinition(Path.Combine(_paths.RemindersDirectory, $"{id.Value}.json"), definition);
+            store = new ReminderHistoryStore(new ReminderDefinitionStore(_paths));
+        }
+        else
+        {
+            _definitionStore.Save(definition);
+            store = _store;
+        }
 
         await store.AppendAsync(id, MakeRecord(true));
 
-        var daemonHistoryPath = Path.Combine(
-            _paths.RemindersDirectory,
-            "existing-session-history.history.jsonl");
         var sessionDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
             new SessionId(definition.Delivery.SessionId!),
             _paths.SessionsDirectory);
-        Assert.True(File.Exists(definitionPath));
-        Assert.True(File.Exists(daemonHistoryPath));
-        Assert.False(File.Exists(Path.Combine(sessionDirectory, "existing-session-history.history.jsonl")));
+        var expectedDirectory = legacyDaemonPath ? _paths.RemindersDirectory : sessionDirectory;
+        var otherDirectory = legacyDaemonPath ? sessionDirectory : _paths.RemindersDirectory;
+        Assert.True(File.Exists(Path.Combine(expectedDirectory, $"{id.Value}.json")));
+        Assert.True(File.Exists(Path.Combine(expectedDirectory, $"{id.Value}.history.jsonl")));
+        Assert.False(File.Exists(Path.Combine(otherDirectory, $"{id.Value}.history.jsonl")));
         Assert.Single(await store.ReadAsync(id, 10));
     }
 

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -453,6 +453,47 @@ public class ReminderManagerActorTests : TestKit
         Assert.Contains("one-shot", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Save_rejects_session_storage_owner_change_before_scheduler_mutation(bool changeSessionId)
+    {
+        var manager = await GetManagerAsync();
+        var definition = CreateCurrentSessionDefinition("owner-transition", deliveryRequired: false);
+        var authorization = new ReminderAudienceAuthorizationContext(TrustAudience.Team, "test");
+        var created = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(definition, Authorization: authorization),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+        Assert.True(created.Success, created.ErrorMessage);
+        var before = await manager.Ask<ReminderStatusResponse>(
+            new GetReminderStatusQuery(definition.Id),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        var changedDelivery = changeSessionId
+            ? definition.Delivery with { SessionId = "C0OTHER/1712000000.000002" }
+            : definition.Delivery with { Kind = DeliveryKind.Channel };
+        var response = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(
+                definition with { Delivery = changedDelivery },
+                ReminderWriteMode.Replace,
+                authorization),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+        var after = await manager.Ask<ReminderStatusResponse>(
+            new GetReminderStatusQuery(definition.Id),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(response.Success);
+        Assert.Equal(ReminderSaveError.Validation, response.Error);
+        Assert.Equal(definition.Delivery, _definitionStore.Get(definition.Id)!.Delivery);
+        Assert.True(after.Found);
+        Assert.True(after.Enabled);
+        Assert.Equal(before.NextFire, after.NextFire);
+    }
+
     [Fact]
     public async Task Save_explicit_audience_within_source_authority_is_persisted()
     {

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -49,7 +49,7 @@ public class ReminderManagerActorTests : TestKit
         _definitionStore = new ReminderDefinitionStore(paths);
         _notificationSink = new TestNotificationSink();
         var definitionStore = _definitionStore;
-        var historyStore = new ReminderHistoryStore(paths);
+        var historyStore = new ReminderHistoryStore(definitionStore);
 
         // Wire local reminders with in-memory storage
         builder.WithLocalReminders(reminders =>
@@ -301,10 +301,11 @@ public class ReminderManagerActorTests : TestKit
             cancellationToken: TestContext.Current.CancellationToken);
 
         var paths = new NetclawPaths(_basePath);
+        var restartedDefinitionStore = new ReminderDefinitionStore(paths);
         var restarted = Sys.ActorOf(
             CreateManagerProps(
-                new ReminderDefinitionStore(paths),
-                new ReminderHistoryStore(paths)),
+                restartedDefinitionStore,
+                new ReminderHistoryStore(restartedDefinitionStore)),
             "reminder-manager-restarted");
         ActorRegistry.For(Sys).Register<ReminderManagerActorKey>(restarted, overwrite: true);
         _sharedResolver.RegisterShardRegion(ReminderManagerActor.ShardRegionName, restarted);
@@ -357,7 +358,7 @@ public class ReminderManagerActorTests : TestKit
             UpdatedAt = now.AddHours(-2)
         };
         _definitionStore.Save(zombie);
-        var historyStore = new ReminderHistoryStore(new NetclawPaths(_basePath));
+        var historyStore = new ReminderHistoryStore(_definitionStore);
         await historyStore.AppendAsync(
             zombie.Id,
             new HistoryRecord(now.AddMinutes(-30), false, 100, "session-1", "recovery failed"));
@@ -564,7 +565,7 @@ public class ReminderManagerActorTests : TestKit
                 new SchedulingConfig(),
                 TimeProvider.System,
                 store,
-                new ReminderHistoryStore(paths),
+                new ReminderHistoryStore(store),
                 sink,
                 NullReminderChannelNotifier.Instance)),
             "legacy-reminder-alert-manager");

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderToolConfigGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderToolConfigGateTests.cs
@@ -75,7 +75,7 @@ public class ReminderToolConfigGateTests : IDisposable
     {
         var paths = new NetclawPaths(_dir.Path);
         Directory.CreateDirectory(paths.RemindersDirectory);
-        var store = new ReminderHistoryStore(paths);
+        var store = new ReminderHistoryStore(new ReminderDefinitionStore(paths));
         var tool = new GetReminderHistoryTool(store, _disabledConfig);
 
         var result = await tool.ExecuteAsync(

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Tools;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tests.Utilities;
@@ -86,6 +87,48 @@ public sealed class AutonomousZoneClampTests : IDisposable
 
         Assert.True(policy.TryResolveWritePath(Path.Combine(_sessionDir, "f.txt"), ctx, out _, out var e1), e1);
         Assert.True(policy.TryResolveWritePath(Path.Combine(_projectDir, "f.txt"), ctx, out _, out var e2), e2);
+    }
+
+    [Theory]
+    [InlineData(SessionDirectoryHelper.RemindersSubdirectory, "daily.json")]
+    [InlineData(SessionDirectoryHelper.JobsSubdirectory, "job-1.json")]
+    public void Generic_writes_cannot_change_session_automation_definitions(
+        string artifactDirectory,
+        string fileName)
+    {
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var definitionPath = Path.Combine(_sessionDir, artifactDirectory, fileName);
+
+        foreach (var autonomous in new[] { true, false })
+        {
+            var allowed = policy.TryResolveWritePath(
+                definitionPath,
+                Ctx(TrustAudience.Personal, autonomous),
+                out _,
+                out var error);
+
+            Assert.False(allowed);
+            Assert.Contains("automation definition", error, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void Generic_writes_keep_session_automation_logs_and_history_writable()
+    {
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var ctx = Ctx(TrustAudience.Personal, autonomous: true);
+        var historyPath = Path.Combine(
+            _sessionDir,
+            SessionDirectoryHelper.RemindersSubdirectory,
+            "daily.history.jsonl");
+        var outputPath = Path.Combine(
+            _sessionDir,
+            SessionDirectoryHelper.JobsSubdirectory,
+            "job-1",
+            "output.log");
+
+        Assert.True(policy.TryResolveWritePath(historyPath, ctx, out _, out var historyError), historyError);
+        Assert.True(policy.TryResolveWritePath(outputPath, ctx, out _, out var outputError), outputError);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -154,6 +154,28 @@ public sealed class AutonomousZoneClampTests : IDisposable
     }
 
     [Fact]
+    public void Symlink_alias_cannot_change_a_session_automation_artifact()
+    {
+        // Windows requires Developer Mode or elevation for this test operation.
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var artifactDirectory = Path.Combine(
+            _sessionDir,
+            SessionDirectoryHelper.RemindersSubdirectory);
+        Directory.CreateDirectory(artifactDirectory);
+        var alias = Path.Combine(_outsideDir, "artifact-alias");
+        Directory.CreateSymbolicLink(alias, artifactDirectory);
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+
+        Assert.False(policy.TryResolveWritePath(
+            Path.Combine(alias, "daily.json"),
+            Ctx(TrustAudience.Personal, autonomous: false),
+            out _,
+            out _));
+    }
+
+    [Fact]
     public void Interactive_personal_outside_zone_is_unrestricted()
     {
         // Contrast: an interactive Personal session keeps Mode.All blanket access —

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -90,45 +90,67 @@ public sealed class AutonomousZoneClampTests : IDisposable
     }
 
     [Theory]
-    [InlineData(SessionDirectoryHelper.RemindersSubdirectory, "daily.json")]
-    [InlineData(SessionDirectoryHelper.JobsSubdirectory, "job-1.json")]
-    public void Generic_writes_cannot_change_session_automation_definitions(
-        string artifactDirectory,
-        string fileName)
+    [InlineData("reminders/daily.json")]
+    [InlineData("reminders/daily.json.tmp/block")]
+    [InlineData("reminders/daily.history.jsonl")]
+    [InlineData("jobs/job-1.json")]
+    [InlineData("jobs/job-1/output.log")]
+    public void Generic_writes_cannot_change_session_automation_artifacts(string relativePath)
     {
         var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
-        var definitionPath = Path.Combine(_sessionDir, artifactDirectory, fileName);
+        var artifactPath = Path.Combine(
+            _sessionDir,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
 
         foreach (var autonomous in new[] { true, false })
         {
             var allowed = policy.TryResolveWritePath(
-                definitionPath,
+                artifactPath,
                 Ctx(TrustAudience.Personal, autonomous),
                 out _,
                 out var error);
 
             Assert.False(allowed);
-            Assert.Contains("automation definition", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("automation artifacts", error, StringComparison.OrdinalIgnoreCase);
         }
     }
 
-    [Fact]
-    public void Generic_writes_keep_session_automation_logs_and_history_writable()
+    [Theory]
+    [InlineData("reminders/daily.json")]
+    [InlineData("reminders/daily.history.jsonl")]
+    [InlineData("jobs/job-1/output.log")]
+    public void Session_automation_artifacts_remain_readable(string relativePath)
     {
         var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
         var ctx = Ctx(TrustAudience.Personal, autonomous: true);
-        var historyPath = Path.Combine(
+        var artifactPath = Path.Combine(
             _sessionDir,
-            SessionDirectoryHelper.RemindersSubdirectory,
-            "daily.history.jsonl");
-        var outputPath = Path.Combine(
-            _sessionDir,
-            SessionDirectoryHelper.JobsSubdirectory,
-            "job-1",
-            "output.log");
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
 
-        Assert.True(policy.TryResolveWritePath(historyPath, ctx, out _, out var historyError), historyError);
-        Assert.True(policy.TryResolveWritePath(outputPath, ctx, out _, out var outputError), outputError);
+        Assert.True(policy.TryResolveReadPath(artifactPath, ctx, out _, out var error), error);
+    }
+
+    [Fact]
+    public void Custom_write_root_cannot_change_a_sibling_session_automation_artifact()
+    {
+        var config = new ToolConfig();
+        config.AudienceProfiles.Team.WriteFiles = new ToolFilesystemAccessProfile
+        {
+            Mode = ToolFilesystemMode.Roots,
+            Roots = [_paths.SessionsDirectory]
+        };
+        var policy = new ScopedFileAccessPolicy(config, _paths);
+        var siblingDefinition = Path.Combine(
+            _paths.SessionsDirectory,
+            "sibling",
+            SessionDirectoryHelper.RemindersSubdirectory,
+            "daily.json");
+
+        Assert.False(policy.TryResolveWritePath(
+            siblingDefinition,
+            Ctx(TrustAudience.Team, autonomous: true),
+            out _,
+            out _));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -164,8 +164,13 @@ public sealed class AutonomousZoneClampTests : IDisposable
             _sessionDir,
             SessionDirectoryHelper.RemindersSubdirectory);
         Directory.CreateDirectory(artifactDirectory);
+        var sessionsAlias = Path.Combine(_outsideDir, "sessions-alias");
+        Directory.CreateSymbolicLink(sessionsAlias, _paths.SessionsDirectory);
         var alias = Path.Combine(_outsideDir, "artifact-alias");
-        Directory.CreateSymbolicLink(alias, artifactDirectory);
+        Directory.CreateSymbolicLink(alias, Path.Combine(
+            sessionsAlias,
+            "s1",
+            SessionDirectoryHelper.RemindersSubdirectory));
         var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
 
         Assert.False(policy.TryResolveWritePath(

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -8,13 +8,15 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Persistence;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
+using Netclaw.Security;
 
 namespace Netclaw.Actors.Jobs;
 
 /// <summary>
 /// File-backed store for background job definitions.
-/// Each job is persisted at <c>~/.netclaw/jobs/{id}.json</c>.
+/// New jobs use their source session directory. Existing jobs stay in their current directory.
 /// </summary>
 public sealed class BackgroundJobDefinitionStore
 {
@@ -24,7 +26,8 @@ public sealed class BackgroundJobDefinitionStore
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _directory;
+    private readonly string _legacyDirectory;
+    private readonly string _sessionsDirectory;
     private readonly object _sync = new();
     private readonly Dictionary<string, RejectedLegacyBackgroundJobDefinition> _rejectedLegacyDefinitions =
         new(StringComparer.Ordinal);
@@ -32,29 +35,11 @@ public sealed class BackgroundJobDefinitionStore
 
     public BackgroundJobDefinitionStore(NetclawPaths paths, ILogger<BackgroundJobDefinitionStore>? logger = null)
     {
-        _directory = paths.JobsDirectory;
+        _legacyDirectory = paths.JobsDirectory;
+        _sessionsDirectory = paths.SessionsDirectory;
         _logger = logger ?? NullLogger<BackgroundJobDefinitionStore>.Instance;
-        Directory.CreateDirectory(_directory);
-    }
-
-    private BackgroundJobDefinition? Deserialize(string text, string path)
-    {
-        // A pre-#994 job document with no persisted trust context cannot be run
-        // safely — its trust tier is unknown. Reject it loudly rather than
-        // coerce a substitute audience.
-        var missing = LegacyTrustFieldGuard.MissingTrustFields(text);
-        if (missing.Count > 0)
-        {
-            RecordRejectedLegacyDefinition(path, $"missing trust field(s): {string.Join(", ", missing)}");
-            _logger.LogError(
-                "Background job document {Path} predates issue #994 and is missing required "
-                + "trust field(s): {MissingFields}. The job will not be loaded — a job with no "
-                + "persisted audience cannot be run safely. Recreate the job or remove the file.",
-                path, string.Join(", ", missing));
-            return null;
-        }
-
-        return JsonSerializer.Deserialize<BackgroundJobDefinition>(text, JsonOptions);
+        Directory.CreateDirectory(_legacyDirectory);
+        Directory.CreateDirectory(_sessionsDirectory);
     }
 
     /// <summary>
@@ -77,46 +62,52 @@ public sealed class BackgroundJobDefinitionStore
     public BackgroundJobDefinition? Get(BackgroundJobId id)
     {
         lock (_sync)
-        {
-            var path = GetPath(id);
-            if (!File.Exists(path))
-                return null;
+            return TryResolveDefinition(id, out var definition, out _) ? definition : null;
+    }
 
-            try
-            {
-                var text = File.ReadAllText(path);
-                return Deserialize(text, path);
-            }
-            catch
-            {
-                return null;
-            }
-        }
+    public BackgroundJobDefinition? Get(BackgroundJobId id, SessionId sessionId)
+    {
+        var definition = Get(id);
+        return definition?.SessionId == sessionId ? definition : null;
     }
 
     public IReadOnlyList<BackgroundJobDefinition> List()
     {
         lock (_sync)
         {
-            var list = new List<BackgroundJobDefinition>();
-            if (!Directory.Exists(_directory))
-                return list;
+            var definitions = new Dictionary<string, BackgroundJobDefinition>(StringComparer.Ordinal);
+            var paths = new Dictionary<string, string>(StringComparer.Ordinal);
+            var duplicates = new HashSet<string>(StringComparer.Ordinal);
 
-            foreach (var file in Directory.EnumerateFiles(_directory, "*.json", SearchOption.TopDirectoryOnly))
+            foreach (var path in EnumerateDefinitionFiles())
             {
-                try
+                var definition = ReadDefinition(path);
+                if (definition is null)
+                    continue;
+
+                if (!IsValidStoragePath(definition, path, out var reason))
                 {
-                    var text = File.ReadAllText(file);
-                    var def = Deserialize(text, file);
-                    if (def is not null && !string.IsNullOrWhiteSpace(def.Id.Value))
-                        list.Add(def);
+                    _logger.LogError("Background job document {Path} has invalid storage ownership: {Reason}", path, reason);
+                    continue;
                 }
-                catch // slopwatch-ignore: SW003 corrupt job JSON is benign — skip and continue listing
+
+                if (duplicates.Contains(definition.Id.Value))
+                    continue;
+
+                if (paths.TryGetValue(definition.Id.Value, out var priorPath))
                 {
+                    paths.Remove(definition.Id.Value);
+                    definitions.Remove(definition.Id.Value);
+                    duplicates.Add(definition.Id.Value);
+                    LogDuplicate(definition.Id, priorPath, path);
+                    continue;
                 }
+
+                paths.Add(definition.Id.Value, path);
+                definitions.Add(definition.Id.Value, definition);
             }
 
-            return list;
+            return definitions.Values.ToArray();
         }
     }
 
@@ -124,8 +115,23 @@ public sealed class BackgroundJobDefinitionStore
     {
         lock (_sync)
         {
-            Directory.CreateDirectory(_directory);
-            var path = GetPath(definition.Id);
+            var existingPaths = FindDefinitionPaths(definition.Id);
+            if (existingPaths.Count > 1)
+            {
+                LogDuplicate(definition.Id, existingPaths[0], existingPaths[1]);
+                throw new InvalidOperationException(
+                    $"Background job '{definition.Id.Value}' has definitions in more than one storage directory.");
+            }
+
+            var path = existingPaths.Count == 1
+                ? existingPaths[0]
+                : GetDefinitionPath(GetSessionDirectory(definition.SessionId), definition.Id);
+
+            if (!IsLegacyPath(path) && !IsValidSessionStoragePath(definition, path, out var reason))
+                throw new InvalidOperationException(
+                    $"Background job '{definition.Id.Value}' cannot use its existing storage directory: {reason}");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             var tempPath = $"{path}.tmp";
             File.WriteAllText(tempPath, JsonSerializer.Serialize(definition, JsonOptions));
             File.Move(tempPath, path, overwrite: true);
@@ -136,39 +142,249 @@ public sealed class BackgroundJobDefinitionStore
     {
         lock (_sync)
         {
-            var path = GetPath(id);
-            if (!File.Exists(path))
+            var paths = FindDefinitionPaths(id);
+            if (paths.Count == 0)
                 return false;
+            if (paths.Count > 1)
+            {
+                LogDuplicate(id, paths[0], paths[1]);
+                return false;
+            }
 
-            File.Delete(path);
+            File.Delete(paths[0]);
             return true;
         }
     }
 
-    /// <summary>
-    /// Returns the output log directory for a job, creating it if needed.
-    /// </summary>
-    public string GetOutputDirectory(BackgroundJobId id)
-    {
-        var dir = Path.Combine(_directory, Uri.EscapeDataString(id.Value));
-        Directory.CreateDirectory(dir);
-        return dir;
-    }
-
-    public string GetOutputLogPath(BackgroundJobId id) =>
-        Path.Combine(GetOutputDirectory(id), "output.log");
+    public bool Delete(BackgroundJobId id, SessionId sessionId) =>
+        Get(id, sessionId) is not null && Delete(id);
 
     /// <summary>
-    /// Returns the output log path without creating any directories.
+    /// Returns the output log directory for a job and creates it when necessary.
     /// </summary>
-    public string GetOutputLogPathOnly(BackgroundJobId id) =>
-        Path.Combine(_directory, Uri.EscapeDataString(id.Value), "output.log");
-
-    private string GetPath(BackgroundJobId id)
+    public string GetOutputDirectory(BackgroundJobId id, SessionId sessionId)
     {
-        var encoded = Uri.EscapeDataString(id.Value);
-        return Path.Combine(_directory, $"{encoded}.json");
+        var directory = GetOutputDirectoryPath(GetStorageDirectory(id, sessionId), id);
+        Directory.CreateDirectory(directory);
+        return directory;
     }
+
+    public string GetOutputLogPath(BackgroundJobId id, SessionId sessionId) =>
+        Path.Combine(GetOutputDirectory(id, sessionId), "output.log");
+
+    /// <summary>
+    /// Returns the output log path without directory creation.
+    /// </summary>
+    public string GetOutputLogPathOnly(BackgroundJobId id, SessionId sessionId) =>
+        Path.Combine(GetOutputDirectoryPath(GetStorageDirectory(id, sessionId), id), "output.log");
+
+    private string GetStorageDirectory(BackgroundJobId id, SessionId sessionId)
+    {
+        lock (_sync)
+        {
+            var paths = FindDefinitionPaths(id);
+            if (paths.Count == 0)
+                return GetSessionDirectory(sessionId);
+
+            if (paths.Count > 1)
+            {
+                LogDuplicate(id, paths[0], paths[1]);
+                throw new InvalidOperationException(
+                    $"Background job '{id.Value}' has definitions in more than one storage directory.");
+            }
+
+            if (!TryResolveDefinition(id, out var definition, out var path))
+                throw new InvalidOperationException($"Background job '{id.Value}' does not have a valid definition.");
+            if (definition.SessionId != sessionId)
+                throw new InvalidOperationException(
+                    $"Background job '{id.Value}' belongs to session '{definition.SessionId.Value}'.");
+            return Path.GetDirectoryName(path)!;
+        }
+    }
+
+    private bool TryResolveDefinition(
+        BackgroundJobId id,
+        out BackgroundJobDefinition definition,
+        out string path)
+    {
+        var paths = FindDefinitionPaths(id);
+        if (paths.Count == 0)
+        {
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        if (paths.Count > 1)
+        {
+            LogDuplicate(id, paths[0], paths[1]);
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        path = paths[0];
+        var stored = ReadDefinition(path);
+        if (stored is null)
+        {
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        if (stored.Id != id)
+        {
+            _logger.LogError(
+                "Background job document {Path} contains id {StoredId}, but its file name identifies {RequestedId}",
+                path, stored.Id.Value, id.Value);
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        if (!IsValidStoragePath(stored, path, out var reason))
+        {
+            _logger.LogError("Background job document {Path} has invalid storage ownership: {Reason}", path, reason);
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        definition = stored;
+        return true;
+    }
+
+    private List<string> FindDefinitionPaths(BackgroundJobId id)
+    {
+        var paths = new List<string>();
+        var fileName = $"{Uri.EscapeDataString(id.Value)}.json";
+        AddIfPresent(paths, GetContainedPath(_legacyDirectory, fileName, id));
+
+        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        {
+            var jobDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory);
+            if (Directory.Exists(jobDirectory))
+                AddIfPresent(paths, GetContainedPath(jobDirectory, fileName, id));
+        }
+
+        return paths;
+    }
+
+    private IEnumerable<string> EnumerateDefinitionFiles()
+    {
+        foreach (var path in Directory.EnumerateFiles(_legacyDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            yield return path;
+
+        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        {
+            var jobDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory);
+            if (!Directory.Exists(jobDirectory))
+                continue;
+
+            foreach (var path in Directory.EnumerateFiles(jobDirectory, "*.json", SearchOption.TopDirectoryOnly))
+                yield return path;
+        }
+    }
+
+    private static void AddIfPresent(List<string> paths, string path)
+    {
+        if (File.Exists(path))
+            paths.Add(path);
+    }
+
+    private bool IsValidStoragePath(BackgroundJobDefinition definition, string path, out string reason)
+    {
+        var expectedPath = GetDefinitionPath(Path.GetDirectoryName(path)!, definition.Id);
+        if (!PathUtility.AreEquivalentPaths(path, expectedPath))
+        {
+            reason = "the file name does not match the stored job id";
+            return false;
+        }
+
+        if (IsLegacyPath(path))
+        {
+            reason = string.Empty;
+            return true;
+        }
+
+        return IsValidSessionStoragePath(definition, path, out reason);
+    }
+
+    private bool IsValidSessionStoragePath(BackgroundJobDefinition definition, string path, out string reason)
+    {
+        var expectedDirectory = GetSessionDirectory(definition.SessionId);
+        if (!PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, expectedDirectory))
+        {
+            reason = $"the stored session owner resolves to '{expectedDirectory}'";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private bool IsLegacyPath(string path) =>
+        PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, _legacyDirectory);
+
+    private string GetSessionDirectory(SessionId sessionId) =>
+        SessionDirectoryHelper.GetSessionJobsDirectory(sessionId, _sessionsDirectory);
+
+    private static string GetDefinitionPath(string directory, BackgroundJobId id) =>
+        GetContainedPath(directory, $"{Uri.EscapeDataString(id.Value)}.json", id);
+
+    private static string GetOutputDirectoryPath(string directory, BackgroundJobId id) =>
+        GetContainedPath(directory, Uri.EscapeDataString(id.Value), id);
+
+    private static string GetContainedPath(string directory, string name, BackgroundJobId id)
+    {
+        var root = Path.GetFullPath(directory);
+        var candidate = Path.GetFullPath(Path.Combine(root, name));
+        if (!PathUtility.IsWithinRoot(candidate, root))
+            throw new ArgumentException(
+                $"Background job id '{id.Value}' resolves outside the job directory.", nameof(id));
+        return candidate;
+    }
+
+    private BackgroundJobDefinition? ReadDefinition(string path)
+    {
+        try
+        {
+            var text = File.ReadAllText(path);
+            var definition = Deserialize(text, path);
+            return definition is not null && !string.IsNullOrWhiteSpace(definition.Id.Value)
+                ? definition
+                : null;
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to read background job document {Path}", path);
+            return null;
+        }
+    }
+
+    private BackgroundJobDefinition? Deserialize(string text, string path)
+    {
+        // A document without trust fields cannot execute safely. Keep it so
+        // the operator can repair or remove the file.
+        var missing = LegacyTrustFieldGuard.MissingTrustFields(text);
+        if (missing.Count > 0)
+        {
+            RecordRejectedLegacyDefinition(path, $"missing trust field(s): {string.Join(", ", missing)}");
+            _logger.LogError(
+                "Background job document {Path} predates issue #994 and is missing required "
+                + "trust field(s): {MissingFields}. The job will not be loaded. "
+                + "Recreate the job or remove the file.",
+                path, string.Join(", ", missing));
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<BackgroundJobDefinition>(text, JsonOptions);
+    }
+
+    private void LogDuplicate(BackgroundJobId id, string firstPath, string secondPath) =>
+        _logger.LogError(
+            "Background job id {JobId} has duplicate definitions at {FirstPath} and {SecondPath}. Neither definition will load.",
+            id.Value, firstPath, secondPath);
 
     private void RecordRejectedLegacyDefinition(string path, string reason)
     {

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="BackgroundJobDefinitionStore.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -81,15 +81,10 @@ public sealed class BackgroundJobDefinitionStore
 
             foreach (var path in EnumerateDefinitionFiles())
             {
-                var definition = ReadDefinition(path);
-                if (definition is null)
+                if (TryReadValidDefinition(path) is not { } stored)
                     continue;
 
-                if (!IsValidStoragePath(definition, path, out var reason))
-                {
-                    _logger.LogError("Background job document {Path} has invalid storage ownership: {Reason}", path, reason);
-                    continue;
-                }
+                var definition = stored.Definition;
 
                 if (duplicates.Contains(definition.Id.Value))
                     continue;
@@ -115,16 +110,16 @@ public sealed class BackgroundJobDefinitionStore
     {
         lock (_sync)
         {
-            var existingPaths = FindDefinitionPaths(definition.Id);
-            if (existingPaths.Count > 1)
+            var definitions = FindValidDefinitions(definition.Id);
+            if (definitions.Count > 1)
             {
-                LogDuplicate(definition.Id, existingPaths[0], existingPaths[1]);
+                LogDuplicate(definition.Id, definitions[0].Path, definitions[1].Path);
                 throw new InvalidOperationException(
                     $"Background job '{definition.Id.Value}' has definitions in more than one storage directory.");
             }
 
-            var path = existingPaths.Count == 1
-                ? existingPaths[0]
+            var path = definitions.Count == 1
+                ? definitions[0].Path
                 : GetDefinitionPath(GetSessionDirectory(definition.SessionId), definition.Id);
 
             if (!IsLegacyPath(path) && !IsValidSessionStoragePath(definition, path, out var reason))
@@ -142,16 +137,16 @@ public sealed class BackgroundJobDefinitionStore
     {
         lock (_sync)
         {
-            var paths = FindDefinitionPaths(id);
-            if (paths.Count == 0)
+            var definitions = FindValidDefinitions(id);
+            if (definitions.Count == 0)
                 return false;
-            if (paths.Count > 1)
+            if (definitions.Count > 1)
             {
-                LogDuplicate(id, paths[0], paths[1]);
+                LogDuplicate(id, definitions[0].Path, definitions[1].Path);
                 return false;
             }
 
-            File.Delete(paths[0]);
+            File.Delete(definitions[0].Path);
             return true;
         }
     }
@@ -165,6 +160,7 @@ public sealed class BackgroundJobDefinitionStore
     public string GetOutputDirectory(BackgroundJobId id, SessionId sessionId)
     {
         var directory = GetOutputDirectoryPath(GetStorageDirectory(id, sessionId), id);
+        EnsureSafeOutputPath(directory);
         Directory.CreateDirectory(directory);
         return directory;
     }
@@ -175,26 +171,30 @@ public sealed class BackgroundJobDefinitionStore
     /// <summary>
     /// Returns the output log path without directory creation.
     /// </summary>
-    public string GetOutputLogPathOnly(BackgroundJobId id, SessionId sessionId) =>
-        Path.Combine(GetOutputDirectoryPath(GetStorageDirectory(id, sessionId), id), "output.log");
+    public string GetOutputLogPathOnly(BackgroundJobId id, SessionId sessionId)
+    {
+        var directory = GetOutputDirectoryPath(GetStorageDirectory(id, sessionId), id);
+        EnsureSafeOutputPath(directory);
+        return Path.Combine(directory, "output.log");
+    }
 
     private string GetStorageDirectory(BackgroundJobId id, SessionId sessionId)
     {
         lock (_sync)
         {
-            var paths = FindDefinitionPaths(id);
-            if (paths.Count == 0)
+            var definitions = FindValidDefinitions(id);
+            if (definitions.Count == 0)
                 return GetSessionDirectory(sessionId);
 
-            if (paths.Count > 1)
+            if (definitions.Count > 1)
             {
-                LogDuplicate(id, paths[0], paths[1]);
+                LogDuplicate(id, definitions[0].Path, definitions[1].Path);
                 throw new InvalidOperationException(
                     $"Background job '{id.Value}' has definitions in more than one storage directory.");
             }
 
-            if (!TryResolveDefinition(id, out var definition, out var path))
-                throw new InvalidOperationException($"Background job '{id.Value}' does not have a valid definition.");
+            var definition = definitions[0].Definition;
+            var path = definitions[0].Path;
             if (definition.SessionId != sessionId)
                 throw new InvalidOperationException(
                     $"Background job '{id.Value}' belongs to session '{definition.SessionId.Value}'.");
@@ -207,51 +207,37 @@ public sealed class BackgroundJobDefinitionStore
         out BackgroundJobDefinition definition,
         out string path)
     {
-        var paths = FindDefinitionPaths(id);
-        if (paths.Count == 0)
+        var definitions = FindValidDefinitions(id);
+        if (definitions.Count == 0)
         {
             definition = null!;
             path = string.Empty;
             return false;
         }
 
-        if (paths.Count > 1)
+        if (definitions.Count > 1)
         {
-            LogDuplicate(id, paths[0], paths[1]);
+            LogDuplicate(id, definitions[0].Path, definitions[1].Path);
             definition = null!;
             path = string.Empty;
             return false;
         }
 
-        path = paths[0];
-        var stored = ReadDefinition(path);
-        if (stored is null)
-        {
-            definition = null!;
-            path = string.Empty;
-            return false;
-        }
-
-        if (stored.Id != id)
-        {
-            _logger.LogError(
-                "Background job document {Path} contains id {StoredId}, but its file name identifies {RequestedId}",
-                path, stored.Id.Value, id.Value);
-            definition = null!;
-            path = string.Empty;
-            return false;
-        }
-
-        if (!IsValidStoragePath(stored, path, out var reason))
-        {
-            _logger.LogError("Background job document {Path} has invalid storage ownership: {Reason}", path, reason);
-            definition = null!;
-            path = string.Empty;
-            return false;
-        }
-
-        definition = stored;
+        definition = definitions[0].Definition;
+        path = definitions[0].Path;
         return true;
+    }
+
+    private List<(BackgroundJobDefinition Definition, string Path)> FindValidDefinitions(BackgroundJobId id)
+    {
+        var definitions = new List<(BackgroundJobDefinition, string)>();
+        foreach (var path in FindDefinitionPaths(id))
+        {
+            if (TryReadValidDefinition(path) is { } stored && stored.Definition.Id == id)
+                definitions.Add(stored);
+        }
+
+        return definitions;
     }
 
     private List<string> FindDefinitionPaths(BackgroundJobId id)
@@ -260,11 +246,13 @@ public sealed class BackgroundJobDefinitionStore
         var fileName = $"{Uri.EscapeDataString(id.Value)}.json";
         AddIfPresent(paths, GetContainedPath(_legacyDirectory, fileName, id));
 
-        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        foreach (var jobDirectory in EnumerateSessionJobDirectories())
         {
-            var jobDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory);
-            if (Directory.Exists(jobDirectory))
-                AddIfPresent(paths, GetContainedPath(jobDirectory, fileName, id));
+            var path = GetContainedPath(jobDirectory, fileName, id);
+            if (IsSafeSessionPath(path, out var reason))
+                AddIfPresent(paths, path);
+            else
+                _logger.LogError("Session job definition {Path} is unsafe: {Reason}", path, reason);
         }
 
         return paths;
@@ -275,14 +263,37 @@ public sealed class BackgroundJobDefinitionStore
         foreach (var path in Directory.EnumerateFiles(_legacyDirectory, "*.json", SearchOption.TopDirectoryOnly))
             yield return path;
 
+        foreach (var jobDirectory in EnumerateSessionJobDirectories())
+        {
+            foreach (var path in Directory.EnumerateFiles(jobDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                if (IsSafeSessionPath(path, out var reason))
+                    yield return path;
+                else
+                    _logger.LogError("Session job definition {Path} is unsafe: {Reason}", path, reason);
+            }
+        }
+    }
+
+    private IEnumerable<string> EnumerateSessionJobDirectories()
+    {
+        if (!IsSafeSessionPath(_sessionsDirectory, out var rootReason))
+        {
+            _logger.LogError("Session job root {Path} is unsafe: {Reason}", _sessionsDirectory, rootReason);
+            yield break;
+        }
+
         foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
         {
             var jobDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory);
-            if (!Directory.Exists(jobDirectory))
+            if (!IsSafeSessionPath(jobDirectory, out var reason))
+            {
+                _logger.LogError("Session job directory {Path} is unsafe: {Reason}", jobDirectory, reason);
                 continue;
+            }
 
-            foreach (var path in Directory.EnumerateFiles(jobDirectory, "*.json", SearchOption.TopDirectoryOnly))
-                yield return path;
+            if (Directory.Exists(jobDirectory))
+                yield return jobDirectory;
         }
     }
 
@@ -312,6 +323,9 @@ public sealed class BackgroundJobDefinitionStore
 
     private bool IsValidSessionStoragePath(BackgroundJobDefinition definition, string path, out string reason)
     {
+        if (!IsSafeSessionPath(path, out reason))
+            return false;
+
         var expectedDirectory = GetSessionDirectory(definition.SessionId);
         if (!PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, expectedDirectory))
         {
@@ -321,6 +335,33 @@ public sealed class BackgroundJobDefinitionStore
 
         reason = string.Empty;
         return true;
+    }
+
+    private bool IsSafeSessionPath(string path, out string reason)
+    {
+        if (!PathUtility.IsWithinRoot(path, _sessionsDirectory))
+        {
+            reason = "the path is outside the session directory";
+            return false;
+        }
+
+        if (PathUtility.ContainsSymlinkSegment(Path.GetDirectoryName(_sessionsDirectory)!, path))
+        {
+            reason = "the path contains a symbolic link or reparse point";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private void EnsureSafeOutputPath(string path)
+    {
+        if (PathUtility.IsWithinRoot(path, _sessionsDirectory)
+            && !IsSafeSessionPath(path, out var reason))
+        {
+            throw new InvalidOperationException($"Background job output path is unsafe: {reason}");
+        }
     }
 
     private bool IsLegacyPath(string path) =>
@@ -360,6 +401,19 @@ public sealed class BackgroundJobDefinitionStore
             _logger.LogError(ex, "Failed to read background job document {Path}", path);
             return null;
         }
+    }
+
+    private (BackgroundJobDefinition Definition, string Path)? TryReadValidDefinition(string path)
+    {
+        var definition = ReadDefinition(path);
+        if (definition is null)
+            return null;
+
+        if (IsValidStoragePath(definition, path, out var reason))
+            return (definition, path);
+
+        _logger.LogError("Background job document {Path} has invalid storage ownership: {Reason}", path, reason);
+        return null;
     }
 
     private BackgroundJobDefinition? Deserialize(string text, string path)
@@ -407,6 +461,7 @@ public sealed class BackgroundJobDefinitionStore
             return encoded;
         }
     }
+
 }
 
 public sealed record RejectedLegacyBackgroundJobDefinition(string JobId, string Reason);

--- a/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobDefinitionStore.cs
@@ -26,8 +26,7 @@ public sealed class BackgroundJobDefinitionStore
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _legacyDirectory;
-    private readonly string _sessionsDirectory;
+    private readonly NetclawPaths _paths;
     private readonly object _sync = new();
     private readonly Dictionary<string, RejectedLegacyBackgroundJobDefinition> _rejectedLegacyDefinitions =
         new(StringComparer.Ordinal);
@@ -35,11 +34,10 @@ public sealed class BackgroundJobDefinitionStore
 
     public BackgroundJobDefinitionStore(NetclawPaths paths, ILogger<BackgroundJobDefinitionStore>? logger = null)
     {
-        _legacyDirectory = paths.JobsDirectory;
-        _sessionsDirectory = paths.SessionsDirectory;
+        _paths = paths;
         _logger = logger ?? NullLogger<BackgroundJobDefinitionStore>.Instance;
-        Directory.CreateDirectory(_legacyDirectory);
-        Directory.CreateDirectory(_sessionsDirectory);
+        Directory.CreateDirectory(_paths.JobsDirectory);
+        Directory.CreateDirectory(_paths.SessionsDirectory);
     }
 
     /// <summary>
@@ -244,7 +242,7 @@ public sealed class BackgroundJobDefinitionStore
     {
         var paths = new List<string>();
         var fileName = $"{Uri.EscapeDataString(id.Value)}.json";
-        AddIfPresent(paths, GetContainedPath(_legacyDirectory, fileName, id));
+        AddIfPresent(paths, GetContainedPath(_paths.JobsDirectory, fileName, id));
 
         foreach (var jobDirectory in EnumerateSessionJobDirectories())
         {
@@ -260,7 +258,7 @@ public sealed class BackgroundJobDefinitionStore
 
     private IEnumerable<string> EnumerateDefinitionFiles()
     {
-        foreach (var path in Directory.EnumerateFiles(_legacyDirectory, "*.json", SearchOption.TopDirectoryOnly))
+        foreach (var path in Directory.EnumerateFiles(_paths.JobsDirectory, "*.json", SearchOption.TopDirectoryOnly))
             yield return path;
 
         foreach (var jobDirectory in EnumerateSessionJobDirectories())
@@ -277,13 +275,13 @@ public sealed class BackgroundJobDefinitionStore
 
     private IEnumerable<string> EnumerateSessionJobDirectories()
     {
-        if (!IsSafeSessionPath(_sessionsDirectory, out var rootReason))
+        if (!IsSafeSessionPath(_paths.SessionsDirectory, out var rootReason))
         {
-            _logger.LogError("Session job root {Path} is unsafe: {Reason}", _sessionsDirectory, rootReason);
+            _logger.LogError("Session job root {Path} is unsafe: {Reason}", _paths.SessionsDirectory, rootReason);
             yield break;
         }
 
-        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        foreach (var sessionDirectory in Directory.EnumerateDirectories(_paths.SessionsDirectory))
         {
             var jobDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory);
             if (!IsSafeSessionPath(jobDirectory, out var reason))
@@ -339,13 +337,13 @@ public sealed class BackgroundJobDefinitionStore
 
     private bool IsSafeSessionPath(string path, out string reason)
     {
-        if (!PathUtility.IsWithinRoot(path, _sessionsDirectory))
+        if (!PathUtility.IsWithinRoot(path, _paths.SessionsDirectory))
         {
             reason = "the path is outside the session directory";
             return false;
         }
 
-        if (PathUtility.ContainsSymlinkSegment(Path.GetDirectoryName(_sessionsDirectory)!, path))
+        if (PathUtility.ContainsSymlinkSegment(Path.GetDirectoryName(_paths.SessionsDirectory)!, path))
         {
             reason = "the path contains a symbolic link or reparse point";
             return false;
@@ -357,7 +355,7 @@ public sealed class BackgroundJobDefinitionStore
 
     private void EnsureSafeOutputPath(string path)
     {
-        if (PathUtility.IsWithinRoot(path, _sessionsDirectory)
+        if (PathUtility.IsWithinRoot(path, _paths.SessionsDirectory)
             && !IsSafeSessionPath(path, out var reason))
         {
             throw new InvalidOperationException($"Background job output path is unsafe: {reason}");
@@ -365,10 +363,10 @@ public sealed class BackgroundJobDefinitionStore
     }
 
     private bool IsLegacyPath(string path) =>
-        PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, _legacyDirectory);
+        PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, _paths.JobsDirectory);
 
     private string GetSessionDirectory(SessionId sessionId) =>
-        SessionDirectoryHelper.GetSessionJobsDirectory(sessionId, _sessionsDirectory);
+        SessionDirectoryHelper.GetSessionJobsDirectory(sessionId, _paths.SessionsDirectory);
 
     private static string GetDefinitionPath(string directory, BackgroundJobId id) =>
         GetContainedPath(directory, $"{Uri.EscapeDataString(id.Value)}.json", id);

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -18,8 +18,8 @@ using static Netclaw.Actors.Jobs.BackgroundJobProtocol;
 namespace Netclaw.Actors.Jobs;
 
 /// <summary>
-/// Infrastructure singleton that manages background job lifecycle independently
-/// of any session. Follows the same pattern as <c>ReminderManagerActor</c>.
+/// Infrastructure singleton that coordinates background jobs across sessions.
+/// Each source session owns its job files.
 /// </summary>
 public sealed class BackgroundJobManagerActor : ReceiveActor
 {
@@ -98,7 +98,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         _store.Save(definition);
         _definitions[jobId.Value] = definition;
 
-        var outputLogPath = _store.GetOutputLogPathOnly(jobId);
+        var outputLogPath = _store.GetOutputLogPathOnly(jobId, cmd.SessionId);
 
         if (_activeJobIds.Count >= MaxConcurrentJobs)
         {
@@ -182,7 +182,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     private void HandleCancel(CancelBackgroundJob cmd)
     {
         if (!_definitions.TryGetValue(cmd.JobId.Value, out var def))
-            def = _store.Get(cmd.JobId);
+            def = _store.Get(cmd.JobId, cmd.SessionId);
 
         if (def is null
             || def.SessionId != cmd.SessionId
@@ -221,7 +221,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
     {
         if (!_definitions.TryGetValue(query.JobId.Value, out var def))
         {
-            var diskDef = _store.Get(query.JobId);
+            var diskDef = _store.Get(query.JobId, query.SessionId);
             if (diskDef is not null)
                 def = diskDef;
         }
@@ -240,7 +240,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
             return;
         }
 
-        var outputFilePath = _store.GetOutputLogPathOnly(query.JobId);
+        var outputFilePath = _store.GetOutputLogPathOnly(query.JobId, query.SessionId);
         string? outputTail = null;
         var outputFileExists = false;
         try
@@ -326,7 +326,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
 
     private void NotifyLostJob(BackgroundJobDefinition lost, long nowMs)
     {
-        var outputFilePath = _store.GetOutputLogPathOnly(lost.Id);
+        var outputFilePath = _store.GetOutputLogPathOnly(lost.Id, lost.SessionId);
         string? outputTail = null;
         try
         {
@@ -386,7 +386,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
         _store.Save(running);
         _activeJobIds.Add(running.Id.Value);
 
-        var outputLogPath = _store.GetOutputLogPath(running.Id);
+        var outputLogPath = _store.GetOutputLogPath(running.Id, running.SessionId);
         var props = DependencyResolver.For(Context.System)
             .Props<BackgroundJobExecutionActor>(running, outputLogPath, _timeProvider);
         Context.ActorOf(props, $"job-{running.Id}");

--- a/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
@@ -185,7 +185,7 @@ internal sealed record BackgroundJobCompleted
 // ── Persistence ──
 
 /// <summary>
-/// Job definition persisted to <c>~/.netclaw/jobs/{id}.json</c>.
+/// Job definition persisted in its source session job directory.
 /// </summary>
 public sealed record BackgroundJobDefinition
 {

--- a/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
@@ -31,6 +31,16 @@ public static class SessionDirectoryHelper
     public const string MediaSubdirectory = "media";
 
     /// <summary>
+    /// Name of the subdirectory that owns current-session reminder files.
+    /// </summary>
+    public const string RemindersSubdirectory = "reminders";
+
+    /// <summary>
+    /// Name of the subdirectory that owns background job files.
+    /// </summary>
+    public const string JobsSubdirectory = "jobs";
+
+    /// <summary>
     /// Computes the session directory path under the given base directory
     /// (e.g. <c>~/.netclaw/sessions/</c>).
     /// </summary>
@@ -39,6 +49,18 @@ public static class SessionDirectoryHelper
         var sanitized = SanitizeSessionId(sessionId);
         return Path.Combine(basePath, sanitized);
     }
+
+    /// <summary>
+    /// Gets the canonical directory for reminders that re-enter one session.
+    /// </summary>
+    public static string GetSessionRemindersDirectory(SessionId sessionId, string basePath) =>
+        GetSessionArtifactDirectory(sessionId, basePath, RemindersSubdirectory);
+
+    /// <summary>
+    /// Gets the canonical directory for background jobs that belong to one session.
+    /// </summary>
+    public static string GetSessionJobsDirectory(SessionId sessionId, string basePath) =>
+        GetSessionArtifactDirectory(sessionId, basePath, JobsSubdirectory);
 
     /// <summary>
     /// Computes and creates the <c>inbox/</c> subdirectory under the
@@ -105,5 +127,16 @@ public static class SessionDirectoryHelper
         for (var i = 0; i < value.Length; i++)
             buf[i] = char.IsLetterOrDigit(value[i]) || value[i] == '-' ? value[i] : '_';
         return new string(buf);
+    }
+
+    private static string GetSessionArtifactDirectory(
+        SessionId sessionId,
+        string basePath,
+        string artifactSubdirectory)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId.Value))
+            throw new ArgumentException("Session id cannot be empty.", nameof(sessionId));
+
+        return Path.Combine(GetSessionDirectory(sessionId, basePath), artifactSubdirectory);
     }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
@@ -8,7 +8,9 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Persistence;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
+using Netclaw.Security;
 
 namespace Netclaw.Actors.Reminders;
 
@@ -27,7 +29,8 @@ public sealed class ReminderDefinitionStore
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _directory;
+    private readonly string _daemonDirectory;
+    private readonly string _sessionsDirectory;
     private readonly object _sync = new();
     private readonly List<DroppedInvalidReminderDefinition> _droppedInvalidDefinitions = [];
     private readonly Dictionary<string, RejectedLegacyReminderDefinition> _rejectedLegacyDefinitions =
@@ -36,9 +39,11 @@ public sealed class ReminderDefinitionStore
 
     public ReminderDefinitionStore(NetclawPaths paths, ILogger<ReminderDefinitionStore>? logger = null)
     {
-        _directory = paths.RemindersDirectory;
+        _daemonDirectory = paths.RemindersDirectory;
+        _sessionsDirectory = paths.SessionsDirectory;
         _logger = logger ?? NullLogger<ReminderDefinitionStore>.Instance;
-        Directory.CreateDirectory(_directory);
+        Directory.CreateDirectory(_daemonDirectory);
+        Directory.CreateDirectory(_sessionsDirectory);
         PruneInvalidDefinitions();
     }
 
@@ -78,47 +83,57 @@ public sealed class ReminderDefinitionStore
     public bool Exists(ReminderId id)
     {
         lock (_sync)
-            return File.Exists(GetPath(id));
+            return TryResolveDefinition(id, out _, out _);
     }
 
     public ReminderDefinition? Get(ReminderId id)
     {
         lock (_sync)
-        {
-            var path = GetPath(id);
-            if (!File.Exists(path))
-                return null;
-
-            var result = TryReadDefinition(path);
-            if (result.Definition is not null)
-                return result.Definition;
-
-            if (result.ShouldDelete)
-                DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
-
-            return null;
-        }
+            return TryResolveDefinition(id, out var definition, out _) ? definition : null;
     }
 
     public IReadOnlyList<ReminderDefinition> List()
     {
         lock (_sync)
         {
-            var list = new List<ReminderDefinition>();
-            foreach (var file in Directory.EnumerateFiles(_directory, "*.json", SearchOption.TopDirectoryOnly))
+            var definitions = new Dictionary<string, ReminderDefinition>(StringComparer.Ordinal);
+            var paths = new Dictionary<string, string>(StringComparer.Ordinal);
+            var duplicates = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var path in EnumerateDefinitionFiles())
             {
-                var result = TryReadDefinition(file);
-                if (result.Definition is not null)
+                var result = TryReadDefinition(path);
+                if (result.Definition is null)
                 {
-                    list.Add(result.Definition);
+                    if (result.ShouldDelete)
+                        DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
                     continue;
                 }
 
-                if (result.ShouldDelete)
-                    DeleteInvalidDefinition(file, result.ErrorMessage ?? "invalid reminder definition");
+                var definition = result.Definition;
+                if (!IsValidStoragePath(definition, path, out var reason))
+                {
+                    _logger.LogError("Reminder document {Path} has invalid storage ownership: {Reason}", path, reason);
+                    continue;
+                }
+
+                if (duplicates.Contains(definition.Id.Value))
+                    continue;
+
+                if (paths.TryGetValue(definition.Id.Value, out var priorPath))
+                {
+                    paths.Remove(definition.Id.Value);
+                    definitions.Remove(definition.Id.Value);
+                    duplicates.Add(definition.Id.Value);
+                    LogDuplicate(definition.Id, priorPath, path);
+                    continue;
+                }
+
+                paths.Add(definition.Id.Value, path);
+                definitions.Add(definition.Id.Value, definition);
             }
 
-            return list;
+            return definitions.Values.ToArray();
         }
     }
 
@@ -126,9 +141,23 @@ public sealed class ReminderDefinitionStore
     {
         lock (_sync)
         {
-            Directory.CreateDirectory(_directory);
+            var existingPaths = FindDefinitionPaths(definition.Id);
+            if (existingPaths.Count > 1)
+            {
+                LogDuplicate(definition.Id, existingPaths[0], existingPaths[1]);
+                throw new InvalidOperationException(
+                    $"Reminder '{definition.Id.Value}' has definitions in more than one storage directory.");
+            }
 
-            var path = GetPath(definition.Id);
+            var path = existingPaths.Count == 1
+                ? existingPaths[0]
+                : GetDefinitionPath(GetDirectoryForNewDefinition(definition), definition.Id);
+
+            if (!IsDaemonPath(path) && !IsValidSessionStoragePath(definition, path, out var reason))
+                throw new InvalidOperationException(
+                    $"Reminder '{definition.Id.Value}' cannot use its existing storage directory: {reason}");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             var tempPath = $"{path}.tmp";
             File.WriteAllText(tempPath, JsonSerializer.Serialize(definition, JsonOptions));
             File.Move(tempPath, path, overwrite: true);
@@ -139,32 +168,197 @@ public sealed class ReminderDefinitionStore
     {
         lock (_sync)
         {
-            var path = GetPath(id);
-            if (!File.Exists(path))
+            var paths = FindDefinitionPaths(id);
+            if (paths.Count == 0)
                 return false;
+            if (paths.Count > 1)
+            {
+                LogDuplicate(id, paths[0], paths[1]);
+                return false;
+            }
 
-            File.Delete(path);
+            File.Delete(paths[0]);
             return true;
         }
     }
 
-    private string GetPath(ReminderId id)
+    internal bool TryGetStorageDirectory(ReminderId id, out string directory)
     {
-        // Uri.EscapeDataString escapes path separators and absolute-path
-        // markers (/, \, :, control chars), so the encoded value cannot encode a
-        // traversal. The post-canonicalization containment check below is the
-        // belt-and-suspenders that CodeQL also recognizes as a path sanitizer.
-        // (cs/path-injection)
-        var encoded = Uri.EscapeDataString(id.Value);
-        var baseDir = Path.GetFullPath(_directory);
-        var candidate = Path.GetFullPath(Path.Combine(baseDir, $"{encoded}.json"));
-        var baseWithSep = baseDir.EndsWith(Path.DirectorySeparatorChar)
-            ? baseDir
-            : baseDir + Path.DirectorySeparatorChar;
-        if (!candidate.StartsWith(baseWithSep, StringComparison.Ordinal))
+        lock (_sync)
+        {
+            if (!TryResolveDefinition(id, out _, out var path))
+            {
+                directory = string.Empty;
+                return false;
+            }
+
+            directory = Path.GetDirectoryName(path)!;
+            return true;
+        }
+    }
+
+    private bool TryResolveDefinition(
+        ReminderId id,
+        out ReminderDefinition definition,
+        out string path)
+    {
+        var paths = FindDefinitionPaths(id);
+        if (paths.Count == 0)
+        {
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        if (paths.Count > 1)
+        {
+            LogDuplicate(id, paths[0], paths[1]);
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        path = paths[0];
+        var result = TryReadDefinition(path);
+        if (result.Definition is null)
+        {
+            if (result.ShouldDelete)
+                DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        if (result.Definition.Id != id)
+        {
+            _logger.LogError(
+                "Reminder document {Path} contains id {StoredId}, but its file name identifies {RequestedId}",
+                path, result.Definition.Id.Value, id.Value);
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        if (!IsValidStoragePath(result.Definition, path, out var reason))
+        {
+            _logger.LogError("Reminder document {Path} has invalid storage ownership: {Reason}", path, reason);
+            definition = null!;
+            path = string.Empty;
+            return false;
+        }
+
+        definition = result.Definition;
+        return true;
+    }
+
+    private List<string> FindDefinitionPaths(ReminderId id)
+    {
+        var paths = new List<string>();
+        var fileName = $"{Uri.EscapeDataString(id.Value)}.json";
+        AddIfPresent(paths, GetContainedPath(_daemonDirectory, fileName, id));
+
+        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        {
+            var reminderDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory);
+            if (Directory.Exists(reminderDirectory))
+                AddIfPresent(paths, GetContainedPath(reminderDirectory, fileName, id));
+        }
+
+        return paths;
+    }
+
+    private IEnumerable<string> EnumerateDefinitionFiles()
+    {
+        foreach (var path in Directory.EnumerateFiles(_daemonDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            yield return path;
+
+        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        {
+            var reminderDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory);
+            if (!Directory.Exists(reminderDirectory))
+                continue;
+
+            foreach (var path in Directory.EnumerateFiles(reminderDirectory, "*.json", SearchOption.TopDirectoryOnly))
+                yield return path;
+        }
+    }
+
+    private static void AddIfPresent(List<string> paths, string path)
+    {
+        if (File.Exists(path))
+            paths.Add(path);
+    }
+
+    private bool IsValidStoragePath(ReminderDefinition definition, string path, out string reason)
+    {
+        var expectedPath = GetDefinitionPath(Path.GetDirectoryName(path)!, definition.Id);
+        if (!PathUtility.AreEquivalentPaths(path, expectedPath))
+        {
+            reason = "the file name does not match the stored reminder id";
+            return false;
+        }
+
+        if (IsDaemonPath(path))
+        {
+            reason = string.Empty;
+            return true;
+        }
+
+        return IsValidSessionStoragePath(definition, path, out reason);
+    }
+
+    private bool IsValidSessionStoragePath(ReminderDefinition definition, string path, out string reason)
+    {
+        if (definition.Delivery.Kind != DeliveryKind.CurrentSession)
+        {
+            reason = $"delivery kind {definition.Delivery.Kind} requires the daemon reminder directory";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(definition.Delivery.SessionId))
+        {
+            reason = "a CurrentSession reminder requires a session id";
+            return false;
+        }
+
+        var expectedDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
+            new SessionId(definition.Delivery.SessionId), _sessionsDirectory);
+        if (!PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, expectedDirectory))
+        {
+            reason = $"the stored session owner resolves to '{expectedDirectory}'";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private bool IsDaemonPath(string path) =>
+        PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, _daemonDirectory);
+
+    private string GetDirectoryForNewDefinition(ReminderDefinition definition) =>
+        definition.Delivery.Kind switch
+        {
+            DeliveryKind.CurrentSession when !string.IsNullOrWhiteSpace(definition.Delivery.SessionId) =>
+                SessionDirectoryHelper.GetSessionRemindersDirectory(
+                    new SessionId(definition.Delivery.SessionId), _sessionsDirectory),
+            DeliveryKind.CurrentSession => throw new InvalidDataException(
+                $"CurrentSession reminder '{definition.Id.Value}' does not have a session id."),
+            DeliveryKind.Channel or DeliveryKind.None => _daemonDirectory,
+            _ => throw new InvalidDataException(
+                $"Reminder '{definition.Id.Value}' has unsupported delivery kind '{definition.Delivery.Kind}'.")
+        };
+
+    private static string GetDefinitionPath(string directory, ReminderId id) =>
+        GetContainedPath(directory, $"{Uri.EscapeDataString(id.Value)}.json", id);
+
+    private static string GetContainedPath(string directory, string fileName, ReminderId id)
+    {
+        var root = Path.GetFullPath(directory);
+        var candidate = Path.GetFullPath(Path.Combine(root, fileName));
+        if (!PathUtility.IsWithinRoot(candidate, root))
             throw new ArgumentException(
-                $"Reminder id '{id.Value}' resolves outside the reminders directory.",
-                nameof(id));
+                $"Reminder id '{id.Value}' resolves outside the reminder directory.", nameof(id));
         return candidate;
     }
 
@@ -172,16 +366,21 @@ public sealed class ReminderDefinitionStore
     {
         lock (_sync)
         {
-            foreach (var file in Directory.EnumerateFiles(_directory, "*.json", SearchOption.TopDirectoryOnly))
+            foreach (var path in EnumerateDefinitionFiles().ToArray())
             {
-                var result = TryReadDefinition(file);
+                var result = TryReadDefinition(path);
                 if (result.Definition is not null || !result.ShouldDelete)
                     continue;
 
-                DeleteInvalidDefinition(file, result.ErrorMessage ?? "invalid reminder definition");
+                DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
             }
         }
     }
+
+    private void LogDuplicate(ReminderId id, string firstPath, string secondPath) =>
+        _logger.LogError(
+            "Reminder id {ReminderId} has duplicate definitions at {FirstPath} and {SecondPath}. Neither definition will run.",
+            id.Value, firstPath, secondPath);
 
     private void DeleteInvalidDefinition(string path, string reason)
     {
@@ -226,10 +425,8 @@ public sealed class ReminderDefinitionStore
         try
         {
             var text = File.ReadAllText(path);
-            // A pre-#994 reminder document with no persisted trust context cannot
-            // be run safely. Reject it loudly without coercing a substitute
-            // audience, and keep the file — it is operator-authored data, not
-            // corrupt JSON, so the operator can repair or remove it.
+            // A document without trust fields cannot execute safely. Keep it so
+            // the operator can repair or remove the file.
             var missingTrustFields = LegacyTrustFieldGuard.MissingTrustFields(text);
             if (missingTrustFields.Count > 0)
             {
@@ -237,8 +434,7 @@ public sealed class ReminderDefinitionStore
                 _logger.LogError(
                     "Reminder document {Path} predates issue #994 and is missing required "
                     + "trust field(s): {MissingFields}. The reminder will not be loaded or "
-                    + "scheduled — a reminder with no persisted audience cannot be run safely. "
-                    + "Recreate the reminder or remove the file.",
+                    + "scheduled. Recreate the reminder or remove the file.",
                     path, fields);
                 RecordRejectedLegacyDefinition(path, $"missing trust field(s): {fields}");
                 return new ReadResult(null, $"missing trust field(s): {fields}", ShouldDelete: false);

--- a/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
@@ -78,12 +78,6 @@ public sealed class ReminderDefinitionStore
         }
     }
 
-    public bool Exists(ReminderId id)
-    {
-        lock (_sync)
-            return TryResolveDefinition(id, out _, out _);
-    }
-
     public ReminderDefinition? Get(ReminderId id)
     {
         lock (_sync)

--- a/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
@@ -29,8 +29,7 @@ public sealed class ReminderDefinitionStore
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _daemonDirectory;
-    private readonly string _sessionsDirectory;
+    private readonly NetclawPaths _paths;
     private readonly object _sync = new();
     private readonly List<DroppedInvalidReminderDefinition> _droppedInvalidDefinitions = [];
     private readonly Dictionary<string, RejectedLegacyReminderDefinition> _rejectedLegacyDefinitions =
@@ -39,11 +38,10 @@ public sealed class ReminderDefinitionStore
 
     public ReminderDefinitionStore(NetclawPaths paths, ILogger<ReminderDefinitionStore>? logger = null)
     {
-        _daemonDirectory = paths.RemindersDirectory;
-        _sessionsDirectory = paths.SessionsDirectory;
+        _paths = paths;
         _logger = logger ?? NullLogger<ReminderDefinitionStore>.Instance;
-        Directory.CreateDirectory(_daemonDirectory);
-        Directory.CreateDirectory(_sessionsDirectory);
+        Directory.CreateDirectory(_paths.RemindersDirectory);
+        Directory.CreateDirectory(_paths.SessionsDirectory);
         PruneInvalidDefinitions();
     }
 
@@ -247,7 +245,7 @@ public sealed class ReminderDefinitionStore
     {
         var paths = new List<string>();
         var fileName = $"{Uri.EscapeDataString(id.Value)}.json";
-        AddIfPresent(paths, GetContainedPath(_daemonDirectory, fileName, id));
+        AddIfPresent(paths, GetContainedPath(_paths.RemindersDirectory, fileName, id));
 
         foreach (var reminderDirectory in EnumerateSessionReminderDirectories())
         {
@@ -263,7 +261,7 @@ public sealed class ReminderDefinitionStore
 
     private IEnumerable<string> EnumerateDefinitionFiles()
     {
-        foreach (var path in Directory.EnumerateFiles(_daemonDirectory, "*.json", SearchOption.TopDirectoryOnly))
+        foreach (var path in Directory.EnumerateFiles(_paths.RemindersDirectory, "*.json", SearchOption.TopDirectoryOnly))
             yield return path;
 
         foreach (var reminderDirectory in EnumerateSessionReminderDirectories())
@@ -280,13 +278,13 @@ public sealed class ReminderDefinitionStore
 
     private IEnumerable<string> EnumerateSessionReminderDirectories()
     {
-        if (!IsSafeSessionPath(_sessionsDirectory, out var rootReason))
+        if (!IsSafeSessionPath(_paths.SessionsDirectory, out var rootReason))
         {
-            _logger.LogError("Session reminder root {Path} is unsafe: {Reason}", _sessionsDirectory, rootReason);
+            _logger.LogError("Session reminder root {Path} is unsafe: {Reason}", _paths.SessionsDirectory, rootReason);
             yield break;
         }
 
-        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        foreach (var sessionDirectory in Directory.EnumerateDirectories(_paths.SessionsDirectory))
         {
             var reminderDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory);
             if (!IsSafeSessionPath(reminderDirectory, out var reason))
@@ -342,7 +340,7 @@ public sealed class ReminderDefinitionStore
         }
 
         var expectedDirectory = SessionDirectoryHelper.GetSessionRemindersDirectory(
-            new SessionId(definition.Delivery.SessionId), _sessionsDirectory);
+            new SessionId(definition.Delivery.SessionId), _paths.SessionsDirectory);
         if (!PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, expectedDirectory))
         {
             reason = $"the stored session owner resolves to '{expectedDirectory}'";
@@ -355,13 +353,13 @@ public sealed class ReminderDefinitionStore
 
     private bool IsSafeSessionPath(string path, out string reason)
     {
-        if (!PathUtility.IsWithinRoot(path, _sessionsDirectory))
+        if (!PathUtility.IsWithinRoot(path, _paths.SessionsDirectory))
         {
             reason = "the path is outside the session directory";
             return false;
         }
 
-        if (PathUtility.ContainsSymlinkSegment(Path.GetDirectoryName(_sessionsDirectory)!, path))
+        if (PathUtility.ContainsSymlinkSegment(Path.GetDirectoryName(_paths.SessionsDirectory)!, path))
         {
             reason = "the path contains a symbolic link or reparse point";
             return false;
@@ -372,17 +370,17 @@ public sealed class ReminderDefinitionStore
     }
 
     private bool IsDaemonPath(string path) =>
-        PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, _daemonDirectory);
+        PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, _paths.RemindersDirectory);
 
     private string GetDirectoryForNewDefinition(ReminderDefinition definition) =>
         definition.Delivery.Kind switch
         {
             DeliveryKind.CurrentSession when !string.IsNullOrWhiteSpace(definition.Delivery.SessionId) =>
                 SessionDirectoryHelper.GetSessionRemindersDirectory(
-                    new SessionId(definition.Delivery.SessionId), _sessionsDirectory),
+                    new SessionId(definition.Delivery.SessionId), _paths.SessionsDirectory),
             DeliveryKind.CurrentSession => throw new InvalidDataException(
                 $"CurrentSession reminder '{definition.Id.Value}' does not have a session id."),
-            DeliveryKind.Channel or DeliveryKind.None => _daemonDirectory,
+            DeliveryKind.Channel or DeliveryKind.None => _paths.RemindersDirectory,
             _ => throw new InvalidDataException(
                 $"Reminder '{definition.Id.Value}' has unsupported delivery kind '{definition.Delivery.Kind}'.")
         };

--- a/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
@@ -247,7 +247,9 @@ public sealed class ReminderDefinitionStore
             if (IsSafeSessionPath(path, out var reason))
                 AddIfPresent(paths, path);
             else
-                _logger.LogError("Session reminder definition {Path} is unsafe: {Reason}", path, reason);
+                _logger.LogError(
+                    "Session reminder definition {Path} is unsafe: {Reason}",
+                    ForLog(path), ForLog(reason));
         }
 
         return paths;
@@ -265,7 +267,9 @@ public sealed class ReminderDefinitionStore
                 if (IsSafeSessionPath(path, out var reason))
                     yield return path;
                 else
-                    _logger.LogError("Session reminder definition {Path} is unsafe: {Reason}", path, reason);
+                    _logger.LogError(
+                        "Session reminder definition {Path} is unsafe: {Reason}",
+                        ForLog(path), ForLog(reason));
             }
         }
     }
@@ -274,7 +278,9 @@ public sealed class ReminderDefinitionStore
     {
         if (!IsSafeSessionPath(_paths.SessionsDirectory, out var rootReason))
         {
-            _logger.LogError("Session reminder root {Path} is unsafe: {Reason}", _paths.SessionsDirectory, rootReason);
+            _logger.LogError(
+                "Session reminder root {Path} is unsafe: {Reason}",
+                ForLog(_paths.SessionsDirectory), ForLog(rootReason));
             yield break;
         }
 
@@ -283,7 +289,9 @@ public sealed class ReminderDefinitionStore
             var reminderDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory);
             if (!IsSafeSessionPath(reminderDirectory, out var reason))
             {
-                _logger.LogError("Session reminder directory {Path} is unsafe: {Reason}", reminderDirectory, reason);
+                _logger.LogError(
+                    "Session reminder directory {Path} is unsafe: {Reason}",
+                    ForLog(reminderDirectory), ForLog(reason));
                 continue;
             }
 
@@ -410,7 +418,11 @@ public sealed class ReminderDefinitionStore
     private void LogDuplicate(ReminderId id, string firstPath, string secondPath) =>
         _logger.LogError(
             "Reminder id {ReminderId} has duplicate definitions at {FirstPath} and {SecondPath}. Neither definition will run.",
-            id.Value, firstPath, secondPath);
+            ForLog(id.Value), ForLog(firstPath), ForLog(secondPath));
+
+    private static string ForLog(string value) =>
+        value.Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal);
 
     private void DeleteInvalidDefinition(string path, string reason)
     {
@@ -465,7 +477,7 @@ public sealed class ReminderDefinitionStore
                     "Reminder document {Path} predates issue #994 and is missing required "
                     + "trust field(s): {MissingFields}. The reminder will not be loaded or "
                     + "scheduled. Recreate the reminder or remove the file.",
-                    path, fields);
+                    ForLog(path), fields);
                 RecordRejectedLegacyDefinition(path, $"missing trust field(s): {fields}");
                 return new ReadResult(null, $"missing trust field(s): {fields}", ShouldDelete: false);
             }
@@ -508,7 +520,9 @@ public sealed class ReminderDefinitionStore
         if (IsValidStoragePath(result.Definition, path, out var reason))
             return (result.Definition, path);
 
-        _logger.LogError("Reminder document {Path} has invalid storage ownership: {Reason}", path, reason);
+        _logger.LogError(
+            "Reminder document {Path} has invalid storage ownership: {Reason}",
+            ForLog(path), ForLog(reason));
         return null;
     }
 

--- a/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ReminderDefinitionStore.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -102,20 +102,10 @@ public sealed class ReminderDefinitionStore
 
             foreach (var path in EnumerateDefinitionFiles())
             {
-                var result = TryReadDefinition(path);
-                if (result.Definition is null)
-                {
-                    if (result.ShouldDelete)
-                        DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
+                if (TryReadValidDefinition(path) is not { } stored)
                     continue;
-                }
 
-                var definition = result.Definition;
-                if (!IsValidStoragePath(definition, path, out var reason))
-                {
-                    _logger.LogError("Reminder document {Path} has invalid storage ownership: {Reason}", path, reason);
-                    continue;
-                }
+                var definition = stored.Definition;
 
                 if (duplicates.Contains(definition.Id.Value))
                     continue;
@@ -141,21 +131,8 @@ public sealed class ReminderDefinitionStore
     {
         lock (_sync)
         {
-            var existingPaths = FindDefinitionPaths(definition.Id);
-            if (existingPaths.Count > 1)
-            {
-                LogDuplicate(definition.Id, existingPaths[0], existingPaths[1]);
-                throw new InvalidOperationException(
-                    $"Reminder '{definition.Id.Value}' has definitions in more than one storage directory.");
-            }
-
-            var path = existingPaths.Count == 1
-                ? existingPaths[0]
-                : GetDefinitionPath(GetDirectoryForNewDefinition(definition), definition.Id);
-
-            if (!IsDaemonPath(path) && !IsValidSessionStoragePath(definition, path, out var reason))
-                throw new InvalidOperationException(
-                    $"Reminder '{definition.Id.Value}' cannot use its existing storage directory: {reason}");
+            if (!TryGetSavePath(definition, out var path, out var error))
+                throw new InvalidOperationException(error);
 
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             var tempPath = $"{path}.tmp";
@@ -164,20 +141,26 @@ public sealed class ReminderDefinitionStore
         }
     }
 
+    internal bool TryValidateSave(ReminderDefinition definition, out string error)
+    {
+        lock (_sync)
+            return TryGetSavePath(definition, out _, out error);
+    }
+
     public bool Delete(ReminderId id)
     {
         lock (_sync)
         {
-            var paths = FindDefinitionPaths(id);
-            if (paths.Count == 0)
+            var definitions = FindValidDefinitions(id);
+            if (definitions.Count == 0)
                 return false;
-            if (paths.Count > 1)
+            if (definitions.Count > 1)
             {
-                LogDuplicate(id, paths[0], paths[1]);
+                LogDuplicate(id, definitions[0].Path, definitions[1].Path);
                 return false;
             }
 
-            File.Delete(paths[0]);
+            File.Delete(definitions[0].Path);
             return true;
         }
     }
@@ -202,53 +185,62 @@ public sealed class ReminderDefinitionStore
         out ReminderDefinition definition,
         out string path)
     {
-        var paths = FindDefinitionPaths(id);
-        if (paths.Count == 0)
+        var definitions = FindValidDefinitions(id);
+        if (definitions.Count == 0)
         {
             definition = null!;
             path = string.Empty;
             return false;
         }
 
-        if (paths.Count > 1)
+        if (definitions.Count > 1)
         {
-            LogDuplicate(id, paths[0], paths[1]);
+            LogDuplicate(id, definitions[0].Path, definitions[1].Path);
             definition = null!;
             path = string.Empty;
             return false;
         }
 
-        path = paths[0];
-        var result = TryReadDefinition(path);
-        if (result.Definition is null)
-        {
-            if (result.ShouldDelete)
-                DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
-            definition = null!;
-            path = string.Empty;
-            return false;
-        }
-
-        if (result.Definition.Id != id)
-        {
-            _logger.LogError(
-                "Reminder document {Path} contains id {StoredId}, but its file name identifies {RequestedId}",
-                path, result.Definition.Id.Value, id.Value);
-            definition = null!;
-            path = string.Empty;
-            return false;
-        }
-
-        if (!IsValidStoragePath(result.Definition, path, out var reason))
-        {
-            _logger.LogError("Reminder document {Path} has invalid storage ownership: {Reason}", path, reason);
-            definition = null!;
-            path = string.Empty;
-            return false;
-        }
-
-        definition = result.Definition;
+        definition = definitions[0].Definition;
+        path = definitions[0].Path;
         return true;
+    }
+
+    private bool TryGetSavePath(ReminderDefinition definition, out string path, out string error)
+    {
+        var definitions = FindValidDefinitions(definition.Id);
+        if (definitions.Count > 1)
+        {
+            LogDuplicate(definition.Id, definitions[0].Path, definitions[1].Path);
+            path = string.Empty;
+            error = $"Reminder '{definition.Id.Value}' has definitions in more than one storage directory.";
+            return false;
+        }
+
+        path = definitions.Count == 1
+            ? definitions[0].Path
+            : GetDefinitionPath(GetDirectoryForNewDefinition(definition), definition.Id);
+
+        if (!IsDaemonPath(path) && !IsValidSessionStoragePath(definition, path, out var reason))
+        {
+            error = $"Reminder '{definition.Id.Value}' cannot use its existing storage directory: {reason}";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private List<(ReminderDefinition Definition, string Path)> FindValidDefinitions(ReminderId id)
+    {
+        var definitions = new List<(ReminderDefinition, string)>();
+        foreach (var path in FindDefinitionPaths(id))
+        {
+            if (TryReadValidDefinition(path) is { } stored && stored.Definition.Id == id)
+                definitions.Add(stored);
+        }
+
+        return definitions;
     }
 
     private List<string> FindDefinitionPaths(ReminderId id)
@@ -257,11 +249,13 @@ public sealed class ReminderDefinitionStore
         var fileName = $"{Uri.EscapeDataString(id.Value)}.json";
         AddIfPresent(paths, GetContainedPath(_daemonDirectory, fileName, id));
 
-        foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
+        foreach (var reminderDirectory in EnumerateSessionReminderDirectories())
         {
-            var reminderDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory);
-            if (Directory.Exists(reminderDirectory))
-                AddIfPresent(paths, GetContainedPath(reminderDirectory, fileName, id));
+            var path = GetContainedPath(reminderDirectory, fileName, id);
+            if (IsSafeSessionPath(path, out var reason))
+                AddIfPresent(paths, path);
+            else
+                _logger.LogError("Session reminder definition {Path} is unsafe: {Reason}", path, reason);
         }
 
         return paths;
@@ -272,14 +266,37 @@ public sealed class ReminderDefinitionStore
         foreach (var path in Directory.EnumerateFiles(_daemonDirectory, "*.json", SearchOption.TopDirectoryOnly))
             yield return path;
 
+        foreach (var reminderDirectory in EnumerateSessionReminderDirectories())
+        {
+            foreach (var path in Directory.EnumerateFiles(reminderDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                if (IsSafeSessionPath(path, out var reason))
+                    yield return path;
+                else
+                    _logger.LogError("Session reminder definition {Path} is unsafe: {Reason}", path, reason);
+            }
+        }
+    }
+
+    private IEnumerable<string> EnumerateSessionReminderDirectories()
+    {
+        if (!IsSafeSessionPath(_sessionsDirectory, out var rootReason))
+        {
+            _logger.LogError("Session reminder root {Path} is unsafe: {Reason}", _sessionsDirectory, rootReason);
+            yield break;
+        }
+
         foreach (var sessionDirectory in Directory.EnumerateDirectories(_sessionsDirectory))
         {
             var reminderDirectory = Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory);
-            if (!Directory.Exists(reminderDirectory))
+            if (!IsSafeSessionPath(reminderDirectory, out var reason))
+            {
+                _logger.LogError("Session reminder directory {Path} is unsafe: {Reason}", reminderDirectory, reason);
                 continue;
+            }
 
-            foreach (var path in Directory.EnumerateFiles(reminderDirectory, "*.json", SearchOption.TopDirectoryOnly))
-                yield return path;
+            if (Directory.Exists(reminderDirectory))
+                yield return reminderDirectory;
         }
     }
 
@@ -309,6 +326,9 @@ public sealed class ReminderDefinitionStore
 
     private bool IsValidSessionStoragePath(ReminderDefinition definition, string path, out string reason)
     {
+        if (!IsSafeSessionPath(path, out reason))
+            return false;
+
         if (definition.Delivery.Kind != DeliveryKind.CurrentSession)
         {
             reason = $"delivery kind {definition.Delivery.Kind} requires the daemon reminder directory";
@@ -326,6 +346,24 @@ public sealed class ReminderDefinitionStore
         if (!PathUtility.AreEquivalentPaths(Path.GetDirectoryName(path)!, expectedDirectory))
         {
             reason = $"the stored session owner resolves to '{expectedDirectory}'";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private bool IsSafeSessionPath(string path, out string reason)
+    {
+        if (!PathUtility.IsWithinRoot(path, _sessionsDirectory))
+        {
+            reason = "the path is outside the session directory";
+            return false;
+        }
+
+        if (PathUtility.ContainsSymlinkSegment(Path.GetDirectoryName(_sessionsDirectory)!, path))
+        {
+            reason = "the path contains a symbolic link or reparse point";
             return false;
         }
 
@@ -463,6 +501,23 @@ public sealed class ReminderDefinitionStore
         {
             return new ReadResult(null, null, ShouldDelete: false);
         }
+    }
+
+    private (ReminderDefinition Definition, string Path)? TryReadValidDefinition(string path)
+    {
+        var result = TryReadDefinition(path);
+        if (result.Definition is null)
+        {
+            if (result.ShouldDelete)
+                DeleteInvalidDefinition(path, result.ErrorMessage ?? "invalid reminder definition");
+            return null;
+        }
+
+        if (IsValidStoragePath(result.Definition, path, out var reason))
+            return (result.Definition, path);
+
+        _logger.LogError("Reminder document {Path} has invalid storage ownership: {Reason}", path, reason);
+        return null;
     }
 
     private sealed record ReadResult(ReminderDefinition? Definition, string? ErrorMessage, bool ShouldDelete);

--- a/src/Netclaw.Actors/Reminders/ReminderHistoryStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderHistoryStore.cs
@@ -5,8 +5,6 @@
 // -----------------------------------------------------------------------
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Netclaw.Configuration;
-
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
@@ -33,13 +31,14 @@ public sealed class ReminderHistoryStore
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _directory;
+    private readonly ReminderDefinitionStore _definitionStore;
 
-    public ReminderHistoryStore(NetclawPaths paths)
+    public ReminderHistoryStore(ReminderDefinitionStore definitionStore)
     {
-        _directory = paths.RemindersDirectory;
-        Directory.CreateDirectory(_directory);
+        _definitionStore = definitionStore;
     }
+
+    internal ReminderDefinitionStore DefinitionStore => _definitionStore;
 
     /// <summary>
     /// Appends <paramref name="record"/> to <c>{id}.history.jsonl</c>.
@@ -49,6 +48,7 @@ public sealed class ReminderHistoryStore
     public async Task AppendAsync(ReminderId id, HistoryRecord record)
     {
         var path = GetHistoryPath(id);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var line = JsonSerializer.Serialize(record, JsonOptions);
 
         if (!File.Exists(path))
@@ -88,7 +88,8 @@ public sealed class ReminderHistoryStore
     /// </summary>
     public async Task<IReadOnlyList<HistoryRecord>> ReadAsync(ReminderId id, int maxRecords)
     {
-        var path = GetHistoryPath(id);
+        if (!TryGetHistoryPath(id, out var path))
+            return [];
         if (!File.Exists(path))
             return [];
 
@@ -122,14 +123,29 @@ public sealed class ReminderHistoryStore
     /// </summary>
     public void DeleteHistory(ReminderId id)
     {
-        var path = GetHistoryPath(id);
+        if (!TryGetHistoryPath(id, out var path))
+            return;
         if (File.Exists(path))
             File.Delete(path);
     }
 
     private string GetHistoryPath(ReminderId id)
     {
+        if (!TryGetHistoryPath(id, out var path))
+            throw new InvalidOperationException($"Reminder '{id.Value}' does not have a valid definition.");
+        return path;
+    }
+
+    private bool TryGetHistoryPath(ReminderId id, out string path)
+    {
+        if (!_definitionStore.TryGetStorageDirectory(id, out var directory))
+        {
+            path = string.Empty;
+            return false;
+        }
+
         var encoded = Uri.EscapeDataString(id.Value);
-        return Path.Combine(_directory, $"{encoded}.history.jsonl");
+        path = Path.Combine(directory, $"{encoded}.history.jsonl");
+        return true;
     }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -285,6 +285,12 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
         normalized.UpdatedAtMs = now.ToUnixTimeMilliseconds();
 
+        if (!_definitionStore.TryValidateSave(normalized, out var storageError))
+        {
+            replyTo.Tell(ValidationFailure(id, title, storageError));
+            return;
+        }
+
         if (exists)
         {
             await CancelScheduleOnlyAsync(id);

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -211,7 +211,8 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             ? cmd.Definition.Id
             : ReminderIdGenerator.Generate(title);
 
-        var exists = _definitionStore.Exists(id);
+        var existing = _definitionStore.Get(id);
+        var exists = existing is not null;
 
         switch (cmd.WriteMode)
         {
@@ -275,8 +276,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
         if (exists)
         {
-            var existing = _definitionStore.Get(id);
-            normalized.CreatedAtMs = existing?.CreatedAtMs ?? (normalized.CreatedAtMs > 0 ? normalized.CreatedAtMs : now.ToUnixTimeMilliseconds());
+            normalized.CreatedAtMs = existing!.CreatedAtMs;
         }
         else
         {

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -443,10 +443,6 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     /// </summary>
     private async Task DeleteReminderInternalAsync(ReminderId id)
     {
-        _definitionStore.Delete(id);
-        await CancelScheduleOnlyAsync(id);
-        _skipCounts.Remove(id);
-
         try
         {
             _historyStore.DeleteHistory(id);
@@ -455,6 +451,10 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         {
             _log.Warning(ex, "Failed to delete history for reminder '{0}'", id.Value);
         }
+
+        _definitionStore.Delete(id);
+        await CancelScheduleOnlyAsync(id);
+        _skipCounts.Remove(id);
     }
 
     private async Task<ReminderStateResponse> EnableReminderInternalAsync(ReminderId id)

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -398,8 +398,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     private async Task HandlePermanentDeleteAsync(DeleteReminderCommand cmd)
     {
         var replyTo = Sender;
-        var found = _definitionStore.Exists(cmd.Id);
-        await DeleteReminderInternalAsync(cmd.Id);
+        var found = await DeleteReminderInternalAsync(cmd.Id);
 
         _log.Info("Permanently delete reminder '{0}': {1}", cmd.Id.Value, found ? "deleted" : "not found");
         replyTo.Tell(new ReminderDeletedResponse(cmd.Id, found));
@@ -447,7 +446,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     /// Permanently removes a reminder definition, its schedule, history, and process state.
     /// Only an explicit delete command uses this path.
     /// </summary>
-    private async Task DeleteReminderInternalAsync(ReminderId id)
+    private async Task<bool> DeleteReminderInternalAsync(ReminderId id)
     {
         try
         {
@@ -458,9 +457,10 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             _log.Warning(ex, "Failed to delete history for reminder '{0}'", id.Value);
         }
 
-        _definitionStore.Delete(id);
+        var deleted = _definitionStore.Delete(id);
         await CancelScheduleOnlyAsync(id);
         _skipCounts.Remove(id);
+        return deleted;
     }
 
     private async Task<ReminderStateResponse> EnableReminderInternalAsync(ReminderId id)

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -1,8 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ScopedFileAccessPolicy.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -87,6 +88,13 @@ internal sealed class ScopedFileAccessPolicy
         {
             fullPath = string.Empty;
             error = $"Error: Invalid path: {ex.Message}";
+            return false;
+        }
+
+        if (accessKind == AccessKind.Write
+            && IsSessionAutomationDefinitionPath(fullPath, context.SessionDirectory))
+        {
+            error = "Error: Session automation definition files can only be changed through reminder and background job tools.";
             return false;
         }
 
@@ -178,6 +186,26 @@ internal sealed class ScopedFileAccessPolicy
             AccessKind.Attach => profile.AttachFiles,
             _ => profile.ReadFiles
         };
+
+    private static bool IsSessionAutomationDefinitionPath(string fullPath, string? sessionDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(sessionDirectory)
+            || !string.Equals(Path.GetExtension(fullPath), ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var parent = Path.GetDirectoryName(fullPath);
+        if (parent is null)
+            return false;
+
+        return PathUtility.AreEquivalentPaths(
+                   parent,
+                   Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory))
+               || PathUtility.AreEquivalentPaths(
+                   parent,
+                   Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory));
+    }
 
     /// <summary>
     /// Resolves profile roots and merges global read roots for read access.

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -92,9 +92,9 @@ internal sealed class ScopedFileAccessPolicy
         }
 
         if (accessKind == AccessKind.Write
-            && IsSessionAutomationDefinitionPath(fullPath, context.SessionDirectory))
+            && IsSessionAutomationArtifactPath(fullPath, _profileResolver.ResolveSessionsDirectory()))
         {
-            error = "Error: Session automation definition files can only be changed through reminder and background job tools.";
+            error = "Error: Session automation artifacts are read-only through generic file and shell tools.";
             return false;
         }
 
@@ -187,24 +187,19 @@ internal sealed class ScopedFileAccessPolicy
             _ => profile.ReadFiles
         };
 
-    private static bool IsSessionAutomationDefinitionPath(string fullPath, string? sessionDirectory)
+    private static bool IsSessionAutomationArtifactPath(string fullPath, string sessionsDirectory)
     {
-        if (string.IsNullOrWhiteSpace(sessionDirectory)
-            || !string.Equals(Path.GetExtension(fullPath), ".json", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var parent = Path.GetDirectoryName(fullPath);
-        if (parent is null)
+        if (!PathUtility.IsWithinRoot(fullPath, sessionsDirectory))
             return false;
 
-        return PathUtility.AreEquivalentPaths(
-                   parent,
-                   Path.Combine(sessionDirectory, SessionDirectoryHelper.RemindersSubdirectory))
-               || PathUtility.AreEquivalentPaths(
-                   parent,
-                   Path.Combine(sessionDirectory, SessionDirectoryHelper.JobsSubdirectory));
+        var segments = Path.GetRelativePath(sessionsDirectory, fullPath).Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2)
+            return false;
+
+        return string.Equals(segments[1], SessionDirectoryHelper.RemindersSubdirectory, StringComparison.OrdinalIgnoreCase)
+               || string.Equals(segments[1], SessionDirectoryHelper.JobsSubdirectory, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -91,11 +91,21 @@ internal sealed class ScopedFileAccessPolicy
             return false;
         }
 
-        if (accessKind == AccessKind.Write
-            && IsSessionAutomationArtifactPath(fullPath, _profileResolver.ResolveSessionsDirectory()))
+        if (accessKind == AccessKind.Write)
         {
-            error = "Error: Session automation artifacts are read-only through generic file and shell tools.";
-            return false;
+            try
+            {
+                if (IsSessionAutomationArtifactPath(fullPath, _profileResolver.ResolveSessionsDirectory()))
+                {
+                    error = "Error: Session automation artifacts are read-only through generic file and shell tools.";
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                error = $"Error: The path could not be checked for session automation artifacts: {ex.Message}";
+                return false;
+            }
         }
 
         var profile = _profileResolver.ResolveProfile(context);
@@ -188,6 +198,16 @@ internal sealed class ScopedFileAccessPolicy
         };
 
     private static bool IsSessionAutomationArtifactPath(string fullPath, string sessionsDirectory)
+    {
+        if (IsSessionAutomationArtifactPathCore(fullPath, sessionsDirectory))
+            return true;
+
+        var canonicalPath = PathUtility.ResolveSymlinksInPath(fullPath);
+        var canonicalSessionsDirectory = PathUtility.ResolveSymlinksInPath(sessionsDirectory);
+        return IsSessionAutomationArtifactPathCore(canonicalPath, canonicalSessionsDirectory);
+    }
+
+    private static bool IsSessionAutomationArtifactPathCore(string fullPath, string sessionsDirectory)
     {
         if (!PathUtility.IsWithinRoot(fullPath, sessionsDirectory))
             return false;

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -101,7 +101,7 @@ internal sealed class ScopedFileAccessPolicy
                     return false;
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!FatalExceptionPolicy.IsFatal(ex))
             {
                 error = $"Error: The path could not be checked for session automation artifacts: {ex.Message}";
                 return false;

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -73,6 +73,9 @@ internal sealed class ToolAudienceProfileResolver
     /// </summary>
     public string? ResolveWorkspacesDirectory() => _paths?.WorkspacesDirectory;
 
+    public string ResolveSessionsDirectory() => _paths?.SessionsDirectory
+        ?? throw new InvalidOperationException("Netclaw paths are required to resolve the sessions directory.");
+
     public bool IsToolAllowed(ToolName toolName, ToolInvocationContext context)
         => IsToolAllowed(toolName, context.Audience);
 

--- a/src/Netclaw.Daemon.Tests/Reminder/ReminderEndpointAuthorizationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Reminder/ReminderEndpointAuthorizationTests.cs
@@ -47,7 +47,7 @@ public sealed class ReminderEndpointAuthorizationTests : IAsyncDisposable
         var paths = new NetclawPaths(_dir.Path);
         paths.EnsureDirectoriesExist();
         _definitionStore = new ReminderDefinitionStore(paths);
-        _historyStore = new ReminderHistoryStore(paths);
+        _historyStore = new ReminderHistoryStore(_definitionStore);
 
         _actorSystem = ActorSystem.Create($"reminder-endpoint-tests-{Guid.NewGuid():N}");
         _testActor = new TestReminderActor();

--- a/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Reminders/ReminderEndpointRouteBuilderExtensions.cs
@@ -304,7 +304,7 @@ public static class ReminderEndpointRouteBuilderExtensions
             CancellationToken ct) =>
         {
             var rid = new ReminderId(id);
-            if (!definitionStore.Exists(rid))
+            if (definitionStore.Get(rid) is null)
                 return TypedResults.NotFound(new ReminderErrorResponse($"Reminder '{id}' not found."));
 
             var maxRecords = Math.Clamp(last ?? 20, 1, 500);

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -242,8 +242,10 @@ public static class PathUtility
                     : null;
             if (target is not null)
             {
+                // The target can contain a symbolic-link ancestor, such as macOS /var.
+                // Resolve that path before the segment walk continues.
                 pathBuilder.Clear();
-                pathBuilder.Append(target.FullName);
+                pathBuilder.Append(ResolveSymlinksInPath(target.FullName));
             }
 
             if (File.Exists(partial))

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using Netclaw.Configuration;
+using System.Text;
 
 namespace Netclaw.Security;
 
@@ -209,5 +210,46 @@ public static class PathUtility
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Resolves each symbolic link in a path and preserves segments that do not exist.
+    /// </summary>
+    /// <remarks>
+    /// This method does not catch exceptions. Each security policy owns its failure behavior.
+    /// </remarks>
+    public static string ResolveSymlinksInPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(fullPath) ?? string.Empty;
+        var remainder = fullPath.Length > root.Length ? fullPath[root.Length..] : string.Empty;
+        var segments = remainder.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        var pathBuilder = new StringBuilder(root);
+
+        foreach (var segment in segments)
+        {
+            if (pathBuilder.Length > 0 && pathBuilder[^1] != Path.DirectorySeparatorChar)
+                pathBuilder.Append(Path.DirectorySeparatorChar);
+            pathBuilder.Append(segment);
+
+            var partial = pathBuilder.ToString();
+            FileSystemInfo? target = Directory.Exists(partial)
+                ? new DirectoryInfo(partial).ResolveLinkTarget(returnFinalTarget: true)
+                : File.Exists(partial)
+                    ? new FileInfo(partial).ResolveLinkTarget(returnFinalTarget: true)
+                    : null;
+            if (target is not null)
+            {
+                pathBuilder.Clear();
+                pathBuilder.Append(target.FullName);
+            }
+
+            if (File.Exists(partial))
+                break;
+        }
+
+        return Normalize(pathBuilder.ToString());
     }
 }

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -3,8 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Text;
-
 namespace Netclaw.Security;
 
 /// <summary>
@@ -58,7 +56,7 @@ public sealed class ToolPathPolicy
 
             // macOS keeps /etc, /var, /tmp as symlinks into /private, so a denied
             // path that traverses one resolves to a different real path. The deny
-            // checks canonicalize the *candidate* path (TryResolveSymlinksInPath /
+            // checks canonicalize the candidate path (ResolveSymlinksInPath /
             // TryResolveSymlinkTarget); without the resolved denied form here, a
             // candidate resolving to /private/etc/... would slip past a /etc deny.
             //
@@ -81,7 +79,8 @@ public sealed class ToolPathPolicy
     {
         try
         {
-            return TryResolveSymlinksInPath(path, out canonical);
+            canonical = PathUtility.ResolveSymlinksInPath(path);
+            return !string.Equals(canonical, PathUtility.Normalize(path), StringComparison.Ordinal);
         }
         catch
         {
@@ -150,8 +149,8 @@ public sealed class ToolPathPolicy
                 return true;
             }
 
-            return TryResolveSymlinksInPath(path, out var canonical)
-                && IsDeniedNormalized(canonical, deniedSet);
+            var canonical = PathUtility.ResolveSymlinksInPath(path);
+            return IsDeniedNormalized(canonical, deniedSet);
         }
         catch
         {
@@ -205,8 +204,8 @@ public sealed class ToolPathPolicy
             {
                 try
                 {
-                    if (TryResolveSymlinksInPath(normalized, out var canonical)
-                        && IsDeniedNormalized(canonical, _shellDeniedPaths))
+                    var canonical = PathUtility.ResolveSymlinksInPath(normalized);
+                    if (IsDeniedNormalized(canonical, _shellDeniedPaths))
                     {
                         return true;
                     }
@@ -277,71 +276,8 @@ public sealed class ToolPathPolicy
         return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
     }
 
-    // Callers own exception policy here on purpose: BuildNormalizedSet (startup)
-    // skips a failed resolution, while the deny-check call sites (IsDeniedAgainst,
-    // CommandReferencesDeniedPath) fail closed. A blanket catch here would hide
-    // that distinction and force every caller back to the same (wrong) answer.
-    private static bool TryResolveSymlinksInPath(string path, out string canonical)
-    {
-        canonical = string.Empty;
-        if (string.IsNullOrEmpty(path))
-            return false;
-
-        // Walk the path component by component, resolving any directory
-        // or file symlinks encountered. ResolveLinkTarget(returnFinalTarget:
-        // true) follows the chain to a non-link, but only operates on the
-        // entity it's invoked against — it does not see symlinks earlier
-        // in the path. Hence the explicit segment walk.
-        var fullPath = Path.GetFullPath(path);
-        // Seed the builder with the full root (drive + separator on Windows,
-        // "/" on Unix) and split only the REMAINDER after the root. Splitting
-        // the whole path re-emits the drive segment ("C:"), which the root
-        // already provides — appending it again yields "C:\C:\Users\..." so
-        // every Directory.Exists/File.Exists probe below misses and symlink
-        // resolution silently no-ops, failing the deny open. See #1724.
-        var root = Path.GetPathRoot(fullPath) ?? string.Empty;
-        var remainder = fullPath.Length > root.Length ? fullPath[root.Length..] : string.Empty;
-        var segments = remainder.Split(
-            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
-            StringSplitOptions.RemoveEmptyEntries);
-        var sb = new StringBuilder();
-        sb.Append(root);
-
-        foreach (var segment in segments)
-        {
-            if (sb.Length > 0 && sb[^1] != Path.DirectorySeparatorChar)
-                sb.Append(Path.DirectorySeparatorChar);
-            sb.Append(segment);
-
-            var partial = sb.ToString();
-            if (Directory.Exists(partial))
-            {
-                var target = new DirectoryInfo(partial).ResolveLinkTarget(returnFinalTarget: true);
-                if (target is not null)
-                {
-                    sb.Clear();
-                    sb.Append(target.FullName);
-                }
-            }
-            else if (File.Exists(partial))
-            {
-                var target = new FileInfo(partial).ResolveLinkTarget(returnFinalTarget: true);
-                if (target is not null)
-                {
-                    sb.Clear();
-                    sb.Append(target.FullName);
-                }
-
-                break;
-            }
-        }
-
-        canonical = PathUtility.Normalize(sb.ToString());
-        return !string.IsNullOrEmpty(canonical) && !string.Equals(canonical, PathUtility.Normalize(fullPath), StringComparison.Ordinal);
-    }
-
     // Only IsDeniedAgainst calls this; it owns exception policy (fails closed).
-    // See the comment on TryResolveSymlinksInPath for why this does not catch.
+    // See ResolveSymlinksInPath for why this does not catch.
     private static bool TryResolveSymlinkTarget(string path, out string normalizedTarget)
     {
         normalizedTarget = string.Empty;


### PR DESCRIPTION
## Summary

- Store new current-session reminder definitions and history in the source session directory.
- Store new background job definitions and logs in the source session directory.
- Keep channel and sessionless reminder files in the daemon reminder directory.
- Preserve current paths for existing reminder and job files.
- Update existing files in place without an automatic migration.
- Reject duplicate IDs and session owner mismatches.
- Reject generic file and shell writes to session automation artifacts.
- Reject writes through symbolic link aliases.

## Compatibility

Existing scheduler payloads remain ID-only.

Existing reminder definitions, histories, job definitions, and logs do not move.

The managers keep their current ownership, limits, retry rules, passivation rules, and delivery routes.

The default agent reminder list shows active reminders.
The operator CLI list includes disabled and terminal reminders.

## Validation

- `Netclaw.Actors.Tests`: 2,940 passed.
- `Netclaw.Security.Tests`: 685 passed.
- `Netclaw.Daemon.Tests`: 951 passed.
- Slopwatch found zero issues.
- The file header check passed.
- Strict OpenSpec validation passed.
- `git diff --check` passed.
- The final adversarial review found no issues.

The eval suite did not run.
This change does not modify an eval-sensitive surface.

Closes #1820
