### PR TITLE
build: pin patched SSH.NET transitive dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,6 +53,7 @@
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="$(ModelContextProtocolVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftAspNetCoreVersion)" />


### PR DESCRIPTION
## Summary

- pin the transitive SSH.NET dependency at patched version 2026.0.0
- retain Testcontainers 4.13.0 while overriding its vulnerable SSH.NET 2025.1.0 dependency through central package management
- unblock warning-as-error restores after GHSA-q939-rpr3-3284 entered the NuGet advisory feed

## Validation

- forced solution restore
- vulnerable transitive package scan: zero vulnerable packages
- Release solution build: zero warnings and zero errors
- Search tests: 46 of 46 passed
- affected environment-gated integration assemblies load successfully; one native-sidecar test and twelve Mattermost tests skip without their external fixtures

## Security

Fixes the restore failure caused by GHSA-q939-rpr3-3284. Versions through 2025.1.0 are affected; 2026.0.0 is the patched release.

This is intentionally separate from #1890 so the approval-policy diff does not absorb an unrelated package upgrade.