### PR TITLE
Reduce approval prompts for GitHub diagnostics

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -178,6 +178,12 @@ Done when:
   root from one-command `WorkingDirectory` scope, prevent redundant project
   switches, and preserve `cd` when directory mutation is the requested shell
   behavior.
+- [x] Unknown Bash scalar data for `echo`, including `$?`, does not make an
+  otherwise complete command complex. Executable substitutions and unknown
+  path operands remain strict.
+- [x] Direct `gh api` endpoints and `gh --repo` remote identifiers do not create
+  false local filesystem scopes. File-bound arguments remain subject to path
+  policy.
 - [x] Sanitized behavioral eval cases cover early project declaration,
   one-command typed scope, failed-path recovery, and deliberate inline `cd`.
 - [ ] Run the new behavioral eval cases against a configured model provider.

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalCaseCatalog.cs
@@ -359,6 +359,14 @@ public static class ShellApprovalCases
             ExpectedApproval.Allow(ToolAllowReason.SafeVerbInTrustedScope)),
 
         Case(
+            "safe-gh-run-diagnostic-exit-status-allows",
+            Bash(
+                "gh run view 123456 --repo example/project --log-failed --verbose 2>&1 "
+                + "| head -200; echo \"---EXIT $?---\""),
+            Approvals.None,
+            ExpectedApproval.Allow(ToolAllowReason.ApprovalExemptShellCandidates)),
+
+        Case(
             "native-project-path-operand-allows-safe-verb",
             Bash("git diff install-skills.sh"),
             Approvals.None,

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.Shell_approval_cases_match_review_table.verified.md
@@ -32,6 +32,7 @@
 | mixed-safe-unsafe-compound-prompts | Bash | Personal | Project | Interactive | git status && git push | none | RequiresApproval | approval required | git push | No |
 | safe-pipe-unsafe-tail-prompts | Bash | Personal | Project | Interactive | git status \| git push | none | RequiresApproval | approval required | git push | No |
 | safe-pipeline-allows | Bash | Personal | Project | Interactive | git log \| head -20 | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
+| safe-gh-run-diagnostic-exit-status-allows | Bash | Personal | Project | Interactive | gh run view 123456 --repo example/project --log-failed --verbose 2>&1 \| head -200; echo "---EXIT $?---" | none | Allowed | ApprovalExemptShellCandidates | none | Not applicable |
 | native-project-path-operand-allows-safe-verb | Bash | Personal | Project | Interactive | git diff install-skills.sh | none | Allowed | SafeVerbInTrustedScope | none | Not applicable |
 | native-external-path-operand-prompts | Bash | Personal | Project | Interactive | git diff /etc/passwd | none | RequiresApproval | approval required | git diff | No |
 | native-project-path-operand-reuses-grant | Bash | Personal | Project | Interactive | kubectl apply deployment.yaml | persistent[project]:kubectl apply | Allowed | StoredApproval | none | Not applicable |

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -51,6 +51,82 @@ public sealed class ShellApprovalMatcherTests
     }
 
     [Fact]
+    public void Gh_run_diagnostic_with_exit_status_is_reusable()
+    {
+        const string command =
+            "gh run view 123456 --repo example/project --log-failed --verbose 2>&1 "
+            + "| head -200; echo \"---EXIT $?---\"";
+        var analysis = _matcher.AnalyzeInvocation(
+            new ToolName("shell_execute"),
+            Args(command, "/work"));
+
+        Assert.False(analysis.IsMessy);
+        Assert.Equal(
+            [
+                new ApprovalCandidate("gh run view", "/work"),
+                new ApprovalCandidate("head", "/work"),
+                new ApprovalCandidate("echo", null)
+            ],
+            analysis.Candidates);
+    }
+
+    [Theory]
+    [InlineData("gh run view 123456 --repo example/project", "gh run view")]
+    [InlineData("gh run view 123456 -R example/project", "gh run view")]
+    [InlineData("gh run view 123456 --repo=example/project", "gh run view")]
+    [InlineData("gh api repos/example/project/actions/jobs/123456/logs", "gh api")]
+    public void Gh_remote_identifiers_are_not_file_system_scopes(
+        string command,
+        string expectedVerb)
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args(command, "/work")));
+
+        Assert.Equal(expectedVerb, candidate.Verb);
+        Assert.Equal("/work", candidate.Directory);
+    }
+
+    [Theory]
+    [InlineData("gh api repos/example/project -F data=@/etc/passwd")]
+    [InlineData("gh api repos/example/project -Fdata=@/etc/passwd")]
+    [InlineData("gh api repos/example/project --field data=@/etc/passwd")]
+    [InlineData("gh api repos/example/project --field=data=@/etc/passwd")]
+    [InlineData("gh api repos/example/project --input /etc/passwd")]
+    [InlineData("gh api repos/example/project --input=/etc/passwd")]
+    [InlineData("gh api graphql -F query=@/etc/passwd")]
+    [InlineData("gh api gists -F data=@/etc/passwd")]
+    public void Gh_api_file_options_keep_external_file_scope(string command)
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args(command, "/work")));
+
+        Assert.Equal("/etc/passwd", candidate.Directory);
+        Assert.StartsWith("gh api", candidate.Verb, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Gh_api_raw_field_at_value_is_not_a_file_scope()
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args("gh api repos/example/project --raw-field data=@/etc/passwd", "/work")));
+
+        Assert.Equal(new ApprovalCandidate("gh api", "/work"), candidate);
+    }
+
+    [Fact]
+    public void Gh_api_field_with_embedded_at_value_is_not_a_file_scope()
+    {
+        var candidate = Assert.Single(_matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            Args("gh api repos/example/project --field data=x=@/etc/passwd", "/work")));
+
+        Assert.Equal(new ApprovalCandidate("gh api", "/work"), candidate);
+    }
+
+    [Fact]
     public void Power_shell_matcher_uses_the_native_power_shell_grammar()
     {
         var matcher = new ShellApprovalMatcher(

--- a/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
@@ -220,6 +220,28 @@ public sealed class ShellCommandAnalysisTests
     }
 
     [Fact]
+    public void Bash_echo_accepts_unknown_exit_status_as_data()
+    {
+        var analyzer = new ShellCommandAnalyzer(BashEnvironment);
+        var analysis = analyzer.Analyze("echo \"---EXIT $?---\"", "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.False(analysis.HasDynamicSyntax, Describe(analysis));
+        var occurrence = Assert.Single(analysis.Commands);
+        Assert.IsType<ShellValueDomain.Unknown>(Assert.Single(occurrence.Arguments).Value);
+    }
+
+    [Fact]
+    public void Bash_unknown_path_operand_stays_dynamic()
+    {
+        var analyzer = new ShellCommandAnalyzer(BashEnvironment);
+        var analysis = analyzer.Analyze("rm \"$?\"", "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.True(analysis.HasDynamicSyntax, Describe(analysis));
+    }
+
+    [Fact]
     public void Power_shell_empty_command_argument_region_stays_dynamic()
     {
         var analyzer = new ShellCommandAnalyzer(PowerShellEnvironment);

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -283,7 +283,23 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         {
             foreach (var arg in clause.Args)
             {
-                if (arg.IsCwdAttribution
+                if (arg.IsCwdAttribution)
+                    continue;
+
+                if (TryGetGhApiFileOperand(clause, arg, verb, out var fileOperand))
+                {
+                    var resolvedFile = ShellTokenizer.NormalizePathToken(
+                        fileOperand,
+                        clauseWorkingDirectory,
+                        pathStyle);
+                    if (string.IsNullOrWhiteSpace(resolvedFile))
+                        return null;
+
+                    directories.Add(ShellTokenizer.ApplyFileParentRule(resolvedFile, pathStyle));
+                    continue;
+                }
+
+                if (IsGhNonFileSystemOperand(clause, arg, verb)
                     || !IsAuthorizationPathArg(arg, clauseWorkingDirectory, pathStyle))
                     continue;
 
@@ -350,6 +366,134 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         }
 
         return directories.Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    private static bool TryGetGhApiFileOperand(
+        ShellSyntaxTree.Clause clause,
+        ShellSyntaxTree.Arg argument,
+        string verb,
+        out string fileOperand)
+    {
+        fileOperand = string.Empty;
+        if (!IsGhApiVerb(verb))
+            return false;
+
+        var authoredArguments = clause.Args
+            .Where(static arg => !arg.IsCwdAttribution)
+            .ToList();
+        var index = authoredArguments.FindIndex(arg => ReferenceEquals(arg, argument));
+        if (index < 0)
+            return false;
+
+        var raw = argument.Raw.Trim('\'', '"');
+        if (TryGetInlineOptionValue(raw, "--input=", out fileOperand))
+            return !string.Equals(fileOperand, "-", StringComparison.Ordinal);
+
+        if (TryGetFieldFileValue(raw, "--field=", out fileOperand)
+            || TryGetFieldFileValue(raw, "-F=", out fileOperand)
+            || TryGetFieldFileValue(raw, "-F", out fileOperand))
+        {
+            return true;
+        }
+
+        if (index == 0)
+            return false;
+
+        var preceding = authoredArguments[index - 1].Raw.Trim('\'', '"');
+        if (preceding == "--input")
+        {
+            fileOperand = raw;
+            return !string.Equals(fileOperand, "-", StringComparison.Ordinal);
+        }
+
+        if (preceding.StartsWith("-F", StringComparison.Ordinal)
+            && preceding.Length > 2
+            && raw.StartsWith('@'))
+        {
+            fileOperand = raw[1..];
+            return fileOperand.Length > 0;
+        }
+
+        return preceding is "--field" or "-F"
+               && TryGetFieldFileValue(raw, string.Empty, out fileOperand);
+    }
+
+    private static bool TryGetInlineOptionValue(
+        string raw,
+        string prefix,
+        out string value)
+    {
+        value = string.Empty;
+        if (!raw.StartsWith(prefix, StringComparison.Ordinal)
+            || raw.Length == prefix.Length)
+        {
+            return false;
+        }
+
+        value = raw[prefix.Length..];
+        return true;
+    }
+
+    private static bool TryGetFieldFileValue(
+        string raw,
+        string prefix,
+        out string fileOperand)
+    {
+        fileOperand = string.Empty;
+        if (!raw.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        var field = raw[prefix.Length..];
+        var valueSeparator = field.IndexOf('=', StringComparison.Ordinal);
+        if (valueSeparator <= 0 || valueSeparator + 2 >= field.Length)
+            return false;
+
+        var value = field[(valueSeparator + 1)..];
+        if (!value.StartsWith('@'))
+            return false;
+
+        fileOperand = value[1..];
+        return true;
+    }
+
+    private static bool IsGhApiVerb(string verb)
+        => string.Equals(verb, "gh api", StringComparison.Ordinal)
+           || verb.StartsWith("gh api ", StringComparison.Ordinal);
+
+    private static bool IsGhNonFileSystemOperand(
+        ShellSyntaxTree.Clause clause,
+        ShellSyntaxTree.Arg argument,
+        string verb)
+    {
+        if (!verb.StartsWith("gh ", StringComparison.Ordinal))
+            return false;
+
+        var authoredArguments = clause.Args
+            .Where(static arg => !arg.IsCwdAttribution)
+            .ToList();
+        var index = authoredArguments.FindIndex(arg => ReferenceEquals(arg, argument));
+        if (index < 0)
+            return false;
+
+        var raw = argument.Raw.Trim('\'', '"');
+        if (raw.StartsWith("--repo=", StringComparison.Ordinal)
+            || raw.StartsWith("-R=", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (index > 0)
+        {
+            var preceding = authoredArguments[index - 1].Raw.Trim('\'', '"');
+            if (preceding is "--repo" or "-R")
+                return true;
+        }
+
+        // The first operand of `gh api` is a REST endpoint, not a local path.
+        // Keep later @file and option-bound operands available to path policy.
+        return IsGhApiVerb(verb)
+               && index == 0
+               && !argument.IsFlag;
     }
 
     private static string? ResolveAuthorizationScope(

--- a/src/Netclaw.Security/ShellCommandAnalysis.cs
+++ b/src/Netclaw.Security/ShellCommandAnalysis.cs
@@ -322,7 +322,10 @@ public sealed record ShellCommandAnalysis
     private bool CommandHasDynamicSyntax(
         CommandOccurrence command,
         HashSet<ClauseElement> accountedRegionArguments)
-        => !command.IsComplete
+    {
+        var acceptsUnknownData = IsDataOnlyCommand(command);
+
+        return !command.IsComplete
             || !Enum.IsDefined(command.ImmediateRole)
             || command.ImmediateRole == CommandOccurrenceRole.Unknown
             || command.Ancestry.Any(static frame =>
@@ -338,7 +341,7 @@ public sealed record ShellCommandAnalysis
                     command,
                     arg,
                     accountedRegionArguments))
-            || command.Clause.Args.Any(static arg =>
+            || !acceptsUnknownData && command.Clause.Args.Any(static arg =>
                 arg.Kind == ArgKind.EnvVar
                 && !arg.IsCwdAttribution
                 && string.IsNullOrWhiteSpace(arg.Resolved))
@@ -350,12 +353,21 @@ public sealed record ShellCommandAnalysis
                 !IsAccountedExecutionRegionArgument(
                     argument,
                     accountedRegionArguments)
-                && HasUnsupportedArgumentDomain(argument))
+                && HasUnsupportedArgumentDomain(argument)
+                && (!acceptsUnknownData || argument.Argument.Kind != ArgKind.EnvVar))
             // A glob in a directory segment can hide traversal or a symlink.
             // Only a leaf glob has a fixed directory scope.
             || command.Clause.Args.Any(arg =>
                 ShellGlobPath.HasUnresolvedDescendantScope(arg, Environment.PathStyle))
             || HasUnresolvedRedirect(command);
+    }
+
+    private static bool IsDataOnlyCommand(CommandOccurrence command)
+        => !command.Clause.Verb.IsDynamic
+           && string.Equals(
+               command.Clause.Verb.CanonicalVerb ?? command.Clause.Verb.Joined,
+               "echo",
+               StringComparison.Ordinal);
 
     private HashSet<ClauseElement> FindAccountedExecutionRegionArguments()
     {


### PR DESCRIPTION
## Summary

- treat the Bash exit status as data when `echo` prints it
- treat GitHub repository names and API endpoints as remote values
- keep local files from `gh api --input` and typed field options under path policy
- add sanitized approval and security test cases

## Cause

Netclaw treated the unresolved `$?` value as executable dynamic syntax. It also treated values such as `example/project` and `repos/example/project/...` as local paths. These two classifications made a normal GitHub diagnostic command complex.

## Security boundaries

This change does not make substitutions or unknown path operands reusable. GitHub API options that read local files keep the exact file scope, so an approval for the project directory cannot cover an external file read.

## Validation

- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build`
- 850 security tests passed
- 3,053 actor tests passed; one Windows-only test skipped
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- Slopwatch on all changed C# files: 0 issues
- adversarial review: PASS
- PII review: no findings