### PR TITLE
fix(deps): pin SSH.NET to 2026.0.0 (CVE-2026-48798)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,6 +93,14 @@
     <PackageVersion Include="CsCheck" Version="4.8.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <!-- Transitive security pin: Testcontainers 4.13.0 pulls SSH.NET 2025.1.0,
+         which trips NU1903 (CVE-2026-48798 / GHSA-q939-rpr3-3284, path traversal
+         in ScpClient.Download recursive downloads, affected <= 2025.1.0).
+         2026.0.0 is the patched line and still satisfies Testcontainers'
+         >= 2025.1.0 constraint. SSH.NET is a test-only transitive dependency with
+         no runtime exposure; remove this pin once Testcontainers ships a
+         non-vulnerable transitive dependency on its own. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <!-- .NET Aspire (samples/Netclaw.Demo.AppHost only) -->
   <ItemGroup>


### PR DESCRIPTION
## What

Add a transitive-dependency pin for **SSH.NET `2026.0.0`** in `Directory.Packages.props`.

```xml
<PackageVersion Include="SSH.NET" Version="2026.0.0" />
```

## Why

CI restore currently fails with:

```
NU1903: Package 'SSH.NET' 2025.1.0 has a known high severity vulnerability (GHSA-q939-rpr3-3284)
```

- The advisory is **CVE-2026-48798 / GHSA-q939-rpr3-3284**: a path traversal in `ScpClient.Download()` recursive downloads, affecting SSH.NET `<= 2025.1.0`, patched in `2026.0.0`.
- SSH.NET is **not used directly** by netclaw (no `Renci.SshNet`, no direct `PackageReference`). It arrives only as a **transitive dependency of `Testcontainers 4.13.0`** (`<dependency id="SSH.NET" version="2025.1.0" />`, a `>=` minimum), so it lands solely in the integration-test projects (`Netclaw.Daemon.IntegrationTests`, `Netclaw.Channels.Mattermost.IntegrationTests`, `Netclaw.Search.Tests`). **Test-only; no runtime or shipped exposure.**
- Under this repo's `TreatWarningsAsErrors` + NuGetAudit policy, the advisory fails restore.

`CentralPackageTransitivePinningEnabled` is already enabled, so this single pin overrides the vulnerable `2025.1.0` wherever Testcontainers pulls it, **without** adding SSH.NET to any project that doesn't already use it. `2026.0.0` still satisfies Testcontainers' `>= 2025.1.0` constraint. Testcontainers is left untouched.

## How validated

- `dotnet restore Netclaw.slnx` succeeds and **no longer emits NU1903** for SSH.NET.
- `dotnet nuget why` confirms SSH.NET resolves to **`2026.0.0`** (transitive via `Testcontainers 4.13.0`) in all three affected test projects; a scan of `project.assets.json` shows only `SSH.NET/2026.0.0` resolved anywhere (no `2025.1.0` remaining).
- The three affected test projects build clean (0 warnings, 0 errors): `Netclaw.Daemon.IntegrationTests`, `Netclaw.Channels.Mattermost.IntegrationTests`, `Netclaw.Search.Tests`.
- Ran the Testcontainers-backed daemon integration test locally (Docker available): it spins up a real container and **passes** with SSH.NET `2026.0.0` in the graph — confirming the bump doesn't break Testcontainers at runtime.

## Scope

Single-line dependency pin plus its explanatory comment (matching the existing transitive-security-pin convention already used for `Microsoft.OpenApi` and `MessagePack` in this file). No other changes.