### PR TITLE
Define native Windows PowerShell execution

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Netclaw Implementation Plan
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 This is the execution plan for Netclaw. Autonomous agents and RALPH-style loops
 SHALL work from `NOW` by default. `NEXT` and `LATER` work belongs in
@@ -147,7 +147,8 @@ Done when:
 - [x] Netclaw consumes ShellSyntaxTree `0.3.0-alpha.2` for one exact POSIX
   `pwsh -NoProfile -NonInteractive -Command '<static payload>'` wrapper. It
   keeps the outer host and every complete PowerShell child as independent
-  approval occurrences.
+  approval occurrences. The native Windows PowerShell work below replaces
+  this temporary cross-language parser.
 - [x] The 204-case shell approval review table proves PowerShell host and child
   grant composition, intrinsic direct-call script blocks, nested hard deny,
   decoded protected paths, and strict handling for dynamic values, named
@@ -159,6 +160,37 @@ Done when:
 - [ ] Netclaw interprets bounded loop arguments only after the executor can
   prove the Bash initial variable state. The inherited shell state remains
   fail closed because an ambient nameref can change assignment semantics.
+
+### Priority: Use Native PowerShell on Windows
+
+**PRDs:** `docs/prd/PRD-001-netclaw-mvp.md`, `docs/prd/PRD-002-gateway-security-envelope.md`, `docs/prd/PRD-006-mcp-tool-integration.md`
+**Specs:** `openspec/changes/native-windows-powershell-host/`
+**Surface area:** shell execution, parsing, approval policy, model context
+**Verification:** L2 plus native Windows L3
+
+This work replaces `cmd.exe` with a native PowerShell host on Windows. Netclaw
+prefers a compatible PowerShell 7.6 host and falls back to Windows PowerShell
+5.1. It keeps Bash and PowerShell as separate host languages.
+
+Done when:
+
+- [ ] One immutable shell environment selects the absolute executable path,
+  grammar, path style, process arguments, and PowerShell dialect for the daemon
+  lifetime.
+- [ ] Windows selects `pwsh.exe` only for versions from 7.6.4 through 7.6.x. It
+  falls back to `powershell.exe` 5.1 and fails clearly if neither host matches.
+- [ ] Execution, parsing, hard deny, approval matching, prompt display, and
+  model context use the same selected environment.
+- [ ] Bash treats `pwsh` as an external command. PowerShell treats `bash` as an
+  external command. Only same-language child hosts can recurse.
+- [ ] Unknown or incomplete facts cannot produce a stored approval candidate
+  or a safe-verb pass. Stored approval cannot bypass hard deny.
+- [ ] Personal sessions state the platform, executable, grammar, and dialect,
+  including sessions that have no project directory.
+- [ ] Native Windows tests cover PowerShell 7.6 and Windows PowerShell 5.1.
+  The security review table covers direct, child, retry, and background paths.
+- [ ] Consumer guidance and canonical specs match the delivered behavior. The
+  OpenSpec change passes verification, is synchronized, and is archived.
 
 ### Priority: Simplify Tool Execution Context Architecture
 

--- a/openspec/changes/native-windows-powershell-host/.openspec.yaml
+++ b/openspec/changes/native-windows-powershell-host/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/native-windows-powershell-host/design.md
+++ b/openspec/changes/native-windows-powershell-host/design.md
@@ -1,0 +1,188 @@
+## Context
+
+Netclaw now selects shell behavior in several places. `ShellTool` uses
+`cmd.exe` on Windows. Approval code uses Bash analysis on POSIX hosts and a
+legacy token path on Windows. A merged POSIX workaround also reparses one
+`pwsh -Command` payload with PowerShell grammar.
+
+ShellSyntaxTree `0.3.0-alpha.5` provides an explicit `PwshDialect` contract.
+It also defines the host grammar boundary. Bash does not parse PowerShell
+payloads, and PowerShell does not parse Bash payloads.
+
+The daemon owns tool execution. Session actors and background-job actors call
+the same registered tool and policy objects. Approval records contain a verb
+and an optional directory. No persisted actor message contains a shell host.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Select one immutable shell environment during daemon composition.
+- Use that identity for execution, parsing, policy, approval, and model context.
+- Prefer compatible PowerShell 7.6 on Windows and use PowerShell 5.1 as the
+  explicit fallback.
+- Preserve Bash behavior on Linux and macOS.
+- Keep unknown or incomplete shell facts strict.
+- Prove the Windows behavior on a native Windows runner.
+
+**Non-Goals:**
+
+- Do not infer a login shell or inspect profile contents.
+- Do not parse a child payload with another language grammar.
+- Do not add `cmd.exe` grammar or command translation.
+- Do not inspect modules, command lookup, inherited variables, or `.ps1` files.
+- Do not add a shell selector to the tool schema or configuration.
+- Do not add `Start-ThreadJob` or module-version policy.
+
+## Decisions
+
+### Use one immutable environment value
+
+Add a `ShellExecutionEnvironment` value in `Netclaw.Security`. It carries the
+platform, executable, grammar, path style, command arguments, and PowerShell
+dialect when applicable.
+
+The value creates a parser with the exact working directory and dialect. It
+uses `PwshInitialStateMode.Unknown` because `-NoProfile` does not prove the
+ambient module or command-resolution state.
+
+Daemon composition resolves this value once. `ShellCommandPolicy` requires it.
+`ShellTool`, `ToolAccessPolicy`, `ShellApprovalMatcher`, and the context provider
+reuse the same instance through existing composition seams.
+
+Alternative: let each consumer call `OperatingSystem.IsWindows()`. Rejected.
+Separate decisions can make the parser authorize text for another executor.
+
+### Resolve the Windows host before service registration
+
+The resolver probes `pwsh.exe` first with `-NoLogo`, `-NoProfile`, and
+`-NonInteractive`. It selects PowerShell 7 only for versions `>=7.6.4` and
+`<7.7`, which matches ShellSyntaxTree's pinned alias contract.
+
+If the preferred host is absent or incompatible, the resolver probes
+`powershell.exe`. It selects `WindowsPowerShell51` only for version 5.1.
+
+The resolver records the selected absolute executable path and dialect. The
+tool executes that path and does not repeat `PATH` lookup after authorization.
+The resolver logs the reason for a fallback. Daemon startup fails with one
+actionable error when neither host satisfies its contract.
+
+The tool does not change hosts during one invocation. If the selected program
+later disappears or fails to start, the call fails visibly. A daemon restart
+resolves a new immutable environment, then reparses and reauthorizes all new
+calls with that environment.
+
+Alternative: retry a failed `pwsh.exe` call through `powershell.exe`. Rejected.
+The first approval used PowerShell 7 syntax and aliases. A runtime retry would
+execute the text with another grammar after authorization.
+
+### Keep language boundaries at the native host
+
+Linux and macOS use `/bin/bash -c` with `BashParser`. Windows uses the selected
+PowerShell host with `-NoLogo -NoProfile -NonInteractive -Command` and
+`PwshParser`.
+
+Remove the Netclaw POSIX `pwsh` child-payload parser. Bash treats `pwsh` as an
+ordinary external command. Native PowerShell analysis keeps the same-language
+recursion that ShellSyntaxTree exposes for `pwsh` and `powershell.exe`.
+
+The parser never reads or executes the submitted command. It analyzes only the
+source text and explicit parser options.
+
+Alternative: retain the exact POSIX wrapper workaround. Rejected. It applies
+PowerShell meaning below a Bash host and conflicts with the accepted boundary.
+
+### Build process start information once
+
+`ShellTool` has buffered and streaming execution paths. Both paths must call
+one process-start builder. The builder uses the environment's absolute
+executable path and fixed argument list. It appends the submitted command as
+one argument.
+
+Alternative: update both process-start blocks independently. Rejected. One path
+could keep `cmd.exe` or use different PowerShell arguments after policy has
+authorized the command for the canonical host.
+
+### Build one analysis result for all security consumers
+
+The environment selects one `ShellCommandAnalysis`. Hard deny, protected-path
+checks, safe-verb policy, stored approvals, prompt candidates, and display use
+that result or the same environment-bound analyzer.
+
+Every complete command occurrence receives policy evaluation. An unparseable
+command, an incomplete occurrence, an unknown policy fact, or a dynamic verb
+cannot produce a persistent approval candidate or a safe-verb auto-pass.
+
+Legacy token scans remain deny-only backstops. They can detect a known hard
+deny in unresolved text, but they cannot authorize or create stored patterns.
+
+PowerShell hard deny adds native equivalents for process termination, recursive
+root removal, and `Start-Process -Verb RunAs`. Hard deny remains before path,
+safe-verb, and approval checks.
+
+Alternative: keep the Windows token matcher. Rejected. It cannot prove
+PowerShell quoting, aliases, pipelines, redirects, or nested execution regions.
+
+### Put the shell identity in the volatile context tail
+
+Extend `WorkingContextSnapshot` with the selected platform, executable,
+grammar, and dialect. Render these facts in the existing `[working-context]`
+tail for Personal sessions, which are the only shell-capable audience.
+
+The context tells the model which syntax `shell_execute` accepts. It does not
+claim that aliases, profiles, modules, environment variables, or external
+programs are known.
+
+Alternative: add a second prompt provider. Rejected. The working-context
+provider already carries volatile per-turn host facts to sessions and children.
+
+### Preserve actor and persistence contracts
+
+The environment is process composition state. Actors do not persist it and do
+not send it in protocol messages. Background jobs use the same registered
+`ShellTool` and `ToolAccessPolicy` as direct calls.
+
+Existing approval entries remain valid intent records. A dialect change causes
+new parser output before approval matching. Dialect-specific alias
+canonicalization prevents a different alias target from reusing an unrelated
+stored verb.
+
+No config, tool argument, actor event, snapshot, or approval-store migration is
+required.
+
+## Risks / Trade-offs
+
+- [Risk] A Windows host has an unsupported PowerShell 7 version. -> Use the
+  explicit 5.1 fallback and show the selected host in logs and model context.
+- [Risk] The selected executable changes after startup. -> Fail the call and
+  require restart. Never switch grammar after approval.
+- [Risk] PowerShell path or provider facts are unknown. -> Withhold persistent
+  candidates and safe-verb access. Offer only the existing strict path.
+- [Risk] A stored grant was created under another dialect. -> Reparse first and
+  match the new canonical candidate. Do not reuse raw source spelling.
+- [Risk] Model-visible shell context changes behavior. -> Add deterministic
+  context tests and run the shell-platform behavioral evaluation when provider
+  credentials are available.
+- [Risk] The old Windows approval table encodes `cmd.exe`. -> Replace its host
+  cases with reviewed PowerShell 7 and 5.1 outcomes. Do not approve snapshots
+  mechanically.
+
+## Migration Plan
+
+1. Land the OpenSpec contract and update the implementation plan.
+2. Retire the superseded PowerShell child-wrapper change. Do not sync it.
+3. Add the environment resolver and deterministic version-probe tests.
+4. Update ShellSyntaxTree and remove the POSIX PowerShell child workaround.
+5. Route execution and all policy consumers through the environment.
+6. Add the context hint and native Windows approval matrix.
+7. Run focused, full, native Windows, header, Slopwatch, and OpenSpec checks.
+8. Merge with auto-merge after adversarial review and green CI.
+
+Rollback restores the prior package and `cmd.exe` execution. No persisted data
+rollback is necessary. A rollback can increase prompts, but it cannot reinterpret
+stored command text because commands are parsed at invocation time.
+
+## Open Questions
+
+None. The host order, version ranges, grammar boundary, context seam, and
+failure behavior are fixed by the accepted ShellSyntaxTree contract.

--- a/openspec/changes/native-windows-powershell-host/proposal.md
+++ b/openspec/changes/native-windows-powershell-host/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+Source PRDs: `PRD-001`, `PRD-002`, `PRD-006`.
+
+Netclaw executes `cmd.exe` on Windows, while its parser and approval policy do
+not share one PowerShell host identity. The new ShellSyntaxTree alpha.5 dialect
+contract now lets Netclaw select, describe, parse, authorize, and execute one
+native Windows PowerShell environment without cross-language analysis.
+
+## What Changes
+
+- Update ShellSyntaxTree to `0.3.0-alpha.5`.
+- Resolve one immutable shell environment during daemon composition.
+- Keep `/bin/bash` and Bash grammar on Linux and macOS.
+- On Windows, prefer a compatible `pwsh.exe` host from the supported PowerShell
+  7.6 range. Fall back to Windows PowerShell 5.1 through `powershell.exe`.
+- Store and execute the absolute path of the executable that passed the version
+  probe. Do not repeat executable lookup after authorization.
+- Carry the selected platform, executable, grammar, and `PwshDialect` through
+  process execution, parsing, hard deny, protected paths, approval matching,
+  safe-verb policy, and the model-visible working-context tail.
+- Remove Netclaw's POSIX-only PowerShell child-payload parser. Bash treats a
+  `pwsh` invocation as one Bash external command. Native PowerShell input uses
+  `PwshParser` and retains only same-language recursion.
+- Keep parser initial state unknown. Netclaw does not infer profiles, modules,
+  inherited variables, command lookup, or external script contents.
+- Keep the shell tool schema and stored approval record shape unchanged.
+- Retire the superseded `adopt-shellsyntax-alpha2-pwsh` change. Do not sync its
+  obsolete cross-language requirement.
+
+In scope: native Windows host selection, exact dialect selection, one shared
+runtime identity, the context hint, the package update, and native Windows
+approval evidence.
+
+Out of scope: a configurable user shell, `cmd.exe` grammar, cross-language
+payload analysis, profile or module inspection, external `.ps1` analysis,
+`Start-ThreadJob` policy, and a runtime retry through another shell.
+
+## Capabilities
+
+### New Capabilities
+
+- `canonical-shell-execution`: Define platform shell selection, PowerShell
+  dialect selection, immutable runtime identity, and explicit failure behavior.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Make `shell_execute` start the selected native shell with
+  grammar-correct non-interactive arguments.
+- `tool-approval-gates`: Parse and authorize commands with the selected host
+  grammar and dialect. Remove cross-language PowerShell child analysis.
+- `netclaw-session`: Add the exact platform and shell identity to the
+  model-visible working-context tail for shell-capable sessions.
+
+## Impact
+
+- Code: daemon composition, shell process execution, shell analysis, security
+  policy, approval matching, working-context snapshots, and system guidance.
+- Dependency: ShellSyntaxTree changes from `0.3.0-alpha.2` to
+  `0.3.0-alpha.5`.
+- Tests: add host-selection, parser-boundary, execution, context, hard-deny,
+  protected-path, safe-verb, approval, and Windows matrix cases.
+- Security: unknown dialects, incomplete syntax, dynamic facts, and unavailable
+  compatible hosts fail closed. Stored approvals never bypass hard deny.
+- Operations: Windows hosts need either compatible PowerShell 7.6 or Windows
+  PowerShell 5.1. Startup reports a clear error when neither contract is met.
+- Persistence: no actor message, tool argument, approval entry, or config
+  migration is required.

--- a/openspec/changes/native-windows-powershell-host/specs/canonical-shell-execution/spec.md
+++ b/openspec/changes/native-windows-powershell-host/specs/canonical-shell-execution/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: One canonical shell environment
+
+The daemon SHALL resolve one immutable shell environment before it registers
+shell execution or security services. The environment SHALL contain the
+platform, absolute executable path, grammar, path style, process arguments, and
+PowerShell dialect when the grammar is PowerShell. Process execution, parsing,
+hard deny, protected paths, safe verbs, approval matching, and model context
+SHALL use the same environment instance.
+
+#### Scenario: Unix host selects Bash
+
+- **GIVEN** Netclaw starts on Linux or macOS
+- **WHEN** the daemon resolves its shell environment
+- **THEN** the executable is `/bin/bash`
+- **AND** the grammar is Bash
+- **AND** the path style is POSIX
+- **AND** the command argument is `-c`
+
+#### Scenario: Consumers share one identity
+
+- **GIVEN** the daemon resolved one shell environment
+- **WHEN** it registers shell execution, policy, approval, and context services
+- **THEN** every service uses that environment
+- **AND** no service makes an independent operating-system shell choice
+
+### Requirement: Windows selects a supported PowerShell dialect
+
+On Windows, the daemon SHALL probe `pwsh.exe` before `powershell.exe`. It SHALL
+select `PwshDialect.PowerShell7` only for PowerShell versions `>=7.6.4` and
+`<7.7`. It SHALL select `PwshDialect.WindowsPowerShell51` only when the fallback
+host reports PowerShell 5.1. The probe SHALL not load a user profile. The
+environment SHALL store the absolute path of the executable that passed the
+probe.
+
+#### Scenario: Compatible PowerShell 7 wins
+
+- **GIVEN** `pwsh.exe` reports version 7.6.4
+- **AND** `powershell.exe` is also available
+- **WHEN** the Windows shell environment resolves
+- **THEN** the selected executable is `pwsh.exe`
+- **AND** the selected dialect is `PowerShell7`
+- **AND** execution uses the absolute path that passed the probe
+- **AND** the fallback host does not replace it
+
+#### Scenario: Incompatible PowerShell 7 uses the fallback
+
+- **GIVEN** `pwsh.exe` is absent or reports a version outside the supported range
+- **AND** `powershell.exe` reports version 5.1
+- **WHEN** the Windows shell environment resolves
+- **THEN** the selected executable is `powershell.exe`
+- **AND** the selected dialect is `WindowsPowerShell51`
+- **AND** execution uses the absolute path that passed the probe
+- **AND** the daemon reports why it did not select `pwsh.exe`
+
+#### Scenario: No compatible Windows host fails startup
+
+- **GIVEN** neither Windows executable satisfies its version contract
+- **WHEN** the daemon resolves the shell environment
+- **THEN** startup fails with an actionable error
+- **AND** the daemon does not use `cmd.exe`
+- **AND** the daemon does not select an unknown parser dialect
+
+### Requirement: A shell host never changes after authorization
+
+The selected shell environment SHALL remain fixed for the daemon process.
+Netclaw SHALL NOT retry an authorized command through another shell executable
+or dialect. A daemon restart SHALL resolve a new environment and SHALL parse and
+authorize each new command with that new environment.
+
+#### Scenario: Selected executable disappears
+
+- **GIVEN** the daemon selected `pwsh.exe`
+- **AND** that executable cannot start for a later tool call
+- **WHEN** `shell_execute` starts the command
+- **THEN** the call fails with the selected executable in the error
+- **AND** the call does not retry through `powershell.exe` or `cmd.exe`
+
+#### Scenario: Executable lookup changes after startup
+
+- **GIVEN** the daemon selected an absolute `pwsh.exe` path
+- **AND** a later environment change puts another `pwsh.exe` first on `PATH`
+- **WHEN** `shell_execute` starts an authorized command
+- **THEN** it starts the path that passed the version probe
+- **AND** it does not repeat executable lookup
+
+#### Scenario: Restart changes the fallback selection
+
+- **GIVEN** one daemon process selected Windows PowerShell 5.1
+- **AND** a later daemon restart finds compatible PowerShell 7.6
+- **WHEN** a new command is submitted
+- **THEN** the new process parses it with `PowerShell7`
+- **AND** approval policy evaluates the new parser result before execution
+
+### Requirement: Native host grammar defines the language boundary
+
+Netclaw SHALL parse the submitted command only with the selected native host
+grammar. Bash SHALL treat `pwsh` and `powershell.exe` as external commands.
+PowerShell SHALL treat `bash` as an external command. Same-language child hosts
+SHALL use the nested command facts that ShellSyntaxTree returns.
+
+#### Scenario: Bash invokes PowerShell as an external command
+
+- **GIVEN** the selected host grammar is Bash
+- **AND** the command invokes `pwsh -Command` with a static payload
+- **WHEN** Netclaw analyzes the command
+- **THEN** it does not parse the payload with `PwshParser`
+- **AND** policy sees the Bash-authored external-command occurrence
+
+#### Scenario: Native PowerShell keeps same-language recursion
+
+- **GIVEN** the selected host grammar is PowerShell
+- **AND** a complete command invokes a static PowerShell child host
+- **WHEN** Netclaw analyzes the command
+- **THEN** policy receives each PowerShell occurrence that ShellSyntaxTree returns
+- **AND** it uses the child host dialect that the parser selected

--- a/openspec/changes/native-windows-powershell-host/specs/netclaw-session/spec.md
+++ b/openspec/changes/native-windows-powershell-host/specs/netclaw-session/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Shell-capable sessions receive the exact host identity
+
+The working-context tail for a Personal session SHALL contain the canonical
+platform, shell executable, grammar, and PowerShell dialect when applicable.
+The tail SHALL appear even when the session has no project directory. Public
+and Team context SHALL NOT gain shell capability from this information.
+
+The context SHALL describe only the selected host contract. It SHALL NOT claim
+knowledge of profiles, modules, aliases outside the parser catalog, inherited
+variables, executable lookup, or external script contents.
+
+#### Scenario: Personal Windows context names PowerShell 7
+
+- **GIVEN** the daemon selected `pwsh.exe` and `PowerShell7`
+- **AND** a Personal session has no project directory
+- **WHEN** the session builds its working-context tail
+- **THEN** the tail names Windows, `pwsh.exe`, PowerShell, and `PowerShell7`
+- **AND** the model can select PowerShell syntax for `shell_execute`
+
+#### Scenario: Personal Windows context names the fallback
+
+- **GIVEN** the daemon selected `powershell.exe` and `WindowsPowerShell51`
+- **WHEN** a Personal session builds its working-context tail
+- **THEN** the tail names the fallback executable and dialect
+- **AND** it does not describe PowerShell 7-only syntax as available
+
+#### Scenario: Personal Unix context names Bash
+
+- **GIVEN** the daemon selected `/bin/bash`
+- **WHEN** a Personal session builds its working-context tail
+- **THEN** the tail names the current Unix platform, `/bin/bash`, and Bash
+- **AND** it does not claim a PowerShell dialect
+
+#### Scenario: Child run receives the same host identity
+
+- **GIVEN** a Personal session creates a child run
+- **WHEN** the child receives its working-context snapshot
+- **THEN** it receives the same canonical shell identity as the parent daemon
+- **AND** the child cannot select another shell grammar

--- a/openspec/changes/native-windows-powershell-host/specs/netclaw-tools/spec.md
+++ b/openspec/changes/native-windows-powershell-host/specs/netclaw-tools/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Shell execution uses the canonical native host
+
+The `shell_execute` tool SHALL start the executable from the canonical shell
+environment. It SHALL pass the submitted command as one process argument after
+the environment's fixed non-interactive arguments. It SHALL close stdin and
+preserve the existing timeout, output, working-directory, and process-tree
+termination behavior. Buffered and streaming execution SHALL use one shared
+process-start builder. The tool schema SHALL remain unchanged.
+
+#### Scenario: Bash command process arguments
+
+- **GIVEN** the canonical environment uses `/bin/bash`
+- **WHEN** `shell_execute` starts `git status`
+- **THEN** the process arguments are `-c` and `git status`
+- **AND** the tool does not invoke PowerShell or `cmd.exe`
+
+#### Scenario: PowerShell command process arguments
+
+- **GIVEN** the canonical environment uses a PowerShell executable
+- **WHEN** `shell_execute` starts `Get-ChildItem`
+- **THEN** the fixed arguments include `-NoLogo`, `-NoProfile`, and
+  `-NonInteractive`
+- **AND** `-Command` precedes one `Get-ChildItem` argument
+- **AND** the tool does not invoke `cmd.exe`
+
+#### Scenario: Missing selected executable fails visibly
+
+- **GIVEN** the environment selected a PowerShell executable
+- **AND** the process cannot start that executable
+- **WHEN** `shell_execute` runs
+- **THEN** the result identifies the required executable
+- **AND** the tool does not run the command through another shell
+
+#### Scenario: Buffered and streaming execution use the same host
+
+- **GIVEN** one canonical environment and one submitted command
+- **WHEN** buffered and streaming execution build their process start data
+- **THEN** both use the same absolute executable path
+- **AND** both use the same fixed arguments in the same order
+- **AND** both append the submitted command as one argument

--- a/openspec/changes/native-windows-powershell-host/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/native-windows-powershell-host/specs/tool-approval-gates/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Shell policy uses the canonical grammar and dialect
+
+The shell policy SHALL analyze every submitted command with the canonical shell
+grammar before process start. Shell hard deny, protected paths, safe verbs,
+stored approvals, prompt candidates, and display SHALL use that analysis.
+PowerShell analysis SHALL pass the selected
+`PwshDialect` and `PwshInitialStateMode.Unknown`. Every policy consumer SHALL
+evaluate the same complete command-occurrence set.
+
+An unparseable result, an incomplete occurrence, a dynamic verb, or an unknown
+policy-sensitive fact SHALL NOT produce a persistent candidate or safe-verb
+auto-pass. A legacy token scan MAY block a known hard deny, but it SHALL NOT
+authorize unresolved text.
+
+#### Scenario: PowerShell pipeline evaluates every stage
+
+- **GIVEN** the native Windows host uses PowerShell
+- **AND** a pipeline contains a safe stage and an unapproved stage
+- **WHEN** approval policy evaluates the command
+- **THEN** it evaluates both command occurrences
+- **AND** the safe stage does not authorize the unapproved stage
+
+#### Scenario: Windows PowerShell 5.1 rejects pipeline chains
+
+- **GIVEN** the selected dialect is `WindowsPowerShell51`
+- **AND** the command uses `&&` or `||`
+- **WHEN** approval policy analyzes the command
+- **THEN** the result cannot create persistent approval candidates
+- **AND** safe-verb policy does not allow it automatically
+
+#### Scenario: Bash PowerShell wrapper is not cross-parsed
+
+- **GIVEN** the canonical grammar is Bash
+- **AND** the command is `pwsh -NoProfile -Command 'Get-Content ./a.txt'`
+- **WHEN** approval policy analyzes the command
+- **THEN** it does not add a `Get-Content` child candidate
+- **AND** it evaluates the authored Bash external-command occurrence
+
+#### Scenario: Dynamic PowerShell command remains strict
+
+- **GIVEN** the canonical grammar is PowerShell
+- **AND** command identity or an executable region depends on an unknown value
+- **WHEN** approval policy evaluates the command
+- **THEN** no stored grant or safe verb covers the unknown occurrence
+- **AND** the caller follows the existing deny-or-approval path
+
+#### Scenario: PowerShell native hard deny precedes approval
+
+- **GIVEN** a PowerShell command stops a process, removes a root recursively,
+  or invokes `Start-Process -Verb RunAs`
+- **WHEN** shell policy evaluates the command
+- **THEN** a matching hard-deny rule blocks the complete invocation
+- **AND** no stored approval or safe verb can bypass the denial
+
+#### Scenario: Dialect change reparses before grant matching
+
+- **GIVEN** a daemon restart changes the selected PowerShell dialect
+- **AND** an existing stored approval remains present
+- **WHEN** a new command requests authorization
+- **THEN** Netclaw derives candidates with the new dialect first
+- **AND** only candidates that match the stored intent can reuse that approval

--- a/openspec/changes/native-windows-powershell-host/tasks.md
+++ b/openspec/changes/native-windows-powershell-host/tasks.md
@@ -1,0 +1,80 @@
+## 1. Contract and Dependency
+
+- [x] 1.1 Add the native Windows shell priority to `IMPLEMENTATION_PLAN.md` and
+  link this OpenSpec change.
+- [ ] 1.2 Update the central ShellSyntaxTree package to `0.3.0-alpha.5` through
+  the package-management workflow.
+- [ ] 1.3 Archive `adopt-shellsyntax-alpha2-pwsh` with `--skip-specs` so its
+  obsolete cross-language requirement cannot enter the canonical spec.
+- [ ] 1.4 Replace stale POSIX PowerShell child-wrapper guidance with the
+  canonical host boundary.
+
+## 2. Canonical Environment Foundation
+
+- [ ] 2.1 Add the immutable shell environment with platform, executable,
+  grammar, path style, command arguments, and optional PowerShell dialect.
+- [ ] 2.2 Add a deterministic Windows resolver that prefers compatible
+  `pwsh.exe`, falls back to PowerShell 5.1, stores the probed absolute path, and
+  fails when neither host matches.
+- [ ] 2.3 Add version, priority, probe-failure, startup-failure, parser-options,
+  and process-argument tests for Bash, PowerShell 7.6, and PowerShell 5.1.
+- [ ] 2.4 Deliver the additive foundation as an adversarially reviewed PR with
+  green CI and auto-merge before activation work starts.
+
+## 3. Atomic Runtime Activation
+
+- [ ] 3.1 Remove Netclaw's POSIX `pwsh -Command` child-payload parser and pin
+  both cross-language non-delegation directions.
+- [ ] 3.2 Route shell analysis and approval matching through the environment's
+  parser, working directory, PowerShell dialect, and unknown initial-state mode.
+- [ ] 3.3 Route hard deny, protected paths, trust zones, safe verbs, approval
+  candidates, and approval display through the environment-bound analysis.
+- [ ] 3.4 Add PowerShell hard-deny coverage for process termination, recursive
+  root removal, and `Start-Process -Verb RunAs` before approval evaluation.
+- [ ] 3.5 Make buffered and streaming `ShellTool` execution use one shared
+  process-start builder. It must use only the selected absolute host path and
+  fixed non-interactive arguments. It must fail visibly and must not use a
+  per-call fallback.
+- [ ] 3.6 Register one environment instance for the parser, policy, matcher,
+  executor, context provider, direct calls, and background-job calls.
+
+## 4. Model Context and Guidance
+
+- [ ] 4.1 Add platform, executable, grammar, and dialect to the Personal
+  working-context tail, including sessions without a project directory.
+- [ ] 4.2 Prove that parent and child runs receive the same shell identity and
+  that Team or Public sessions gain no shell capability.
+- [ ] 4.3 Update the embedded operations guidance with native Bash and
+  PowerShell examples. State that ambient profiles, modules, and lookup remain
+  outside parser proof.
+
+## 5. Security and Approval Evidence
+
+- [ ] 5.1 Replace `cmd.exe` host rows with reviewed PowerShell 7.6 and Windows
+  PowerShell 5.1 allow, prompt, deny, safe-verb, and stored-grant rows.
+- [ ] 5.2 Add parser-boundary cases for ordinary Bash `pwsh` arguments,
+  ordinary PowerShell `bash` arguments, and same-language child recursion.
+- [ ] 5.3 Add incomplete, dynamic, unknown-dialect, 5.1 pipeline-chain,
+  protected-path, redirect, provider-drive, alias, and hard-deny cases.
+- [ ] 5.4 Prove that a dialect change reparses before grant matching and that a
+  stored approval cannot bypass a changed canonical candidate.
+- [ ] 5.5 Prove buffered, streaming, direct, sub-agent, background, retry, and
+  redrive paths use the same selected environment and approval decision.
+
+## 6. Verification and Delivery
+
+- [ ] 6.1 Run focused security, actor, context, buffered-executor,
+  streaming-executor, resolver, and approval matrix tests on Linux and native
+  Windows.
+- [ ] 6.2 Run restore, Release build, the full test suite, format verification,
+  header verification, Slopwatch, `git diff --check`, and strict OpenSpec
+  validation.
+- [ ] 6.3 Run the shell-platform behavioral evaluation when provider
+  credentials are available. Record an unavailable provider as blocked, not
+  passed.
+- [ ] 6.4 Run an adversarial review for every implementation PR, enable
+  auto-merge only after the review passes, and follow required CI to merge.
+- [ ] 6.5 Update `IMPLEMENTATION_PLAN.md`, user guidance, and review-table
+  evidence with observed results.
+- [ ] 6.6 Run `openspec-verify-change`, sync the capability deltas, and archive
+  this change only after all runtime and downstream acceptance gates pass.


### PR DESCRIPTION
## Source

- PRD-001
- PRD-002
- PRD-006
- ShellSyntaxTree `0.3.0-alpha.5` host and dialect contract

## Summary

- define one immutable shell environment for execution, parsing, approval, and model context
- prefer a compatible `pwsh.exe` host on Windows and fall back to Windows PowerShell 5.1
- require the exact probed executable path and one shared buffered and streaming process-start path
- keep Bash and PowerShell at separate native host boundaries
- plan removal of the obsolete POSIX PowerShell child parser
- keep unknown parser state and incomplete facts strict

## Scope controls

- no profile or module inspection
- no `Start-ThreadJob` policy
- no module-version policy
- no cross-language payload parsing
- no per-call shell fallback
- no stored approval or tool schema migration

## Validation

- `openspec validate native-windows-powershell-host --strict`
- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build --no-restore` (6,705 passed; 15 existing opt-in or platform tests skipped)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `dotnet slopwatch analyze` (0 findings)
- `git diff --check`
- adversarial review: PASS