### PR TITLE
Fix subagent project scope corrections

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -226,11 +226,15 @@ Done when:
   root from one-command `WorkingDirectory` scope, prevent redundant project
   switches, and preserve `cd` when directory mutation is the requested shell
   behavior.
-- [x] Reviewed-safe shell work beneath an undeclared cwd returns a
-  `set_working_directory` correction to the agent before any user prompt. The
-  original tool call remains unchanged; the shared directory policy must accept
-  the exact non-temp cwd, while unsafe phrases, outside paths, Public sessions,
-  and unavailable scope tools retain normal approval behavior.
+- [x] Reviewed-safe shell work beneath an undeclared cwd returns the same
+  `set_working_directory` correction in parent sessions and subagents before
+  any user prompt. The original tool call remains unchanged. The registered
+  tool must accept the exact non-temp cwd; unsafe phrases, outside paths,
+  Public sessions, and unavailable scope tools retain normal approval behavior.
+  A successful child declaration updates only the child scope, reloads its
+  project instructions, and leaves the parent project unchanged. Headless
+  declarations prevent repeated corrections but do not grant execution
+  authority.
 - [x] Bounded non-path `IntegerRange` and `Concatenation` data do not make a
   complete shell command complex. Unknown values, identities, paths, and
   redirects stay strict.

--- a/openspec/changes/structure-shell-approval-policy/design.md
+++ b/openspec/changes/structure-shell-approval-policy/design.md
@@ -265,6 +265,31 @@ authority outside code review. At minimum `find`, `awk`, `rg`, and `sort` are
 not eligible. Production code has no flag-specific exceptions. The existing
 `git ls-tree` special case is deleted.
 
+Parent sessions and subagents consume the same project-scope correction before
+they open an approval request. The correction is available only when the
+registered `set_working_directory` tool accepts the exact suggested directory
+under its normal filesystem policy. A subagent returns the correction as the
+tool result and leaves the authored call in history. If the tool is absent or
+rejects the directory, the subagent keeps the existing parent approval bridge
+path.
+
+A headless subagent may receive this model-facing correction even though it
+cannot open an approval bridge. After a successful declaration, the unchanged
+retry follows the ordinary headless authority rules. The declared root prevents
+another correction; it does not grant reviewed-safe or stored authority.
+
+A successful child `set_working_directory` call replaces only the child run's
+immutable project-scope snapshot. It reloads project instructions through the
+same prompt provider and rebuilds the child's system prompt before the next
+model call. Later child tool calls use the new scope. The child reports the
+local scope in its result, but the parent merge keeps its existing rule: child
+project selection does not replace the parent project directory.
+
+The shared `set_working_directory` validation rejects NUL, CR, and LF before
+filesystem resolution. This rule applies to both execution and the eligibility
+probe. An invalid path returns a bounded error and cannot enter model history,
+child scope, or project-instruction lookup as a successful declaration.
+
 ### 7. Consume ShellSyntaxTree 0.3.1 facts through 0.3.3 explicitly
 
 Netclaw uses effective `AnalyzedArgument.Value` for runtime-sensitive checks.

--- a/openspec/changes/structure-shell-approval-policy/specs/session-cwd/spec.md
+++ b/openspec/changes/structure-shell-approval-policy/specs/session-cwd/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Project-directory declarations reject control characters
+
+The `set_working_directory` tool SHALL reject a path that contains NUL, CR, or
+LF before filesystem resolution. The tool SHALL return a bounded error without
+echoing the authored path.
+
+#### Scenario: Controlled path cannot become project scope
+
+- **GIVEN** a path contains NUL, CR, or LF
+- **WHEN** an agent calls `set_working_directory` with that path
+- **THEN** the tool returns an error without the authored path
+- **AND** the project scope remains unchanged
+- **AND** project instructions are not loaded from that path

--- a/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
@@ -590,6 +590,45 @@ paths SHALL retain existing strict checks.
 - **AND** the correction tells the agent to declare the exact cwd and retry the
   exact command unchanged
 
+#### Scenario: Subagent scope correction precedes parent approval
+
+- **GIVEN** a subagent submits eligible reviewed-safe shell work beneath an
+  undeclared cwd
+- **AND** its registered `set_working_directory` tool accepts that exact cwd
+- **WHEN** policy would otherwise open the parent approval bridge
+- **THEN** the subagent returns the same scope-declaration correction as a
+  parent session
+- **AND** it does not execute the shell command or request parent approval
+- **AND** the authored tool call remains unchanged in model history
+
+#### Scenario: Subagent declaration applies to the unchanged retry
+
+- **GIVEN** a subagent received a scope-declaration correction
+- **WHEN** it calls `set_working_directory` with the exact suggested cwd
+- **THEN** the child replaces its local project-scope snapshot
+- **AND** it reloads project instructions before the next model call
+- **AND** an unchanged eligible shell retry uses the declared child scope
+- **AND** the child does not replace the parent project directory
+
+#### Scenario: Headless subagent declaration does not grant authority
+
+- **GIVEN** a headless subagent received a scope-declaration correction
+- **AND** it successfully declared the exact suggested cwd
+- **WHEN** it retries the unchanged shell call
+- **THEN** the declared child scope prevents another correction
+- **AND** the retry follows ordinary headless authority rules
+- **AND** the declaration does not grant reviewed-safe, session, or persistent
+  authority
+
+#### Scenario: Subagent keeps the approval bridge when scope cannot change
+
+- **GIVEN** a subagent submits eligible reviewed-safe shell work beneath an
+  undeclared cwd
+- **AND** `set_working_directory` is absent or rejects that cwd
+- **WHEN** policy requires approval
+- **THEN** the scope-declaration correction does not apply
+- **AND** the existing parent approval bridge handles the request
+
 #### Scenario: Scope correction cannot hide unsafe work
 
 - **GIVEN** any candidate lacks reviewed-safe phrase coverage
@@ -599,7 +638,8 @@ paths SHALL retain existing strict checks.
 - **OR** `set_working_directory` is unavailable
 - **OR** `set_working_directory` policy would reject or substitute the cwd
 - **WHEN** policy evaluates the call
-- **THEN** the scope-declaration correction does not apply
+- **THEN** the scope-declaration correction does not apply in a parent session
+  or subagent
 - **AND** the normal approval or deny result remains
 
 #### Scenario: Unsafe argument surface excludes whole phrase

--- a/openspec/changes/structure-shell-approval-policy/tasks.md
+++ b/openspec/changes/structure-shell-approval-policy/tasks.md
@@ -88,10 +88,16 @@
   checks as separate effects.
 - [ ] 5.6 Preserve native PowerShell provider checks, including strict
   `Get-Content Env:SECRET` behavior.
-- [ ] 5.7 Return an agent scope-declaration correction before a user prompt
-  only when each reviewed-safe candidate remains beneath the exact shell cwd
-  and the shared `set_working_directory` policy accepts that non-temp cwd;
-  preserve the authored call and tool history.
+- [x] 5.7 Return an agent scope-declaration correction before a parent-session
+  or subagent user prompt only when each reviewed-safe candidate remains
+  beneath the exact shell cwd and the registered `set_working_directory` tool
+  accepts that non-temp cwd; preserve the authored call and tool history, and
+  retain the approval bridge when the tool is absent or rejects the cwd. Apply
+  a successful child declaration to later child contexts, reload project
+  instructions, and keep the parent project unchanged. Reject NUL, CR, and LF
+  at the shared declaration boundary; prove the tool returns a bounded error
+  without a child-scope or prompt update. Prove a headless declaration prevents
+  a repeated correction but does not grant authority to the unchanged retry.
 
 ## 6. Bash causal approval intent
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Threading.Channels;
 using Netclaw.Actors.SubAgents;
+using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Actors.Tools;
 using Netclaw.Actors.Tests.Memory;
@@ -29,6 +30,7 @@ namespace Netclaw.Actors.Tests.SubAgents;
 public class SubAgentActorTests : TestKit
 {
     private static readonly TimeSpan ApprovalAskTimeout = TimeSpan.FromSeconds(30);
+    public static bool IsPosix => !OperatingSystem.IsWindows();
 
     public SubAgentActorTests(ITestOutputHelper output) : base(output: output) { }
 
@@ -630,6 +632,171 @@ public class SubAgentActorTests : TestKit
             GetLastToolResult(fakeClient, "call-scratch-correction"));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Subagent_reviewed_safe_external_cwd_receives_project_scope_correction_before_bridge(
+        bool supportsApproval)
+    {
+        const string callId = "call-project-scope-correction";
+        var approvalBridge = supportsApproval
+            ? new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce)
+            : null;
+        var scenario = await RunProjectScopeScenarioAsync(
+            callId,
+            includeScopeTool: true,
+            scopeToolAccepts: true,
+            approvalBridge);
+
+        Assert.True(scenario.Result.Success, scenario.Result.Output);
+        Assert.False(scenario.Shell.WasCalled);
+        Assert.Equal(0, approvalBridge?.RequestCount ?? 0);
+        var correction = GetLastToolResult(scenario.Client, callId);
+        Assert.Contains("working_directory_not_declared", correction, StringComparison.Ordinal);
+        Assert.Contains(scenario.Worktree, correction, StringComparison.Ordinal);
+        Assert.Contains(SetWorkingDirectoryTool.ToolName, correction, StringComparison.Ordinal);
+        var preservedCall = scenario.Client.LastReceivedMessages!
+            .SelectMany(message => message.Contents.OfType<FunctionCallContent>())
+            .Single(call => call.CallId == callId);
+        Assert.Equal(
+            "grep -rn 'Metric' tests src; cat tests/project.csproj",
+            preservedCall.Arguments!["Command"]);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task Subagent_unavailable_project_scope_keeps_parent_approval_bridge(
+        bool includeScopeTool,
+        bool scopeToolAccepts)
+    {
+        const string callId = "call-project-scope-approval";
+        var approvalBridge = new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce);
+        var scenario = await RunProjectScopeScenarioAsync(
+            callId,
+            includeScopeTool,
+            scopeToolAccepts,
+            approvalBridge);
+
+        Assert.True(scenario.Result.Success, scenario.Result.Output);
+        Assert.True(scenario.Shell.WasCalled);
+        Assert.Equal(1, approvalBridge.RequestCount);
+        Assert.Equal(scenario.Worktree, approvalBridge.RequestedCwd);
+        Assert.DoesNotContain(
+            "working_directory_not_declared",
+            GetLastToolResult(scenario.Client, callId),
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Subagent_project_declaration_updates_child_prompt_before_unchanged_retry(
+        bool supportsApproval)
+    {
+        const string firstCallId = "call-project-scope-first";
+        const string declarationCallId = "call-project-scope-declare";
+        const string retryCallId = "call-project-scope-retry";
+        const string projectGuidance = "Project instructions: use the local test conventions.";
+        var worktree = Path.GetFullPath(AppContext.BaseDirectory);
+        var shell = new FakeNetclawTool(ShellTool.ToolName, "inspected");
+        var setWorkingDirectory = new SetWorkingDirectoryTool(
+            new ToolConfig(),
+            new NetclawPaths(worktree, worktree));
+        var client = new SequencedToolCallChatClient(
+        [
+            ProjectScopeCall(firstCallId, worktree),
+            new FunctionCallContent(
+                declarationCallId,
+                SetWorkingDirectoryTool.ToolName,
+                new Dictionary<string, object?> { ["Path"] = worktree }),
+            ProjectScopeCall(retryCallId, worktree)
+        ]);
+        var approvalBridge = supportsApproval
+            ? new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce)
+            : null;
+        var actor = Sys.ActorOf(SubAgentActor.CreatePropsWithProjectInstructionProvider(
+            CreateDefinition([shell, setWorkingDirectory]),
+            client,
+            CreateProjectScopeCorrectionPolicy(worktree),
+            new ProjectPromptProvider(worktree, projectGuidance)));
+
+        var result = await actor.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
+                Task = "Declare the project and retry the exact inspection.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            ApprovalAskTimeout,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(supportsApproval, result.Success);
+        Assert.Equal(supportsApproval, shell.WasCalled);
+        Assert.Equal(0, approvalBridge?.RequestCount ?? 0);
+        Assert.Contains(
+            projectGuidance,
+            client.LastReceivedMessages!.Single(message => message.Role == ChatRole.System).Text,
+            StringComparison.Ordinal);
+
+        if (supportsApproval)
+        {
+            Assert.Equal(worktree, result.WorkingContext!.ProjectDirectory);
+            var parent = new WorkingContext { ProjectDirectory = "/parent/project" };
+            var merged = LlmSessionActor.MergeSuccessfulSubAgentWorkingContext(parent, result.Completion);
+            Assert.Equal("/parent/project", merged.ProjectDirectory);
+        }
+    }
+
+    [Theory]
+    [InlineData("\0")]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    public async Task Subagent_rejects_control_characters_from_project_scope_result(string controlCharacter)
+    {
+        const string projectGuidance = "Project instructions that must not load.";
+        var worktree = Path.GetFullPath(AppContext.BaseDirectory);
+        var controlledDirectory = Path.Combine(worktree, $"project-{controlCharacter}-candidate");
+        var setWorkingDirectory = new SetWorkingDirectoryTool(
+            new ToolConfig(),
+            new NetclawPaths(worktree, worktree));
+        var client = new SequencedToolCallChatClient(
+        [
+            new FunctionCallContent(
+                "call-control-project",
+                SetWorkingDirectoryTool.ToolName,
+                new Dictionary<string, object?> { ["Path"] = controlledDirectory })
+        ]);
+        var promptProvider = new ProjectPromptProvider(controlledDirectory, projectGuidance);
+        var actor = Sys.ActorOf(SubAgentActor.CreatePropsWithProjectInstructionProvider(
+            CreateDefinition([setWorkingDirectory]),
+            client,
+            PermissivePolicy(),
+            promptProvider));
+
+        var result = await actor.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Scope = SubAgentTestScope.Create(),
+                Task = "Try to declare the project.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            ApprovalAskTimeout,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success, result.Output);
+        Assert.Null(result.WorkingContext!.ProjectDirectory);
+        Assert.Equal(
+            "Error: path contains an invalid control character.",
+            GetLastToolResult(client.LastReceivedMessages, "call-control-project"));
+        Assert.DoesNotContain(controlledDirectory, result.Output, StringComparison.Ordinal);
+        Assert.Equal(0, promptProvider.CallCount);
+        Assert.DoesNotContain(
+            projectGuidance,
+            client.LastReceivedMessages!.Single(message => message.Role == ChatRole.System).Text,
+            StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task Subagent_parallel_temp_calls_both_receive_first_attempt_corrections()
     {
@@ -1075,11 +1242,110 @@ public class SubAgentActorTests : TestKit
                 new AlwaysSafeTemporaryPathInspector()));
     }
 
+    private async Task<ProjectScopeScenario> RunProjectScopeScenarioAsync(
+        string callId,
+        bool includeScopeTool,
+        bool scopeToolAccepts,
+        IParentApprovalBridge? approvalBridge)
+    {
+        var worktree = Path.GetFullPath(AppContext.BaseDirectory);
+        var shell = new FakeNetclawTool(ShellTool.ToolName, "approved");
+        var tools = new List<INetclawTool> { shell };
+        if (includeScopeTool)
+        {
+            var allowedRoot = scopeToolAccepts
+                ? worktree
+                : Path.Combine(worktree, "different-workspace-root");
+            tools.Add(new SetWorkingDirectoryTool(
+                new ToolConfig(),
+                new NetclawPaths(allowedRoot, allowedRoot)));
+        }
+
+        var client = new FakeChatClient
+        {
+            ToolCallsOnFirstCall = [ProjectScopeCall(callId, worktree)]
+        };
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(
+            CreateDefinition(tools),
+            client,
+            CreateProjectScopeCorrectionPolicy(worktree)));
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Scope = SubAgentTestScope.Create(approvalBridge: approvalBridge),
+                Task = "Inspect project metrics.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            ApprovalAskTimeout,
+            TestContext.Current.CancellationToken);
+
+        return new ProjectScopeScenario(result, shell, client, worktree);
+    }
+
+    private sealed record ProjectScopeScenario(
+        SubAgentResult Result,
+        FakeNetclawTool Shell,
+        FakeChatClient Client,
+        string Worktree);
+
+    private sealed class ProjectPromptProvider(
+        string expectedProjectDirectory,
+        string projectInstructions) : ISystemPromptProvider
+    {
+        public int CallCount { get; private set; }
+
+        public string GetSystemPrompt(TrustAudience audience, string? projectDirectory = null)
+            => string.Empty;
+
+        public string? GetProjectInstructions(TrustAudience audience, string? projectDirectory)
+        {
+            CallCount++;
+            return string.Equals(projectDirectory, expectedProjectDirectory, StringComparison.Ordinal)
+                ? projectInstructions
+                : null;
+        }
+
+        public string? GetOperatingRules(TrustAudience audience) => null;
+    }
+
+    private static ToolAccessPolicy CreateProjectScopeCorrectionPolicy(string workspacesDirectory)
+    {
+        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                [ShellTool.ToolName] = ToolApprovalMode.Approval
+            }
+        };
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+        return new ToolAccessPolicy(
+            toolConfig,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy(environment),
+            new ToolPathPolicy(environment, []),
+            shellTrustZonePolicy: new ShellTrustZonePolicy(
+                toolConfig,
+                new NetclawPaths(workspacesDirectory, workspacesDirectory)),
+            safeVerbs: SafeVerbList.FromVerbs(["grep", "cat"]));
+    }
+
     private static FunctionCallContent ScratchCall(string callId)
         => new(callId, ShellTool.ToolName, new Dictionary<string, object?>
         {
             ["Command"] = "gh api repos/example/project",
             ["WorkingDirectory"] = "/tmp"
+        });
+
+    private static FunctionCallContent ProjectScopeCall(string callId, string workingDirectory)
+        => new(callId, ShellTool.ToolName, new Dictionary<string, object?>
+        {
+            ["Command"] = "grep -rn 'Metric' tests src; cat tests/project.csproj",
+            ["WorkingDirectory"] = workingDirectory
         });
 
     private static string? GetLastToolResult(FakeChatClient fakeClient, string callId)

--- a/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
@@ -308,6 +308,16 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
     }
 
     [Fact]
+    public void Already_declared_project_scope_does_not_request_another_declaration()
+    {
+        var policy = new ScopedShellSafeVerbPolicy(VerbList("head"));
+        var ctx = PersonalContext(projectDir: _outsideDir);
+        var candidates = new[] { new ApprovalCandidate("head", _outsideDir) };
+
+        Assert.False(policy.CanShortCircuitAfterProjectDeclaration(candidates, _outsideDir, ctx));
+    }
+
+    [Fact]
     public void Unsafe_work_cannot_request_project_declaration()
     {
         var policy = new ScopedShellSafeVerbPolicy(VerbList("head"));

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -64,6 +64,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private readonly IChatClient _chatClient;
     private readonly ToolAccessPolicy _toolAccessPolicy;
     private readonly IToolApprovalService? _approvalService;
+    private readonly ISystemPromptProvider _promptProvider;
     private readonly int _maxToolIterations;
 
     // Process-wide daily-stats sink (the same singleton the parent session records
@@ -121,6 +122,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private string? _parentSessionId;
     private string? _subSessionId;
     private ChildFileActivityTracker _fileActivity = new(WorkingContext.Empty);
+    private string? _projectInstructions;
 
     // Default wait-for-first-delta budget when the spawn message carries none
     // (direct/test callers). Mirrors SessionConfig.PrefillTimeout so an unset
@@ -159,6 +161,25 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         IToolApprovalService? approvalService = null,
         int maxToolIterations = DefaultMaxToolIterations,
         Telemetry.ISessionMetrics? sessionMetrics = null)
+        : this(
+            definition,
+            chatClient,
+            toolAccessPolicy,
+            NullSystemPromptProvider.Instance,
+            approvalService,
+            maxToolIterations,
+            sessionMetrics)
+    {
+    }
+
+    private SubAgentActor(
+        SubAgentDefinition definition,
+        IChatClient chatClient,
+        ToolAccessPolicy toolAccessPolicy,
+        ISystemPromptProvider promptProvider,
+        IToolApprovalService? approvalService,
+        int maxToolIterations,
+        Telemetry.ISessionMetrics? sessionMetrics)
     {
         if (maxToolIterations <= 0)
             throw new ArgumentOutOfRangeException(nameof(maxToolIterations), maxToolIterations,
@@ -172,8 +193,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _chatClient = chatClient;
         _sessionMetrics = sessionMetrics;
         _toolAccessPolicy = toolAccessPolicy;
+        _promptProvider = promptProvider;
         _approvalService = approvalService;
         _maxToolIterations = maxToolIterations;
+        _projectInstructions = definition.ProjectInstructions;
         _log = Context.GetLogger();
 
         // Build a private ToolRegistry for this subagent's tool subset
@@ -204,6 +227,52 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             approvalService,
             maxToolIterations,
             sessionMetrics));
+    }
+
+    internal static Props CreatePropsWithProjectInstructionProvider(
+        SubAgentDefinition definition,
+        IChatClient chatClient,
+        ToolAccessPolicy toolAccessPolicy,
+        ISystemPromptProvider promptProvider,
+        IToolApprovalService? approvalService = null,
+        int maxToolIterations = DefaultMaxToolIterations,
+        Telemetry.ISessionMetrics? sessionMetrics = null)
+    {
+        ArgumentNullException.ThrowIfNull(promptProvider);
+        return Props.CreateBy(new SubAgentActorProducer(
+            definition,
+            chatClient,
+            toolAccessPolicy,
+            promptProvider,
+            approvalService,
+            maxToolIterations,
+            sessionMetrics));
+    }
+
+    private sealed class SubAgentActorProducer(
+        SubAgentDefinition definition,
+        IChatClient chatClient,
+        ToolAccessPolicy toolAccessPolicy,
+        ISystemPromptProvider promptProvider,
+        IToolApprovalService? approvalService,
+        int maxToolIterations,
+        Telemetry.ISessionMetrics? sessionMetrics) : IIndirectActorProducer
+    {
+        public Type ActorType => typeof(SubAgentActor);
+
+        public ActorBase Produce()
+            => new SubAgentActor(
+                definition,
+                chatClient,
+                toolAccessPolicy,
+                promptProvider,
+                approvalService,
+                maxToolIterations,
+                sessionMetrics);
+
+        public void Release(ActorBase actor)
+        {
+        }
     }
 
     /// <summary>
@@ -291,7 +360,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             // Build initial conversation: system prompt (from file, verbatim) + task as user message.
             // If the caller supplied runtime context, prefix it onto the user message so the
             // system prompt stays reproducible across invocations.
-            _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.System, BuildSystemPrompt(_definition)));
+            _history.Add(new AiChatMessage(
+                Microsoft.Extensions.AI.ChatRole.System,
+                BuildSystemPrompt(_definition, _projectInstructions)));
             _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User,
                 BuildUserMessage(
                     msg.RuntimeContext,
@@ -439,6 +510,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 _history.Add(ChatMessageConverter.ToAiMessage(result));
                 if (result.ToolCallId is { } callId)
                     _fileActivity.Complete(callId.Value, result.Content);
+                TryApplyProjectDirectory(result);
                 var preview = result.Content is { Length: > 200 }
                     ? result.Content[..200] + "..."
                     : result.Content ?? "(null)";
@@ -689,6 +761,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         var self = Self;
         var executor = new DispatchingToolExecutor(_toolRegistry, _toolAccessPolicy, _approvalService);
+        var setWorkingDirectoryTool =
+            _toolRegistry.GetByName(SetWorkingDirectoryTool.ToolName) as SetWorkingDirectoryTool;
+        Func<string, ToolInvocationContext, bool>? canDeclareWorkingDirectory =
+            setWorkingDirectoryTool is null ? null : setWorkingDirectoryTool.CanDeclare;
         _toolExecutionWatchdogState = _approvalBridge is null
             ? ToolExecutionWatchdogState.None
             : ToolExecutionWatchdogState.RunningApprovalCapableTools;
@@ -701,7 +777,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _externalCts?.Token ?? CancellationToken.None,
             self,
             _approvalBridge,
-            _sessionScratchCorrections.Snapshot());
+            _sessionScratchCorrections.Snapshot(),
+            canDeclareWorkingDirectory);
     }
 
     private void FireLlmCall(bool forceNoTools = false)
@@ -952,6 +1029,51 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         return _fileActivity.BuildResult();
     }
 
+    private void TryApplyProjectDirectory(SerializableChatMessage result)
+    {
+        if (result.Name is not SetWorkingDirectoryTool.ToolName
+            || result.Content is null
+            || _toolRegistry.GetByName(SetWorkingDirectoryTool.ToolName) is not SetWorkingDirectoryTool tool)
+        {
+            return;
+        }
+
+        var projectDirectory = result.Content.Trim();
+        var validatedWorkingContext = WorkingContext.Empty.WithProjectDirectory(projectDirectory);
+        if (!string.Equals(
+                validatedWorkingContext.ProjectDirectory,
+                projectDirectory,
+                StringComparison.Ordinal)
+            || !Path.IsPathRooted(projectDirectory)
+            || !tool.CanDeclare(projectDirectory, ToolExecutionContext.Invocation))
+        {
+            return;
+        }
+
+        var nextScope = ToolExecutionContext.RunScope with
+        {
+            ProjectDirectory = projectDirectory
+        };
+        _toolExecutionContext = new ToolExecutionContext(
+            nextScope,
+            ToolExecutionContext.ExecutionTimeout);
+        _fileActivity.SetProjectDirectory(projectDirectory);
+        _projectInstructions = _promptProvider.GetProjectInstructions(
+            nextScope.Audience,
+            projectDirectory);
+
+        var prompt = BuildSystemPrompt(_definition, _projectInstructions);
+        var systemMessage = new AiChatMessage(Microsoft.Extensions.AI.ChatRole.System, prompt);
+        if (_history.Count > 0 && _history[0].Role == Microsoft.Extensions.AI.ChatRole.System)
+            _history[0] = systemMessage;
+        else
+            _history.Insert(0, systemMessage);
+
+        _log.Info("SubAgent [{AgentName}] project directory set to {ProjectDir}",
+            _definition.Name,
+            projectDirectory);
+    }
+
     private static string ExtractText(AiChatMessage message)
     {
         var sb = new StringBuilder();
@@ -1134,7 +1256,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         CancellationToken externalCt,
         IActorRef self,
         IParentApprovalBridge? approvalBridge,
-        SessionScratchCorrectionDispatch scratchCorrections)
+        SessionScratchCorrectionDispatch scratchCorrections,
+        Func<string, ToolInvocationContext, bool>? canDeclareWorkingDirectory)
     {
         try
         {
@@ -1187,10 +1310,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             : null);
                 }
                 catch (ToolApprovalRequiredException approvalEx)
-                    when (approvalBridge is not null)
                 {
                     var ctx = approvalEx.ApprovalContext;
-                    if (ctx.AgentCorrection is
+                    if (approvalBridge is not null
+                        && ctx.AgentCorrection is
                         ToolAgentCorrection.SessionScratchSuggested scratchCorrection
                         && scratchCall is { } correctedCall)
                     {
@@ -1206,6 +1329,27 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             toolContext,
                             modelInputBudget,
                             new SessionScratchCorrectionChange.Arm(newCorrectionKey));
+                    }
+
+                    var projectScopeCorrection =
+                        SessionToolExecutionPipeline.BuildProjectScopeDeclarationCorrection(
+                            ctx,
+                            canDeclareWorkingDirectory is not null,
+                            toolContext.Invocation,
+                            canDeclareWorkingDirectory);
+                    if (!string.IsNullOrEmpty(projectScopeCorrection))
+                    {
+                        return BuildToolResult(
+                            cleanedTc,
+                            projectScopeCorrection,
+                            toolContext,
+                            modelInputBudget);
+                    }
+
+                    if (approvalBridge is null)
+                    {
+                        throw new ParentApprovalUnavailableException(
+                            $"Tool '{tc.Name}' requires interactive approval, but no parent approval bridge is available.");
                     }
 
                     var bridgeCandidates = ctx.Candidates is { Count: > 0 } c
@@ -1282,13 +1426,6 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         consumedScratchKey is { } deniedConsumed
                             ? new SessionScratchCorrectionChange.Consume(deniedConsumed)
                             : null);
-                }
-                catch (ToolApprovalRequiredException)
-                {
-                    // Missing bridge wiring is a security/configuration failure,
-                    // not a recoverable tool error for the model to continue past.
-                    throw new ParentApprovalUnavailableException(
-                        $"Tool '{tc.Name}' requires interactive approval, but no parent approval bridge is available.");
                 }
                 catch (ParentApprovalUnavailableException)
                 {
@@ -1391,14 +1528,16 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         IReadOnlyList<SerializableMediaReference> ModelInputMediaReferences,
         SessionScratchCorrectionChange? ScratchCorrectionChange);
 
-    private static string BuildSystemPrompt(SubAgentDefinition definition)
+    private static string BuildSystemPrompt(
+        SubAgentDefinition definition,
+        string? projectInstructions)
     {
         // Assemble the identity stack that sub-agents inherit from the parent session:
         // 1. Embedded operating core + deployment AGENTS.md mission playbook
         // 2. Project instructions (workspace/domain context from the parent's working directory)
         var basePrompt = SystemPromptAssembler.Assemble(
             agents: definition.OperatingRules,
-            projectInstructions: definition.ProjectInstructions);
+            projectInstructions: projectInstructions);
 
         // Append the sub-agent's own system prompt (markdown body + optional skill overlay)
         var rolePrompt = string.IsNullOrWhiteSpace(basePrompt)
@@ -1450,6 +1589,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             else
                 _confirmedChangedFiles.Add(activity.Path);
         }
+
+        public void SetProjectDirectory(string projectDirectory)
+            => _workingContext = _workingContext.WithProjectDirectory(projectDirectory);
 
         public WorkingContextDelta BuildResult() => new()
         {

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -204,10 +204,11 @@ public sealed class SubAgentSpawner
         });
 
         // Spawn as child of the session actor via the context factory
-        var props = SubAgentActor.CreateProps(
+        var props = SubAgentActor.CreatePropsWithProjectInstructionProvider(
             definition,
             chatClient,
             _toolAccessPolicy,
+            _promptProvider,
             _approvalService,
             SubAgentMaxToolIterations,
             _sessionMetrics);

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -149,6 +149,12 @@ internal sealed class ScopedShellSafeVerbPolicy
             return false;
         }
 
+        if (ResolveSafeSpaceRoots(context)
+            .Any(root => PathUtility.IsWithinRoot(fullCwd, root)))
+        {
+            return false;
+        }
+
         foreach (var candidate in candidates)
         {
             var effectiveDirectory = candidate.Directory ?? fullCwd;

--- a/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
@@ -12,8 +12,8 @@ namespace Netclaw.Actors.Tools;
 
 /// <summary>
 /// Sets the session's project directory — the root of the codebase or project
-/// the agent is currently working on. The session actor intercepts successful
-/// results by tool name to update <c>WorkingContext.ProjectDirectory</c> and
+/// the agent is currently working on. The owning session or subagent actor
+/// intercepts successful results by tool name to update its project scope and
 /// re-assemble the system prompt with project-scoped identity files.
 /// </summary>
 [NetclawTool(ToolName,
@@ -45,6 +45,9 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
 
     protected override Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
+        if (ContainsInvalidControlCharacter(args.Path))
+            return Task.FromResult("Error: path contains an invalid control character.");
+
         var raw = args.Path?.Trim() ?? string.Empty;
         if (string.IsNullOrEmpty(raw))
             return Task.FromResult("Error: path is required.");
@@ -59,12 +62,16 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
     }
 
     internal bool CanDeclare(string path, ToolInvocationContext context)
-        => _fileAccessPolicy.TryResolveWorkingDirectory(
+        => !ContainsInvalidControlCharacter(path)
+           && _fileAccessPolicy.TryResolveWorkingDirectory(
                path,
                context,
                out var fullPath,
                out _)
            && PathUtility.AreEquivalentPaths(path, fullPath)
            && Directory.Exists(fullPath);
+
+    private static bool ContainsInvalidControlCharacter(string? path)
+        => path is not null && path.AsSpan().IndexOfAny('\0', '\r', '\n') >= 0;
 
 }


### PR DESCRIPTION
## Summary

- return the existing project-scope declaration correction to subagents before opening the parent approval bridge
- apply a successful `set_working_directory` declaration only to the child run, reload its project instructions, and keep the parent project unchanged
- prevent headless correction loops without granting headless execution authority
- reject NUL, CR, and LF at the shared working-directory declaration boundary

## Why

A subagent could issue reviewed-safe work beneath an undeclared project cwd, receive a user approval prompt, and never get the same model-facing correction available to a parent session. Merely returning the correction was insufficient: the child did not apply the declaration to later tool contexts or reload project guidance.

This keeps the original shell call and history intact. It teaches the child to declare the project through the existing tool and filesystem policy, then reevaluates the unchanged retry under the resulting child scope.

## Validation

- adversarial production review: PASS, no warnings
- focused actor/policy/tool tests: 85/85
- full actor suite before final rebase: 3,181 passed, 1 expected Windows-only skip
- Release build: 0 warnings/errors
- strict OpenSpec validation
- copyright headers
- changed-file format verification
- changed-file Slopwatch: 0 findings
- PII review: no findings

The full solution run also surfaced one unrelated existing MCP diagnostic assertion mismatch in `McpSdkCatalogNotificationIntegrationTests`; this PR does not touch that test or MCP production code.
