### PR TITLE
Release 0.26.0-beta.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,9 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.26.0</VersionPrefix>
-    <VersionSuffix>beta.1</VersionSuffix>
+    <VersionSuffix>beta.2</VersionSuffix>
     <PackageReleaseNotes>
-      Features: MCP OAuth surfaced at add time; mention-required thread replies with history backfill; file-read permissions match shell reach; TUI state preserved across navigation; background job and one-shot reminder cleanup. Bug fixes: approval prompts skip already-granted candidates; safe shell stages compose with one-time grants; background job control bypasses approval; failed one-shot reminders retry; phantom directory scopes and quoted free-text operands removed from stored patterns; trailing-slash globs scoped to parent; ToolAccessPolicy fail-closed. Dependency updates: Termina 0.16.1, SkiaSharp 4.151.1, Verify.XunitV3 31.28.0.
+      Features: MCP server prompts loadable as dynamic skills; native PowerShell on Windows with 5.1 fallback. Bug fixes: reminders no longer skipped on execution capacity; OAuth-broken MCP connections demote to AwaitingAuth with operator alert; MCP HTTP fallback header race fixed; daemon working directory preserved across restarts; /dev/null redirects no longer open a reusable /dev scope; PowerShell host probe retries cold starts and falls back to 5.1. Internal: shell approval analysis migrated to ShellSyntaxTree fail-closed parser; reduced PowerShell approval repetition; pinned Bash hidden-execution boundaries; PowerShell execution-region approvals. Dependency updates: SlackNet 0.17.11, ShellSyntaxTree 0.3.0-alpha.6.
     </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,29 @@
 # NetClaw Release Notes
 
+## 0.26.0-beta.2 (2026-08-10)
+
+### Features
+- **MCP server prompts as dynamic skills** — Prompts exposed by connected MCP servers are now loadable through the skill index, with argument validation and cross-server conflict rejection ([#1813](https://github.com/netclaw-dev/netclaw/pull/1813))
+- **Native PowerShell on Windows** — The daemon now runs Windows shell execution through native PowerShell (7.6 preferred, 5.1 fallback) instead of cross-language emulation, with unified execution, analysis, and approval policy ([#1848](https://github.com/netclaw-dev/netclaw/pull/1848))
+
+### Bug Fixes
+- **Reminders no longer skipped on capacity** — The execution-capacity gate that settled reminders as skipped is removed; reminders now defer instead of silently dropping ([#1839](https://github.com/netclaw-dev/netclaw/pull/1839))
+- **MCP: dead OAuth connections no longer report Connected forever** — Servers with expired OAuth tokens demote to AwaitingAuth with an operator alert instead of wedging the daemon ([#1841](https://github.com/netclaw-dev/netclaw/pull/1841))
+- **MCP: HTTP protocol fallback header race fixed** — The stale MCP protocol-version header is only removed from initialize requests; daemon and CLI now share one HTTP client ([#1861](https://github.com/netclaw-dev/netclaw/pull/1861))
+- **Daemon working directory preserved** — The daemon no longer runs from a temp directory that cleanup could delete out from under it ([#1853](https://github.com/netclaw-dev/netclaw/pull/1853))
+- **`/dev/null` approval scope fixed** — Safe commands redirecting to `/dev/null` no longer create a reusable `/dev` approval scope ([#1852](https://github.com/netclaw-dev/netclaw/pull/1852))
+- **PowerShell host probe hardened** — Slow `pwsh` cold starts no longer brick daemon startup; the probe retries and falls back to Windows PowerShell 5.1 ([#1859](https://github.com/netclaw-dev/netclaw/pull/1859))
+
+### Internal Improvements
+- **Shell approval analysis migrated to ShellSyntaxTree** — Bash and PowerShell approval decisions now use the ShellSyntaxTree parser with fail-closed unknown syntax ([#1835](https://github.com/netclaw-dev/netclaw/pull/1835), [#1836](https://github.com/netclaw-dev/netclaw/pull/1836), [#1855](https://github.com/netclaw-dev/netclaw/pull/1855))
+- **PowerShell approval repetition reduced** — Safe PowerShell command sequences prompt less often ([#1837](https://github.com/netclaw-dev/netclaw/pull/1837))
+- **Bash hidden-execution approval boundaries pinned** — `source` builtins and nameref-deferred execution now require one-shot approvals ([#1838](https://github.com/netclaw-dev/netclaw/pull/1838))
+- **PowerShell execution-region approvals improved** — Host and body commands must each match approval policy independently ([#1857](https://github.com/netclaw-dev/netclaw/pull/1857))
+
+### Dependency Updates
+- **Bump SlackNet** — 0.17.10 → 0.17.11 ([#1844](https://github.com/netclaw-dev/netclaw/pull/1844))
+- **Bump ShellSyntaxTree** — 0.2.0 → 0.3.0-alpha.6
+
 ## 0.26.0-beta.1 (2026-08-09)
 
 ### Features


### PR DESCRIPTION
## Release 0.26.0-beta.2

Version bump: `0.26.0-beta.1` → `0.26.0-beta.2`

### Features
- **MCP server prompts as dynamic skills** (#1813)
- **Native PowerShell on Windows** (#1848)

### Bug Fixes
- Reminders no longer skipped on capacity (#1839)
- MCP dead OAuth connections no longer report Connected forever (#1841)
- MCP HTTP protocol fallback header race fixed (#1861)
- Daemon working directory preserved (#1853)
- `/dev/null` approval scope fixed (#1852)
- PowerShell host probe hardened against cold-start timeouts (#1859)

### Internal
- Shell approval analysis migrated to ShellSyntaxTree (#1835, #1836, #1855)
- PowerShell approval repetition reduced (#1837)
- Bash hidden-execution approval boundaries pinned (#1838)
- PowerShell execution-region approvals improved (#1857)

### Dependency Updates
- SlackNet 0.17.10 → 0.17.11 (#1844)
- ShellSyntaxTree 0.2.0 → 0.3.0-alpha.6

Full notes: [RELEASE_NOTES.md](RELEASE_NOTES.md)