### PR TITLE
Fix shell approval scopes for dotted paths

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -170,6 +170,10 @@ Done when:
   each effective directory, across live, sub-agent, and redrive paths.
 - [x] External paths, mismatched grants, dynamic syntax, and hard-deny rules
   keep their strict behavior.
+- [x] Directory operands preserve dotted directory names without weakening the
+  external-path or symlink checks.
+- [x] The policy normalizes a variable `git ls-tree` tree operand to the
+  reviewed read-only verb. Other Git subcommands keep exact parser output.
 - [ ] A constrained executable grammar proves any future safe `sed` form. The
   `-n` option alone is not proof because a `sed` program can write files or
   execute commands.
@@ -180,7 +184,7 @@ Done when:
   patterns, redirect alternatives, and redirect-source alternatives. The
   unchanged 225-test Bash, PowerShell 7, and Windows PowerShell 5.1 approval
   matrix passes locally.
-- [x] The expanded 244-test matrix covers command-substitution and PowerShell
+- [x] The expanded 247-test matrix covers command-substitution and PowerShell
   execution-region behavior. Known command-owned regions reuse independently
   matched host and body grants after Netclaw accounts for the parsed body.
   Unknown receivers and incomplete region facts remain prompt-only.

--- a/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
@@ -214,6 +214,68 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
     }
 
     [Fact]
+    public void Git_ls_tree_operand_normalizes_to_read_only_verb()
+    {
+        var policy = new ScopedShellSafeVerbPolicy(VerbList("git ls-tree"));
+        var candidate = new ApprovalCandidate("git ls-tree feature", _projectDir);
+
+        var normalized = policy.NormalizeCandidate(candidate);
+
+        Assert.Equal("git ls-tree", normalized.Verb);
+        Assert.Equal(_projectDir, normalized.Directory);
+    }
+
+    [Fact]
+    public void Git_subcommand_without_an_operand_rule_stays_exact()
+    {
+        var policy = new ScopedShellSafeVerbPolicy(VerbList("git remote"));
+        var candidate = new ApprovalCandidate("git remote add", _projectDir);
+
+        Assert.Equal(candidate, policy.NormalizeCandidate(candidate));
+    }
+
+    [Fact]
+    public void Same_length_safe_verb_does_not_normalize_to_git_ls_tree()
+    {
+        var policy = new ScopedShellSafeVerbPolicy(VerbList("git ls-tree", "gh run list"));
+        var candidate = new ApprovalCandidate("gh run list feature", _projectDir);
+
+        Assert.Equal(candidate, policy.NormalizeCandidate(candidate));
+    }
+
+    [Fact]
+    public void Git_ls_tree_normalization_requires_safe_list_membership()
+    {
+        var policy = new ScopedShellSafeVerbPolicy(VerbList("git status"));
+        var candidate = new ApprovalCandidate("git ls-tree feature", _projectDir);
+
+        Assert.Equal(candidate, policy.NormalizeCandidate(candidate));
+    }
+
+    [Fact]
+    public void Dotted_symlink_directory_does_not_short_circuit()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var target = CreateTempDir("dotted-target");
+        var link = Path.Combine(_projectDir, "service.repo");
+        try
+        {
+            Directory.CreateSymbolicLink(link, target);
+            var policy = new ScopedShellSafeVerbPolicy(VerbList("find"));
+            var ctx = PersonalContext(projectDir: _projectDir);
+            var candidate = new ApprovalCandidate("find", link);
+
+            Assert.False(policy.AllShortCircuit([candidate], _projectDir, ctx));
+        }
+        finally
+        {
+            SafeDelete(target);
+        }
+    }
+
+    [Fact]
     public void Candidate_path_outside_safe_spaces_falls_through_to_prompt()
     {
         var policy = new ScopedShellSafeVerbPolicy(VerbList("cat"));

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
@@ -263,6 +263,21 @@ public static class ShellApprovalCases
             Approvals.None,
             ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
         Case(
+            "safe-git-ls-tree-ref-allows",
+            Bash("git ls-tree feature"),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
+        Case(
+            "safe-git-ls-tree-external-prompts-with-canonical-verb",
+            Bash("git ls-tree feature", ApprovalDirectoryShape.External),
+            Approvals.None,
+            ExpectedApproval.Require(["git ls-tree"])),
+        Case(
+            "safe-git-ls-tree-external-reuses-canonical-grant",
+            Bash("git ls-tree feature", ApprovalDirectoryShape.External),
+            Approvals.PersistentHere(ApprovalDirectoryShape.External, "git ls-tree"),
+            ExpectedApproval.Allow(ToolAllowReason.StoredApproval, 1, "persistent:git ls-tree")),
+        Case(
             "safe-verb-context-project-fallback-allows",
             Bash("cat src/readme.txt", ApprovalDirectoryShape.None),
             Approvals.None,

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
@@ -13,6 +13,9 @@
 | hard-deny-beats-stored-grant | Bash | Personal | Project | Interactive | netclaw daemon stop | persistent[anywhere]:netclaw daemon stop | Denied | hard_deny_self_destructive | none | Not applicable |
 | compound-hard-deny-denies | Bash | Personal | Project | Interactive | git status && netclaw daemon stop | none | Denied | hard_deny_self_destructive | none | Not applicable |
 | safe-verb-project-allows | Bash | Personal | Project | Interactive | git status | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| safe-git-ls-tree-ref-allows | Bash | Personal | Project | Interactive | git ls-tree feature | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| safe-git-ls-tree-external-prompts-with-canonical-verb | Bash | Personal | External | Interactive | git ls-tree feature | none | RequiresApproval | approval required | git ls-tree | No |
+| safe-git-ls-tree-external-reuses-canonical-grant | Bash | Personal | External | Interactive | git ls-tree feature | persistent[external]:git ls-tree | Allowed | StoredApproval | none | Not applicable |
 | safe-verb-context-project-fallback-allows | Bash | Personal | None | Interactive | cat src/readme.txt | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | safe-verb-context-project-traversal-prompts | Bash | Personal | None | Interactive | cat ../secret.txt | none | RequiresApproval | approval required | cat | No |
 | safe-verb-session-allows | Bash | Personal | Session | Interactive | git status | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -103,10 +103,11 @@ public sealed class ToolApprovalGateTests
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
     public void Static_shell_glob_uses_covering_directory_and_offers_persistent_approval()
     {
+        using var dir = new DisposableTempDir();
         var policy = CreatePolicy(ToolApprovalMode.Approval);
         var args = ToolInput.Create(
-            "Command", "rm /tmp/*.bak",
-            "WorkingDirectory", "/home/user/project");
+            "Command", $"rm {dir.Path}/*.bak",
+            "WorkingDirectory", dir.Path);
 
         var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
 
@@ -114,7 +115,7 @@ public sealed class ToolApprovalGateTests
         Assert.False(decision.ApprovalContext!.IsMessy);
         var candidate = Assert.Single(decision.ApprovalContext.Candidates!);
         Assert.Equal("rm", candidate.Verb);
-        Assert.Equal("/tmp", candidate.Directory);
+        Assert.Equal(dir.Path, candidate.Directory);
         Assert.Contains(
             decision.ApprovalContext.Options,
             option => option.Key.Value == ApprovalOptionKeys.ApproveAlways);

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -30,6 +30,7 @@ namespace Netclaw.Actors.Tools;
 /// </summary>
 internal sealed class ScopedShellSafeVerbPolicy
 {
+    private const string GitLsTreeVerb = "git ls-tree";
     private readonly SafeVerbList _safeVerbs;
 
     public ScopedShellSafeVerbPolicy(SafeVerbList safeVerbs)
@@ -45,6 +46,21 @@ internal sealed class ScopedShellSafeVerbPolicy
     /// </summary>
     public bool ShortCircuitsApproval(string candidateVerb, string? cwd, ToolInvocationContext context)
         => AllShortCircuit([new ApprovalCandidate(candidateVerb, Directory: null)], cwd, context);
+
+    /// <summary>
+    /// Removes the variable tree operand from a read-only <c>git ls-tree</c>
+    /// candidate. Other Git commands keep exact parser output because a
+    /// trailing token can name a mutating subcommand.
+    /// </summary>
+    public ApprovalCandidate NormalizeCandidate(ApprovalCandidate candidate)
+    {
+        if (_safeVerbs.IsOperandBearingMatch(candidate.Verb, GitLsTreeVerb))
+        {
+            return candidate with { Verb = GitLsTreeVerb };
+        }
+
+        return candidate;
+    }
 
     /// <summary>
     /// Returns true when each candidate has a safe verb and a safe effective

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -388,7 +388,9 @@ public sealed class ToolAccessPolicy
         var isMessy = shellApproval?.IsMessy
             ?? matcher.IsMessy(toolName, analysisArguments);
 
-        IReadOnlyList<ApprovalCandidate> approvalCandidates = candidates;
+        IReadOnlyList<ApprovalCandidate> approvalCandidates = _safeVerbPolicy is not null && isShell
+            ? candidates.Select(_safeVerbPolicy.NormalizeCandidate).Distinct().ToList()
+            : candidates;
 
         // A clean shell command can combine safe candidates with candidates
         // that need a stored grant. Remove only candidates that independently
@@ -397,9 +399,9 @@ public sealed class ToolAccessPolicy
         if (_safeVerbPolicy is not null
             && isShell
             && !isMessy
-            && candidates.Count > 0)
+            && approvalCandidates.Count > 0)
         {
-            approvalCandidates = candidates
+            approvalCandidates = approvalCandidates
                 .Where(candidate => !_safeVerbPolicy.AllShortCircuit(
                     [candidate],
                     context.Approval.Cwd,

--- a/src/Netclaw.Configuration.Tests/SafeVerbLoaderTests.cs
+++ b/src/Netclaw.Configuration.Tests/SafeVerbLoaderTests.cs
@@ -28,6 +28,7 @@ public sealed class SafeVerbLoaderTests
         Assert.True(list.Contains("uname"));
         Assert.True(list.Contains("whoami"));
         Assert.True(list.Contains("git describe"));
+        Assert.True(list.Contains("git ls-tree"));
         Assert.True(list.Contains("gh pr view"));
         Assert.True(list.Contains("gh run list"));
 
@@ -59,6 +60,7 @@ public sealed class SafeVerbLoaderTests
         Assert.True(list.Contains("Get-Date"));
         Assert.True(list.Contains("whoami"));
         Assert.True(list.Contains("git describe"));
+        Assert.True(list.Contains("git ls-tree"));
         Assert.True(list.Contains("gh pr view"));
 
         // Excluded on purpose: gh api can issue any HTTP method; Get-Process
@@ -89,6 +91,19 @@ public sealed class SafeVerbLoaderTests
         Assert.True(linux.Contains("ls"));
         Assert.True(windows.Contains("GET-CONTENT"));
         Assert.True(windows.Contains("Get-Content"));
+    }
+
+    [Fact]
+    public void Operand_match_uses_platform_case_rules_and_exact_verb_identity()
+    {
+        var linux = SafeVerbLoader.Load(isWindows: false);
+        var windows = SafeVerbLoader.Load(isWindows: true);
+
+        Assert.True(linux.IsOperandBearingMatch("git ls-tree feature", "git ls-tree"));
+        Assert.False(linux.IsOperandBearingMatch("GIT LS-TREE feature", "git ls-tree"));
+        Assert.True(windows.IsOperandBearingMatch("GIT LS-TREE feature", "git ls-tree"));
+        Assert.False(windows.IsOperandBearingMatch("Get-Content X", "git ls-tree"));
+        Assert.False(windows.IsOperandBearingMatch("gh run list X", "git ls-tree"));
     }
 
     [Fact]

--- a/src/Netclaw.Configuration/SafeVerbList.cs
+++ b/src/Netclaw.Configuration/SafeVerbList.cs
@@ -57,6 +57,16 @@ public sealed class SafeVerbList
     public bool Contains(string candidateVerb)
         => !string.IsNullOrEmpty(candidateVerb) && _verbs.Contains(candidateVerb);
 
+    /// <summary>
+    /// Returns true when a listed verb starts the candidate and an operand
+    /// follows it. The comparison uses the selected platform rules.
+    /// </summary>
+    public bool IsOperandBearingMatch(string candidateVerb, string listedVerb)
+        => _verbs.Contains(listedVerb)
+           && candidateVerb.Length > listedVerb.Length
+           && candidateVerb[listedVerb.Length] == ' '
+           && _verbs.Comparer.Equals(candidateVerb[..listedVerb.Length], listedVerb);
+
     /// <summary>The verbs in this list. Stable ordering; intended for diagnostics, not lookups.</summary>
     public IReadOnlyCollection<string> Verbs => _verbs;
 }

--- a/src/Netclaw.Configuration/SafeVerbs/safe-verbs.linux.json
+++ b/src/Netclaw.Configuration/SafeVerbs/safe-verbs.linux.json
@@ -48,6 +48,7 @@
     "git remote",
     "git rev-parse",
     "git ls-files",
+    "git ls-tree",
     "git blame",
     "git describe",
     "git rev-list",

--- a/src/Netclaw.Configuration/SafeVerbs/safe-verbs.windows.json
+++ b/src/Netclaw.Configuration/SafeVerbs/safe-verbs.windows.json
@@ -32,6 +32,7 @@
     "git remote",
     "git rev-parse",
     "git ls-files",
+    "git ls-tree",
     "git blame",
     "git describe",
     "git rev-list",

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -67,6 +67,27 @@ public sealed class ShellApprovalMatcherTests
     }
 
     [Theory]
+    [InlineData(@"Set-Location C:\workspace\service.repo", "Set-Location")]
+    [InlineData(@"cd C:\workspace\service.repo", "Set-Location")]
+    [InlineData(@"Push-Location C:\workspace\service.repo", "Push-Location")]
+    public void Power_shell_location_command_preserves_dotted_directory(
+        string command,
+        string expectedVerb)
+    {
+        var matcher = new ShellApprovalMatcher(
+            ShellExecutionEnvironment.CreatePowerShell(
+                @"C:\Program Files\PowerShell\7\pwsh.exe",
+                PwshDialect.PowerShell7));
+
+        var candidate = Assert.Single(matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args(command, @"C:\workspace")));
+
+        Assert.Equal(expectedVerb, candidate.Verb);
+        Assert.Equal("C:/workspace/service.repo", candidate.Directory);
+    }
+
+    [Theory]
     [InlineData(@"Get-Content Env:\Path")]
     [InlineData(@"Get-Item HKLM:\Software\Vendor")]
     [InlineData(@"Remove-Item CustomDrive:\target")]
@@ -1329,6 +1350,49 @@ public sealed class ShellApprovalMatcherPathExtractionTests
         Assert.Contains(candidates,
             c => c.Verb == "git remote"
               && c.Directory == "/home/user/repos/example");
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_preserves_dotted_cd_target_as_directory()
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            new Dictionary<string, object?>
+            {
+                ["Command"] = "cd /workspace/service.repo"
+            }));
+
+        Assert.Equal("cd", candidate.Verb);
+        Assert.Equal("/workspace/service.repo", candidate.Directory);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_find_dot_preserves_dotted_working_directory()
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            new Dictionary<string, object?>
+            {
+                ["Command"] = "find . -maxdepth 1 -type f",
+                ["WorkingDirectory"] = "/workspace/service.repo"
+            }));
+
+        Assert.Equal("find", candidate.Verb);
+        Assert.Equal("/workspace/service.repo", candidate.Directory);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]
+    public void ExtractCandidates_file_operand_in_dotted_directory_uses_parent_directory()
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            new Dictionary<string, object?>
+            {
+                ["Command"] = "cat /workspace/service.repo/readme.md"
+            }));
+
+        Assert.Equal("cat", candidate.Verb);
+        Assert.Equal("/workspace/service.repo", candidate.Directory);
     }
 
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only path semantics")]

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -84,11 +84,7 @@ public sealed class ShellApprovalMatcherTests
             Args(command, @"C:\workspace")));
 
         Assert.Equal(expectedVerb, candidate.Verb);
-        Assert.Equal(
-            OperatingSystem.IsWindows()
-                ? @"C:\workspace\service.repo"
-                : "C:/workspace/service.repo",
-            candidate.Directory);
+        Assert.Equal("C:/workspace/service.repo", candidate.Directory);
     }
 
     [Theory]

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -84,7 +84,11 @@ public sealed class ShellApprovalMatcherTests
             Args(command, @"C:\workspace")));
 
         Assert.Equal(expectedVerb, candidate.Verb);
-        Assert.Equal("C:/workspace/service.repo", candidate.Directory);
+        Assert.Equal(
+            OperatingSystem.IsWindows()
+                ? @"C:\workspace\service.repo"
+                : "C:/workspace/service.repo",
+            candidate.Directory);
     }
 
     [Theory]

--- a/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
+++ b/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
@@ -261,6 +261,24 @@ public sealed class ShellTokenizerTests
         Assert.Equal(expected, ShellTokenizer.IsPathToken(token));
     }
 
+    [Theory]
+    [InlineData(@"C:\workspace\service.repo", true)]
+    [InlineData("\"C:\\workspace\\service.repo\"", true)]
+    [InlineData("C:/workspace/service.repo", true)]
+    [InlineData("'/workspace/service.repo'", true)]
+    [InlineData(@"\\server\share\service.repo", true)]
+    [InlineData(@".\service.repo", true)]
+    [InlineData(@"..\service.repo", true)]
+    [InlineData(@"~\service.repo", true)]
+    [InlineData("origin/main", false)]
+    [InlineData(@"module\command", false)]
+    [InlineData("https://example.com/service", false)]
+    [InlineData(@"Env:\Path", false)]
+    public void Windows_path_style_recognizes_lexical_path_roots(string token, bool expected)
+    {
+        Assert.Equal(expected, ShellTokenizer.IsPathToken(token, ShellPathStyle.Windows));
+    }
+
     // ── ExtractFirstPathArgument ──
 
     [Theory]

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -503,7 +503,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         var containsSeparator = pathStyle == ShellPathStyle.Windows
             ? arg.Raw.IndexOfAny(['/', '\\']) >= 0
             : arg.Raw.Contains('/', StringComparison.Ordinal);
-        if (ShellTokenizer.IsPathToken(arg.Raw) || !containsSeparator)
+        if (ShellTokenizer.IsPathToken(arg.Raw, pathStyle) || !containsSeparator)
             return true;
 
         // An internal slash can also name a ref such as feature/x. Native

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -300,10 +300,11 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
 
                 // A parser path without a canonical value cannot use the broader
                 // cwd grant. Return no candidates so the command fails closed.
-                if (string.IsNullOrWhiteSpace(arg.Resolved))
+                var resolved = arg.Resolved;
+                if (string.IsNullOrWhiteSpace(resolved))
                     return null;
 
-                directories.Add(ShellTokenizer.ApplyFileParentRule(arg.Resolved, pathStyle));
+                directories.Add(ResolveAuthorizationScope(occurrence, arg, resolved, pathStyle));
             }
         }
 
@@ -347,6 +348,42 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         }
 
         return directories.Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    private static string? ResolveAuthorizationScope(
+        ShellSyntaxTree.CommandOccurrence occurrence,
+        ShellSyntaxTree.Arg arg,
+        string resolved,
+        ShellPathStyle pathStyle)
+    {
+        var raw = arg.Raw.Trim();
+        if (raw.Length >= 2 && raw[0] is '\'' or '"' && raw[^1] == raw[0])
+            raw = raw[1..^1];
+
+        var hasDirectorySyntax = raw is "." or ".."
+            || raw.EndsWith("/", StringComparison.Ordinal)
+            || pathStyle == ShellPathStyle.Windows
+                && raw.EndsWith("\\", StringComparison.Ordinal);
+
+        var parsedVerb = occurrence.Clause.Verb.CanonicalVerb
+            ?? string.Join(" ", TrimTrailingValueTokens(occurrence.Clause.Verb.Tokens));
+        var verb = ShellTokenizer.ApplyVerbShortCircuit(parsedVerb);
+        var hasDirectoryOperand = verb.Equals("find", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("cd", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("chdir", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("pushd", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("popd", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("Set-Location", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("Push-Location", StringComparison.OrdinalIgnoreCase)
+            || verb.Equals("Pop-Location", StringComparison.OrdinalIgnoreCase);
+
+        // A dotted basename can name either a file or a directory. Navigation
+        // and traversal commands need the exact scope, not the file-parent
+        // heuristic. The safe-space policy still rejects external and
+        // symlinked paths.
+        return hasDirectorySyntax || hasDirectoryOperand
+            ? resolved
+            : ShellTokenizer.ApplyFileParentRule(resolved, pathStyle);
     }
 
     private static string? ResolveGlobCoveringDirectory(

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -242,6 +242,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             var isSideEffectVerb = ShellTokenizer.SingleTokenSideEffectVerbs.Contains(verb);
             var directories = ResolveCommandDirectories(
                 occurrence,
+                verb,
                 isSideEffectVerb,
                 workingDirectory,
                 Environment.PathStyle);
@@ -261,6 +262,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
 
     private static IReadOnlyList<string?>? ResolveCommandDirectories(
         ShellSyntaxTree.CommandOccurrence occurrence,
+        string verb,
         bool isSideEffectVerb,
         string? workingDirectory,
         ShellPathStyle pathStyle)
@@ -304,7 +306,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
                 if (string.IsNullOrWhiteSpace(resolved))
                     return null;
 
-                directories.Add(ResolveAuthorizationScope(occurrence, arg, resolved, pathStyle));
+                directories.Add(ResolveAuthorizationScope(verb, arg, resolved, pathStyle));
             }
         }
 
@@ -351,7 +353,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     }
 
     private static string? ResolveAuthorizationScope(
-        ShellSyntaxTree.CommandOccurrence occurrence,
+        string verb,
         ShellSyntaxTree.Arg arg,
         string resolved,
         ShellPathStyle pathStyle)
@@ -365,9 +367,6 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             || pathStyle == ShellPathStyle.Windows
                 && raw.EndsWith("\\", StringComparison.Ordinal);
 
-        var parsedVerb = occurrence.Clause.Verb.CanonicalVerb
-            ?? string.Join(" ", TrimTrailingValueTokens(occurrence.Clause.Verb.Tokens));
-        var verb = ShellTokenizer.ApplyVerbShortCircuit(parsedVerb);
         var hasDirectoryOperand = verb.Equals("find", StringComparison.OrdinalIgnoreCase)
             || verb.Equals("cd", StringComparison.OrdinalIgnoreCase)
             || verb.Equals("chdir", StringComparison.OrdinalIgnoreCase)
@@ -1031,6 +1030,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (analysis.Commands.Any(command =>
                 ResolveCommandDirectories(
                     command,
+                    NormalizedVerb(command),
                     IsSideEffectCommand(command),
                     workingDirectory,
                     Environment.PathStyle) is null))
@@ -1089,12 +1089,14 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
     }
 
     private static bool IsSideEffectCommand(ShellSyntaxTree.CommandOccurrence occurrence)
+        => ShellTokenizer.SingleTokenSideEffectVerbs.Contains(NormalizedVerb(occurrence));
+
+    private static string NormalizedVerb(ShellSyntaxTree.CommandOccurrence occurrence)
     {
         var clause = occurrence.Clause;
         var parsedVerb = clause.Verb.CanonicalVerb
             ?? string.Join(" ", TrimTrailingValueTokens(clause.Verb.Tokens));
-        var verb = ShellTokenizer.ApplyVerbShortCircuit(parsedVerb);
-        return ShellTokenizer.SingleTokenSideEffectVerbs.Contains(verb);
+        return ShellTokenizer.ApplyVerbShortCircuit(parsedVerb);
     }
 
     public string FormatForDisplay(ToolName toolName, IDictionary<string, object?>? arguments)

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -295,6 +295,24 @@ public static class ShellTokenizer
             || token.StartsWith("../", StringComparison.Ordinal);
     }
 
+    internal static bool IsPathToken(string token, ShellPathStyle pathStyle)
+    {
+        var isPortablePath = IsPathToken(token);
+        if (isPortablePath || pathStyle != ShellPathStyle.Windows)
+            return isPortablePath;
+
+        var value = token.Trim('\'', '"');
+        return IsPathToken(value)
+            || value.StartsWith('\\')
+            || value.StartsWith("~\\", StringComparison.Ordinal)
+            || value.StartsWith(".\\", StringComparison.Ordinal)
+            || value.StartsWith("..\\", StringComparison.Ordinal)
+            || value.Length >= 3
+            && char.IsAsciiLetter(value[0])
+            && value[1] == ':'
+            && value[2] is '/' or '\\';
+    }
+
     /// <summary>
     /// Produces an exact shell approval unit string with recognizable local paths
     /// normalized against the working directory. Non-path tokens remain in order.


### PR DESCRIPTION
This PR reduces repeat shell approval prompts.

It makes these changes:

- Preserve dotted directory scopes for Bash and native PowerShell navigation.
- Recognize drive-rooted, UNC, relative-rooted, and quoted Windows path roots under the selected shell grammar.
- Keep Git refs, module-qualified names, URLs, PowerShell provider paths, external paths, and symlink checks strict.
- Normalize variable `git ls-tree` operands to the reviewed read-only verb.
- Keep other Git subcommands exact.
- Add sanitized approval cases with synthetic paths and branch names.
- Isolate the static-glob test from shared runner state.

Validation:

- Release build passed with no warnings.
- Local Security and focused actor approval suites passed.
- Native Windows CI proved the dotted directory result is the canonical full path `C:/workspace/service.repo`.
- Header verification passed.
- Slopwatch found no new issues in changed files.
- The added diff passed the PII scan.
- The adversarial review passed with no findings.