### PR TITLE
Use ShellSyntaxTree v0.3 for Bash approvals

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,7 +75,7 @@
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
-    <PackageVersion Include="ShellSyntaxTree" Version="0.2.0" />
+    <PackageVersion Include="ShellSyntaxTree" Version="0.3.0-alpha" />
     <PackageVersion Include="Termina" Version="0.16.1" />
   </ItemGroup>
   <!-- Serialization -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -137,8 +137,12 @@ Done when:
 - [ ] A constrained executable grammar proves any future safe `sed` form. The
   `-n` option alone is not proof because a `sed` program can write files or
   execute commands.
-- [ ] Netclaw consumes the ShellSyntaxTree v0.3 occurrence model for bounded
-  loops, substitutions, and explicit redirects after the composition slice.
+- [x] Netclaw consumes ShellSyntaxTree 0.3.0-alpha command occurrences and
+  explicit Bash redirect facts for the existing grammar.
+- [x] Unknown occurrences, cwd facts, wrappers, and redirects stay prompt-only.
+  Static descriptor redirects no longer appear dynamic.
+- [ ] Netclaw interprets bounded loop arguments and promotes the new mutation
+  cases after the next ShellSyntaxTree prerelease.
 
 ### Priority: Simplify Tool Execution Context Architecture
 

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
@@ -274,10 +274,10 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Require(["cat"])),
         Case(
-            "safe-verb-namespaced-external-path-prompts",
+            "safe-verb-bash-provider-looking-relative-path-allows",
             Bash("cat filesystem::/etc/netclaw.secret"),
             Approvals.None,
-            ExpectedApproval.Require(["cat"])),
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
         Case(
             "safe-verb-external-redirect-prompts",
             Bash($"git status > {TemporaryFile("netclaw-approval-matrix.txt")}"),
@@ -469,6 +469,16 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Deny("hard_deny_self_destructive")),
         Case(
+            "hard-deny-sudo-nested-shell-blocks",
+            Bash("sudo bash -lc \"git status\""),
+            Approvals.None,
+            ExpectedApproval.Deny("hard_deny_privilege_escalation")),
+        Case(
+            "hard-deny-dash-shell-blocks",
+            Bash("/bin/dash -c \"netclaw daemon stop\""),
+            Approvals.PersistentAnywhere("/bin/dash"),
+            ExpectedApproval.Deny("hard_deny_self_destructive")),
+        Case(
             "nested-shell-prompts-for-inner-command",
             Bash("bash -lc \"git push\""),
             Approvals.None,
@@ -487,7 +497,12 @@ public static class ShellApprovalCases
             "env-nested-shell-prompts",
             Bash("env bash -lc \"git push\""),
             Approvals.None,
-            ExpectedApproval.Require(["git push"])),
+            ExpectedApproval.Require(["env bash", "git push"])),
+        Case(
+            "nohup-nested-shell-prompts",
+            Bash("nohup bash -lc \"git push\""),
+            Approvals.None,
+            ExpectedApproval.Require(["nohup bash", "git push"])),
         Case(
             "timeout-nested-shell-prompts",
             Bash("timeout 5 bash -lc \"git push\""),
@@ -534,6 +549,21 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
         Case(
+            "combined-output-project-redirect-safe-verb-allows",
+            Bash("git status &> result.log"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
+            "combined-output-append-project-redirect-safe-verb-allows",
+            Bash("git status &>> result.log"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
+            "numeric-source-project-redirect-safe-verb-allows",
+            Bash("git status 3> result.log"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
             "fd-dup-redirect-mutating-no-grant-prompts-not-messy",
             Bash("git push origin dev 2>&1 | tail -2"),
             Approvals.None,
@@ -576,7 +606,7 @@ public static class ShellApprovalCases
                 "persistent:curl")),
         Case(
             "input-redirect-outside-zone-prompts",
-            Bash("cat < /etc/passwd"),
+            Bash($"cat < {TemporaryFile("netclaw-approval-input.txt")}"),
             Approvals.None,
             ExpectedApproval.Require(["cat"])),
         Case(
@@ -1189,7 +1219,7 @@ public static class ShellApprovalCases
         => new(command, workingDirectory, audience, interactive);
 
     private static string TemporaryFile(string fileName)
-        => Path.Join(Path.GetTempPath(), fileName);
+        => $"/netclaw-approval-external/{fileName}";
 
     private static string Escape(string value)
         => value

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
@@ -20,8 +20,8 @@
 | safe-verb-external-path-prompts | Personal | Project | Interactive | cat /etc/passwd | none | RequiresApproval | approval required | cat | No |
 | safe-verb-quoted-external-path-prompts | Personal | Project | Interactive | cat "/etc/netclaw.secret" | none | RequiresApproval | approval required | cat | No |
 | safe-verb-traversal-external-path-prompts | Personal | Project | Interactive | cat safe/../../../../../../etc/netclaw.secret | none | RequiresApproval | approval required | cat | No |
-| safe-verb-namespaced-external-path-prompts | Personal | Project | Interactive | cat filesystem::/etc/netclaw.secret | none | RequiresApproval | approval required | cat | No |
-| safe-verb-external-redirect-prompts | Personal | Project | Interactive | git status > {TempPath}netclaw-approval-matrix.txt | none | RequiresApproval | approval required | git status | No |
+| safe-verb-bash-provider-looking-relative-path-allows | Personal | Project | Interactive | cat filesystem::/etc/netclaw.secret | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| safe-verb-external-redirect-prompts | Personal | Project | Interactive | git status > /netclaw-approval-external/netclaw-approval-matrix.txt | none | RequiresApproval | approval required | git status | No |
 | mutating-verb-project-prompts | Personal | Project | Interactive | git push | none | RequiresApproval | approval required | git push | No |
 | all-safe-compound-allows | Personal | Project | Interactive | git status && git log | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | four-safe-mixed-operator-clauses-allow | Personal | Project | Interactive | git status && git log \| head -20; pwd | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
@@ -43,7 +43,7 @@
 | native-dynamic-file-reference-fails-closed | Personal | Project | Interactive | curl --data=@$REQUEST_FILE https://example.invalid/api | persistent[project]:curl | RequiresApproval | approval required | none | Yes |
 | local-glob-allows-safe-verb | Personal | Project | Interactive | ls *.txt | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | local-glob-reuses-project-grant | Personal | Project | Interactive | rm *.tmp | persistent[project]:rm | Allowed | StoredApproval | none | Not applicable |
-| external-glob-does-not-reuse-project-grant | Personal | Project | Interactive | rm {TempPath}netclaw-ext-glob/*.bak | persistent[project]:rm | RequiresApproval | approval required | rm | No |
+| external-glob-does-not-reuse-project-grant | Personal | Project | Interactive | rm /netclaw-approval-external/netclaw-ext-glob/*.bak | persistent[project]:rm | RequiresApproval | approval required | rm | No |
 | glob-traversal-fails-closed | Personal | Project | Interactive | cat */../../secret.txt | persistent[anywhere]:cat | RequiresApproval | approval required | none | Yes |
 | glob-intermediate-symlink-scope-fails-closed | Personal | Project | Interactive | cat artifacts/*/secret.txt | persistent[anywhere]:cat | RequiresApproval | approval required | none | Yes |
 | directory-listing-glob-in-project-auto-allows | Personal | Project | Interactive | ls -d subdirs/*/ | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
@@ -56,10 +56,13 @@
 | three-step-release-prompts | Personal | Project | Interactive | git add . && git commit -m fix && git push origin dev | none | RequiresApproval | approval required | git add, git commit, git push origin dev | No |
 | hard-deny-pipeline-tail-blocks | Personal | Project | Interactive | echo safe \| netclaw daemon stop | none | Denied | hard_deny_self_destructive | none | Not applicable |
 | hard-deny-nested-shell-blocks | Personal | Project | Interactive | bash -lc "netclaw daemon stop" | none | Denied | hard_deny_self_destructive | none | Not applicable |
+| hard-deny-sudo-nested-shell-blocks | Personal | Project | Interactive | sudo bash -lc "git status" | none | Denied | hard_deny_privilege_escalation | none | Not applicable |
+| hard-deny-dash-shell-blocks | Personal | Project | Interactive | /bin/dash -c "netclaw daemon stop" | persistent[anywhere]:/bin/dash | Denied | hard_deny_self_destructive | none | Not applicable |
 | nested-shell-prompts-for-inner-command | Personal | Project | Interactive | bash -lc "git push" | none | RequiresApproval | approval required | git push | No |
 | nested-shell-inner-grant-allows | Personal | Project | Interactive | bash -lc "git push" | persistent[anywhere]:git push | Allowed | StoredApproval | none | Not applicable |
 | nested-shell-wrapper-grant-does-not-cover-inner-command | Personal | Project | Interactive | bash -lc "git push" | persistent[anywhere]:bash | RequiresApproval | approval required | git push | No |
-| env-nested-shell-prompts | Personal | Project | Interactive | env bash -lc "git push" | none | RequiresApproval | approval required | git push | No |
+| env-nested-shell-prompts | Personal | Project | Interactive | env bash -lc "git push" | none | RequiresApproval | approval required | env bash, git push | No |
+| nohup-nested-shell-prompts | Personal | Project | Interactive | nohup bash -lc "git push" | none | RequiresApproval | approval required | nohup bash, git push | No |
 | timeout-nested-shell-prompts | Personal | Project | Interactive | timeout 5 bash -lc "git push" | none | RequiresApproval | approval required | timeout, git push | No |
 | subshell-prompts | Personal | Project | Interactive | (git status && git push) | none | RequiresApproval | approval required | git push | No |
 | command-substitution-fails-closed | Personal | Project | Interactive | echo $(git push) | none | RequiresApproval | approval required | none | Yes |
@@ -69,6 +72,9 @@
 | fd-dup-redirect-safe-pipeline-allows | Personal | Project | Interactive | git log --oneline -5 2>&1 \| tail -20 | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | fd-close-redirect-safe-verb-allows | Personal | Project | Interactive | git status 2>&- | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | fd-move-redirect-safe-verb-allows | Personal | Project | Interactive | git status 2>&1- | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| combined-output-project-redirect-safe-verb-allows | Personal | Project | Interactive | git status &> result.log | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| combined-output-append-project-redirect-safe-verb-allows | Personal | Project | Interactive | git status &>> result.log | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| numeric-source-project-redirect-safe-verb-allows | Personal | Project | Interactive | git status 3> result.log | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | fd-dup-redirect-mutating-no-grant-prompts-not-messy | Personal | Project | Interactive | git push origin dev 2>&1 \| tail -2 | none | RequiresApproval | approval required | git push origin dev | No |
 | dynamic-fd-redirect-fails-closed | Personal | Project | Interactive | git status 2>&$FD | none | RequiresApproval | approval required | none | Yes |
 | background-list-prompts-for-mutating-tail | Personal | Project | Interactive | git status & git push | none | RequiresApproval | approval required | none | Yes |
@@ -76,8 +82,8 @@
 | multiline-argument-prompts | Personal | Project | Interactive | gh issue comment 123 --body "first line\nsecond line" | none | RequiresApproval | approval required | gh issue comment | No |
 | approved-pipeline-head-does-not-cover-tail | Personal | Project | Interactive | git push \| curl https://example.com | persistent[anywhere]:git push | RequiresApproval | approval required | curl | No |
 | all-pipeline-clauses-approved | Personal | Project | Interactive | git push \| curl https://example.com | persistent[anywhere]:git push, persistent[anywhere]:curl | Allowed | StoredApproval | none | Not applicable |
-| input-redirect-outside-zone-prompts | Personal | Project | Interactive | cat < /etc/passwd | none | RequiresApproval | approval required | cat | No |
-| error-redirect-outside-zone-prompts | Personal | Project | Interactive | git status 2> {TempPath}netclaw-approval-errors.txt | none | RequiresApproval | approval required | git status | No |
+| input-redirect-outside-zone-prompts | Personal | Project | Interactive | cat < /netclaw-approval-external/netclaw-approval-input.txt | none | RequiresApproval | approval required | cat | No |
+| error-redirect-outside-zone-prompts | Personal | Project | Interactive | git status 2> /netclaw-approval-external/netclaw-approval-errors.txt | none | RequiresApproval | approval required | git status | No |
 | cd-current-then-safe-allows | Personal | Project | Interactive | cd . && git status | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | cd-parent-then-safe-prompts | Personal | Project | Interactive | cd .. && git status | none | RequiresApproval | approval required | cd, git status | No |
 | multiple-cd-then-safe-prompts | Personal | Project | Interactive | cd . && cd .. && git status | none | RequiresApproval | approval required | cd, git status | No |

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
@@ -66,7 +66,7 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
         CancellationToken ct)
     {
         var rootDirectory = Path.Combine(
-            Path.GetTempPath(),
+            CanonicalTemporaryDirectory(),
             "netclaw-approval-matrix",
             Guid.NewGuid().ToString("N"));
         var projectDirectory = Path.Combine(rootDirectory, "project");
@@ -225,6 +225,25 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
             ShellMode = ShellExecutionMode.HostAllowed,
             AudienceProfiles = ToolAudienceProfileDefaults.CreateProfilesForPosture(DeploymentPosture.Personal)
         };
+
+    private static string CanonicalTemporaryDirectory()
+    {
+        var fullPath = Path.GetFullPath(Path.GetTempPath());
+        var pathRoot = Path.GetPathRoot(fullPath)
+            ?? throw new InvalidOperationException("The temporary directory has no path root.");
+        var current = pathRoot;
+        var relative = fullPath[pathRoot.Length..];
+        foreach (var segment in relative.Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(current, segment);
+            current = new DirectoryInfo(candidate).ResolveLinkTarget(returnFinalTarget: true)?.FullName
+                ?? candidate;
+        }
+
+        return current;
+    }
 
     private static IActorRef CreateApprovalActor(ActorSystem actorSystem, ToolApprovalStore store)
         => actorSystem.ActorOf(

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -929,7 +929,9 @@ public sealed class ToolApprovalGateTests
     public void Shell_multi_root_command_uses_fixed_labels()
     {
         var policy = CreatePolicy(ToolApprovalMode.Approval);
-        var args = ToolInput.Create("Command", "cat /home/user/.netclaw/logs/app.log > /home/user/.netclaw/output/report.txt");
+        var args = ToolInput.Create(
+            "Command",
+            "cat /netclaw-approval-test/logs/app.log > /netclaw-approval-test/output/report.txt");
 
         var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
 

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherMultilineTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherMultilineTests.cs
@@ -77,4 +77,15 @@ public sealed class ShellApprovalMatcherMultilineTests
         Assert.Contains(candidates, c => c.Verb == "cd" && c.Directory == "/tmp");
         Assert.Contains(candidates, c => c.Verb == "rm" && c.Directory == "/tmp/foo");
     }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_uncertain_cwd_without_absolute_scope_fails_closed()
+    {
+        // A newline runs git even if cd fails. Its cwd can therefore be the
+        // original directory or /tmp, and no persistent scope is safe.
+        var arguments = Args("cd /tmp\ngit status");
+
+        Assert.Empty(_matcher.ExtractCandidates(new ToolName("shell_execute"), arguments));
+        Assert.True(_matcher.IsMessy(new ToolName("shell_execute"), arguments));
+    }
 }

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -733,6 +733,25 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     /// </summary>
     public static bool IsPosix => !OperatingSystem.IsWindows();
 
+    private static string CanonicalTemporaryDirectory()
+    {
+        var fullPath = Path.GetFullPath(Path.GetTempPath());
+        var pathRoot = Path.GetPathRoot(fullPath)
+            ?? throw new InvalidOperationException("The temporary directory has no path root.");
+        var current = pathRoot;
+        var relative = fullPath[pathRoot.Length..];
+        foreach (var segment in relative.Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(current, segment);
+            current = new DirectoryInfo(candidate).ResolveLinkTarget(returnFinalTarget: true)?.FullName
+                ?? candidate;
+        }
+
+        return current;
+    }
+
     [SlopwatchSuppress("SW001", "This theory verifies Bash parser path scopes, which do not apply to the Windows shell parser.")]
     [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
     [MemberData(nameof(ParserPathScopeCases))]
@@ -741,7 +760,7 @@ public sealed class ShellApprovalMatcherPathExtractionTests
         string expectedVerb,
         string[] expectedScopeNames)
     {
-        var root = Path.Combine(Path.GetTempPath(), $"netclaw-path-scopes-{Guid.NewGuid():N}");
+        var root = Path.Combine(CanonicalTemporaryDirectory(), $"netclaw-path-scopes-{Guid.NewGuid():N}");
         var projectDirectory = Path.Combine(root, "project");
         var externalDirectory = Path.Combine(root, "external");
         var command = commandTemplate.Replace(
@@ -1230,6 +1249,73 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_bundled_wrapper_inherits_outer_proven_cwd()
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args(
+                "cd /tmp && bash -lc \"cat relative.txt\"",
+                "/work")),
+            candidate => candidate.Verb == "cat");
+
+        Assert.Equal("/tmp", candidate.Directory);
+    }
+
+    [SlopwatchSuppress("SW001", "This theory verifies Bash wrapper approval scopes, which do not apply to the Windows shell parser.")]
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    [InlineData("sudo bash -lc \"git status\"", "sudo bash", "/work")]
+    [InlineData("sudo /bin/bash -lc \"git status\"", "sudo", "/bin/bash")]
+    [InlineData("env bash -lc \"git status\"", "env bash", "/work")]
+    [InlineData("env /bin/bash -lc \"git status\"", "env", "/bin/bash")]
+    [InlineData("nohup bash -lc \"git status\"", "nohup bash", "/work")]
+    [InlineData("timeout 5 bash -lc \"git status\"", "timeout", "/work")]
+    [InlineData("nice -n 5 bash -lc \"git status\"", "nice", "/work")]
+    public void ExtractCandidates_retains_prefix_executable(
+        string command,
+        string expectedPrefix,
+        string expectedDirectory)
+    {
+        var candidates = _matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args(command, "/work"));
+
+        Assert.Contains(candidates, candidate =>
+            candidate.Verb == expectedPrefix && candidate.Directory == expectedDirectory);
+        Assert.Contains(candidates, candidate =>
+            candidate.Verb == "git status" && candidate.Directory == "/work");
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void Redirect_to_symlink_target_fails_closed()
+    {
+        var root = Path.Combine(CanonicalTemporaryDirectory(), $"netclaw-redirect-symlink-{Guid.NewGuid():N}");
+        var projectDirectory = Path.Combine(root, "project");
+        var externalDirectory = Path.Combine(root, "external");
+        var externalFile = Path.Combine(externalDirectory, "result.log");
+        var redirectTarget = Path.Combine(projectDirectory, "result.log");
+        Directory.CreateDirectory(projectDirectory);
+        Directory.CreateDirectory(externalDirectory);
+        File.WriteAllText(externalFile, "external");
+        File.CreateSymbolicLink(redirectTarget, externalFile);
+
+        try
+        {
+            var arguments = Args("git status > result.log", projectDirectory);
+
+            Assert.Empty(_matcher.ExtractCandidates(
+                new ToolName("shell_execute"),
+                arguments));
+            Assert.True(_matcher.IsMessy(
+                new ToolName("shell_execute"),
+                arguments));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
     public void ExtractCandidates_prefers_explicit_path_arg_over_cd_attribution()
     {
         // When a clause has its own anchored path argument, that wins —
@@ -1320,7 +1406,7 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
     public void ExtractCandidates_uses_redirect_target_and_invocation_working_directory()
     {
-        var workingDirectory = Path.Combine(Path.GetTempPath(), $"netclaw-redirect-{Guid.NewGuid():N}");
+        var workingDirectory = Path.Combine(CanonicalTemporaryDirectory(), $"netclaw-redirect-{Guid.NewGuid():N}");
         var candidates = _matcher.ExtractCandidates(
             new ToolName("shell_execute"),
             new Dictionary<string, object?>
@@ -1331,6 +1417,38 @@ public sealed class ShellApprovalMatcherPathExtractionTests
 
         Assert.Contains(candidates, candidate =>
             candidate.Verb == "echo" && candidate.Directory == workingDirectory);
+    }
+
+    [SlopwatchSuppress("SW001", "This test verifies POSIX symlink redirect behavior, which does not apply to the Windows shell parser.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_rejects_redirect_through_symlink_directory()
+    {
+        var root = Path.Combine(
+            CanonicalTemporaryDirectory(),
+            $"netclaw-redirect-parent-symlink-{Guid.NewGuid():N}");
+        var workingDirectory = Path.Combine(root, "project");
+        var externalDirectory = Path.Combine(root, "external");
+        var redirectDirectory = Path.Combine(workingDirectory, "output");
+        Directory.CreateDirectory(workingDirectory);
+        Directory.CreateDirectory(externalDirectory);
+        Directory.CreateSymbolicLink(redirectDirectory, externalDirectory);
+
+        try
+        {
+            var arguments = Args("echo hello > output/result.txt", workingDirectory);
+
+            Assert.Empty(_matcher.ExtractCandidates(
+                new ToolName("shell_execute"),
+                arguments));
+            Assert.True(_matcher.IsMessy(
+                new ToolName("shell_execute"),
+                arguments));
+        }
+        finally
+        {
+            Directory.Delete(redirectDirectory);
+            Directory.Delete(root, recursive: true);
+        }
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
@@ -1358,14 +1476,10 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
-    public void ExtractCandidates_bare_numeric_operand_is_not_a_path_scope()
+    public void ExtractCandidates_bare_numeric_operand_uses_command_cwd()
     {
-        // Regression for #1795: `head -c 2000` treats the bare numeric
-        // operand `2000` as a path arg (slash-free token branch of
-        // IsAuthorizationPathArg) and resolves it relative to cwd, producing
-        // the phantom scope `/cwd/2000`. `head -c 2000` touches no filesystem
-        // path; head is a read-only verb with no path argument, so its
-        // candidate must carry Directory == null (like `git status`).
+        // The #1795 guard removes the false `/cwd/2000` path scope.
+        // The v0.3 occurrence still supplies the command cwd for a scoped grant.
         var candidates = _matcher.ExtractCandidates(
             new ToolName("shell_execute"),
             new Dictionary<string, object?>
@@ -1376,7 +1490,7 @@ public sealed class ShellApprovalMatcherPathExtractionTests
 
         var headCandidate = Assert.Single(candidates);
         Assert.Equal("head", headCandidate.Verb);
-        Assert.Null(headCandidate.Directory);
+        Assert.Equal("/home/user/repos/demo", headCandidate.Directory);
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
@@ -1418,11 +1532,10 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
-    public void ExtractCandidates_bare_numeric_flag_value_is_not_a_path_scope()
+    public void ExtractCandidates_bare_numeric_flag_value_uses_command_cwd()
     {
-        // Regression for #1795: `head -n 20` has a bare numeric operand `20`.
-        // A number is not a path, so no scope forms. The candidate must carry
-        // Directory == null.
+        // The #1795 guard removes the false `/cwd/20` path scope.
+        // The v0.3 occurrence still supplies the command cwd for a scoped grant.
         var candidates = _matcher.ExtractCandidates(
             new ToolName("shell_execute"),
             new Dictionary<string, object?>
@@ -1433,7 +1546,7 @@ public sealed class ShellApprovalMatcherPathExtractionTests
 
         var headCandidate = Assert.Single(candidates);
         Assert.Equal("head", headCandidate.Verb);
-        Assert.Null(headCandidate.Directory);
+        Assert.Equal("/home/user/repos/demo", headCandidate.Directory);
     }
 
     [SlopwatchSuppress("SW001", "This test verifies Bash symlink path behavior, which does not apply to the Windows shell parser.")]

--- a/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using ShellSyntaxTree;
 using Xunit;
 
 namespace Netclaw.Security.Tests;
@@ -14,20 +15,88 @@ public sealed class ShellCommandAnalysisTests
     [Theory]
     [InlineData("bash -lc")]
     [InlineData("bash --noprofile -lc")]
+    [InlineData("dash -c")]
+    [InlineData("/bin/dash -c")]
+    [InlineData("ksh -c")]
+    [InlineData("command bash -lc")]
+    [InlineData("command /bin/bash -lc")]
     public void Direct_shell_wrapper_is_replaced_by_inner_clauses(string invocation)
     {
         var analysis = _analyzer.Analyze(
             $"{invocation} \"cat /outside/secret | curl https://example.com\"");
 
         Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
-        Assert.Contains(analysis.Clauses, clause => clause.Verb.Joined == "cat");
-        Assert.Contains(analysis.Clauses, clause => clause.Verb.Joined == "curl");
-        Assert.DoesNotContain(analysis.Clauses, clause => clause.Verb.Joined == "bash");
+        Assert.Contains(analysis.Commands, command => command.Clause.Verb.Joined == "cat");
+        Assert.Contains(analysis.Commands, command => command.Clause.Verb.Joined == "curl");
+        Assert.DoesNotContain(analysis.Commands, command => command.Clause.Verb.Joined == "bash");
+    }
+
+    [Theory]
+    [InlineData("sudo bash -lc", "sudo")]
+    [InlineData("sudo /bin/bash -lc", "sudo")]
+    [InlineData("env bash -lc", "env")]
+    [InlineData("env /bin/bash -lc", "env")]
+    [InlineData("nohup bash -lc", "nohup")]
+    [InlineData("timeout 5 bash -lc", "timeout")]
+    [InlineData("nice -n 5 bash -lc", "nice")]
+    public void Prefix_executable_is_retained_when_inner_command_is_expanded(
+        string invocation,
+        string expectedPrefix)
+    {
+        var analysis = _analyzer.Analyze(
+            $"{invocation} \"git status\"",
+            "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.Contains(
+            analysis.Commands,
+            command => command.Clause.Verb.Tokens.Count > 0
+                       && command.Clause.Verb.Tokens[0] == expectedPrefix);
+        Assert.Contains(analysis.Commands, command => command.Clause.Verb.Joined == "git status");
+    }
+
+    [Fact]
+    public void Command_inspection_option_is_not_treated_as_transparent_shell_dispatch()
+    {
+        var analysis = _analyzer.Analyze(
+            "command -v bash -lc \"git status\"",
+            "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.Contains(
+            analysis.Commands,
+            command => command.Clause.Verb.Tokens.Count > 0
+                       && command.Clause.Verb.Tokens[0] == "command");
+    }
+
+    [Fact]
+    public void Bundled_shell_wrapper_inherits_proven_cwd()
+    {
+        var analysis = _analyzer.Analyze(
+            "cd /tmp && bash -lc \"cat relative.txt\"",
+            "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        var inner = Assert.Single(
+            analysis.Commands,
+            command => command.Clause.Verb.Joined == "cat");
+        Assert.Contains(
+            inner.Clause.Args,
+            arg => arg.Raw == "relative.txt" && arg.Resolved == "/tmp/relative.txt");
+    }
+
+    [Fact]
+    public void Bundled_shell_wrapper_with_uncertain_cwd_fails_closed()
+    {
+        var analysis = _analyzer.Analyze(
+            "cd /tmp\nbash -lc \"git status\"",
+            "/work");
+
+        Assert.Equal(ShellAnalysisFailure.Unresolved, analysis.Failure);
     }
 
     [Theory]
     [InlineData("echo $(git push)")]
-    [InlineData("echo `$command`")]
     public void Dynamic_command_syntax_is_explicit(string command)
     {
         var analysis = _analyzer.Analyze(command);
@@ -36,17 +105,35 @@ public sealed class ShellCommandAnalysisTests
         Assert.True(analysis.HasDynamicSyntax);
     }
 
+    [Fact]
+    public void Unsupported_legacy_backticks_fail_closed()
+    {
+        var analysis = _analyzer.Analyze("echo `$command`");
+
+        Assert.Equal(ShellAnalysisFailure.Unresolved, analysis.Failure);
+        Assert.Empty(analysis.Commands);
+    }
+
     [Theory]
-    [InlineData("git status 2>&1")]
-    [InlineData("git status 2>&123")]
-    [InlineData("git status 2>&1-")]
-    [InlineData("git status 2>&-")]
-    public void Static_file_descriptor_redirect_is_not_dynamic(string command)
+    [InlineData("git status 2>&1", RedirectOperation.DescriptorDuplicate, 1)]
+    [InlineData("git status 2>&123", RedirectOperation.DescriptorDuplicate, 123)]
+    [InlineData("git status 2>&1-", RedirectOperation.DescriptorMove, 1)]
+    [InlineData("git status 2>&-", RedirectOperation.DescriptorClose, null)]
+    public void Static_file_descriptor_redirect_is_not_dynamic(
+        string command,
+        RedirectOperation expectedOperation,
+        int? expectedTargetDescriptor)
     {
         var analysis = _analyzer.Analyze(command);
 
         Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
         Assert.False(analysis.HasDynamicSyntax);
+        var occurrence = Assert.Single(analysis.Commands);
+        var redirect = Assert.Single(occurrence.Redirects);
+        Assert.Equal(expectedOperation, redirect.Operation);
+        Assert.Equal(expectedTargetDescriptor, redirect.TargetDescriptor);
+        Assert.False(redirect.IsPathRelevant);
+        Assert.True(redirect.IsComplete);
     }
 
     [Theory]
@@ -67,6 +154,137 @@ public sealed class ShellCommandAnalysisTests
         var analysis = _analyzer.Analyze("git status & git push");
 
         Assert.Equal(ShellAnalysisFailure.Unresolved, analysis.Failure);
-        Assert.Empty(analysis.Clauses);
+        Assert.Empty(analysis.Commands);
     }
+
+    [Fact]
+    public void Exact_file_redirect_has_bounded_path_target()
+    {
+        var analysis = _analyzer.Analyze("git status > result.log", "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.False(analysis.HasDynamicSyntax);
+        var redirect = Assert.Single(Assert.Single(analysis.Commands).Redirects);
+        Assert.Equal(RedirectOperation.FileOutput, redirect.Operation);
+        Assert.Equal(ShellValueDomainKind.Exact, redirect.Target.Kind);
+        Assert.Equal("/work/result.log", Assert.Single(redirect.Target.Values));
+        Assert.True(redirect.IsPathRelevant);
+    }
+
+    [Fact]
+    public void Heredoc_stays_approval_sensitive()
+    {
+        var analysis = _analyzer.Analyze("cat <<EOF\nbody\nEOF");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.True(analysis.HasDynamicSyntax);
+        Assert.Single(Assert.Single(analysis.Commands).Redirects);
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedRedirects))]
+    public void Malformed_or_future_redirect_facts_fail_closed(RedirectAnalysis redirect)
+    {
+        var occurrence = new CommandOccurrence
+        {
+            Clause = new Clause
+            {
+                Verb = new VerbChain { Tokens = ["command"] }
+            },
+            ImmediateRole = CommandOccurrenceRole.Ordinary,
+            Redirects = [redirect],
+            IsComplete = true
+        };
+        var analysis = new ShellCommandAnalysis([occurrence], ShellAnalysisFailure.None);
+
+        Assert.True(analysis.HasDynamicSyntax);
+    }
+
+    [Fact]
+    public void Unknown_ancestry_fails_closed()
+    {
+        var occurrence = new CommandOccurrence
+        {
+            Clause = new Clause
+            {
+                Verb = new VerbChain { Tokens = ["command"] }
+            },
+            ImmediateRole = CommandOccurrenceRole.Ordinary,
+            Ancestry =
+            [
+                new CommandAncestryFrame
+                {
+                    AncestorKind = ShellSyntaxKind.Unknown,
+                    Region = CommandAncestryRegion.Root
+                }
+            ],
+            IsComplete = true
+        };
+        var analysis = new ShellCommandAnalysis([occurrence], ShellAnalysisFailure.None);
+
+        Assert.True(analysis.HasDynamicSyntax);
+    }
+
+    [Theory]
+    [InlineData(ShellValueDomainKind.FiniteSet)]
+    [InlineData(ShellValueDomainKind.Pattern)]
+    [InlineData((ShellValueDomainKind)999)]
+    public void Unsupported_working_directory_domain_fails_closed(
+        ShellValueDomainKind workingDirectoryKind)
+    {
+        var occurrence = new CommandOccurrence
+        {
+            Clause = new Clause
+            {
+                Verb = new VerbChain { Tokens = ["command"] }
+            },
+            ImmediateRole = CommandOccurrenceRole.Ordinary,
+            WorkingDirectory = new ShellValueDomain { Kind = workingDirectoryKind },
+            IsComplete = true
+        };
+        var analysis = new ShellCommandAnalysis([occurrence], ShellAnalysisFailure.None);
+
+        Assert.True(analysis.HasDynamicSyntax);
+    }
+
+    public static TheoryData<RedirectAnalysis> MalformedRedirects => new()
+    {
+        new RedirectAnalysis
+        {
+            Source = new RedirectSource { Kind = RedirectSourceKind.Descriptor },
+            Operation = RedirectOperation.DescriptorDuplicate,
+            TargetDescriptor = 1,
+            IsComplete = true
+        },
+        new RedirectAnalysis
+        {
+            Source = new RedirectSource { Kind = RedirectSourceKind.Default },
+            Operation = RedirectOperation.DescriptorDuplicate,
+            IsComplete = true
+        },
+        new RedirectAnalysis
+        {
+            Source = new RedirectSource { Kind = RedirectSourceKind.Default },
+            Operation = RedirectOperation.DescriptorClose,
+            TargetDescriptor = 1,
+            IsComplete = true
+        },
+        new RedirectAnalysis
+        {
+            Source = new RedirectSource { Kind = RedirectSourceKind.Default },
+            Operation = (RedirectOperation)999,
+            IsComplete = true
+        },
+        new RedirectAnalysis
+        {
+            Source = new RedirectSource { Kind = RedirectSourceKind.Default },
+            Operation = RedirectOperation.FileOutput,
+            Target = new ShellValueDomain
+            {
+                Kind = ShellValueDomainKind.Exact,
+                Values = ["/work/result.log"]
+            },
+            IsComplete = true
+        }
+    };
 }

--- a/src/Netclaw.Security.Tests/ShellCommandPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandPolicyTests.cs
@@ -36,6 +36,8 @@ public sealed class ShellCommandPolicyTests
     [InlineData("echo hello && sudo kill -9 123")]
     [InlineData("SUDO rm -rf /tmp")]
     [InlineData("bash -c \"sudo kill -9 123\"")]
+    [InlineData("sudo bash -lc \"git status\"")]
+    [InlineData("sudo /bin/bash -lc \"git status\"")]
     public void Denies_privilege_escalation_commands(string command)
     {
         var decision = _policy.Evaluate(command);
@@ -118,7 +120,11 @@ public sealed class ShellCommandPolicyTests
     [InlineData("timeout 5 bash -lc \"netclaw daemon stop\"")]
     [InlineData("nice -n 5 bash -lc \"netclaw daemon stop\"")]
     [InlineData("bash -c \"echo safe\" && bash -lc \"netclaw daemon stop\"")]
-    public void Denies_bash_wrapping_denied_command(string command)
+    [InlineData("dash -c \"netclaw daemon stop\"")]
+    [InlineData("/bin/dash -c \"netclaw daemon stop\"")]
+    [InlineData("/usr/bin/zsh -c \"netclaw daemon stop\"")]
+    [InlineData("ksh -c \"netclaw daemon stop\"")]
+    public void Denies_bourne_shell_wrapping_denied_command(string command)
     {
         var decision = _policy.EvaluateBash(command);
         Assert.False(decision.Allowed);

--- a/src/Netclaw.Security.Tests/ShellSyntaxTreeIntegrationTests.cs
+++ b/src/Netclaw.Security.Tests/ShellSyntaxTreeIntegrationTests.cs
@@ -50,6 +50,11 @@ public sealed class ShellSyntaxTreeIntegrationTests
         Assert.Equal("ls", clause.Verb.Joined);
         Assert.Contains(clause.Args, a => a.Raw == "-la" && a.IsFlag);
         Assert.Contains(clause.Args, a => a.Raw == "/tmp" && a.IsPath);
+
+        var occurrence = Assert.Single(result.Commands);
+        Assert.Same(clause, occurrence.Clause);
+        Assert.Equal(CommandOccurrenceRole.Ordinary, occurrence.ImmediateRole);
+        Assert.True(occurrence.IsComplete);
     }
 
     [Fact]
@@ -279,6 +284,23 @@ public sealed class ShellSyntaxTreeIntegrationTests
         Assert.Equal(2, result.Clauses.Count);
         Assert.Equal("cat", result.Clauses[0].Verb.Joined);
         Assert.Equal("echo after", result.Clauses[1].Verb.Joined);
+    }
+
+    [Fact]
+    public void Static_descriptor_redirect_has_explicit_non_path_facts()
+    {
+        var parser = new BashParser();
+
+        var result = parser.Parse("dotnet test 2>&1");
+
+        Assert.False(result.IsUnparseable);
+        var redirect = Assert.Single(Assert.Single(result.Commands).Redirects);
+        Assert.Equal(RedirectSourceKind.Descriptor, redirect.Source.Kind);
+        Assert.Equal(2, redirect.Source.Descriptor);
+        Assert.Equal(RedirectOperation.DescriptorDuplicate, redirect.Operation);
+        Assert.Equal(1, redirect.TargetDescriptor);
+        Assert.False(redirect.IsPathRelevant);
+        Assert.True(redirect.IsComplete);
     }
 
     [Fact]

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -201,7 +201,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         string? workingDirectory = null)
     {
         var result = Analyzer.Analyze(command, workingDirectory);
-        return result.Failure == ShellAnalysisFailure.None && result.Clauses.Count > 0
+        return result.Failure == ShellAnalysisFailure.None && result.Commands.Count > 0
             ? result
             : null;
     }
@@ -219,8 +219,9 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         var seen = new HashSet<(string, string?)>();
         var candidates = new List<ApprovalCandidate>();
 
-        foreach (var clause in result.Clauses)
+        foreach (var occurrence in result.Commands)
         {
+            var clause = occurrence.Clause;
             // ShellSyntaxTree's greedy verb walk (SPEC §6.1) folds
             // lowercase-leading value tokens into the verb chain (`git tag
             // v0.4.2`, `git show aa211dcb`, `git checkout feature2`), while
@@ -241,7 +242,10 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
                 continue;
 
             var isSideEffectVerb = ShellTokenizer.SingleTokenSideEffectVerbs.Contains(verb);
-            var directories = ResolveClauseDirectories(clause, isSideEffectVerb, workingDirectory);
+            var directories = ResolveCommandDirectories(
+                occurrence,
+                isSideEffectVerb,
+                workingDirectory);
             if (directories is null)
                 return [];
 
@@ -256,28 +260,23 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         return candidates;
     }
 
-    private static IReadOnlyList<string?>? ResolveClauseDirectories(
-        ShellSyntaxTree.Clause clause,
+    private static IReadOnlyList<string?>? ResolveCommandDirectories(
+        ShellSyntaxTree.CommandOccurrence occurrence,
         bool isSideEffectVerb,
         string? workingDirectory)
     {
+        var clause = occurrence.Clause;
         var directories = new List<string?>();
-        var clauseWorkingDirectory = clause.Args
-            .FirstOrDefault(arg => arg.IsCwdAttribution)?.Resolved
-            ?? workingDirectory;
+        var cwdAttribution = clause.Args.FirstOrDefault(static arg => arg.IsCwdAttribution);
+        var clauseWorkingDirectory = ExactValue(occurrence.WorkingDirectory)
+            ?? cwdAttribution?.Resolved
+            ?? (cwdAttribution is null ? workingDirectory : null);
 
         // Each parser path is an authorization scope. A grant must cover all
         // scopes, or a later external path could hide behind an earlier local
         // path. The resolved value also handles native forms such as @file.
-        //
-        // Temporary containment for #1795. ShellSyntaxTree 0.2 tags an echo or
-        // printf text operand as a path arg or a glob arg. The matcher then
-        // makes a phantom directory scope from literal text. A pure side-effect
-        // verb writes only to stdout. Its operands are never filesystem paths.
-        // So this verb derives no arg-based scope. A redirect still gives a real
-        // scope below. This code only removes a false scope. It never grants a
-        // new one. ShellSyntaxTree v0.3.0 fixes the misclassification in the
-        // parser. Remove this guard then.
+        // ShellSyntaxTree 0.3.0-alpha still has the #1795 classification.
+        // Remove this guard after a later v0.3 prerelease contains the parser correction.
         if (!isSideEffectVerb)
         {
             foreach (var arg in clause.Args)
@@ -304,20 +303,43 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             }
         }
 
-        foreach (var redirect in clause.Redirects)
+        foreach (var redirect in occurrence.Redirects)
         {
-            var directory = ResolveRedirectDirectory(redirect);
-            if (directory is not null)
-                directories.Add(directory);
+            var redirectDirectories = ResolveRedirectDirectories(redirect);
+            if (redirectDirectories is null)
+                return null;
+
+            directories.AddRange(redirectDirectories);
         }
 
         if (directories.Count == 0)
         {
-            // A side-effect verb ignores cwd. Other verbs inherit a prior cd.
-            var cwdAttribution = isSideEffectVerb
-                ? null
-                : clause.Args.FirstOrDefault(a => a.IsCwdAttribution)?.Resolved;
-            directories.Add(cwdAttribution);
+            // A side-effect verb ignores cwd. Other verbs use the parser's
+            // exact state proof. An unresolved synthetic attribution means a
+            // preceding state change may have failed, so the outer cwd cannot
+            // safely substitute for it.
+            if (isSideEffectVerb)
+            {
+                directories.Add(null);
+            }
+            else if (cwdAttribution is not null)
+            {
+                var attributedDirectory = ExactValue(occurrence.WorkingDirectory)
+                    ?? cwdAttribution.Resolved;
+                if (string.IsNullOrWhiteSpace(attributedDirectory))
+                    return null;
+
+                directories.Add(attributedDirectory);
+            }
+            else if (!string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                directories.Add(
+                    ExactValue(occurrence.WorkingDirectory) ?? workingDirectory);
+            }
+            else
+            {
+                directories.Add(null);
+            }
         }
 
         return directories.Distinct(StringComparer.Ordinal).ToList();
@@ -407,22 +429,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (!arg.IsPath)
             return false;
 
-        // Temporary containment for #1795. ShellSyntaxTree 0.2 tags a bare
-        // numeric operand such as `head -c 2000` as a path arg. The matcher
-        // then makes a phantom scope `/cwd/2000`. A token of only ASCII digits
-        // is normally a numeric value, not a path.
-        //
-        // Drop the token ONLY when no filesystem entry exists at its resolved
-        // path. A real file, directory, or symlink named `2000` stays a path
-        // arg, so its directory scope and the later symlink-segment check
-        // survive. Without this existence gate, `cat 2000` where `2000` is a
-        // symlink out of the granted tree would collapse to the cwd and skip
-        // the symlink check — a prompt-to-auto-approve escalation on the ACL
-        // perimeter. ShouldDropNumericToken safe-fails: it keeps the arg as a
-        // path on any doubt, so the gate prompts. This guard stays narrow:
-        // `2000.txt`, `file1234`, and `1234/x` still pass. This code only
-        // removes a false scope. It never grants a new one. ShellSyntaxTree
-        // v0.3.0 classifies the operand in the parser. Remove this guard then.
+        // ShellSyntaxTree 0.3.0-alpha still has the #1795 classification.
+        // Remove this guard after a later v0.3 prerelease contains the parser correction.
         if (arg.Raw.Length > 0 && arg.Raw.All(char.IsAsciiDigit)
             && ShouldDropNumericToken(arg, workingDirectory))
         {
@@ -463,12 +471,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     }
 
     /// <summary>
-    /// Decides if an all-digit operand is a plain numeric value and not a real
-    /// filesystem object. This is temporary containment for #1795. It returns
-    /// <c>true</c> only when the matcher can prove no entry exists at the
-    /// resolved path. On any doubt it returns <c>false</c>, so the caller keeps
-    /// the token as a path and the gate prompts. It never fails toward an
-    /// automatic grant.
+    /// Returns true only when an all-digit operand does not identify a filesystem object.
+    /// A probe failure keeps the operand as a path, so the approval gate prompts.
     /// </summary>
     private static bool ShouldDropNumericToken(ShellSyntaxTree.Arg arg, string? workingDirectory)
     {
@@ -487,13 +491,9 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             }
             else
             {
-                // No absolute path to probe. Keep the token as a path.
                 return false;
             }
 
-            // File.Exists and Directory.Exists follow a symlink to its target.
-            // A real symlink to an outside path returns true here, so the token
-            // stays a path and keeps its symlink-segment check downstream.
             return !File.Exists(path) && !Directory.Exists(path);
         }
         catch (Exception ex) when (ex is ArgumentException
@@ -502,32 +502,71 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
                                       or UnauthorizedAccessException
                                       or System.Security.SecurityException)
         {
-            // The probe failed. Keep the token as a path so the gate prompts.
             return false;
         }
     }
 
-    private static string? ResolveRedirectDirectory(ShellSyntaxTree.Redirect redirect)
+    private static string? ExactValue(ShellSyntaxTree.ShellValueDomain domain)
+        => domain.Kind == ShellSyntaxTree.ShellValueDomainKind.Exact
+            && domain.Values.Count == 1
+            ? domain.Values[0]
+            : null;
+
+    private static IReadOnlyList<string>? ResolveRedirectDirectories(
+        ShellSyntaxTree.RedirectAnalysis redirect)
     {
-        if (string.IsNullOrWhiteSpace(redirect.Target)
-            || IsHeredocRedirect(redirect)
-            || redirect.Target.StartsWith('&'))
+        if (!redirect.IsPathRelevant)
+            return [];
+
+        if (!redirect.IsComplete)
+            return null;
+
+        if (redirect.Target.Kind == ShellSyntaxTree.ShellValueDomainKind.Pattern)
+        {
+            var coveringDirectory = redirect.Target.CoveringDirectory;
+            return string.IsNullOrWhiteSpace(coveringDirectory)
+                || ContainsSymlinkEntry(coveringDirectory)
+                ? null
+                : [coveringDirectory];
+        }
+
+        if (redirect.Target.Kind is not (
+            ShellSyntaxTree.ShellValueDomainKind.Exact
+            or ShellSyntaxTree.ShellValueDomainKind.FiniteSet))
         {
             return null;
         }
 
-        // A dynamic target must still block an automatic side-effect grant.
-        if (redirect.IsDynamicSkip)
-            return redirect.Target;
+        var directories = new List<string>(redirect.Target.Values.Count);
+        foreach (var target in redirect.Target.Values)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+                return null;
 
-        try
-        {
-            return Path.GetDirectoryName(redirect.Target) ?? redirect.Target;
+            try
+            {
+                var normalizedTarget = PathUtility.Normalize(target);
+                var pathRoot = Path.GetPathRoot(normalizedTarget);
+                if (string.IsNullOrWhiteSpace(pathRoot)
+                    || PathUtility.ContainsSymlinkSegment(pathRoot, normalizedTarget))
+                {
+                    return null;
+                }
+
+                directories.Add(Path.GetDirectoryName(normalizedTarget) ?? normalizedTarget);
+            }
+            catch (Exception ex) when (ex is ArgumentException
+                                       or IOException
+                                       or NotSupportedException
+                                       or PathTooLongException
+                                       or UnauthorizedAccessException
+                                       or System.Security.SecurityException)
+            {
+                return null;
+            }
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            return redirect.Target;
-        }
+
+        return directories;
     }
 
     /// <summary>
@@ -553,8 +592,9 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             var units = new List<string>();
             var current = new StringBuilder();
 
-            foreach (var clause in result.Clauses)
+            foreach (var occurrence in result.Commands)
             {
+                var clause = occurrence.Clause;
                 // AndIf / OrIf / Sequence (and the leading None clause) each
                 // open a fresh approval unit; Pipe clauses fold into the unit
                 // in progress. A bare newline produces Sequence, so multi-line
@@ -843,10 +883,35 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (analysis is null || analysis.HasDynamicSyntax)
             return true;
 
-        return analysis.Clauses
-            .SelectMany(static clause => clause.Args)
+        if (analysis.Commands
+            .SelectMany(static command => command.Clause.Args)
             .Where(static arg => arg.IsPath && arg.Kind == ShellSyntaxTree.ArgKind.Glob)
-            .Any(arg => ResolveGlobCoveringDirectory(arg, workingDirectory) is null);
+            .Any(arg => ResolveGlobCoveringDirectory(arg, workingDirectory) is null))
+        {
+            return true;
+        }
+
+        if (analysis.Commands.Any(command =>
+                ResolveCommandDirectories(
+                    command,
+                    IsSideEffectCommand(command),
+                    workingDirectory) is null))
+        {
+            return true;
+        }
+
+        return analysis.Commands
+            .SelectMany(static command => command.Redirects)
+            .Any(static redirect => ResolveRedirectDirectories(redirect) is null);
+    }
+
+    private static bool IsSideEffectCommand(ShellSyntaxTree.CommandOccurrence occurrence)
+    {
+        var clause = occurrence.Clause;
+        var parsedVerb = clause.Verb.CanonicalVerb
+            ?? string.Join(" ", TrimTrailingValueTokens(clause.Verb.Tokens));
+        var verb = ShellTokenizer.ApplyVerbShortCircuit(parsedVerb);
+        return ShellTokenizer.SingleTokenSideEffectVerbs.Contains(verb);
     }
 
     public string FormatForDisplay(ToolName toolName, IDictionary<string, object?>? arguments)
@@ -894,7 +959,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (result is null)
             return command;
 
-        if (result.Clauses.Any(c => c.IsSubshell || c.Redirects.Any(IsHeredocRedirect)))
+        if (result.Commands.Any(c =>
+            c.Clause.IsSubshell || c.Clause.Redirects.Any(IsHeredocRedirect)))
             return command;
 
         try
@@ -902,8 +968,9 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             var sb = new StringBuilder();
             var first = true;
 
-            foreach (var clause in result.Clauses)
+            foreach (var occurrence in result.Commands)
             {
+                var clause = occurrence.Clause;
                 if (!first)
                     sb.Append(ClauseOperatorText(clause.Operator));
                 first = false;

--- a/src/Netclaw.Security/ShellApprovalSemantics.cs
+++ b/src/Netclaw.Security/ShellApprovalSemantics.cs
@@ -417,8 +417,11 @@ internal sealed class PosixShellApprovalSemantics : ShellApprovalSemanticsBase
 
     internal static bool IsPosixShellInvoker(string verb)
     {
-        return verb is "bash" or "sh" or "/bin/bash" or "/bin/sh"
-            or "/usr/bin/bash" or "/usr/bin/sh" or "zsh" or "/bin/zsh";
+        return verb is "bash" or "sh" or "dash" or "ash" or "ksh" or "mksh" or "zsh"
+            or "/bin/bash" or "/bin/sh" or "/bin/dash" or "/bin/ash"
+            or "/bin/ksh" or "/bin/mksh" or "/bin/zsh"
+            or "/usr/bin/bash" or "/usr/bin/sh" or "/usr/bin/dash" or "/usr/bin/ash"
+            or "/usr/bin/ksh" or "/usr/bin/mksh" or "/usr/bin/zsh";
     }
 
     private static bool LooksLikePosixAbsoluteShellPath(string path)

--- a/src/Netclaw.Security/ShellCommandAnalysis.cs
+++ b/src/Netclaw.Security/ShellCommandAnalysis.cs
@@ -23,23 +23,22 @@ internal sealed class ShellCommandAnalyzer
 
     public ShellCommandAnalysis Analyze(string command, string? workingDirectory = null)
     {
-        var clauses = new List<Clause>();
-        var failure = Analyze(command, workingDirectory, depth: 0, clauses);
-        return new ShellCommandAnalysis(clauses, failure);
+        var commands = new List<CommandOccurrence>();
+        var failure = Analyze(command, workingDirectory, depth: 0, commands);
+        return new ShellCommandAnalysis(commands, failure);
     }
 
     private static ShellAnalysisFailure Analyze(
         string command,
         string? workingDirectory,
         int depth,
-        List<Clause> clauses)
+        List<CommandOccurrence> commands)
     {
         if (depth > MaxWrapperDepth)
             return ShellAnalysisFailure.Unresolved;
 
-        // ShellSyntaxTree 0.2 does not expose a background-list tail.
-        // Treat that parser boundary as unresolved so the tail cannot inherit
-        // the first command's safe-verb or stored-approval result.
+        // Stable v0.3 excludes background lists. Keep this guard until the
+        // parser exposes their concurrency and shell-state boundaries.
         if (ContainsBackgroundListOperator(command))
             return ShellAnalysisFailure.Unresolved;
 
@@ -56,25 +55,45 @@ internal sealed class ShellCommandAnalyzer
             return ShellAnalysisFailure.Unresolved;
         }
 
-        if (parsed.IsUnparseable || parsed.Clauses.Count == 0)
+        if (parsed.IsUnparseable || parsed.Commands.Count == 0)
             return ShellAnalysisFailure.Unresolved;
 
         var innerCommands = PosixShellApprovalSemantics.Instance.ExtractInnerCommands(command);
-        var hasUnexpandedWrapper = parsed.Clauses.Any(IsUnexpandedWrapperClause);
-        if (innerCommands.Count == 0 || !hasUnexpandedWrapper)
+        var unexpandedWrappers = parsed.Commands
+            .Where(static occurrence => IsUnexpandedWrapperClause(occurrence.Clause))
+            .ToList();
+        if (innerCommands.Count == 0 || unexpandedWrappers.Count == 0)
         {
-            clauses.AddRange(parsed.Clauses);
+            commands.AddRange(parsed.Commands);
             return ShellAnalysisFailure.None;
         }
 
-        // A direct shell wrapper adds no independent authority scope.
-        // Prefix wrappers such as env and timeout remain visible.
-        clauses.AddRange(parsed.Clauses.Where(clause =>
-            !IsUnexpandedWrapperClause(clause) || HasShellInvokerInArguments(clause)));
+        // The v0.3 parser owns contracted wrapper forms. This fallback keeps
+        // Netclaw's extra bundled bash -lc form. Remove only a direct shell
+        // dispatch: prefix executables such as sudo, env, and nohup remain
+        // visible to hard-deny and approval policy.
+        commands.AddRange(parsed.Commands.Where(static occurrence =>
+            !IsUnexpandedWrapperClause(occurrence.Clause)
+            || !IsTransparentShellDispatch(occurrence.Clause)));
 
-        foreach (var innerCommand in innerCommands)
+        if (innerCommands.Count != unexpandedWrappers.Count)
+            return ShellAnalysisFailure.Unresolved;
+
+        for (var i = 0; i < innerCommands.Count; i++)
         {
-            var failure = Analyze(innerCommand, workingDirectory, depth + 1, clauses);
+            if (!TryResolveWrapperWorkingDirectory(
+                    unexpandedWrappers[i],
+                    workingDirectory,
+                    out var innerWorkingDirectory))
+            {
+                return ShellAnalysisFailure.Unresolved;
+            }
+
+            var failure = Analyze(
+                innerCommands[i],
+                innerWorkingDirectory,
+                depth + 1,
+                commands);
             if (failure != ShellAnalysisFailure.None)
                 return failure;
         }
@@ -82,13 +101,47 @@ internal sealed class ShellCommandAnalyzer
         return ShellAnalysisFailure.None;
     }
 
+    private static bool TryResolveWrapperWorkingDirectory(
+        CommandOccurrence occurrence,
+        string? inheritedWorkingDirectory,
+        out string? workingDirectory)
+    {
+        var cwdAttribution = occurrence.Clause.Args
+            .FirstOrDefault(static arg => arg.IsCwdAttribution);
+        if (cwdAttribution is null)
+        {
+            workingDirectory = inheritedWorkingDirectory;
+            return true;
+        }
+
+        if (occurrence.WorkingDirectory.Kind == ShellValueDomainKind.Exact
+            && occurrence.WorkingDirectory.Values.Count == 1
+            && !string.IsNullOrWhiteSpace(occurrence.WorkingDirectory.Values[0]))
+        {
+            workingDirectory = occurrence.WorkingDirectory.Values[0];
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(cwdAttribution.Resolved))
+        {
+            workingDirectory = cwdAttribution.Resolved;
+            return true;
+        }
+
+        workingDirectory = null;
+        return false;
+    }
+
     private static bool IsUnexpandedWrapperClause(Clause clause)
     {
         if (clause.Verb.Tokens.Count == 0 || clause.Args.Count == 0)
             return false;
 
-        if (!clause.Verb.Tokens.Any(IsShellInvokerToken) && !HasShellInvokerInArguments(clause))
+        if (!clause.Verb.Tokens.Any(IsShellInvokerToken)
+            && !HasShellInvokerInArguments(clause))
+        {
             return false;
+        }
 
         return clause.Args.Any(static arg =>
             arg.Raw.Length > 1
@@ -100,6 +153,40 @@ internal sealed class ShellCommandAnalyzer
     private static bool HasShellInvokerInArguments(Clause clause)
         => clause.Args.Any(static arg =>
             arg.Kind != ArgKind.DynamicSkip && IsShellInvokerToken(arg.Raw));
+
+    private static bool IsTransparentShellDispatch(Clause clause)
+    {
+        if (clause.Verb.Tokens.Count == 0)
+            return false;
+
+        if (IsShellInvokerToken(clause.Verb.Tokens[0]))
+            return true;
+
+        if (!string.Equals(
+                ShellTokenizer.TrimShellPunctuation(clause.Verb.Tokens[0]),
+                "command",
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (clause.Verb.Tokens.Count > 1)
+            return IsShellInvokerToken(clause.Verb.Tokens[1]);
+
+        foreach (var arg in clause.Args.Where(static arg => !arg.IsCwdAttribution))
+        {
+            if (arg.Kind == ArgKind.DynamicSkip)
+                return false;
+
+            var token = ShellTokenizer.TrimShellPunctuation(arg.Raw);
+            if (token is "--" or "-p")
+                continue;
+
+            return IsShellInvokerToken(token);
+        }
+
+        return false;
+    }
 
     private static bool IsShellInvokerToken(string token)
         => PosixShellApprovalSemantics.IsPosixShellInvoker(
@@ -178,49 +265,99 @@ internal static class ShellGlobPath
 }
 
 internal sealed record ShellCommandAnalysis(
-    IReadOnlyList<Clause> Clauses,
+    IReadOnlyList<CommandOccurrence> Commands,
     ShellAnalysisFailure Failure)
 {
-    public bool HasDynamicSyntax => Clauses.Any(static clause =>
-        clause.Verb.IsDynamic
-        || clause.Args.Any(static arg => arg.Kind == ArgKind.DynamicSkip)
-        || clause.Args.Any(static arg =>
+    public bool HasDynamicSyntax => Commands.Any(static command =>
+        !command.IsComplete
+        || !Enum.IsDefined(command.ImmediateRole)
+        || command.ImmediateRole == CommandOccurrenceRole.Unknown
+        || command.Ancestry.Any(static frame =>
+            !Enum.IsDefined(frame.AncestorKind)
+            || frame.AncestorKind == ShellSyntaxKind.Unknown
+            || !Enum.IsDefined(frame.Region)
+            || frame.Region == CommandAncestryRegion.Unknown)
+        || HasUnsupportedWorkingDirectory(command.WorkingDirectory)
+        || command.Clause.Verb.IsDynamic
+        || command.Clause.Args.Any(static arg =>
+            arg.Kind == ArgKind.DynamicSkip && !arg.IsCwdAttribution)
+        || command.Clause.Args.Any(static arg =>
             arg.IsPath
             && arg.Kind != ArgKind.Glob
             && string.IsNullOrWhiteSpace(arg.Resolved))
         // A glob in a directory segment can hide traversal or a symlink.
         // Only a leaf glob has a fixed directory scope.
-        || clause.Args.Any(ShellGlobPath.HasUnresolvedDescendantScope)
-        // An fd-dup target (&1, &2, &-) is a static file-descriptor number,
-        // not a dynamic token: ShellSyntaxTree marks it IsDynamicSkip to mean
-        // "do not path-resolve", but it carries no unresolved syntax and no
-        // filesystem scope (ResolveRedirectDirectory skips &-prefixed targets).
-        // Treating it as dynamic fails the whole command closed to an approval
-        // prompt for every `2>&1`-shaped command, even fully safe ones.
-        || clause.Redirects.Any(static redirect =>
-            redirect.IsDynamicSkip
-            && !IsStaticFileDescriptor(redirect.Target)));
+        || command.Clause.Args.Any(ShellGlobPath.HasUnresolvedDescendantScope)
+        || command.Redirects.Any(HasUnresolvedRedirect));
 
-    /// <summary>
-    /// Returns true only for the static file-descriptor targets that
-    /// ShellSyntaxTree 0.2 recognizes: &amp;N, &amp;N-, and &amp;-.
-    /// </summary>
-    private static bool IsStaticFileDescriptor(string target)
+    private static bool HasUnsupportedWorkingDirectory(ShellValueDomain workingDirectory)
     {
-        if (target == "&-")
+        if (!Enum.IsDefined(workingDirectory.Kind))
             return true;
 
-        if (target.Length < 2 || target[0] != '&')
-            return false;
-
-        var index = 1;
-        while (index < target.Length && char.IsAsciiDigit(target[index]))
-            index++;
-
-        if (index == 1)
-            return false;
-
-        return index == target.Length
-               || index == target.Length - 1 && target[index] == '-';
+        return workingDirectory.Kind switch
+        {
+            ShellValueDomainKind.Unknown => workingDirectory.Values.Count != 0
+                || workingDirectory.Pattern is not null
+                || workingDirectory.CoveringDirectory is not null,
+            ShellValueDomainKind.Exact => workingDirectory.Values.Count != 1
+                || string.IsNullOrWhiteSpace(workingDirectory.Values[0])
+                || workingDirectory.Pattern is not null
+                || workingDirectory.CoveringDirectory is not null,
+            _ => true
+        };
     }
+
+    private static bool HasUnresolvedRedirect(RedirectAnalysis redirect)
+    {
+        if (!redirect.IsComplete
+            || !Enum.IsDefined(redirect.Source.Kind)
+            || redirect.Source.Kind == RedirectSourceKind.Unknown
+            || !Enum.IsDefined(redirect.Operation)
+            || redirect.Operation == RedirectOperation.Unknown)
+        {
+            return true;
+        }
+
+        var hasValidSource = redirect.Source.Kind switch
+        {
+            RedirectSourceKind.Default => redirect.Source.Descriptor is null,
+            RedirectSourceKind.Descriptor => redirect.Source.Descriptor is >= 0,
+            _ => false
+        };
+        if (!hasValidSource)
+        {
+            return true;
+        }
+
+        return redirect.Operation switch
+        {
+            // Netclaw keeps shell-fed stdin approval-sensitive. The parser can
+            // prove its syntax without proving executable-specific data use.
+            RedirectOperation.HereDocument or RedirectOperation.HereString => true,
+            RedirectOperation.DescriptorDuplicate or RedirectOperation.DescriptorMove =>
+                redirect.IsPathRelevant || redirect.TargetDescriptor is < 0 or null,
+            RedirectOperation.DescriptorClose =>
+                redirect.IsPathRelevant || redirect.TargetDescriptor is not null,
+            RedirectOperation.FileInput
+                or RedirectOperation.FileOutput
+                or RedirectOperation.FileAppend
+                or RedirectOperation.CombinedOutput
+                or RedirectOperation.CombinedOutputAppend =>
+                !redirect.IsPathRelevant || !HasBoundedPathTarget(redirect.Target),
+            _ => true
+        };
+    }
+
+    private static bool HasBoundedPathTarget(ShellValueDomain target)
+        => target.Kind switch
+        {
+            ShellValueDomainKind.Exact => target.Values.Count == 1
+                && !string.IsNullOrWhiteSpace(target.Values[0]),
+            ShellValueDomainKind.FiniteSet => target.Values.Count is >= 2 and <= 32
+                && target.Values.All(static value => !string.IsNullOrWhiteSpace(value)),
+            ShellValueDomainKind.Pattern => !string.IsNullOrWhiteSpace(target.Pattern)
+                && !string.IsNullOrWhiteSpace(target.CoveringDirectory),
+            _ => false
+        };
 }

--- a/src/Netclaw.Security/ShellCommandPolicy.cs
+++ b/src/Netclaw.Security/ShellCommandPolicy.cs
@@ -145,12 +145,12 @@ public sealed class ShellCommandPolicy
     private ShellCommandDecision EvaluateBashAnalysis(string command)
     {
         var analysis = Analyzer.Analyze(command);
-        if (analysis.Failure == ShellAnalysisFailure.Unresolved || analysis.Clauses.Count == 0)
+        if (analysis.Failure == ShellAnalysisFailure.Unresolved || analysis.Commands.Count == 0)
             return EvaluateLegacySegments(command);
 
-        foreach (var clause in analysis.Clauses)
+        foreach (var occurrence in analysis.Commands)
         {
-            var decision = EvaluateClause(clause);
+            var decision = EvaluateClause(occurrence.Clause);
             if (!decision.Allowed)
                 return decision;
         }


### PR DESCRIPTION
## Summary

- update ShellSyntaxTree from 0.2.0 to 0.3.0-alpha
- consume command occurrences, working-directory domains, and redirect facts
- keep unknown syntax, wrapper state, redirects, and path scopes fail closed
- preserve the approval composition from #1828 and the candidate narrowing from #1830
- retain prefix executables so `sudo bash -lc` cannot bypass the hard deny

## Current alpha boundary

This change covers the grammar in 0.3.0-alpha. It keeps the #1795 numeric-operand containment until a later prerelease includes the new Bash mutation work. Loop and mutation acceptance cases will follow that package update.

## Validation

- `dotnet build Netclaw.slnx -c Release --no-restore --verbosity minimal`
- `dotnet test Netclaw.slnx -c Release --no-build --no-restore`
- 729 security tests passed
- 2,937 actor tests passed
- 951 daemon tests passed
- file-header verification passed
- Slopwatch passed with zero findings
- adversarial security review passed after a wrapper-prefix bypass was found and fixed
- adversarial follow-up passed after the macOS fixture correction; production redirect checks remain unchanged
