### PR TITLE
Enforce ordered shell policy preflight

### DIFF
--- a/openspec/changes/structure-shell-approval-policy/tasks.md
+++ b/openspec/changes/structure-shell-approval-policy/tasks.md
@@ -34,7 +34,7 @@
 
 ## 3. Ordered security stages and coverage
 
-- [ ] 3.1 Implement parse validation, hard deny, protected path, approval mode,
+- [x] 3.1 Implement parse validation, hard deny, protected path, approval mode,
   candidate construction, noninteractive trust-zone enforcement, actor match,
   safe policy, exact-set one-time matching, and prompt completion in the
   specified order.

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -54,12 +54,14 @@ public sealed class ToolApprovalGateTests
     public void Shell_in_deny_mode_returns_deny()
     {
         var policy = CreatePolicy(ToolApprovalMode.Deny);
+        var context = PersonalContext();
         var args = ToolInput.Create("Command", "git push");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.AuthorizeInvocation(ShellTool(), context, args);
 
         Assert.False(decision.Allowed);
         Assert.Equal("tool_denied_by_approval_policy", decision.DenyReason);
+        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
     }
 
     [Fact]
@@ -73,6 +75,84 @@ public sealed class ToolApprovalGateTests
         Assert.True(decision.Allowed);
         Assert.False(decision.NeedsApproval);
         Assert.Equal(ToolAllowReason.PolicyAuto, decision.AllowReason);
+    }
+
+    [Theory]
+    [InlineData(ToolApprovalMode.Auto)]
+    [InlineData(ToolApprovalMode.Deny)]
+    [InlineData((ToolApprovalMode)999)]
+    public void Shell_hard_deny_precedes_approval_mode(ToolApprovalMode mode)
+    {
+        var policy = CreatePolicy(mode);
+
+        var decision = policy.AuthorizeInvocation(
+            ShellTool(),
+            PersonalContext(),
+            ToolInput.Create("Command", "rm -rf /"));
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("hard_deny_system_destructive", decision.DenyReason);
+    }
+
+    [Theory]
+    [InlineData(ToolApprovalMode.Auto)]
+    [InlineData(ToolApprovalMode.Deny)]
+    [InlineData((ToolApprovalMode)999)]
+    public void Shell_protected_path_precedes_approval_mode(ToolApprovalMode mode)
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+        const string protectedRoot = "/protected";
+        var config = CreateShellConfig(mode);
+        var commandPolicy = new ShellCommandPolicy(environment);
+        var pathPolicy = new ToolPathPolicy(environment, [protectedRoot]);
+        var policy = new ToolAccessPolicy(config, Defaults(), commandPolicy, pathPolicy);
+        var tool = new ShellTool(config, pathPolicy, commandPolicy);
+
+        var decision = policy.AuthorizeInvocation(
+            tool,
+            PersonalContext(),
+            ToolInput.Create("Command", "cat /protected/secret.txt"));
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("shell_references_protected_path", decision.DenyReason);
+    }
+
+    [Theory]
+    [InlineData(ToolApprovalMode.Auto, "shell_trust_zone_policy_not_configured")]
+    [InlineData(ToolApprovalMode.Deny, "tool_denied_by_approval_policy")]
+    public void Shell_approval_mode_preserves_noninteractive_trust_zone(
+        ToolApprovalMode mode,
+        string expectedDenyReason)
+    {
+        var policy = CreatePolicy(mode);
+        var context = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(
+            ShellTool(),
+            context,
+            ToolInput.Create("Command", "cat /external/data.txt"));
+
+        Assert.False(decision.Allowed);
+        Assert.Equal(expectedDenyReason, decision.DenyReason);
+        Assert.False(decision.NeedsApproval);
+        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
+    }
+
+    [Fact]
+    public void Invalid_shell_approval_mode_fails_closed()
+    {
+        var policy = CreatePolicy((ToolApprovalMode)999);
+        var context = PersonalContext();
+
+        var decision = policy.AuthorizeInvocation(
+            ShellTool(),
+            context,
+            ToolInput.Create("Command", "git status"));
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("internal_policy_failure", decision.DenyReason);
+        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
+        Assert.Null(context.Cwd);
     }
 
     [Fact]
@@ -914,6 +994,26 @@ public sealed class ToolApprovalGateTests
             toolPathPolicy: new ToolPathPolicy(environment, []),
             shellTrustZonePolicy: trustZone);
     }
+
+    private static ToolConfig CreateShellConfig(ToolApprovalMode mode)
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = mode
+            }
+        };
+        return config;
+    }
+
+    private static EffectivePolicyDefaults Defaults()
+        => new(
+            DeploymentPosture.Personal,
+            TrustAudience.Personal,
+            ShellExecutionMode.HostAllowed,
+            UsedStrictFallback: false);
 
     // Simulates a Mode.Roots audience: a path is write-authorized iff it falls
     // within one of the configured roots (the same IsWithinAnyRoot semantics the

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -189,7 +189,17 @@ public sealed class ToolAccessPolicy
             var (_, approvalArguments) = ToolCallMeta.ExtractFrom(
                 arguments,
                 key => ToolArgumentValidator.ResolveMetaField(mcp, key));
-            return CheckApprovalGate(mcpToolName, context, approvalArguments, McpApprovalMatcher.Instance);
+            var approvalMode = GetApprovalMode(
+                mcpToolName,
+                context,
+                approvalArguments,
+                McpApprovalMatcher.Instance);
+            return CheckApprovalGate(
+                mcpToolName,
+                context,
+                approvalArguments,
+                McpApprovalMatcher.Instance,
+                approvalMode);
         }
 
         var toolName = new ToolName(tool.Name);
@@ -198,7 +208,11 @@ public sealed class ToolAccessPolicy
             return ToolAccessDecision.Deny("tool_not_allowed_for_audience_profile");
 
         if (!IsShellCoupledTool(tool))
-            return CheckApprovalGate(toolName, context, arguments, SelectMatcherForTool(toolName));
+        {
+            var matcher = SelectMatcherForTool(toolName);
+            var approvalMode = GetApprovalMode(toolName, context, arguments, matcher);
+            return CheckApprovalGate(toolName, context, arguments, matcher, approvalMode);
+        }
 
         var shellMode = ResolveShellMode();
         if (shellMode == ShellExecutionMode.Off)
@@ -232,6 +246,11 @@ public sealed class ToolAccessPolicy
                 return ToolAccessDecision.Deny("shell_references_protected_path");
         }
 
+        var mode = GetApprovalMode(toolName, context, arguments, _shellApprovalMatcher);
+        var approvalModeDecision = GetApprovalModeDecision(mode);
+        if (approvalModeDecision is { Allowed: false })
+            return approvalModeDecision;
+
         // All shell policy checks use the directory that ShellTool executes.
         // The explicit tool argument can be absent while the context supplies
         // an active project, session, or inherited directory.
@@ -242,9 +261,6 @@ public sealed class ToolAccessPolicy
                 toolName,
                 analysisArguments,
                 shellAnalysis);
-
-        if (shellAnalysis is not null)
-            _authorizedShellAnalyses.Add(context, shellAnalysis);
 
         // Non-interactive channels: sandbox shell commands to trust zone paths.
         // Even if the verb-chain is pre-approved, path arguments must fall within
@@ -268,11 +284,18 @@ public sealed class ToolAccessPolicy
             }
         }
 
+        if (shellAnalysis is not null)
+            _authorizedShellAnalyses.Add(context, shellAnalysis);
+
+        if (approvalModeDecision is not null)
+            return approvalModeDecision;
+
         return CheckApprovalGate(
             toolName,
             context,
             arguments,
             _shellApprovalMatcher,
+            mode,
             shellApproval,
             shellAnalysis,
             deferReviewedSafeCoverage);
@@ -473,27 +496,14 @@ public sealed class ToolAccessPolicy
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments,
         IToolApprovalMatcher matcher,
+        ToolApprovalMode mode,
         ShellApprovalAnalysis? shellApproval = null,
         ShellCommandAnalysis? shellAnalysis = null,
         bool deferReviewedSafeCoverage = false)
     {
-        var audience = ResolveAudience(context.Invocation);
-        var profile = ToolAudienceProfileDefaults.GetResolvedProfile(_toolConfig.AudienceProfiles, audience);
-        var approvalPolicy = profile.ApprovalPolicy;
-        var approvalModeKey = matcher.GetApprovalModeKey(toolName, arguments);
-        var mode = ResolveApprovalMode(
-            approvalPolicy,
-            approvalModeKey,
-            toolName,
-            arguments,
-            audience,
-            matcher);
-
-        if (mode == ToolApprovalMode.Deny)
-            return ToolAccessDecision.Deny("tool_denied_by_approval_policy");
-
-        if (mode == ToolApprovalMode.Auto)
-            return ToolAccessDecision.Allow(ToolAllowReason.PolicyAuto);
+        var approvalModeDecision = GetApprovalModeDecision(mode);
+        if (approvalModeDecision is not null)
+            return approvalModeDecision;
 
         // The approval policy is authoritative for every channel — there is no
         // safe-list auto-grant for non-interactive callers. A non-interactive
@@ -618,6 +628,33 @@ public sealed class ToolAccessPolicy
 
         return ToolAccessDecision.RequiresApproval(approvalContext);
     }
+
+    private ToolApprovalMode GetApprovalMode(
+        ToolName toolName,
+        ToolExecutionContext context,
+        IDictionary<string, object?>? arguments,
+        IToolApprovalMatcher matcher)
+    {
+        var audience = ResolveAudience(context.Invocation);
+        var profile = ToolAudienceProfileDefaults.GetResolvedProfile(_toolConfig.AudienceProfiles, audience);
+        var approvalModeKey = matcher.GetApprovalModeKey(toolName, arguments);
+        return ResolveApprovalMode(
+            profile.ApprovalPolicy,
+            approvalModeKey,
+            toolName,
+            arguments,
+            audience,
+            matcher);
+    }
+
+    private static ToolAccessDecision? GetApprovalModeDecision(ToolApprovalMode mode)
+        => mode switch
+        {
+            ToolApprovalMode.Approval => null,
+            ToolApprovalMode.Auto => ToolAccessDecision.Allow(ToolAllowReason.PolicyAuto),
+            ToolApprovalMode.Deny => ToolAccessDecision.Deny("tool_denied_by_approval_policy"),
+            _ => ToolAccessDecision.Deny("internal_policy_failure")
+        };
 
     internal static ToolApprovalContext NarrowShellApprovalContext(
         ToolApprovalContext context,


### PR DESCRIPTION
## Summary

- resolve shell approval mode after canonical hard-deny and protected-path checks
- keep Auto mode behind noninteractive trust-zone enforcement
- fail closed for invalid approval modes
- retain authorized shell analysis only after terminal preflight gates pass

## Validation

- focused policy and evidence tests: 331/331
- full Netclaw.Actors.Tests: 3,274 passed; 1 expected native-Windows skip
- independent adversarial review: PASS
- strict OpenSpec validation
- headers and dotnet format
- git diff --check
- Slopwatch: only pre-existing SW004 in unrelated PowerShellHostProbeTests.cs

This PR is stacked on #1926. It adds no executable-specific command parsing and changes no public API.