### PR TITLE
fix(mcp): adopt ModelContextProtocol 2.1.0 without losing invalid_client discard

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
          that trips NU1902 under our TreatWarningsAsErrors policy. -->
     <AspireHostingVersion>13.4.6</AspireHostingVersion>
     <CommunityToolkitAspireVersion>13.4.0</CommunityToolkitAspireVersion>
-    <ModelContextProtocolVersion>2.0.0</ModelContextProtocolVersion>
+    <ModelContextProtocolVersion>2.1.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/src/Netclaw.Configuration.Tests/Http/OAuthClientRejectionHandlerTests.cs
+++ b/src/Netclaw.Configuration.Tests/Http/OAuthClientRejectionHandlerTests.cs
@@ -1,0 +1,118 @@
+// -----------------------------------------------------------------------
+// <copyright file="OAuthClientRejectionHandlerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using Netclaw.Configuration.Http;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Http;
+
+public sealed class OAuthClientRejectionHandlerTests
+{
+    [Fact]
+    public async Task Authorization_code_exchange_rejected_with_invalid_client_throws()
+    {
+        var error = await Assert.ThrowsAsync<McpOAuthClientRejectedException>(() =>
+            ExchangeAsync(
+                grant: "authorization_code",
+                status: HttpStatusCode.BadRequest,
+                body: """{"error":"invalid_client"}"""));
+
+        // The message carries the OAuth error code so the manager's message-based checks match.
+        Assert.Contains("invalid_client", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Refresh_grant_rejected_with_invalid_client_passes_through()
+    {
+        // A refresh failure must keep the SDK's graceful null path, so the handler stays out
+        // of the way even when the error code matches.
+        var response = await ExchangeAsync(
+            grant: "refresh_token",
+            status: HttpStatusCode.BadRequest,
+            body: """{"error":"invalid_client"}""");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(
+            "invalid_client",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Authorization_code_exchange_with_other_error_passes_through()
+    {
+        var response = await ExchangeAsync(
+            grant: "authorization_code",
+            status: HttpStatusCode.BadRequest,
+            body: """{"error":"invalid_grant"}""");
+
+        // The body must survive the handler's inspection so the SDK can still read it.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(
+            "invalid_grant",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Successful_authorization_code_exchange_passes_through()
+    {
+        var response = await ExchangeAsync(
+            grant: "authorization_code",
+            status: HttpStatusCode.OK,
+            body: """{"access_token":"token"}""");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains(
+            "access_token",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Non_form_request_passes_through_even_on_bad_request()
+    {
+        // MCP JSON-RPC traffic never carries a grant_type; a 400 with the literal text must
+        // not be mistaken for a token rejection.
+        using var handler = new OAuthClientRejectionHandler { InnerHandler = new StubHandler(HttpStatusCode.BadRequest, """{"error":"invalid_client"}""") };
+        using var client = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.invalid/mcp")
+        {
+            Content = new StringContent("""{"jsonrpc":"2.0"}""", System.Text.Encoding.UTF8, "application/json"),
+        };
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static async Task<HttpResponseMessage> ExchangeAsync(string grant, HttpStatusCode status, string body)
+    {
+        var handler = new OAuthClientRejectionHandler { InnerHandler = new StubHandler(status, body) };
+        var client = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.invalid/oauth/token")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = grant,
+                ["client_id"] = "client-1",
+            }),
+        };
+
+        return await client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            });
+    }
+}

--- a/src/Netclaw.Configuration/Http/McpHttpClientFactory.cs
+++ b/src/Netclaw.Configuration/Http/McpHttpClientFactory.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
+
 namespace Netclaw.Configuration.Http;
 
 /// <summary>
@@ -29,9 +31,15 @@ internal static class McpHttpClientFactory
     internal static HttpClient Create(HttpMessageHandler innerHandler)
     {
         ArgumentNullException.ThrowIfNull(innerHandler);
-        return new HttpClient(new ProtocolVersionHandler
+
+        // Order matters: the rejection handler must see the token endpoint's final
+        // response, so it wraps the protocol-version handler rather than the reverse.
+        return new HttpClient(new OAuthClientRejectionHandler
         {
-            InnerHandler = innerHandler,
+            InnerHandler = new ProtocolVersionHandler
+            {
+                InnerHandler = innerHandler,
+            },
         });
     }
 
@@ -61,3 +69,73 @@ internal static class McpHttpClientFactory
         }
     }
 }
+
+/// <summary>
+/// Surfaces an OAuth <c>invalid_client</c> rejection from the token endpoint as a distinct
+/// exception the MCP SDK does not recognize.
+/// </summary>
+/// <remarks>
+/// MCP SDK 2.1 probes the server with <c>server/discover</c> before the initialize
+/// handshake. When the authorization-code exchange for that probe fails with
+/// <c>400 invalid_client</c>, the SDK reads the 400 as an unsupported-protocol signal,
+/// falls back to the initialize handshake, and calls the one-shot authorization callback a
+/// second time. That second call fails as "authorization already in progress" and hides the
+/// real reason the exchange failed, so the manager can no longer tell a dead dynamic client
+/// registration from any other connection failure. This handler reads the token error before
+/// the SDK sees the 400 and throws a type the discover fallback does not catch, so the true
+/// cause reaches the manager. The exchange is doomed either way; the throw only replaces the
+/// misleading failure with an accurate one.
+/// </remarks>
+internal sealed class OAuthClientRejectionHandler : DelegatingHandler
+{
+    private const string FormContentType = "application/x-www-form-urlencoded";
+    private const string AuthorizationCodeGrant = "grant_type=authorization_code";
+    private const string InvalidClientError = "invalid_client";
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Only the OAuth token endpoint sends form-urlencoded bodies; MCP JSON-RPC traffic is
+        // JSON. Skip the body read for everything else so tool-call payloads stay untouched.
+        if (request.Method != HttpMethod.Post
+            || request.Content?.Headers.ContentType?.MediaType != FormContentType)
+        {
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        var requestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+        var response = await base.SendAsync(request, cancellationToken);
+
+        // Only the authorization-code exchange drives client-identity discard. A refresh
+        // failure keeps the SDK's graceful null path, so it is deliberately left untouched.
+        if (response.StatusCode is HttpStatusCode.BadRequest
+            && requestBody.Contains(AuthorizationCodeGrant, StringComparison.Ordinal)
+            && await IsInvalidClientErrorAsync(response))
+        {
+            response.Dispose();
+            throw new McpOAuthClientRejectedException();
+        }
+
+        return response;
+    }
+
+    private static async Task<bool> IsInvalidClientErrorAsync(HttpResponseMessage response)
+    {
+        // Buffer the small error body so the check does not consume the stream the caller
+        // would read on the pass-through path.
+        await response.Content.LoadIntoBufferAsync();
+        var body = await response.Content.ReadAsStringAsync();
+        return body.Contains(InvalidClientError, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Signals that the OAuth token endpoint rejected the client registration with
+/// <c>invalid_client</c>. The message carries the OAuth error code so the manager's
+/// message-based auth-failure checks recognize it.
+/// </summary>
+internal sealed class McpOAuthClientRejectedException()
+    : Exception(
+        "The OAuth token endpoint rejected the client registration (invalid_client). " +
+        "The dynamic client identity is no longer valid and must be discarded.");

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -25,6 +25,7 @@ using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Configuration.Http;
 using Netclaw.Configuration.Secrets;
 using Netclaw.Daemon.Mcp;
 using Netclaw.Tests.Utilities;
@@ -812,7 +813,10 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         public IClientTransport CreateHttpTransport(HttpClientTransportOptions options)
         {
             LastHttpOptions = options;
-            return new HttpClientTransport(options, server.CreateHttpClient(), ownsHttpClient: true);
+            // Mirror the production runtime: the SDK's OAuth token exchange runs through the
+            // rejection handler, so a 400 invalid_client surfaces instead of the SDK's
+            // protocol fallback masking it.
+            return new HttpClientTransport(options, server.CreateTransportHttpClient(), ownsHttpClient: true);
         }
 
         public Task<McpClient> CreateAsync(
@@ -1033,6 +1037,22 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         {
             var client = _app.GetTestClient();
             client.BaseAddress = _state.Origin;
+            return client;
+        }
+
+        /// <summary>
+        /// Builds the client the SDK transport uses, wrapping the in-memory test server with
+        /// the same OAuth rejection handler the production runtime installs.
+        /// </summary>
+        public HttpClient CreateTransportHttpClient()
+        {
+            var client = new HttpClient(new OAuthClientRejectionHandler
+            {
+                InnerHandler = _app.GetTestServer().CreateHandler(),
+            })
+            {
+                BaseAddress = _state.Origin,
+            };
             return client;
         }
 

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -1410,7 +1410,11 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     /// so an operator-pinned OAuthClientId is never discarded behind their back.
     /// </summary>
     private static bool IsInvalidClientFailure(Exception ex)
-        => ex.Message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
+        // SDK 2.1's discover probe swallows the token endpoint's 400 invalid_client as a
+        // protocol-fallback signal, so OAuthClientRejectionHandler re-throws it as this type
+        // before the SDK can hide it. The message check below still covers a raw SDK failure.
+        => ex is McpOAuthClientRejectedException
+           || ex.Message.Contains("invalid_client", StringComparison.OrdinalIgnoreCase)
            // A registration is bound to the issuer that granted it. When the resource server
            // moves to a new issuer, SDK 2.0 refuses to reuse the old one and offers no remedy
            // of its own, so the stale identity has to go or every retry repeats the failure.


### PR DESCRIPTION
## Summary

Adopt the ModelContextProtocol 2.1.0 SDK (`ModelContextProtocol.Core` and
`ModelContextProtocol.AspNetCore`, both driven by the shared
`ModelContextProtocolVersion` property). This supersedes the two failing
Dependabot PRs #1777 (AspNetCore) and #1778 (Core), which can be closed.

The straight version bump fails one test:
`McpSdkOAuthFlowIntegrationTests.RejectedClientIdentityIsDiscardedSoTheNextAuthorizationRegistersAfresh`.

## Root cause

SDK 2.1 sends a `server/discover` probe before the `initialize` handshake. Its
new catch reads any `400`/`404` response as an unsupported-protocol signal and
falls back to the initialize handshake. During interactive OAuth, the probe's
authorization-code exchange returns `400 invalid_client` when the provider has
dropped the dynamic client registration. The SDK swallows that `400` as a
protocol-fallback signal and re-invokes the one-shot authorization callback a
second time. The second call trips the flow's single-owner guard and throws
`OAuth authorization is already in progress`, which hides the real
`invalid_client`. `McpClientManager.IsInvalidClientFailure` no longer matches,
so the dead dynamic client identity is never discarded and every retry repeats
the failure.

`ClientOAuthProvider` itself is byte-identical between 2.0.0 and 2.1.0
(decompiled and diffed). The change is entirely in `McpClientImpl`'s new
discover/fallback path.

## Fix

Add `OAuthClientRejectionHandler` to the shared MCP HTTP pipeline
(`McpHttpClientFactory`). The handler reads the token endpoint's `invalid_client`
error for the `authorization_code` grant and throws
`McpOAuthClientRejectedException` before the SDK sees the `400`. The SDK fallback
does not catch that type, so the true cause reaches the manager and the dead
identity is discarded — restoring the exact 2.0.0 behavior without disabling
protocol negotiation. The handler is scoped to the authorization-code grant, so
a refresh failure keeps the SDK's graceful null path.

## Testing

- `McpSdkOAuthFlowIntegrationTests` — 23/23 pass (was 22/23)
- `Netclaw.Daemon.Tests` full — 1001 pass
- `Netclaw.Cli.Tests` — 1318 pass
- `Netclaw.Actors.Tests` — 3042 pass (1 Windows-only skip)
- `Netclaw.Configuration.Tests` Http/Mcp — 16 pass, plus 5 new
  `OAuthClientRejectionHandlerTests` locking the handler's discriminators
  (authorization-code invalid_client throws; refresh invalid_client, other
  errors, success, and non-form requests pass through)
- Full solution build clean; `dotnet slopwatch analyze` reports 0 issues;
  copyright headers verified
