### PR TITLE
chore(ci): auto-format changed code on pull requests

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,0 +1,53 @@
+name: autoformat
+
+# Auto-format .cs files changed in a pull request and commit the fixes back
+# to the PR branch. This is the fix-in-place pattern used by dotnet/maui
+# (dotnet-autoformat-pr.yml): formatting never blocks a PR, it repairs it.
+# BOM enforcement stays separate - see scripts/check-no-bom.sh / the no-bom
+# job in pr_validation.yml, because a whitespace-scope format does not strip
+# BOMs.
+on:
+  pull_request:
+
+# Only this workflow needs write access - it pushes formatting commits back
+# to the PR branch. pr_validation.yml stays read-only.
+permissions:
+  contents: write
+
+# A push to the PR branch re-fires pull_request (synchronize). Serialize runs
+# per PR so two pushes cannot race on the same branch; if the push already
+# landed, the new run finds nothing to do and no-ops.
+concurrency:
+  group: autoformat-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autoformat-code:
+    name: Auto-format changed code
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v7
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: "Install .NET SDK"
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: "./global.json"
+
+      - name: "Restore .NET tools"
+        run: dotnet tool restore
+
+      - name: "Restore solution"
+        run: dotnet restore Netclaw.slnx
+
+      - name: "Autoformat"
+        uses: rolfbjarne/autoformat@v0.5
+        with:
+          script: 'dotnet format Netclaw.slnx --no-restore'
+          onlyFilesModifiedInPullRequest: true
+          git_commit_message: 'Auto-format source code'

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           lfs: true
           fetch-depth: 0
 
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           global-json-file: "./global.json"
 
@@ -46,7 +46,7 @@ jobs:
         run: dotnet restore Netclaw.slnx
 
       - name: "Autoformat"
-        uses: rolfbjarne/autoformat@v0.5
+        uses: rolfbjarne/autoformat@6651f9ce43cbbc99f74186f20fe17b8e9f8001a3 # v0.5
         with:
           script: 'dotnet format Netclaw.slnx --no-restore'
           onlyFilesModifiedInPullRequest: true


### PR DESCRIPTION
## Summary

Add a GitHub Action that auto-formats `.cs` files modified in a pull request and commits the fixes back to the PR branch — the fix-in-place pattern used by [dotnet/maui's dotnet-autoformat-pr.yml](https://github.com/dotnet/maui/blob/main/.github/workflows/dotnet-autoformat-pr.yml), rather than a blocking `--verify-no-changes` gate (which no first-party Microsoft repo uses, and which would fail on this repo's pre-existing whitespace drift).

## How it works

- `on: pull_request` → runs the `rolfbjarne/autoformat` action, which:
  - runs `dotnet format Netclaw.slnx --no-restore`
  - scoped to **files modified in the PR only** (`onlyFilesModifiedInPullRequest: true`), so it never reflows the whole repo
  - commits the result back to the PR branch as `Auto-format source code`
- Concurrency group per-PR serializes runs, so two pushes can't race on the same branch. If a format commit already landed, the next run finds nothing to do and no-ops.
- Formatting commits are made with `GITHUB_TOKEN`; normal CI (`pr_validation.yml`) then validates the final state including the format commit.

## Scope decisions

- **BOM enforcement stays separate.** `scripts/check-no-bom.sh` + the `no-bom` job remain the gate; a whitespace-scope `dotnet format` does not strip BOMs. (The full `dotnet format` run here *can* normalize charset on touched files, which aligns with the no-BOM convention from #1863.)
- **Not a blocking gate.** A PR with format drift still merges if CI passes — the action fixes it in place instead. Matches how dotnet/runtime and dotnet/maui treat formatting.
- **Fork caveat:** for PRs from forks, the action can only push back when "Allow edits from maintainers" is enabled on the PR. Same-repo branches (our normal workflow) always work.

## Validation

- YAML parses cleanly.
- Mirrors the proven maui workflow; no new infrastructure, no third-party services beyond the `rolfbjarne/autoformat` action maui already uses.

Follow-up opportunity (not in this PR): a one-time `dotnet format` cleanup of the 14 files with pre-existing whitespace drift, if desired.