### PR TITLE
Design a simpler shell policy evaluator

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/.openspec.yaml
+++ b/openspec/changes/simplify-shell-policy-evaluator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/simplify-shell-policy-evaluator/design.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/design.md
@@ -1,0 +1,345 @@
+## Context
+
+The shell policy now has a typed projection, one actor batch, per-candidate coverage, and an ordered coordinator. The behavior is correct, but policy ownership remains spread across several large classes.
+
+The measured baseline covers these production files:
+
+| File | Lines | Control-flow lines |
+| --- | ---: | ---: |
+| `ToolAccessPolicy.cs` | 1,016 | 59 |
+| `ShellPolicyCoordinator.cs` | 671 | 48 |
+| `ShellPolicyProjection.cs` | 331 | 11 |
+| `IToolApprovalMatcher.cs` | 1,864 | 156 |
+| `ScopedShellSafeVerbPolicy.cs` | 366 | 27 |
+| `PlatformTemporaryScopePolicy.cs` | 617 | 54 |
+| `BashCausalApprovalIntent.cs` | 271 | 18 |
+| **Total** | **5,136** | **373** |
+
+The baseline uses `wc -l` for lines. This command counts control-flow statement lines:
+
+```bash
+rg -c '^\s*(if|for|foreach|while|switch)\b' \
+  src/Netclaw.Actors/Tools/{ToolAccessPolicy,ShellPolicyCoordinator,ShellPolicyProjection,ScopedShellSafeVerbPolicy,PlatformTemporaryScopePolicy,BashCausalApprovalIntent}.cs \
+  src/Netclaw.Security/IToolApprovalMatcher.cs \
+  | awk -F: '{ total += $NF } END { print total }'
+```
+
+This count is a stable structure metric, not cyclomatic complexity. The final audit also reports method complexity and coverage risk.
+
+The policy path has two phases today. `ToolAccessPolicy` performs synchronous preflight, then caches analysis inside the tool context. `ShellPolicyCoordinator` retrieves that analysis and completes asynchronous policy.
+
+`ShellPolicyCoordinator.CompleteAsync` currently owns many concerns. It validates candidates, checks causal paths, requests actor evidence, mutates coverage, narrows prompts, applies one-time authority, and emits terminal trace facts.
+
+The actor owns session and persistent grant snapshots. The coordinator owns one-time authority and final policy. This ownership split remains correct.
+
+The exact D-case fixtures, 12 adversarial cases, 11 live cases, and the full policy matrix form the behavior contract. The refactor must keep their outcomes and traces unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace the context analysis cache with one explicit preflight result.
+- Give each ordered policy stage one clear owner.
+- Keep one call-local state for candidates, coverage, evidence, trace facts, and terminal status.
+- Validate actor output once before any grant coverage applies.
+- Compute parser-derived path facts once and reuse them across policy stages.
+- Reduce total production lines and control-flow lines below the measured baseline.
+- Preserve all public, wire, persistence, prompt, trace, and operator contracts.
+- Keep every unknown or invalid internal state fail-closed.
+
+**Non-Goals:**
+
+- Change any allow, prompt, deny, correction, or approval option.
+- Expand the reviewed-safe catalog.
+- Parse executable-private arguments inside Netclaw.
+- Add ShellSyntaxTree grammar or public API.
+- Change approval entry schema, actor persistence, or session events.
+- Change channel prompts, model guidance, or eval prompts.
+- Combine shell policy with generic MCP approval policy.
+
+## Decisions
+
+### 1. One explicit authorization result replaces the context cache
+
+Add an internal `ShellPolicyPreflightResult` family:
+
+```csharp
+internal abstract record ShellPolicyPreflightResult
+{
+    internal sealed record Complete(
+        ToolAccessDecision Decision,
+        ShellCommandAnalysis? AuthorizedAnalysis)
+        : ShellPolicyPreflightResult;
+
+    internal sealed record Continue(
+        ShellCommandAnalysis Analysis,
+        ToolApprovalContext ApprovalContext,
+        ShellExecutionEnvironment Environment)
+        : ShellPolicyPreflightResult;
+}
+```
+
+`ToolAccessPolicy` will return this result for shell calls. The coordinator will receive the exact `Continue.Analysis` value.
+
+An immediate preflight allow may carry `AuthorizedAnalysis`. A preflight prompt or deny must carry no analysis.
+
+The coordinator will return an internal `ShellPolicyAuthorization` value:
+
+```csharp
+internal sealed record ShellPolicyAuthorization(
+    ToolAuthorizationDecision Decision,
+    ShellCommandAnalysis? AuthorizedAnalysis);
+```
+
+Only an allow result may carry `AuthorizedAnalysis`. Every allowed parsed shell execution must carry the exact preflight analysis.
+
+`DispatchingToolExecutor` will pass that value directly to `ShellTool`. The stream and non-stream paths will use the same transfer rule.
+
+The current internal `EvaluateAuthorizationAsync` method will return only `Decision` for tests. It will not retain analysis after it returns.
+
+Authorization-only calls will also discard the analysis. No method will read or write analysis through `ToolExecutionContext` cache methods.
+
+Why:
+
+- Data flow becomes explicit.
+- One parse result reaches projection directly.
+- The same parse result reaches execution directly.
+- Context state cannot survive beyond the authorization call.
+- Tests can construct and inspect the exact preflight result.
+
+Alternative: retain the cache and wrap it. Rejected because the hidden side channel remains.
+
+### 2. One call-local evaluation state owns mutable policy facts
+
+Add one internal `ShellPolicyEvaluation` class. It exists for one authorization call and never crosses an actor boundary.
+
+It owns:
+
+- the preflight result and `ShellPolicyProjection`;
+- candidate IDs and immutable candidate facts;
+- one coverage slot per candidate;
+- validated actor evidence;
+- approval matches;
+- persistent-store status;
+- the trace builder;
+- the terminal decision, when present.
+
+Only methods on this type may change coverage. A stage cannot replace candidate facts or IDs.
+
+Why:
+
+- Mutation stays local and auditable.
+- Stages no longer pass parallel lists and maps.
+- Coverage and trace updates can occur through one atomic method.
+- The class avoids a new immutable array allocation after each stage.
+
+Alternative: return a new immutable state after every stage. Rejected because it adds allocation and code without stronger call-local safety.
+
+### 3. Ordered stages return one closed result family
+
+Each stage returns `ShellPolicyStageResult`:
+
+```csharp
+internal abstract record ShellPolicyStageResult
+{
+    internal sealed record Continue : ShellPolicyStageResult;
+
+    internal sealed record Complete(ToolAuthorizationDecision Decision)
+        : ShellPolicyStageResult;
+
+    internal sealed record Fault(ShellPolicyFault Reason)
+        : ShellPolicyStageResult;
+}
+```
+
+The pipeline invokes stages in this order:
+
+1. syntax and candidate validation;
+2. protected real and fallback paths;
+3. causal directory eligibility;
+4. approval-exempt side effects;
+5. actor grant evidence;
+6. reviewed-safe real-scope coverage;
+7. reviewed-safe intent coverage;
+8. exact one-time coverage;
+9. persistent-store availability;
+10. prompt or allow completion.
+
+Synchronous preflight keeps its current order before these stages:
+
+1. parse validation;
+2. hard deny;
+3. protected paths;
+4. approval mode;
+5. candidate construction;
+6. noninteractive trust zones.
+
+A terminal result stops the pipeline. A later stage cannot revise an earlier deny or prompt.
+
+Why:
+
+- Order becomes data, not incidental control flow.
+- Each stage has a narrow test surface.
+- Terminal precedence is visible.
+- Internal faults map through one fail-closed path.
+
+Alternative: retain one large method with regions. Rejected because regions do not enforce ownership or terminal precedence.
+
+### 4. Actor evidence has one validation boundary
+
+Add an internal `ValidatedShellGrantEvidence` value. A factory validates the complete `ShellApprovalMatchResult` against projected candidates.
+
+The factory validates:
+
+- persistent-store status and enum values;
+- candidate count, IDs, and uniqueness;
+- candidate fact identity;
+- grant coverage and source consistency;
+- canonical session and persistent scopes;
+- grant timestamps;
+- near-miss count and enum values;
+- the unavailable-store restrictions.
+
+No grant enters coverage before this factory succeeds. The coordinator receives only validated evidence or a typed fault.
+
+Why:
+
+- Redundant actor fields remain contained at the protocol edge.
+- The coordinator no longer repeats actor consistency branches.
+- Test doubles must satisfy the same contract as the actor.
+
+Alternative: remove redundant actor fields now. Rejected because that changes the actor protocol as part of a behavior refactor.
+
+### 5. Parser facts remain separate from policy decisions
+
+`ShellApprovalMatcher` will produce syntax facts and approval candidates only. It will not decide safe policy, grant authority, audience, or prompt options.
+
+`ShellPolicyProjection` will remain the sole bridge from ShellSyntaxTree facts into policy candidates. It will not parse command-specific arguments.
+
+Add one internal `ShellPolicyPathFacts` projection. It contains resolved real scopes, intent scopes, fallback scopes, redirects, and authored filesystem values.
+
+Policy stages consume these facts through `ToolPathPolicy`, temporary-scope policy, and reviewed-safe policy. They do not rescan command text.
+
+Why:
+
+- ShellSyntaxTree remains the syntax authority.
+- Netclaw remains the trust and containment authority.
+- One projection prevents path-rule drift.
+- Command-specific exceptions cannot hide inside completion logic.
+
+Alternative: move executable argument rules into the evaluator. Rejected by the Netclaw constitution and the approved threat model.
+
+### 6. Prompt context has one constructor
+
+Add one method on the evaluation state that returns the prompt context for current uncovered candidates. It preserves the full causal context when required.
+
+This method owns:
+
+- candidate order;
+- session-scratch option limits;
+- reusable phrase eligibility;
+- path-style depth rules;
+- causal full-context retention;
+- exact one-time key input.
+
+The one-time stage and prompt stage call the same method. They cannot derive different candidate sets.
+
+Alternative: keep two calls to `NarrowShellApprovalContext`. Rejected because future edits can create one-time and prompt drift.
+
+### 7. Trace output observes state transitions
+
+Coverage changes will add their trace row through the same state method. Terminal completion will append exactly one completion row.
+
+The trace builder remains bounded and redacted. Stages cannot write raw commands, arguments, paths, session values, or secrets.
+
+Why:
+
+- Coverage and trace cannot disagree.
+- Tests can compare state transitions with trace rows.
+- Redaction remains centralized.
+
+Alternative: let each stage write trace rows directly. Rejected because coverage and trace can diverge.
+
+### 8. Compatibility code remains an isolated adapter
+
+The public `IToolApprovalService` shape remains for generic tools and compatibility. One adapter converts its result into raw typed actor evidence before validation.
+
+The main coordinator will depend on the typed grant-evidence interface. New code cannot call the legacy aggregate path directly.
+
+The adapter cannot infer shell identity or widen a phrase. It must preserve exact candidate facts.
+
+Runtime shell calls already enter one coordinator through `DispatchingToolExecutor`. The internal `IShellApprovalMatchService` remains the preferred actor contract.
+
+This change will not remove the public compatibility interface. A later generic approval API version may remove it.
+
+### 9. Complexity reduction is an acceptance gate
+
+The final change must reduce aggregate lines and control-flow lines below 5,136 and 373. The task report will include both counts.
+
+The report will also include method complexity, line coverage, branch coverage, and CRAP risk. It will state the exact tool version and command.
+
+The final review will also inspect:
+
+- production file count;
+- duplicate path and coverage helpers;
+- coordinator method size;
+- public API changes;
+- command-name branches;
+- test duplication.
+
+The corpus, not a metric, remains the behavior authority. A smaller implementation cannot pass if it removes required checks.
+
+## Actor and persistence boundaries
+
+The actor still owns one immutable session and persistent snapshot per request. The coordinator still sends one candidate batch and performs no second store scan.
+
+One-time authority remains in `ToolApprovalAttempt`. It does not enter the actor request or persistent store.
+
+No new event, snapshot, manifest, or approval entry is added. Recovery and passivation behavior remain unchanged.
+
+The compatibility adapter is process-local. It creates no durable state.
+
+## Failure modes and recovery
+
+| Failure | Required result |
+| --- | --- |
+| Parser or projection fault | `internal_policy_failure` deny |
+| Invalid stage transition | `internal_policy_failure` deny |
+| Invalid actor result | `internal_policy_failure` deny |
+| Required persistent state unavailable | `approval_store_unavailable` deny |
+| Expected unresolved shell input | one-time or deny prompt only |
+| Caller cancellation | propagate cancellation |
+| Trace limit reached | bounded trace with current terminal result |
+| Process restart | current actor and session recovery behavior |
+
+No failure path creates session or persistent authority. No rollback needs data repair.
+
+## Risks / Trade-offs
+
+- **Risk: stage extraction changes precedence** → Lock each terminal overlap with exact matrix cases before code moves.
+- **Risk: a new state class hides mutation** → Keep mutation methods narrow and expose immutable candidate views.
+- **Risk: metric goals reward compressed code** → Require readable stages, corpus parity, and adversarial review.
+- **Risk: the compatibility adapter survives indefinitely** → Add a removal inventory and make new callers depend on typed evidence.
+- **Risk: path facts lose source provenance** → Carry parser occurrence identity only inside call-local projection types.
+- **Risk: a broad slice becomes hard to review** → Deliver dependency-ordered slices with full parity after each slice.
+
+## Migration Plan
+
+1. Merge the live corpus before production refactor code.
+2. Add stage-state types and parity tests with no route changes.
+3. Replace the context analysis cache with explicit preflight data.
+4. Move actor-result validation behind the typed evidence boundary.
+5. Route reviewed-safe, one-time, store, and completion logic through stages.
+6. Consolidate path and prompt-context helpers.
+7. Remove dead compatibility branches and duplicate helpers.
+8. Run full local, Linux, macOS, and native Windows gates after each production slice.
+
+Each slice must preserve corpus bytes and expected outcomes. Normal Git revert rolls back a slice because no durable schema changes.
+
+## Resolved boundaries
+
+- Keep `IToolApprovalService` for generic tools and public compatibility.
+- Keep the exact shell adapter until a separate generic approval API version.
+- Keep `ShellPolicyPathFacts` internal to `Netclaw.Actors` because it contains causal policy facts.
+- Reuse `ToolPathPolicy` and `PathUtility` from `Netclaw.Security`.
+- Do not move actor-owned causal or prompt facts into `Netclaw.Security`.

--- a/openspec/changes/simplify-shell-policy-evaluator/proposal.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+PRD-002 and PRD-006 require shell authorization to remain fail-closed, explainable, and practical for routine agent work. The current policy now behaves correctly, but seven core files contain 5,136 lines and about 373 branch points.
+
+The live corpus now supplies a stable contract for a behavior-compatible refactor. This change reduces policy complexity before more exceptions make the evaluator harder to audit.
+
+## What Changes
+
+- Introduce one typed evaluation state for candidates, coverage, actor evidence, trace facts, and the persistent-store result.
+- Give each ordered policy stage one input and one typed result.
+- Move actor-result validation behind one protocol boundary.
+- Consolidate repeated prompt-context, path-fact, coverage, and terminal-decision logic.
+- Shrink shell-specific branches inside `ToolAccessPolicy` and `ShellApprovalMatcher`.
+- Preserve every current allow, prompt, deny, correction, trace, and grant outcome.
+- Use the exact D-case, adversarial, and live regression fixtures as equivalence tests.
+- Deliver the refactor as small dependency-ordered production slices.
+
+In scope:
+
+- `ShellPolicyCoordinator`, `ShellPolicyProjection`, and their internal policy state.
+- Shell preflight seams inside `ToolAccessPolicy`.
+- Shell candidate projection seams inside `ShellApprovalMatcher`.
+- Shared path, coverage, actor-result, and terminal-decision helpers.
+- Tests and operator documentation that explain the internal flow.
+
+Out of scope:
+
+- New reviewed-safe phrases or changes to current catalog authority.
+- New grant, persistence, prompt, audience, or approval-mode semantics.
+- New ShellSyntaxTree grammar or public API.
+- Approval-store migration or wire-format changes.
+- Channel UI changes, new eval behavior, or command-specific production rules.
+
+## Capabilities
+
+### New Capabilities
+
+- `shell-policy-evaluator-architecture`: Defines the typed stage model, ownership boundaries, equivalence contract, and fail-closed internal protocol.
+
+### Modified Capabilities
+
+None. The refactor preserves current `tool-approval-gates` behavior.
+
+## Impact
+
+The change affects internal code in `Netclaw.Actors` and `Netclaw.Security`. Public tool APIs, persisted events, configuration, approval entries, prompts, and traces retain their current contracts.
+
+Security impact is neutral by design. Unknown facts, invalid stage results, internal faults, protected paths, and unavailable required authority remain terminal deny or prompt under the current contract.
+
+Operational impact is limited to ordinary binary rollout. No configuration edit, approval-store reset, database migration, or session migration is required.

--- a/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
@@ -1,0 +1,182 @@
+## ADDED Requirements
+
+### Requirement: Shell policy uses one explicit evaluation state
+
+The system SHALL use one call-local shell policy state for projected candidates, coverage, grant evidence, trace facts, and terminal status.
+
+The state SHALL preserve candidate identity and order for the complete authorization call. No state instance SHALL cross an actor, persistence, or session boundary.
+
+#### Scenario: Partial coverage composes in one state
+
+- **WHEN** a call has candidates covered by a session grant, reviewed-safe policy, and one-time authority
+- **THEN** one evaluation state SHALL record each distinct coverage source
+- **AND** the final call SHALL allow only after every candidate has coverage
+
+#### Scenario: Candidate identity cannot change
+
+- **WHEN** any stage returns a candidate ID or fact that differs from projection
+- **THEN** policy SHALL deny with `internal_policy_failure`
+- **AND** no later stage SHALL apply authority
+
+#### Scenario: Allowed analysis reaches execution
+
+- **WHEN** shell policy allows a stream or non-stream execution
+- **THEN** the executor SHALL receive the exact analysis that policy authorized
+- **AND** no analysis SHALL pass through a context cache
+
+#### Scenario: Preflight allows without completion stages
+
+- **WHEN** preflight allows a parsed shell call through Auto mode or another terminal rule
+- **THEN** its terminal result SHALL carry the exact authorized analysis
+- **AND** execution SHALL not parse the command again
+
+#### Scenario: Authorization does not execute
+
+- **WHEN** a caller requests authorization without execution
+- **THEN** policy SHALL return the current decision
+- **AND** policy SHALL retain no analysis for a later call
+
+### Requirement: Shell policy stages have one fixed order
+
+The system SHALL execute synchronous preflight and asynchronous completion stages in the documented order. A terminal stage result SHALL stop all later policy stages.
+
+#### Scenario: Protected path precedes grant and safe policy
+
+- **WHEN** a candidate references a protected real or fallback path
+- **THEN** policy SHALL deny before actor grant coverage or reviewed-safe coverage applies
+
+#### Scenario: Persistent-store failure follows available authority
+
+- **WHEN** one-time or session authority covers every candidate and persistent state is unavailable
+- **THEN** policy SHALL preserve the current allow result
+- **AND** policy SHALL deny when an uncovered candidate still depends on persistent state
+
+#### Scenario: Invalid stage result fails closed
+
+- **WHEN** a stage returns an unknown result, invalid enum, or impossible transition
+- **THEN** policy SHALL deny with `internal_policy_failure`
+- **AND** policy SHALL not open an approval prompt
+
+### Requirement: Actor grant evidence has one validation boundary
+
+The system SHALL validate the complete actor result before any actor grant enters candidate coverage.
+
+Validation SHALL cover store status, candidate count, IDs, facts, grant source, scope, timestamps, near misses, and unavailable-store restrictions.
+
+#### Scenario: Valid mixed actor evidence
+
+- **WHEN** the actor returns canonical session and persistent evidence for distinct candidates
+- **THEN** policy SHALL apply each coverage source to its exact candidate
+- **AND** policy SHALL retain the current approval match order
+
+#### Scenario: Malformed actor evidence
+
+- **WHEN** actor evidence has a duplicate ID, mismatched phrase, impossible scope, invalid enum, or inconsistent store state
+- **THEN** policy SHALL deny with `internal_policy_failure`
+- **AND** no actor grant SHALL enter coverage
+
+### Requirement: Syntax facts and policy authority remain separate
+
+ShellSyntaxTree and the shell matcher SHALL provide syntax, occurrence, value, redirect, directory, and candidate facts. They SHALL NOT decide trust, audience, grant authority, or prompt options.
+
+Netclaw policy SHALL consume those facts without an executable-private command parser. Unknown policy-relevant facts SHALL retain their current strict outcome.
+
+#### Scenario: Parser facts reach path policy once
+
+- **WHEN** projection contains exact or finite filesystem facts
+- **THEN** policy SHALL evaluate each fact through the current path rules
+- **AND** later stages SHALL reuse the projected result without command-text scans
+
+#### Scenario: Executable-private argument remains outside policy
+
+- **WHEN** safety would require private grammar for one executable
+- **THEN** Netclaw SHALL retain the current prompt or deny outcome
+- **AND** production policy SHALL not add a command-name branch
+
+### Requirement: Prompt and one-time authority share one candidate context
+
+The system SHALL derive one prompt context from the current uncovered candidate set. Exact one-time authority and user prompts SHALL use that same context.
+
+#### Scenario: Safe and granted candidates leave the prompt
+
+- **WHEN** some candidates already have reviewed-safe or stored-grant coverage
+- **THEN** the one-time key and prompt SHALL contain only uncovered candidates
+- **AND** candidate order SHALL remain stable
+
+#### Scenario: Causal policy retains full context
+
+- **WHEN** causal intent requires prerequisite and consumer candidates as one unit
+- **THEN** the one-time key and prompt SHALL retain the complete causal context
+
+### Requirement: Coverage and trace facts remain atomic
+
+Each coverage change SHALL add its bounded trace fact through the same state operation. Terminal completion SHALL add exactly one completion row.
+
+#### Scenario: Coverage trace parity
+
+- **WHEN** a candidate gains session, persistent, reviewed-safe, or one-time coverage
+- **THEN** its trace row SHALL report the same coverage source and policy reason
+
+#### Scenario: Trace data remains redacted
+
+- **WHEN** any stage emits trace evidence
+- **THEN** trace data SHALL exclude raw commands, arguments, paths, prompts, session values, and secrets
+
+### Requirement: Refactor preserves observable policy behavior
+
+The refactor SHALL preserve all current decisions, deny reasons, allow reasons, corrections, approval options, candidate order, actor request count, grant matches, and trace rows.
+
+#### Scenario: Exact fixture equivalence
+
+- **WHEN** the D-case, adversarial, and live regression fixtures execute after each slice
+- **THEN** every expected outcome and ordered trace SHALL remain unchanged
+
+#### Scenario: Full matrix equivalence
+
+- **WHEN** the complete Bash, PowerShell 7, and Windows PowerShell 5.1 policy matrix executes
+- **THEN** every current snapshot and expected result SHALL remain unchanged
+
+#### Scenario: Channel and headless neutrality
+
+- **WHEN** the same shell facts arrive from Slack, another interactive channel, a reminder, webhook, or subagent
+- **THEN** current audience and interactive-capability rules SHALL remain unchanged
+
+### Requirement: Refactor reduces policy complexity
+
+The completed change SHALL reduce aggregate production lines and control-flow lines below the frozen baseline. It SHALL report method complexity and coverage risk.
+
+It SHALL not add a public API, durable schema, command parser, or duplicate policy scan.
+
+#### Scenario: Final complexity audit
+
+- **WHEN** all refactor slices are complete
+- **THEN** the task evidence SHALL report before and after production line and control-flow counts
+- **AND** the after counts SHALL be lower than 5,136 lines and 373 control-flow lines
+- **AND** the evidence SHALL report method complexity, coverage, and CRAP risk with a versioned command
+
+#### Scenario: Public and durable compatibility
+
+- **WHEN** the final API and persistence audits run
+- **THEN** public APIs, approval entries, actor events, snapshots, session history, and configuration SHALL remain compatible
+
+#### Scenario: Public compatibility service remains bounded
+
+- **WHEN** a shell caller uses the public compatibility service
+- **THEN** one internal adapter SHALL preserve exact candidate facts
+- **AND** new typed policy code SHALL not call the aggregate compatibility methods directly
+
+### Requirement: Internal failures remain fail-closed
+
+The system SHALL map unexpected internal faults to `internal_policy_failure`. Caller cancellation SHALL still propagate without conversion to a policy result.
+
+#### Scenario: Stage throws an internal exception
+
+- **WHEN** a policy stage throws outside caller cancellation
+- **THEN** the call SHALL deny with `internal_policy_failure`
+- **AND** the failure SHALL create no approval authority
+
+#### Scenario: Caller cancels evaluation
+
+- **WHEN** the caller cancellation token is canceled
+- **THEN** evaluation SHALL propagate cancellation
+- **AND** policy SHALL not emit a false allow, prompt, or deny result

--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -1,0 +1,77 @@
+## 1. Freeze the behavior contract
+
+- [ ] 1.1 Rebase onto the merged live-regression corpus and record its exact commit and fixture hashes.
+- [ ] 1.2 Pin terminal-precedence overlaps for protected paths, invalid evidence, unavailable persistence, corrections, one-time authority, prompts, and allows.
+- [ ] 1.3 Record the baseline files, lines, control-flow lines, method complexity, coverage risk, coordinator size, helper duplication, and callers.
+- [ ] 1.4 Record public API, approval-store, actor-event, snapshot, session-history, configuration, prompt, and trace compatibility baselines.
+- [ ] 1.5 Run the D-case, adversarial, live-regression, and full disposition suites before production edits.
+
+## 2. Add call-local policy state
+
+- [ ] 2.1 Add internal closed result types for preflight, stage completion, and typed policy faults.
+- [ ] 2.2 Add the internal call-local evaluation state with immutable candidate identity and one coverage slot per candidate.
+- [ ] 2.3 Route coverage and its bounded trace row through one atomic state operation.
+- [ ] 2.4 Add tests for duplicate coverage, changed candidate facts, invalid candidate IDs, invalid transitions, and multiple terminal results.
+- [ ] 2.5 Run exact fixture parity and adversarial review before production decisions use the new state.
+
+## 3. Make preflight data flow explicit
+
+- [ ] 3.1 Return one explicit shell preflight result from `ToolAccessPolicy` with no change to gate order or decisions.
+- [ ] 3.2 Pass the successful preflight result directly into projection and asynchronous completion.
+- [ ] 3.3 Return the exact authorized analysis with the internal shell authorization result.
+- [ ] 3.4 Pass the authorized analysis directly into stream and non-stream shell execution.
+- [ ] 3.5 Preserve the decision-only internal test seam without analysis retention.
+- [ ] 3.6 Remove shell analysis cache reads and writes after all execution paths migrate.
+- [ ] 3.7 Add exact-analysis, Auto allow, consume-once, authorization-only, overlap, and cross-call isolation tests.
+- [ ] 3.8 Run exact fixture parity, focused actor tests, and adversarial review for the preflight slice.
+
+## 4. Validate actor evidence once
+
+- [ ] 4.1 Add the validated actor-evidence factory and bind every result field to projected candidates.
+- [ ] 4.2 Reject malformed store status, enums, candidate identity, scopes, timestamps, near misses, and unavailable-store combinations.
+- [ ] 4.3 Move session and persistent coverage behind the validated evidence boundary.
+- [ ] 4.4 Isolate shell use of public `IToolApprovalService` behind one exact, non-inferential adapter.
+- [ ] 4.5 Add malformed protocol, mixed coverage, unavailable store, and exact one-batch actor tests.
+- [ ] 4.6 Run exact fixture parity and adversarial review for the actor-evidence slice.
+
+## 5. Extract the ordered policy stages
+
+- [ ] 5.1 Add one pipeline runner that stops on the first complete or fault result.
+- [ ] 5.2 Extract syntax, protected-path, causal-path, and causal-directory stages with no change to precedence.
+- [ ] 5.3 Extract approval-exempt and actor-evidence stages with no change to candidate order or request count.
+- [ ] 5.4 Extract reviewed-safe real-scope and intent-scope stages with no change to catalog behavior.
+- [ ] 5.5 Extract exact one-time and persistent-store availability stages while their authority owners stay fixed.
+- [ ] 5.6 Extract final correction, prompt, and allow completion into one terminal stage.
+- [ ] 5.7 Add stage-isolation tests and terminal-overlap tests after each extraction.
+- [ ] 5.8 Run exact fixture parity and adversarial review after each production stage slice.
+
+## 6. Consolidate policy facts and prompt context
+
+- [ ] 6.1 Project real scopes, intent scopes, fallback scopes, redirects, and authored filesystem values once.
+- [ ] 6.2 Route every filesystem fact through current path policy without command-text rescans.
+- [ ] 6.3 Derive one uncovered-candidate context for exact one-time authority and user prompts.
+- [ ] 6.4 Preserve causal full-context, scratch limits, reusable phrases, directory depth, and candidate order.
+- [ ] 6.5 Centralize bounded trace completion and preserve exact redaction and row order.
+- [ ] 6.6 Add path-fact, prompt-context, one-time-key, causal-context, and trace-parity regressions.
+- [ ] 6.7 Run exact fixture parity and adversarial review for the consolidation slice.
+
+## 7. Remove obsolete structure
+
+- [ ] 7.1 Remove dead coordinator branches, duplicate coverage mutation, duplicate path helpers, and duplicate prompt-scope logic.
+- [ ] 7.2 Keep the required public compatibility adapter isolated from new typed policy code.
+- [ ] 7.3 Record the separate generic approval API work that can remove the compatibility adapter.
+- [ ] 7.4 Verify production policy contains no new executable names or executable-private argument rules.
+- [ ] 7.5 Verify no call-local parser occurrence, command text, path, or secret crosses actor or persistence boundaries.
+- [ ] 7.6 Run API and durable-contract comparisons against the frozen baseline.
+
+## 8. Prove equivalence and reduction
+
+- [ ] 8.1 Run Release build, full tests, headers, format checks, strict OpenSpec, diff checks, and changed-file Slopwatch.
+- [ ] 8.2 Run the exact D-case, adversarial, live-regression, full Bash, PowerShell 7, and Windows PowerShell 5.1 matrices.
+- [ ] 8.3 Run native Linux, macOS, and Windows validation for platform-specific path and shell behavior.
+- [ ] 8.4 Confirm channel, reminder, webhook, headless, recovery, and subagent outcomes remain unchanged.
+- [ ] 8.5 Compare public APIs and persisted wire bytes against the frozen baseline.
+- [ ] 8.6 Report final lines, control-flow lines, method complexity, coverage risk, files, largest methods, and duplicate helpers beside the baseline.
+- [ ] 8.7 Require aggregate lines and control-flow lines below 5,136 and 373 while all required checks remain.
+- [ ] 8.8 Obtain final adversarial review of authority, precedence, compatibility, test sufficiency, and code reduction.
+- [ ] 8.9 Stop and revise this change if any expected outcome, trace row, authority boundary, or compatibility contract differs.


### PR DESCRIPTION
## Why

The live corpus now freezes current shell policy outcomes. The evaluator still spreads policy state and precedence across several large classes.

## What

- Adds one call-local evaluation state.
- Defines a fixed stage order and terminal precedence.
- Validates actor grant evidence at one boundary.
- Replaces the hidden analysis cache with an explicit execution handoff.
- Reuses one path-fact projection and one prompt context.
- Preserves all public, durable, prompt, trace, and authority contracts.
- Requires lower production lines and control-flow lines.
- Requires method complexity, coverage, and CRAP risk reports.

## Validation

- Strict OpenSpec validation passes.
- The STE audit passes.
- The diff check passes.
- The rebase retained stable patch ID 5bb0f8ab292a83ec2fcc5543fbf005e21151fa3c.
- The change contains no production code.

## Execution boundary

Production work starts in separate reversible slices after this design merges. Every slice must preserve the frozen fixture outcomes and traces.