### PR TITLE
test(mcp): preserve startup failure diagnostics

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkCatalogNotificationIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkCatalogNotificationIntegrationTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
 
-public sealed class McpSdkCatalogNotificationIntegrationTests
+public sealed class McpSdkCatalogNotificationIntegrationTests(ITestOutputHelper output)
 {
     private static readonly McpServerName ServerName = new("notifications");
 
@@ -27,9 +27,11 @@ public sealed class McpSdkCatalogNotificationIntegrationTests
         var registry = new ToolRegistry();
         await using var harness = McpSmokeHarness.Create(
             new Dictionary<string, McpServerEntry> { [ServerName.Value] = entry },
-            registry);
+            registry,
+            output);
 
         await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+        harness.AssertConnected(ServerName.Value);
         var first = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
         var lease = Assert.IsType<McpCatalogNotificationLease>(first.NotificationLease);
         Assert.Equal(McpCatalogNotificationMode.Modern, lease.Mode);
@@ -46,5 +48,31 @@ public sealed class McpSdkCatalogNotificationIntegrationTests
         var second = Assert.IsType<McpServerSnapshot>(harness.Manager.GetSnapshot(ServerName));
         Assert.Equal(first.Generation + 1, second.Generation);
         Assert.Contains("dynamic-added", second.ToolFunctions.Keys);
+    }
+
+    [Fact]
+    public async Task FailedStdioStartup_IsReportedBeforeLeaseAssertions()
+    {
+        var entry = new McpServerEntry
+        {
+            Transport = "stdio",
+            Command = $"netclaw-missing-mcp-server-{Guid.NewGuid():N}",
+            Enabled = true,
+        };
+        await using var harness = McpSmokeHarness.Create(
+            new Dictionary<string, McpServerEntry> { [ServerName.Value] = entry },
+            new ToolRegistry(),
+            output);
+
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        var failure = Assert.Throws<Xunit.Sdk.TrueException>(
+            () => harness.AssertConnected(ServerName.Value));
+        Assert.Contains("state=Unreachable", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("Failed to reach MCP server", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("Failed to connect to MCP server", output.Output, StringComparison.Ordinal);
+        Assert.Contains("System.IO.IOException: Failed to connect transport", output.Output, StringComparison.Ordinal);
+        Assert.Contains(entry.Command, output.Output, StringComparison.Ordinal);
+        Assert.Null(harness.Manager.GetSnapshot(ServerName)?.NotificationLease);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkCatalogNotificationIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkCatalogNotificationIntegrationTests.cs
@@ -71,7 +71,7 @@ public sealed class McpSdkCatalogNotificationIntegrationTests(ITestOutputHelper 
         Assert.Contains("state=Unreachable", failure.Message, StringComparison.Ordinal);
         Assert.Contains("Failed to reach MCP server", failure.Message, StringComparison.Ordinal);
         Assert.Contains("Failed to connect to MCP server", output.Output, StringComparison.Ordinal);
-        Assert.Contains("System.IO.IOException: Failed to connect transport", output.Output, StringComparison.Ordinal);
+        Assert.Contains("System.IO.IOException", output.Output, StringComparison.Ordinal);
         Assert.Contains(entry.Command, output.Output, StringComparison.Ordinal);
         Assert.Null(harness.Manager.GetSnapshot(ServerName)?.NotificationLease);
     }


### PR DESCRIPTION
## Summary

- assert the MCP connection contract before reading the notification lease
- forward full manager exceptions to test output and cover failed stdio startup diagnostics

## Evidence and scope

Windows run `31560045253`, job `94000330013`, failed after `StartAsync` because the test read a null `NotificationLease`. The test used a null logger and did not call the existing `AssertConnected` helper, so the run discarded the startup exception that would identify the production cause.

This change does not alter MCP runtime behavior, timeout values, retries, or lease assertions. It makes any connection failure fail first with the server state and status message. It also retains the manager's full exception in test output. The negative test proves that a missing stdio process reports `Unreachable` and `Failed to reach MCP server`, and that its command and transport exception reach the output, before the lease assertion.

This PR does not prove or fix an underlying production MCP startup defect. If the intermittent Windows startup failure remains, the next run will retain the exception needed for a causal follow-up.

## Verification

- focused MCP notification and manager tests: 22 passed
- complete `Netclaw.Daemon.Tests` Release suite: 1,019 passed, repeated 3 times
- `dotnet build Netclaw.slnx -c Release --no-restore`: passed with 0 warnings and 0 errors
- changed-file `dotnet format --verify-no-changes`: passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`: passed
- changed-file Slopwatch: 0 findings

The repo-wide Slopwatch scan still reports one pre-existing warning in `PowerShellHostProbeTests.cs`; this change does not touch that file.
