### PR TITLE
Add canonical shell environment foundation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,7 +75,7 @@
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
-    <PackageVersion Include="ShellSyntaxTree" Version="0.3.0-alpha.2" />
+    <PackageVersion Include="ShellSyntaxTree" Version="0.3.0-alpha.5" />
     <PackageVersion Include="Termina" Version="0.16.1" />
   </ItemGroup>
   <!-- Serialization -->
@@ -124,7 +124,6 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
   </ItemGroup>
-
   <!-- Transitive audit suppress: Microsoft.Data.Sqlite → SQLitePCLRaw.lib.e_sqlite3 2.1.11
        is flagged by NuGetAudit (GHSA-2m69-gcr7-jv3q, CVE-2025-6965 — SQLite < 3.50.2
        memory corruption in aggregate-term handling). No patched version of

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -170,6 +170,11 @@ This work replaces `cmd.exe` with a native PowerShell host on Windows. Netclaw
 prefers a compatible PowerShell 7.6 host and falls back to Windows PowerShell
 5.1. It keeps Bash and PowerShell as separate host languages.
 
+The additive foundation now pins ShellSyntaxTree `0.3.0-alpha.5` and defines
+the immutable environment, strict host probe, and process arguments. The
+current runtime remains transitional until the activation tasks route every
+executor and security consumer through that environment.
+
 Done when:
 
 - [ ] One immutable shell environment selects the absolute executable path,

--- a/openspec/changes/native-windows-powershell-host/tasks.md
+++ b/openspec/changes/native-windows-powershell-host/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Add the native Windows shell priority to `IMPLEMENTATION_PLAN.md` and
   link this OpenSpec change.
-- [ ] 1.2 Update the central ShellSyntaxTree package to `0.3.0-alpha.5` through
+- [x] 1.2 Update the central ShellSyntaxTree package to `0.3.0-alpha.5` through
   the package-management workflow.
 - [x] 1.3 Archive `adopt-shellsyntax-alpha2-pwsh` with `--skip-specs` so its
   obsolete cross-language requirement cannot enter the canonical spec.
@@ -11,12 +11,12 @@
 
 ## 2. Canonical Environment Foundation
 
-- [ ] 2.1 Add the immutable shell environment with platform, executable,
+- [x] 2.1 Add the immutable shell environment with platform, executable,
   grammar, path style, command arguments, and optional PowerShell dialect.
-- [ ] 2.2 Add a deterministic Windows resolver that prefers compatible
+- [x] 2.2 Add a deterministic Windows resolver that prefers compatible
   `pwsh.exe`, falls back to PowerShell 5.1, stores the probed absolute path, and
   fails when neither host matches.
-- [ ] 2.3 Add version, priority, probe-failure, startup-failure, parser-options,
+- [x] 2.3 Add version, priority, probe-failure, startup-failure, parser-options,
   and process-argument tests for Bash, PowerShell 7.6, and PowerShell 5.1.
 - [ ] 2.4 Deliver the additive foundation as an adversarially reviewed PR with
   green CI and auto-merge before activation work starts.

--- a/src/Netclaw.Daemon.Tests/PowerShellHostProbeTests.cs
+++ b/src/Netclaw.Daemon.Tests/PowerShellHostProbeTests.cs
@@ -1,0 +1,419 @@
+// -----------------------------------------------------------------------
+// <copyright file="PowerShellHostProbeTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.ComponentModel;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests;
+
+public class PowerShellHostProbeTests
+{
+    private const string ExecutablePath = "C:\\PowerShell\\7\\pwsh.exe";
+
+    [Fact]
+    public void Probe_process_uses_exact_non_interactive_arguments()
+    {
+        var startInfo = PowerShellProbeProcessFactory.CreateStartInfo(ExecutablePath);
+
+        Assert.Equal(ExecutablePath, startInfo.FileName);
+        Assert.Equal(
+            [
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                PowerShellProbeProcessFactory.VersionProbeSource
+            ],
+            startInfo.ArgumentList);
+        Assert.True(startInfo.RedirectStandardInput);
+        Assert.True(startInfo.RedirectStandardOutput);
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.False(startInfo.UseShellExecute);
+    }
+
+    [Fact]
+    public void Windows_PATH_locator_uses_first_fully_qualified_match()
+    {
+        var inspected = new List<string>();
+        var locator = new WindowsPathPowerShellExecutableLocator(
+            () => "relative;\"C:\\First Tools\";C:\\Second",
+            path =>
+            {
+                inspected.Add(path);
+                return path.StartsWith("C:\\First", StringComparison.Ordinal)
+                    ? ExecutablePathInspection.File
+                    : ExecutablePathInspection.Missing;
+            },
+            path => path);
+
+        var result = locator.Locate("pwsh.exe");
+
+        var found = Assert.IsType<PowerShellExecutableLookup.Found>(result);
+        Assert.Equal("C:\\First Tools\\pwsh.exe", found.ExecutablePath);
+        Assert.Equal(["C:\\First Tools\\pwsh.exe"], inspected);
+    }
+
+    [Fact]
+    public void Windows_PATH_locator_keeps_access_failure_distinct_from_missing()
+    {
+        var locator = new WindowsPathPowerShellExecutableLocator(
+            () => "C:\\Restricted;C:\\Later",
+            _ => ExecutablePathInspection.AccessDenied,
+            path => path);
+
+        var result = locator.Locate("pwsh.exe");
+
+        var failed = Assert.IsType<PowerShellExecutableLookup.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.AccessDenied, failed.Failure);
+    }
+
+    [Fact]
+    public async Task Valid_single_version_returns_absolute_host_identity()
+    {
+        var process = new ControlledProbeProcess("7.6.4", string.Empty);
+        var probe = CreateProbe(process);
+
+        var result = await probe.ProbeAsync(
+            "pwsh.exe",
+            TestContext.Current.CancellationToken);
+
+        var found = Assert.IsType<PowerShellHostProbeResult.Found>(result);
+        Assert.Equal(ExecutablePath, found.ExecutablePath);
+        Assert.Equal(new Version(7, 6, 4), found.Version);
+        Assert.True(process.Disposed);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-version")]
+    [InlineData("7.6.4\n5.1")]
+    public async Task Malformed_version_output_fails_closed(string output)
+    {
+        var probe = CreateProbe(new ControlledProbeProcess(output, string.Empty));
+
+        var result = await probe.ProbeAsync(
+            "pwsh.exe",
+            TestContext.Current.CancellationToken);
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.MalformedVersion, failed.Failure);
+    }
+
+    [Fact]
+    public async Task Error_output_fails_closed_even_with_zero_exit()
+    {
+        var probe = CreateProbe(new ControlledProbeProcess("7.6.4", "unexpected warning"));
+
+        var result = await probe.ProbeAsync(
+            "pwsh.exe",
+            TestContext.Current.CancellationToken);
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.UnexpectedErrorOutput, failed.Failure);
+    }
+
+    [Fact]
+    public async Task Nonzero_exit_fails_closed()
+    {
+        var probe = CreateProbe(new ControlledProbeProcess("7.6.4", string.Empty, exitCode: 9));
+
+        var result = await probe.ProbeAsync(
+            "pwsh.exe",
+            TestContext.Current.CancellationToken);
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.NonZeroExit, failed.Failure);
+        Assert.Equal(9, failed.ExitCode);
+    }
+
+    [Fact]
+    public async Task Oversized_output_fails_closed_after_bounded_capture()
+    {
+        var probe = CreateProbe(new ControlledProbeProcess(new string('7', 4097), string.Empty));
+
+        var result = await probe.ProbeAsync(
+            "pwsh.exe",
+            TestContext.Current.CancellationToken);
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.OutputTooLarge, failed.Failure);
+    }
+
+    [Fact]
+    public async Task Timeout_terminates_process_tree_without_waiting_real_time()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var process = new ControlledProbeProcess(
+            "7.6.4",
+            string.Empty,
+            waitForKill: true);
+        var probe = CreateProbe(process, timeProvider);
+
+        var pending = probe.ProbeAsync("pwsh.exe", TestContext.Current.CancellationToken);
+        await process.WaitStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(PowerShellHostProbe.ProbeTimeout);
+        var result = await pending;
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.Timeout, failed.Failure);
+        Assert.True(process.KillTreeCalled);
+        Assert.True(process.WaitedAfterKill);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task Post_start_failure_terminates_process_and_observes_both_readers()
+    {
+        await AssertPostStartFailureCleanupAsync(
+            new IOException("Synthetic post-start wait failure."),
+            cleanupWaitException: null,
+            PowerShellProbeFailure.StartFailed);
+    }
+
+    [Theory]
+    [InlineData(false, (int)PowerShellProbeFailure.StartFailed)]
+    [InlineData(true, (int)PowerShellProbeFailure.TerminationFailed)]
+    public async Task Win32_wait_failure_cannot_bypass_cleanup(
+        bool cleanupWaitFails,
+        int expectedFailureValue)
+    {
+        await AssertPostStartFailureCleanupAsync(
+            new Win32Exception(5, "Synthetic initial wait failure."),
+            cleanupWaitFails
+                ? new Win32Exception(6, "Synthetic cleanup wait failure.")
+                : null,
+            (PowerShellProbeFailure)expectedFailureValue);
+    }
+
+    [Fact]
+    public async Task Termination_wait_is_bounded_by_fake_time()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var process = new ControlledProbeProcess(
+            "7.6.4",
+            string.Empty,
+            waitForKill: true,
+            completeAfterKill: false);
+        var probe = CreateProbe(process, timeProvider);
+
+        var pending = probe.ProbeAsync("pwsh.exe", TestContext.Current.CancellationToken);
+        await process.WaitStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(PowerShellHostProbe.ProbeTimeout);
+        await process.CleanupWaitStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(pending.IsCompleted);
+
+        timeProvider.Advance(PowerShellHostProbe.TerminationTimeout);
+        var result = await pending;
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.TerminationFailed, failed.Failure);
+        Assert.True(process.KillTreeCalled);
+        Assert.True(process.Disposed);
+    }
+
+    private static PowerShellHostProbe CreateProbe(
+        IPowerShellProbeProcess process,
+        TimeProvider? timeProvider = null) =>
+        new(
+            timeProvider ?? TimeProvider.System,
+            new FixedExecutableLocator(),
+            new FixedProcessFactory(process));
+
+    private static async Task AssertPostStartFailureCleanupAsync(
+        Exception initialWaitException,
+        Exception? cleanupWaitException,
+        PowerShellProbeFailure expectedFailure)
+    {
+        var process = new FaultingLiveProbeProcess(
+            initialWaitException,
+            cleanupWaitException);
+        var probe = CreateProbe(process);
+
+        var pending = probe.ProbeAsync("pwsh.exe", TestContext.Current.CancellationToken);
+        await process.StandardOutputReader.CancellationObserved.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        await process.StandardErrorReader.CancellationObserved.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+
+        Assert.True(process.KillTreeCalled);
+        Assert.True(process.WaitedAfterKill);
+        Assert.False(pending.IsCompleted);
+
+        process.StandardOutputReader.Complete();
+        process.StandardErrorReader.Complete();
+        var result = await pending;
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(expectedFailure, failed.Failure);
+        Assert.True(process.Disposed);
+    }
+
+    private sealed class FixedExecutableLocator : IPowerShellExecutableLocator
+    {
+        public PowerShellExecutableLookup Locate(string executableName) =>
+            new PowerShellExecutableLookup.Found(ExecutablePath);
+    }
+
+    private sealed class FixedProcessFactory(IPowerShellProbeProcess process)
+        : IPowerShellProbeProcessFactory
+    {
+        public IPowerShellProbeProcess Start(string executablePath)
+        {
+            Assert.Equal(ExecutablePath, executablePath);
+            return process;
+        }
+    }
+
+    private sealed class ControlledProbeProcess : IPowerShellProbeProcess
+    {
+        private readonly TaskCompletionSource _exit =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly bool _waitForKill;
+        private readonly bool _completeAfterKill;
+        private int _waitCount;
+
+        public ControlledProbeProcess(
+            string standardOutput,
+            string standardError,
+            int exitCode = 0,
+            bool waitForKill = false,
+            bool completeAfterKill = true)
+        {
+            StandardOutput = new StringReader(standardOutput);
+            StandardError = new StringReader(standardError);
+            ExitCode = exitCode;
+            _waitForKill = waitForKill;
+            _completeAfterKill = completeAfterKill;
+            if (!waitForKill)
+                _exit.TrySetResult();
+        }
+
+        public TaskCompletionSource WaitStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource CleanupWaitStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TextReader StandardOutput { get; }
+
+        public TextReader StandardError { get; }
+
+        public int ExitCode { get; }
+
+        public bool KillTreeCalled { get; private set; }
+
+        public bool WaitedAfterKill { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public async Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            var waitCount = Interlocked.Increment(ref _waitCount);
+            if (waitCount == 1)
+                WaitStarted.TrySetResult();
+            else
+                CleanupWaitStarted.TrySetResult();
+            if (KillTreeCalled)
+                WaitedAfterKill = true;
+            await _exit.Task.WaitAsync(cancellationToken);
+        }
+
+        public bool TryKillTree()
+        {
+            KillTreeCalled = true;
+            if (_waitForKill && _completeAfterKill)
+                _exit.TrySetResult();
+            return true;
+        }
+
+        public void Dispose()
+        {
+            StandardOutput.Dispose();
+            StandardError.Dispose();
+            Disposed = true;
+        }
+    }
+
+    private sealed class FaultingLiveProbeProcess(
+        Exception initialWaitException,
+        Exception? cleanupWaitException) : IPowerShellProbeProcess
+    {
+        public BlockingTrackingTextReader StandardOutputReader { get; } = new();
+
+        public BlockingTrackingTextReader StandardErrorReader { get; } = new();
+
+        public TextReader StandardOutput => StandardOutputReader;
+
+        public TextReader StandardError => StandardErrorReader;
+
+        public int ExitCode => 0;
+
+        public bool KillTreeCalled { get; private set; }
+
+        public bool WaitedAfterKill { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!KillTreeCalled)
+                throw initialWaitException;
+
+            WaitedAfterKill = true;
+            if (cleanupWaitException is not null)
+                throw cleanupWaitException;
+            return Task.CompletedTask;
+        }
+
+        public bool TryKillTree()
+        {
+            KillTreeCalled = true;
+            return true;
+        }
+
+        public void Dispose()
+        {
+            StandardOutputReader.Dispose();
+            StandardErrorReader.Dispose();
+            Disposed = true;
+        }
+    }
+
+    internal sealed class BlockingTrackingTextReader : TextReader
+    {
+        private readonly TaskCompletionSource<int> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private CancellationTokenRegistration _cancellationRegistration;
+
+        public TaskCompletionSource CancellationObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override ValueTask<int> ReadAsync(
+            Memory<char> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            _cancellationRegistration = cancellationToken.Register(
+                static state => ((TaskCompletionSource)state!).TrySetResult(),
+                CancellationObserved);
+            return new ValueTask<int>(_completion.Task);
+        }
+
+        public void Complete()
+        {
+            _completion.TrySetResult(0);
+            _cancellationRegistration.Dispose();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _cancellationRegistration.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/ShellExecutionEnvironmentResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/ShellExecutionEnvironmentResolverTests.cs
@@ -1,0 +1,173 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellExecutionEnvironmentResolverTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Security;
+using ShellSyntaxTree;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests;
+
+public class ShellExecutionEnvironmentResolverTests
+{
+    [Theory]
+    [InlineData(ShellPlatform.Linux)]
+    [InlineData(ShellPlatform.MacOS)]
+    public async Task Unix_platform_selects_Bash_without_a_probe(ShellPlatform platform)
+    {
+        var probe = new SequencePowerShellProbe();
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var resolution = await resolver.ResolveAsync(
+            platform,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(platform, resolution.Environment.Platform);
+        Assert.Equal("/bin/bash", resolution.Environment.ExecutablePath);
+        Assert.Empty(probe.Calls);
+        Assert.Null(resolution.FallbackReason);
+    }
+
+    [Theory]
+    [InlineData("7.6.4")]
+    [InlineData("7.6.99")]
+    public async Task Compatible_PowerShell7_wins_without_fallback(string version)
+    {
+        var probe = new SequencePowerShellProbe(
+            ("pwsh.exe", Found("C:\\PowerShell\\7\\pwsh.exe", version)));
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var resolution = await resolver.ResolveAsync(
+            ShellPlatform.Windows,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("C:\\PowerShell\\7\\pwsh.exe", resolution.Environment.ExecutablePath);
+        Assert.Equal(PwshDialect.PowerShell7, resolution.Environment.PowerShellDialect);
+        Assert.Equal(["pwsh.exe"], probe.Calls);
+        Assert.Null(resolution.FallbackReason);
+    }
+
+    [Fact]
+    public async Task Missing_preferred_host_selects_Windows_PowerShell51()
+    {
+        var probe = new SequencePowerShellProbe(
+            ("pwsh.exe", new PowerShellHostProbeResult.NotFound()),
+            ("powershell.exe", Found(
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "5.1.26100.1")));
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var resolution = await resolver.ResolveAsync(
+            ShellPlatform.Windows,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(PwshDialect.WindowsPowerShell51, resolution.Environment.PowerShellDialect);
+        Assert.Equal(PowerShellFallbackReason.PreferredHostNotFound, resolution.FallbackReason);
+        Assert.Null(resolution.RejectedPreferredVersion);
+        Assert.Equal(["pwsh.exe", "powershell.exe"], probe.Calls);
+    }
+
+    [Theory]
+    [InlineData("7.6.3")]
+    [InlineData("7.7.0")]
+    [InlineData("8.0.0")]
+    public async Task Unsupported_preferred_version_selects_Windows_PowerShell51(
+        string version)
+    {
+        var rejected = Version.Parse(version);
+        var probe = new SequencePowerShellProbe(
+            ("pwsh.exe", new PowerShellHostProbeResult.Found(
+                "C:\\PowerShell\\7\\pwsh.exe",
+                rejected)),
+            ("powershell.exe", Found(
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "5.1")));
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var resolution = await resolver.ResolveAsync(
+            ShellPlatform.Windows,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(PwshDialect.WindowsPowerShell51, resolution.Environment.PowerShellDialect);
+        Assert.Equal(PowerShellFallbackReason.PreferredVersionUnsupported, resolution.FallbackReason);
+        Assert.Equal(rejected, resolution.RejectedPreferredVersion);
+    }
+
+    [Theory]
+    [InlineData((int)PowerShellProbeFailure.AccessDenied)]
+    [InlineData((int)PowerShellProbeFailure.StartFailed)]
+    [InlineData((int)PowerShellProbeFailure.Timeout)]
+    [InlineData((int)PowerShellProbeFailure.MalformedVersion)]
+    public async Task Preferred_operational_failure_stops_without_fallback(
+        int failureValue)
+    {
+        var failure = (PowerShellProbeFailure)failureValue;
+        var probe = new SequencePowerShellProbe(
+            ("pwsh.exe", new PowerShellHostProbeResult.Failed(failure)));
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            resolver.ResolveAsync(ShellPlatform.Windows, TestContext.Current.CancellationToken));
+
+        Assert.Contains(failure.ToString(), exception.Message);
+        Assert.Equal(["pwsh.exe"], probe.Calls);
+    }
+
+    [Fact]
+    public async Task Incompatible_fallback_fails_with_actionable_versions()
+    {
+        var probe = new SequencePowerShellProbe(
+            ("pwsh.exe", Found("C:\\PowerShell\\7\\pwsh.exe", "7.7.0")),
+            ("powershell.exe", Found("C:\\Windows\\powershell.exe", "5.2")));
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            resolver.ResolveAsync(ShellPlatform.Windows, TestContext.Current.CancellationToken));
+
+        Assert.Contains("7.7.0", exception.Message);
+        Assert.Contains("5.2", exception.Message);
+        Assert.Contains("PowerShell 5.1", exception.Message);
+    }
+
+    [Fact]
+    public async Task Fallback_operational_failure_stops_startup()
+    {
+        var probe = new SequencePowerShellProbe(
+            ("pwsh.exe", new PowerShellHostProbeResult.NotFound()),
+            ("powershell.exe", new PowerShellHostProbeResult.Failed(
+                PowerShellProbeFailure.NonZeroExit,
+                9)));
+        var resolver = new ShellExecutionEnvironmentResolver(probe);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            resolver.ResolveAsync(ShellPlatform.Windows, TestContext.Current.CancellationToken));
+
+        Assert.Contains(nameof(PowerShellProbeFailure.NonZeroExit), exception.Message);
+        Assert.Equal(["pwsh.exe", "powershell.exe"], probe.Calls);
+    }
+
+    private static PowerShellHostProbeResult Found(string path, string version) =>
+        new PowerShellHostProbeResult.Found(path, Version.Parse(version));
+
+    private sealed class SequencePowerShellProbe(
+        params (string ExecutableName, PowerShellHostProbeResult Result)[] results)
+        : IPowerShellHostProbe
+    {
+        private readonly Queue<(string ExecutableName, PowerShellHostProbeResult Result)> _results =
+            new(results);
+
+        public List<string> Calls { get; } = [];
+
+        public Task<PowerShellHostProbeResult> ProbeAsync(
+            string executableName,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Calls.Add(executableName);
+            var next = _results.Dequeue();
+            Assert.Equal(next.ExecutableName, executableName);
+            return Task.FromResult(next.Result);
+        }
+    }
+}

--- a/src/Netclaw.Daemon/PowerShellHostProbe.cs
+++ b/src/Netclaw.Daemon/PowerShellHostProbe.cs
@@ -1,0 +1,505 @@
+// -----------------------------------------------------------------------
+// <copyright file="PowerShellHostProbe.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Security;
+using System.Text;
+
+namespace Netclaw.Daemon;
+
+internal enum PowerShellProbeFailure
+{
+    ExecutableLookupFailed,
+    AccessDenied,
+    StartFailed,
+    Timeout,
+    TerminationFailed,
+    NonZeroExit,
+    UnexpectedErrorOutput,
+    OutputTooLarge,
+    MalformedVersion
+}
+
+internal abstract record PowerShellHostProbeResult
+{
+    private PowerShellHostProbeResult()
+    {
+    }
+
+    internal sealed record NotFound : PowerShellHostProbeResult;
+
+    internal sealed record Found(string ExecutablePath, Version Version) : PowerShellHostProbeResult;
+
+    internal sealed record Failed(PowerShellProbeFailure Failure, int? ExitCode = null) : PowerShellHostProbeResult;
+}
+
+internal interface IPowerShellHostProbe
+{
+    Task<PowerShellHostProbeResult> ProbeAsync(
+        string executableName,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class PowerShellHostProbe(
+    TimeProvider timeProvider,
+    IPowerShellExecutableLocator executableLocator,
+    IPowerShellProbeProcessFactory processFactory) : IPowerShellHostProbe
+{
+    internal static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+    internal static readonly TimeSpan TerminationTimeout = TimeSpan.FromSeconds(1);
+    private const int MaxOutputChars = 4096;
+
+    public async Task<PowerShellHostProbeResult> ProbeAsync(
+        string executableName,
+        CancellationToken cancellationToken)
+    {
+        var lookup = executableLocator.Locate(executableName);
+        if (lookup is PowerShellExecutableLookup.NotFound)
+            return new PowerShellHostProbeResult.NotFound();
+        if (lookup is PowerShellExecutableLookup.Failed lookupFailure)
+            return new PowerShellHostProbeResult.Failed(lookupFailure.Failure);
+
+        var executablePath = ((PowerShellExecutableLookup.Found)lookup).ExecutablePath;
+        IPowerShellProbeProcess process;
+        try
+        {
+            process = processFactory.Start(executablePath);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new PowerShellHostProbeResult.Failed(PowerShellProbeFailure.AccessDenied);
+        }
+        catch (SecurityException)
+        {
+            return new PowerShellHostProbeResult.Failed(PowerShellProbeFailure.AccessDenied);
+        }
+        catch (Exception ex) when (ex is Win32Exception or IOException or InvalidOperationException)
+        {
+            return new PowerShellHostProbeResult.Failed(PowerShellProbeFailure.StartFailed);
+        }
+
+        using (process)
+        using (var timeout = new CancellationTokenSource(ProbeTimeout, timeProvider))
+        using (var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                   cancellationToken,
+                   timeout.Token))
+        {
+            var stdout = ReadBoundedAsync(process.StandardOutput, linked.Token);
+            var stderr = ReadBoundedAsync(process.StandardError, linked.Token);
+
+            try
+            {
+                await process.WaitForExitAsync(linked.Token).ConfigureAwait(false);
+                await Task.WhenAll(stdout, stderr).WaitAsync(linked.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                var probeTimedOut = timeout.IsCancellationRequested;
+                TryCancel(timeout);
+                var terminated = await TerminateAsync(process, stdout, stderr).ConfigureAwait(false);
+
+                cancellationToken.ThrowIfCancellationRequested();
+                if (ex is OperationCanceledException && probeTimedOut)
+                {
+                    return new PowerShellHostProbeResult.Failed(
+                        terminated
+                            ? PowerShellProbeFailure.Timeout
+                            : PowerShellProbeFailure.TerminationFailed);
+                }
+
+                if (IsExpectedPostStartFailure(ex))
+                {
+                    return new PowerShellHostProbeResult.Failed(
+                        terminated
+                            ? PowerShellProbeFailure.StartFailed
+                            : PowerShellProbeFailure.TerminationFailed);
+                }
+
+                throw;
+            }
+
+            var standardOutput = await stdout.ConfigureAwait(false);
+            var standardError = await stderr.ConfigureAwait(false);
+            if (standardOutput.Truncated || standardError.Truncated)
+                return new PowerShellHostProbeResult.Failed(
+                    PowerShellProbeFailure.OutputTooLarge);
+            if (process.ExitCode != 0)
+            {
+                return new PowerShellHostProbeResult.Failed(
+                    PowerShellProbeFailure.NonZeroExit,
+                    process.ExitCode);
+            }
+
+            if (!string.IsNullOrWhiteSpace(standardError.Text))
+                return new PowerShellHostProbeResult.Failed(PowerShellProbeFailure.UnexpectedErrorOutput);
+            if (!TryParseVersion(standardOutput.Text, out var version))
+                return new PowerShellHostProbeResult.Failed(PowerShellProbeFailure.MalformedVersion);
+
+            return new PowerShellHostProbeResult.Found(executablePath, version);
+        }
+    }
+
+    internal static bool TryParseVersion(string output, out Version version)
+    {
+        var value = output.Trim();
+        if (value.Length == 0 || value.IndexOfAny(['\r', '\n']) >= 0)
+        {
+            version = new Version();
+            return false;
+        }
+
+        return Version.TryParse(value, out version!);
+    }
+
+    private static bool IsExpectedPostStartFailure(Exception exception) =>
+        exception is OperationCanceledException or Win32Exception or IOException or
+            ObjectDisposedException or InvalidOperationException;
+
+    private static void TryCancel(CancellationTokenSource cancellation)
+    {
+        try
+        {
+            cancellation.Cancel();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"PowerShell probe reader cancellation failed: {ex.Message}");
+        }
+    }
+
+    private static async Task<BoundedText> ReadBoundedAsync(
+        TextReader reader,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new char[256];
+        var output = new StringBuilder();
+        var truncated = false;
+
+        while (true)
+        {
+            var read = await reader.ReadAsync(buffer.AsMemory(), cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+                break;
+
+            var remaining = MaxOutputChars - output.Length;
+            if (remaining > 0)
+                output.Append(buffer, 0, Math.Min(read, remaining));
+            if (read > remaining)
+                truncated = true;
+        }
+
+        return new BoundedText(output.ToString(), truncated);
+    }
+
+    private async Task<bool> TerminateAsync(
+        IPowerShellProbeProcess process,
+        Task<BoundedText> stdout,
+        Task<BoundedText> stderr)
+    {
+        var terminated = false;
+        try
+        {
+            terminated = process.TryKillTree();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"PowerShell probe process-tree termination failed: {ex.Message}");
+        }
+
+        using var cleanupTimeout = new CancellationTokenSource(TerminationTimeout, timeProvider);
+        var exitObserved = terminated;
+        if (terminated)
+        {
+            try
+            {
+                await process.WaitForExitAsync(cleanupTimeout.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cleanupTimeout.IsCancellationRequested)
+            {
+                exitObserved = false;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"PowerShell probe exit observation failed: {ex.Message}");
+                exitObserved = false;
+            }
+        }
+
+        var stdoutObserved = await ObserveReadAsync(stdout, cleanupTimeout.Token).ConfigureAwait(false);
+        var stderrObserved = await ObserveReadAsync(stderr, cleanupTimeout.Token).ConfigureAwait(false);
+        return terminated && exitObserved && stdoutObserved && stderrObserved;
+    }
+
+    private static async Task<bool> ObserveReadAsync(
+        Task<BoundedText> read,
+        CancellationToken cleanupToken)
+    {
+        try
+        {
+            await read.WaitAsync(cleanupToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when (read.IsCompleted)
+        {
+            Debug.WriteLine($"PowerShell probe reader completed with an error: {ex.Message}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"PowerShell probe reader observation failed: {ex.Message}");
+            ObserveEventually(read);
+            return false;
+        }
+    }
+
+    private static void ObserveEventually(Task read)
+    {
+        _ = read.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private sealed record BoundedText(string Text, bool Truncated);
+}
+
+internal abstract record PowerShellExecutableLookup
+{
+    private PowerShellExecutableLookup()
+    {
+    }
+
+    internal sealed record NotFound : PowerShellExecutableLookup;
+
+    internal sealed record Found(string ExecutablePath) : PowerShellExecutableLookup;
+
+    internal sealed record Failed(PowerShellProbeFailure Failure) : PowerShellExecutableLookup;
+}
+
+internal interface IPowerShellExecutableLocator
+{
+    PowerShellExecutableLookup Locate(string executableName);
+}
+
+internal enum ExecutablePathInspection
+{
+    Missing,
+    File,
+    AccessDenied,
+    Failed
+}
+
+internal sealed class WindowsPathPowerShellExecutableLocator : IPowerShellExecutableLocator
+{
+    private readonly Func<string?> _pathProvider;
+    private readonly Func<string, ExecutablePathInspection> _pathInspector;
+    private readonly Func<string, string> _getFullPath;
+
+    public WindowsPathPowerShellExecutableLocator()
+        : this(
+            () => Environment.GetEnvironmentVariable("PATH"),
+            InspectPath,
+            Path.GetFullPath)
+    {
+    }
+
+    internal WindowsPathPowerShellExecutableLocator(
+        Func<string?> pathProvider,
+        Func<string, ExecutablePathInspection> pathInspector,
+        Func<string, string> getFullPath)
+    {
+        _pathProvider = pathProvider;
+        _pathInspector = pathInspector;
+        _getFullPath = getFullPath;
+    }
+
+    public PowerShellExecutableLookup Locate(string executableName)
+    {
+        if (executableName is not ("pwsh.exe" or "powershell.exe"))
+            throw new ArgumentOutOfRangeException(nameof(executableName), executableName, "The PowerShell executable name is not supported.");
+
+        var path = _pathProvider();
+        if (string.IsNullOrWhiteSpace(path))
+            return new PowerShellExecutableLookup.NotFound();
+
+        foreach (var rawEntry in path.Split(';'))
+        {
+            if (!TryNormalizeEntry(rawEntry, out var entry))
+                continue;
+
+            var candidate = $"{entry.TrimEnd('\\', '/')}\\{executableName}";
+            switch (_pathInspector(candidate))
+            {
+                case ExecutablePathInspection.Missing:
+                    continue;
+                case ExecutablePathInspection.AccessDenied:
+                    return new PowerShellExecutableLookup.Failed(PowerShellProbeFailure.AccessDenied);
+                case ExecutablePathInspection.Failed:
+                    return new PowerShellExecutableLookup.Failed(PowerShellProbeFailure.ExecutableLookupFailed);
+                case ExecutablePathInspection.File:
+                    try
+                    {
+                        return new PowerShellExecutableLookup.Found(_getFullPath(candidate));
+                    }
+                    catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or SecurityException)
+                    {
+                        return new PowerShellExecutableLookup.Failed(PowerShellProbeFailure.ExecutableLookupFailed);
+                    }
+                default:
+                    return new PowerShellExecutableLookup.Failed(PowerShellProbeFailure.ExecutableLookupFailed);
+            }
+        }
+
+        return new PowerShellExecutableLookup.NotFound();
+    }
+
+    private static bool TryNormalizeEntry(string rawEntry, out string entry)
+    {
+        entry = rawEntry.Trim();
+        if (entry.Length >= 2 && entry[0] == '"' && entry[^1] == '"')
+            entry = entry[1..^1];
+        else if (entry.Contains('"', StringComparison.Ordinal))
+            return false;
+
+        return IsFullyQualifiedWindowsPath(entry);
+    }
+
+    private static bool IsFullyQualifiedWindowsPath(string path)
+    {
+        if (path.Length >= 3
+            && char.IsAsciiLetter(path[0])
+            && path[1] == ':'
+            && IsSeparator(path[2]))
+        {
+            return true;
+        }
+
+        if (path.Length < 5 || !IsSeparator(path[0]) || !IsSeparator(path[1]))
+            return false;
+
+        var serverEnd = path.IndexOfAny(['\\', '/'], 2);
+        return serverEnd > 2 && serverEnd < path.Length - 1;
+    }
+
+    private static bool IsSeparator(char value) => value is '\\' or '/';
+
+    private static ExecutablePathInspection InspectPath(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            return attributes.HasFlag(FileAttributes.Directory)
+                ? ExecutablePathInspection.Missing
+                : ExecutablePathInspection.File;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return ExecutablePathInspection.Missing;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException)
+        {
+            return ExecutablePathInspection.AccessDenied;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException)
+        {
+            return ExecutablePathInspection.Failed;
+        }
+    }
+}
+
+internal interface IPowerShellProbeProcessFactory
+{
+    IPowerShellProbeProcess Start(string executablePath);
+}
+
+internal interface IPowerShellProbeProcess : IDisposable
+{
+    TextReader StandardOutput { get; }
+
+    TextReader StandardError { get; }
+
+    int ExitCode { get; }
+
+    Task WaitForExitAsync(CancellationToken cancellationToken);
+
+    bool TryKillTree();
+}
+
+internal sealed class PowerShellProbeProcessFactory : IPowerShellProbeProcessFactory
+{
+    internal const string VersionProbeSource =
+        "[Console]::Out.Write($PSVersionTable.PSVersion.ToString())";
+
+    public IPowerShellProbeProcess Start(string executablePath)
+    {
+        var process = new Process { StartInfo = CreateStartInfo(executablePath) };
+        try
+        {
+            if (!process.Start())
+                throw new InvalidOperationException("Process.Start returned false.");
+            process.StandardInput.Close();
+            return new RunningPowerShellProbeProcess(process);
+        }
+        catch
+        {
+            process.Dispose();
+            throw;
+        }
+    }
+
+    internal static ProcessStartInfo CreateStartInfo(string executablePath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(VersionProbeSource);
+        return startInfo;
+    }
+}
+
+internal sealed class RunningPowerShellProbeProcess(Process process) : IPowerShellProbeProcess
+{
+    public TextReader StandardOutput => process.StandardOutput;
+
+    public TextReader StandardError => process.StandardError;
+
+    public int ExitCode => process.ExitCode;
+
+    public Task WaitForExitAsync(CancellationToken cancellationToken) =>
+        process.WaitForExitAsync(cancellationToken);
+
+    public bool TryKillTree()
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    public void Dispose() => process.Dispose();
+}

--- a/src/Netclaw.Daemon/ShellExecutionEnvironmentResolver.cs
+++ b/src/Netclaw.Daemon/ShellExecutionEnvironmentResolver.cs
@@ -1,0 +1,126 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellExecutionEnvironmentResolver.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Security;
+using ShellSyntaxTree;
+
+namespace Netclaw.Daemon;
+
+internal enum PowerShellFallbackReason
+{
+    PreferredHostNotFound,
+    PreferredVersionUnsupported
+}
+
+internal sealed record ShellEnvironmentResolution(
+    ShellExecutionEnvironment Environment,
+    PowerShellFallbackReason? FallbackReason = null,
+    Version? RejectedPreferredVersion = null);
+
+internal sealed class ShellExecutionEnvironmentResolver(IPowerShellHostProbe powerShellProbe)
+{
+    private static readonly Version MinimumPowerShell7 = new(7, 6, 4);
+    private static readonly Version PowerShell7UpperBound = new(7, 7);
+
+    public static ShellExecutionEnvironmentResolver CreateDefault(TimeProvider timeProvider) =>
+        new(new PowerShellHostProbe(
+            timeProvider,
+            new WindowsPathPowerShellExecutableLocator(),
+            new PowerShellProbeProcessFactory()));
+
+    public static ShellPlatform DetectCurrentPlatform()
+    {
+        if (OperatingSystem.IsWindows())
+            return ShellPlatform.Windows;
+        if (OperatingSystem.IsLinux())
+            return ShellPlatform.Linux;
+        if (OperatingSystem.IsMacOS())
+            return ShellPlatform.MacOS;
+
+        throw new PlatformNotSupportedException(
+            "Netclaw supports native shell execution only on Windows, Linux, and macOS.");
+    }
+
+    public async Task<ShellEnvironmentResolution> ResolveAsync(
+        ShellPlatform platform,
+        CancellationToken cancellationToken = default)
+    {
+        if (platform is ShellPlatform.Linux or ShellPlatform.MacOS)
+            return new ShellEnvironmentResolution(ShellExecutionEnvironment.CreateBash(platform));
+        if (platform != ShellPlatform.Windows)
+            throw new ArgumentOutOfRangeException(nameof(platform), platform, "The shell platform is not supported.");
+
+        var preferred = await powerShellProbe.ProbeAsync("pwsh.exe", cancellationToken)
+            .ConfigureAwait(false);
+        if (preferred is PowerShellHostProbeResult.Found preferredFound
+            && IsSupportedPowerShell7(preferredFound.Version))
+        {
+            return new ShellEnvironmentResolution(
+                ShellExecutionEnvironment.CreatePowerShell(
+                    preferredFound.ExecutablePath,
+                    PwshDialect.PowerShell7));
+        }
+
+        if (preferred is PowerShellHostProbeResult.Failed preferredFailure)
+            throw OperationalProbeFailure("pwsh.exe", preferredFailure);
+
+        var (fallbackReason, rejectedVersion) = preferred switch
+        {
+            PowerShellHostProbeResult.NotFound =>
+                (PowerShellFallbackReason.PreferredHostNotFound, (Version?)null),
+            PowerShellHostProbeResult.Found found =>
+                (PowerShellFallbackReason.PreferredVersionUnsupported, found.Version),
+            _ => throw new InvalidOperationException("The preferred PowerShell probe returned an unknown result.")
+        };
+
+        var fallback = await powerShellProbe.ProbeAsync("powershell.exe", cancellationToken)
+            .ConfigureAwait(false);
+        if (fallback is PowerShellHostProbeResult.Found fallbackFound
+            && IsWindowsPowerShell51(fallbackFound.Version))
+        {
+            return new ShellEnvironmentResolution(
+                ShellExecutionEnvironment.CreatePowerShell(
+                    fallbackFound.ExecutablePath,
+                    PwshDialect.WindowsPowerShell51),
+                fallbackReason,
+                rejectedVersion);
+        }
+
+        if (fallback is PowerShellHostProbeResult.Failed fallbackFailure)
+            throw OperationalProbeFailure("powershell.exe", fallbackFailure);
+
+        var preferredDescription = preferred switch
+        {
+            PowerShellHostProbeResult.NotFound => "pwsh.exe was not found",
+            PowerShellHostProbeResult.Found found =>
+                $"pwsh.exe reported unsupported version {found.Version}",
+            _ => "pwsh.exe was unavailable"
+        };
+        var fallbackDescription = fallback switch
+        {
+            PowerShellHostProbeResult.NotFound => "powershell.exe was not found",
+            PowerShellHostProbeResult.Found found =>
+                $"powershell.exe reported unsupported version {found.Version}",
+            _ => "powershell.exe was unavailable"
+        };
+
+        throw new InvalidOperationException(
+            $"No compatible Windows PowerShell host is available: {preferredDescription}; "
+            + $"{fallbackDescription}. Install PowerShell >=7.6.4 and <7.7, or provide Windows PowerShell 5.1 on PATH.");
+    }
+
+    private static bool IsSupportedPowerShell7(Version version) =>
+        version >= MinimumPowerShell7 && version < PowerShell7UpperBound;
+
+    private static bool IsWindowsPowerShell51(Version version) =>
+        version.Major == 5 && version.Minor == 1;
+
+    private static InvalidOperationException OperationalProbeFailure(
+        string executableName,
+        PowerShellHostProbeResult.Failed failure) =>
+        new(
+            $"Netclaw could not safely probe {executableName} ({failure.Failure}). "
+            + "Startup stopped so an operational probe error cannot change the selected shell grammar.");
+}

--- a/src/Netclaw.Security.Tests/ShellExecutionEnvironmentTests.cs
+++ b/src/Netclaw.Security.Tests/ShellExecutionEnvironmentTests.cs
@@ -1,0 +1,175 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellExecutionEnvironmentTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using ShellSyntaxTree;
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public class ShellExecutionEnvironmentTests
+{
+    [Theory]
+    [InlineData(ShellPlatform.Linux)]
+    [InlineData(ShellPlatform.MacOS)]
+    public void Bash_environment_has_fixed_native_identity(ShellPlatform platform)
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(platform);
+
+        Assert.Equal(platform, environment.Platform);
+        Assert.Equal("/bin/bash", environment.ExecutablePath);
+        Assert.Equal("bash", environment.ExecutableName);
+        Assert.Equal(ShellGrammar.Bash, environment.Grammar);
+        Assert.Equal(ShellPathStyle.Posix, environment.PathStyle);
+        Assert.Equal(["-c"], environment.CommandArguments);
+        Assert.Null(environment.PowerShellDialect);
+    }
+
+    [Fact]
+    public void Bash_environment_rejects_Windows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ShellExecutionEnvironment.CreateBash(ShellPlatform.Windows));
+    }
+
+    [Theory]
+    [InlineData(PwshDialect.PowerShell7, "C:\\Program Files\\PowerShell\\pwsh.exe")]
+    [InlineData(PwshDialect.WindowsPowerShell51, "C:\\Windows\\PowerShell\\powershell.exe")]
+    public void PowerShell_environment_has_fixed_native_identity(
+        PwshDialect dialect,
+        string executable)
+    {
+        var environment = ShellExecutionEnvironment.CreatePowerShell(executable, dialect);
+
+        Assert.Equal(ShellPlatform.Windows, environment.Platform);
+        Assert.Equal(executable, environment.ExecutablePath);
+        Assert.Equal(
+            dialect == PwshDialect.PowerShell7 ? "pwsh.exe" : "powershell.exe",
+            environment.ExecutableName);
+        Assert.Equal(ShellGrammar.PowerShell, environment.Grammar);
+        Assert.Equal(ShellPathStyle.Windows, environment.PathStyle);
+        Assert.Equal(
+            ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"],
+            environment.CommandArguments);
+        Assert.Equal(dialect, environment.PowerShellDialect);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("pwsh.exe")]
+    [InlineData("C:pwsh.exe")]
+    [InlineData("\\pwsh.exe")]
+    [InlineData("\\\\server\\pwsh.exe")]
+    public void PowerShell_environment_rejects_non_absolute_path(string executable)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ShellExecutionEnvironment.CreatePowerShell(executable, PwshDialect.PowerShell7));
+    }
+
+    [Theory]
+    [InlineData(PwshDialect.Unknown)]
+    [InlineData((PwshDialect)999)]
+    public void PowerShell_environment_rejects_unknown_dialect(PwshDialect dialect)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ShellExecutionEnvironment.CreatePowerShell("C:\\PowerShell\\pwsh.exe", dialect));
+    }
+
+    [Theory]
+    [InlineData("C:\\PowerShell\\powershell.exe", PwshDialect.PowerShell7)]
+    [InlineData("C:\\PowerShell\\pwsh.exe", PwshDialect.WindowsPowerShell51)]
+    public void PowerShell_environment_rejects_dialect_executable_mismatch(
+        string executable,
+        PwshDialect dialect)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ShellExecutionEnvironment.CreatePowerShell(executable, dialect));
+    }
+
+    [Fact]
+    public void Bash_parser_keeps_unknown_initial_state()
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+
+        var parsed = environment.Parse("printf '%s' \"$value\"", "/repo");
+
+        Assert.True(parsed.IsUnparseable);
+        Assert.Contains("variable-attribute state", parsed.UnparseableReason);
+    }
+
+    [Fact]
+    public void PowerShell_parser_uses_selected_dialect()
+    {
+        var powerShell7 = ShellExecutionEnvironment.CreatePowerShell(
+            "C:\\PowerShell\\7\\pwsh.exe",
+            PwshDialect.PowerShell7);
+        var windowsPowerShell = ShellExecutionEnvironment.CreatePowerShell(
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+            PwshDialect.WindowsPowerShell51);
+
+        var accepted = powerShell7.Parse("Get-Item a && Get-Item b", "C:\\repo");
+        var rejected = windowsPowerShell.Parse("Get-Item a && Get-Item b", "C:\\repo");
+
+        Assert.False(accepted.IsUnparseable, accepted.UnparseableReason);
+        Assert.Equal(2, accepted.Commands.Count);
+        Assert.True(rejected.IsUnparseable);
+        Assert.Contains("PowerShell 7 dialect", rejected.UnparseableReason);
+    }
+
+    [Theory]
+    [InlineData(PwshDialect.PowerShell7, "C:\\PowerShell\\7\\pwsh.exe")]
+    [InlineData(
+        PwshDialect.WindowsPowerShell51,
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")]
+    public void PowerShell_parser_keeps_unknown_initial_state(
+        PwshDialect dialect,
+        string executable)
+    {
+        var environment = ShellExecutionEnvironment.CreatePowerShell(executable, dialect);
+
+        var parsed = environment.Parse(
+            "foreach ($f in @('a.txt', 'b.txt')) { Remove-Item -LiteralPath $f }");
+
+        Assert.False(parsed.IsUnparseable, parsed.UnparseableReason);
+        var occurrence = Assert.Single(parsed.Commands);
+        Assert.False(occurrence.IsComplete);
+        Assert.Equal(
+            ShellValueDomainKind.Unknown,
+            Assert.Single(occurrence.EffectiveArguments).Value.Kind);
+    }
+
+    [Fact]
+    public void Process_start_info_appends_source_as_one_argument()
+    {
+        var environment = ShellExecutionEnvironment.CreatePowerShell(
+            "C:\\PowerShell\\7\\pwsh.exe",
+            PwshDialect.PowerShell7);
+        const string command = "Write-Output \"hello world\"\nGet-ChildItem";
+
+        var startInfo = environment.CreateProcessStartInfo(command);
+
+        Assert.Equal(environment.ExecutablePath, startInfo.FileName);
+        Assert.Equal(
+            ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+            startInfo.ArgumentList);
+        Assert.True(startInfo.RedirectStandardInput);
+        Assert.True(startInfo.RedirectStandardOutput);
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.True(startInfo.CreateNoWindow);
+    }
+
+    [Fact]
+    public void Process_start_info_is_fresh_for_each_call()
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.MacOS);
+
+        var first = environment.CreateProcessStartInfo("git status");
+        first.ArgumentList.Add("unexpected");
+        var second = environment.CreateProcessStartInfo("git diff");
+
+        Assert.NotSame(first, second);
+        Assert.Equal(["-c", "git diff"], second.ArgumentList);
+    }
+}

--- a/src/Netclaw.Security/ShellExecutionEnvironment.cs
+++ b/src/Netclaw.Security/ShellExecutionEnvironment.cs
@@ -1,0 +1,247 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellExecutionEnvironment.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Immutable;
+using System.Diagnostics;
+using ShellSyntaxTree;
+
+namespace Netclaw.Security;
+
+/// <summary>
+/// Identifies the operating-system family that owns the native shell host.
+/// </summary>
+public enum ShellPlatform
+{
+    Linux,
+    MacOS,
+    Windows
+}
+
+/// <summary>
+/// Identifies the grammar used to parse submitted shell source.
+/// </summary>
+public enum ShellGrammar
+{
+    Bash,
+    PowerShell
+}
+
+/// <summary>
+/// Identifies the path rules used by the selected shell host.
+/// </summary>
+public enum ShellPathStyle
+{
+    Posix,
+    Windows
+}
+
+/// <summary>
+/// Describes one immutable native shell identity for a daemon process.
+/// </summary>
+public sealed class ShellExecutionEnvironment
+{
+    private static readonly ImmutableArray<string> BashCommandArguments = ["-c"];
+    private static readonly ImmutableArray<string> PowerShellCommandArguments =
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"];
+
+    private ShellExecutionEnvironment(
+        ShellPlatform platform,
+        string executablePath,
+        ShellGrammar grammar,
+        ShellPathStyle pathStyle,
+        ImmutableArray<string> commandArguments,
+        PwshDialect? powerShellDialect)
+    {
+        if (string.IsNullOrWhiteSpace(executablePath))
+            throw new ArgumentException("The shell executable path is required.", nameof(executablePath));
+        if (!IsFullyQualified(executablePath, pathStyle))
+            throw new ArgumentException("The shell executable path must be absolute for its path style.", nameof(executablePath));
+        if (commandArguments.IsDefaultOrEmpty)
+            throw new ArgumentException("At least one fixed shell argument is required.", nameof(commandArguments));
+
+        Platform = platform;
+        ExecutablePath = executablePath;
+        Grammar = grammar;
+        PathStyle = pathStyle;
+        CommandArguments = commandArguments;
+        PowerShellDialect = powerShellDialect;
+    }
+
+    /// <summary>
+    /// Gets the native platform selected at daemon startup.
+    /// </summary>
+    public ShellPlatform Platform { get; }
+
+    /// <summary>
+    /// Gets the absolute executable path that passed host resolution.
+    /// </summary>
+    public string ExecutablePath { get; }
+
+    /// <summary>
+    /// Gets the executable file name for logs and model context.
+    /// </summary>
+    public string ExecutableName
+    {
+        get
+        {
+            var separator = Math.Max(
+                ExecutablePath.LastIndexOf('/'),
+                ExecutablePath.LastIndexOf('\\'));
+            return separator < 0 ? ExecutablePath : ExecutablePath[(separator + 1)..];
+        }
+    }
+
+    /// <summary>
+    /// Gets the grammar that parses submitted source.
+    /// </summary>
+    public ShellGrammar Grammar { get; }
+
+    /// <summary>
+    /// Gets the path rules used by policy and parser resolution.
+    /// </summary>
+    public ShellPathStyle PathStyle { get; }
+
+    /// <summary>
+    /// Gets the fixed arguments placed before one submitted command argument.
+    /// </summary>
+    public IReadOnlyList<string> CommandArguments { get; }
+
+    /// <summary>
+    /// Gets the selected PowerShell dialect, or <see langword="null"/> for Bash.
+    /// </summary>
+    public PwshDialect? PowerShellDialect { get; }
+
+    /// <summary>
+    /// Creates the fixed Bash identity used on Linux and macOS.
+    /// </summary>
+    public static ShellExecutionEnvironment CreateBash(ShellPlatform platform)
+    {
+        if (platform is not (ShellPlatform.Linux or ShellPlatform.MacOS))
+            throw new ArgumentOutOfRangeException(nameof(platform), platform, "Bash is supported only on Linux and macOS.");
+
+        return new ShellExecutionEnvironment(
+            platform,
+            "/bin/bash",
+            ShellGrammar.Bash,
+            ShellPathStyle.Posix,
+            BashCommandArguments,
+            powerShellDialect: null);
+    }
+
+    /// <summary>
+    /// Creates a Windows PowerShell identity from the executable path that passed probing.
+    /// </summary>
+    public static ShellExecutionEnvironment CreatePowerShell(
+        string executablePath,
+        PwshDialect dialect)
+    {
+        if (string.IsNullOrWhiteSpace(executablePath))
+            throw new ArgumentException("The shell executable path is required.", nameof(executablePath));
+        if (dialect is not (PwshDialect.PowerShell7 or PwshDialect.WindowsPowerShell51))
+            throw new ArgumentOutOfRangeException(nameof(dialect), dialect, "A supported PowerShell dialect is required.");
+
+        var expectedExecutableName = dialect == PwshDialect.PowerShell7
+            ? "pwsh.exe"
+            : "powershell.exe";
+        var separator = Math.Max(
+            executablePath.LastIndexOf('/'),
+            executablePath.LastIndexOf('\\'));
+        var executableName = separator < 0
+            ? executablePath
+            : executablePath[(separator + 1)..];
+        if (!string.Equals(executableName, expectedExecutableName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"Dialect {dialect} requires {expectedExecutableName}.",
+                nameof(executablePath));
+        }
+
+        return new ShellExecutionEnvironment(
+            ShellPlatform.Windows,
+            executablePath,
+            ShellGrammar.PowerShell,
+            ShellPathStyle.Windows,
+            PowerShellCommandArguments,
+            dialect);
+    }
+
+    /// <summary>
+    /// Parses source with the environment's grammar, dialect, working directory, and unknown initial state.
+    /// </summary>
+    public ParsedCommand Parse(string source, string? workingDirectory = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return Grammar switch
+        {
+            ShellGrammar.Bash => new BashParser(new BashParserOptions
+            {
+                WorkingDirectory = workingDirectory,
+                InitialStateMode = BashInitialStateMode.Unknown
+            }).Parse(source),
+            ShellGrammar.PowerShell when PowerShellDialect is { } dialect =>
+                new PwshParser(new PwshParserOptions
+                {
+                    WorkingDirectory = workingDirectory,
+                    InitialStateMode = PwshInitialStateMode.Unknown,
+                    Dialect = dialect
+                }).Parse(source),
+            _ => throw new InvalidOperationException("The shell environment has no supported parser identity.")
+        };
+    }
+
+    /// <summary>
+    /// Creates fresh process-start data for one submitted command.
+    /// </summary>
+    public ProcessStartInfo CreateProcessStartInfo(string command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = ExecutablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in CommandArguments)
+            startInfo.ArgumentList.Add(argument);
+        startInfo.ArgumentList.Add(command);
+        return startInfo;
+    }
+
+    private static bool IsFullyQualified(string path, ShellPathStyle pathStyle) => pathStyle switch
+    {
+        ShellPathStyle.Posix => path.Length > 1 && path[0] == '/',
+        ShellPathStyle.Windows => IsFullyQualifiedWindowsPath(path),
+        _ => false
+    };
+
+    private static bool IsFullyQualifiedWindowsPath(string path)
+    {
+        if (path.Length >= 3
+            && char.IsAsciiLetter(path[0])
+            && path[1] == ':'
+            && IsWindowsSeparator(path[2]))
+        {
+            return true;
+        }
+
+        if (path.Length < 5 || !IsWindowsSeparator(path[0]) || !IsWindowsSeparator(path[1]))
+            return false;
+
+        var serverEnd = path.IndexOfAny(['\\', '/'], 2);
+        if (serverEnd <= 2 || serverEnd == path.Length - 1)
+            return false;
+
+        var shareEnd = path.IndexOfAny(['\\', '/'], serverEnd + 1);
+        return shareEnd > serverEnd + 1 && shareEnd < path.Length - 1;
+    }
+
+    private static bool IsWindowsSeparator(char value) => value is '\\' or '/';
+}


### PR DESCRIPTION
## Summary

- Update ShellSyntaxTree to `0.3.0-alpha.5` through central package management.
- Add one immutable shell environment for host identity, parsing, and process arguments.
- Add deterministic Windows host resolution for supported PowerShell 7.6 and Windows PowerShell 5.1.
- Store the absolute executable path that passed the version probe.
- Fail startup on operational probe errors or when no compatible host exists.
- Keep runtime activation and policy changes in the next atomic slice.

## Security

- The resolver only falls back when `pwsh.exe` is absent or its version is unsupported.
- Operational probe failures stop startup and cannot change the selected grammar.
- Every post-start failure uses bounded process-tree cleanup and observes both output readers.
- The environment uses `PwshInitialStateMode.Unknown` for both PowerShell dialects.
- The process builder appends each submitted command as one final argument.

## Validation

- `dotnet restore` passed.
- `dotnet build -c Release --no-restore` passed with zero warnings.
- `dotnet test -c Release --no-build --no-restore` passed.
- Focused daemon tests passed: 29 of 29.
- Focused security tests passed: 20 of 20.
- Changed-file format verification passed.
- Slopwatch reported zero issues.
- Header verification passed.
- All 14 active OpenSpec changes passed strict validation.
- `git diff --check` passed.
- A local PowerShell 7.6.4 probe returned one clean version value.

## Adversarial review

The first review found a live-child cleanup defect after a probe wait failure.
The second review found a documented `Win32Exception` path with the same risk.
The implementation now uses structural cleanup before it classifies or rethrows any post-start exception.
The final adversarial review returned PASS with no blocking findings.
