### PR TITLE
Make shell policy evidence executable

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -193,6 +193,10 @@ Done when:
   executable basename, grant scope, and grant time. The actor derives a match
   or one near miss from one store snapshot pass. Raw paths, command text,
   arguments, secrets, prompts, and session events never receive trace data.
+- [x] The approval runbook documents the complete parser-fact-to-policy flow,
+  bounded status and finite-loop examples, partial candidate coverage, and a
+  trace-first operator diagnostic procedure. The source-generated fixture
+  replay pins current D02, D10, and D14 coordinator behavior.
 - [ ] The bundled safe catalog removes every executable whose accepted
   arguments can write, delete, execute code, or mutate a remote service through
   executable argv interpretation. Redirect, parser-owned path/provider, and

--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -76,9 +76,11 @@ commands must run without approval.
 ### Headless mode
 
 Headless mode (`netclaw chat -p "prompt"`) cannot ask for approval — there is no
-interactive user. Approval-gated tools are **automatically denied** in headless
-mode. If you need unrestricted shell in headless scripts, explicitly set
-`shell_execute` to `Auto`:
+interactive user. Netclaw still applies hard deny, path policy, trust zones, and
+stored grants. If any candidate remains uncovered and would need a
+prompt, the call is denied. The reviewed-safe catalog alone does not grant a
+headless call; approval-exempt side effects can still pass. For unrestricted
+shell in headless scripts, explicitly set `shell_execute` to `Auto`:
 
 ```json
 {
@@ -100,26 +102,44 @@ mode. If you need unrestricted shell in headless scripts, explicitly set
 
 When the agent calls a tool in `Approval` mode:
 
-1. The system extracts a **command pattern** (e.g., `git push` from
-   `git push origin main`).
+1. The system extracts a **command pattern** (for example,
+   `git push origin main` from that exact call).
 2. It checks the **approval cache** — has this pattern been approved before?
-3. If not approved, the channel posts an approval prompt:
+3. If a clean reusable shell call in an ordinary directory remains uncovered,
+   the channel posts the default five-choice prompt:
    ```
    🔒 Tool approval required
    > shell_execute: git push origin main
-   Pattern: git push
+   Pattern: git push origin main
 
    Reply with:
-     A) Approve once
-     B) Approve always
-     C) Deny
+     A) Once
+     B) This chat
+     C) Always here
+     D) Always anywhere
+     E) Deny
    ```
 4. The tool execution pauses until the user responds. Other tool calls in the
    same batch continue running independently.
 5. Based on the response:
-   - **Approve once** — command executes; approval valid for this session only
-   - **Approve always** — command executes; pattern persisted to disk
-   - **Deny** — command returns "Command denied by user" to the LLM
+   - **Once** — the exact blocked call retries once; no grant is saved
+   - **This chat** — the covered phrase remains valid anywhere in this session
+   - **Always here** — a folder-scoped grant is saved to disk
+   - **Always anywhere** — a global phrase grant is saved to disk
+   - **Deny** — the call returns "Command denied by user" to the LLM
+
+The policy can remove reusable choices when a command has no clean phrase. It
+also removes `Always here` for a shallow root, session scratch, and non-shell
+tools that have no directory scope. See [When the prompt offers fewer
+buttons](#when-the-prompt-offers-fewer-buttons).
+
+### When the prompt offers fewer buttons
+
+`Once` and `Deny` are the fail-closed choices. Netclaw omits `This chat` and
+the persistent choices when the shell parser cannot produce a clean reusable
+phrase for every uncovered command occurrence. It also omits `Always here`
+when no safe directory scope can be stored. This rule prevents a one-time
+decision from becoming broader reusable authority.
 
 ### Command patterns
 
@@ -172,8 +192,10 @@ path-scoped patterns (for example,
 
 ### Read-only verbs skip the prompt
 
-Demonstrably read-only verbs auto-run with no prompt when invoked inside a
-trusted zone (`session_dir`, or `project_dir` for Personal/Team). The bundled
+In an interactive session, demonstrably read-only verbs auto-run with no prompt
+when invoked inside a trusted zone (`session_dir`, or `project_dir` for
+Personal/Team). In a headless session, this catalog does not grant authority;
+the call still needs an exact one-time, session, or persistent grant. The bundled
 safe-verb lists (`safe-verbs.linux.json`, `safe-verbs.windows.json`) cover file
 readers (for example `ls`, `grep`, and `cat` on Bash; `Get-ChildItem`,
 `Get-Content`, and `Select-String` on PowerShell), system/info verbs (`date`,
@@ -188,9 +210,130 @@ code review — the agent cannot extend its own auto-pass surface. A compound
 command auto-runs only when every clause is a safe verb; a single mutating
 clause makes the whole command prompt.
 
+### How parser facts become one policy result
+
+ShellSyntaxTree describes shell syntax. It does not grant authority. Netclaw
+projects those facts into one immutable call-local view and then decides which
+authority, if any, covers each command occurrence.
+
+| Step | Input | Output | Owner |
+|------|-------|--------|-------|
+| Preflight and syntax analysis | Original tool call, shell environment, initial cwd, audience, and run scope | ShellSyntaxTree facts followed by hard deny, path deny, approval mode, or auto allow | ShellSyntaxTree and Netclaw |
+| Policy projection | Syntax facts plus the unchanged approval context | Stable call-local candidate IDs and immutable scope facts | Netclaw |
+| Grant match | Candidates plus one session/persistent store snapshot | One typed match or one bounded near miss per candidate | Approval actor |
+| Coverage | Grant matches, reviewed-safe policy, and an exact one-time retry | One coverage result per candidate | Netclaw |
+| Completion | All candidate coverage results | `Allowed`, `RequiresApproval`, or `Denied` | Netclaw |
+
+The coordinator does not rewrite the original command. A prompt and an eventual
+execution still refer to the exact tool call the model authored. Candidate IDs
+exist only for that call; they are not durable grant IDs.
+
+The coordinator returns one closed result shape:
+
+| Outcome | Consumer data | Next action |
+|---------|---------------|-------------|
+| `Allowed` | One allow reason and any stored matches that helped cover the call | Execute the original tool call |
+| `RequiresApproval` | A narrowed approval context plus any partial stored matches | Prompt only for the uncovered candidates |
+| `Denied` | One stable deny reason | Return the denial without execution or prompt |
+
+The important value-domain rules are:
+
+- Effective `Exact` and `FiniteSet` path values pass through `ToolPathPolicy`.
+- An `Exact` or `FiniteSet` `AuthoredFileSystemValue` also passes through
+  `ToolPathPolicy`. This is the strong parser fact used for a finite loop path.
+- `AuthoredPathShape` is lexical evidence only. A slash-shaped value may be a
+  repository slug, URL segment, image name, or other data, so shape alone never
+  creates filesystem authority.
+- `IntegerRange` and `Concatenation` can prove bounded scalar data. They cannot
+  select an executable, justify a redirect, or create path authority.
+- `Unknown`, incomplete control flow, a dynamic executable, an unresolved path,
+  or an unresolved redirect stays strict.
+
+The result can compose. A three-part command can use a stored grant for one
+candidate and reviewed-safe policy for the other two. Netclaw prompts only for
+the candidates that remain uncovered.
+
+#### Example: bounded status data in a compound command
+
+Input:
+
+```bash
+gh run view 123456 --repo example/project --log-failed --verbose 2>&1 \
+  | head -200; echo "---EXIT $?---"
+```
+
+With a trusted `/work` scope and no stored grants, the facts and result are:
+
+| Candidate | Parser fact | Coverage |
+|-----------|-------------|----------|
+| `gh run view` | Complete Bash occurrence with canonical tokens | Reviewed-safe policy |
+| `head` | Complete occurrence under the real trusted root | Reviewed-safe policy |
+| `echo` | Argument is `Concatenation(Exact, IntegerRange(0..255), Exact)` and is not a path | Approval-exempt side effect |
+
+Output: `Allowed`. The status expansion is bounded data; it does not make the
+command complex and it does not add filesystem authority.
+
+If the call is outside every trusted root, `gh run view` and `head` remain
+uncovered. When an eligible Personal or Team call names a directory that the
+session can declare, Netclaw can first return a `set_working_directory`
+correction to the agent. Otherwise the uncovered candidates require approval.
+The bare `echo` side effect does not become a reusable prompt choice.
+
+#### Example: a finite Bash loop over known files
+
+Input:
+
+```bash
+for f in src/A.cs src/B.cs; do cat /work/$f; done
+```
+
+ShellSyntaxTree reports one complete `cat` occurrence. Its effective value is
+unknown because Bash can apply runtime word transforms, but its stronger
+authored filesystem value is:
+
+```text
+FiniteSet("/work/src/A.cs", "/work/src/B.cs")
+```
+
+Netclaw checks both values through `ToolPathPolicy`. If both paths are allowed
+and a stored grant or reviewed-safe policy covers `cat`, the output is
+`Allowed`. A protected path is denied before grant coverage. A non-protected
+external path stays exact, but it is not reviewed-safe merely because it is
+finite; it needs a folder or global grant that matches, or it requires approval. A
+runtime iterator, active glob, or command substitution does not receive this
+finite fact.
+
+#### Example: stored mutation grants compose with reviewed-safe readers
+
+Input:
+
+```bash
+cd /work && git fetch upstream feature/update 2>&1 | tail -2 \
+  && echo "===REMOTE TIP===" && git rev-parse FETCH_HEAD \
+  && git log --oneline -3 FETCH_HEAD \
+  && echo "===HAS FIX?===" \
+  && git show FETCH_HEAD:src/App/App.csproj | grep -n "ProtocolPackage" \
+  ; echo "exit: $?"
+```
+
+With explicit global grants for `cd`, `git fetch`, `git rev-parse`, `git log`,
+and `git show`, the actor covers those exact candidates. It returns `NoGrant`
+for `tail` and `grep`; reviewed-safe policy then covers both under `/work`.
+Each `echo` occurrence is an approval-exempt side effect, including the final
+bounded `Concatenation` that contains `$?`. The final output is `Allowed` with
+reason `AllCandidatesCovered`. No single grant covers the compound command.
+
+#### Example: a folder grant near miss
+
+Suppose the store has a Bash token-prefix grant for `git status` under
+`/work/project-a`, but the call runs under `/work/project-b`. The actor returns
+an `OutsideDirectory` near miss. The candidate remains uncovered, so the final
+output is `RequiresApproval`. A same-verb grant is diagnostic evidence, not
+authority for a peer directory.
+
 ### Persistent approvals
 
-"Approve always" decisions are stored in
+Persistent decisions are stored in
 `~/.netclaw/config/tool-approvals.json`:
 
 ```json
@@ -292,15 +435,19 @@ Custom patterns are added to the defaults — they don't replace them.
 
 | Channel | Supports approval? | Rendering |
 |---------|-------------------|-----------|
-| Slack | Yes | Text prompt with ABC options (Block Kit buttons planned) |
+| Slack | Yes | Block Kit buttons with text-compatible option labels |
+| Discord | Yes | Native buttons with text-compatible option labels |
+| Mattermost | Yes | Interactive buttons with text-compatible option labels |
 | TUI (`netclaw chat`) | Yes | Inline prompt |
 | SignalR (web client) | Yes | Inline prompt |
-| Headless (`netclaw chat -p`) | No — auto-deny | N/A |
-| Reminders | No — auto-deny | N/A |
-| Webhooks | No — auto-deny | N/A |
+| Headless (`netclaw chat -p`) | No — deny uncovered calls | N/A |
+| Reminders | No — deny uncovered calls | N/A |
+| Webhooks | No — deny uncovered calls | N/A |
 
-If a channel doesn't support approval, the tool is immediately denied with
-reason `channel_does_not_support_approval`.
+If a channel doesn't support approval, an uncovered call that would require a
+prompt is denied with reason `channel_does_not_support_approval`. A stored
+grant or an approval-exempt side effect can still cover the call. The
+reviewed-safe catalog alone does not grant unattended authority.
 
 ## Diagnostics
 
@@ -317,8 +464,9 @@ Tool audit entries include `ApprovalDecision` and `ApprovalPattern` fields when
 a tool goes through the approval flow. Later calls that are satisfied by a
 session or persistent approval are audited as `PreviouslyApproved`; the pattern
 includes the matched source and scope so operators can tell which grant applied.
-Near-miss diagnostics are also emitted to the daemon log when a same-verb
-persistent shell grant exists but does not match the candidate directory/cwd.
+Near-miss diagnostics are also emitted to the daemon log when a persistent
+shell grant almost matches but differs by token phrase, shell, absent folder
+scope, directory containment, or symlink safety.
 
 ```
 Tool executed: shell_execute (approved, pattern=git push)
@@ -327,11 +475,54 @@ Tool denied: shell_execute (denied_by_user, pattern=docker rm)
 Tool denied: shell_execute (timed_out, pattern=kubectl apply)
 ```
 
+Each shell decision also emits ordered `Shell policy trace:` rows to the daemon
+log. A row contains only enum facts, a call-local candidate ID, a bounded and
+redacted executable basename, coverage kind, scope relation, and grant time. It
+does not contain the full command, arguments, raw paths, tokens, redirects,
+secrets, or model content. The trace never enters the prompt or session journal.
+
+Example for the compound status command above:
+
+```text
+Shell policy trace: stage=StoredGrantMatch outcome=Uncovered reason=NoGrant candidate_id=0 executable=gh coverage=Uncovered scope_relation=None grant_timestamp=(null)
+Shell policy trace: stage=StoredGrantMatch outcome=Uncovered reason=NoGrant candidate_id=1 executable=head coverage=Uncovered scope_relation=None grant_timestamp=(null)
+Shell policy trace: stage=ReviewedSafePolicy outcome=Covered reason=ApprovalExemptSideEffect candidate_id=2 executable=echo coverage=ReviewedSafePolicy scope_relation=None grant_timestamp=(null)
+Shell policy trace: stage=ReviewedSafePolicy outcome=Covered reason=ReviewedSafePhrase candidate_id=0 executable=gh coverage=ReviewedSafePolicy scope_relation=UnderRealRoot grant_timestamp=(null)
+Shell policy trace: stage=ReviewedSafePolicy outcome=Covered reason=ReviewedSafePhrase candidate_id=1 executable=head coverage=ReviewedSafePolicy scope_relation=UnderRealRoot grant_timestamp=(null)
+Shell policy trace: stage=Completion outcome=Allow reason=SafeVerbInTrustedScope candidate_id=(null) executable=(null) coverage=(null) scope_relation=None grant_timestamp=(null)
+```
+
+Read a trace from the final row backward:
+
+1. `Completion/RequiresApproval/UncoveredCandidates` means at least one
+   candidate lacked coverage.
+2. Find that candidate ID in `StoredGrantMatch`. `NoGrant` means no same-call
+   grant matched. `TokenMismatch`, `ShellMismatch`, `OutsideDirectory`, or
+   `Symlink` explains a bounded near miss.
+3. Check whether that ID has a `ReviewedSafePolicy` or `OneTimeApproval` row.
+   If it does, that stage supplied coverage after the grant check.
+4. `Completion/Deny/InternalPolicyFailure` is not an ordinary approval case.
+   Treat it as a policy defect or malformed internal result; do not add a grant
+   to work around it.
+5. `Trace/TraceTruncated/TraceLimitReached` means the diagnostic row cap was
+   reached. It never changes the authorization result.
+
+Use the trace to classify a repeated prompt before a policy change:
+
+- A valid same-phrase folder near miss usually indicates scope or cwd drift.
+- `NoGrant` plus a reviewed-safe candidate outside a trusted root usually points
+  to project/scratch alignment.
+- A complete candidate with no general safe proof is an expected approval.
+- A command that should have a strong parser fact but remains unresolved is a
+  ShellSyntaxTree evidence gap, not a reason to add executable-specific Netclaw
+  parser logic.
+
 ## FAQ
 
 **Q: Can I disable approval gates entirely?**
-A: Yes. Either remove the `ApprovalPolicy` section from your audience profile,
-or set all tools to `Auto` mode.
+A: Yes. Set an exact `shell_execute` override to `Auto`. Removal alone does not
+disable the Personal shell default. If the exact override is absent, the shell
+stays fail-closed in `Approval` mode.
 
 **Q: Can I require approval for MCP tools?**
 A: Yes. Add the tool name to `ToolOverrides`:

--- a/openspec/changes/structure-shell-approval-policy/design.md
+++ b/openspec/changes/structure-shell-approval-policy/design.md
@@ -335,9 +335,11 @@ inputs, expected coverage, the ordered bounded trace, and final outcome for the
 policy-owned acceptance cases. Tests load these structured fields directly;
 they do not branch on Dxx IDs or derive expectations from prose.
 
-The fixture's top-level defaults are executable inputs, not test conventions:
-tool name, audience, approval mode, interactive capability, session identity
-and safe root, project safe root, inherited cwd, and persistent-store status.
+The fixture's top-level defaults are executable inputs, not test conventions.
+They include tool, audience, approval mode, interactive capability, session,
+safe roots, inherited cwd, store status, and a fixed clock. Parser facts use
+command indexes. Policy rows use stable candidate
+IDs because one parser occurrence can project a different policy cardinality.
 Each case supplies its canonical shell environment, initial cwd, and every
 stored grant includes its canonical shell tag. The exact executable cases are
 D02, D03, D07, D08, D09, D10, D11, D14, D17, and D18.
@@ -346,11 +348,13 @@ Complete D03 example:
 
 ```text
 Input: cd /tmp && gh api ... > slopwatch.log 2>&1; wc -c slopwatch.log; head -100 slopwatch.log
-Preflight: candidates C0=cd, C1=gh api, C2=wc, C3=head; intent=/tmp
-Actor: C0=PersistentGlobal, C1=PersistentGlobal, C2/C3=Uncovered
-Safe policy: C2=ReviewedSafePolicy, C3=ReviewedSafePolicy
-Final: Allow(AllCandidatesCovered)
+Preflight: unresolved approval scope; no reusable candidate rows
+Trace: Completion/RequiresApproval/UncoveredCandidates
+Final: RequiresApproval(IsMessy=true)
 ```
+
+This current result remains explicit evidence debt. The fixture does not claim
+that a future session-scratch correction or stronger parser fact already exists.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json
+++ b/openspec/changes/structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json
@@ -5,6 +5,7 @@
     "audience": "Personal",
     "approvalMode": "Approval",
     "interactiveApprovalCapability": "Available",
+    "clockUtc": "2026-08-13T00:00:00+00:00",
     "session": {
       "sessionId": "fixture-session",
       "sessionDirectory": "/work"
@@ -29,29 +30,29 @@
       "available": {
         "oneTimeApprovalKeys": [],
         "sessionGrants": [],
-        "persistentGrants": [
-          { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["gh", "run", "view"], "directory": null }
-        ],
+        "persistentGrants": [],
         "safePhrases": [
-          { "tokens": ["head"], "proof": "ReadOnlyForAllArguments" },
-          { "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" }
+          { "tokens": ["gh", "run", "view"], "proof": "ReadOnlyForAllArguments" },
+          { "tokens": ["head"], "proof": "ReadOnlyForAllArguments" }
         ]
       },
       "candidates": [
-        { "id": 0, "tokens": ["gh", "run", "view"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "PersistentGlobal" },
+        { "id": 0, "tokens": ["gh", "run", "view"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "ReviewedSafePolicy" },
         { "id": 1, "tokens": ["head"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "ReviewedSafePolicy" },
         { "id": 2, "tokens": ["echo"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "ReviewedSafePolicy" }
       ],
       "valueFacts": [
-        { "candidateId": 2, "argumentIndex": 0, "domain": "Concatenation", "parts": [{ "exact": "---EXIT " }, { "integerRange": [0, 255] }, { "exact": "---" }] }
+        { "commandIndex": 2, "verbTokens": ["echo"], "argumentIndex": 0, "domain": "Concatenation", "parts": [{ "exact": "---EXIT " }, { "integerRange": [0, 255] }, { "exact": "---" }] }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 1, "executableBasename": "head", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "gh", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "head", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 0, "executableBasename": "gh", "outcome": "Covered", "reason": "ReviewedSafePhrase", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 1, "executableBasename": "head", "outcome": "Covered", "reason": "ReviewedSafePhrase", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "SafeVerbInTrustedScope", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
-      "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
+      "expectedFinal": { "outcome": "Allow", "reason": "SafeVerbInTrustedScope" }
     },
     {
       "evidenceId": "D03",
@@ -77,25 +78,16 @@
           { "tokens": ["head"], "proof": "ReadOnlyForAllArguments" }
         ]
       },
-      "candidates": [
-        { "id": 0, "tokens": ["cd"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "PersistentGlobal" },
-        { "id": 1, "tokens": ["gh", "api"], "realDirectory": "/tmp", "intentDirectory": "/tmp", "expectedCoverage": "PersistentGlobal" },
-        { "id": 2, "tokens": ["wc"], "realDirectory": null, "intentDirectory": "/tmp", "expectedCoverage": "ReviewedSafePolicy" },
-        { "id": 3, "tokens": ["head"], "realDirectory": null, "intentDirectory": "/tmp", "expectedCoverage": "ReviewedSafePolicy" }
-      ],
+      "candidates": [],
       "shellEffects": {
         "redirects": [
-          { "candidateId": 1, "target": "/tmp/slopwatch.log", "mode": "Write", "expectedPathPolicy": "Allow" }
+          { "commandIndex": 1, "target": "/tmp/slopwatch.log", "mode": "Output", "expectedPathPolicy": "Allow" }
         ]
       },
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "wc", "outcome": "Covered", "reason": "ReadOnlyUnderEligibleIntent", "coverage": "ReviewedSafePolicy", "scopeRelation": "EligibleIntent", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "head", "outcome": "Covered", "reason": "ReadOnlyUnderEligibleIntent", "coverage": "ReviewedSafePolicy", "scopeRelation": "EligibleIntent", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "RequiresApproval", "reason": "UncoveredCandidates", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
-      "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
+      "expectedFinal": { "outcome": "RequiresApproval", "reason": "UncoveredCandidates", "approvalCandidates": [], "isMessy": true, "agentCorrection": null }
     },
     {
       "evidenceId": "D07",
@@ -126,10 +118,11 @@
         { "id": 2, "tokens": ["tail"], "realDirectory": "/work", "intentDirectory": "/work", "expectedCoverage": "ReviewedSafePolicy" }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "tail", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 2, "executableBasename": "tail", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "tail", "outcome": "Covered", "reason": "ReviewedSafePhrase", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -147,7 +140,7 @@
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["git", "rev-parse"], "directory": null },
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["git", "log"], "directory": null }
         ],
-        "safePhrases": [{ "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" }]
+        "safePhrases": []
       },
       "candidates": [
         { "id": 0, "tokens": ["cd"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "PersistentGlobal" },
@@ -157,12 +150,12 @@
         { "id": 4, "tokens": ["git", "log"], "realDirectory": "/work", "intentDirectory": "/work", "expectedCoverage": "PersistentGlobal" }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 3, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 3, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -180,7 +173,6 @@
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["gh", "run", "view"], "directory": null }
         ],
         "safePhrases": [
-          { "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" },
           { "tokens": ["head"], "proof": "ReadOnlyForAllArguments" }
         ]
       },
@@ -192,12 +184,13 @@
         { "id": 4, "tokens": ["head"], "realDirectory": "/work", "intentDirectory": "/work", "expectedCoverage": "ReviewedSafePolicy" }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 3, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 4, "executableBasename": "head", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "gh", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 3, "executableBasename": "gh", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "head", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 4, "executableBasename": "head", "outcome": "Covered", "reason": "ReviewedSafePhrase", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -218,7 +211,6 @@
         ],
         "safePhrases": [
           { "tokens": ["tail"], "proof": "ReadOnlyForAllArguments" },
-          { "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" },
           { "tokens": ["grep"], "proof": "ReadOnlyForAllArguments" }
         ]
       },
@@ -235,20 +227,22 @@
         { "id": 9, "tokens": ["echo"], "realDirectory": "/work", "intentDirectory": "/work", "expectedCoverage": "ReviewedSafePolicy" }
       ],
       "valueFacts": [
-        { "candidateId": 9, "argumentIndex": 0, "domain": "Concatenation", "parts": [{ "exact": "exit: " }, { "integerRange": [0, 255] }] }
+        { "commandIndex": 9, "verbTokens": ["echo"], "argumentIndex": 0, "domain": "Concatenation", "parts": [{ "exact": "exit: " }, { "integerRange": [0, 255] }] }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 5, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 7, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "tail", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 6, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 8, "executableBasename": "grep", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 9, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 2, "executableBasename": "tail", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 5, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 7, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 8, "executableBasename": "grep", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 6, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 9, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 2, "executableBasename": "tail", "outcome": "Covered", "reason": "ReviewedSafePhrase", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 8, "executableBasename": "grep", "outcome": "Covered", "reason": "ReviewedSafePhrase", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -265,7 +259,7 @@
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["gh", "api"], "directory": null },
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["gh", "pr", "view"], "directory": null }
         ],
-        "safePhrases": [{ "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" }]
+        "safePhrases": []
       },
       "candidates": [
         { "id": 0, "tokens": ["cd"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "PersistentGlobal" },
@@ -275,12 +269,12 @@
         { "id": 4, "tokens": ["gh", "pr", "view"], "realDirectory": "/work", "intentDirectory": "/work", "expectedCoverage": "PersistentGlobal" }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 2, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 1, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 2, "executableBasename": "gh", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "gh", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "ReviewedSafePolicy", "candidateId": 1, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -297,7 +291,7 @@
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["gh", "api"], "directory": null },
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["git", "ls-remote"], "directory": null }
         ],
-        "safePhrases": [{ "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" }]
+        "safePhrases": []
       },
       "candidates": [
         { "id": 0, "tokens": ["cd"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "PersistentGlobal" },
@@ -309,14 +303,14 @@
         { "id": 6, "tokens": ["gh", "api"], "realDirectory": "/work", "intentDirectory": "/work", "expectedCoverage": "PersistentGlobal" }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 2, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "git", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "StoredGrantMatch", "candidateId": 6, "executableBasename": "gh", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 1, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 5, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "cd", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 2, "executableBasename": "gh", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 4, "executableBasename": "git", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "StoredGrantMatch", "candidateId": 6, "executableBasename": "gh", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "ReviewedSafePolicy", "candidateId": 1, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 3, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "ReviewedSafePolicy", "candidateId": 5, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -332,16 +326,13 @@
         "powerShellDialect": null
       },
       "initialWorkingDirectory": "/work",
-      "parserOptions": { "publishAuthoredSourceFacts": true },
       "available": {
         "oneTimeApprovalKeys": [],
         "sessionGrants": [],
         "persistentGrants": [
           { "kind": "PersistentGlobal", "shell": "Bash", "match": "TokenPrefix", "tokens": ["cat"], "directory": null }
         ],
-        "safePhrases": [
-          { "tokens": ["echo"], "proof": "ReadOnlyForAllArguments" }
-        ]
+        "safePhrases": []
       },
       "candidates": [
         { "id": 0, "tokens": ["echo"], "realDirectory": "/work", "intentDirectory": null, "expectedCoverage": "ReviewedSafePolicy" },
@@ -349,7 +340,8 @@
       ],
       "authoredPathFacts": [
         {
-          "candidateId": 1,
+          "commandIndex": 1,
+          "verbTokens": ["cat"],
           "argumentIsPath": false,
           "effectiveValue": "Unknown",
           "authoredValues": [
@@ -369,9 +361,9 @@
         }
       ],
       "expectedTrace": [
-        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "cat", "outcome": "Covered", "reason": "GlobalPhraseMatch", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": null },
-        { "stage": "ReviewedSafePolicy", "candidateId": 0, "executableBasename": "echo", "outcome": "Covered", "reason": "ReadOnlyUnderRealRoot", "coverage": "ReviewedSafePolicy", "scopeRelation": "UnderRealRoot", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "StoredGrantMatch", "candidateId": 1, "executableBasename": "cat", "outcome": "Covered", "reason": "PersistentGlobalGrant", "coverage": "PersistentGlobal", "scopeRelation": "Global", "grantTimestamp": "2026-08-13T00:00:00.0000000+00:00" },
+        { "stage": "ReviewedSafePolicy", "candidateId": 0, "executableBasename": "echo", "outcome": "Covered", "reason": "ApprovalExemptSideEffect", "coverage": "ReviewedSafePolicy", "scopeRelation": "None", "grantTimestamp": null },
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "Allow", "reason": "AllCandidatesCovered", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
       "expectedFinal": { "outcome": "Allow", "reason": "AllCandidatesCovered" }
     },
@@ -398,9 +390,9 @@
       ],
       "expectedTrace": [
         { "stage": "StoredGrantMatch", "candidateId": 0, "executableBasename": "gh", "outcome": "Uncovered", "reason": "NoGrant", "coverage": "Uncovered", "scopeRelation": "None", "grantTimestamp": null },
-        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "RequiresApproval", "reason": "UncoveredCandidates", "coverage": null, "scopeRelation": null, "grantTimestamp": null }
+        { "stage": "Completion", "candidateId": null, "executableBasename": null, "outcome": "RequiresApproval", "reason": "UncoveredCandidates", "coverage": null, "scopeRelation": "None", "grantTimestamp": null }
       ],
-      "expectedFinal": { "outcome": "RequiresApproval", "reason": "UncoveredCandidates" }
+      "expectedFinal": { "outcome": "RequiresApproval", "reason": "UncoveredCandidates", "approvalCandidates": ["gh pr close"], "isMessy": false, "agentCorrection": null }
     }
   ]
 }

--- a/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
@@ -268,12 +268,21 @@ expected per-candidate coverage, ordered trace rows, and final outcome for the
 policy-owned acceptance cases. Tests SHALL load those fields directly and
 SHALL NOT branch on Dxx identifiers to manufacture expected results.
 
-Fixture defaults SHALL explicitly provide tool name, audience, approval mode,
-interactive capability, session identity and safe root, project safe root,
-inherited cwd, and persistent-store status. Each case SHALL provide canonical
-shell environment and initial cwd. Every stored grant SHALL carry a canonical
-shell tag. D02, D03, D07, D08, D09, D10, D11, D14, D17, and D18 SHALL be exact
-executable fixtures.
+Fixture defaults SHALL explicitly provide:
+
+- tool name, audience, and approval mode;
+- interactive capability;
+- session identity and safe root;
+- project safe root and inherited cwd;
+- persistent-store status; and
+- a fixed clock.
+
+Each case SHALL provide canonical shell environment and initial cwd. Parser facts SHALL use
+command indexes. Policy facts SHALL use stable candidate IDs. Every stored
+grant SHALL carry a canonical shell tag. D02, D03, D07, D08, D09, D10, D11,
+D14, D17, and D18 SHALL be exact executable fixtures. Tests SHALL deserialize
+the schema through source-generated `System.Text.Json` metadata and reject
+unknown members.
 
 Additional adversarial rows SHALL cover dynamic identity, deny-only wrappers,
 redirects, protected paths, prefix collisions, runtime iterators, PowerShell

--- a/openspec/changes/structure-shell-approval-policy/tasks.md
+++ b/openspec/changes/structure-shell-approval-policy/tasks.md
@@ -118,7 +118,7 @@
   `AuthoredPathShape` as lexical-only. Keep unknown path values strict.
 - [x] 7.5 Delete the broad Bash environment-variable relaxation and its
   superseded tests.
-- [ ] 7.6 Pin exact D02, D10, and D14 input-to-coverage results.
+- [x] 7.6 Pin exact D02, D10, and D14 input-to-coverage results.
 
 ## 8. Trace, guides, and behavioral evals
 
@@ -127,7 +127,7 @@
 - [x] 8.2 Append actor grant rows without a second scan; project near-miss logs
   from the same trace.
 - [x] 8.3 Keep trace data out of model prompts and session journals.
-- [ ] 8.4 Update consumer and operator guides with complete input, facts,
+- [x] 8.4 Update consumer and operator guides with complete input, facts,
   coverage, trace, and output examples.
 - [ ] 8.5 Update the `netclaw-operations` skill and deterministic approval evals
   for schema 3 and the authored-source boundary.

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -34,6 +34,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="../Netclaw.Security.Tests/ShellPolicyEvidenceModels.cs"
+             Link="Tools/ApprovalEvidence/ShellPolicyEvidenceModels.cs" />
+    <None Include="../../openspec/changes/structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json"
+          Link="ApprovalEvidence/netclaw-policy-fixtures.json"
+          CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.html" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
@@ -25,6 +25,11 @@ internal sealed record ObservedApproval(
     bool? IsMessy,
     IReadOnlyList<string> ApprovalMatches);
 
+internal sealed record ShellApprovalHarnessScope(
+    string ProjectDirectory,
+    string SessionDirectory,
+    string InvocationSessionId);
+
 internal sealed class ShellApprovalHarness : IAsyncDisposable
 {
     private const string InvocationSessionId = "signalr/approval-matrix";
@@ -60,10 +65,26 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
 
     public CountingApprovalService ApprovalService { get; }
 
-    public static async Task<ShellApprovalHarness> CreateAsync(
+    public static Task<ShellApprovalHarness> CreateAsync(
         ShellApprovalCase testCase,
         ActorSystem actorSystem,
         CancellationToken ct)
+        => CreateAsync(
+            testCase.Id,
+            testCase.Invocation,
+            testCase.Approvals,
+            actorSystem,
+            ct);
+
+    internal static async Task<ShellApprovalHarness> CreateAsync(
+        string caseId,
+        ShellApprovalInvocation invocation,
+        ApprovalState approvals,
+        ActorSystem actorSystem,
+        CancellationToken ct,
+        TimeProvider? timeProvider = null,
+        ShellApprovalHarnessScope? scope = null,
+        SafeVerbList? safeVerbs = null)
     {
         var rootDirectory = Path.Combine(
             CanonicalTemporaryDirectory(),
@@ -76,9 +97,9 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
         Directory.CreateDirectory(sessionDirectory);
         Directory.CreateDirectory(externalDirectory);
 
-        var environment = testCase.Invocation.CreateEnvironment();
-        var approvalProjectDirectory = projectDirectory;
-        var approvalSessionDirectory = sessionDirectory;
+        var environment = invocation.CreateEnvironment();
+        var approvalProjectDirectory = scope?.ProjectDirectory ?? projectDirectory;
+        var approvalSessionDirectory = scope?.SessionDirectory ?? sessionDirectory;
         var approvalExternalDirectory = externalDirectory;
         if (environment.PathStyle == ShellPathStyle.Windows)
         {
@@ -93,13 +114,13 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
             : ApprovalShell.PowerShell;
         var store = new ToolApprovalStore(
             Path.Combine(rootDirectory, "tool-approvals.json"),
-            timeProvider: null,
+            timeProvider,
             migrationContext: new ApprovalStoreMigrationContext(approvalShell),
             lockTimeout: TimeSpan.Zero);
         var approvalActor = CreateApprovalActor(actorSystem, store);
         var approvalService = CreateApprovalService(approvalActor);
 
-        var persistentSeeds = testCase.Approvals.Seeds
+        var persistentSeeds = approvals.Seeds
             .Where(seed => seed.Source == ApprovalSeedSource.Persistent)
             .ToList();
         foreach (var seed in persistentSeeds)
@@ -124,10 +145,12 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
             approvalService = CreateApprovalService(approvalActor);
         }
 
-        foreach (var seed in testCase.Approvals.Seeds.Where(seed => seed.Source == ApprovalSeedSource.Session))
+        foreach (var seed in approvals.Seeds.Where(seed => seed.Source == ApprovalSeedSource.Session))
         {
             await approvalService.RecordApprovalCandidatesAsync(
-                (ToolApprovalSessionId)ResolveSession(seed.Session),
+                (ToolApprovalSessionId)ResolveSession(
+                    seed.Session,
+                    scope?.InvocationSessionId ?? InvocationSessionId),
                 seed.Audience,
                 new ToolName(ShellTool.ToolName),
                 [CreateGrant(seed.Pattern, approvalShell, directory: null)],
@@ -161,28 +184,28 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
             shellTrustZonePolicy: new ShellTrustZonePolicy(
                 config,
                 new NetclawPaths(rootDirectory, Path.Combine(rootDirectory, "workspaces"))),
-            safeVerbs: SafeVerbLoader.Load(environment.Platform == ShellPlatform.Windows));
+            safeVerbs: safeVerbs ?? SafeVerbLoader.Load(environment.Platform == ShellPlatform.Windows));
         var executor = new DispatchingToolExecutor(registry, policy, countingApprovalService);
 
         var workingDirectory = ResolveDirectory(
-            testCase.Invocation.WorkingDirectory,
+            invocation.WorkingDirectory,
             approvalProjectDirectory,
             approvalSessionDirectory,
             approvalExternalDirectory);
         var arguments = workingDirectory is null
-            ? ToolInput.Create("Command", testCase.Invocation.Command)
+            ? ToolInput.Create("Command", invocation.Command)
             : ToolInput.Create(
-                "Command", testCase.Invocation.Command,
+                "Command", invocation.Command,
                 "WorkingDirectory", workingDirectory);
-        var toolCall = new FunctionCallContent(testCase.Id, ShellTool.ToolName, arguments);
+        var toolCall = new FunctionCallContent(caseId, ShellTool.ToolName, arguments);
         var context = TestToolExecutionContext.CreateBound(
-            InvocationSessionId,
+            scope?.InvocationSessionId ?? InvocationSessionId,
             approvalSessionDirectory,
             new TestToolExecutionContextOptions
             {
-                Audience = testCase.Invocation.Audience,
+                Audience = invocation.Audience,
                 ProjectDirectory = approvalProjectDirectory,
-                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(testCase.Invocation.Interactive)
+                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(invocation.Interactive)
             });
 
         return new ShellApprovalHarness(
@@ -295,10 +318,12 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
     private static AkkaToolApprovalService CreateApprovalService(IActorRef actor)
         => new(new StubRequiredActor(actor), TestShellEnvironment.Current);
 
-    private static string ResolveSession(ApprovalSessionShape session)
+    private static string ResolveSession(
+        ApprovalSessionShape session,
+        string invocationSessionId)
         => session switch
         {
-            ApprovalSessionShape.Invocation => InvocationSessionId,
+            ApprovalSessionShape.Invocation => invocationSessionId,
             ApprovalSessionShape.Other => OtherSessionId,
             _ => throw new ArgumentOutOfRangeException(nameof(session), session, "Unknown approval session shape.")
         };

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvidenceFixtureTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvidenceFixtureTests.cs
@@ -1,0 +1,221 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyEvidenceFixtureTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Security.Tests;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class ShellPolicyEvidenceFixtureTests(ShellApprovalMatrixFixture fixture) :
+    IClassFixture<ShellApprovalMatrixFixture>
+{
+    [Fact]
+    public async Task Policy_fixtures_execute_through_the_coordinator()
+    {
+        var catalog = JsonSerializer.Deserialize(
+                          File.ReadAllBytes(EvidencePath()),
+                          ShellPolicyFixtureJsonContext.Default.PolicyFixtureCatalog)
+                      ?? throw new InvalidDataException("The policy fixture catalog has no root object.");
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse(
+            catalog.FixtureDefaults.ClockUtc,
+            CultureInfo.InvariantCulture));
+        var expectedRows = new List<string>();
+        var actualRows = new List<string>();
+        var expectedOutcomes = new List<ToolAuthorizationOutcome>();
+        var actualOutcomes = new List<ToolAuthorizationOutcome>();
+
+        foreach (var policyCase in catalog.Cases)
+        {
+            var invocation = CreateInvocation(catalog.FixtureDefaults, policyCase);
+            AssertProjectedCandidates(policyCase, invocation);
+            var approvals = CreateApprovals(policyCase);
+            await using var harness = await ShellApprovalHarness.CreateAsync(
+                policyCase.EvidenceId,
+                invocation,
+                approvals,
+                fixture.ActorSystem,
+                TestContext.Current.CancellationToken,
+                timeProvider,
+                new ShellApprovalHarnessScope(
+                    catalog.FixtureDefaults.ProjectDirectory,
+                    catalog.FixtureDefaults.Session.SessionDirectory,
+                    catalog.FixtureDefaults.Session.SessionId),
+                CreateSafeVerbs(policyCase));
+            var decision = await harness.EvaluateDecisionAsync(TestContext.Current.CancellationToken);
+            TestContext.Current.TestOutputHelper?.WriteLine(
+                $"{policyCase.EvidenceId}: outcome={decision.Outcome}; "
+                + $"candidates={string.Join(", ", decision.ApprovalContext?.CandidateVerbs ?? [])}; "
+                + $"messy={decision.ApprovalContext?.IsMessy}\n"
+                + string.Join(Environment.NewLine, decision.ShellPolicyTrace.Rows.Select(FormatActualTraceRow)));
+
+            expectedOutcomes.Add(ParseOutcome(policyCase.ExpectedFinal.Outcome));
+            actualOutcomes.Add(decision.Outcome);
+            Assert.Equal(
+                policyCase.ExpectedFinal.ApprovalCandidates,
+                decision.ApprovalContext?.CandidateVerbs);
+            Assert.Equal(policyCase.ExpectedFinal.IsMessy, decision.ApprovalContext?.IsMessy);
+            Assert.Equal(
+                policyCase.ExpectedFinal.AgentCorrection,
+                decision.ApprovalContext?.AgentCorrection?.GetType().Name);
+            expectedRows.AddRange(policyCase.ExpectedTrace.Select(row =>
+                $"{policyCase.EvidenceId}|{FormatExpectedTraceRow(row)}"));
+            actualRows.AddRange(decision.ShellPolicyTrace.Rows.Select(row =>
+                $"{policyCase.EvidenceId}|{FormatActualTraceRow(row)}"));
+        }
+
+        Assert.Equal(expectedOutcomes, actualOutcomes);
+        Assert.Equal(expectedRows, actualRows);
+    }
+
+    private static void AssertProjectedCandidates(
+        PolicyFixtureCase policyCase,
+        ShellApprovalInvocation invocation)
+    {
+        var environment = invocation.CreateEnvironment();
+        var arguments = new Dictionary<string, object?>
+        {
+            ["Command"] = policyCase.Command,
+            ["WorkingDirectory"] = policyCase.InitialWorkingDirectory,
+        };
+        var actual = new ShellApprovalMatcher(environment)
+            .AnalyzeInvocation(new ToolName(ShellTool.ToolName), arguments)
+            .Candidates;
+
+        Assert.Equal(policyCase.Candidates.Count, actual.Count);
+        for (var index = 0; index < policyCase.Candidates.Count; index++)
+        {
+            var expected = policyCase.Candidates[index];
+            Assert.Equal(index, expected.Id);
+            Assert.Equal(expected.Tokens, actual[index].VerbTokens);
+            Assert.Equal(expected.RealDirectory, policyCase.InitialWorkingDirectory);
+            Assert.Equal(
+                expected.IntentDirectory ?? expected.RealDirectory,
+                actual[index].Directory ?? policyCase.InitialWorkingDirectory);
+        }
+    }
+
+    private static ShellApprovalInvocation CreateInvocation(
+        PolicyFixtureDefaults defaults,
+        PolicyFixtureCase policyCase)
+    {
+        if (defaults.ToolName != "shell_execute"
+            || defaults.ApprovalMode != "Approval"
+            || defaults.PersistentStoreStatus != "Ready"
+            || defaults.InheritedWorkingDirectory is not null
+            || policyCase.Available.OneTimeApprovalKeys.Count != 0
+            || policyCase.Environment.Grammar != "Bash"
+            || policyCase.Environment.Platform != "Linux"
+            || policyCase.Environment.ExecutablePath != "/bin/bash"
+            || !policyCase.Environment.CommandArguments.SequenceEqual(["-c"])
+            || policyCase.Environment.PathStyle != "Posix"
+            || policyCase.Environment.PowerShellDialect is not null
+            || policyCase.InitialWorkingDirectory != defaults.ProjectDirectory)
+        {
+            throw new InvalidDataException($"Unsupported fixture shape: {policyCase.EvidenceId}.");
+        }
+
+        return new ShellApprovalInvocation(
+            policyCase.Command,
+            ApprovalDirectoryShape.Project,
+            Enum.Parse<TrustAudience>(defaults.Audience),
+            defaults.InteractiveApprovalCapability == "Available");
+    }
+
+    private static ApprovalState CreateApprovals(PolicyFixtureCase policyCase)
+        => new(policyCase.Available.PersistentGrants
+            .Select(CreatePersistentSeed)
+            .Concat(policyCase.Available.SessionGrants.Select(CreateSessionSeed))
+            .ToList());
+
+    private static SafeVerbList CreateSafeVerbs(PolicyFixtureCase policyCase)
+    {
+        if (policyCase.Available.SafePhrases.Any(phrase =>
+                phrase.Proof != "ReadOnlyForAllArguments"))
+        {
+            throw new InvalidDataException("The fixture has an unsupported safe-phrase proof.");
+        }
+
+        return SafeVerbList.FromVerbs(policyCase.Available.SafePhrases.Select(phrase =>
+            string.Join(' ', phrase.Tokens)));
+    }
+
+    private static ApprovalSeed CreatePersistentSeed(PolicyGrant grant)
+    {
+        if (grant.Shell != "Bash" || grant.Match != "TokenPrefix")
+            throw new InvalidDataException("The fixture has a noncanonical persistent grant.");
+
+        var directory = grant.Kind switch
+        {
+            "PersistentGlobal" when grant.Directory is null => ApprovalDirectoryShape.None,
+            "PersistentFolder" when grant.Directory == "/work" => ApprovalDirectoryShape.Project,
+            _ => throw new InvalidDataException($"Unsupported persistent grant kind: {grant.Kind}.")
+        };
+        return new ApprovalSeed(
+            ApprovalSeedSource.Persistent,
+            string.Join(' ', grant.Tokens),
+            TrustAudience.Personal,
+            ApprovalSessionShape.Invocation,
+            directory);
+    }
+
+    private static ApprovalSeed CreateSessionSeed(PolicyGrant grant)
+    {
+        if (grant.Kind != "Session" || grant.Shell != "Bash" || grant.Match != "TokenPrefix")
+            throw new InvalidDataException("The fixture has a noncanonical session grant.");
+
+        return new ApprovalSeed(
+            ApprovalSeedSource.Session,
+            string.Join(' ', grant.Tokens),
+            TrustAudience.Personal,
+            ApprovalSessionShape.Invocation,
+            ApprovalDirectoryShape.None);
+    }
+
+    private static string FormatExpectedTraceRow(PolicyTraceRow row)
+        => string.Join(
+            '|',
+            row.Stage,
+            row.CandidateId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            row.ExecutableBasename ?? string.Empty,
+            row.Outcome,
+            row.Reason,
+            row.Coverage ?? string.Empty,
+            row.ScopeRelation ?? string.Empty,
+            row.GrantTimestamp ?? string.Empty);
+
+    private static string FormatActualTraceRow(ShellPolicyTraceRow row)
+        => string.Join(
+            '|',
+            row.Stage,
+            row.CandidateId?.Value.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            row.ExecutableBasename ?? string.Empty,
+            row.Outcome,
+            row.Reason,
+            row.Coverage?.ToString() ?? string.Empty,
+            row.ScopeRelation,
+            row.GrantTimestamp?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty);
+
+    private static ToolAuthorizationOutcome ParseOutcome(string outcome)
+        => outcome switch
+        {
+            "Allow" => ToolAuthorizationOutcome.Allowed,
+            "RequiresApproval" => ToolAuthorizationOutcome.RequiresApproval,
+            "Deny" => ToolAuthorizationOutcome.Denied,
+            _ => throw new InvalidDataException($"Unsupported fixture outcome: {outcome}.")
+        };
+
+    private static string EvidencePath()
+        => Path.Combine(
+            AppContext.BaseDirectory,
+            "ApprovalEvidence",
+            "netclaw-policy-fixtures.json");
+}

--- a/src/Netclaw.Security.Tests/ShellApprovalEvidenceContractTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalEvidenceContractTests.cs
@@ -57,6 +57,7 @@ public sealed partial class ShellApprovalEvidenceContractTests
         Assert.Equal("Personal", fixtures.FixtureDefaults.Audience);
         Assert.Equal("Approval", fixtures.FixtureDefaults.ApprovalMode);
         Assert.Equal("Available", fixtures.FixtureDefaults.InteractiveApprovalCapability);
+        Assert.Equal("2026-08-13T00:00:00+00:00", fixtures.FixtureDefaults.ClockUtc);
         Assert.Equal("Ready", fixtures.FixtureDefaults.PersistentStoreStatus);
         Assert.Equal("fixture-session", fixtures.FixtureDefaults.Session.SessionId);
         Assert.Equal("/work", fixtures.FixtureDefaults.Session.SessionDirectory);
@@ -95,12 +96,27 @@ public sealed partial class ShellApprovalEvidenceContractTests
     }
 
     [Fact]
+    public void Policy_fixture_schema_rejects_unknown_members()
+    {
+        var json = File.ReadAllText(EvidencePath(PolicyFixturesFile));
+        var malformed = json.Replace(
+            "\"schemaVersion\": 1,",
+            "\"schemaVersion\": 1, \"unexpected\": true,",
+            StringComparison.Ordinal);
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(
+            malformed,
+            ShellPolicyFixtureJsonContext.Default.PolicyFixtureCatalog));
+    }
+
+    [Fact]
     public void Exact_symbolic_parser_facts_match_the_policy_fixtures()
     {
         var fixtures = DeserializeFixtures(File.ReadAllBytes(EvidencePath(PolicyFixturesFile)));
         var factCases = fixtures.Cases.Where(item =>
             item.ValueFacts is { Count: > 0 }
-            || item.AuthoredPathFacts is { Count: > 0 });
+            || item.AuthoredPathFacts is { Count: > 0 }
+            || item.ShellEffects is not null);
 
         foreach (var fixture in factCases)
         {
@@ -108,20 +124,14 @@ public sealed partial class ShellApprovalEvidenceContractTests
             var analysis = new ShellCommandAnalyzer(environment).Analyze(
                 fixture.Command,
                 fixture.InitialWorkingDirectory);
+            var allowedPathPolicy = new ToolPathPolicy(environment, ["/protected"]);
 
             Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
-            Assert.Equal(fixture.Candidates.Count, analysis.Commands.Count);
-
-            for (var index = 0; index < fixture.Candidates.Count; index++)
-            {
-                Assert.Equal(
-                    fixture.Candidates[index].Tokens,
-                    analysis.Commands[index].Clause.Verb.Tokens);
-            }
-
             foreach (var fact in fixture.ValueFacts ?? [])
             {
-                var argument = analysis.Commands[fact.CandidateId].Arguments[fact.ArgumentIndex];
+                var command = analysis.Commands[fact.CommandIndex];
+                Assert.Equal(fact.VerbTokens, command.Clause.Verb.Tokens);
+                var argument = command.Arguments[fact.ArgumentIndex];
                 var concatenation = Assert.IsType<ShellValueDomain.Concatenation>(argument.Value);
                 Assert.Equal("Concatenation", fact.Domain);
                 Assert.Equal(fact.Parts.Count, concatenation.Parts.Count);
@@ -134,8 +144,10 @@ public sealed partial class ShellApprovalEvidenceContractTests
 
             foreach (var fact in fixture.AuthoredPathFacts ?? [])
             {
+                var command = analysis.Commands[fact.CommandIndex];
+                Assert.Equal(fact.VerbTokens, command.Clause.Verb.Tokens);
                 var argument = Assert.Single(
-                    analysis.Commands[fact.CandidateId].Arguments,
+                    command.Arguments,
                     item => item.AuthoredPathShape.ToString() == fact.AuthoredPathShape);
                 Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
                 Assert.Equal("Unknown", fact.EffectiveValue);
@@ -146,6 +158,20 @@ public sealed partial class ShellApprovalEvidenceContractTests
                 Assert.Equal(fact.AuthoredFileSystemValues, authoredFileSystem.Values);
                 Assert.Equal(fact.AuthoredPathShape, argument.AuthoredPathShape.ToString());
             }
+
+            foreach (var expected in fixture.ShellEffects?.Redirects ?? [])
+            {
+                var redirect = Assert.Single(
+                    analysis.Commands[expected.CommandIndex].Redirects.OfType<FileRedirectAnalysis>());
+                var target = Assert.IsType<ShellValueDomain.Exact>(redirect.Target);
+                Assert.Equal(expected.Target, target.Value);
+                Assert.Equal(expected.Mode, redirect.Mode.ToString());
+                Assert.Equal(
+                    expected.ExpectedPathPolicy,
+                    allowedPathPolicy.CommandReferencesDeniedPath(analysis) ? "Deny" : "Allow");
+                Assert.True(new ToolPathPolicy(environment, [expected.Target])
+                    .CommandReferencesDeniedPath(StructuredOnly(analysis)));
+            }
         }
     }
 
@@ -155,11 +181,12 @@ public sealed partial class ShellApprovalEvidenceContractTests
         var fixtures = DeserializeFixtures(File.ReadAllBytes(EvidencePath(PolicyFixturesFile)));
         var fixture = Assert.Single(fixtures.Cases, item => item.AuthoredPathFacts is { Count: > 0 });
         var fact = Assert.Single(fixture.AuthoredPathFacts!);
-        var analysis = new ShellCommandAnalyzer(CreateEnvironment(fixture.Environment)).Analyze(
+        var environment = CreateEnvironment(fixture.Environment);
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(
             fixture.Command,
             fixture.InitialWorkingDirectory);
         var argument = Assert.Single(
-            analysis.Commands[fact.CandidateId].Arguments,
+            analysis.Commands[fact.CommandIndex].Arguments,
             item => item.AuthoredPathShape.ToString() == fact.AuthoredPathShape);
 
         Assert.False(fact.ArgumentIsPath);
@@ -168,6 +195,11 @@ public sealed partial class ShellApprovalEvidenceContractTests
             argument.AuthoredFileSystemValue);
         Assert.Equal(fact.AuthoredFileSystemValues, authoredFileSystem.Values);
         Assert.Equal("Allow", fact.ExpectedPathPolicy);
+        Assert.False(new ToolPathPolicy(environment, ["/protected"])
+            .CommandReferencesDeniedPath(analysis));
+        Assert.All(fact.AuthoredFileSystemValues, path =>
+            Assert.True(new ToolPathPolicy(environment, [path])
+                .CommandReferencesDeniedPath(StructuredOnly(analysis))));
         Assert.Equal("Allow", fixture.ExpectedFinal.Outcome);
     }
 
@@ -323,6 +355,14 @@ public sealed partial class ShellApprovalEvidenceContractTests
                 $"Unsupported fixture environment: {environment.Platform}/{environment.Grammar}.")
         };
 
+    private static ShellCommandAnalysis StructuredOnly(ShellCommandAnalysis analysis)
+        => new(
+            analysis.Environment,
+            source: string.Empty,
+            analysis.WorkingDirectory,
+            analysis.Commands,
+            ShellAnalysisFailure.None);
+
     private static ApprovalEvidenceMatrix DeserializeMatrix(byte[] bytes)
         => JsonSerializer.Deserialize(
                bytes,
@@ -332,7 +372,7 @@ public sealed partial class ShellApprovalEvidenceContractTests
     private static PolicyFixtureCatalog DeserializeFixtures(byte[] bytes)
         => JsonSerializer.Deserialize(
                bytes,
-               ShellApprovalEvidenceJsonContext.Default.PolicyFixtureCatalog)
+               ShellPolicyFixtureJsonContext.Default.PolicyFixtureCatalog)
            ?? throw new InvalidDataException($"{PolicyFixturesFile} has no root object.");
 
     private static string EvidencePath(string fileName)
@@ -408,209 +448,6 @@ internal sealed record ApprovalEvidenceCase
     public required string NetclawExpectation { get; init; }
 }
 
-internal sealed record PolicyFixtureCatalog
-{
-    public required int SchemaVersion { get; init; }
-
-    public required PolicyFixtureDefaults FixtureDefaults { get; init; }
-
-    public required List<PolicyFixtureCase> Cases { get; init; }
-}
-
-internal sealed record PolicyFixtureDefaults
-{
-    public required string ToolName { get; init; }
-
-    public required string Audience { get; init; }
-
-    public required string ApprovalMode { get; init; }
-
-    public required string InteractiveApprovalCapability { get; init; }
-
-    public required PolicyFixtureSession Session { get; init; }
-
-    public required string ProjectDirectory { get; init; }
-
-    public string? InheritedWorkingDirectory { get; init; }
-
-    public required string PersistentStoreStatus { get; init; }
-}
-
-internal sealed record PolicyFixtureSession
-{
-    public required string SessionId { get; init; }
-
-    public required string SessionDirectory { get; init; }
-}
-
-internal sealed record PolicyFixtureCase
-{
-    public required string EvidenceId { get; init; }
-
-    public required string Command { get; init; }
-
-    public required PolicyFixtureEnvironment Environment { get; init; }
-
-    public required string InitialWorkingDirectory { get; init; }
-
-    public required PolicyFixtureAuthority Available { get; init; }
-
-    public required List<PolicyFixtureCandidate> Candidates { get; init; }
-
-    public List<PolicyValueFact>? ValueFacts { get; init; }
-
-    public List<PolicyAuthoredPathFact>? AuthoredPathFacts { get; init; }
-
-    public PolicyShellEffects? ShellEffects { get; init; }
-
-    public PolicyParserOptions? ParserOptions { get; init; }
-
-    public required List<PolicyTraceRow> ExpectedTrace { get; init; }
-
-    public required PolicyExpectedFinal ExpectedFinal { get; init; }
-}
-
-internal sealed record PolicyFixtureEnvironment
-{
-    public required string Platform { get; init; }
-
-    public required string ExecutablePath { get; init; }
-
-    public required List<string> CommandArguments { get; init; }
-
-    public required string Grammar { get; init; }
-
-    public required string PathStyle { get; init; }
-
-    public string? PowerShellDialect { get; init; }
-}
-
-internal sealed record PolicyFixtureAuthority
-{
-    public required List<string> OneTimeApprovalKeys { get; init; }
-
-    public required List<PolicyGrant> SessionGrants { get; init; }
-
-    public required List<PolicyGrant> PersistentGrants { get; init; }
-
-    public required List<PolicySafePhrase> SafePhrases { get; init; }
-}
-
-internal sealed record PolicyGrant
-{
-    public required string Kind { get; init; }
-
-    public required string Shell { get; init; }
-
-    public required string Match { get; init; }
-
-    public required List<string> Tokens { get; init; }
-
-    public string? Directory { get; init; }
-}
-
-internal sealed record PolicySafePhrase
-{
-    public required List<string> Tokens { get; init; }
-
-    public required string Proof { get; init; }
-}
-
-internal sealed record PolicyFixtureCandidate
-{
-    public required int Id { get; init; }
-
-    public required List<string> Tokens { get; init; }
-
-    public string? RealDirectory { get; init; }
-
-    public string? IntentDirectory { get; init; }
-
-    public required string ExpectedCoverage { get; init; }
-}
-
-internal sealed record PolicyValueFact
-{
-    public required int CandidateId { get; init; }
-
-    public required int ArgumentIndex { get; init; }
-
-    public required string Domain { get; init; }
-
-    public required List<PolicyValuePart> Parts { get; init; }
-}
-
-internal sealed record PolicyValuePart
-{
-    public string? Exact { get; init; }
-
-    public List<long>? IntegerRange { get; init; }
-}
-
-internal sealed record PolicyAuthoredPathFact
-{
-    public required int CandidateId { get; init; }
-
-    public required bool ArgumentIsPath { get; init; }
-
-    public required string EffectiveValue { get; init; }
-
-    public required List<string> AuthoredValues { get; init; }
-
-    public required List<string> AuthoredFileSystemValues { get; init; }
-
-    public required string AuthoredPathShape { get; init; }
-
-    public required string ExpectedPathPolicy { get; init; }
-}
-
-internal sealed record PolicyShellEffects
-{
-    public required List<PolicyRedirect> Redirects { get; init; }
-}
-
-internal sealed record PolicyRedirect
-{
-    public required int CandidateId { get; init; }
-
-    public required string Target { get; init; }
-
-    public required string Mode { get; init; }
-
-    public required string ExpectedPathPolicy { get; init; }
-}
-
-internal sealed record PolicyParserOptions
-{
-    public required bool PublishAuthoredSourceFacts { get; init; }
-}
-
-internal sealed record PolicyTraceRow
-{
-    public required string Stage { get; init; }
-
-    public int? CandidateId { get; init; }
-
-    public string? ExecutableBasename { get; init; }
-
-    public required string Outcome { get; init; }
-
-    public required string Reason { get; init; }
-
-    public string? Coverage { get; init; }
-
-    public string? ScopeRelation { get; init; }
-
-    public string? GrantTimestamp { get; init; }
-}
-
-internal sealed record PolicyExpectedFinal
-{
-    public required string Outcome { get; init; }
-
-    public required string Reason { get; init; }
-}
-
 internal sealed record PostMergeApprovalHarvest
 {
     public required int SchemaVersion { get; init; }
@@ -658,6 +495,5 @@ internal sealed record PostMergeApprovalCase
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow)]
 [JsonSerializable(typeof(ApprovalEvidenceMatrix))]
-[JsonSerializable(typeof(PolicyFixtureCatalog))]
 [JsonSerializable(typeof(PostMergeApprovalHarvest))]
 internal sealed partial class ShellApprovalEvidenceJsonContext : JsonSerializerContext;

--- a/src/Netclaw.Security.Tests/ShellPolicyEvidenceModels.cs
+++ b/src/Netclaw.Security.Tests/ShellPolicyEvidenceModels.cs
@@ -1,0 +1,222 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyEvidenceModels.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Security.Tests;
+
+internal sealed record PolicyFixtureCatalog
+{
+    public required int SchemaVersion { get; init; }
+
+    public required PolicyFixtureDefaults FixtureDefaults { get; init; }
+
+    public required List<PolicyFixtureCase> Cases { get; init; }
+}
+
+internal sealed record PolicyFixtureDefaults
+{
+    public required string ToolName { get; init; }
+
+    public required string Audience { get; init; }
+
+    public required string ApprovalMode { get; init; }
+
+    public required string InteractiveApprovalCapability { get; init; }
+
+    public required string ClockUtc { get; init; }
+
+    public required PolicyFixtureSession Session { get; init; }
+
+    public required string ProjectDirectory { get; init; }
+
+    public string? InheritedWorkingDirectory { get; init; }
+
+    public required string PersistentStoreStatus { get; init; }
+}
+
+internal sealed record PolicyFixtureSession
+{
+    public required string SessionId { get; init; }
+
+    public required string SessionDirectory { get; init; }
+}
+
+internal sealed record PolicyFixtureCase
+{
+    public required string EvidenceId { get; init; }
+
+    public required string Command { get; init; }
+
+    public required PolicyFixtureEnvironment Environment { get; init; }
+
+    public required string InitialWorkingDirectory { get; init; }
+
+    public required PolicyFixtureAuthority Available { get; init; }
+
+    public required List<PolicyFixtureCandidate> Candidates { get; init; }
+
+    public List<PolicyValueFact>? ValueFacts { get; init; }
+
+    public List<PolicyAuthoredPathFact>? AuthoredPathFacts { get; init; }
+
+    public PolicyShellEffects? ShellEffects { get; init; }
+
+    public required List<PolicyTraceRow> ExpectedTrace { get; init; }
+
+    public required PolicyExpectedFinal ExpectedFinal { get; init; }
+}
+
+internal sealed record PolicyFixtureEnvironment
+{
+    public required string Platform { get; init; }
+
+    public required string ExecutablePath { get; init; }
+
+    public required List<string> CommandArguments { get; init; }
+
+    public required string Grammar { get; init; }
+
+    public required string PathStyle { get; init; }
+
+    public string? PowerShellDialect { get; init; }
+}
+
+internal sealed record PolicyFixtureAuthority
+{
+    public required List<string> OneTimeApprovalKeys { get; init; }
+
+    public required List<PolicyGrant> SessionGrants { get; init; }
+
+    public required List<PolicyGrant> PersistentGrants { get; init; }
+
+    public required List<PolicySafePhrase> SafePhrases { get; init; }
+}
+
+internal sealed record PolicyGrant
+{
+    public required string Kind { get; init; }
+
+    public required string Shell { get; init; }
+
+    public required string Match { get; init; }
+
+    public required List<string> Tokens { get; init; }
+
+    public string? Directory { get; init; }
+}
+
+internal sealed record PolicySafePhrase
+{
+    public required List<string> Tokens { get; init; }
+
+    public required string Proof { get; init; }
+}
+
+internal sealed record PolicyFixtureCandidate
+{
+    public required int Id { get; init; }
+
+    public required List<string> Tokens { get; init; }
+
+    public string? RealDirectory { get; init; }
+
+    public string? IntentDirectory { get; init; }
+
+    public required string ExpectedCoverage { get; init; }
+}
+
+internal sealed record PolicyValueFact
+{
+    public required int CommandIndex { get; init; }
+
+    public required List<string> VerbTokens { get; init; }
+
+    public required int ArgumentIndex { get; init; }
+
+    public required string Domain { get; init; }
+
+    public required List<PolicyValuePart> Parts { get; init; }
+}
+
+internal sealed record PolicyValuePart
+{
+    public string? Exact { get; init; }
+
+    public List<long>? IntegerRange { get; init; }
+}
+
+internal sealed record PolicyAuthoredPathFact
+{
+    public required int CommandIndex { get; init; }
+
+    public required List<string> VerbTokens { get; init; }
+
+    public required bool ArgumentIsPath { get; init; }
+
+    public required string EffectiveValue { get; init; }
+
+    public required List<string> AuthoredValues { get; init; }
+
+    public required List<string> AuthoredFileSystemValues { get; init; }
+
+    public required string AuthoredPathShape { get; init; }
+
+    public required string ExpectedPathPolicy { get; init; }
+}
+
+internal sealed record PolicyShellEffects
+{
+    public required List<PolicyRedirect> Redirects { get; init; }
+}
+
+internal sealed record PolicyRedirect
+{
+    public required int CommandIndex { get; init; }
+
+    public required string Target { get; init; }
+
+    public required string Mode { get; init; }
+
+    public required string ExpectedPathPolicy { get; init; }
+}
+
+internal sealed record PolicyTraceRow
+{
+    public required string Stage { get; init; }
+
+    public int? CandidateId { get; init; }
+
+    public string? ExecutableBasename { get; init; }
+
+    public required string Outcome { get; init; }
+
+    public required string Reason { get; init; }
+
+    public string? Coverage { get; init; }
+
+    public string? ScopeRelation { get; init; }
+
+    public string? GrantTimestamp { get; init; }
+}
+
+internal sealed record PolicyExpectedFinal
+{
+    public required string Outcome { get; init; }
+
+    public required string Reason { get; init; }
+
+    public List<string>? ApprovalCandidates { get; init; }
+
+    public bool? IsMessy { get; init; }
+
+    public string? AgentCorrection { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow)]
+[JsonSerializable(typeof(PolicyFixtureCatalog))]
+internal sealed partial class ShellPolicyFixtureJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary

- execute the exact sanitized D02, D03, D07-D11, D14, D17, and D18 policy fixtures through the real shell matcher and coordinator
- validate parser value facts and structured path-policy routing independently from policy candidate identity
- deserialize the strict fixture schema with source-generated System.Text.Json metadata and reject unknown members
- update the operator guide with current prompt, session-grant, headless, trace, loop, and compound-command behavior
- preserve the interactive-only reviewed-safe authority contract from #1918

## Validation

- `dotnet build Netclaw.slnx -c Release --no-restore -v:q` — 0 warnings/errors
- Security evidence contract: 13/13
- Actor fixture plus approval matrix: 258/258
- `openspec validate structure-shell-approval-policy --strict`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff upstream/dev --check`
- adversarial review: PASS, no warnings
- repository Slopwatch reports only pre-existing SW004 in untouched `PowerShellHostProbeTests.cs:279` (blame `868204947`)
