### PR TITLE
fix(test): per-delivery hang-guard budget in webhook delivery wait

### DIFF
--- a/src/Netclaw.Daemon.Tests/Services/WebhookTestInfrastructure.cs
+++ b/src/Netclaw.Daemon.Tests/Services/WebhookTestInfrastructure.cs
@@ -17,9 +17,17 @@ internal static class WebhookTestInfrastructure
         int expectedCount,
         int timeoutMs = 5000)
     {
-        using var cts = new CancellationTokenSource(timeoutMs);
+        // One budget per delivery — this is a hang guard, not a wall-clock limit
+        // for the whole batch. Deliveries are sequential (DeliverToAllTargetsAsync),
+        // so a single shared CTS let a slow delivery #1 consume the budget of the
+        // rest on loaded CI machines. A genuinely stuck delivery still fails in
+        // timeoutMs. A bare timeout bump would keep the coupling between
+        // deliveries; per-delivery removes it.
         for (var i = 0; i < expectedCount; i++)
+        {
+            using var cts = new CancellationTokenSource(timeoutMs);
             await handler.DeliverySemaphore.WaitAsync(cts.Token);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`SlackBlockKitWebhookFormatterTests.MixedFormats_EachTargetGetsCorrectPayload` flaked on Windows CI (run 31445886074, dev push) with `TaskCanceledException` from `WaitForDeliveryAsync`.

The helper created **one** `CancellationTokenSource` before the loop, so a single 5s budget covered **all** `expectedCount` deliveries — while production delivery (`DeliverToAllTargetsAsync`) is **sequential** (`foreach` + `await`). On a loaded runner, delivery #1 consumed most of the budget and delivery #2's semaphore wait threw. Same family as issue #1442 (fixed budget racing sequential async work).

## Fix

Move the CTS **inside** the loop so each delivery gets its own `timeoutMs` hang-guard budget.

- Not a timeout bump — removes the coupling between deliveries (budget scales with N instead of staying constant).
- Preserves hang detection: a genuinely stuck delivery still fails in `timeoutMs`.
- Preserves the semaphore-release ordering the payload assertions rely on (handler records under lock, then releases).
- Single-point fix also covers two latent twins with the same shared-budget hazard: `DeliversAlert_ToMultipleTargets` (@3 deliveries) and `AllowsDifferentContextKeys_EvenWithDedup` (@2).

## Verification

- Full `Netclaw.Daemon.Tests`: 1016/1016 pass on Linux.
- 10x stress loop of the failing test + `DeliversAlert_ToMultipleTargets`: all green.
- Windows CI on this PR is the definitive check.