### PR TITLE
Upgrade ShellSyntaxTree to 0.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,7 +75,7 @@
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
-    <PackageVersion Include="ShellSyntaxTree" Version="0.3.0-alpha.6" />
+    <PackageVersion Include="ShellSyntaxTree" Version="0.3.0" />
     <PackageVersion Include="Termina" Version="0.16.1" />
   </ItemGroup>
   <!-- Serialization -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -175,7 +175,7 @@ Done when:
   execute commands.
 - [x] Netclaw consumes ShellSyntaxTree 0.3.0-alpha command occurrences and
   explicit Bash redirect facts for the existing grammar.
-- [x] Netclaw consumes ShellSyntaxTree `0.3.0-alpha.6` through its corrected
+- [x] Netclaw consumes ShellSyntaxTree `0.3.0` through its corrected
   closed analysis API. The consumer uses joined arguments, value-domain type
   patterns, redirect alternatives, and redirect-source alternatives. The
   unchanged 225-test Bash, PowerShell 7, and Windows PowerShell 5.1 approval

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -275,8 +275,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         // Each parser path is an authorization scope. A grant must cover all
         // scopes, or a later external path could hide behind an earlier local
         // path. The resolved value also handles native forms such as @file.
-        // ShellSyntaxTree 0.3.0-alpha still has the #1795 classification.
-        // Remove this guard after a later v0.3 prerelease contains the parser correction.
+        // ShellSyntaxTree 0.3.0 still has the #1795 classification.
+        // Remove this guard after a later release contains the parser correction.
         if (!isSideEffectVerb)
         {
             foreach (var arg in clause.Args)
@@ -456,8 +456,8 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (!arg.IsPath)
             return false;
 
-        // ShellSyntaxTree 0.3.0-alpha still has the #1795 classification.
-        // Remove this guard after a later v0.3 prerelease contains the parser correction.
+        // ShellSyntaxTree 0.3.0 still has the #1795 classification.
+        // Remove this guard after a later release contains the parser correction.
         if (arg.Raw.Length > 0 && arg.Raw.All(char.IsAsciiDigit)
             && ShouldDropNumericToken(arg, workingDirectory))
         {


### PR DESCRIPTION
## Summary

- Upgrade ShellSyntaxTree from 0.3.0-alpha.6 to 0.3.0.
- Update the implementation plan and two version-specific comments.
- Keep approval policy behavior unchanged.

Stable 0.3.0 has the same source, tests, and public API as alpha.6.

## Validation

- `dotnet restore Netclaw.slnx`
- `dotnet build Netclaw.slnx -c Release --no-restore`
- `dotnet test Netclaw.slnx -c Release --no-build`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `openspec validate --all --strict`
- Adversarial review: pass.

Slopwatch reports one existing SW004 warning in an unchanged PowerShell test.