### PR TITLE
docs(shell): record native Windows validation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -172,8 +172,9 @@ prefers a compatible PowerShell 7.6 host and falls back to Windows PowerShell
 The additive foundation pins ShellSyntaxTree `0.3.0-alpha.5` and defines the
 immutable environment, strict host probe, and process arguments. Runtime
 activation now routes execution, policy, approval, background jobs, and model
-context through the same resolved environment. Native Windows CI and final
-OpenSpec delivery remain before this priority is complete.
+context through the same resolved environment. PR #1848 auto-merged after
+adversarial review and green native Windows CI. Final OpenSpec delivery remains
+before this priority is complete.
 
 Local validation on 2026-08-10 passed restore, the zero-warning Release build,
 the full solution test suite, changed-file format verification, headers,
@@ -182,6 +183,12 @@ behavioral evaluation was unavailable because the required
 `NETCLAW_EVAL_PROVIDER_TYPE`, `NETCLAW_EVAL_PROVIDER_ENDPOINT`, and
 `NETCLAW_EVAL_MODEL_ID` settings were absent. This result is blocked evidence,
 not an evaluation pass.
+
+Native Windows workflow run `31381580072` passed the zero-warning Release build,
+the complete security, actor, and daemon test suites, package staging, and CLI
+smoke tests. The production resolver and deterministic dialect matrix cover
+PowerShell 7.6 and Windows PowerShell 5.1. The Windows suite also executed the
+explicit Windows PowerShell 5.1 host test.
 
 Done when:
 
@@ -198,7 +205,7 @@ Done when:
   or a safe-verb pass. Stored approval cannot bypass hard deny.
 - [x] Personal sessions state the platform, executable, grammar, and dialect,
   including sessions that have no project directory.
-- [ ] Native Windows tests cover PowerShell 7.6 and Windows PowerShell 5.1.
+- [x] Native Windows tests cover PowerShell 7.6 and Windows PowerShell 5.1.
   The security review table covers direct, child, retry, and background paths.
 - [ ] Consumer guidance and canonical specs match the delivered behavior. The
   OpenSpec change passes verification, is synchronized, and is archived.

--- a/openspec/changes/native-windows-powershell-host/tasks.md
+++ b/openspec/changes/native-windows-powershell-host/tasks.md
@@ -63,7 +63,7 @@
 
 ## 6. Verification and Delivery
 
-- [ ] 6.1 Run focused security, actor, context, buffered-executor,
+- [x] 6.1 Run focused security, actor, context, buffered-executor,
   streaming-executor, resolver, and approval matrix tests on Linux and native
   Windows.
 - [x] 6.2 Run restore, Release build, the full test suite, format verification,
@@ -72,7 +72,7 @@
 - [x] 6.3 Run the shell-platform behavioral evaluation when provider
   credentials are available. Record an unavailable provider as blocked, not
   passed.
-- [ ] 6.4 Run an adversarial review for every implementation PR, enable
+- [x] 6.4 Run an adversarial review for every implementation PR, enable
   auto-merge only after the review passes, and follow required CI to merge.
 - [x] 6.5 Update `IMPLEMENTATION_PLAN.md`, user guidance, and review-table
   evidence with observed results.


### PR DESCRIPTION
## Summary

- Record the merged native Windows validation evidence from PR #1848.
- Mark OpenSpec tasks 6.1 and 6.4 complete.
- Keep final verification, canonical spec synchronization, and archive work open.
- Keep the unavailable behavioral evaluation recorded as blocked, not passed.

## Validation

- openspec validate native-windows-powershell-host --strict --json
- git diff --check
- Adversarial review: PASS with no findings
- No production code changed