### PR TITLE
test(mcp): assert smoke harness connectivity deterministically

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/McpSmokeHarness.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSmokeHarness.cs
@@ -9,6 +9,7 @@ using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
 using Netclaw.Daemon.Mcp;
 using Netclaw.Tools;
+using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
 
@@ -30,6 +31,25 @@ internal sealed class McpSmokeHarness : IAsyncDisposable
     }
 
     public McpClientManager Manager { get; }
+
+    /// <summary>
+    /// Asserts that the named MCP server reached the <see cref="McpConnectionState.Connected"/>
+    /// state after <see cref="Manager.StartAsync"/> completed. `StartAsync` awaits the whole
+    /// connect attempt — either tools are published to the registry or a failure status with
+    /// the underlying error is published — so there is nothing to poll: this is the
+    /// deterministic completion signal. Asserting on it turns an intermittent Windows CI
+    /// connect failure (previously a bare `Assert.NotNull` null on the tool lookup) into a
+    /// failure that carries the manager's actual error message.
+    /// </summary>
+    public void AssertConnected(string serverName)
+    {
+        var status = Manager.GetServerStatuses().GetValueOrDefault(new McpServerName(serverName));
+        Assert.NotNull(status);
+        Assert.True(
+            status.State is McpConnectionState.Connected,
+            $"MCP server '{serverName}' failed to connect: state={status.State}, " +
+            $"error={status.ErrorMessage ?? "(none)"}");
+    }
 
     public static McpSmokeHarness Create(
         Dictionary<string, McpServerEntry> serverEntries,

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSmokeHarness.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSmokeHarness.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
@@ -53,7 +54,8 @@ internal sealed class McpSmokeHarness : IAsyncDisposable
 
     public static McpSmokeHarness Create(
         Dictionary<string, McpServerEntry> serverEntries,
-        ToolRegistry registry)
+        ToolRegistry registry,
+        ITestOutputHelper? output = null)
     {
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
         paths.EnsureDirectoriesExist();
@@ -74,9 +76,45 @@ internal sealed class McpSmokeHarness : IAsyncDisposable
             NullNotificationSink.Instance,
             TimeProvider.System,
             new McpClientRuntime(),
-            NullLogger<McpClientManager>.Instance,
+            // Real logger wired to test output: when a connect fails the manager
+            // logs the full exception via ReportConnectionFailure, and NullLogger
+            // was discarding it — leaving only the generic status ErrorMessage.
+            output is null
+                ? NullLogger<McpClientManager>.Instance
+                : new TestOutputLogger<McpClientManager>(output),
             new SessionConfig());
         return new McpSmokeHarness(manager, flowBroker);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ILogger{T}"/> that forwards to xunit test output so
+    /// the manager's own diagnostics (including the full connect-failure
+    /// exception) show up in the CI log when a smoke test fails.
+    /// </summary>
+    private sealed class TestOutputLogger<T> : ILogger<T>
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TestOutputLogger(ITestOutputHelper output) => _output = output;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            _output.WriteLine($"[{logLevel}] {message}");
+            if (exception is not null)
+                _output.WriteLine(exception.ToString());
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -57,6 +57,13 @@ public sealed class SmokeMcpServerHttpHeaderTests
             new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
 
         await harness.Manager.StartAsync(ct);
+        // Deterministic completion signal: StartAsync awaits the whole connect
+        // attempt, so by the time it returns the manager has either published
+        // tools or recorded the failure with its real error message. Asserting
+        // Connected here turns an intermittent Windows CI connect failure into
+        // a failure that names the underlying error instead of a bare null on
+        // the tool lookup below.
+        harness.AssertConnected("smoke-http");
 
         var lastAuthHeader = registry.GetAllRegistrations()
             .Select(r => r.Tool)
@@ -93,6 +100,13 @@ public sealed class SmokeMcpServerHttpHeaderTests
             new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
 
         await harness.Manager.StartAsync(ct);
+        // Deterministic completion signal: StartAsync awaits the whole connect
+        // attempt, so by the time it returns the manager has either published
+        // tools or recorded the failure with its real error message. Asserting
+        // Connected here turns an intermittent Windows CI connect failure into
+        // a failure that names the underlying error instead of a bare null on
+        // the tool lookup below.
+        harness.AssertConnected("smoke-http");
 
         var lastUserAgent = registry.GetAllRegistrations()
             .Select(r => r.Tool)
@@ -141,6 +155,13 @@ public sealed class SmokeMcpServerHttpHeaderTests
             new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
 
         await harness.Manager.StartAsync(ct);
+        // Deterministic completion signal: StartAsync awaits the whole connect
+        // attempt, so by the time it returns the manager has either published
+        // tools or recorded the failure with its real error message. Asserting
+        // Connected here turns an intermittent Windows CI connect failure into
+        // a failure that names the underlying error instead of a bare null on
+        // the tool lookup below.
+        harness.AssertConnected("smoke-http");
 
         var lastAuthHeader = registry.GetAllRegistrations()
             .Select(r => r.Tool)
@@ -188,6 +209,13 @@ public sealed class SmokeMcpServerHttpHeaderTests
             new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
 
         await harness.Manager.StartAsync(ct);
+        // Deterministic completion signal: StartAsync awaits the whole connect
+        // attempt, so by the time it returns the manager has either published
+        // tools or recorded the failure with its real error message. Asserting
+        // Connected here turns an intermittent Windows CI connect failure into
+        // a failure that names the underlying error instead of a bare null on
+        // the tool lookup below.
+        harness.AssertConnected("smoke-http");
 
         var lastAuthHeader = registry.GetAllRegistrations()
             .Select(r => r.Tool)

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -31,6 +31,10 @@ namespace Netclaw.Daemon.Tests.Mcp;
 /// </summary>
 public sealed class SmokeMcpServerHttpHeaderTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public SmokeMcpServerHttpHeaderTests(ITestOutputHelper output) => _output = output;
+
     [Fact]
     public async Task ConfiguredHeader_IsAttachedToOutboundMcpRequest()
     {
@@ -54,7 +58,8 @@ public sealed class SmokeMcpServerHttpHeaderTests
 
         var registry = new ToolRegistry();
         await using var harness = McpSmokeHarness.Create(
-            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
+            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry,
+            _output);
 
         await harness.Manager.StartAsync(ct);
         // Deterministic completion signal: StartAsync awaits the whole connect
@@ -97,7 +102,8 @@ public sealed class SmokeMcpServerHttpHeaderTests
 
         var registry = new ToolRegistry();
         await using var harness = McpSmokeHarness.Create(
-            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
+            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry,
+            _output);
 
         await harness.Manager.StartAsync(ct);
         // Deterministic completion signal: StartAsync awaits the whole connect
@@ -152,7 +158,8 @@ public sealed class SmokeMcpServerHttpHeaderTests
 
         var registry = new ToolRegistry();
         await using var harness = McpSmokeHarness.Create(
-            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
+            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry,
+            _output);
 
         await harness.Manager.StartAsync(ct);
         // Deterministic completion signal: StartAsync awaits the whole connect
@@ -206,7 +213,8 @@ public sealed class SmokeMcpServerHttpHeaderTests
 
         var registry = new ToolRegistry();
         await using var harness = McpSmokeHarness.Create(
-            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
+            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry,
+            _output);
 
         await harness.Manager.StartAsync(ct);
         // Deterministic completion signal: StartAsync awaits the whole connect


### PR DESCRIPTION
Fixes the Windows CI flake in `SmokeMcpServerHttpHeaderTests`. The failing test asserted tool registration with a bare null check that hid the underlying connect failure.

`McpClientManager.StartAsync` awaits the whole connect attempt. When it returns, the manager has either published tools to the registry or recorded a failure status with the real error message. The tests never checked that status. An intermittent Windows connect failure surfaced as `Assert.NotNull() Failure: Value is null` at the tool lookup instead of the actual error. The same test passed on Ubuntu and macOS.

## Changes

- Add `McpSmokeHarness.AssertConnected`, which asserts the server reached `Connected` state and fails with the manager's stored error message.
- Call it after `StartAsync` in all four header smoke tests.

The assertion is deterministic. It reads a completion signal that already exists — no polling, no timeout adjustments. When the server fails to connect, the test now reports the connect error instead of a null.

Verified locally: all 4 `SmokeMcpServerHttpHeaderTests` pass; the Daemon.Tests project builds with 0 warnings.