### PR TITLE
feat: send client_uri and logo_uri in OAuth client registration

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -66,6 +66,11 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         Assert.Equal("client-1", active!.ClientId);
         Assert.Equal("secret-client-1", active.ClientSecret?.Value);
         Assert.Equal("http://127.0.0.1:7331/api/mcp/oauth/callback", server.DynamicClientRegistrations.Single().RedirectUris.Single());
+        Assert.Equal("netclaw", server.DynamicClientRegistrations.Single().ClientName);
+        Assert.Equal("https://netclaw.dev", server.DynamicClientRegistrations.Single().ClientUri);
+        Assert.Equal(
+            "https://raw.githubusercontent.com/netclaw-dev/netclaw-brand/dev/logo/netclaw-icon-purple.png",
+            server.DynamicClientRegistrations.Single().LogoUri);
 
         await harness.Runtime.LastHttpOptions!.OAuth!.TokenCache!.StoreTokensAsync(
             new TokenContainer
@@ -1195,6 +1200,9 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
             using var document = await JsonDocument.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
             var root = document.RootElement;
+            var clientName = ReadOptionalString(root, "client_name");
+            var clientUri = ReadOptionalString(root, "client_uri");
+            var logoUri = ReadOptionalString(root, "logo_uri");
             var redirectUris = ReadStringArray(root, "redirect_uris");
             var grantTypes = ReadStringArray(root, "grant_types");
             var responseTypes = ReadStringArray(root, "response_types");
@@ -1207,6 +1215,9 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             _registrations.Enqueue(new DynamicClientRegistrationObservation(
                 clientId,
                 clientSecret,
+                clientName,
+                clientUri,
+                logoUri,
                 redirectUris,
                 grantTypes,
                 responseTypes,
@@ -1475,6 +1486,9 @@ public sealed class McpSdkOAuthFlowIntegrationTests
     private sealed record DynamicClientRegistrationObservation(
         string ClientId,
         string ClientSecret,
+        string? ClientName,
+        string? ClientUri,
+        string? LogoUri,
         IReadOnlyList<string> RedirectUris,
         IReadOnlyList<string> GrantTypes,
         IReadOnlyList<string> ResponseTypes,

--- a/src/Netclaw.Daemon/Mcp/McpOAuthClientRegistrar.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthClientRegistrar.cs
@@ -42,6 +42,20 @@ internal sealed class McpOAuthClientRegistrar(
     private const string SdkDefaultAuthMethod = "client_secret_post";
 
     /// <summary>
+    /// Home page presented to operators on the authorization server's consent screen.
+    /// RFC 7591 §2 <c>client_uri</c>.
+    /// </summary>
+    private const string ClientUri = "https://netclaw.dev";
+
+    /// <summary>
+    /// Netclaw logo presented on the authorization server's consent screen.
+    /// RFC 7591 §2 <c>logo_uri</c>. Served as a raw asset from the public brand
+    /// repo (square PNG icon) so any authorization server can fetch it without
+    /// a Netclaw deployment running, and PNG keeps SVG-picky servers happy.
+    /// </summary>
+    private const string LogoUri = "https://raw.githubusercontent.com/netclaw-dev/netclaw-brand/dev/logo/netclaw-icon-purple.png";
+
+    /// <summary>
     /// Registers a client for <paramref name="endpoint"/> and returns its identity.
     /// Returns <c>null</c> when the server advertises no OAuth protected-resource
     /// metadata, which is how an unauthenticated MCP server is recognized.
@@ -76,6 +90,8 @@ internal sealed class McpOAuthClientRegistrar(
         var request = new Dictionary<string, object>
         {
             ["client_name"] = "netclaw",
+            ["client_uri"] = ClientUri,
+            ["logo_uri"] = LogoUri,
             ["redirect_uris"] = new[] { redirectUri.ToString() },
             ["grant_types"] = new[] { "authorization_code", "refresh_token" },
             ["response_types"] = new[] { "code" },


### PR DESCRIPTION
## What

RFC 7591 dynamic client registration (`McpOAuthClientRegistrar`) now includes two optional metadata fields in the registration request:

- `client_uri` — `https://netclaw.dev`
- `logo_uri` — `https://raw.githubusercontent.com/netclaw-dev/netclaw-brand/dev/logo/netclaw-icon-purple.png` (square PNG icon)

## Why

Authorization servers display these on the consent screen. Without them, Netclaw shows up as a bare `client_name: netclaw` with no link or logo — indistinguishable from any other OAuth client. Providers that support RFC 7591 (e.g. TextForge) will now render a recognizable Netclaw identity.

## How

- Added `ClientUri` / `LogoUri` constants to `McpOAuthClientRegistrar`
- Included both fields in the registration request dictionary
- Extended the integration test fake DCR server to capture `client_name` / `client_uri` / `logo_uri` and assert them

## Validation

- `dotnet build` — 0 warnings, 0 errors
- `McpSdkOAuthFlowIntegrationTests` — 23/23 passed
- Both URLs verified reachable (200, `image/png`)