### PR TITLE
Preserve daemon CWD after temporary-directory cleanup

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -110,6 +110,23 @@ the smallest repeatable manual script plus expected output.
 
 ## NOW
 
+### Priority: Preserve The Daemon Working Directory
+
+**PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
+**Specs:** `openspec/specs/netclaw-tools/spec.md`, `openspec/specs/tool-approval-gates/spec.md`
+**Surface area:** daemon lifecycle, path normalization, shell authorization
+**Verification:** L1 plus a live daemon restart
+
+The daemon process directory must survive routine system temporary-directory
+cleanup. Absolute path validation must not depend on that process directory.
+
+Done when:
+
+- [x] The daemon uses a durable runtime directory below the Netclaw home.
+- [x] Absolute path normalization does not read the process working directory.
+- [x] Focused tests and the full repository quality gates pass.
+- [ ] An installed daemon restart confirms the live process uses the durable directory.
+
 ### Priority: Reduce Shell Approval Fatigue
 
 **PRDs:** `docs/prd/PRD-002-gateway-security-envelope.md`, `docs/prd/PRD-006-mcp-tool-integration.md`

--- a/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
+++ b/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="NetclawPathsTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -56,6 +56,41 @@ public sealed class NetclawPathsTests : IDisposable
         Assert.Equal(Path.Combine(envPath, "netclaw.db"), paths.SqliteDbPath);
         Assert.Equal(Path.Combine(envPath, "logs"), paths.LogsDirectory);
         Assert.Equal(Path.Combine(envPath, "identity"), paths.IdentityDirectory);
+    }
+
+    [Fact]
+    public void Relative_env_var_is_canonicalized_once_for_daemon_reuse()
+    {
+        var relativePath = "netclaw-relative-" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(EnvVar, relativePath);
+
+        var bootstrapPaths = new NetclawPaths();
+        var reusedPaths = new NetclawPaths(bootstrapPaths.BasePath);
+
+        Assert.Equal(Path.GetFullPath(relativePath), bootstrapPaths.BasePath);
+        Assert.Equal(bootstrapPaths.BasePath, reusedPaths.BasePath);
+        Assert.Equal(bootstrapPaths.RuntimeDirectory, reusedPaths.RuntimeDirectory);
+    }
+
+    [Fact]
+    public void EnsureDirectoriesExist_creates_runtime_directory_idempotently()
+    {
+        var basePath = Path.Combine(Path.GetTempPath(), "netclaw-runtime-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var paths = new NetclawPaths(basePath);
+
+            paths.EnsureDirectoriesExist();
+            paths.EnsureDirectoriesExist();
+
+            Assert.Equal(Path.Combine(basePath, "runtime"), paths.RuntimeDirectory);
+            Assert.True(Directory.Exists(paths.RuntimeDirectory));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath))
+                Directory.Delete(basePath, recursive: true);
+        }
     }
 
     [Theory]

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="NetclawPaths.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -111,6 +111,7 @@ public sealed class NetclawPaths
     public string DevicesPath => Path.Combine(ConfigDirectory, "devices.json");
     public string BootstrapStatePath => Path.Combine(ConfigDirectory, "bootstrap-state.json");
     public string LogsDirectory => Path.Combine(BasePath, "logs");
+    public string RuntimeDirectory => Path.Combine(BasePath, "runtime");
     /// <summary>
     /// Per-session log files live at <c>{SessionLogsDirectory}/{sanitized_id}/session.log</c>.
     /// This tree is deliberately kept outside <see cref="SessionsDirectory"/> so
@@ -127,11 +128,14 @@ public sealed class NetclawPaths
 
     public NetclawPaths(string? basePath = null, string? workspacesDirectory = null)
     {
-        BasePath = PathExpansion.ExpandHome(basePath)
+        var resolvedBasePath = PathExpansion.ExpandHome(basePath)
             ?? PathExpansion.ExpandHome(Environment.GetEnvironmentVariable("NETCLAW_HOME"))
             ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".netclaw");
+        // The daemon changes its process directory after bootstrap. Freeze the base
+        // path now so soft restarts cannot reinterpret a relative NETCLAW_HOME.
+        BasePath = Path.GetFullPath(resolvedBasePath);
         WorkspacesDirectory = PathExpansion.ExpandHome(workspacesDirectory) ?? Path.Combine(BasePath, "workspaces");
     }
 
@@ -179,6 +183,7 @@ public sealed class NetclawPaths
         yield return ConfigDirectory;
         yield return WebhooksDirectory;
         yield return LogsDirectory;
+        yield return RuntimeDirectory;
         yield return SessionLogsDirectory;
         yield return AgentsDirectory;
         yield return ServerFeedAgentsDirectory;

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -101,7 +101,7 @@ try
             // surfaced on /api/health/ready so the init wizard can confirm a config
             // reload actually restarted the daemon (#1302).
             restartSignal.AdvanceGeneration();
-            await RunDaemonAsync(args, restartSignal, crashMonitor);
+            await RunDaemonAsync(args, restartSignal, crashMonitor, bootstrapPaths);
         } while (restartSignal.RestartRequested);
     }
 }
@@ -117,15 +117,19 @@ catch (Exception ex)
     throw;
 }
 
-static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSignal, DaemonCrashMonitor crashMonitor)
+static async Task RunDaemonAsync(
+    string[] args,
+    DaemonRestartSignal restartSignal,
+    DaemonCrashMonitor crashMonitor,
+    NetclawPaths bootstrapPaths)
 {
-    // Anchor process CWD to a user-owned temp directory.
+    // Anchor the process CWD to a durable user-owned directory.
     // Without this, the daemon runs from its install location (e.g. /usr/local/bin),
     // which means shell commands, relative file paths, and stdio MCP child processes
     // (Playwright screenshots, etc.) all default to a potentially privileged directory.
-    var netclawTempDir = Path.Combine(Path.GetTempPath(), "netclaw");
-    Directory.CreateDirectory(netclawTempDir);
-    Environment.CurrentDirectory = netclawTempDir;
+    // OS temp cleanup can remove a live process CWD, so this directory must stay
+    // under the Netclaw home instead of the system temp directory.
+    Environment.CurrentDirectory = bootstrapPaths.RuntimeDirectory;
 
     // Resolve inside each daemon generation. A soft restart is allowed to
     // select a newly installed compatible host, but one running generation
@@ -141,7 +145,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     // Load configuration first (netclaw.json, secrets.json, env vars) so that
     // DaemonConfig.Host/Port can be read before binding the WebHost URL.
-    var paths = ConfigureConfigServices(builder.Services, builder.Configuration);
+    var paths = ConfigureConfigServices(builder.Services, builder.Configuration, bootstrapPaths);
 
     // Bind listen address from DaemonConfig; falls back to 127.0.0.1:5199 if
     // the Daemon section is absent from netclaw.json.
@@ -355,11 +359,11 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 // Shared configuration services
 // ═══════════════════════════════════════════════════════════════════════
 
-static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfigurationManager configuration)
+static NetclawPaths ConfigureConfigServices(
+    IServiceCollection services,
+    IConfigurationManager configuration,
+    NetclawPaths bootstrapPaths)
 {
-    // Bootstrap paths with defaults to locate config files.
-    var bootstrapPaths = new NetclawPaths();
-
     // Initialize Data Protection for secrets encryption/decryption.
     // Must happen before config binding so SensitiveStringTypeConverter
     // can transparently decrypt ENC: values.
@@ -378,7 +382,7 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
 
     // Re-create paths with config-driven overrides (e.g. custom workspaces directory).
     var workspacesDir = configuration.GetValue<string>("Workspaces:Directory");
-    var paths = new NetclawPaths(workspacesDirectory: workspacesDir);
+    var paths = new NetclawPaths(bootstrapPaths.BasePath, workspacesDir);
     paths.EnsureDirectoriesExist();
     services.AddSingleton(paths);
 

--- a/src/Netclaw.Security.Tests/PathUtilityTests.cs
+++ b/src/Netclaw.Security.Tests/PathUtilityTests.cs
@@ -50,6 +50,33 @@ public sealed class PathUtilityTests
     }
 
     [Fact]
+    public void TryNormalize_does_not_resolve_process_directory_for_fully_qualified_path()
+    {
+        var absolutePath = Path.GetTempPath();
+        var success = PathUtility.TryNormalize(
+            absolutePath,
+            workingDirectory: null,
+            static () => throw new DirectoryNotFoundException("Process working directory was deleted."),
+            out var normalized);
+
+        Assert.True(success);
+        Assert.Equal(PathUtility.Normalize(absolutePath), normalized);
+    }
+
+    [Fact]
+    public void TryNormalize_fails_closed_when_relative_path_has_no_process_directory()
+    {
+        var success = PathUtility.TryNormalize(
+            "relative/path",
+            workingDirectory: null,
+            static () => throw new DirectoryNotFoundException("Process working directory was deleted."),
+            out var normalized);
+
+        Assert.False(success);
+        Assert.Empty(normalized);
+    }
+
+    [Fact]
     public void IsWithinRoot_returns_true_for_exact_match()
     {
         Assert.True(PathUtility.IsWithinRoot("/home/user", "/home/user"));

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -29,17 +29,33 @@ public static class PathUtility
     /// Attempts to normalize a path relative to a working directory.
     /// </summary>
     public static bool TryNormalize(string path, string? workingDirectory, out string normalized)
+        => TryNormalize(
+            path,
+            workingDirectory,
+            static () => Environment.CurrentDirectory,
+            out normalized);
+
+    internal static bool TryNormalize(
+        string path,
+        string? workingDirectory,
+        Func<string> currentDirectoryResolver,
+        out string normalized)
     {
+        ArgumentNullException.ThrowIfNull(currentDirectoryResolver);
         normalized = string.Empty;
         try
         {
+            if (Path.IsPathFullyQualified(path))
+            {
+                normalized = Normalize(path);
+                return true;
+            }
+
             var baseDir = !string.IsNullOrWhiteSpace(workingDirectory)
                 ? workingDirectory
-                : Environment.CurrentDirectory;
+                : currentDirectoryResolver();
 
-            normalized = Path.IsPathRooted(path)
-                ? Normalize(path)
-                : Normalize(Path.Combine(baseDir, path));
+            normalized = Normalize(Path.Combine(baseDir, path));
             return true;
         }
         catch


### PR DESCRIPTION
## Summary

- move the daemon process working directory from `/tmp/netclaw` to the durable Netclaw runtime directory
- canonicalize the Netclaw base path before the daemon changes directories and reuse it across soft restarts
- let fully qualified path normalization proceed without reading a deleted process CWD while relative paths remain fail closed
- add regression coverage for relative `NETCLAW_HOME`, idempotent runtime-directory creation, and deleted-CWD normalization

## Root cause

The installed daemon used `/tmp/netclaw` as its process working directory. Routine temporary-directory cleanup could delete that directory while the daemon was still alive. `PathUtility.TryNormalize` then read `Environment.CurrentDirectory` even for fully qualified paths, so otherwise valid shell working directories failed authorization as `shell_invalid_working_directory`.

## Validation

- `dotnet build Netclaw.slnx -c Release --no-restore` (0 warnings, 0 errors)
- `dotnet test Netclaw.slnx -c Release --no-restore` (6,802 passed, 15 skipped, 0 failed)
- `dotnet slopwatch analyze --fail-on warning` (0 issues)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- scoped `dotnet format --verify-no-changes`
- `git diff --check`
- adversarial review: no blockers

The deployed 0.26.0-beta.1 daemon was restarted and is healthy. It still uses `/tmp/netclaw` because the installed binary predates this change; a build that contains this PR will use `~/.netclaw/runtime`.
