### PR TITLE
fix(tests): stop SessionLogActor diagnostic test racing the FlushTick

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionLogActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionLogActorTests.cs
@@ -201,9 +201,13 @@ public sealed class SessionLogActorTests : TestKit
         {
             var dispatcher = SpawnDispatcher(Sys, basePath, timeProvider);
 
-            dispatcher.Tell(new TextOutput("audit-line") { SessionId = sessionId }, ActorRefs.NoSender);
+            // Buffered diagnostic first; the durable audit write below drains
+            // it synchronously (SessionLogActor.WriteDurable) — no dependence
+            // on the 1s FlushTick wall-clock timer, which is what made this
+            // test flaky on loaded Windows CI runners.
             timeProvider.Advance(TimeSpan.FromMilliseconds(1));
             dispatcher.Tell(new SessionLogDiagnostic(sessionId, "[2026-05-07T13:30:00.001+00:00] Diagnostic: provider sent request"), ActorRefs.NoSender);
+            dispatcher.Tell(new TextOutput("audit-line") { SessionId = sessionId }, ActorRefs.NoSender);
 
             await AwaitAssertAsync(async () =>
             {


### PR DESCRIPTION
## Problem

`SessionLogActorTests.Dispatcher_writes_audit_and_diagnostic_to_same_session_log` is flaky on Windows CI. It failed on run 31715544081 (job 94499226187, 2026-08-13): after the full ~3s `AwaitAssertAsync` budget, the file contained the assistant line but **not** the diagnostic line, even though the write was correct.

Root cause (confirmed by `dotnet-concurrency-specialist` + `akka-net-specialist`):
- The test sent the durable audit `TextOutput` **first** (flushed immediately via `WriteDurable`), then the **buffered** `SessionLogDiagnostic` (`Write` only — no flush).
- Buffered diagnostics only reach the OS at a flush point: the 1s `FlushTick` (real wall-clock scheduler, not the test's `FakeTimeProvider`), the 256-write threshold, a later durable write, or `PostStop`.
- On a loaded 2-core Windows runner the tick can land past the 3s assert budget → flake. The test predates the batching refactor (#1499) that introduced the buffered diagnostic path.

## Fix (test-only, deterministic)

Send the buffered diagnostic **first**, then the durable audit line — the audit write's `WriteDurable` → `Flush()` drains the buffered diagnostic synchronously in the same mailbox turn. This is the exact behavior documented in `SessionLogActor.cs`: "audit lines are natural flush points."

No production change: the buffered-diagnostic path is deliberate (batching, per #1499) and bounded in production.

## Verification

- 10/10 stress runs pass in **433–702ms** (previously ~1s every run, gated on the tick).
- Full `SessionLogActorTests` class: 4/4 pass.
- Fix removes the wall-clock dependency entirely, so the loaded-runner failure mode cannot resurface.

## Notes

- Test-only change; no OpenSpec, no system-skill change.