### PR TITLE
test: bind shell approval policy evidence

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,10 @@
 *.verified.* text eol=lf working-tree-encoding=UTF-8
 *.received.* text eol=lf working-tree-encoding=UTF-8
 
+# Cross-repository evidence uses a canonical byte hash. Keep its checkout
+# bytes stable when Git runs on Windows with automatic CRLF conversion.
+openspec/changes/**/evidence/*.json text eol=lf working-tree-encoding=UTF-8
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/openspec/changes/structure-shell-approval-policy/design.md
+++ b/openspec/changes/structure-shell-approval-policy/design.md
@@ -271,9 +271,17 @@ Netclaw uses effective `AnalyzedArgument.Value` for runtime-sensitive checks.
 It may use `AuthoredValue` for approval matching only after the maintainer
 accepts that ambient Bash attributes, ambient `IFS`, and field splitting are
 outside the approval claim. The existing parser-owned `Argument.IsPath`
-contract decides whether a value is path-relevant. Every effective or authored
-finite value for an `IsPath` argument still passes `ToolPathPolicy`; an unknown
-path-relevant value stays strict.
+contract decides whether an effective value is path-relevant. Every finite
+effective value for an `IsPath` argument still passes `ToolPathPolicy`; an
+unknown path-relevant value stays strict.
+
+ShellSyntaxTree 0.3.2 publishes D14's finite `AuthoredValue`, but its effective
+argument has `Argument.IsPath == false`. Netclaw cannot infer file authority
+from that contradiction. An authored finite value may enter `ToolPathPolicy`
+only after ShellSyntaxTree supplies a separate general parser-owned authored
+operand-role fact. Until that additive fact exists and Netclaw adopts it, D14
+remains strict. The change does not invent the public member name or infer the
+role from an executable's private grammar.
 
 `AuthoredPathShape` is lexical shape only. It may make review stricter, but it
 never establishes that an executable treats an argument as a filesystem

--- a/openspec/changes/structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json
+++ b/openspec/changes/structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json
@@ -16,6 +16,7 @@
   "cases": [
     {
       "evidenceId": "D02",
+      "command": "gh run view 123456 --repo example/project --log-failed --verbose 2>&1 | head -200; echo \"---EXIT $?---\"",
       "environment": {
         "platform": "Linux",
         "executablePath": "/bin/bash",
@@ -54,6 +55,7 @@
     },
     {
       "evidenceId": "D03",
+      "command": "cd /tmp && gh api repos/example/project/actions/jobs/123456/logs > slopwatch.log 2>&1; wc -c slopwatch.log; head -100 slopwatch.log",
       "environment": {
         "platform": "Linux",
         "executablePath": "/bin/bash",
@@ -97,6 +99,7 @@
     },
     {
       "evidenceId": "D07",
+      "command": "cd /work && git push upstream feature/update:automation/update 2>&1 | tail -5",
       "environment": {
         "platform": "Linux",
         "executablePath": "/bin/bash",
@@ -132,6 +135,7 @@
     },
     {
       "evidenceId": "D08",
+      "command": "cd /work && git ls-remote upstream feature/update; echo \"---LOCAL---\"; git rev-parse HEAD; git log --oneline -3",
       "environment": { "platform": "Linux", "executablePath": "/bin/bash", "commandArguments": ["-c"], "grammar": "Bash", "pathStyle": "Posix", "powerShellDialect": null },
       "initialWorkingDirectory": "/work",
       "available": {
@@ -164,6 +168,7 @@
     },
     {
       "evidenceId": "D09",
+      "command": "cd /work && gh api repos/example/project/commits/deadbeef --jq '{sha: .sha, message: .commit.message}' 2>&1; echo \"===RUN 123456===\"; gh run view 123456 --repo example/project --json status,conclusion 2>&1 | head -40",
       "environment": { "platform": "Linux", "executablePath": "/bin/bash", "commandArguments": ["-c"], "grammar": "Bash", "pathStyle": "Posix", "powerShellDialect": null },
       "initialWorkingDirectory": "/work",
       "available": {
@@ -198,6 +203,7 @@
     },
     {
       "evidenceId": "D10",
+      "command": "cd /work && git fetch upstream feature/update 2>&1 | tail -2 && echo \"===REMOTE TIP===\" && git rev-parse FETCH_HEAD && git log --oneline -3 FETCH_HEAD && echo \"===HAS FIX?===\" && git show FETCH_HEAD:src/App/App.csproj | grep -n \"ProtocolPackage\"; echo \"exit: $?\"",
       "environment": { "platform": "Linux", "executablePath": "/bin/bash", "commandArguments": ["-c"], "grammar": "Bash", "pathStyle": "Posix", "powerShellDialect": null },
       "initialWorkingDirectory": "/work",
       "available": {
@@ -248,6 +254,7 @@
     },
     {
       "evidenceId": "D11",
+      "command": "cd /work && echo \"===PARENT===\" && gh api repos/example/project/commits/deadbeef --jq '.parents[] | {sha: .sha}' 2>&1; echo \"===CURRENT PR HEAD===\" && gh pr view 123 --repo example/project --json headRefOid,updatedAt",
       "environment": { "platform": "Linux", "executablePath": "/bin/bash", "commandArguments": ["-c"], "grammar": "Bash", "pathStyle": "Posix", "powerShellDialect": null },
       "initialWorkingDirectory": "/work",
       "available": {
@@ -279,6 +286,7 @@
     },
     {
       "evidenceId": "D17",
+      "command": "cd /work && echo \"===API BRANCH===\" && gh api repos/example/project/branches/feature%2Fupdate --jq '.commit.sha' 2>&1; echo \"===GIT REMOTE===\" && git ls-remote upstream 'refs/heads/feature/update'; echo \"===COMMIT===\" && gh api repos/example/project/commits/deadbeef --jq '{sha: .sha, message: .commit.message}' 2>&1",
       "environment": { "platform": "Linux", "executablePath": "/bin/bash", "commandArguments": ["-c"], "grammar": "Bash", "pathStyle": "Posix", "powerShellDialect": null },
       "initialWorkingDirectory": "/work",
       "available": {
@@ -314,6 +322,7 @@
     },
     {
       "evidenceId": "D14",
+      "command": "for f in src/App/App.csproj src/Hosting/Hosting.csproj src/Discovery/Discovery.csproj tests/Hosting.Tests/Hosting.Tests.csproj; do echo \"=== $f ===\"; cat /work/$f; done",
       "environment": {
         "platform": "Linux",
         "executablePath": "/bin/bash",
@@ -336,12 +345,12 @@
       },
       "candidates": [
         { "id": 0, "tokens": ["echo"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "ReviewedSafePolicy" },
-        { "id": 1, "tokens": ["cat"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "PersistentGlobal" }
+        { "id": 1, "tokens": ["cat"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "Uncovered" }
       ],
       "authoredPathFacts": [
         {
           "candidateId": 1,
-          "argumentIsPath": true,
+          "argumentIsPath": false,
           "effectiveValue": "Unknown",
           "authoredValues": [
             "/work/src/App/App.csproj",
@@ -350,18 +359,19 @@
             "/work/tests/Hosting.Tests/Hosting.Tests.csproj"
           ],
           "authoredPathShape": "Posix",
-          "expectedPathPolicy": "Allow"
+          "expectedPathPolicy": "RequiresApproval"
         }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "cat", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
+        { "stage": "CanonicalFacts", "candidateId": 1, "executableBasename": "cat", "outcome": "Uncovered", "reason": "MissingAuthoredOperandRole", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
         { "stage": "ReviewedSafePolicy", "candidateId": 0, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "RequiresApproval", "reason": "UnresolvedPathFacts", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
       ],
-      "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
+      "expectedFinal": { "outcome": "RequiresApproval", "reason": "UnresolvedPathFacts" }
     },
     {
       "evidenceId": "D18",
+      "command": "gh pr close 123 --repo example/project --comment \"Closing this automated update because it is being replaced by a coordinated change.\" 2>&1",
       "environment": {
         "platform": "Linux",
         "executablePath": "/bin/bash",

--- a/openspec/changes/structure-shell-approval-policy/evidence/post-1890-approval-harvest.json
+++ b/openspec/changes/structure-shell-approval-policy/evidence/post-1890-approval-harvest.json
@@ -1,0 +1,245 @@
+{
+  "schemaVersion": 1,
+  "sourceRuntime": {
+    "version": "0.26.0",
+    "commit": "e35444c",
+    "windowStartUtc": "2026-08-13T01:16:00Z",
+    "windowEndUtc": "2026-08-13T01:46:00Z",
+    "shellCallCount": 112,
+    "approvalPromptCount": 25
+  },
+  "sanitization": {
+    "home": "/home/user",
+    "repositoryRoot": "/work/project",
+    "remoteRepository": "example/project",
+    "internalHost": "service.example.invalid",
+    "inlineBodies": "Long inline programs were replaced by a semantic placeholder."
+  },
+  "cases": [
+    {
+      "id": "P01",
+      "sourcePromptTimeUtc": "2026-08-13T01:24:54.961Z",
+      "commandShape": "gh pr update-branch 42 --repo example/project; gh pr update-branch 40 --repo example/project; gh pr merge 40 --repo example/project --squash --auto",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call mutates remote pull requests and merge state."
+    },
+    {
+      "id": "P02",
+      "sourcePromptTimeUtc": "2026-08-13T01:26:03.524Z",
+      "commandShape": "cd /work/project && for i in $(seq 1 25); do output=$(dotnet test); inspect \"$output\"; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "Runtime iteration and command substitution hide future command data."
+    },
+    {
+      "id": "P03",
+      "sourcePromptTimeUtc": "2026-08-13T01:26:18.620Z",
+      "commandShape": "cat > /tmp/probe.csx <<'EOF'\n<inline program>\nEOF\ndotnet script /tmp/probe.csx",
+      "observedResponse": "Session",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call writes and executes an authored program."
+    },
+    {
+      "id": "P04",
+      "sourcePromptTimeUtc": "2026-08-13T01:26:26.509Z",
+      "commandShape": "python3 - <<'PY'\n<inline database program>\nPY",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "An inline interpreter can perform arbitrary effects."
+    },
+    {
+      "id": "P05",
+      "sourcePromptTimeUtc": "2026-08-13T01:26:45.478Z",
+      "commandShape": "mkdir -p /tmp/probe && cd /tmp/probe && cat > probe.csproj <<'EOF'\n<project>\nEOF\ndotnet run",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call creates files and executes restored code."
+    },
+    {
+      "id": "P06",
+      "sourcePromptTimeUtc": "2026-08-13T01:26:57.675Z",
+      "commandShape": "cd /tmp/probe && mv Program.cs Program.old.cs && cat > Program.cs <<'EOF'\n<program>\nEOF\ndotnet run",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call moves files, replaces source, and executes it."
+    },
+    {
+      "id": "P07",
+      "sourcePromptTimeUtc": "2026-08-13T01:27:10.483Z",
+      "commandShape": "cd /tmp/probe && rm Program.old.cs && dotnet run | tail -8",
+      "observedResponse": "Session",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call deletes a file before program execution."
+    },
+    {
+      "id": "P08",
+      "sourcePromptTimeUtc": "2026-08-13T01:27:41.061Z",
+      "commandShape": "cd /tmp/probe && cat > Program.cs <<'EOF'\n<program>\nEOF\ndotnet run",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call replaces source and executes it."
+    },
+    {
+      "id": "P09",
+      "sourcePromptTimeUtc": "2026-08-13T01:27:43.124Z",
+      "commandShape": "gh --version; which gh; dpkg -l | grep gh; apt-cache policy gh; snap list gh",
+      "observedResponse": "Session",
+      "classification": "AgentAlignmentDebt",
+      "owner": "AgentGuidance",
+      "reason": "The exact flags are read-only, but several executables can mutate state with other arguments."
+    },
+    {
+      "id": "P10",
+      "sourcePromptTimeUtc": "2026-08-13T01:27:55.469Z",
+      "commandShape": "curl -sS https://service.example.invalid/api/signals | python3 -c '<inline parser>'",
+      "observedResponse": "Session",
+      "classification": "AgentAlignmentDebt",
+      "owner": "AgentGuidance",
+      "reason": "The agent used an inline interpreter for a read-only HTTP inspection."
+    },
+    {
+      "id": "P11",
+      "sourcePromptTimeUtc": "2026-08-13T01:28:24.290Z",
+      "commandShape": "curl -sS https://api.github.com/repos/example/project/releases/latest | python3 -c '<inline parser>'",
+      "observedResponse": "Session",
+      "classification": "AgentAlignmentDebt",
+      "owner": "AgentGuidance",
+      "reason": "A structured HTTP or GitHub tool can avoid an inline interpreter."
+    },
+    {
+      "id": "P12",
+      "sourcePromptTimeUtc": "2026-08-13T01:29:13.402Z",
+      "commandShape": "cd /work/project && for i in $(seq 1 30); do output=$(dotnet test); inspect \"$output\"; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "Runtime iteration and command substitution remain unresolved."
+    },
+    {
+      "id": "P13",
+      "sourcePromptTimeUtc": "2026-08-13T01:29:26.116Z",
+      "commandShape": "cd /work/project && git fetch origin && echo \"origin/dev: $(git rev-parse --short origin/dev)\" && git -C /work/project-worktree log -3 && echo \"behind: $(git -C /work/project-worktree rev-list --count HEAD..origin/dev)\"",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "Git fetch mutates repository state and contacts a remote."
+    },
+    {
+      "id": "P14",
+      "sourcePromptTimeUtc": "2026-08-13T01:29:42.585Z",
+      "commandShape": "git -C /work/project-worktree merge origin/dev 2>&1 | tail -4 && git -C /work/project-worktree push origin feature/update 2>&1 | tail -3 && echo \"behind: $(git -C /work/project-worktree rev-list --count HEAD..origin/dev)\"",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call mutates local history and a remote branch."
+    },
+    {
+      "id": "P15",
+      "sourcePromptTimeUtc": "2026-08-13T01:31:28.359Z",
+      "commandShape": "for pr in 37 36 15; do gh api --method POST repos/example/project/pulls/$pr/update-branch; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call uses runtime iteration to mutate remote pull requests."
+    },
+    {
+      "id": "P16",
+      "sourcePromptTimeUtc": "2026-08-13T01:32:52.729Z",
+      "commandShape": "cd /work/project && for branch in <fixed branch tuples>; do git branch -f; git checkout; git merge origin/dev; git push origin; git checkout dev; git branch -D; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The loop creates and deletes local branches, merges commits, and force-updates remote branch refs."
+    },
+    {
+      "id": "P17",
+      "sourcePromptTimeUtc": "2026-08-13T01:34:04.438Z",
+      "commandShape": "cd /work/project && git checkout dev && git fetch origin && git merge --ff-only origin/dev && echo \"dev: $(git rev-parse --short HEAD)\" && git worktree add /work/project-worktree -b feature/update dev",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call changes branches, fetches, merges, and creates a worktree."
+    },
+    {
+      "id": "P18",
+      "sourcePromptTimeUtc": "2026-08-13T01:34:28.861Z",
+      "commandShape": "ls -la /work/project/tests && cat /work/project/tests/project.csproj",
+      "observedResponse": "Everywhere",
+      "classification": "AgentAlignmentDebt",
+      "owner": "AgentGuidance",
+      "reason": "The subagent used shell inspection although file tools were available."
+    },
+    {
+      "id": "P19",
+      "sourcePromptTimeUtc": "2026-08-13T01:35:54.318Z",
+      "commandShape": "rg -l 'Metric' /work/project/tests /work/project/src",
+      "observedResponse": "Once",
+      "classification": "AgentAlignmentDebt",
+      "owner": "AgentGuidance",
+      "reason": "The subagent repeated shell search after it had file access."
+    },
+    {
+      "id": "P20",
+      "sourcePromptTimeUtc": "2026-08-13T01:36:01.530Z",
+      "commandShape": "cd /work/project-worktree && grep -rn 'Metric' tests src; cat tests/project.csproj",
+      "observedResponse": "Once",
+      "classification": "NetclawPolicyDebt",
+      "owner": "NetclawPolicy",
+      "reason": "The read-only fallback named an exact worktree, but no scope correction reached the subagent."
+    },
+    {
+      "id": "P21",
+      "sourcePromptTimeUtc": "2026-08-13T01:38:40.173Z",
+      "commandShape": "find /home/user/.nuget/packages/xunit.execution -name '*.dll' | head; dll=$(find /home/user/.nuget/packages/xunit.execution -name 'xunit.execution.dll'); inspect \"$dll\"",
+      "observedResponse": "Once",
+      "classification": "AgentAlignmentDebt",
+      "owner": "AgentGuidance",
+      "reason": "The subagent used broad search and command substitution for package inspection."
+    },
+    {
+      "id": "P22",
+      "sourcePromptTimeUtc": "2026-08-13T01:40:02.975Z",
+      "commandShape": "cd /work/project-worktree && for i in $(seq 1 40); do output=$(dotnet test); inspect \"$output\"; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "Runtime iteration and command substitution remain unresolved."
+    },
+    {
+      "id": "P23",
+      "sourcePromptTimeUtc": "2026-08-13T01:42:28.911Z",
+      "commandShape": "cd /work/project-worktree && for i in $(seq 1 40); do output=$(dotnet test); inspect \"$output\"; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The repeated call has the same unresolved runtime structure."
+    },
+    {
+      "id": "P24",
+      "sourcePromptTimeUtc": "2026-08-13T01:44:09.424Z",
+      "commandShape": "cd /work/project-worktree && for i in $(seq 1 40); do output=$(dotnet test); inspect \"$output\"; done",
+      "observedResponse": "Once",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The repeated call has the same unresolved runtime structure."
+    },
+    {
+      "id": "P25",
+      "sourcePromptTimeUtc": "2026-08-13T01:45:54.517Z",
+      "commandShape": "gh pr create --base dev --head feature/update --title '<title>' --body '<body>'",
+      "observedResponse": "Session",
+      "classification": "ExpectedApproval",
+      "owner": "ApprovalPolicy",
+      "reason": "The call creates remote pull-request state."
+    }
+  ]
+}

--- a/openspec/changes/structure-shell-approval-policy/proposal.md
+++ b/openspec/changes/structure-shell-approval-policy/proposal.md
@@ -27,6 +27,9 @@ session and persistent grant snapshots.
 - Emit a bounded, redacted decision trace that also supplies near-miss data.
 - Adopt the authored/effective fact separation introduced in ShellSyntaxTree
   0.3.1 through the corrected public 0.3.2 package.
+- Keep D14 strict until ShellSyntaxTree supplies a general parser-owned
+  authored operand-role fact; lexical path shape alone cannot create file
+  authority.
 - Pin the exact sanitized D01-D18 catalog and adversarial cases.
 
 No production branch will parse an executable's private options or operands.
@@ -52,5 +55,7 @@ No production branch will parse an executable's private options or operands.
   per-candidate coverage from one atomic snapshot.
 - UX: covered diagnostic chains stop prompting; unresolved syntax remains
   one-time-only.
-- Dependencies: implementation consumes public ShellSyntaxTree 0.3.2.
+- Dependencies: implementation consumes public ShellSyntaxTree 0.3.2 for the
+  current authored/effective facts. D14 requires a later additive parser fact
+  before its authored paths can receive policy coverage.
 - Documentation/evals: operator guidance and approval behavioral evals change.

--- a/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
@@ -601,15 +601,29 @@ Authorization SHALL use canonical ShellSyntaxTree completeness rather than a
 second control-flow tokenizer. Supported static loops SHALL expose candidates.
 Unsupported branches and runtime-generated loops SHALL remain strict.
 
+An effective finite argument SHALL enter path policy when the parser-owned
+`Argument.IsPath` role is true. An authored finite argument whose effective
+role is false SHALL remain strict until ShellSyntaxTree supplies a separate,
+general parser-owned authored operand-role fact. `AuthoredPathShape` SHALL NOT
+substitute for that fact or create file authority.
+
 A legacy scanner MAY add a denial when canonical analysis is incomplete. It
 SHALL NOT allow, create candidates, create persistent options, or widen scope.
 
-#### Scenario: Static loop exposes authored candidates
+#### Scenario: ShellSyntaxTree 0.3.2 keeps D14 path coverage strict
 
-- **GIVEN** ShellSyntaxTree 0.3.2 reports D14 authored values and the existing
-  parser-owned `Argument.IsPath` role
+- **GIVEN** ShellSyntaxTree 0.3.2 reports D14 finite authored values
+- **AND** its effective argument has `Argument.IsPath` false
 - **WHEN** the maintainer-approved authored-source policy evaluates it
-- **THEN** finite `cat` paths are checked individually
+- **THEN** the authored values do not create file authority
+- **AND** lexical `AuthoredPathShape` does not cover the candidate
+
+#### Scenario: General authored operand role unlocks finite path checks
+
+- **GIVEN** a later ShellSyntaxTree version reports D14 finite authored values
+- **AND** it supplies a parser-owned authored filesystem-operand role
+- **WHEN** the maintainer-approved authored-source policy evaluates it
+- **THEN** each finite `cat` path passes `ToolPathPolicy`
 - **AND** the presence of `for` alone does not force a prompt
 
 #### Scenario: Runtime iterator stays one-time

--- a/openspec/changes/structure-shell-approval-policy/tasks.md
+++ b/openspec/changes/structure-shell-approval-policy/tasks.md
@@ -4,15 +4,15 @@
   approval fact. Effective facts retain runtime semantics.
 - [x] 1.2 Keep all v2 grants exact until the user approves a new token-prefix
   grant.
-- [ ] 1.3 Keep `evidence/approval-matrix.json` byte-identical to the paired
+- [x] 1.3 Keep `evidence/approval-matrix.json` byte-identical to the paired
   ShellSyntaxTree artifact.
-- [ ] 1.4 Add `evidence/netclaw-policy-fixtures.json` with exact structured
+- [x] 1.4 Add `evidence/netclaw-policy-fixtures.json` with exact structured
   candidates, phrases, scopes, grant and safe inputs, coverage, ordered trace,
   and outcome for D02, D03, D07, D08, D09, D10, D11, D14, D17, and D18; tests
   must load explicit authority defaults and fields, not branch on IDs.
 - [ ] 1.5 Add adversarial dynamic identity, redirect, protected path, prefix
   collision, runtime loop, wrapper, provider, and unsafe-catalog cases.
-- [ ] 1.6 Run the PII audit and manually inspect every command and fixture.
+- [x] 1.6 Run the PII audit and manually inspect every command and fixture.
 
 ## 2. Typed coordinator and actor protocol
 
@@ -107,9 +107,11 @@
 - [x] 7.2 Consume effective `Value` for runtime checks and approved
   `AuthoredValue` only for the documented approval perspective.
 - [x] 7.3 Treat `IntegerRange` and `Concatenation` as bounded scalar data only.
-- [ ] 7.4 Check every effective or authored finite value whose existing
-  `Argument.IsPath` is true through `ToolPathPolicy`; treat
-  `AuthoredPathShape` as lexical-only and keep unknown path values strict.
+- [ ] 7.4 Check every finite effective value whose `Argument.IsPath` is true
+  through `ToolPathPolicy`. Keep D14 strict until ShellSyntaxTree supplies a
+  general parser-owned authored operand-role fact; after adoption, check every
+  finite authored path through the same policy. Treat `AuthoredPathShape` as
+  lexical-only and keep unknown path values strict.
 - [x] 7.5 Delete the broad Bash environment-variable relaxation and its
   superseded tests.
 - [ ] 7.6 Pin exact D02, D10, and D14 input-to-coverage results.

--- a/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
+++ b/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
@@ -20,4 +20,10 @@
     <ProjectReference Include="../Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="../../openspec/changes/structure-shell-approval-policy/evidence/*.json"
+          Link="ApprovalEvidence/%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Netclaw.Security.Tests/ShellApprovalEvidenceContractTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalEvidenceContractTests.cs
@@ -1,0 +1,619 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellApprovalEvidenceContractTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using ShellSyntaxTree;
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed partial class ShellApprovalEvidenceContractTests
+{
+    private const string ApprovalMatrixFile = "approval-matrix.json";
+    private const string PolicyFixturesFile = "netclaw-policy-fixtures.json";
+    private const string PostMergeHarvestFile = "post-1890-approval-harvest.json";
+    private const string ApprovalMatrixSha256 =
+        "d2a6e64421af337d1c54f1f955934057398176b456e585bfce015ef7ffa24e7d";
+
+    [Fact]
+    public void Approval_matrix_matches_the_locked_cross_repository_artifact()
+    {
+        var bytes = File.ReadAllBytes(EvidencePath(ApprovalMatrixFile));
+        var hash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        var matrix = DeserializeMatrix(bytes);
+
+        Assert.Equal(ApprovalMatrixSha256, hash);
+        Assert.Equal("Netclaw 0.26.0-beta.3", matrix.SourceRelease);
+        Assert.Equal(
+            Enumerable.Range(1, 18).Select(number => $"D{number:00}"),
+            matrix.Cases.Select(item => item.Id));
+        string[] allowedClassifications =
+        [
+            "CorrectPrompt",
+            "IrreduciblyDynamic",
+            "NetclawPolicyDefect",
+            "ShellSyntaxTreeFactGap"
+        ];
+        Assert.All(matrix.Cases, item =>
+            Assert.Contains(item.Classification, allowedClassifications));
+    }
+
+    [Fact]
+    public void Policy_fixtures_load_exact_authority_and_trace_fields()
+    {
+        var matrix = DeserializeMatrix(File.ReadAllBytes(EvidencePath(ApprovalMatrixFile)));
+        var fixtures = DeserializeFixtures(File.ReadAllBytes(EvidencePath(PolicyFixturesFile)));
+        var commands = matrix.Cases.ToDictionary(item => item.Id, item => item.Command);
+
+        Assert.Equal(1, fixtures.SchemaVersion);
+        Assert.Equal("shell_execute", fixtures.FixtureDefaults.ToolName);
+        Assert.Equal("Personal", fixtures.FixtureDefaults.Audience);
+        Assert.Equal("Approval", fixtures.FixtureDefaults.ApprovalMode);
+        Assert.Equal("Available", fixtures.FixtureDefaults.InteractiveApprovalCapability);
+        Assert.Equal("Ready", fixtures.FixtureDefaults.PersistentStoreStatus);
+        Assert.Equal("fixture-session", fixtures.FixtureDefaults.Session.SessionId);
+        Assert.Equal("/work", fixtures.FixtureDefaults.Session.SessionDirectory);
+        Assert.Equal("/work", fixtures.FixtureDefaults.ProjectDirectory);
+        Assert.Null(fixtures.FixtureDefaults.InheritedWorkingDirectory);
+        Assert.Equal(10, fixtures.Cases.Count);
+
+        foreach (var fixture in fixtures.Cases)
+        {
+            Assert.Equal(commands[fixture.EvidenceId], fixture.Command);
+            Assert.Equal("shell_execute", fixtures.FixtureDefaults.ToolName);
+            Assert.Equal("Ready", fixtures.FixtureDefaults.PersistentStoreStatus);
+            Assert.Equal(
+                Enumerable.Range(0, fixture.Candidates.Count),
+                fixture.Candidates.Select(candidate => candidate.Id));
+            Assert.All(fixture.Available.PersistentGrants, grant =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(grant.Shell));
+                Assert.NotEmpty(grant.Tokens);
+            });
+
+            foreach (var candidate in fixture.Candidates)
+            {
+                Assert.NotEmpty(candidate.Tokens);
+                Assert.Single(fixture.ExpectedTrace, row =>
+                    row.CandidateId == candidate.Id
+                    && row.Coverage == candidate.ExpectedCoverage);
+            }
+
+            var completion = fixture.ExpectedTrace[^1];
+            Assert.Equal("Completion", completion.Stage);
+            Assert.Null(completion.CandidateId);
+            Assert.Equal(fixture.ExpectedFinal.Outcome, completion.Outcome);
+            Assert.Equal(fixture.ExpectedFinal.Reason, completion.Reason);
+        }
+    }
+
+    [Fact]
+    public void Exact_symbolic_parser_facts_match_the_policy_fixtures()
+    {
+        var fixtures = DeserializeFixtures(File.ReadAllBytes(EvidencePath(PolicyFixturesFile)));
+        var factCases = fixtures.Cases.Where(item =>
+            item.ValueFacts is { Count: > 0 }
+            || item.AuthoredPathFacts is { Count: > 0 });
+
+        foreach (var fixture in factCases)
+        {
+            var environment = CreateEnvironment(fixture.Environment);
+            var analysis = new ShellCommandAnalyzer(environment).Analyze(
+                fixture.Command,
+                fixture.InitialWorkingDirectory);
+
+            Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+            Assert.Equal(fixture.Candidates.Count, analysis.Commands.Count);
+
+            for (var index = 0; index < fixture.Candidates.Count; index++)
+            {
+                Assert.Equal(
+                    fixture.Candidates[index].Tokens,
+                    analysis.Commands[index].Clause.Verb.Tokens);
+            }
+
+            foreach (var fact in fixture.ValueFacts ?? [])
+            {
+                var argument = analysis.Commands[fact.CandidateId].Arguments[fact.ArgumentIndex];
+                var concatenation = Assert.IsType<ShellValueDomain.Concatenation>(argument.Value);
+                Assert.Equal("Concatenation", fact.Domain);
+                Assert.Equal(fact.Parts.Count, concatenation.Parts.Count);
+
+                for (var index = 0; index < fact.Parts.Count; index++)
+                {
+                    AssertValuePart(fact.Parts[index], concatenation.Parts[index]);
+                }
+            }
+
+            foreach (var fact in fixture.AuthoredPathFacts ?? [])
+            {
+                var argument = Assert.Single(
+                    analysis.Commands[fact.CandidateId].Arguments,
+                    item => item.AuthoredPathShape.ToString() == fact.AuthoredPathShape);
+                Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
+                Assert.Equal("Unknown", fact.EffectiveValue);
+                var authored = Assert.IsType<ShellValueDomain.FiniteSet>(argument.AuthoredValue);
+                Assert.Equal(fact.AuthoredValues, authored.Values);
+                Assert.Equal(fact.AuthoredPathShape, argument.AuthoredPathShape.ToString());
+            }
+        }
+    }
+
+    [Fact]
+    public void Authored_path_fixture_keeps_missing_operand_role_strict()
+    {
+        var fixtures = DeserializeFixtures(File.ReadAllBytes(EvidencePath(PolicyFixturesFile)));
+        var fixture = Assert.Single(fixtures.Cases, item => item.AuthoredPathFacts is { Count: > 0 });
+        var fact = Assert.Single(fixture.AuthoredPathFacts!);
+        var analysis = new ShellCommandAnalyzer(CreateEnvironment(fixture.Environment)).Analyze(
+            fixture.Command,
+            fixture.InitialWorkingDirectory);
+        var argument = Assert.Single(
+            analysis.Commands[fact.CandidateId].Arguments,
+            item => item.AuthoredPathShape.ToString() == fact.AuthoredPathShape);
+
+        Assert.False(fact.ArgumentIsPath);
+        Assert.Equal(fact.ArgumentIsPath, argument.Argument.IsPath);
+        Assert.Equal("RequiresApproval", fact.ExpectedPathPolicy);
+        Assert.Equal("RequiresApproval", fixture.ExpectedFinal.Outcome);
+    }
+
+    [Fact]
+    public void Approval_evidence_contains_no_source_identity()
+    {
+        var evidenceDirectory = Path.GetDirectoryName(EvidencePath(ApprovalMatrixFile))
+                                ?? throw new InvalidDataException("Approval evidence has no directory.");
+        foreach (var path in Directory.EnumerateFiles(evidenceDirectory, "*.json"))
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotMatch(SlackChannelPattern(), text);
+            Assert.DoesNotMatch(SlackThreadPattern(), text);
+            Assert.DoesNotMatch(EmailPattern(), text);
+            Assert.DoesNotMatch(PrivateHomePattern(), text);
+            Assert.DoesNotMatch(PrivateWindowsUserPattern(), text);
+            Assert.DoesNotMatch(KnownSourceIdentityPattern(), text);
+            Assert.DoesNotMatch(AccessTokenPattern(), text);
+            Assert.DoesNotMatch(BearerCredentialPattern(), text);
+            Assert.DoesNotMatch(CredentialAssignmentPattern(), text);
+
+            foreach (Match match in UriHostPattern().Matches(text))
+            {
+                Assert.Contains(
+                    match.Groups["host"].Value,
+                    new[]
+                    {
+                        "api.github.com",
+                        "packages.example.invalid",
+                        "service.example.invalid"
+                    },
+                    StringComparer.OrdinalIgnoreCase);
+            }
+
+            foreach (Match match in RemoteRepositoryPattern().Matches(text))
+            {
+                Assert.Equal("example/project", match.Groups["repository"].Value);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("ghp_000000000000000000000000000000000000")]
+    [InlineData("github_pat_00000000000000000000000000000000")]
+    [InlineData("xoxb-0000000000-0000000000-0000000000")]
+    [InlineData("Authorization: Bearer example-credential-value")]
+    [InlineData("api_key=examplecredentialvalue")]
+    public void Pii_audit_detects_common_credential_shapes(string value)
+    {
+        Assert.True(
+            AccessTokenPattern().IsMatch(value)
+            || BearerCredentialPattern().IsMatch(value)
+            || CredentialAssignmentPattern().IsMatch(value));
+    }
+
+    [Fact]
+    public void Post_merge_harvest_classifies_every_prompt_in_the_frozen_window()
+    {
+        var harvest = JsonSerializer.Deserialize(
+                          File.ReadAllBytes(EvidencePath(PostMergeHarvestFile)),
+                          ShellApprovalEvidenceJsonContext.Default.PostMergeApprovalHarvest)
+                      ?? throw new InvalidDataException($"{PostMergeHarvestFile} has no root object.");
+
+        Assert.Equal(1, harvest.SchemaVersion);
+        Assert.Equal("0.26.0", harvest.SourceRuntime.Version);
+        Assert.Equal("e35444c", harvest.SourceRuntime.Commit);
+        Assert.Equal(112, harvest.SourceRuntime.ShellCallCount);
+        Assert.Equal(25, harvest.SourceRuntime.ApprovalPromptCount);
+        Assert.Equal(
+            Enumerable.Range(1, 25).Select(number => $"P{number:00}"),
+            harvest.Cases.Select(item => item.Id));
+        Assert.Equal(
+            harvest.Cases.Select(item => item.SourcePromptTimeUtc).Order(),
+            harvest.Cases.Select(item => item.SourcePromptTimeUtc));
+        Assert.All(harvest.Cases, item =>
+        {
+            Assert.InRange(
+                item.SourcePromptTimeUtc,
+                DateTimeOffset.Parse(harvest.SourceRuntime.WindowStartUtc),
+                DateTimeOffset.Parse(harvest.SourceRuntime.WindowEndUtc));
+        });
+        Assert.Equal(18, harvest.Cases.Count(item => item.Classification == "ExpectedApproval"));
+        Assert.Equal(6, harvest.Cases.Count(item => item.Classification == "AgentAlignmentDebt"));
+        Assert.Single(harvest.Cases, item => item.Classification == "NetclawPolicyDebt");
+        Assert.DoesNotContain(
+            harvest.Cases,
+            item => item.Classification == "ShellSyntaxTreeFactGap");
+        Assert.All(harvest.Cases, item =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(item.CommandShape));
+            Assert.False(string.IsNullOrWhiteSpace(item.Reason));
+        });
+    }
+
+    private static void AssertValuePart(PolicyValuePart expected, ShellValueDomain actual)
+    {
+        if (expected.Exact is { } exact)
+        {
+            Assert.Equal(exact, Assert.IsType<ShellValueDomain.Exact>(actual).Value);
+            return;
+        }
+
+        var range = Assert.IsType<ShellValueDomain.IntegerRange>(actual);
+        Assert.NotNull(expected.IntegerRange);
+        Assert.Equal(2, expected.IntegerRange.Count);
+        Assert.Equal(expected.IntegerRange[0], range.MinimumInclusive);
+        Assert.Equal(expected.IntegerRange[1], range.MaximumInclusive);
+    }
+
+    private static ShellExecutionEnvironment CreateEnvironment(PolicyFixtureEnvironment environment)
+        => environment.Grammar switch
+        {
+            "Bash" when environment.Platform == "Linux"
+                && environment.PathStyle == "Posix"
+                && environment.ExecutablePath == "/bin/bash"
+                && environment.CommandArguments.SequenceEqual(["-c"])
+                => ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux),
+            _ => throw new InvalidDataException(
+                $"Unsupported fixture environment: {environment.Platform}/{environment.Grammar}.")
+        };
+
+    private static ApprovalEvidenceMatrix DeserializeMatrix(byte[] bytes)
+        => JsonSerializer.Deserialize(
+               bytes,
+               ShellApprovalEvidenceJsonContext.Default.ApprovalEvidenceMatrix)
+           ?? throw new InvalidDataException($"{ApprovalMatrixFile} has no root object.");
+
+    private static PolicyFixtureCatalog DeserializeFixtures(byte[] bytes)
+        => JsonSerializer.Deserialize(
+               bytes,
+               ShellApprovalEvidenceJsonContext.Default.PolicyFixtureCatalog)
+           ?? throw new InvalidDataException($"{PolicyFixturesFile} has no root object.");
+
+    private static string EvidencePath(string fileName)
+        => Path.Combine(AppContext.BaseDirectory, "ApprovalEvidence", fileName);
+
+    [GeneratedRegex(@"\bD[A-Z0-9]{10}\b", RegexOptions.CultureInvariant)]
+    private static partial Regex SlackChannelPattern();
+
+    [GeneratedRegex(@"\b\d{10}\.\d{6}\b", RegexOptions.CultureInvariant)]
+    private static partial Regex SlackThreadPattern();
+
+    [GeneratedRegex(@"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", RegexOptions.CultureInvariant)]
+    private static partial Regex EmailPattern();
+
+    [GeneratedRegex(@"/home/(?!user/|test/|foo/|dev/|runner/|gh-actions/|ci/)[a-zA-Z0-9_.-]+/", RegexOptions.CultureInvariant)]
+    private static partial Regex PrivateHomePattern();
+
+    [GeneratedRegex(@"[A-Za-z]:[\\/]Users[\\/](?!user[\\/]|test[\\/]|foo[\\/]|dev[\\/]|runner[\\/]|ci[\\/])[A-Za-z0-9_.-]+[\\/]", RegexOptions.CultureInvariant)]
+    private static partial Regex PrivateWindowsUserPattern();
+
+    [GeneratedRegex(@"petabridge|stannard|testlab|D0AC6", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex KnownSourceIdentityPattern();
+
+    [GeneratedRegex(
+        @"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,})\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AccessTokenPattern();
+
+    [GeneratedRegex(@"\bBearer\s+[A-Za-z0-9._~+/-]{8,}=*", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex BearerCredentialPattern();
+
+    [GeneratedRegex(
+        @"[""']?(?:token|access[_-]?token|api[_-]?key|client[_-]?secret|password)[""']?\s*[:=]\s*[""']?(?!<)[A-Za-z0-9+/=_-]{8,}",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialAssignmentPattern();
+
+    [GeneratedRegex(
+        @"https?://(?<host>[A-Za-z0-9.-]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex UriHostPattern();
+
+    [GeneratedRegex(
+        @"(?:--repo\s+|gh\s+api\s+repos/|api\.github\.com/repos/)(?<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RemoteRepositoryPattern();
+}
+
+internal sealed record ApprovalEvidenceMatrix
+{
+    public required string SourceRelease { get; init; }
+
+    public required string CutoffUtc { get; init; }
+
+    public required Dictionary<string, string> Sanitization { get; init; }
+
+    public required List<ApprovalEvidenceCase> Cases { get; init; }
+}
+
+internal sealed record ApprovalEvidenceCase
+{
+    public required string Id { get; init; }
+
+    public required string Command { get; init; }
+
+    public required string Observed { get; init; }
+
+    public required string Classification { get; init; }
+
+    public required string Owner { get; init; }
+
+    public required string SstExpectation { get; init; }
+
+    public required string NetclawExpectation { get; init; }
+}
+
+internal sealed record PolicyFixtureCatalog
+{
+    public required int SchemaVersion { get; init; }
+
+    public required PolicyFixtureDefaults FixtureDefaults { get; init; }
+
+    public required List<PolicyFixtureCase> Cases { get; init; }
+}
+
+internal sealed record PolicyFixtureDefaults
+{
+    public required string ToolName { get; init; }
+
+    public required string Audience { get; init; }
+
+    public required string ApprovalMode { get; init; }
+
+    public required string InteractiveApprovalCapability { get; init; }
+
+    public required PolicyFixtureSession Session { get; init; }
+
+    public required string ProjectDirectory { get; init; }
+
+    public string? InheritedWorkingDirectory { get; init; }
+
+    public required string PersistentStoreStatus { get; init; }
+}
+
+internal sealed record PolicyFixtureSession
+{
+    public required string SessionId { get; init; }
+
+    public required string SessionDirectory { get; init; }
+}
+
+internal sealed record PolicyFixtureCase
+{
+    public required string EvidenceId { get; init; }
+
+    public required string Command { get; init; }
+
+    public required PolicyFixtureEnvironment Environment { get; init; }
+
+    public required string InitialWorkingDirectory { get; init; }
+
+    public required PolicyFixtureAuthority Available { get; init; }
+
+    public required List<PolicyFixtureCandidate> Candidates { get; init; }
+
+    public List<PolicyValueFact>? ValueFacts { get; init; }
+
+    public List<PolicyAuthoredPathFact>? AuthoredPathFacts { get; init; }
+
+    public PolicyShellEffects? ShellEffects { get; init; }
+
+    public PolicyParserOptions? ParserOptions { get; init; }
+
+    public required List<PolicyTraceRow> ExpectedTrace { get; init; }
+
+    public required PolicyExpectedFinal ExpectedFinal { get; init; }
+}
+
+internal sealed record PolicyFixtureEnvironment
+{
+    public required string Platform { get; init; }
+
+    public required string ExecutablePath { get; init; }
+
+    public required List<string> CommandArguments { get; init; }
+
+    public required string Grammar { get; init; }
+
+    public required string PathStyle { get; init; }
+
+    public string? PowerShellDialect { get; init; }
+}
+
+internal sealed record PolicyFixtureAuthority
+{
+    public required List<string> OneTimeApprovalKeys { get; init; }
+
+    public required List<PolicyGrant> SessionGrants { get; init; }
+
+    public required List<PolicyGrant> PersistentGrants { get; init; }
+
+    public required List<PolicySafePhrase> SafePhrases { get; init; }
+}
+
+internal sealed record PolicyGrant
+{
+    public required string Kind { get; init; }
+
+    public required string Shell { get; init; }
+
+    public required string Match { get; init; }
+
+    public required List<string> Tokens { get; init; }
+
+    public string? Directory { get; init; }
+}
+
+internal sealed record PolicySafePhrase
+{
+    public required List<string> Tokens { get; init; }
+
+    public required string Proof { get; init; }
+}
+
+internal sealed record PolicyFixtureCandidate
+{
+    public required int Id { get; init; }
+
+    public required List<string> Tokens { get; init; }
+
+    public string? RealDirectory { get; init; }
+
+    public string? IntentDirectory { get; init; }
+
+    public required string ExpectedCoverage { get; init; }
+}
+
+internal sealed record PolicyValueFact
+{
+    public required int CandidateId { get; init; }
+
+    public required int ArgumentIndex { get; init; }
+
+    public required string Domain { get; init; }
+
+    public required List<PolicyValuePart> Parts { get; init; }
+}
+
+internal sealed record PolicyValuePart
+{
+    public string? Exact { get; init; }
+
+    public List<long>? IntegerRange { get; init; }
+}
+
+internal sealed record PolicyAuthoredPathFact
+{
+    public required int CandidateId { get; init; }
+
+    public required bool ArgumentIsPath { get; init; }
+
+    public required string EffectiveValue { get; init; }
+
+    public required List<string> AuthoredValues { get; init; }
+
+    public required string AuthoredPathShape { get; init; }
+
+    public required string ExpectedPathPolicy { get; init; }
+}
+
+internal sealed record PolicyShellEffects
+{
+    public required List<PolicyRedirect> Redirects { get; init; }
+}
+
+internal sealed record PolicyRedirect
+{
+    public required int CandidateId { get; init; }
+
+    public required string Target { get; init; }
+
+    public required string Mode { get; init; }
+
+    public required string ExpectedPathPolicy { get; init; }
+}
+
+internal sealed record PolicyParserOptions
+{
+    public required bool PublishAuthoredSourceFacts { get; init; }
+}
+
+internal sealed record PolicyTraceRow
+{
+    public required string Stage { get; init; }
+
+    public int? CandidateId { get; init; }
+
+    public string? ExecutableBasename { get; init; }
+
+    public required string Outcome { get; init; }
+
+    public required string Reason { get; init; }
+
+    public string? Coverage { get; init; }
+
+    public string? ScopeRelation { get; init; }
+
+    public string? GrantTimestamp { get; init; }
+}
+
+internal sealed record PolicyExpectedFinal
+{
+    public required string Outcome { get; init; }
+
+    public required string Reason { get; init; }
+}
+
+internal sealed record PostMergeApprovalHarvest
+{
+    public required int SchemaVersion { get; init; }
+
+    public required PostMergeSourceRuntime SourceRuntime { get; init; }
+
+    public required Dictionary<string, string> Sanitization { get; init; }
+
+    public required List<PostMergeApprovalCase> Cases { get; init; }
+}
+
+internal sealed record PostMergeSourceRuntime
+{
+    public required string Version { get; init; }
+
+    public required string Commit { get; init; }
+
+    public required string WindowStartUtc { get; init; }
+
+    public required string WindowEndUtc { get; init; }
+
+    public required int ShellCallCount { get; init; }
+
+    public required int ApprovalPromptCount { get; init; }
+}
+
+internal sealed record PostMergeApprovalCase
+{
+    public required string Id { get; init; }
+
+    public required DateTimeOffset SourcePromptTimeUtc { get; init; }
+
+    public required string CommandShape { get; init; }
+
+    public required string ObservedResponse { get; init; }
+
+    public required string Classification { get; init; }
+
+    public required string Owner { get; init; }
+
+    public required string Reason { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow)]
+[JsonSerializable(typeof(ApprovalEvidenceMatrix))]
+[JsonSerializable(typeof(PolicyFixtureCatalog))]
+[JsonSerializable(typeof(PostMergeApprovalHarvest))]
+internal sealed partial class ShellApprovalEvidenceJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary

- add a sanitized post-#1890 approval harvest with exact prompt timestamps and classifications
- bind the shared D01-D18 catalog to executable Netclaw policy fixtures
- add source-generated JSON contract tests, cross-repository hash checks, and PII regression checks
- keep D14 strict until ShellSyntaxTree exposes a general authored operand-role fact

## Measured result

The sampled runtime window contains 112 shell calls and 25 approval prompts: 18 expected approvals, 6 agent-alignment cases, and 1 Netclaw policy defect. This PR records evidence; it does not change production authorization.

## Validation

- Netclaw.Security.Tests: 898 passed
- OpenSpec strict validation: passed
- file headers: passed
- Slopwatch changed-file scan: passed
- adversarial review: passed before and after rebase
