### PR TITLE
Release 0.26.0-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,10 +8,10 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.25.4</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
     <PackageReleaseNotes>
-      Bug fixes: MCP tool catalog changes on connected servers are detected and refreshed automatically; MCP permissions tool-grid scroll position preserved when editing rows; static fd-dup redirects (2&amp;>1) no longer treated as dynamic shell syntax. 
+      Features: MCP OAuth surfaced at add time; mention-required thread replies with history backfill; file-read permissions match shell reach; TUI state preserved across navigation; background job and one-shot reminder cleanup. Bug fixes: approval prompts skip already-granted candidates; safe shell stages compose with one-time grants; background job control bypasses approval; failed one-shot reminders retry; phantom directory scopes and quoted free-text operands removed from stored patterns; trailing-slash globs scoped to parent; ToolAccessPolicy fail-closed. Dependency updates: Termina 0.16.1, SkiaSharp 4.151.1, Verify.XunitV3 31.28.0.
     </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,33 @@
 # NetClaw Release Notes
 
+## 0.26.0-beta.1 (2026-08-09)
+
+### Features
+- **MCP OAuth surfaced at add time** — `netclaw mcp auth` now runs before permission prompts when adding a server ([#1773](https://github.com/netclaw-dev/netclaw/pull/1773))
+- **Mention-required thread replies** — Slack, Discord, and Mattermost channels can gate thread replies on an @-mention, with per-channel control ([#1783](https://github.com/netclaw-dev/netclaw/pull/1783))
+- **Mention-triggered thread history backfill** — Thread history is backfilled when a mention arrives on mention-gated channels ([#1798](https://github.com/netclaw-dev/netclaw/pull/1798))
+- **File reads reach as far as the shell** — File-read tool permission scope now matches the shell tool's reach ([#1770](https://github.com/netclaw-dev/netclaw/pull/1770))
+- **TUI state preserved across navigation** — Provider and model pages keep their state when navigating or refreshing ([#1804](https://github.com/netclaw-dev/netclaw/pull/1804))
+- **Background job and one-shot reminder cleanup** — Completed background job definitions and successful one-shot reminders are pruned automatically ([#1821](https://github.com/netclaw-dev/netclaw/pull/1821))
+
+### Bug Fixes
+- **Approval prompts: already-granted candidates skipped** — Shell candidates with existing grants no longer re-trigger approval ([#1830](https://github.com/netclaw-dev/netclaw/pull/1830))
+- **Approval: safe shell stages compose with grants** — Pipelines of safe stages now compose correctly with one-time grants ([#1828](https://github.com/netclaw-dev/netclaw/pull/1828))
+- **Approval: background job control bypasses prompts** — `check_background_job` and cancellation no longer demand approval ([#1817](https://github.com/netclaw-dev/netclaw/pull/1817))
+- **Reminders: failed one-shot executions retained** — Failed one-shot reminders retry instead of being dropped, with execution history recorded ([#1812](https://github.com/netclaw-dev/netclaw/pull/1812))
+- **Approval: phantom directory scopes removed** — Stored approval patterns no longer fabricate fake directory scopes ([#1799](https://github.com/netclaw-dev/netclaw/pull/1799))
+- **Approval: quoted free-text operands dropped from stored patterns** — Quoted free-text arguments are no longer baked into stored approval patterns ([#1815](https://github.com/netclaw-dev/netclaw/pull/1815))
+- **Approval: trailing-slash globs scoped to parent** — `dir/`-style globs are scoped to their parent directory, closing a scope-expansion gap ([#1785](https://github.com/netclaw-dev/netclaw/pull/1785))
+- **Approval: immediate-retry bypass seeded per approved scope** — Every approved scope now gets the immediate-retry bypass ([#1800](https://github.com/netclaw-dev/netclaw/pull/1800))
+- **Sessions: tool-batch wedge fixed** — Unanswered tool calls are closed out before the error reply is sent ([#1796](https://github.com/netclaw-dev/netclaw/pull/1796))
+- **TUI: stale provider/model state refreshed** — Provider and model manager pages no longer show stale data ([#1827](https://github.com/netclaw-dev/netclaw/pull/1827))
+- **Security: ToolAccessPolicy fail-closed** — Deny-list and protected-path policies are now required; a policy missing them can no longer silently allow blocked commands ([#1787](https://github.com/netclaw-dev/netclaw/pull/1787))
+
+### Dependency Updates
+- **Bump Termina** — 0.16.0 → 0.16.1
+- **Bump SkiaSharp.NativeAssets.Linux.NoDependencies** — 4.151.0 → 4.151.1
+- **Bump Verify.XunitV3** — 31.20.0 → 31.28.0
+
 ## 0.25.4 (2026-08-06)
 
 ### Bug Fixes


### PR DESCRIPTION
## Release 0.26.0-beta.1

Bumps version to `0.26.0-beta.1` and updates release notes.

**Release notes:** see [RELEASE_NOTES.md](RELEASE_NOTES.md)

Highlights:
- MCP OAuth surfaced at add time
- Mention-required thread replies with history backfill
- File-read permissions match shell reach
- TUI state preserved across navigation
- Background job and one-shot reminder cleanup
- 11 bug fixes including approval-prompt hardening and fail-closed ToolAccessPolicy
- Dependency updates: Termina 0.16.1, SkiaSharp 4.151.1, Verify.XunitV3 31.28.0
