### PR TITLE
Fix /dev/null approval scope

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -141,6 +141,9 @@ Done when:
   explicit Bash redirect facts for the existing grammar.
 - [x] Unknown occurrences, cwd facts, wrappers, and redirects stay prompt-only.
   Static descriptor redirects no longer appear dynamic.
+- [x] The resolved POSIX `/dev/null` device does not create an approval
+  directory after host symlink checks. Other device paths and dynamic redirect
+  targets stay strict.
 - [x] Netclaw consumes ShellSyntaxTree `0.3.0-alpha.1` and promotes Bash
   command-resolution mutation and reserved execution forms into the strict
   181-case review matrix.

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
@@ -308,6 +308,11 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Require(["git status"])),
         Case(
+            "safe-verb-null-device-redirect-allows",
+            Bash("ls -la 2>/dev/null"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
             "mutating-verb-project-prompts",
             Bash("git push"),
             Approvals.None,

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
@@ -22,6 +22,7 @@
 | safe-verb-traversal-external-path-prompts | Bash | Personal | Project | Interactive | cat safe/../../../../../../etc/netclaw.secret | none | RequiresApproval | approval required | cat | No |
 | safe-verb-bash-provider-looking-relative-path-allows | Bash | Personal | Project | Interactive | cat filesystem::/etc/netclaw.secret | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | safe-verb-external-redirect-prompts | Bash | Personal | Project | Interactive | git status > /netclaw-approval-external/netclaw-approval-matrix.txt | none | RequiresApproval | approval required | git status | No |
+| safe-verb-null-device-redirect-allows | Bash | Personal | Project | Interactive | ls -la 2>/dev/null | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | mutating-verb-project-prompts | Bash | Personal | Project | Interactive | git push | none | RequiresApproval | approval required | git push | No |
 | all-safe-compound-allows | Bash | Personal | Project | Interactive | git status && git log | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | four-safe-mixed-operator-clauses-allow | Bash | Personal | Project | Interactive | git status && git log \| head -20; pwd | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -1606,12 +1606,15 @@ public sealed class ShellApprovalMatcherPathExtractionTests
         Assert.Equal("/etc", candidate.Directory);
     }
 
-    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
-    public void ExtractCandidates_does_not_generalize_posix_null_device_exception()
+    [SlopwatchSuppress("SW001", "This theory verifies POSIX null device lookalikes, which do not apply to the Windows shell parser.")]
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    [InlineData("ls -la 2>/dev/nul")]
+    [InlineData("ls -la 2>/dev/null.backup")]
+    public void ExtractCandidates_does_not_generalize_posix_null_device_exception(string command)
     {
         var candidates = _matcher.ExtractCandidates(
             new ToolName("shell_execute"),
-            Args("ls -la 2>/dev/null.backup"));
+            Args(command));
 
         var candidate = Assert.Single(candidates);
         Assert.Equal("ls", candidate.Verb);

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -126,6 +126,22 @@ public sealed class ShellApprovalMatcherTests
     }
 
     [Fact]
+    public void Power_shell_redirect_does_not_use_the_posix_null_device_exception()
+    {
+        var matcher = new ShellApprovalMatcher(
+            ShellExecutionEnvironment.CreatePowerShell(
+                @"C:\Program Files\PowerShell\7\pwsh.exe",
+                PwshDialect.PowerShell7));
+
+        var analysis = matcher.AnalyzeInvocation(
+            new ToolName("shell_execute"),
+            Args("Get-Content .\\input.txt > /dev/null", @"C:\work"));
+
+        Assert.True(analysis.IsMessy);
+        Assert.Empty(analysis.Candidates);
+    }
+
+    [Fact]
     public void Dialect_change_reparses_before_candidates_can_match_a_grant()
     {
         const string command = @"Get-ChildItem && Get-Content .\input.txt";
@@ -1545,6 +1561,61 @@ public sealed class ShellApprovalMatcherPathExtractionTests
 
         Assert.Contains(candidates, candidate =>
             candidate.Verb == "echo" && candidate.Directory == workingDirectory);
+    }
+
+    [SlopwatchSuppress("SW001", "This theory verifies POSIX null device behavior, which does not apply to the Windows shell parser.")]
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    [InlineData("ls -la 2>/dev/null", "ls")]
+    [InlineData("ls -la 2>/dev/./null", "ls")]
+    [InlineData("cat </dev/null", "cat")]
+    public void ExtractCandidates_ignores_resolved_posix_null_device_redirect(
+        string command,
+        string expectedVerb)
+    {
+        var candidates = _matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args(command));
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal(expectedVerb, candidate.Verb);
+        Assert.Null(candidate.Directory);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_uses_invocation_directory_after_null_device_redirect()
+    {
+        const string workingDirectory = "/home/user/repos/demo";
+        var candidates = _matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args("tmux ls 2>/dev/null", workingDirectory));
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal("tmux ls", candidate.Verb);
+        Assert.Equal(workingDirectory, candidate.Directory);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_keeps_other_redirect_scope_after_null_device_redirect()
+    {
+        var candidates = _matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args("tmux ls 2>/dev/null >/etc/netclaw-output.txt", "/work"));
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal("tmux ls", candidate.Verb);
+        Assert.Equal("/etc", candidate.Directory);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_does_not_generalize_posix_null_device_exception()
+    {
+        var candidates = _matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args("ls -la 2>/dev/null.backup"));
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal("ls", candidate.Verb);
+        Assert.Equal("/dev", candidate.Directory);
     }
 
     [SlopwatchSuppress("SW001", "This test verifies POSIX symlink redirect behavior, which does not apply to the Windows shell parser.")]

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -1599,11 +1599,13 @@ public sealed class ShellApprovalMatcherPathExtractionTests
     {
         var candidates = _matcher.ExtractCandidates(
             new ToolName("shell_execute"),
-            Args("tmux ls 2>/dev/null >/etc/netclaw-output.txt", "/work"));
+            Args(
+                "tmux ls 2>/dev/null >/netclaw-approval-external/netclaw-output.txt",
+                "/work"));
 
         var candidate = Assert.Single(candidates);
         Assert.Equal("tmux ls", candidate.Verb);
-        Assert.Equal("/etc", candidate.Directory);
+        Assert.Equal("/netclaw-approval-external", candidate.Directory);
     }
 
     [SlopwatchSuppress("SW001", "This theory verifies POSIX null device lookalikes, which do not apply to the Windows shell parser.")]

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -115,6 +115,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
 {
     public static readonly ShellApprovalMatcher Instance = new();
 
+    private const string PosixNullDevicePath = "/dev/null";
+
     private readonly ShellCommandAnalyzer _analyzer;
 
     public ShellApprovalMatcher()
@@ -578,7 +580,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             // The resolved POSIX null device creates no reusable filesystem
             // authority. Other device paths stay strict.
             if (pathStyle == ShellPathStyle.Posix
-                && string.Equals(target, "/dev/null", StringComparison.Ordinal))
+                && string.Equals(target, PosixNullDevicePath, StringComparison.Ordinal))
             {
                 continue;
             }

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -572,11 +572,19 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (string.IsNullOrWhiteSpace(target))
                 return null;
 
-            var directory = GetRedirectDirectory(target, pathStyle);
-            if (directory is null)
+            if (UsesHostPathStyle(pathStyle) && HasUnsafeHostPath(target))
                 return null;
 
-            if (UsesHostPathStyle(pathStyle) && HasUnsafeHostPath(target))
+            // The resolved POSIX null device creates no reusable filesystem
+            // authority. Other device paths stay strict.
+            if (pathStyle == ShellPathStyle.Posix
+                && string.Equals(target, "/dev/null", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var directory = GetRedirectDirectory(target, pathStyle);
+            if (directory is null)
                 return null;
 
             directories.Add(directory);


### PR DESCRIPTION
## Summary

- Do not turn the resolved POSIX `/dev/null` redirect target into a reusable `/dev` approval scope.
- Run the existing host symlink check before the null-device exception.
- Keep all other device paths, external redirects, dynamic redirects, and PowerShell paths strict.
- Add direct matcher regressions and an end-to-end approval matrix case.

## User impact

Safe commands such as `ls -la 2>/dev/null` can use the trusted working-directory policy instead of prompting for `/dev` access. Commands such as `tmux` or `systemctl` can still prompt when their verbs require approval, but the prompt uses the invocation working directory instead of claiming that the command runs in `/dev`.

This is a Netclaw policy correction. It does not require a new ShellSyntaxTree package.

## Security boundaries

- `/dev/null.backup` still creates a `/dev` scope.
- A second redirect such as `>/etc/output.txt` still creates an `/etc` scope.
- Dynamic targets remain fail closed.
- Host symlink checks run before the exception.
- Native PowerShell does not use the POSIX exception.

## Verification

- Release solution build: 0 warnings, 0 errors.
- Full solution tests: 6,797 passed, 15 environment-specific skips, 0 failed.
- Bash approval matrix: 193 cases passed before the expanded full run.
- Slopwatch: 0 issues.
- File headers: verified.
- Formatting and `git diff --check`: passed.
- Adversarial security review: no remaining blocking findings after the symlink-order correction.
