### PR TITLE
ci: backfill per-version checksum files for older releases (one-time)

### DIFF
--- a/.github/workflows/backfill_release_checksums.yml
+++ b/.github/workflows/backfill_release_checksums.yml
@@ -1,0 +1,243 @@
+# One-time, manually invoked backfill of per-version checksums-<rid>.txt files.
+#
+# Why this exists:
+#   PR #1792 made install.sh require $FEED_BASE_URL/$VERSION/checksums-$RID.txt,
+#   and PR #1793 started uploading that file — but only for releases cut AFTER
+#   those PRs merged. Every earlier version has its archives on the feed with no
+#   checksum file, so the current installer fails with a 404 for them.
+#
+# What it does:
+#   Rebuilds each missing checksum file from the SIGNED release manifest, which
+#   already records the sha256 and sizeBytes of every asset. The manifest values
+#   are authoritative: the release pipeline computes them from the exact archive
+#   it uploads to R2 in the same job. This workflow verifies the manifest
+#   signature before it trusts a byte, confirms each archive exists on the feed
+#   before it publishes a checksum for it, and skips files that already exist.
+#
+# This workflow is disposable. Delete it once the backfill is complete.
+name: Backfill Release Checksums (one-time)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Plan only: stage files and print the plan, upload nothing"
+        type: boolean
+        default: true
+      force:
+        description: "Overwrite checksum files that already exist on the feed"
+        type: boolean
+        default: false
+      only_version:
+        description: "Limit to a single version (blank = all versions in the manifest)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+# Never let two backfills write the feed at the same time.
+concurrency:
+  group: backfill-release-checksums
+  cancel-in-progress: false
+
+env:
+  FEED_BASE_URL: https://releases.netclaw.dev
+
+jobs:
+  backfill:
+    name: Backfill checksums to R2
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (for the manifest public key)
+        uses: actions/checkout@v7
+
+      - name: Fetch signed manifest from the feed
+        run: |
+          set -euo pipefail
+          mkdir -p ./feed
+          curl -fsSL --max-time 30 "$FEED_BASE_URL/manifest.json"     -o ./feed/manifest.json
+          curl -fsSL --max-time 30 "$FEED_BASE_URL/manifest.json.sig" -o ./feed/manifest.json.sig
+
+      - name: Install minisign
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Verify manifest signature
+        # The manifest's sha256 values are the source every checksum file is built
+        # from. Verify the signature against the committed public key before we
+        # trust any of them — a tampered manifest must not become published checksums.
+        run: |
+          minisign -V \
+            -p ./feeds/releases/manifest.pub \
+            -m ./feed/manifest.json \
+            -x ./feed/manifest.json.sig
+
+      - name: Stage missing checksum files
+        id: stage
+        env:
+          MANIFEST: ./feed/manifest.json
+          STAGING: ./staging
+          ONLY_VERSION: ${{ inputs.only_version }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          python3 - <<'PY'
+          import json, os, time, urllib.request, urllib.error
+          from pathlib import PurePosixPath
+          from concurrent.futures import ThreadPoolExecutor
+
+          BASE = os.environ["FEED_BASE_URL"].rstrip("/")
+          MANIFEST = os.environ["MANIFEST"]
+          STAGING = os.environ["STAGING"]
+          ONLY = os.environ.get("ONLY_VERSION", "").strip()
+          FORCE = os.environ.get("FORCE", "false").lower() == "true"
+
+          # Cloudflare 403s the default Python-urllib User-Agent, so send a
+          # curl-like UA. These are read-only existence probes, not auth.
+          UA = {"User-Agent": "netclaw-backfill/1.0 (+https://github.com/netclaw-dev/netclaw)"}
+
+          # Only 200 (present) and 404 (absent) are decisive. Any other outcome —
+          # 429/5xx/timeout under concurrency — is transient: retry, then fail
+          # loudly. Never treat a transient error as "absent", or we would drop a
+          # real archive and publish an incomplete checksum file.
+          def head_ok(url, attempts=4):
+              last = None
+              for i in range(attempts):
+                  req = urllib.request.Request(url, method="HEAD", headers=UA)
+                  try:
+                      with urllib.request.urlopen(req, timeout=20) as r:
+                          return url, r.status == 200
+                  except urllib.error.HTTPError as e:
+                      if e.code == 404:
+                          return url, False
+                      last = f"HTTP {e.code}"
+                  except urllib.error.URLError as e:
+                      last = f"URLError {e.reason}"
+                  time.sleep(1.5 * (i + 1))
+              raise SystemExit(f"HEAD {url} unresolved after {attempts} attempts (last={last})")
+
+          with open(MANIFEST) as f:
+              manifest = json.load(f)
+
+          releases = [r for r in manifest.get("releases", []) if not ONLY or r["version"] == ONLY]
+          if ONLY and not releases:
+              raise SystemExit(f"version '{ONLY}' is not in the manifest")
+
+          # Collect every URL we need to probe, then check them concurrently.
+          probe = set()
+          for rel in releases:
+              v = rel["version"]
+              rids = {a["rid"] for a in rel.get("assets", [])}
+              for rid in rids:
+                  probe.add(f"{BASE}/{v}/checksums-{rid}.txt")
+              for a in rel.get("assets", []):
+                  probe.add(f"{BASE}/{v}/{PurePosixPath(a['url']).name}")
+
+          with ThreadPoolExecutor(max_workers=16) as ex:
+              exists = dict(ex.map(head_ok, probe))
+
+          os.makedirs(STAGING, exist_ok=True)
+          staged, skip_present, skip_no_archive = [], [], []
+
+          for rel in releases:
+              v = rel["version"]
+              by_rid = {}
+              for a in rel.get("assets", []):
+                  by_rid.setdefault(a["rid"], []).append(a)
+
+              for rid, assets in sorted(by_rid.items()):
+                  ck_url = f"{BASE}/{v}/checksums-{rid}.txt"
+                  present = exists[ck_url]
+                  if present and not FORCE:
+                      skip_present.append((v, rid))
+                      continue
+
+                  lines, missing = [], []
+                  for a in sorted(assets, key=lambda a: PurePosixPath(a["url"]).name):
+                      fn = PurePosixPath(a["url"]).name
+                      if exists[f"{BASE}/{v}/{fn}"]:
+                          lines.append(f"{a['sha256']}  {fn}  {a['sizeBytes']}")
+                      else:
+                          missing.append(fn)
+
+                  if not lines:
+                      skip_no_archive.append((v, rid, missing))
+                      continue
+
+                  out_dir = os.path.join(STAGING, v)
+                  os.makedirs(out_dir, exist_ok=True)
+                  with open(os.path.join(out_dir, f"checksums-{rid}.txt"), "w", newline="\n") as fh:
+                      fh.write("\n".join(lines) + "\n")
+                  staged.append((v, rid, len(lines), missing, present))
+
+          # Console log
+          print(f"stage (upload): {len(staged)}")
+          print(f"skip (already present): {len(skip_present)}")
+          print(f"skip (no archive on feed): {len(skip_no_archive)}")
+          for v, rid, missing in skip_no_archive:
+              print(f"  - {v}/checksums-{rid}.txt  (no archives on feed: {', '.join(missing)})")
+
+          # Job summary (markdown)
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a") as s:
+                  s.write("## Checksum backfill plan\n\n")
+                  s.write(f"- **Stage (upload):** {len(staged)}\n")
+                  s.write(f"- **Skip (already present):** {len(skip_present)}\n")
+                  s.write(f"- **Skip (no archive on feed):** {len(skip_no_archive)}\n\n")
+                  if staged:
+                      s.write("### Files to upload\n\n")
+                      for v, rid, n, missing, ov in sorted(staged):
+                          tag = " _(overwrite)_" if ov else ""
+                          m = f" — partial, missing: {', '.join(missing)}" if missing else ""
+                          s.write(f"- `{v}/checksums-{rid}.txt` ({n} lines){tag}{m}\n")
+                      s.write("\n")
+                  if skip_no_archive:
+                      s.write("### Skipped: archives absent from feed\n\n")
+                      for v, rid, missing in sorted(skip_no_archive):
+                          s.write(f"- `{v}/checksums-{rid}.txt` — {', '.join(missing)}\n")
+
+          out = os.environ.get("GITHUB_OUTPUT")
+          if out:
+              with open(out, "a") as o:
+                  o.write(f"staged_count={len(staged)}\n")
+          PY
+
+      - name: Show staged files
+        run: |
+          echo "Staged checksum files:"
+          find ./staging -type f -name 'checksums-*.txt' 2>/dev/null | sort || true
+
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "::notice::Dry run — nothing uploaded. Re-run with dry_run=false to publish."
+
+      - name: Install Wrangler
+        if: ${{ !inputs.dry_run && steps.stage.outputs.staged_count != '0' }}
+        run: |
+          npm install wrangler@3.90.0 --include=optional
+          echo "$(pwd)/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Upload staged checksum files to R2
+        if: ${{ !inputs.dry_run && steps.stage.outputs.staged_count != '0' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          count=0
+          for f in ./staging/*/checksums-*.txt; do
+            [ -f "$f" ] || continue
+            version="$(basename "$(dirname "$f")")"
+            rid="$(basename "$f" .txt)"; rid="${rid#checksums-}"
+            echo "Uploading $version/checksums-$rid.txt"
+            wrangler r2 object put \
+              "netclaw-releases/$version/checksums-$rid.txt" \
+              --file="$f" \
+              --content-type=text/plain
+            count=$((count + 1))
+          done
+          echo "Uploaded $count checksum file(s)." | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The install script requires a `checksums-<rid>.txt` file for each version.
PR #1792 added the requirement. PR #1793 started to upload the file. Both
merged together, so only releases after that pair have the file. Every older
version fails:

```
curl: (22) The requested URL returned error: 404
Error: Failed to fetch checksum file from
https://releases.netclaw.dev/0.25.4/checksums-linux-x64.txt
```

Version `0.25.4` is the current stable `latest`, so the plain
`curl install.sh | bash` path is broken too.

## Fix

A one-time, manually invoked workflow rebuilds each absent checksum file from
the **signed** release manifest. The manifest already records the `sha256` and
`sizeBytes` of every asset, so no archive re-download is needed.

Safety properties:

- Verifies the manifest signature (`minisign` + committed `manifest.pub`)
  before it trusts any value.
- Publishes a checksum only for an archive that exists on the feed. The
  per-asset guard drops phantom lines; `0.1.3` is partial (CLI absent, daemon
  present) and stages only its real lines.
- Idempotent. It skips files already on the feed; `force` overwrites.
- `dry_run` defaults to `true`. A production write needs `dry_run=false`.
- Retries transient errors and fails loudly. It never treats a 429/5xx as
  "archive absent".

## Validation (against the live feed)

- **Byte-exact:** generation reproduces the real `0.26.0-beta.1` checksum files
  for all four RIDs, byte for byte.
- **Plan scope:** 276 files to upload (`0.2.0` through `0.25.4`), 4 already
  present (`0.26.0-beta.1`), 9 phantom skips (`0.1.0`-`0.1.2`, never on R2).
- **Heredoc:** the embedded Python was extracted through a real YAML parse; it
  compiles and runs after block-scalar de-indent.

## How to run

1. Dispatch with `dry_run: true`. Read the plan in the job summary.
2. Dispatch with `dry_run: false`. It uploads via the release R2 credentials.
3. Delete this workflow file after the backfill lands.
