### PR TITLE
Release 0.26.0-beta.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.26.0</VersionPrefix>
-    <VersionSuffix>beta.2</VersionSuffix>
+    <VersionSuffix>beta.3</VersionSuffix>
     <PackageReleaseNotes>
       Features: MCP server prompts loadable as dynamic skills; native PowerShell on Windows with 5.1 fallback. Bug fixes: reminders no longer skipped on execution capacity; OAuth-broken MCP connections demote to AwaitingAuth with operator alert; MCP HTTP fallback header race fixed; daemon working directory preserved across restarts; /dev/null redirects no longer open a reusable /dev scope; PowerShell host probe retries cold starts and falls back to 5.1. Internal: shell approval analysis migrated to ShellSyntaxTree fail-closed parser; reduced PowerShell approval repetition; pinned Bash hidden-execution boundaries; PowerShell execution-region approvals. Dependency updates: SlackNet 0.17.11, ShellSyntaxTree 0.3.0-alpha.6.
     </PackageReleaseNotes>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # NetClaw Release Notes
 
+## 0.26.0-beta.3 (2026-08-11)
+
+### Features
+- **Agents declare shell working scope up front** — Agents are now guided to declare their working directory once before multi-command work in a named project, pass the directory to the shell tool instead of inline `cd`, and retry rejected paths instead of working around them — fewer redundant approval prompts and more reliable scoped approvals ([#1870](https://github.com/netclaw-dev/netclaw/pull/1870))
+
+### Bug Fixes
+- **Shell approval scopes fixed for dotted paths** — Dotted and hidden paths (e.g. `.netclaw/`) and git refs now produce correct approval scopes, with normalized-verb matching and `git ls-tree` recognized as safe ([#1868](https://github.com/netclaw-dev/netclaw/pull/1868))
+- **MCP: dead OAuth registrations discarded again under SDK 2.1** — The MCP SDK 2.1 discovery probe no longer swallows token-endpoint `invalid_client` rejections during interactive OAuth; rejected client registrations are discarded instead of wedging ([#1865](https://github.com/netclaw-dev/netclaw/pull/1865))
+
+### Dependency Updates
+- **Bump ModelContextProtocol** — 2.0.0 → 2.1.0 ([#1865](https://github.com/netclaw-dev/netclaw/pull/1865))
+- **Bump Anthropic** — 12.39.0 → 12.40.0 ([#1842](https://github.com/netclaw-dev/netclaw/pull/1842))
+- **Bump ShellSyntaxTree** — 0.2.0 → 0.3.0 ([#1867](https://github.com/netclaw-dev/netclaw/pull/1867))
+
 ## 0.26.0-beta.2 (2026-08-10)
 
 ### Features


### PR DESCRIPTION
Release 0.26.0-beta.3

- Version bump to 0.26.0-beta.3 in Directory.Build.props
- Release notes added to RELEASE_NOTES.md

See RELEASE_NOTES.md for details.