### PR TITLE
Make shell analysis flow explicit

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -16,14 +16,14 @@
 
 ## 3. Make preflight data flow explicit
 
-- [ ] 3.1 Return one explicit shell preflight result from `ToolAccessPolicy` with no change to gate order or decisions.
-- [ ] 3.2 Pass the successful preflight result directly into projection and asynchronous completion.
-- [ ] 3.3 Return the exact authorized analysis with the internal shell authorization result.
-- [ ] 3.4 Pass the authorized analysis directly into stream and non-stream shell execution.
-- [ ] 3.5 Preserve the decision-only internal test seam without analysis retention.
-- [ ] 3.6 Remove shell analysis cache reads and writes after all execution paths migrate.
-- [ ] 3.7 Add exact-analysis, Auto allow, consume-once, authorization-only, overlap, and cross-call isolation tests.
-- [ ] 3.8 Run exact fixture parity, focused actor tests, and adversarial review for the preflight slice.
+- [x] 3.1 Return one explicit shell preflight result from `ToolAccessPolicy` with no change to gate order or decisions.
+- [x] 3.2 Pass the successful preflight result directly into projection and asynchronous completion.
+- [x] 3.3 Return the exact authorized analysis with the internal shell authorization result.
+- [x] 3.4 Pass the authorized analysis directly into stream and non-stream shell execution.
+- [x] 3.5 Preserve the decision-only internal test seam without analysis retention.
+- [x] 3.6 Remove shell analysis cache reads and writes after all execution paths migrate.
+- [x] 3.7 Add exact-analysis, Auto allow, consume-once, authorization-only, overlap, and cross-call isolation tests.
+- [x] 3.8 Run exact fixture parity, focused actor tests, and adversarial review for the preflight slice.
 
 ## 4. Validate actor evidence once
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -21,6 +21,8 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public class DispatchingToolExecutorTests
 {
+    private const string MissingShellCommandError =
+        "Error parsing arguments for tool 'shell_execute': Required parameter 'Command' is missing.";
     private static readonly ShellExecutionEnvironment ShellEnvironment = TestShellEnvironment.Current;
     private readonly DispatchingToolExecutor _executor;
     private readonly DispatchingToolExecutor _restrictedExecutor;
@@ -1752,6 +1754,52 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
+    public async Task Unexpected_coordinator_fault_preserves_completed_trace_rows()
+    {
+        var approvalService = new FixedShellApprovalService(request =>
+        {
+            var matches = request.Candidates.Select(candidate =>
+                new ShellGrantCandidateMatch(
+                    candidate.CandidateId,
+                    new ToolApprovalMatch(
+                        candidate.Candidate.Verb,
+                        "session",
+                        "this chat"),
+                    ShellCoverageKind.Session,
+                    NearMisses: [])).ToArray();
+            return new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                new ThrowAfterFirstOnSecondEnumerationList<ShellGrantCandidateMatch>(matches));
+        });
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = new FunctionCallContent(
+            "call-trace-preserved-after-fault",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", "git status && git push"));
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/trace-preserved-after-fault"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.Equal("internal_policy_failure", decision.DenyReason);
+        Assert.Collection(
+            decision.ShellPolicyTrace.Rows,
+            row =>
+            {
+                Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, row.Stage);
+                Assert.Equal(ShellPolicyTraceOutcome.Covered, row.Outcome);
+            },
+            row =>
+            {
+                Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+                Assert.Equal(ShellPolicyTraceOutcome.Deny, row.Outcome);
+                Assert.Equal(ShellPolicyTraceReason.InternalPolicyFailure, row.Reason);
+            });
+    }
+
+    [Fact]
     public async Task Authorization_evaluation_denies_uncovered_candidate_when_store_is_unavailable()
     {
         var approvalService = new FixedShellApprovalService(request =>
@@ -2957,6 +3005,251 @@ public class DispatchingToolExecutorTests
         await executor.AuthorizeAsync(toolCall, context, TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Shell_completion_returns_the_exact_preflight_analysis()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"shell-preflight-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+            config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+            {
+                ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+                {
+                    [ShellTool.ToolName] = ToolApprovalMode.Approval
+                }
+            };
+            var commandPolicy = new ShellCommandPolicy(ShellEnvironment);
+            var pathPolicy = new ToolPathPolicy(ShellEnvironment, []);
+            var phrase = ShellEnvironment.Grammar == ShellGrammar.PowerShell
+                ? "Get-Location"
+                : "pwd";
+            var shell = ShellEnvironment.Grammar == ShellGrammar.PowerShell
+                ? ApprovalShell.PowerShell
+                : ApprovalShell.Bash;
+            var policy = new ToolAccessPolicy(
+                config,
+                new EffectivePolicyDefaults(
+                    DeploymentPosture.Personal,
+                    TrustAudience.Personal,
+                    ShellExecutionMode.HostAllowed,
+                    UsedStrictFallback: false),
+                commandPolicy,
+                pathPolicy,
+                safeVerbs: SafeVerbList.FromVerbs(shell, [phrase]));
+            var tool = new ShellTool(config, pathPolicy, commandPolicy);
+            var context = TestToolExecutionContext.CreateBound(
+                "signalr/exact-preflight-analysis",
+                sessionDirectory: null,
+                new TestToolExecutionContextOptions
+                {
+                    Audience = TrustAudience.Personal,
+                    ProjectDirectory = root,
+                    InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true)
+                });
+            var call = new FunctionCallContent(
+                "call-exact-preflight-analysis",
+                ShellTool.ToolName,
+                ToolInput.Create("Command", phrase, "WorkingDirectory", root));
+            var preflight = policy.AuthorizeShellPreflight(tool, context, call.Arguments);
+            var continuation = Assert.IsType<ShellPolicyPreflightResult.Continue>(preflight);
+            var coordinator = new ShellPolicyCoordinator(policy, approvalService: null);
+
+            var authorization = await coordinator.EvaluateAsync(
+                tool,
+                call,
+                context,
+                preflight,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(ToolAuthorizationOutcome.Allowed, authorization.Decision.Outcome);
+            Assert.Same(continuation.Analysis, authorization.AuthorizedAnalysis);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Authorization_only_and_each_execution_use_separate_authorizations()
+    {
+        var approvalService = GrantEveryShellCandidate();
+        var executor = CreateApprovalGatedShellExecutor(ShellEnvironment, approvalService);
+        var context = CreateInteractivePersonalContext("signalr/authorization-only");
+        var call = new FunctionCallContent(
+            "call-authorization-only",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", TestShellEnvironment.PrintWorkingDirectoryCommand));
+
+        await executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken);
+        _ = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
+        _ = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, approvalService.RequestCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Auto_shell_without_command_returns_argument_error(bool includeNullCommand)
+    {
+        var arguments = includeNullCommand
+            ? ToolInput.Create("Command", null)
+            : ToolInput.Empty();
+        var call = new FunctionCallContent(
+            $"call-missing-command-{includeNullCommand}",
+            ShellTool.ToolName,
+            arguments);
+
+        var result = await _executor.ExecuteAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/missing-shell-command"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(MissingShellCommandError, result);
+    }
+
+    [Fact]
+    public async Task Auto_shell_stream_without_command_returns_argument_error()
+    {
+        var call = new FunctionCallContent(
+            "call-stream-missing-command",
+            ShellTool.ToolName,
+            ToolInput.Empty());
+
+        ToolCompletedUpdate? completed = null;
+        await foreach (var update in _executor.ExecuteStreamAsync(
+                           call,
+                           CreateInteractivePersonalContext("signalr/stream-missing-shell-command"),
+                           TestContext.Current.CancellationToken))
+        {
+            completed = update as ToolCompletedUpdate ?? completed;
+        }
+
+        Assert.NotNull(completed);
+        Assert.Equal(MissingShellCommandError, completed.Result);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Approved_shell_without_command_reaches_argument_error(bool includeNullCommand)
+    {
+        var executor = CreateApprovalGatedShellExecutor();
+        var arguments = includeNullCommand
+            ? ToolInput.Create("Command", null)
+            : ToolInput.Empty();
+        var call = new FunctionCallContent(
+            $"call-approved-missing-command-{includeNullCommand}",
+            ShellTool.ToolName,
+            arguments);
+        var context = CreateInteractivePersonalContext("signalr/approved-missing-shell-command");
+
+        var firstAttempt = await Assert.ThrowsAsync<ToolApprovalRequiredException>(() =>
+            executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken));
+        context.Approval.SeedOneTimeApproval(
+            call.Name,
+            OneTimeApprovalKeys.Create(firstAttempt.ApprovalContext));
+
+        var result = await executor.ExecuteAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(MissingShellCommandError, result);
+    }
+
+    [Fact]
+    public async Task Parallel_shell_calls_keep_their_authorized_analyses_isolated()
+    {
+        var firstRoot = Path.Combine(Path.GetTempPath(), $"shell-first-{Guid.NewGuid():N}");
+        var secondRoot = Path.Combine(Path.GetTempPath(), $"shell-second-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(firstRoot);
+        Directory.CreateDirectory(secondRoot);
+        try
+        {
+            var context = CreateInteractivePersonalContext("signalr/parallel-shell-analysis");
+            var firstCall = new FunctionCallContent(
+                "call-parallel-shell-first",
+                ShellTool.ToolName,
+                ToolInput.Create(
+                    "Command",
+                    TestShellEnvironment.PrintWorkingDirectoryCommand,
+                    "WorkingDirectory",
+                    firstRoot));
+            var secondCall = new FunctionCallContent(
+                "call-parallel-shell-second",
+                ShellTool.ToolName,
+                ToolInput.Create(
+                    "Command",
+                    TestShellEnvironment.PrintWorkingDirectoryCommand,
+                    "WorkingDirectory",
+                    secondRoot));
+
+            var results = await Task.WhenAll(
+                _executor.ExecuteAsync(firstCall, context, TestContext.Current.CancellationToken),
+                _executor.ExecuteAsync(secondCall, context, TestContext.Current.CancellationToken));
+
+            Assert.Contains(firstRoot, results[0], StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(secondRoot, results[1], StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(firstRoot, recursive: true);
+            Directory.Delete(secondRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Stream_and_non_stream_shell_calls_use_explicit_authorized_analysis()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"shell-flow-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var context = CreateInteractivePersonalContext("signalr/shell-analysis-paths");
+            var nonStreamCall = new FunctionCallContent(
+                "call-shell-analysis-non-stream",
+                ShellTool.ToolName,
+                ToolInput.Create(
+                    "Command",
+                    TestShellEnvironment.PrintWorkingDirectoryCommand,
+                    "WorkingDirectory",
+                    root));
+            var streamCall = new FunctionCallContent(
+                "call-shell-analysis-stream",
+                ShellTool.ToolName,
+                ToolInput.Create(
+                    "Command",
+                    TestShellEnvironment.PrintWorkingDirectoryCommand,
+                    "WorkingDirectory",
+                    root));
+
+            var nonStreamResult = await _executor.ExecuteAsync(
+                nonStreamCall,
+                context,
+                TestContext.Current.CancellationToken);
+            ToolCompletedUpdate? completed = null;
+            await foreach (var update in _executor.ExecuteStreamAsync(
+                               streamCall,
+                               context,
+                               TestContext.Current.CancellationToken))
+            {
+                completed = update as ToolCompletedUpdate ?? completed;
+            }
+
+            Assert.Contains(root, nonStreamResult, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(completed);
+            Assert.Contains(root, completed.Result, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static DispatchingToolExecutor CreateApprovalGatedShellExecutor(
         IToolApprovalService? approvalService = null,
         ILogger<DispatchingToolExecutor>? logger = null,
@@ -3171,6 +3464,33 @@ public class DispatchingToolExecutorTests
             string? cwd,
             CancellationToken ct = default)
             => throw new InvalidOperationException("The authorization evaluator must not record an approval.");
+    }
+
+    private sealed class ThrowAfterFirstOnSecondEnumerationList<T>(IReadOnlyList<T> items)
+        : IReadOnlyList<T>
+    {
+        private int _enumerationCount;
+
+        public int Count => items.Count;
+
+        public T this[int index] => items[index];
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            _enumerationCount++;
+            return _enumerationCount == 2
+                ? EnumerateThenThrow().GetEnumerator()
+                : items.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        private IEnumerable<T> EnumerateThenThrow()
+        {
+            yield return items[0];
+            throw new InvalidOperationException("Injected coordinator fault.");
+        }
     }
 
     private sealed class RecordingLogger<T> : ILogger<T>

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3081,7 +3081,9 @@ public class DispatchingToolExecutorTests
         var call = new FunctionCallContent(
             "call-authorization-only",
             ShellTool.ToolName,
-            ToolInput.Create("Command", TestShellEnvironment.PrintWorkingDirectoryCommand));
+            ToolInput.Create(
+                "Command",
+                ShellEnvironment.Grammar == ShellGrammar.PowerShell ? "Get-Location" : "pwd"));
 
         await executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken);
         _ = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyRequiredDependenciesTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyRequiredDependenciesTests.cs
@@ -112,7 +112,7 @@ public sealed class ToolAccessPolicyRequiredDependenciesTests
     }
 
     [Fact]
-    public void Shell_authorization_captures_one_analysis_for_execution()
+    public void Shell_preflight_returns_one_analysis_for_completion()
     {
         var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
         var commandPolicy = new ShellCommandPolicy(environment);
@@ -126,12 +126,12 @@ public sealed class ToolAccessPolicyRequiredDependenciesTests
         var context = PersonalContext();
         var arguments = ToolInput.Create("Command", "git status");
 
-        _ = policy.AuthorizeInvocation(shellTool, context, arguments);
+        var preflight = policy.AuthorizeShellPreflight(shellTool, context, arguments);
 
-        Assert.True(policy.TryTakeAuthorizedShellAnalysis(context, out var analysis));
-        Assert.NotNull(analysis);
-        Assert.Equal("git status", analysis.Source);
-        Assert.Equal(context.ResolveShellCwd(null), analysis.WorkingDirectory);
-        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
+        var continuation = Assert.IsType<ShellPolicyPreflightResult.Continue>(preflight);
+        Assert.Equal("git status", continuation.Analysis.Source);
+        Assert.Equal(context.ResolveShellCwd(null), continuation.Analysis.WorkingDirectory);
+        Assert.Same(environment, continuation.Environment);
+        Assert.Equal(shellTool.Name, continuation.ApprovalContext.ToolName);
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -61,7 +61,6 @@ public sealed class ToolApprovalGateTests
 
         Assert.False(decision.Allowed);
         Assert.Equal("tool_denied_by_approval_policy", decision.DenyReason);
-        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
     }
 
     [Fact]
@@ -70,11 +69,38 @@ public sealed class ToolApprovalGateTests
         var policy = CreatePolicy(ToolApprovalMode.Auto);
         var args = ToolInput.Create("Command", "git push");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var preflight = policy.AuthorizeShellPreflight(
+            ShellTool(),
+            PersonalContext(),
+            args);
 
+        var complete = Assert.IsType<ShellPolicyPreflightResult.Complete>(preflight);
+        var decision = complete.Decision;
         Assert.True(decision.Allowed);
         Assert.False(decision.NeedsApproval);
         Assert.Equal(ToolAllowReason.PolicyAuto, decision.AllowReason);
+        Assert.NotNull(complete.AuthorizedAnalysis);
+        Assert.Equal("git push", complete.AuthorizedAnalysis.Source);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Shell_approval_without_command_preserves_prompt(bool includeNullCommand)
+    {
+        var policy = CreatePolicy(ToolApprovalMode.Approval);
+        var arguments = includeNullCommand
+            ? ToolInput.Create("Command", null)
+            : ToolInput.Empty();
+
+        var preflight = policy.AuthorizeShellPreflight(
+            ShellTool(),
+            PersonalContext(),
+            arguments);
+
+        var complete = Assert.IsType<ShellPolicyPreflightResult.Complete>(preflight);
+        Assert.True(complete.Decision.NeedsApproval);
+        Assert.Null(complete.AuthorizedAnalysis);
     }
 
     [Theory]
@@ -135,7 +161,6 @@ public sealed class ToolApprovalGateTests
         Assert.False(decision.Allowed);
         Assert.Equal(expectedDenyReason, decision.DenyReason);
         Assert.False(decision.NeedsApproval);
-        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
     }
 
     [Fact]
@@ -151,7 +176,6 @@ public sealed class ToolApprovalGateTests
 
         Assert.False(decision.Allowed);
         Assert.Equal("internal_policy_failure", decision.DenyReason);
-        Assert.False(policy.TryTakeAuthorizedShellAnalysis(context, out _));
         Assert.Null(context.Cwd);
     }
 

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -154,14 +154,14 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
             return rejection.Message;
         }
 
-        var tool = await GetAuthorizedToolAsync(toolCall, context, ct);
+        var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
+        var tool = authorized.Tool;
 
         var sw = Stopwatch.StartNew();
         try
         {
             var result = tool is ShellTool shellTool
-                         && _policy.TryTakeAuthorizedShellAnalysis(context, out var shellAnalysis)
-                         && shellAnalysis is not null
+                         && authorized.AuthorizedAnalysis is { } shellAnalysis
                 ? await shellTool.ExecuteAuthorizedAsync(
                     toolCall.Arguments,
                     context.Invocation,
@@ -241,10 +241,10 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         // Authorization throws (ToolApprovalRequiredException / ToolAccessDeniedException)
         // before the first item is produced; the tool-execution pipeline handles
         // those exactly as it does for the non-streaming path.
-        var tool = await GetAuthorizedToolAsync(toolCall, context, ct);
+        var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
+        var tool = authorized.Tool;
         var updates = tool is ShellTool shellTool
-                      && _policy.TryTakeAuthorizedShellAnalysis(context, out var shellAnalysis)
-                      && shellAnalysis is not null
+                      && authorized.AuthorizedAnalysis is { } shellAnalysis
             ? shellTool.ExecuteAuthorizedStreamAsync(
                 toolCall.Arguments,
                 context.Invocation,
@@ -288,6 +288,13 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         CancellationToken ct)
+        => (await EvaluateAuthorizationResultAsync(toolCall, context, ct)).Decision;
+
+    private async Task<(ToolAuthorizationDecision Decision, ShellCommandAnalysis? AuthorizedAnalysis)>
+        EvaluateAuthorizationResultAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext context,
+            CancellationToken ct)
     {
         context.Approval.ClearAppliedDecision();
 
@@ -296,18 +303,36 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         {
             var missingToolDecision = ToolAuthorizationDecision.Deny("tool_not_found");
             LogAuthorizationDecision(toolCall.Name, missingToolDecision);
-            return missingToolDecision;
+            return (missingToolDecision, null);
         }
 
         if (string.Equals(tool.Name, ShellTool.ToolName, StringComparison.Ordinal))
         {
-            var shellDecision = await _shellPolicyCoordinator.EvaluateAsync(
-                tool,
-                toolCall,
-                context,
-                ct);
-            LogAuthorizationDecision(toolCall.Name, shellDecision);
-            return shellDecision;
+            ShellPolicyAuthorization shellAuthorization;
+            try
+            {
+                var preflight = _policy.AuthorizeShellPreflight(
+                    tool,
+                    context,
+                    toolCall.Arguments);
+                shellAuthorization = await _shellPolicyCoordinator.EvaluateAsync(
+                    tool,
+                    toolCall,
+                    context,
+                    preflight,
+                    ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                shellAuthorization = ShellPolicyCoordinator.CompleteInternalFailure();
+            }
+
+            LogAuthorizationDecision(toolCall.Name, shellAuthorization.Decision);
+            return (shellAuthorization.Decision, shellAuthorization.AuthorizedAnalysis);
         }
 
         var accessDecision = _policy.AuthorizeInvocation(tool, context, toolCall.Arguments);
@@ -371,7 +396,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
 
         var authorizationDecision = CompleteAuthorizationDecision(accessDecision, approvalMatches);
         LogAuthorizationDecision(toolCall.Name, authorizationDecision);
-        return authorizationDecision;
+        return (authorizationDecision, null);
     }
 
     void ISessionScratchRetryAwareExecutor.MarkSessionScratchRetry(
@@ -381,12 +406,14 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
 
     ApprovalShell ISessionScratchRetryAwareExecutor.Shell => _policy.Shell;
 
-    private async Task<INetclawTool> GetAuthorizedToolAsync(
+    private async Task<(INetclawTool Tool, ShellCommandAnalysis? AuthorizedAnalysis)>
+        GetAuthorizedToolAsync(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         CancellationToken ct)
     {
-        var decision = await EvaluateAuthorizationAsync(toolCall, context, ct);
+        var authorization = await EvaluateAuthorizationResultAsync(toolCall, context, ct);
+        var decision = authorization.Decision;
 
         if (decision.Outcome is ToolAuthorizationOutcome.RequiresApproval)
         {
@@ -402,8 +429,10 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
                 ?? throw new InvalidOperationException("Denied decision missing a deny reason."));
         }
 
-        return _registry.GetByName(toolCall.Name)
-            ?? throw new InvalidOperationException("Allowed decision missing its registered tool.");
+        var tool = _registry.GetByName(toolCall.Name)
+                   ?? throw new InvalidOperationException(
+                       "Allowed decision is missing its registered tool.");
+        return (tool, authorization.AuthorizedAnalysis);
     }
 
     private static ToolAuthorizationDecision CompleteAuthorizationDecision(
@@ -553,17 +582,16 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         if (approvalContext is null)
             return false;
 
-        if (string.IsNullOrEmpty(context.Approval.OneTimeApprovedToolName)
-            || !string.Equals(context.Approval.OneTimeApprovedToolName, toolCall.Name, StringComparison.Ordinal))
-            return false;
-
         // Patterns bind the authored approval units. Candidate keys bind the
         // filtered verb and effective-directory set that the user approved.
         // Exact equality forces a new prompt when a formerly safe candidate
         // becomes unsafe before the retry, for example after a symlink swap.
         // An unchanged messy command has an empty key set on both attempts,
         // while a clean-to-messy transition cannot match its original keys.
-        return context.Approval.OneTimeApprovedPatterns.SetEquals(
-            OneTimeApprovalKeys.Create(approvalContext));
+        return OneTimeApprovalKeys.Matches(
+            context.Approval.OneTimeApprovedToolName,
+            context.Approval.OneTimeApprovedPatterns,
+            toolCall.Name,
+            approvalContext);
     }
 }

--- a/src/Netclaw.Actors/Tools/OneTimeApprovalKeys.cs
+++ b/src/Netclaw.Actors/Tools/OneTimeApprovalKeys.cs
@@ -28,6 +28,15 @@ internal static class OneTimeApprovalKeys
         return keys;
     }
 
+    public static bool Matches(
+        string? approvedToolName,
+        IReadOnlySet<string> approvedKeys,
+        string toolName,
+        ToolApprovalContext approvalContext)
+        => !string.IsNullOrEmpty(approvedToolName)
+           && string.Equals(approvedToolName, toolName, StringComparison.Ordinal)
+           && approvedKeys.SetEquals(Create(approvalContext));
+
     private static string CreateCandidateKey(ApprovalCandidate candidate, string? cwd)
     {
         var ignoreCase = candidate.Shell == ApprovalShell.PowerShell ||

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -17,16 +17,25 @@ internal sealed class ShellPolicyCoordinator(
     ToolAccessPolicy policy,
     IToolApprovalService? approvalService)
 {
-    internal async Task<ToolAuthorizationDecision> EvaluateAsync(
+    internal async Task<ShellPolicyAuthorization> EvaluateAsync(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
+        ShellPolicyPreflightResult preflight,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(preflight);
+
         var trace = new ShellPolicyDecisionTraceBuilder();
         try
         {
-            return await EvaluateCoreAsync(tool, toolCall, context, trace, cancellationToken);
+            return await EvaluateCoreAsync(
+                tool,
+                toolCall,
+                context,
+                preflight,
+                trace,
+                cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -34,48 +43,81 @@ internal sealed class ShellPolicyCoordinator(
         }
         catch (Exception)
         {
-            return CompleteWithTrace(
-                ToolAuthorizationDecision.Deny("internal_policy_failure"),
-                trace);
+            return new ShellPolicyAuthorization(
+                CompleteWithTrace(
+                    ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                    trace),
+                authorizedAnalysis: null);
         }
     }
 
-    private async Task<ToolAuthorizationDecision> EvaluateCoreAsync(
+    private async Task<ShellPolicyAuthorization> EvaluateCoreAsync(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
+        ShellPolicyPreflightResult preflight,
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
-        var preflight = policy.AuthorizeShellPreflight(tool, context, toolCall.Arguments);
-        if (!preflight.NeedsApproval)
-            return Complete(preflight, [], trace);
+        if (preflight is ShellPolicyPreflightResult.Complete complete)
+        {
+            var preflightDecision = complete.Decision;
+            if (preflightDecision.NeedsApproval
+                && preflightDecision.ApprovalContext is { } approvalContext
+                && OneTimeApprovalKeys.Matches(
+                    context.Approval.OneTimeApprovedToolName,
+                    context.Approval.OneTimeApprovedPatterns,
+                    toolCall.Name,
+                    approvalContext))
+            {
+                preflightDecision = ToolAccessDecision.Allow(ToolAllowReason.OneTimeApproval);
+            }
 
-        var approvalContext = preflight.ApprovalContext;
-        policy.TryGetAuthorizedShellAnalysis(context, out var execution);
-        if (approvalContext is null
+            return new ShellPolicyAuthorization(
+                Complete(preflightDecision, [], trace),
+                complete.AuthorizedAnalysis);
+        }
+
+        if (preflight is not ShellPolicyPreflightResult.Continue continuation
             || !ShellPolicyProjection.TryCreate(
-                policy.ShellEnvironment,
+                continuation.Environment,
                 policy.ShellApprovalMatcher,
-                execution,
-                approvalContext,
+                continuation.Analysis,
+                continuation.ApprovalContext,
                 context,
                 policy.IsSafePlatformTemporaryPath,
                 out var projection)
             || projection is null)
         {
-            return CompleteWithTrace(
-                ToolAuthorizationDecision.Deny("internal_policy_failure"),
-                trace);
+            return new ShellPolicyAuthorization(
+                CompleteWithTrace(
+                    ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                    trace),
+                authorizedAnalysis: null);
         }
 
-        return await CompleteAsync(
+        var decision = await CompleteAsync(
             tool,
             toolCall,
             context,
             projection,
             trace,
             cancellationToken);
+        return new ShellPolicyAuthorization(
+            decision,
+            decision.Outcome == ToolAuthorizationOutcome.Allowed
+                ? continuation.Analysis
+                : null);
+    }
+
+    internal static ShellPolicyAuthorization CompleteInternalFailure()
+    {
+        var trace = new ShellPolicyDecisionTraceBuilder();
+        return new ShellPolicyAuthorization(
+            CompleteWithTrace(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"),
+                trace),
+            authorizedAnalysis: null);
     }
 
     private async Task<ToolAuthorizationDecision> CompleteAsync(

--- a/src/Netclaw.Actors/Tools/ShellPolicyProjection.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyProjection.cs
@@ -124,15 +124,11 @@ internal sealed record ShellPolicyProjection
     internal bool HasExactOneTimeApproval(
         string toolName,
         ToolApprovalContext approvalContext)
-    {
-        if (string.IsNullOrEmpty(ApprovedOneTimeToolName)
-            || !string.Equals(ApprovedOneTimeToolName, toolName, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        return ApprovedOneTimeKeys.SetEquals(OneTimeApprovalKeys.Create(approvalContext));
-    }
+        => OneTimeApprovalKeys.Matches(
+            ApprovedOneTimeToolName,
+            ApprovedOneTimeKeys,
+            toolName,
+            approvalContext);
 
     internal static bool TryCreate(
         ShellExecutionEnvironment environment,

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -34,8 +34,6 @@ public sealed class ToolAccessPolicy
     private readonly FeatureGates _featureGates;
     private readonly ScopedShellSafeVerbPolicy? _safeVerbPolicy;
     private readonly PlatformTemporaryScopePolicy _platformTemporaryScopePolicy;
-    private readonly ConditionalWeakTable<ToolExecutionContext, ShellCommandAnalysis>
-        _authorizedShellAnalyses = new();
     private readonly ConditionalWeakTable<ToolExecutionContext, SessionScratchRetryMarker>
         _sessionScratchRetries = new();
 
@@ -161,21 +159,57 @@ public sealed class ToolAccessPolicy
         INetclawTool tool,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments)
-        => AuthorizeInvocationCore(tool, context, arguments, deferReviewedSafeCoverage: false);
+        => AuthorizeInvocationCore(
+            tool,
+            context,
+            arguments,
+            deferReviewedSafeCoverage: false,
+            out _);
 
-    internal ToolAccessDecision AuthorizeShellPreflight(
+    internal ShellPolicyPreflightResult AuthorizeShellPreflight(
         INetclawTool tool,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments)
-        => AuthorizeInvocationCore(tool, context, arguments, deferReviewedSafeCoverage: true);
+    {
+        var decision = AuthorizeInvocationCore(
+            tool,
+            context,
+            arguments,
+            deferReviewedSafeCoverage: true,
+            out var analysis);
+
+        if (!decision.NeedsApproval)
+        {
+            return new ShellPolicyPreflightResult.Complete(
+                decision,
+                decision.Allowed ? analysis : null);
+        }
+
+        if (analysis is null)
+        {
+            return new ShellPolicyPreflightResult.Complete(
+                decision,
+                authorizedAnalysis: null);
+        }
+
+        return decision.ApprovalContext is { } approvalContext
+            ? new ShellPolicyPreflightResult.Continue(
+                analysis,
+                approvalContext,
+                ShellEnvironment)
+            : new ShellPolicyPreflightResult.Complete(
+                ToolAccessDecision.Deny("internal_policy_failure"),
+                authorizedAnalysis: null);
+    }
 
     private ToolAccessDecision AuthorizeInvocationCore(
         INetclawTool tool,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments,
-        bool deferReviewedSafeCoverage)
+        bool deferReviewedSafeCoverage,
+        out ShellCommandAnalysis? authorizedAnalysis)
     {
-        _authorizedShellAnalyses.Remove(context);
+        authorizedAnalysis = null;
 
         if (tool is McpToolAdapter mcp)
         {
@@ -284,8 +318,7 @@ public sealed class ToolAccessPolicy
             }
         }
 
-        if (shellAnalysis is not null)
-            _authorizedShellAnalyses.Add(context, shellAnalysis);
+        authorizedAnalysis = shellAnalysis;
 
         if (approvalModeDecision is not null)
             return approvalModeDecision;
@@ -300,22 +333,6 @@ public sealed class ToolAccessPolicy
             shellAnalysis,
             deferReviewedSafeCoverage);
     }
-
-    internal bool TryTakeAuthorizedShellAnalysis(
-        ToolExecutionContext context,
-        out ShellCommandAnalysis? analysis)
-    {
-        if (!_authorizedShellAnalyses.TryGetValue(context, out analysis))
-            return false;
-
-        _authorizedShellAnalyses.Remove(context);
-        return true;
-    }
-
-    internal bool TryGetAuthorizedShellAnalysis(
-        ToolExecutionContext context,
-        out ShellCommandAnalysis? analysis)
-        => _authorizedShellAnalyses.TryGetValue(context, out analysis);
 
     internal void MarkSessionScratchRetry(
         ToolExecutionContext context,


### PR DESCRIPTION
## Summary

- replace the context-keyed shell analysis cache with an explicit preflight result
- carry the exact authorized analysis through the coordinator into stream and non-stream execution
- preserve missing/null command prompts, Approve Once retries, bounded argument errors, and partial policy traces
- centralize exact one-time approval-key matching
- complete simplify-shell-policy-evaluator tasks 3.1 through 3.8

This is the second behavior-preserving refactor slice after #1932. It does not change approval-store data, public APIs, prompts, tool schemas, or policy outcomes.

## Validation

- adversarial review: PASS on the frozen pre-rebase patch
- post-rebase patch ID: unchanged
- focused actor policy and fixture suite: 463 passed
- full Netclaw.Actors.Tests: 3,324 passed, 1 expected Windows-only skip
- full Netclaw.Security.Tests: 913 passed
- Release Netclaw.Actors build: 0 warnings, 0 errors
- strict OpenSpec validation: passed
- file headers and diff check: passed
- Slopwatch: no changed-file findings; one pre-existing unrelated warning remains