### PR TITLE
Add call-local shell policy evaluation state

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-baseline.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-baseline.md
@@ -1,0 +1,115 @@
+# Shell Policy Refactor Baseline
+
+This baseline freezes behavior before production edits.
+
+## Source and fixtures
+
+The live-regression corpus commit is `8b4108aa92a229f4727377299d9dd2ed19f70e07`.
+The design commit above it is `3e6f9bb805fd33bc9f8cd5198de2c117d80838dc`.
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `approval-matrix.json` | `0169105efe87b345d9a82d777ef86909e31fa81a5255cc0cc30f32fbe4d0d6b0` |
+| `netclaw-policy-fixtures.json` | `bdfdc56d509bf0783db15cb468b4cb01ee3eca9dc01c517590c83d832c2be25c` |
+| `post-1890-approval-harvest.json` | `4f40850ede2cd2b334f2ae5bcc207473df70cc9d39e0812b23b6558c9357095a` |
+| `post-1925-binary-swap-approval-harvest.json` | `09420e69e50d06204934c01f3856103ea546b9e10c529e156e67594eaad6aaa5` |
+| `post-1925-extended-approval-harvest.json` | `87048616083017f80e8a2cb35fadcc6a145715e7acc9ee95ad04f481f6818554` |
+
+The actor fixture and disposition tests passed 362 cases.
+The security evidence tests passed 15 cases.
+
+## Terminal precedence
+
+| Boundary | Exact regression |
+| --- | --- |
+| Protected path before causal authority | `Causal_intent_cannot_bypass_protected_path_policy` |
+| Protected path before symlink rejection | `Protected_path_denial_precedes_symlink_fallback_rejection` |
+| Duplicate actor identity denies | `Authorization_evaluation_denies_duplicate_actor_candidate_id` |
+| Changed actor facts deny | `Authorization_evaluation_denies_mismatched_actor_match` |
+| Malformed persistent scope denies | `Authorization_evaluation_denies_malformed_persistent_actor_scope` |
+| Invalid store failure denies | `Authorization_evaluation_denies_invalid_store_failure_enum` |
+| Unavailable store denies uncovered work | `Authorization_evaluation_denies_uncovered_candidate_when_store_is_unavailable` |
+| Exact one-time authority survives store failure | `One_time_approval_remains_valid_when_persistent_store_is_unavailable` |
+| Scope correction precedes a prompt | `Reviewed_safe_external_cwd_exposes_project_scope_correction` |
+| Unsafe external scope keeps the approval path | `Unsafe_external_cwd_does_not_expose_project_scope_correction` |
+| Prompt and allow parity | `Shell_approval_cases_match_review_table` |
+
+## Source size
+
+The control-flow count uses line starts for `if`, `for`, `foreach`, `while`, and `switch`.
+
+| File | Lines | Control-flow lines |
+| --- | ---: | ---: |
+| `ToolAccessPolicy.cs` | 1,016 | 59 |
+| `ShellPolicyCoordinator.cs` | 671 | 48 |
+| `ShellPolicyProjection.cs` | 331 | 11 |
+| `IToolApprovalMatcher.cs` | 1,864 | 156 |
+| `ScopedShellSafeVerbPolicy.cs` | 366 | 27 |
+| `PlatformTemporaryScopePolicy.cs` | 617 | 54 |
+| `BashCausalApprovalIntent.cs` | 271 | 18 |
+| Total | 5,136 | 373 |
+
+`DispatchingToolExecutor` is the sole coordinator caller.
+`ToolAccessPolicy` owns parser, safe-catalog, and temporary-scope dependencies.
+`ShellPolicyProjection` alone invokes `BashCausalApprovalIntent`.
+
+`ShellPolicyCoordinator` derives the narrowed approval context twice.
+It pairs coverage and trace writes across four separate loops.
+`ShellCoverageSet` and the trace builder accept independent writes.
+
+## Complexity and coverage
+
+The baseline uses `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.
+The actor suite passed 3,296 cases with one expected skip.
+The security suite passed 913 cases.
+
+Actors had 68.17% line coverage and 44.70% branch coverage.
+Security had 61.86% line coverage and 51.79% branch coverage.
+
+| File | Methods | Total CRAP | Average CRAP | Risk methods | Worst method | Complexity | Coverage |
+| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: |
+| `BashCausalApprovalIntent.cs` | 7 | 55.26 | 7.89 | 0 | `TryProject` | 27 | 96.30% |
+| `IToolApprovalMatcher.cs` | 89 | 568.88 | 6.39 | 2 | `ResolveGlobCoveringDirectory` | 13 | 50.00% |
+| `PlatformTemporaryScopePolicy.cs` | 33 | 211.05 | 6.40 | 1 | `AllScopesStayWithinTemporaryRoot` | 21 | 57.50% |
+| `ScopedShellSafeVerbPolicy.cs` | 10 | 112.80 | 11.28 | 1 | `AllEffectivePathsStayWithinIntent` | 13 | 42.31% |
+| `ShellPolicyCoordinator.cs` | 16 | 2,701.01 | 168.81 | 1 | `CompleteAsync` | 50 | 0.00%* |
+| `ShellPolicyProjection.cs` | 14 | 37.94 | 2.71 | 0 | `TryCreate` | 9 | 81.25% |
+| `ToolAccessPolicy.cs` | 55 | 194.05 | 3.53 | 0 | `AuthorizeInvocationCore` | 22 | 91.67% |
+
+The CRAP tool does not bind async state-machine coverage back to `CompleteAsync`.
+The raw value remains a repeatable comparison point.
+
+The actor coverage file reports 90.57% line coverage and 73.88% branch coverage for the coordinator class.
+
+## Compatibility surfaces
+
+The public API baseline is each Release assembly from corpus commit `8b4108aa`.
+`dotnet-inspect diff --library BASELINE.dll..CURRENT.dll` performs the comparison.
+The first internal-state slice reports no public API change.
+
+| Surface | Baseline contract |
+| --- | --- |
+| Approval store | V3 global, folder, migration-backup, custom-tool, and detached-snapshot tests remain exact. |
+| Actor event | `ToolApprovalRequested_round_trips_all_persisted_context` remains exact. |
+| Legacy event | `ToolApprovalRequested_legacy_event_round_trips_without_turn_context` remains exact. |
+| Snapshot and history | Approval recovery and passivation tests retain prompt state and one-time semantics. |
+| Configuration | Approval modes, safe catalogs, and store JSON retain their current wire values. |
+| Prompt | Slack, Discord, Mattermost, CLI, and session prompt tests retain exact options and text. |
+| Trace | Fixture rows and `Shell_approval_cases_match_review_table` retain exact order, reason, scope, and outcome. |
+
+No refactor slice may alter these public or durable outcomes without a new approved change.
+
+## Commands
+
+```bash
+dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --no-restore \
+  --filter 'FullyQualifiedName~ShellPolicyEvidenceFixtureTests|FullyQualifiedName~ShellApprovalDispositionMatrixTests|FullyQualifiedName~DispatchingToolExecutorTests'
+dotnet test src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj -c Release --no-restore \
+  --filter 'FullyQualifiedName~ShellApprovalEvidenceContractTests'
+
+dotnet-coverage collect 'dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --no-build --no-restore' \
+  -f cobertura -o /tmp/netclaw-actors.cobertura.xml
+dotnet-coverage collect 'dotnet test src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj -c Release --no-build --no-restore' \
+  -f cobertura -o /tmp/netclaw-security.cobertura.xml
+dotnet-crap analyze SOURCE.cs --coverage COVERAGE.xml --min-crap 0 --output REPORT.json
+```

--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Freeze the behavior contract
 
-- [ ] 1.1 Rebase onto the merged live-regression corpus and record its exact commit and fixture hashes.
-- [ ] 1.2 Pin terminal-precedence overlaps for protected paths, invalid evidence, unavailable persistence, corrections, one-time authority, prompts, and allows.
-- [ ] 1.3 Record the baseline files, lines, control-flow lines, method complexity, coverage risk, coordinator size, helper duplication, and callers.
-- [ ] 1.4 Record public API, approval-store, actor-event, snapshot, session-history, configuration, prompt, and trace compatibility baselines.
-- [ ] 1.5 Run the D-case, adversarial, live-regression, and full disposition suites before production edits.
+- [x] 1.1 Rebase onto the merged live-regression corpus and record its exact commit and fixture hashes.
+- [x] 1.2 Pin terminal-precedence overlaps for protected paths, invalid evidence, unavailable persistence, corrections, one-time authority, prompts, and allows.
+- [x] 1.3 Record the baseline files, lines, control-flow lines, method complexity, coverage risk, coordinator size, helper duplication, and callers.
+- [x] 1.4 Record public API, approval-store, actor-event, snapshot, session-history, configuration, prompt, and trace compatibility baselines.
+- [x] 1.5 Run the D-case, adversarial, live-regression, and full disposition suites before production edits.
 
 ## 2. Add call-local policy state
 
-- [ ] 2.1 Add internal closed result types for preflight, stage completion, and typed policy faults.
-- [ ] 2.2 Add the internal call-local evaluation state with immutable candidate identity and one coverage slot per candidate.
-- [ ] 2.3 Route coverage and its bounded trace row through one atomic state operation.
-- [ ] 2.4 Add tests for duplicate coverage, changed candidate facts, invalid candidate IDs, invalid transitions, and multiple terminal results.
-- [ ] 2.5 Run exact fixture parity and adversarial review before production decisions use the new state.
+- [x] 2.1 Add internal closed result types for preflight, stage completion, and typed policy faults.
+- [x] 2.2 Add the internal call-local evaluation state with immutable candidate identity and one coverage slot per candidate.
+- [x] 2.3 Route coverage and its bounded trace row through one atomic state operation.
+- [x] 2.4 Add tests for duplicate coverage, changed candidate facts, invalid candidate IDs, invalid transitions, and multiple terminal results.
+- [x] 2.5 Run exact fixture parity and adversarial review before production decisions use the new state.
 
 ## 3. Make preflight data flow explicit
 

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -1,0 +1,337 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyEvaluationTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class ShellPolicyEvaluationTests
+{
+    [Fact]
+    public void Coverage_and_trace_change_together()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        var grantTimestamp = new DateTimeOffset(2026, 8, 14, 0, 0, 0, TimeSpan.Zero);
+
+        var result = evaluation.Cover(
+            candidate,
+            ShellCoverageKind.PersistentGlobal,
+            ShellPolicyReason.PersistentGlobalGrant,
+            ShellScopeRelation.Global,
+            grantTimestamp);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellCoverageKind.PersistentGlobal, evaluation.CoverageFor(candidate.Id).Kind);
+
+        var decision = ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval);
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(decision));
+        Assert.NotNull(evaluation.CompletedTrace);
+        var rows = evaluation.CompletedTrace.Rows;
+        Assert.Collection(
+            rows,
+            row =>
+            {
+                Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, row.Stage);
+                Assert.Equal(ShellCoverageKind.PersistentGlobal, row.Coverage);
+                Assert.Equal(ShellPolicyTraceReason.PersistentGlobalGrant, row.Reason);
+                Assert.Equal(ShellScopeRelation.Global, row.ScopeRelation);
+                Assert.Equal(grantTimestamp, row.GrantTimestamp);
+            },
+            row =>
+            {
+                Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+                Assert.Equal(ShellPolicyTraceOutcome.Allow, row.Outcome);
+            });
+    }
+
+    [Fact]
+    public void Candidate_view_cannot_replace_projection_identity()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+
+        Assert.IsNotType<ShellPolicyCandidate[]>(evaluation.Candidates);
+        var list = Assert.IsAssignableFrom<IList<ShellPolicyCandidate>>(evaluation.Candidates);
+        Assert.Throws<NotSupportedException>(() =>
+            list[0] = list[0] with { Candidate = BashCandidate("git push") });
+    }
+
+    [Fact]
+    public void Duplicate_coverage_fails_without_a_second_trace_row()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+
+        var duplicate = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.PersistentGlobal,
+            ShellPolicyReason.PersistentGlobalGrant,
+            ShellScopeRelation.Global));
+
+        Assert.Equal(ShellPolicyFault.CoverageAlreadyAssigned, duplicate.Reason);
+        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.Equal(ShellPolicyFault.CoverageAlreadyAssigned, evaluation.TerminalFault);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Equal(2, evaluation.CompletedTrace.Rows.Count);
+        Assert.Equal(ShellPolicyTraceOutcome.Deny, evaluation.CompletedTrace.Rows[^1].Outcome);
+    }
+
+    [Fact]
+    public void Changed_candidate_facts_fail_closed()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        var changed = candidate with
+        {
+            Candidate = BashCandidate("git push")
+        };
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+            changed,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+
+        Assert.Equal(ShellPolicyFault.CandidateFactsChanged, result.Reason);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.Equal(ShellPolicyFault.CandidateFactsChanged, evaluation.TerminalFault);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Single(evaluation.CompletedTrace.Rows);
+
+        var later = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+        Assert.Same(evaluation.TerminalDecision, later.Decision);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+    }
+
+    [Fact]
+    public void Invalid_candidate_id_fails_closed()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var changed = Assert.Single(evaluation.Candidates) with
+        {
+            Id = new ShellPolicyCandidateId(7)
+        };
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+            changed,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+
+        Assert.Equal(ShellPolicyFault.InvalidCandidateId, result.Reason);
+        Assert.Single(evaluation.UncoveredIds);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+    }
+
+    [Theory]
+    [InlineData(nameof(ShellCoverageKind.Uncovered), nameof(ShellPolicyReason.None), nameof(ShellScopeRelation.None))]
+    [InlineData(nameof(ShellCoverageKind.Denied), nameof(ShellPolicyReason.None), nameof(ShellScopeRelation.None))]
+    [InlineData(nameof(ShellCoverageKind.Session), nameof(ShellPolicyReason.PersistentGlobalGrant), nameof(ShellScopeRelation.ThisChat))]
+    [InlineData(nameof(ShellCoverageKind.Session), nameof(ShellPolicyReason.SessionGrant), nameof(ShellScopeRelation.Global))]
+    public void Invalid_coverage_transition_fails_closed(
+        string coverageName,
+        string reasonName,
+        string scopeRelationName)
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        var coverage = Enum.Parse<ShellCoverageKind>(coverageName);
+        var reason = Enum.Parse<ShellPolicyReason>(reasonName);
+        var scopeRelation = Enum.Parse<ShellScopeRelation>(scopeRelationName);
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+            candidate,
+            coverage,
+            reason,
+            scopeRelation));
+
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+    }
+
+    [Fact]
+    public void Invalid_coverage_enum_fails_closed()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+            candidate,
+            (ShellCoverageKind)999,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Single(evaluation.CompletedTrace.Rows);
+    }
+
+    [Fact]
+    public void Session_coverage_rejects_a_persistent_timestamp()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat,
+            new DateTimeOffset(2026, 8, 14, 0, 0, 0, TimeSpan.Zero)));
+
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Single(evaluation.CompletedTrace.Rows);
+        Assert.Equal(ShellPolicyTraceStage.Completion, evaluation.CompletedTrace.Rows[0].Stage);
+    }
+
+    [Fact]
+    public void Allow_requires_every_candidate_to_have_coverage()
+    {
+        var evaluation = CreateEvaluation(
+            BashCandidate("git status"),
+            BashCandidate("git diff"));
+        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+            evaluation.Candidates[0],
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval)));
+
+        Assert.Equal(ShellPolicyFault.InvalidTerminalTransition, result.Reason);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.Equal(ShellPolicyFault.InvalidTerminalTransition, evaluation.TerminalFault);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Equal(2, evaluation.CompletedTrace.Rows.Count);
+        Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, evaluation.CompletedTrace.Rows[0].Stage);
+        Assert.Equal(ShellPolicyTraceOutcome.Deny, evaluation.CompletedTrace.Rows[1].Outcome);
+    }
+
+    [Fact]
+    public void Multiple_terminal_results_return_the_first_terminal_result()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(prompt));
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+            ToolAuthorizationDecision.Deny("internal_policy_failure")));
+
+        Assert.Same(prompt, result.Decision);
+        Assert.Same(prompt, evaluation.TerminalDecision);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Single(evaluation.CompletedTrace.Rows);
+    }
+
+    [Fact]
+    public void Coverage_cannot_change_after_a_terminal_allow()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+        var allow = ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval);
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(allow));
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.PersistentGlobal,
+            ShellPolicyReason.PersistentGlobalGrant,
+            ShellScopeRelation.Global));
+
+        Assert.Same(allow, result.Decision);
+        Assert.Same(allow, evaluation.TerminalDecision);
+        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Equal(2, evaluation.CompletedTrace.Rows.Count);
+        Assert.Equal(ShellPolicyTraceOutcome.Allow, evaluation.CompletedTrace.Rows[^1].Outcome);
+    }
+
+    [Fact]
+    public void Prompt_can_complete_without_reusable_candidates()
+    {
+        var evaluation = CreateEvaluation();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(prompt));
+        Assert.Same(prompt, evaluation.TerminalDecision);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Equal(ShellPolicyTraceOutcome.RequiresApproval, evaluation.CompletedTrace.Rows[^1].Outcome);
+    }
+
+    [Fact]
+    public void Analysis_cannot_attach_to_a_prompt_result()
+    {
+        var projection = CreateEvaluation(BashCandidate("git status")).Projection;
+        var analysis = new ShellCommandPolicy(projection.Environment)
+            .Analyze("git status", "/work");
+        var prompt = ToolAuthorizationDecision.RequiresApproval(projection.ApprovalContext);
+
+        Assert.Throws<ArgumentException>(() => new ShellPolicyAuthorization(prompt, analysis));
+        Assert.Throws<ArgumentException>(() => new ShellPolicyPreflightResult.Complete(
+            ToolAccessDecision.RequiresApproval(projection.ApprovalContext),
+            analysis));
+    }
+
+    private static ShellPolicyEvaluation CreateEvaluation(params ApprovalCandidate[] candidates)
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+        var approvalContext = new ToolApprovalContext(
+            ShellTool.ToolName,
+            "shell command",
+            candidates.Select(static candidate => candidate.Verb).ToArray(),
+            candidates.Select(static candidate => candidate.Verb).ToArray(),
+            [],
+            Cwd: "/work",
+            Candidates: candidates);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-evaluation",
+            "/work/session",
+            TrustAudience.Personal);
+        var created = ShellPolicyProjection.TryCreate(
+            environment,
+            new ShellApprovalMatcher(environment),
+            execution: null,
+            approvalContext,
+            context,
+            static _ => false,
+            out var projection);
+
+        Assert.True(created);
+        Assert.NotNull(projection);
+        return new ShellPolicyEvaluation(projection);
+    }
+
+    private static ApprovalCandidate BashCandidate(string verb) => new(verb, "/work")
+    {
+        Shell = ApprovalShell.Bash,
+        VerbTokens = Array.AsReadOnly(verb.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+    };
+}

--- a/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
@@ -137,7 +137,8 @@ internal sealed class ShellPolicyDecisionTraceBuilder
         ShellPolicyCandidate candidate,
         ShellCoverageKind coverage,
         ShellPolicyReason reason,
-        ShellScopeRelation scopeRelation)
+        ShellScopeRelation scopeRelation,
+        DateTimeOffset? grantTimestamp = null)
         => AddDetail(new ShellPolicyTraceRow(
             stage,
             ShellPolicyTraceOutcome.Covered,
@@ -146,7 +147,7 @@ internal sealed class ShellPolicyDecisionTraceBuilder
             GetExecutableBasename(candidate.Candidate),
             coverage,
             scopeRelation,
-            GrantTimestamp: null));
+            grantTimestamp));
 
     internal ShellPolicyDecisionTrace Complete(ToolAuthorizationDecision decision)
     {

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -1,0 +1,283 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyEvaluation.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Security;
+
+namespace Netclaw.Actors.Tools;
+
+internal enum ShellPolicyFault
+{
+    InvalidCandidateId = 0,
+    CandidateFactsChanged = 1,
+    InvalidCoverage = 2,
+    CoverageAlreadyAssigned = 3,
+    InvalidTerminalTransition = 4,
+}
+
+internal abstract record ShellPolicyPreflightResult
+{
+    private ShellPolicyPreflightResult()
+    {
+    }
+
+    internal sealed record Complete : ShellPolicyPreflightResult
+    {
+        internal Complete(
+            ToolAccessDecision decision,
+            ShellCommandAnalysis? authorizedAnalysis)
+        {
+            ArgumentNullException.ThrowIfNull(decision);
+            if (authorizedAnalysis is not null
+                && (!decision.Allowed || decision.NeedsApproval))
+            {
+                throw new ArgumentException(
+                    "Only an immediate shell allow can carry analysis.",
+                    nameof(authorizedAnalysis));
+            }
+
+            Decision = decision;
+            AuthorizedAnalysis = authorizedAnalysis;
+        }
+
+        internal ToolAccessDecision Decision { get; }
+
+        internal ShellCommandAnalysis? AuthorizedAnalysis { get; }
+    }
+
+    internal sealed record Continue : ShellPolicyPreflightResult
+    {
+        internal Continue(
+            ShellCommandAnalysis analysis,
+            ToolApprovalContext approvalContext,
+            ShellExecutionEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(analysis);
+            ArgumentNullException.ThrowIfNull(approvalContext);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            Analysis = analysis;
+            ApprovalContext = approvalContext;
+            Environment = environment;
+        }
+
+        internal ShellCommandAnalysis Analysis { get; }
+
+        internal ToolApprovalContext ApprovalContext { get; }
+
+        internal ShellExecutionEnvironment Environment { get; }
+    }
+}
+
+internal abstract record ShellPolicyStageResult
+{
+    private ShellPolicyStageResult()
+    {
+    }
+
+    internal sealed record Continue : ShellPolicyStageResult;
+
+    internal sealed record Complete : ShellPolicyStageResult
+    {
+        internal Complete(ToolAuthorizationDecision decision)
+        {
+            ArgumentNullException.ThrowIfNull(decision);
+            Decision = decision;
+        }
+
+        internal ToolAuthorizationDecision Decision { get; }
+    }
+
+    internal sealed record Fault(ShellPolicyFault Reason)
+        : ShellPolicyStageResult;
+}
+
+internal sealed record ShellPolicyAuthorization
+{
+    internal ShellPolicyAuthorization(
+        ToolAuthorizationDecision decision,
+        ShellCommandAnalysis? authorizedAnalysis)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        if (authorizedAnalysis is not null
+            && decision.Outcome != ToolAuthorizationOutcome.Allowed)
+        {
+            throw new ArgumentException(
+                "Only an allowed shell decision can carry analysis.",
+                nameof(authorizedAnalysis));
+        }
+
+        Decision = decision;
+        AuthorizedAnalysis = authorizedAnalysis;
+    }
+
+    internal ToolAuthorizationDecision Decision { get; }
+
+    internal ShellCommandAnalysis? AuthorizedAnalysis { get; }
+}
+
+internal sealed class ShellPolicyEvaluation
+{
+    private readonly ShellPolicyCandidate[] _candidates;
+    private readonly IReadOnlyList<ShellPolicyCandidate> _candidateView;
+    private readonly ShellCandidateCoverage[] _coverage;
+    private readonly ShellPolicyDecisionTraceBuilder _trace = new();
+    private ToolAuthorizationDecision? _terminalDecision;
+    private ShellPolicyDecisionTrace? _completedTrace;
+    private ShellPolicyFault? _terminalFault;
+
+    internal ShellPolicyEvaluation(ShellPolicyProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        Projection = projection;
+        _candidates = projection.Candidates.ToArray();
+        _candidateView = Array.AsReadOnly(_candidates);
+        _coverage = new ShellCandidateCoverage[_candidates.Length];
+        for (var index = 0; index < _candidates.Length; index++)
+        {
+            var candidate = _candidates[index];
+            if (candidate.Id.Value != index)
+                throw new InvalidOperationException("Shell candidate IDs must match projection order.");
+
+            _coverage[index] = new ShellCandidateCoverage(
+                candidate.Id,
+                ShellCoverageKind.Uncovered,
+                ShellPolicyReason.None);
+        }
+    }
+
+    internal ShellPolicyProjection Projection { get; }
+
+    internal IReadOnlyList<ShellPolicyCandidate> Candidates => _candidateView;
+
+    internal IReadOnlyList<ShellPolicyCandidateId> UncoveredIds => Array.AsReadOnly(
+        _coverage
+            .Where(static item => item.Kind == ShellCoverageKind.Uncovered)
+            .Select(static item => item.CandidateId)
+            .ToArray());
+
+    internal bool AllCovered => _coverage.All(static item =>
+        item.Kind is not ShellCoverageKind.Uncovered and not ShellCoverageKind.Denied);
+
+    internal ToolAuthorizationDecision? TerminalDecision => _terminalDecision;
+
+    internal ShellPolicyDecisionTrace? CompletedTrace => _completedTrace;
+
+    internal ShellPolicyFault? TerminalFault => _terminalFault;
+
+    internal ShellCandidateCoverage CoverageFor(ShellPolicyCandidateId candidateId)
+    {
+        var index = candidateId.Value;
+        if ((uint)index >= (uint)_coverage.Length)
+            throw new ArgumentOutOfRangeException(nameof(candidateId));
+
+        return _coverage[index];
+    }
+
+    internal ShellPolicyStageResult Cover(
+        ShellPolicyCandidate candidate,
+        ShellCoverageKind coverage,
+        ShellPolicyReason reason,
+        ShellScopeRelation scopeRelation,
+        DateTimeOffset? grantTimestamp = null)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        if (_terminalDecision is not null)
+            return new ShellPolicyStageResult.Complete(_terminalDecision);
+
+        var index = candidate.Id.Value;
+        if ((uint)index >= (uint)_candidates.Length)
+            return Fail(ShellPolicyFault.InvalidCandidateId);
+
+        if (!ReferenceEquals(candidate, _candidates[index]))
+            return Fail(ShellPolicyFault.CandidateFactsChanged);
+
+        if (_coverage[index].Kind != ShellCoverageKind.Uncovered)
+            return Fail(ShellPolicyFault.CoverageAlreadyAssigned);
+
+        if (!TryGetTraceStage(
+                coverage,
+                reason,
+                scopeRelation,
+                grantTimestamp,
+                out var traceStage))
+        {
+            return Fail(ShellPolicyFault.InvalidCoverage);
+        }
+
+        _trace.AddCoverage(
+            traceStage,
+            candidate,
+            coverage,
+            reason,
+            scopeRelation,
+            grantTimestamp);
+        _coverage[index] = new ShellCandidateCoverage(candidate.Id, coverage, reason);
+        return new ShellPolicyStageResult.Continue();
+    }
+
+    internal ShellPolicyStageResult Complete(ToolAuthorizationDecision decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+
+        if (_terminalDecision is not null)
+            return new ShellPolicyStageResult.Complete(_terminalDecision);
+
+        var mayComplete = decision.Outcome switch
+        {
+            ToolAuthorizationOutcome.Allowed => AllCovered,
+            ToolAuthorizationOutcome.RequiresApproval => _candidates.Length == 0 || !AllCovered,
+            ToolAuthorizationOutcome.Denied => true,
+            _ => false,
+        };
+        if (!mayComplete)
+            return Fail(ShellPolicyFault.InvalidTerminalTransition);
+
+        _completedTrace = _trace.Complete(decision);
+        _terminalDecision = decision;
+        return new ShellPolicyStageResult.Complete(decision);
+    }
+
+    private ShellPolicyStageResult.Fault Fail(ShellPolicyFault reason)
+    {
+        var decision = ToolAuthorizationDecision.Deny("internal_policy_failure");
+        _completedTrace = _trace.Complete(decision);
+        _terminalDecision = decision;
+        _terminalFault = reason;
+        return new ShellPolicyStageResult.Fault(reason);
+    }
+
+    private static bool TryGetTraceStage(
+        ShellCoverageKind coverage,
+        ShellPolicyReason reason,
+        ShellScopeRelation scopeRelation,
+        DateTimeOffset? grantTimestamp,
+        out ShellPolicyTraceStage traceStage)
+    {
+        traceStage = coverage switch
+        {
+            ShellCoverageKind.OneTime => ShellPolicyTraceStage.OneTimeApproval,
+            ShellCoverageKind.Session or
+                ShellCoverageKind.PersistentGlobal or
+                ShellCoverageKind.PersistentFolder => ShellPolicyTraceStage.StoredGrantMatch,
+            ShellCoverageKind.ReviewedSafePolicy => ShellPolicyTraceStage.ReviewedSafePolicy,
+            _ => default,
+        };
+
+        return (coverage, reason, scopeRelation, grantTimestamp) switch
+        {
+            (ShellCoverageKind.OneTime, ShellPolicyReason.OneTimeGrant, ShellScopeRelation.None, null) => true,
+            (ShellCoverageKind.Session, ShellPolicyReason.SessionGrant, ShellScopeRelation.ThisChat, null) => true,
+            (ShellCoverageKind.PersistentGlobal, ShellPolicyReason.PersistentGlobalGrant, ShellScopeRelation.Global, _) => true,
+            (ShellCoverageKind.PersistentFolder, ShellPolicyReason.PersistentFolderGrant, ShellScopeRelation.UnderGrantRoot, _) => true,
+            (ShellCoverageKind.ReviewedSafePolicy, ShellPolicyReason.ReviewedSafePhrase,
+                ShellScopeRelation.UnderRealRoot or ShellScopeRelation.UnderIntentRoot, null) => true,
+            (ShellCoverageKind.ReviewedSafePolicy, ShellPolicyReason.ApprovalExemptSideEffect,
+                ShellScopeRelation.None, null) => true,
+            _ => false,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- freeze the merged live-regression corpus, compatibility surfaces, and complexity baseline
- add internal closed preflight, stage, fault, and authorization result types
- add one call-local shell policy state with immutable candidate identity
- make coverage and its bounded trace row one atomic operation
- keep terminal outcomes sticky and post-terminal calls idempotent

This first refactor slice does not route production authorization through the new state yet. It changes no approval decision, prompt, grant, public API, or durable wire contract.

## Evidence

- focused state tests: 16 passed
- policy fixture, disposition, and coordinator tests: 377 passed
- security evidence tests: 15 passed
- full Actors suite under adversarial review: 3,312 passed, 1 expected skip
- strict OpenSpec: passed
- headers: passed
- changed-file Slopwatch: zero findings
- public API diff: no changes
- adversarial review: PASS on the production snapshot

## Baseline

The evidence records:

- exact corpus commit and five fixture hashes
- 5,136 lines and 373 control-flow lines across seven policy files
- method-level complexity, coverage, and CRAP risk
- public, store, actor-event, snapshot, prompt, and trace compatibility boundaries
