### PR TITLE
Add bounded shell policy decision trace

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -188,6 +188,11 @@ Done when:
 - [x] The actor response preserves stable candidate IDs and typed persistent
   store status. Duplicate IDs, mismatched facts, impossible grant states, and
   internal stage faults deny without a prompt.
+- [x] The shell coordinator returns a typed operator trace with at most 256
+  rows. Each row uses enum facts, a call-local candidate ID, a redacted
+  executable basename, grant scope, and grant time. The actor derives a match
+  or one near miss from one store snapshot pass. Raw paths, command text,
+  arguments, secrets, prompts, and session events never receive trace data.
 - [ ] The bundled safe catalog removes every executable whose accepted
   arguments can write, delete, execute code, or mutate a remote service through
   executable argv interpretation. Redirect, parser-owned path/provider, and

--- a/openspec/changes/structure-shell-approval-policy/tasks.md
+++ b/openspec/changes/structure-shell-approval-policy/tasks.md
@@ -117,11 +117,11 @@
 
 ## 8. Trace, guides, and behavioral evals
 
-- [ ] 8.1 Emit the capped trace schema and enforce control/bidi escaping,
+- [x] 8.1 Emit the capped trace schema and enforce control/bidi escaping,
   secret redaction, and truncation.
-- [ ] 8.2 Append actor grant rows without a second scan; project near-miss logs
+- [x] 8.2 Append actor grant rows without a second scan; project near-miss logs
   from the same trace.
-- [ ] 8.3 Keep trace data out of model prompts and session journals.
+- [x] 8.3 Keep trace data out of model prompts and session journals.
 - [ ] 8.4 Update consumer and operator guides with complete input, facts,
   coverage, trace, and output examples.
 - [ ] 8.5 Update the `netclaw-operations` skill and deterministic approval evals

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -724,11 +724,277 @@ public class DispatchingToolExecutorTests
                 request.Candidates.Select(candidate => candidate.CandidateId.Value));
             Assert.Contains(request.Candidates, candidate => candidate.Candidate.Verb == "git status");
             Assert.Contains(request.Candidates, candidate => candidate.Candidate.Verb == "head");
+            Assert.Collection(
+                decision.ShellPolicyTrace.Rows,
+                row =>
+                {
+                    Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, row.Stage);
+                    Assert.Equal(ShellPolicyTraceOutcome.Covered, row.Outcome);
+                    Assert.Equal(ShellPolicyTraceReason.SessionGrant, row.Reason);
+                    Assert.Equal("git", row.ExecutableBasename);
+                    Assert.Equal(ShellCoverageKind.Session, row.Coverage);
+                    Assert.Equal(ShellScopeRelation.ThisChat, row.ScopeRelation);
+                },
+                row =>
+                {
+                    Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, row.Stage);
+                    Assert.Equal(ShellPolicyTraceOutcome.Uncovered, row.Outcome);
+                    Assert.Equal(ShellPolicyTraceReason.NoGrant, row.Reason);
+                    Assert.Equal("head", row.ExecutableBasename);
+                    Assert.Equal(ShellCoverageKind.Uncovered, row.Coverage);
+                    Assert.Equal(ShellScopeRelation.None, row.ScopeRelation);
+                },
+                row =>
+                {
+                    Assert.Equal(ShellPolicyTraceStage.ReviewedSafePolicy, row.Stage);
+                    Assert.Equal(ShellPolicyTraceOutcome.Covered, row.Outcome);
+                    Assert.Equal(ShellPolicyTraceReason.ReviewedSafePhrase, row.Reason);
+                    Assert.Equal("head", row.ExecutableBasename);
+                    Assert.Equal(ShellCoverageKind.ReviewedSafePolicy, row.Coverage);
+                    Assert.Equal(ShellScopeRelation.UnderRealRoot, row.ScopeRelation);
+                },
+                row =>
+                {
+                    Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+                    Assert.Equal(ShellPolicyTraceOutcome.Allow, row.Outcome);
+                    Assert.Equal(ShellPolicyTraceReason.AllCandidatesCovered, row.Reason);
+                });
         }
         finally
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task Authorization_trace_carries_persistent_grant_timestamp()
+    {
+        var grantTimestamp = new DateTimeOffset(2026, 8, 13, 7, 0, 0, TimeSpan.Zero);
+        var approvalService = new FixedShellApprovalService(request =>
+        {
+            var matches = request.Candidates.Select(candidate =>
+            {
+                var shell = Assert.IsType<ApprovalShell>(candidate.Candidate.Shell);
+                var tokens = Assert.IsAssignableFrom<IReadOnlyList<string>>(candidate.Candidate.VerbTokens);
+                var entry = ApprovalEntry.CreateTokenPrefix(
+                    shell,
+                    tokens,
+                    directory: null,
+                    grantTimestamp);
+                return new ShellGrantCandidateMatch(
+                    candidate.CandidateId,
+                    new ToolApprovalMatch(candidate.Candidate.Verb, "persistent", entry.FormatScope()),
+                    ShellCoverageKind.PersistentGlobal,
+                    NearMisses: [])
+                {
+                    GrantCreatedAt = grantTimestamp
+                };
+            }).ToArray();
+            return new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                Array.AsReadOnly(matches));
+        });
+        var logger = new RecordingLogger<DispatchingToolExecutor>();
+        var executor = CreateApprovalGatedShellExecutor(approvalService, logger);
+        var call = new FunctionCallContent(
+            "call-trace-persistent-grant",
+            "shell_execute",
+            ToolInput.Create("Command", "git status"));
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/trace-persistent-grant"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, decision.Outcome);
+        var grantRow = Assert.Single(
+            decision.ShellPolicyTrace.Rows,
+            row => row.Stage == ShellPolicyTraceStage.StoredGrantMatch);
+        Assert.Equal(ShellPolicyTraceReason.PersistentGlobalGrant, grantRow.Reason);
+        Assert.Equal(grantTimestamp, grantRow.GrantTimestamp);
+        Assert.Contains(logger.Entries, entry =>
+            Equals(entry.GetValueOrDefault("GrantTimestamp"), grantTimestamp));
+    }
+
+    [Fact]
+    public async Task Authorization_trace_projects_redacted_near_miss_without_raw_evidence()
+    {
+        const string rawGrantPath = "/private/ghp_12345678901234567890/path";
+        var grantTimestamp = new DateTimeOffset(2026, 8, 13, 7, 30, 0, TimeSpan.Zero);
+        var approvalService = new FixedShellApprovalService(request =>
+            new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                Array.AsReadOnly(request.Candidates.Select(candidate =>
+                {
+                    var shell = Assert.IsType<ApprovalShell>(candidate.Candidate.Shell);
+                    var grant = ApprovalEntry.CreateTokenPrefix(
+                        shell,
+                        ["git", "push"],
+                        rawGrantPath,
+                        grantTimestamp);
+                    return new ShellGrantCandidateMatch(
+                        candidate.CandidateId,
+                        Match: null,
+                        GrantCoverage: null,
+                        NearMisses:
+                        [
+                            new ShellApprovalNearMiss(
+                                grant,
+                                ShellApprovalNearMissReason.OutsideDirectory)
+                        ]);
+                }).ToArray())));
+        var logger = new RecordingLogger<DispatchingToolExecutor>();
+        var executor = CreateApprovalGatedShellExecutor(approvalService, logger);
+        var call = new FunctionCallContent(
+            "call-trace-near-miss",
+            "shell_execute",
+            ToolInput.Create("Command", "git push"));
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/trace-near-miss"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, decision.Outcome);
+        var nearMissRow = Assert.Single(
+            decision.ShellPolicyTrace.Rows,
+            row => row.Stage == ShellPolicyTraceStage.StoredGrantMatch);
+        Assert.Equal(ShellPolicyTraceOutcome.Uncovered, nearMissRow.Outcome);
+        Assert.Equal(ShellPolicyTraceReason.OutsideDirectory, nearMissRow.Reason);
+        Assert.Equal(ShellCoverageKind.PersistentFolder, nearMissRow.Coverage);
+        Assert.Equal(ShellScopeRelation.OutsideGrantRoot, nearMissRow.ScopeRelation);
+        Assert.Equal(grantTimestamp, nearMissRow.GrantTimestamp);
+        Assert.NotNull(decision.ApprovalContext);
+        Assert.DoesNotContain(
+            typeof(ToolApprovalContext).GetProperties(),
+            property => property.Name.Contains("Trace", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            typeof(Netclaw.Actors.Sessions.SessionProtocol.ToolApprovalRequested).GetProperties(),
+            property => property.Name.Contains("Trace", StringComparison.Ordinal));
+
+        var logValues = string.Join(
+            '\n',
+            logger.Entries.SelectMany(static entry => entry.Values)
+                .Select(static value => value?.ToString() ?? string.Empty));
+        Assert.DoesNotContain(rawGrantPath, logValues, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Shell_policy_trace_caps_rows_without_authority_change()
+    {
+        var builder = new ShellPolicyDecisionTraceBuilder();
+        for (var index = 0; index < 300; index++)
+        {
+            builder.AddCoverage(
+                ShellPolicyTraceStage.ReviewedSafePolicy,
+                new ShellPolicyCandidate(
+                    new ShellPolicyCandidateId(index),
+                    BashCandidate($"/usr/bin/tool-{index}")),
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyReason.ReviewedSafePhrase,
+                ShellScopeRelation.UnderRealRoot);
+        }
+
+        var decision = ToolAuthorizationDecision.Allow(ToolAllowReason.SafeVerbInTrustedScope);
+        var trace = builder.Complete(decision);
+
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, decision.Outcome);
+        Assert.Equal(ShellPolicyDecisionTraceBuilder.MaximumRows, trace.Rows.Count);
+        Assert.Single(trace.Rows, row => row.Outcome == ShellPolicyTraceOutcome.TraceTruncated);
+        var finalRow = trace.Rows[^1];
+        Assert.Equal(ShellPolicyTraceStage.Completion, finalRow.Stage);
+        Assert.Equal(ShellPolicyTraceOutcome.Allow, finalRow.Outcome);
+    }
+
+    [Fact]
+    public void Shell_policy_trace_sanitizes_controls_secrets_and_invalid_unicode()
+    {
+        const string secret = "ghp_12345678901234567890";
+        var input = $"{secret}\r\n\u202Ebad\uD800{new string('x', 200)}";
+
+        var sanitized = ShellPolicyDecisionTraceBuilder.SanitizeText(input);
+
+        Assert.DoesNotContain(secret, sanitized, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", sanitized, StringComparison.Ordinal);
+        Assert.Contains("\\u000D\\u000A", sanitized, StringComparison.Ordinal);
+        Assert.Contains("\\u202E", sanitized, StringComparison.Ordinal);
+        Assert.Contains("\\uD800", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', sanitized);
+        Assert.DoesNotContain('\n', sanitized);
+        Assert.True(sanitized.Length <= ShellPolicyDecisionTraceBuilder.MaximumTextCodeUnits);
+    }
+
+    [Fact]
+    public void Shell_policy_trace_fails_closed_before_a_long_private_key_can_be_truncated()
+    {
+        var privateKey = $"-----BEGIN PRIVATE KEY-----\n{new string('A', 600)}\n-----END PRIVATE KEY-----";
+
+        var sanitized = ShellPolicyDecisionTraceBuilder.SanitizeText(privateKey);
+
+        Assert.Equal("***REDACTED***", sanitized);
+        Assert.DoesNotContain("PRIVATE KEY", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("AAAAAAAA", sanitized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Shell_policy_trace_logs_one_row_for_malicious_executable_text()
+    {
+        const string secret = "ghp_12345678901234567890";
+        var logger = new RecordingLogger<DispatchingToolExecutor>();
+        var executor = CreateApprovalGatedShellExecutor(logger: logger);
+        var builder = new ShellPolicyDecisionTraceBuilder();
+        builder.AddCoverage(
+            ShellPolicyTraceStage.ReviewedSafePolicy,
+            new ShellPolicyCandidate(
+                new ShellPolicyCandidateId(0),
+                BashCandidate($"/usr/bin/{secret}\r\n\u202Espoof")),
+            ShellCoverageKind.ReviewedSafePolicy,
+            ShellPolicyReason.ReviewedSafePhrase,
+            ShellScopeRelation.UnderRealRoot);
+        var trace = builder.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.SafeVerbInTrustedScope));
+
+        executor.LogShellPolicyTrace(trace);
+
+        Assert.Equal(trace.Rows.Count, logger.Entries.Count);
+        var candidateLog = logger.Entries[0];
+        var executable = Assert.IsType<string>(candidateLog["ExecutableBasename"]);
+        Assert.DoesNotContain(secret, executable, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", executable, StringComparison.Ordinal);
+        Assert.Contains("\\u000D\\u000A", executable, StringComparison.Ordinal);
+        Assert.Contains("\\u202E", executable, StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', executable);
+        Assert.DoesNotContain('\n', executable);
+    }
+
+    [Theory]
+    [InlineData(nameof(ShellApprovalNearMissReason.TokenMismatch), nameof(ShellPolicyTraceReason.TokenMismatch))]
+    [InlineData(nameof(ShellApprovalNearMissReason.ShellMismatch), nameof(ShellPolicyTraceReason.ShellMismatch))]
+    public void Shell_policy_trace_maps_typed_phrase_near_misses(
+        string nearMissReasonName,
+        string traceReasonName)
+    {
+        var nearMissReason = Enum.Parse<ShellApprovalNearMissReason>(nearMissReasonName);
+        var traceReason = Enum.Parse<ShellPolicyTraceReason>(traceReasonName);
+        var candidate = new ShellPolicyCandidate(
+            new ShellPolicyCandidateId(0),
+            BashCandidate("git push"));
+        var grant = ApprovalEntry.CreateTokenPrefix(
+            ApprovalShell.Bash,
+            ["git", "status"]);
+        var actorMatch = new ShellGrantCandidateMatch(
+            candidate.Id,
+            Match: null,
+            GrantCoverage: null,
+            NearMisses: [new ShellApprovalNearMiss(grant, nearMissReason)]);
+        var builder = new ShellPolicyDecisionTraceBuilder();
+
+        builder.AddActorEvidence(candidate, actorMatch);
+        var trace = builder.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.SafeVerbInTrustedScope));
+
+        Assert.Equal(traceReason, trace.Rows[0].Reason);
+        Assert.Equal(ShellPolicyTraceOutcome.Uncovered, trace.Rows[0].Outcome);
     }
 
     [Fact]
@@ -2056,7 +2322,8 @@ public class DispatchingToolExecutorTests
     }
 
     private static DispatchingToolExecutor CreateApprovalGatedShellExecutor(
-        IToolApprovalService? approvalService = null)
+        IToolApprovalService? approvalService = null,
+        ILogger<DispatchingToolExecutor>? logger = null)
     {
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
         config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
@@ -2083,7 +2350,8 @@ public class DispatchingToolExecutorTests
                     UsedStrictFallback: false),
                 new ShellCommandPolicy(),
                 new ToolPathPolicy([])),
-            approvalService ?? new UnexpectedApprovalService());
+            approvalService ?? new UnexpectedApprovalService(),
+            logger: logger);
     }
 
     private static ToolExecutionContext CreateInteractivePersonalContext(string sessionId)

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
@@ -435,7 +436,7 @@ public sealed class ToolApprovalActorTests : TestKit
     }
 
     [Fact]
-    public async Task Directory_near_miss_is_logged_without_changing_the_decision()
+    public async Task Legacy_shell_check_does_not_log_raw_near_miss_data()
     {
         var ct = TestContext.Current.CancellationToken;
         var tempFile = Path.GetTempFileName();
@@ -452,16 +453,13 @@ public sealed class ToolApprovalActorTests : TestKit
             var actor = Sys.ActorOf(ToolApprovalActor.CreateProps(store));
             var service = CreateService(actor);
 
-            IReadOnlyList<string> unapproved = [];
-            await EventFilter.Info(contains: "approval_near_miss").ExpectAsync(2, async () =>
+            await EventFilter.Info(contains: "approval_near_miss").ExpectAsync(0, async () =>
             {
-                unapproved = await service.GetUnapprovedPatternsAsync(
+                var unapproved = await service.GetUnapprovedPatternsAsync(
                     "session-a", TrustAudience.Personal, new ToolName("shell_execute"),
                     ["git push"], cwd: otherDir, ct);
+                Assert.Equal(["git push"], unapproved);
             }, cancellationToken: ct);
-
-            // The diagnostic is read-only: the candidate is still unapproved.
-            Assert.Equal(["git push"], unapproved);
         }
         finally
         {
@@ -778,6 +776,110 @@ public sealed class ToolApprovalActorTests : TestKit
             Assert.NotNull(result.CandidateMatches[0].Match);
             Assert.Null(result.CandidateMatches[1].GrantCoverage);
             Assert.Null(result.CandidateMatches[1].Match);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Typed_shell_batch_returns_persistent_grant_timestamp()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grantTimestamp = new DateTimeOffset(2026, 8, 13, 8, 0, 0, TimeSpan.Zero);
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.Delete(tempFile);
+            var store = new ToolApprovalStore(
+                tempFile,
+                new FakeTimeProvider(grantTimestamp),
+                new ApprovalStoreMigrationContext(NativeShell),
+                TimeSpan.Zero);
+            var actor = Sys.ActorOf(ToolApprovalActor.CreateProps(store));
+            var service = CreateService(actor);
+            var candidate = NativeCandidate("git status");
+            await service.RecordApprovalCandidatesAsync(
+                (ToolApprovalSessionId)"session-a",
+                TrustAudience.Personal,
+                new ToolName("shell_execute"),
+                [new ToolApprovalGrant(candidate, Directory: null)],
+                persistent: true,
+                ct);
+
+            var result = await ((IShellApprovalMatchService)service).MatchShellCandidatesAsync(
+                new ShellApprovalMatchRequest(
+                    SessionId: null,
+                    TrustAudience.Personal,
+                    new ToolName("shell_execute"),
+                    TestShellEnvironment.Current,
+                    [
+                        new ShellGrantCandidate(
+                            new ShellPolicyCandidateId(0),
+                            candidate,
+                            RealDirectory: null)
+                    ]),
+                ct);
+
+            var match = Assert.Single(result.CandidateMatches);
+            Assert.Equal(ShellCoverageKind.PersistentGlobal, match.GrantCoverage);
+            Assert.Equal(grantTimestamp, match.GrantCreatedAt);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Typed_shell_batch_returns_bounded_folder_near_miss_from_one_snapshot()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grantTimestamp = new DateTimeOffset(2026, 8, 13, 8, 15, 0, TimeSpan.Zero);
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.Delete(tempFile);
+            var grantDirectory = Path.Combine(Path.GetTempPath(), "netclaw-trace", "grant");
+            var otherDirectory = Path.Combine(Path.GetTempPath(), "netclaw-trace", "other");
+            var store = new ToolApprovalStore(
+                tempFile,
+                new FakeTimeProvider(grantTimestamp),
+                new ApprovalStoreMigrationContext(NativeShell),
+                TimeSpan.Zero);
+            var actor = Sys.ActorOf(ToolApprovalActor.CreateProps(store));
+            var service = CreateService(actor);
+            var candidate = NativeCandidate("git status");
+            await service.RecordApprovalCandidatesAsync(
+                (ToolApprovalSessionId)"session-a",
+                TrustAudience.Personal,
+                new ToolName("shell_execute"),
+                [new ToolApprovalGrant(candidate, grantDirectory)],
+                persistent: true,
+                ct);
+
+            var result = await ((IShellApprovalMatchService)service).MatchShellCandidatesAsync(
+                new ShellApprovalMatchRequest(
+                    SessionId: null,
+                    TrustAudience.Personal,
+                    new ToolName("shell_execute"),
+                    TestShellEnvironment.Current,
+                    [
+                        new ShellGrantCandidate(
+                            new ShellPolicyCandidateId(0),
+                            candidate,
+                            otherDirectory)
+                    ]),
+                ct);
+
+            var match = Assert.Single(result.CandidateMatches);
+            Assert.Null(match.Match);
+            Assert.Null(match.GrantCoverage);
+            Assert.Null(match.GrantCreatedAt);
+            var nearMiss = Assert.Single(match.NearMisses);
+            Assert.Equal(ShellApprovalNearMissReason.OutsideDirectory, nearMiss.Reason);
+            Assert.Equal(grantTimestamp, nearMiss.Grant.CreatedAt);
         }
         finally
         {

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -516,6 +516,27 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
             default:
                 throw new ArgumentOutOfRangeException(nameof(decision), decision.Outcome, "Unknown authorization outcome.");
         }
+
+        LogShellPolicyTrace(decision.ShellPolicyTrace);
+    }
+
+    internal void LogShellPolicyTrace(ShellPolicyDecisionTrace trace)
+    {
+        foreach (var row in trace.Rows)
+        {
+            _logger.LogInformation(
+                "Shell policy trace: stage={PolicyStage} outcome={PolicyOutcome} reason={PolicyReason} " +
+                "candidate_id={CandidateId} executable={ExecutableBasename} " +
+                "coverage={CoverageKind} scope_relation={ScopeRelation} grant_timestamp={GrantTimestamp}",
+                row.Stage.ToString(),
+                row.Outcome.ToString(),
+                row.Reason.ToString(),
+                row.CandidateId?.Value,
+                row.ExecutableBasename,
+                row.Coverage.ToString(),
+                row.ScopeRelation.ToString(),
+                row.GrantTimestamp);
+        }
     }
 
     private static string FormatApprovalMatches(IReadOnlyList<ToolApprovalMatch> matches)

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -23,9 +23,10 @@ internal sealed class ShellPolicyCoordinator(
         ToolExecutionContext context,
         CancellationToken cancellationToken)
     {
+        var trace = new ShellPolicyDecisionTraceBuilder();
         try
         {
-            return await EvaluateCoreAsync(tool, toolCall, context, cancellationToken);
+            return await EvaluateCoreAsync(tool, toolCall, context, trace, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -33,7 +34,9 @@ internal sealed class ShellPolicyCoordinator(
         }
         catch (Exception)
         {
-            return ToolAuthorizationDecision.Deny("internal_policy_failure");
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                trace);
         }
     }
 
@@ -41,11 +44,12 @@ internal sealed class ShellPolicyCoordinator(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
+        ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
         var preflight = policy.AuthorizeShellPreflight(tool, context, toolCall.Arguments);
         if (!preflight.NeedsApproval)
-            return Complete(preflight, []);
+            return Complete(preflight, [], trace);
 
         var approvalContext = preflight.ApprovalContext;
         policy.TryGetAuthorizedShellAnalysis(context, out var execution);
@@ -58,7 +62,9 @@ internal sealed class ShellPolicyCoordinator(
                 out var projection)
             || projection is null)
         {
-            return ToolAuthorizationDecision.Deny("internal_policy_failure");
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                trace);
         }
 
         return await CompleteAsync(
@@ -66,6 +72,7 @@ internal sealed class ShellPolicyCoordinator(
             toolCall,
             context,
             projection,
+            trace,
             cancellationToken);
     }
 
@@ -74,13 +81,14 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyProjection projection,
+        ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
         if (projection.ApprovalContext.IsMessy)
-            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, []);
+            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, [], trace);
 
         if (projection.Candidates.Count == 0)
-            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, []);
+            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, [], trace);
 
         var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
             ? ApprovalShell.Bash
@@ -88,7 +96,7 @@ internal sealed class ShellPolicyCoordinator(
         if (projection.Candidates.Any(candidate => candidate.Candidate.Shell is null
                                                     || candidate.Candidate.VerbTokens is null))
         {
-            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, []);
+            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, [], trace);
         }
 
         if (projection.Candidates.Any(candidate =>
@@ -97,7 +105,9 @@ internal sealed class ShellPolicyCoordinator(
                 || candidate.Candidate.VerbTokens!.Any(static token =>
                     token.Length == 0 || token.Any(char.IsWhiteSpace))))
         {
-            return ToolAuthorizationDecision.Deny("internal_policy_failure");
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                trace);
         }
 
         var coverage = new ShellCoverageSet(projection.Candidates);
@@ -124,7 +134,29 @@ internal sealed class ShellPolicyCoordinator(
                 projection.ApprovalContext.Cwd,
                 coverage,
                 out var approvalMatches))
-            return ToolAuthorizationDecision.Deny("internal_policy_failure");
+        {
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                trace);
+        }
+
+        foreach (var actorMatch in actorResult.CandidateMatches)
+        {
+            var candidate = grantCandidates.First(item => item.Id == actorMatch.CandidateId);
+            trace.AddActorEvidence(candidate, actorMatch);
+        }
+
+        foreach (var candidate in projection.Candidates.Where(item =>
+                     approvalService is not null
+                     && ApprovalPatternMatching.IsPureSideEffect(item.Candidate)))
+        {
+            trace.AddCoverage(
+                ShellPolicyTraceStage.ReviewedSafePolicy,
+                candidate,
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyReason.ApprovalExemptSideEffect,
+                ShellScopeRelation.None);
+        }
 
         foreach (var candidate in grantCandidates.Where(candidate =>
                      coverage.UncoveredIds.Contains(candidate.Id)))
@@ -138,6 +170,12 @@ internal sealed class ShellPolicyCoordinator(
                     candidate.Id,
                     ShellCoverageKind.ReviewedSafePolicy,
                     ShellPolicyReason.ReviewedSafePhrase);
+                trace.AddCoverage(
+                    ShellPolicyTraceStage.ReviewedSafePolicy,
+                    candidate,
+                    ShellCoverageKind.ReviewedSafePolicy,
+                    ShellPolicyReason.ReviewedSafePhrase,
+                    ShellScopeRelation.UnderRealRoot);
             }
         }
 
@@ -157,6 +195,12 @@ internal sealed class ShellPolicyCoordinator(
                         candidate.Id,
                         ShellCoverageKind.OneTime,
                         ShellPolicyReason.OneTimeGrant);
+                    trace.AddCoverage(
+                        ShellPolicyTraceStage.OneTimeApproval,
+                        candidate,
+                        ShellCoverageKind.OneTime,
+                        ShellPolicyReason.OneTimeGrant,
+                        ShellScopeRelation.None);
                 }
 
                 uncovered = [];
@@ -167,7 +211,9 @@ internal sealed class ShellPolicyCoordinator(
         if (uncovered.Count > 0
             && actorResult.PersistentStore is PersistentGrantStoreStatus.Unavailable)
         {
-            return ToolAuthorizationDecision.Deny("approval_store_unavailable");
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("approval_store_unavailable"),
+                trace);
         }
 
         if (uncovered.Count > 0)
@@ -176,17 +222,25 @@ internal sealed class ShellPolicyCoordinator(
                 projection.ApprovalContext,
                 uncovered.Select(static candidate => candidate.Candidate).ToArray(),
                 context.SessionDirectory);
-            return ToolAuthorizationDecision.RequiresApproval(promptContext, approvalMatches);
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.RequiresApproval(promptContext, approvalMatches),
+                trace);
         }
 
         if (!coverage.AllCovered)
-            return ToolAuthorizationDecision.Deny("internal_policy_failure");
+        {
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                trace);
+        }
 
         if (oneTimeApplied)
         {
-            return ToolAuthorizationDecision.Allow(
-                ToolAllowReason.OneTimeApproval,
-                approvalMatches);
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Allow(
+                    ToolAllowReason.OneTimeApproval,
+                    approvalMatches),
+                trace);
         }
 
         if (approvalMatches.Count > 0)
@@ -198,15 +252,19 @@ internal sealed class ShellPolicyCoordinator(
                     FormatApprovalMatches(approvalMatches));
             }
 
-            return ToolAuthorizationDecision.Allow(
-                ToolAllowReason.StoredApproval,
-                approvalMatches);
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Allow(
+                    ToolAllowReason.StoredApproval,
+                    approvalMatches),
+                trace);
         }
 
-        return ToolAuthorizationDecision.Allow(
-            grantCandidates.Count == 0
-                ? ToolAllowReason.ApprovalExemptShellCandidates
-                : ToolAllowReason.SafeVerbInTrustedScope);
+        return CompleteWithTrace(
+            ToolAuthorizationDecision.Allow(
+                grantCandidates.Count == 0
+                    ? ToolAllowReason.ApprovalExemptShellCandidates
+                    : ToolAllowReason.SafeVerbInTrustedScope),
+            trace);
     }
 
     private async Task<ShellApprovalMatchResult> MatchCandidatesAsync(
@@ -359,8 +417,14 @@ internal sealed class ShellPolicyCoordinator(
 
             if (candidateMatch.Match is null)
             {
-                if (candidateMatch.GrantCoverage is not null)
+                if (candidateMatch.GrantCoverage is not null
+                    || candidateMatch.GrantCreatedAt is not null
+                    || candidateMatch.NearMisses.Count > 1
+                    || candidateMatch.NearMisses.Any(static nearMiss =>
+                        !Enum.IsDefined(nearMiss.Reason)))
+                {
                     return false;
+                }
 
                 continue;
             }
@@ -368,7 +432,10 @@ internal sealed class ShellPolicyCoordinator(
             if (candidateMatch.GrantCoverage is not
                 (ShellCoverageKind.Session
                 or ShellCoverageKind.PersistentGlobal
-                or ShellCoverageKind.PersistentFolder))
+                or ShellCoverageKind.PersistentFolder)
+                || candidateMatch.NearMisses.Count > 0
+                || (candidateMatch.GrantCoverage == ShellCoverageKind.Session
+                    && candidateMatch.GrantCreatedAt is not null))
             {
                 return false;
             }
@@ -464,10 +531,14 @@ internal sealed class ShellPolicyCoordinator(
         string toolName,
         ShellPolicyProjection projection,
         ToolApprovalContext approvalContext,
-        IReadOnlyList<ToolApprovalMatch> approvalMatches)
-        => projection.HasExactOneTimeApproval(toolName, approvalContext)
+        IReadOnlyList<ToolApprovalMatch> approvalMatches,
+        ShellPolicyDecisionTraceBuilder trace)
+    {
+        var decision = projection.HasExactOneTimeApproval(toolName, approvalContext)
             ? ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval, approvalMatches)
             : ToolAuthorizationDecision.RequiresApproval(approvalContext, approvalMatches);
+        return CompleteWithTrace(decision, trace);
+    }
 
     private static bool HasSameCandidateFacts(
         ApprovalCandidate first,
@@ -482,28 +553,40 @@ internal sealed class ShellPolicyCoordinator(
 
     private static ToolAuthorizationDecision Complete(
         ToolAccessDecision decision,
-        IReadOnlyList<ToolApprovalMatch> approvalMatches)
+        IReadOnlyList<ToolApprovalMatch> approvalMatches,
+        ShellPolicyDecisionTraceBuilder trace)
     {
         if (decision.NeedsApproval)
         {
-            return ToolAuthorizationDecision.RequiresApproval(
-                decision.ApprovalContext
-                ?? throw new InvalidOperationException("Approval decision missing approval context."),
-                approvalMatches);
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.RequiresApproval(
+                    decision.ApprovalContext
+                    ?? throw new InvalidOperationException("Approval decision missing approval context."),
+                    approvalMatches),
+                trace);
         }
 
         if (!decision.Allowed)
         {
-            return ToolAuthorizationDecision.Deny(
-                decision.DenyReason
-                ?? throw new InvalidOperationException("Denied decision missing a deny reason."));
+            return CompleteWithTrace(
+                ToolAuthorizationDecision.Deny(
+                    decision.DenyReason
+                    ?? throw new InvalidOperationException("Denied decision missing a deny reason.")),
+                trace);
         }
 
-        return ToolAuthorizationDecision.Allow(
-            decision.AllowReason
-            ?? throw new InvalidOperationException("Allowed decision missing an allow reason."),
-            approvalMatches);
+        return CompleteWithTrace(
+            ToolAuthorizationDecision.Allow(
+                decision.AllowReason
+                ?? throw new InvalidOperationException("Allowed decision missing an allow reason."),
+                approvalMatches),
+            trace);
     }
+
+    private static ToolAuthorizationDecision CompleteWithTrace(
+        ToolAuthorizationDecision decision,
+        ShellPolicyDecisionTraceBuilder trace)
+        => decision.WithShellPolicyTrace(trace.Complete(decision));
 
     private static string FormatApprovalMatches(IReadOnlyList<ToolApprovalMatch> matches)
         => string.Join(", ", matches.Select(match =>

--- a/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
@@ -1,0 +1,339 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyDecisionTrace.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text;
+using Netclaw.Configuration;
+using Netclaw.Security;
+
+namespace Netclaw.Actors.Tools;
+
+internal enum ShellPolicyTraceStage
+{
+    StoredGrantMatch = 0,
+    ReviewedSafePolicy = 1,
+    OneTimeApproval = 2,
+    Completion = 3,
+    Trace = 4,
+}
+
+internal enum ShellPolicyTraceOutcome
+{
+    Covered = 0,
+    Uncovered = 1,
+    Allow = 2,
+    RequiresApproval = 3,
+    Deny = 4,
+    TraceTruncated = 5,
+}
+
+internal enum ShellPolicyTraceReason
+{
+    None = 0,
+    NoGrant = 1,
+    OneTimeGrant = 2,
+    SessionGrant = 3,
+    PersistentGlobalGrant = 4,
+    PersistentFolderGrant = 5,
+    ReviewedSafePhrase = 6,
+    ApprovalExemptSideEffect = 7,
+    OutsideDirectory = 8,
+    Symlink = 9,
+    MissingDirectory = 10,
+    TokenMismatch = 11,
+    ShellMismatch = 12,
+    AllCandidatesCovered = 13,
+    UncoveredCandidates = 14,
+    ApprovalStoreUnavailable = 15,
+    InternalPolicyFailure = 16,
+    PolicyAuto = 17,
+    BackgroundJobLifecycle = 18,
+    SafeVerbInTrustedScope = 19,
+    ApprovalExemptShellCandidates = 20,
+    TraceLimitReached = 21,
+    PolicyDenied = 22,
+}
+
+internal enum ShellScopeRelation
+{
+    None = 0,
+    ThisChat = 1,
+    Global = 2,
+    UnderGrantRoot = 3,
+    UnderRealRoot = 4,
+    OutsideGrantRoot = 5,
+    SymlinkBoundary = 6,
+}
+
+internal sealed record ShellPolicyTraceRow(
+    ShellPolicyTraceStage Stage,
+    ShellPolicyTraceOutcome Outcome,
+    ShellPolicyTraceReason Reason,
+    ShellPolicyCandidateId? CandidateId,
+    string? ExecutableBasename,
+    ShellCoverageKind? Coverage,
+    ShellScopeRelation ScopeRelation,
+    DateTimeOffset? GrantTimestamp);
+
+internal sealed record ShellPolicyDecisionTrace(IReadOnlyList<ShellPolicyTraceRow> Rows)
+{
+    internal static ShellPolicyDecisionTrace Empty { get; } = new([]);
+}
+
+internal sealed class ShellPolicyDecisionTraceBuilder
+{
+    internal const int MaximumRows = 256;
+    internal const int MaximumTextCodeUnits = 128;
+
+    private const int MaximumDetailRows = MaximumRows - 1;
+    private const int MaximumSourceTextCodeUnits = 512;
+    private const string RedactedText = "***REDACTED***";
+
+    private readonly List<ShellPolicyTraceRow> _rows = [];
+    private readonly HashSet<(ShellPolicyTraceStage Stage, int? CandidateId)> _rowKeys = [];
+    private bool _truncated;
+    private ShellPolicyDecisionTrace? _completedTrace;
+
+    internal void AddActorEvidence(
+        ShellPolicyCandidate candidate,
+        ShellGrantCandidateMatch actorMatch)
+    {
+        if (actorMatch.Match is not null && actorMatch.GrantCoverage is { } coverage)
+        {
+            AddDetail(new ShellPolicyTraceRow(
+                ShellPolicyTraceStage.StoredGrantMatch,
+                ShellPolicyTraceOutcome.Covered,
+                ToTraceReason(coverage),
+                candidate.Id,
+                GetExecutableBasename(candidate.Candidate),
+                coverage,
+                ToScopeRelation(coverage),
+                actorMatch.GrantCreatedAt));
+            return;
+        }
+
+        var nearMiss = actorMatch.NearMisses.FirstOrDefault();
+        AddDetail(new ShellPolicyTraceRow(
+            ShellPolicyTraceStage.StoredGrantMatch,
+            ShellPolicyTraceOutcome.Uncovered,
+            nearMiss is null ? ShellPolicyTraceReason.NoGrant : ToTraceReason(nearMiss.Reason),
+            candidate.Id,
+            GetExecutableBasename(candidate.Candidate),
+            nearMiss is null
+                ? ShellCoverageKind.Uncovered
+                : nearMiss.Grant.Directory is null
+                    ? ShellCoverageKind.PersistentGlobal
+                    : ShellCoverageKind.PersistentFolder,
+            nearMiss is null
+                ? ShellScopeRelation.None
+                : ToScopeRelation(nearMiss),
+            nearMiss?.Grant.CreatedAt));
+    }
+
+    internal void AddCoverage(
+        ShellPolicyTraceStage stage,
+        ShellPolicyCandidate candidate,
+        ShellCoverageKind coverage,
+        ShellPolicyReason reason,
+        ShellScopeRelation scopeRelation)
+        => AddDetail(new ShellPolicyTraceRow(
+            stage,
+            ShellPolicyTraceOutcome.Covered,
+            ToTraceReason(reason),
+            candidate.Id,
+            GetExecutableBasename(candidate.Candidate),
+            coverage,
+            scopeRelation,
+            GrantTimestamp: null));
+
+    internal ShellPolicyDecisionTrace Complete(ToolAuthorizationDecision decision)
+    {
+        if (_completedTrace is not null)
+            return _completedTrace;
+
+        var completion = ToCompletionRow(decision);
+        _rows.Add(completion);
+        _completedTrace = new ShellPolicyDecisionTrace(Array.AsReadOnly(_rows.ToArray()));
+        return _completedTrace;
+    }
+
+    internal static string SanitizeText(string value)
+    {
+        // A partial private-key block cannot be recognized after truncation.
+        // Fail closed for oversized executable text and redact complete
+        // bounded input before projecting the trace field.
+        var redacted = value.Length <= MaximumSourceTextCodeUnits
+            ? SecretOutputRedactor.Redact(value)
+            : RedactedText;
+        var result = new StringBuilder(Math.Min(redacted.Length, MaximumTextCodeUnits));
+        for (var index = 0; index < redacted.Length; index++)
+        {
+            var current = redacted[index];
+            if (char.IsHighSurrogate(current)
+                && index + 1 < redacted.Length
+                && char.IsLowSurrogate(redacted[index + 1]))
+            {
+                if (result.Length + 2 > MaximumTextCodeUnits)
+                    break;
+
+                result.Append(current).Append(redacted[++index]);
+                continue;
+            }
+
+            if (char.IsSurrogate(current) || IsUnsafeTextCodeUnit(current))
+            {
+                if (result.Length + 6 > MaximumTextCodeUnits)
+                    break;
+
+                result.Append("\\u").Append(((int)current).ToString("X4"));
+                continue;
+            }
+
+            if (result.Length == MaximumTextCodeUnits)
+                break;
+
+            result.Append(current);
+        }
+
+        return result.ToString();
+    }
+
+    private void AddDetail(ShellPolicyTraceRow row)
+    {
+        if (_completedTrace is not null || _truncated)
+            return;
+
+        var key = (row.Stage, row.CandidateId?.Value);
+        if (!_rowKeys.Add(key))
+            return;
+
+        if (_rows.Count < MaximumDetailRows)
+        {
+            _rows.Add(row);
+            return;
+        }
+
+        _rows[^1] = new ShellPolicyTraceRow(
+            ShellPolicyTraceStage.Trace,
+            ShellPolicyTraceOutcome.TraceTruncated,
+            ShellPolicyTraceReason.TraceLimitReached,
+            CandidateId: null,
+            ExecutableBasename: null,
+            Coverage: null,
+            ShellScopeRelation.None,
+            GrantTimestamp: null);
+        _truncated = true;
+    }
+
+    private static ShellPolicyTraceRow ToCompletionRow(ToolAuthorizationDecision decision)
+    {
+        var (outcome, reason) = decision.Outcome switch
+        {
+            ToolAuthorizationOutcome.Allowed => (
+                ShellPolicyTraceOutcome.Allow,
+                ToTraceReason(decision.AllowReason)),
+            ToolAuthorizationOutcome.RequiresApproval => (
+                ShellPolicyTraceOutcome.RequiresApproval,
+                ShellPolicyTraceReason.UncoveredCandidates),
+            ToolAuthorizationOutcome.Denied => (
+                ShellPolicyTraceOutcome.Deny,
+                ToTraceReason(decision.DenyReason)),
+            _ => (
+                ShellPolicyTraceOutcome.Deny,
+                ShellPolicyTraceReason.InternalPolicyFailure),
+        };
+        return new ShellPolicyTraceRow(
+            ShellPolicyTraceStage.Completion,
+            outcome,
+            reason,
+            CandidateId: null,
+            ExecutableBasename: null,
+            Coverage: null,
+            ShellScopeRelation.None,
+            GrantTimestamp: null);
+    }
+
+    private static string? GetExecutableBasename(ApprovalCandidate candidate)
+    {
+        if (candidate.VerbTokens is not { Count: > 0 })
+            return null;
+
+        var executable = candidate.VerbTokens[0];
+        var separator = executable.LastIndexOfAny(['/', '\\']);
+        var basename = separator < 0 ? executable : executable[(separator + 1)..];
+        return SanitizeText(basename);
+    }
+
+    private static ShellPolicyTraceReason ToTraceReason(ShellCoverageKind coverage) => coverage switch
+    {
+        ShellCoverageKind.Session => ShellPolicyTraceReason.SessionGrant,
+        ShellCoverageKind.PersistentGlobal => ShellPolicyTraceReason.PersistentGlobalGrant,
+        ShellCoverageKind.PersistentFolder => ShellPolicyTraceReason.PersistentFolderGrant,
+        _ => ShellPolicyTraceReason.None,
+    };
+
+    private static ShellPolicyTraceReason ToTraceReason(ShellPolicyReason reason) => reason switch
+    {
+        ShellPolicyReason.OneTimeGrant => ShellPolicyTraceReason.OneTimeGrant,
+        ShellPolicyReason.SessionGrant => ShellPolicyTraceReason.SessionGrant,
+        ShellPolicyReason.PersistentGlobalGrant => ShellPolicyTraceReason.PersistentGlobalGrant,
+        ShellPolicyReason.PersistentFolderGrant => ShellPolicyTraceReason.PersistentFolderGrant,
+        ShellPolicyReason.ReviewedSafePhrase => ShellPolicyTraceReason.ReviewedSafePhrase,
+        ShellPolicyReason.ApprovalExemptSideEffect => ShellPolicyTraceReason.ApprovalExemptSideEffect,
+        _ => ShellPolicyTraceReason.None,
+    };
+
+    private static ShellPolicyTraceReason ToTraceReason(ShellApprovalNearMissReason reason) => reason switch
+    {
+        ShellApprovalNearMissReason.OutsideDirectory => ShellPolicyTraceReason.OutsideDirectory,
+        ShellApprovalNearMissReason.Symlink => ShellPolicyTraceReason.Symlink,
+        ShellApprovalNearMissReason.MissingDirectory => ShellPolicyTraceReason.MissingDirectory,
+        ShellApprovalNearMissReason.TokenMismatch => ShellPolicyTraceReason.TokenMismatch,
+        ShellApprovalNearMissReason.ShellMismatch => ShellPolicyTraceReason.ShellMismatch,
+        _ => ShellPolicyTraceReason.None,
+    };
+
+    private static ShellPolicyTraceReason ToTraceReason(ToolAllowReason? reason) => reason switch
+    {
+        ToolAllowReason.PolicyAuto => ShellPolicyTraceReason.PolicyAuto,
+        ToolAllowReason.BackgroundJobLifecycle => ShellPolicyTraceReason.BackgroundJobLifecycle,
+        ToolAllowReason.SafeVerbInTrustedScope => ShellPolicyTraceReason.SafeVerbInTrustedScope,
+        ToolAllowReason.ApprovalExemptShellCandidates => ShellPolicyTraceReason.ApprovalExemptShellCandidates,
+        ToolAllowReason.StoredApproval or ToolAllowReason.OneTimeApproval =>
+            ShellPolicyTraceReason.AllCandidatesCovered,
+        _ => ShellPolicyTraceReason.InternalPolicyFailure,
+    };
+
+    private static ShellPolicyTraceReason ToTraceReason(string? denyReason) => denyReason switch
+    {
+        "approval_store_unavailable" => ShellPolicyTraceReason.ApprovalStoreUnavailable,
+        "internal_policy_failure" => ShellPolicyTraceReason.InternalPolicyFailure,
+        _ => ShellPolicyTraceReason.PolicyDenied,
+    };
+
+    private static ShellScopeRelation ToScopeRelation(ShellCoverageKind coverage) => coverage switch
+    {
+        ShellCoverageKind.Session => ShellScopeRelation.ThisChat,
+        ShellCoverageKind.PersistentGlobal => ShellScopeRelation.Global,
+        ShellCoverageKind.PersistentFolder => ShellScopeRelation.UnderGrantRoot,
+        _ => ShellScopeRelation.None,
+    };
+
+    private static ShellScopeRelation ToScopeRelation(ShellApprovalNearMiss nearMiss)
+        => nearMiss.Reason switch
+        {
+            ShellApprovalNearMissReason.OutsideDirectory => ShellScopeRelation.OutsideGrantRoot,
+            ShellApprovalNearMissReason.Symlink => ShellScopeRelation.SymlinkBoundary,
+            _ => nearMiss.Grant.Directory is null
+                ? ShellScopeRelation.Global
+                : ShellScopeRelation.None,
+        };
+
+    private static bool IsUnsafeTextCodeUnit(char value)
+        => char.IsControl(value)
+           || value is '\u061C' or '\u200E' or '\u200F'
+           or >= '\u2028' and <= '\u202E'
+           or >= '\u2066' and <= '\u2069'
+           or '\uFEFF';
+}

--- a/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
@@ -47,7 +47,6 @@ internal sealed class ToolApprovalActor : ReceiveActor
                 if (match is null)
                 {
                     unapproved.Add(candidate.Verb);
-                    LogApprovalNearMisses(msg.ToolName, candidate, msg.Cwd, snapshot.Approvals);
                     continue;
                 }
 
@@ -68,25 +67,21 @@ internal sealed class ToolApprovalActor : ReceiveActor
             var candidateMatches = new List<ShellGrantCandidateMatch>(msg.Candidates.Count);
             foreach (var candidate in msg.Candidates)
             {
-                var grantMatch = MatchShellApproval(
+                var grantEvaluation = EvaluateShellApproval(
                     msg.SessionId,
                     msg.Audience,
                     msg.ToolName,
                     candidate.Candidate,
                     candidate.RealDirectory,
                     snapshot.Approvals);
-                var nearMisses = grantMatch is null
-                    ? ApprovalPatternMatching.ExplainShellNearMisses(
-                        candidate.Candidate.Verb,
-                        candidate.Candidate.Directory,
-                        candidate.RealDirectory,
-                        snapshot.Approvals)
-                    : [];
                 candidateMatches.Add(new ShellGrantCandidateMatch(
                     candidate.CandidateId,
-                    grantMatch?.Match,
-                    grantMatch?.Coverage,
-                    nearMisses));
+                    grantEvaluation.Match,
+                    grantEvaluation.Coverage,
+                    grantEvaluation.NearMisses)
+                {
+                    GrantCreatedAt = grantEvaluation.GrantCreatedAt
+                });
             }
 
             var storeStatus = snapshot.Failure is { } failure
@@ -237,7 +232,7 @@ internal sealed class ToolApprovalActor : ReceiveActor
         return MatchPersistedEntry(toolName, candidate, cwd, persistedApprovals);
     }
 
-    private ShellActorGrantMatch? MatchShellApproval(
+    private ShellActorGrantEvaluation EvaluateShellApproval(
         SessionId? sessionId,
         TrustAudience audience,
         ToolName toolName,
@@ -248,24 +243,34 @@ internal sealed class ToolApprovalActor : ReceiveActor
         if (sessionId.HasValue
             && IsSessionApproved(sessionId.Value, audience, toolName, candidate))
         {
-            return new ShellActorGrantMatch(
+            return new ShellActorGrantEvaluation(
                 new ToolApprovalMatch(candidate.Verb, "session", "this chat"),
-                ShellCoverageKind.Session);
+                ShellCoverageKind.Session,
+                GrantCreatedAt: null,
+                NearMisses: []);
         }
 
-        foreach (var entry in persistedApprovals)
+        var evaluation = ApprovalPatternMatching.EvaluateShellApproval(
+            candidate,
+            cwd,
+            persistedApprovals,
+            maximumNearMisses: 1);
+        if (evaluation.MatchedEntry is { } entry)
         {
-            if (!ApprovalPatternMatching.MatchesShellApproval(candidate, cwd, [entry]))
-                continue;
-
-            return new ShellActorGrantMatch(
+            return new ShellActorGrantEvaluation(
                 new ToolApprovalMatch(candidate.Verb, "persistent", entry.FormatScope()),
                 entry.Directory is null
                     ? ShellCoverageKind.PersistentGlobal
-                    : ShellCoverageKind.PersistentFolder);
+                    : ShellCoverageKind.PersistentFolder,
+                entry.CreatedAt,
+                NearMisses: []);
         }
 
-        return null;
+        return new ShellActorGrantEvaluation(
+            Match: null,
+            Coverage: null,
+            GrantCreatedAt: null,
+            evaluation.NearMisses);
     }
 
     private bool IsSessionApproved(
@@ -425,37 +430,6 @@ internal sealed class ToolApprovalActor : ReceiveActor
         return null;
     }
 
-    /// <summary>
-    /// Emits a diagnostic when a shell pattern is prompted for despite a
-    /// persisted grant existing for the same verb — the operator's
-    /// "I already approved this" case. Read-only: it does not affect the
-    /// gate decision. Non-shell tools authorize on a verb match alone, so a
-    /// same-verb persisted entry would have approved them; nothing to explain.
-    /// </summary>
-    private void LogApprovalNearMisses(ToolName toolName, ApprovalCandidate candidate, string? cwd, IReadOnlyList<ApprovalEntry> approved)
-    {
-        if (!string.Equals(toolName.Value, ShellTool.ToolName, StringComparison.Ordinal))
-            return;
-
-        var nearMisses = ApprovalPatternMatching.ExplainShellNearMisses(
-            candidate.Verb, candidate.Directory, cwd, approved);
-
-        foreach (var miss in nearMisses)
-        {
-            _log.Info(
-                "approval_near_miss tool={ToolName} verb={CandidateVerb} candidate_dir={CandidateDirectory} cwd={Cwd}",
-                toolName.Value,
-                candidate.Verb,
-                candidate.Directory ?? "(none)",
-                cwd ?? "(none)");
-            _log.Info(
-                "approval_near_miss grant={GrantScope} grant_created_at={GrantCreatedAt} reason={Reason}",
-                miss.Grant.FormatScope(),
-                miss.Grant.CreatedAt?.ToString("u") ?? "unknown",
-                miss.Describe());
-        }
-    }
-
     private static string BuildSessionKey(SessionId sessionId, TrustAudience audience)
         => $"{sessionId.Value}|{audience.ToWireValue()}";
 
@@ -463,9 +437,11 @@ internal sealed class ToolApprovalActor : ReceiveActor
         IReadOnlyList<ApprovalEntry> Approvals,
         ApprovalStoreFailure? Failure);
 
-    private sealed record ShellActorGrantMatch(
-        ToolApprovalMatch Match,
-        ShellCoverageKind Coverage);
+    private sealed record ShellActorGrantEvaluation(
+        ToolApprovalMatch? Match,
+        ShellCoverageKind? Coverage,
+        DateTimeOffset? GrantCreatedAt,
+        IReadOnlyList<ShellApprovalNearMiss> NearMisses);
 }
 
 internal sealed record ToolApprovalRecorded(ApprovalStoreFailure? Failure)

--- a/src/Netclaw.Actors/Tools/ToolApprovalMessages.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalMessages.cs
@@ -104,4 +104,7 @@ internal sealed record ShellGrantCandidateMatch(
     ShellPolicyCandidateId CandidateId,
     ToolApprovalMatch? Match,
     ShellCoverageKind? GrantCoverage,
-    IReadOnlyList<ApprovalNearMiss> NearMisses);
+    IReadOnlyList<ShellApprovalNearMiss> NearMisses)
+{
+    internal DateTimeOffset? GrantCreatedAt { get; init; }
+}

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -148,13 +148,15 @@ internal sealed record ToolAuthorizationDecision
         ToolAllowReason? allowReason,
         string? denyReason,
         ToolApprovalContext? approvalContext,
-        IReadOnlyList<ToolApprovalMatch> approvalMatches)
+        IReadOnlyList<ToolApprovalMatch> approvalMatches,
+        ShellPolicyDecisionTrace? shellPolicyTrace = null)
     {
         Outcome = outcome;
         AllowReason = allowReason;
         DenyReason = denyReason;
         ApprovalContext = approvalContext;
         ApprovalMatches = approvalMatches;
+        ShellPolicyTrace = shellPolicyTrace ?? ShellPolicyDecisionTrace.Empty;
     }
 
     /// <summary>
@@ -187,6 +189,8 @@ internal sealed record ToolAuthorizationDecision
     /// Policy, safe-rule, approval-exempt, and deny decisions contain an empty list.
     /// </remarks>
     public IReadOnlyList<ToolApprovalMatch> ApprovalMatches { get; }
+
+    internal ShellPolicyDecisionTrace ShellPolicyTrace { get; init; }
 
     /// <summary>
     /// Creates an allowed result without stored approval matches.
@@ -247,6 +251,12 @@ internal sealed record ToolAuthorizationDecision
             null,
             context,
             [.. approvalMatches]);
+    }
+
+    internal ToolAuthorizationDecision WithShellPolicyTrace(ShellPolicyDecisionTrace trace)
+    {
+        ArgumentNullException.ThrowIfNull(trace);
+        return this with { ShellPolicyTrace = trace };
     }
 
     private static void ValidateAllowReason(ToolAllowReason reason)

--- a/src/Netclaw.Security.Tests/ApprovalNearMissTests.cs
+++ b/src/Netclaw.Security.Tests/ApprovalNearMissTests.cs
@@ -119,4 +119,86 @@ public sealed class ApprovalNearMissTests
 
         Assert.Empty(misses);
     }
+
+    [Fact]
+    public void Typed_evaluation_returns_token_mismatch_from_one_grant_pass()
+    {
+        var candidate = new ApprovalCandidate("git push", Directory: null)
+        {
+            Shell = ApprovalShell.Bash,
+            VerbTokens = ["git", "push"],
+        };
+        var grant = ApprovalEntry.CreateTokenPrefix(
+            ApprovalShell.Bash,
+            ["git", "status"]);
+
+        var evaluation = ApprovalPatternMatching.EvaluateShellApproval(
+            candidate,
+            cwd: "/work",
+            [grant],
+            maximumNearMisses: 1);
+
+        Assert.Null(evaluation.MatchedEntry);
+        var nearMiss = Assert.Single(evaluation.NearMisses);
+        Assert.Same(grant, nearMiss.Grant);
+        Assert.Equal(ShellApprovalNearMissReason.TokenMismatch, nearMiss.Reason);
+    }
+
+    [Fact]
+    public void Typed_evaluation_returns_shell_mismatch_from_one_grant_pass()
+    {
+        var candidate = new ApprovalCandidate("git status", Directory: null)
+        {
+            Shell = ApprovalShell.Bash,
+            VerbTokens = ["git", "status"],
+        };
+        var grant = ApprovalEntry.CreateTokenPrefix(
+            ApprovalShell.PowerShell,
+            ["git", "status"]);
+
+        var evaluation = ApprovalPatternMatching.EvaluateShellApproval(
+            candidate,
+            cwd: "/work",
+            [grant],
+            maximumNearMisses: 1);
+
+        Assert.Null(evaluation.MatchedEntry);
+        var nearMiss = Assert.Single(evaluation.NearMisses);
+        Assert.Same(grant, nearMiss.Grant);
+        Assert.Equal(ShellApprovalNearMissReason.ShellMismatch, nearMiss.Reason);
+    }
+
+    [Fact]
+    public void Typed_evaluation_enumerates_the_grant_snapshot_once()
+    {
+        var candidate = new ApprovalCandidate("git push", Directory: null)
+        {
+            Shell = ApprovalShell.Bash,
+            VerbTokens = ["git", "push"],
+        };
+        var grant = ApprovalEntry.CreateTokenPrefix(
+            ApprovalShell.Bash,
+            ["git", "push"],
+            "/work/repository");
+        var enumerationCount = 0;
+
+        IEnumerable<ApprovalEntry> Snapshot()
+        {
+            enumerationCount++;
+            if (enumerationCount > 1)
+                throw new InvalidOperationException("The grant snapshot was enumerated more than once.");
+
+            yield return grant;
+        }
+
+        var evaluation = ApprovalPatternMatching.EvaluateShellApproval(
+            candidate,
+            cwd: "/work/other",
+            Snapshot(),
+            maximumNearMisses: 1);
+
+        Assert.Null(evaluation.MatchedEntry);
+        Assert.Equal(ShellApprovalNearMissReason.OutsideDirectory, Assert.Single(evaluation.NearMisses).Reason);
+        Assert.Equal(1, enumerationCount);
+    }
 }

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -67,52 +67,62 @@ public static class ApprovalPatternMatching
 
         foreach (var entry in approvedEntries)
         {
-            // Global wildcard: matches any candidate by definition.
-            if (entry.Directory is null)
-                return true;
-
-            // Folder-scoped entry requires a concrete effective directory.
-            if (string.IsNullOrEmpty(effectiveDirectory))
-                continue;
-
-            try
+            if (EvaluateApprovalScope(
+                    effectiveDirectory,
+                    entry,
+                    shell,
+                    ref normalizedCandidate) == ShellApprovalScopeResult.Match)
             {
-                if (shell == ApprovalShell.PowerShell)
-                {
-                    normalizedCandidate ??= NormalizeWindowsPath(effectiveDirectory, baseDirectory: null);
-                    var normalizedRoot = NormalizeWindowsPath(entry.Directory, baseDirectory: null);
-                    if (normalizedCandidate is null || normalizedRoot is null ||
-                        !IsWithinWindowsRoot(normalizedCandidate, normalizedRoot))
-                    {
-                        continue;
-                    }
-
-                    if (OperatingSystem.IsWindows() &&
-                        PathUtility.ContainsSymlinkSegment(normalizedRoot, normalizedCandidate))
-                    {
-                        continue;
-                    }
-
-                    return true;
-                }
-
-                normalizedCandidate ??= PathUtility.Normalize(effectiveDirectory);
-
-                if (!PathUtility.IsNormalizedWithinRoot(normalizedCandidate, entry.Directory))
-                    continue;
-
-                if (PathUtility.ContainsSymlinkSegment(entry.Directory, effectiveDirectory))
-                    continue;
-
                 return true;
-            }
-            catch (Exception ex) when (ex is ArgumentException or IOException)
-            {
-                continue;
             }
         }
 
         return false;
+    }
+
+    private static ShellApprovalScopeResult EvaluateApprovalScope(
+        string? effectiveDirectory,
+        ApprovalEntry entry,
+        ApprovalShell? shell,
+        ref string? normalizedCandidate)
+    {
+        if (entry.Directory is null)
+            return ShellApprovalScopeResult.Match;
+
+        if (string.IsNullOrEmpty(effectiveDirectory))
+            return ShellApprovalScopeResult.MissingDirectory;
+
+        try
+        {
+            if (shell == ApprovalShell.PowerShell)
+            {
+                normalizedCandidate ??= NormalizeWindowsPath(effectiveDirectory, baseDirectory: null);
+                var normalizedRoot = NormalizeWindowsPath(entry.Directory, baseDirectory: null);
+                if (normalizedCandidate is null || normalizedRoot is null ||
+                    !IsWithinWindowsRoot(normalizedCandidate, normalizedRoot))
+                {
+                    return ShellApprovalScopeResult.OutsideDirectory;
+                }
+
+                return OperatingSystem.IsWindows() &&
+                       PathUtility.ContainsSymlinkSegment(normalizedRoot, normalizedCandidate)
+                    ? ShellApprovalScopeResult.Symlink
+                    : ShellApprovalScopeResult.Match;
+            }
+
+            normalizedCandidate ??= PathUtility.Normalize(effectiveDirectory);
+
+            if (!PathUtility.IsNormalizedWithinRoot(normalizedCandidate, entry.Directory))
+                return ShellApprovalScopeResult.OutsideDirectory;
+
+            return PathUtility.ContainsSymlinkSegment(entry.Directory, effectiveDirectory)
+                ? ShellApprovalScopeResult.Symlink
+                : ShellApprovalScopeResult.Match;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException)
+        {
+            return ShellApprovalScopeResult.OutsideDirectory;
+        }
     }
 
     /// <summary>
@@ -130,6 +140,95 @@ public static class ApprovalPatternMatching
             phraseMatches,
             candidate.Shell);
     }
+
+    internal static ShellApprovalEvaluation EvaluateShellApproval(
+        ApprovalCandidate candidate,
+        string? cwd,
+        IEnumerable<ApprovalEntry> approvedEntries,
+        int maximumNearMisses)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumNearMisses);
+        var effectiveDirectory = ResolveEffectiveDirectory(
+            candidate.Directory,
+            cwd,
+            candidate.Shell);
+        string? normalizedCandidate = null;
+        List<ShellApprovalNearMiss>? nearMisses = null;
+
+        foreach (var entry in approvedEntries)
+        {
+            if (PhraseMatches(candidate, entry))
+            {
+                var scopeResult = EvaluateApprovalScope(
+                    effectiveDirectory,
+                    entry,
+                    candidate.Shell,
+                    ref normalizedCandidate);
+                if (scopeResult == ShellApprovalScopeResult.Match)
+                    return new ShellApprovalEvaluation(entry, []);
+
+                if ((nearMisses?.Count ?? 0) < maximumNearMisses)
+                {
+                    (nearMisses ??= []).Add(new ShellApprovalNearMiss(
+                        entry,
+                        ToNearMissReason(scopeResult)));
+                }
+
+                continue;
+            }
+
+            if ((nearMisses?.Count ?? 0) >= maximumNearMisses
+                || !TryGetPhraseNearMissReason(candidate, entry, out var reason))
+            {
+                continue;
+            }
+
+            (nearMisses ??= []).Add(new ShellApprovalNearMiss(entry, reason));
+        }
+
+        return new ShellApprovalEvaluation(
+            MatchedEntry: null,
+            nearMisses ?? (IReadOnlyList<ShellApprovalNearMiss>)[]);
+    }
+
+    private static bool TryGetPhraseNearMissReason(
+        ApprovalCandidate candidate,
+        ApprovalEntry entry,
+        out ShellApprovalNearMissReason reason)
+    {
+        reason = default;
+        if (candidate.VerbTokens is not { Count: > 0 }
+            || entry.VerbTokens is not { Count: > 0 }
+            || entry.Shell is null)
+        {
+            return false;
+        }
+
+        var sameExecutable = string.Equals(
+            candidate.VerbTokens[0],
+            entry.VerbTokens[0],
+            StringComparison.OrdinalIgnoreCase);
+        if (!sameExecutable)
+            return false;
+
+        if (candidate.Shell != entry.Shell)
+        {
+            reason = ShellApprovalNearMissReason.ShellMismatch;
+            return true;
+        }
+
+        reason = ShellApprovalNearMissReason.TokenMismatch;
+        return true;
+    }
+
+    private static ShellApprovalNearMissReason ToNearMissReason(ShellApprovalScopeResult result)
+        => result switch
+        {
+            ShellApprovalScopeResult.OutsideDirectory => ShellApprovalNearMissReason.OutsideDirectory,
+            ShellApprovalScopeResult.Symlink => ShellApprovalNearMissReason.Symlink,
+            ShellApprovalScopeResult.MissingDirectory => ShellApprovalNearMissReason.MissingDirectory,
+            _ => throw new ArgumentOutOfRangeException(nameof(result), result, "The scope result is not a near miss."),
+        };
 
     private static bool PhraseMatches(ApprovalCandidate candidate, ApprovalEntry entry)
     {
@@ -488,3 +587,28 @@ public sealed record ApprovalNearMiss(
         _ => "unrecognized near-miss reason",
     };
 }
+
+internal enum ShellApprovalScopeResult
+{
+    Match = 0,
+    OutsideDirectory = 1,
+    Symlink = 2,
+    MissingDirectory = 3,
+}
+
+internal enum ShellApprovalNearMissReason
+{
+    OutsideDirectory = 0,
+    Symlink = 1,
+    MissingDirectory = 2,
+    TokenMismatch = 3,
+    ShellMismatch = 4,
+}
+
+internal sealed record ShellApprovalNearMiss(
+    ApprovalEntry Grant,
+    ShellApprovalNearMissReason Reason);
+
+internal sealed record ShellApprovalEvaluation(
+    ApprovalEntry? MatchedEntry,
+    IReadOnlyList<ShellApprovalNearMiss> NearMisses);

--- a/src/Netclaw.Security/Netclaw.Security.csproj
+++ b/src/Netclaw.Security/Netclaw.Security.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Actors" />
+    <InternalsVisibleTo Include="Netclaw.Actors.Tests" />
     <InternalsVisibleTo Include="Netclaw.Security.Tests" />
   </ItemGroup>
 


### PR DESCRIPTION
## Outcome

Adds a typed, bounded operator trace to the shell policy coordinator so approval-fatigue investigations can identify which stage covered or rejected each candidate without exposing commands, arguments, paths, secrets, or model content.

## Key boundaries

- at most 256 rows, with one row per stage and candidate
- enum stage, outcome, reason, coverage, and scope facts
- only a redacted, escaped, bounded executable basename as text
- trace remains internal and never enters prompts or session journals
- grant match, timestamp, and one bounded near miss come from one actor store-snapshot pass
- malformed actor matches and impossible persistent scopes deny with `internal_policy_failure`
- trace data never changes the authorization decision

## Verification

- Release solution build passed with zero warnings or errors
- full Actors and Security test suites passed; one expected Windows-only skip
- focused coordinator, malformed-result, trace cap, redaction, and private-key boundary tests passed
- strict OpenSpec validation passed
- headers and changed-file formatting passed
- changed-method CRAP scores remain below 5
- adversarial review passed after two corrections: canonical persistent-scope validation and fail-closed long-secret handling
- Slopwatch reports only the pre-existing unrelated `PowerShellHostProbeTests` SW004 warning

Completes `structure-shell-approval-policy` tasks 8.1 through 8.3.