### PR TITLE
Validate shell approval actor evidence once

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -27,11 +27,11 @@
 
 ## 4. Validate actor evidence once
 
-- [ ] 4.1 Add the validated actor-evidence factory and bind every result field to projected candidates.
-- [ ] 4.2 Reject malformed store status, enums, candidate identity, scopes, timestamps, near misses, and unavailable-store combinations.
-- [ ] 4.3 Move session and persistent coverage behind the validated evidence boundary.
-- [ ] 4.4 Isolate shell use of public `IToolApprovalService` behind one exact, non-inferential adapter.
-- [ ] 4.5 Add malformed protocol, mixed coverage, unavailable store, and exact one-batch actor tests.
+- [x] 4.1 Add the validated actor-evidence factory and bind every result field to projected candidates.
+- [x] 4.2 Reject malformed store status, enums, candidate identity, scopes, timestamps, near misses, and unavailable-store combinations.
+- [x] 4.3 Move session and persistent coverage behind the validated evidence boundary.
+- [x] 4.4 Isolate shell use of public `IToolApprovalService` behind one exact, non-inferential adapter.
+- [x] 4.5 Add malformed protocol, mixed coverage, unavailable store, and exact one-batch actor tests.
 - [ ] 4.6 Run exact fixture parity and adversarial review for the actor-evidence slice.
 
 ## 5. Extract the ordered policy stages

--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -32,7 +32,7 @@
 - [x] 4.3 Move session and persistent coverage behind the validated evidence boundary.
 - [x] 4.4 Isolate shell use of public `IToolApprovalService` behind one exact, non-inferential adapter.
 - [x] 4.5 Add malformed protocol, mixed coverage, unavailable store, and exact one-batch actor tests.
-- [ ] 4.6 Run exact fixture parity and adversarial review for the actor-evidence slice.
+- [x] 4.6 Run exact fixture parity and adversarial review for the actor-evidence slice.
 
 ## 5. Extract the ordered policy stages
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -1906,6 +1906,48 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
+    public async Task Changing_actor_batch_applies_no_partial_evidence()
+    {
+        var approvalService = new FixedShellApprovalService(request =>
+        {
+            var first = request.Candidates[0];
+            var second = request.Candidates[1];
+            return new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                new ShrinkingCandidateMatchList(
+                [
+                    new ShellGrantCandidateMatch(
+                        first.CandidateId,
+                        new ToolApprovalMatch(first.Candidate.Verb, "session", "this chat"),
+                        ShellCoverageKind.Session,
+                        NearMisses: []),
+                    new ShellGrantCandidateMatch(
+                        second.CandidateId,
+                        new ToolApprovalMatch("unrelated", "session", "this chat"),
+                        ShellCoverageKind.Session,
+                        NearMisses: [])
+                ]));
+        });
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = new FunctionCallContent(
+            "call-changing-actor-batch",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", "git status && git push"));
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/changing-actor-batch"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.Equal("internal_policy_failure", decision.DenyReason);
+        var row = Assert.Single(decision.ShellPolicyTrace.Rows);
+        Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+        Assert.Equal(ShellPolicyTraceOutcome.Deny, row.Outcome);
+        Assert.Equal(ShellPolicyTraceReason.InternalPolicyFailure, row.Reason);
+    }
+
+    [Fact]
     public async Task Authorization_evaluation_denies_uncovered_candidate_when_store_is_unavailable()
     {
         var approvalService = new FixedShellApprovalService(request =>
@@ -3664,6 +3706,24 @@ public class DispatchingToolExecutorTests
             string? cwd,
             CancellationToken ct = default)
             => throw new InvalidOperationException("The authorization evaluator must not record an approval.");
+    }
+
+    private sealed class ShrinkingCandidateMatchList(
+        ShellGrantCandidateMatch[] items) : IReadOnlyList<ShellGrantCandidateMatch>
+    {
+        private int _countReads;
+
+        public int Count => Interlocked.Increment(ref _countReads) == 1
+            ? items.Length
+            : 1;
+
+        public ShellGrantCandidateMatch this[int index] => items[index];
+
+        public IEnumerator<ShellGrantCandidateMatch> GetEnumerator()
+            => ((IEnumerable<ShellGrantCandidateMatch>)items).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            => items.GetEnumerator();
     }
 
     private sealed class RecordingLogger<T> : ILogger<T>

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -1487,7 +1487,15 @@ public class DispatchingToolExecutorTests
 
         var decision = await executor.EvaluateAuthorizationAsync(
             call,
-            CreateInteractivePersonalContext("signalr/trace-near-miss"),
+            TestToolExecutionContext.CreateBound(
+                "signalr/trace-near-miss",
+                sessionDirectory: null,
+                new TestToolExecutionContextOptions
+                {
+                    Audience = TrustAudience.Personal,
+                    ProjectDirectory = "/work",
+                    InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true)
+                }),
             TestContext.Current.CancellationToken);
 
         Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, decision.Outcome);
@@ -1753,23 +1761,130 @@ public class DispatchingToolExecutorTests
         Assert.Equal("internal_policy_failure", decision.DenyReason);
     }
 
+    [Theory]
+    [InlineData(MalformedActorEvidenceCase.InvalidCoverage)]
+    [InlineData(MalformedActorEvidenceCase.SessionTimestamp)]
+    [InlineData(MalformedActorEvidenceCase.MultipleNearMisses)]
+    [InlineData(MalformedActorEvidenceCase.InvalidNearMissReason)]
+    [InlineData(MalformedActorEvidenceCase.NearMissWithUnavailableStore)]
+    [InlineData(MalformedActorEvidenceCase.MatchWithNearMiss)]
+    [InlineData(MalformedActorEvidenceCase.CoverageWithoutMatch)]
+    [InlineData(MalformedActorEvidenceCase.NullStoreStatus)]
+    [InlineData(MalformedActorEvidenceCase.WrongCandidateCount)]
+    public async Task Authorization_evaluation_rejects_malformed_actor_evidence(
+        MalformedActorEvidenceCase malformedCase)
+    {
+        var approvalService = new FixedShellApprovalService(request =>
+            CreateMalformedActorResult(request, malformedCase));
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = new FunctionCallContent(
+            "call-malformed-actor-evidence",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", "git status"));
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/malformed-actor-evidence"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.Equal("internal_policy_failure", decision.DenyReason);
+        var row = Assert.Single(decision.ShellPolicyTrace.Rows);
+        Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+        Assert.Equal(ShellPolicyTraceOutcome.Deny, row.Outcome);
+        Assert.Equal(ShellPolicyTraceReason.InternalPolicyFailure, row.Reason);
+        Assert.Equal(1, approvalService.RequestCount);
+    }
+
     [Fact]
-    public async Task Unexpected_coordinator_fault_preserves_completed_trace_rows()
+    public async Task Authorization_evaluation_preserves_mixed_actor_match_order_in_one_batch()
+    {
+        var grantTimestamp = new DateTimeOffset(2026, 8, 14, 1, 0, 0, TimeSpan.Zero);
+        var approvalService = new FixedShellApprovalService(request =>
+        {
+            var sessionCandidate = request.Candidates[0];
+            var persistentCandidate = request.Candidates[1];
+            var persistentEntry = ApprovalEntry.CreateTokenPrefix(
+                Assert.IsType<ApprovalShell>(persistentCandidate.Candidate.Shell),
+                Assert.IsAssignableFrom<IReadOnlyList<string>>(
+                    persistentCandidate.Candidate.VerbTokens),
+                createdAt: grantTimestamp);
+            return new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                Array.AsReadOnly(
+                [
+                    new ShellGrantCandidateMatch(
+                        persistentCandidate.CandidateId,
+                        new ToolApprovalMatch(
+                            persistentCandidate.Candidate.Verb,
+                            "persistent",
+                            persistentEntry.FormatScope()),
+                        ShellCoverageKind.PersistentGlobal,
+                        NearMisses: [])
+                    {
+                        GrantCreatedAt = grantTimestamp
+                    },
+                    new ShellGrantCandidateMatch(
+                        sessionCandidate.CandidateId,
+                        new ToolApprovalMatch(
+                            sessionCandidate.Candidate.Verb,
+                            "session",
+                            "this chat"),
+                        ShellCoverageKind.Session,
+                        NearMisses: [])
+                ]));
+        });
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = new FunctionCallContent(
+            "call-mixed-actor-evidence",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", "git status && git push"));
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            CreateInteractivePersonalContext("signalr/mixed-actor-evidence"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, decision.Outcome);
+        Assert.Equal(ToolAllowReason.StoredApproval, decision.AllowReason);
+        Assert.Equal(1, approvalService.RequestCount);
+        Assert.Equal(
+            ["git push", "git status"],
+            decision.ApprovalMatches.Select(static match => match.Pattern));
+        Assert.Collection(
+            decision.ShellPolicyTrace.Rows.Where(static row =>
+                row.Stage == ShellPolicyTraceStage.StoredGrantMatch),
+            row =>
+            {
+                Assert.Equal(ShellCoverageKind.PersistentGlobal, row.Coverage);
+                Assert.Equal(grantTimestamp, row.GrantTimestamp);
+            },
+            row => Assert.Equal(ShellCoverageKind.Session, row.Coverage));
+    }
+
+    [Fact]
+    public async Task Malformed_actor_batch_applies_no_partial_evidence()
     {
         var approvalService = new FixedShellApprovalService(request =>
         {
-            var matches = request.Candidates.Select(candidate =>
+            var first = request.Candidates[0];
+            var second = request.Candidates[1];
+            var matches = new[]
+            {
                 new ShellGrantCandidateMatch(
-                    candidate.CandidateId,
-                    new ToolApprovalMatch(
-                        candidate.Candidate.Verb,
-                        "session",
-                        "this chat"),
+                    first.CandidateId,
+                    new ToolApprovalMatch(first.Candidate.Verb, "session", "this chat"),
                     ShellCoverageKind.Session,
-                    NearMisses: [])).ToArray();
+                    NearMisses: []),
+                new ShellGrantCandidateMatch(
+                    second.CandidateId,
+                    new ToolApprovalMatch("unrelated", "session", "this chat"),
+                    ShellCoverageKind.Session,
+                    NearMisses: [])
+            };
             return new ShellApprovalMatchResult(
                 new PersistentGrantStoreStatus.Ready(),
-                new ThrowAfterFirstOnSecondEnumerationList<ShellGrantCandidateMatch>(matches));
+                Array.AsReadOnly(matches));
         });
         var executor = CreateApprovalGatedShellExecutor(approvalService);
         var call = new FunctionCallContent(
@@ -1784,19 +1899,10 @@ public class DispatchingToolExecutorTests
 
         Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
         Assert.Equal("internal_policy_failure", decision.DenyReason);
-        Assert.Collection(
-            decision.ShellPolicyTrace.Rows,
-            row =>
-            {
-                Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, row.Stage);
-                Assert.Equal(ShellPolicyTraceOutcome.Covered, row.Outcome);
-            },
-            row =>
-            {
-                Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
-                Assert.Equal(ShellPolicyTraceOutcome.Deny, row.Outcome);
-                Assert.Equal(ShellPolicyTraceReason.InternalPolicyFailure, row.Reason);
-            });
+        var row = Assert.Single(decision.ShellPolicyTrace.Rows);
+        Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+        Assert.Equal(ShellPolicyTraceOutcome.Deny, row.Outcome);
+        Assert.Equal(ShellPolicyTraceReason.InternalPolicyFailure, row.Reason);
     }
 
     [Fact]
@@ -3334,6 +3440,85 @@ public class DispatchingToolExecutorTests
                 Array.AsReadOnly(matches));
         });
 
+    private static ShellApprovalMatchResult CreateMalformedActorResult(
+        ShellApprovalMatchRequest request,
+        MalformedActorEvidenceCase malformedCase)
+    {
+        var candidate = request.Candidates[0];
+        var sessionMatch = new ToolApprovalMatch(
+            candidate.Candidate.Verb,
+            "session",
+            "this chat");
+        var mismatchedGrant = ApprovalEntry.CreateTokenPrefix(
+            Assert.IsType<ApprovalShell>(candidate.Candidate.Shell),
+            ["git", "push"]);
+        var tokenNearMiss = new ShellApprovalNearMiss(
+            mismatchedGrant,
+            ShellApprovalNearMissReason.TokenMismatch);
+        var store = malformedCase switch
+        {
+            MalformedActorEvidenceCase.NullStoreStatus => null!,
+            MalformedActorEvidenceCase.NearMissWithUnavailableStore =>
+                new PersistentGrantStoreStatus.Unavailable(ApprovalStoreFailure.InvalidData),
+            _ => (PersistentGrantStoreStatus)new PersistentGrantStoreStatus.Ready(),
+        };
+        var match = malformedCase switch
+        {
+            MalformedActorEvidenceCase.MultipleNearMisses => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                Match: null,
+                GrantCoverage: null,
+                NearMisses: [tokenNearMiss, tokenNearMiss]),
+            MalformedActorEvidenceCase.InvalidNearMissReason => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                Match: null,
+                GrantCoverage: null,
+                NearMisses:
+                [
+                    new ShellApprovalNearMiss(
+                        mismatchedGrant,
+                        (ShellApprovalNearMissReason)999)
+                ]),
+            MalformedActorEvidenceCase.NearMissWithUnavailableStore => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                Match: null,
+                GrantCoverage: null,
+                NearMisses: [tokenNearMiss]),
+            MalformedActorEvidenceCase.MatchWithNearMiss => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                sessionMatch,
+                ShellCoverageKind.Session,
+                NearMisses: [tokenNearMiss]),
+            MalformedActorEvidenceCase.CoverageWithoutMatch => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                Match: null,
+                GrantCoverage: ShellCoverageKind.Session,
+                NearMisses: []),
+            MalformedActorEvidenceCase.InvalidCoverage => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                sessionMatch,
+                (ShellCoverageKind)999,
+                NearMisses: []),
+            MalformedActorEvidenceCase.SessionTimestamp => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                sessionMatch,
+                ShellCoverageKind.Session,
+                NearMisses: [])
+            {
+                GrantCreatedAt = new DateTimeOffset(2026, 8, 14, 1, 0, 0, TimeSpan.Zero)
+            },
+            _ => new ShellGrantCandidateMatch(
+                candidate.CandidateId,
+                Match: null,
+                GrantCoverage: null,
+                NearMisses: []),
+        };
+        var matches = malformedCase == MalformedActorEvidenceCase.WrongCandidateCount
+            ? Array.Empty<ShellGrantCandidateMatch>()
+            : [match];
+        return new ShellApprovalMatchResult(store, Array.AsReadOnly(matches));
+    }
+
     private static ToolExecutionContext CreateInteractivePersonalContext(string sessionId)
         => TestToolExecutionContext.CreateBound(
             sessionId,
@@ -3351,6 +3536,19 @@ public class DispatchingToolExecutorTests
     }
 
     public static bool IsPosix => !OperatingSystem.IsWindows();
+
+    public enum MalformedActorEvidenceCase
+    {
+        InvalidCoverage,
+        SessionTimestamp,
+        MultipleNearMisses,
+        InvalidNearMissReason,
+        NearMissWithUnavailableStore,
+        MatchWithNearMiss,
+        CoverageWithoutMatch,
+        NullStoreStatus,
+        WrongCandidateCount,
+    }
 
     private static ApprovalCandidate BashCandidate(string verb, string? directory = null) =>
         new(verb, directory)
@@ -3466,33 +3664,6 @@ public class DispatchingToolExecutorTests
             string? cwd,
             CancellationToken ct = default)
             => throw new InvalidOperationException("The authorization evaluator must not record an approval.");
-    }
-
-    private sealed class ThrowAfterFirstOnSecondEnumerationList<T>(IReadOnlyList<T> items)
-        : IReadOnlyList<T>
-    {
-        private int _enumerationCount;
-
-        public int Count => items.Count;
-
-        public T this[int index] => items[index];
-
-        public IEnumerator<T> GetEnumerator()
-        {
-            _enumerationCount++;
-            return _enumerationCount == 2
-                ? EnumerateThenThrow().GetEnumerator()
-                : items.GetEnumerator();
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        private IEnumerable<T> EnumerateThenThrow()
-        {
-            yield return items[0];
-            throw new InvalidOperationException("Injected coordinator fault.");
-        }
     }
 
     private sealed class RecordingLogger<T> : ILogger<T>

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalEvidenceTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalEvidenceTests.cs
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellApprovalEvidenceTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class ShellApprovalEvidenceTests
+{
+    [Theory]
+    [InlineData(
+        ApprovalShell.Bash,
+        "git status",
+        "/danger",
+        "Bash token-prefix \"git status\" in /safe/../danger")]
+    [InlineData(
+        ApprovalShell.PowerShell,
+        "Get-Location",
+        "C:\\danger",
+        "PowerShell token-prefix \"Get-Location\" in C:\\safe\\..\\danger")]
+    [InlineData(
+        ApprovalShell.Bash,
+        "git status",
+        null,
+        "Bash token-prefix \"git  status\" anywhere")]
+    public void Persistent_scope_must_be_canonical(
+        ApprovalShell shell,
+        string verb,
+        string? directory,
+        string scope)
+    {
+        var candidate = CreateCandidate(0, shell, verb, directory);
+        var result = new ShellApprovalMatchResult(
+            new PersistentGrantStoreStatus.Ready(),
+            [
+                new ShellGrantCandidateMatch(
+                    candidate.Id,
+                    new ToolApprovalMatch(verb, "persistent", scope),
+                    directory is null
+                        ? ShellCoverageKind.PersistentGlobal
+                        : ShellCoverageKind.PersistentFolder,
+                    NearMisses: [])
+            ]);
+
+        var valid = ValidatedShellGrantEvidence.TryCreate(
+            result,
+            [candidate],
+            directory,
+            out var evidence);
+
+        Assert.False(valid);
+        Assert.Null(evidence);
+    }
+
+    [Theory]
+    [InlineData(MalformedNearMissGrantCase.InvalidShell)]
+    [InlineData(MalformedNearMissGrantCase.InvalidMatch)]
+    [InlineData(MalformedNearMissGrantCase.NonShell)]
+    public void Malformed_near_miss_grant_invalidates_the_whole_batch(
+        MalformedNearMissGrantCase malformedCase)
+    {
+        var covered = CreateCandidate(0, ApprovalShell.Bash, "git status", null);
+        var uncovered = CreateCandidate(1, ApprovalShell.Bash, "git push", null);
+        var typedGrant = ApprovalEntry.CreateTokenPrefix(
+            ApprovalShell.Bash,
+            ["git", "status"]);
+        var malformedGrant = malformedCase switch
+        {
+            MalformedNearMissGrantCase.InvalidShell => typedGrant with
+            {
+                Shell = (ApprovalShell)999
+            },
+            MalformedNearMissGrantCase.InvalidMatch => typedGrant with
+            {
+                Match = (ApprovalMatchKind)999
+            },
+            MalformedNearMissGrantCase.NonShell => ApprovalEntry.CreateNonShell(
+                "git status",
+                "/outside"),
+            _ => throw new ArgumentOutOfRangeException(nameof(malformedCase), malformedCase, null)
+        };
+        var result = new ShellApprovalMatchResult(
+            new PersistentGrantStoreStatus.Ready(),
+            [
+                new ShellGrantCandidateMatch(
+                    covered.Id,
+                    new ToolApprovalMatch(covered.Candidate.Verb, "session", "this chat"),
+                    ShellCoverageKind.Session,
+                    NearMisses: []),
+                new ShellGrantCandidateMatch(
+                    uncovered.Id,
+                    Match: null,
+                    GrantCoverage: null,
+                    NearMisses:
+                    [
+                        new ShellApprovalNearMiss(
+                            malformedGrant,
+                            ShellApprovalNearMissReason.ShellMismatch)
+                    ])
+            ]);
+
+        var valid = ValidatedShellGrantEvidence.TryCreate(
+            result,
+            [covered, uncovered],
+            cwd: null,
+            out var evidence);
+
+        Assert.False(valid);
+        Assert.Null(evidence);
+    }
+
+    private static ShellPolicyCandidate CreateCandidate(
+        int id,
+        ApprovalShell shell,
+        string verb,
+        string? directory)
+        => new(
+            new ShellPolicyCandidateId(id),
+            new ApprovalCandidate(verb, directory)
+            {
+                Shell = shell,
+                VerbTokens = Array.AsReadOnly(
+                    verb.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            },
+            SourceOccurrence: null);
+
+    public enum MalformedNearMissGrantCase
+    {
+        InvalidShell,
+        InvalidMatch,
+        NonShell,
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalEvidenceTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalEvidenceTests.cs
@@ -12,6 +12,44 @@ namespace Netclaw.Actors.Tests.Tools;
 public sealed class ShellApprovalEvidenceTests
 {
     [Theory]
+    [InlineData(ApprovalShell.Bash, "/")]
+    [InlineData(ApprovalShell.Bash, "/work/repo")]
+    [InlineData(ApprovalShell.PowerShell, "C:\\")]
+    [InlineData(ApprovalShell.PowerShell, "C:\\work\\repo")]
+    [InlineData(ApprovalShell.PowerShell, "\\\\server\\share")]
+    [InlineData(ApprovalShell.PowerShell, "\\\\server\\share\\repo")]
+    [InlineData(ApprovalShell.PowerShell, "\\\\?\\C:\\repo")]
+    public void Canonical_persistent_scope_remains_valid(
+        ApprovalShell shell,
+        string directory)
+    {
+        var verb = shell == ApprovalShell.Bash ? "git status" : "Get-Location";
+        var candidate = CreateCandidate(0, shell, verb, directory);
+        var entry = ApprovalEntry.CreateTokenPrefix(
+            shell,
+            Assert.IsAssignableFrom<IReadOnlyList<string>>(candidate.Candidate.VerbTokens),
+            directory);
+        var result = new ShellApprovalMatchResult(
+            new PersistentGrantStoreStatus.Ready(),
+            [
+                new ShellGrantCandidateMatch(
+                    candidate.Id,
+                    new ToolApprovalMatch(verb, "persistent", entry.FormatScope()),
+                    ShellCoverageKind.PersistentFolder,
+                    NearMisses: [])
+            ]);
+
+        var valid = ValidatedShellGrantEvidence.TryCreate(
+            result,
+            [candidate],
+            directory,
+            out var evidence);
+
+        Assert.True(valid);
+        Assert.NotNull(evidence);
+    }
+
+    [Theory]
     [InlineData(
         ApprovalShell.Bash,
         "git status",

--- a/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
+++ b/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
@@ -386,61 +386,20 @@ internal sealed class ValidatedShellGrantEvidence
 
     private static bool IsCanonicalShellEntry(ApprovalEntry entry)
     {
-        if (entry.Shell is not { } shell
-            || !Enum.IsDefined(shell)
-            || entry.Match is not { } match
-            || !Enum.IsDefined(match))
+        if (entry.Shell is null || entry.Match is null)
         {
             return false;
         }
 
-        if (entry.Directory is { } directory)
+        try
         {
-            var pathStyle = shell == ApprovalShell.PowerShell
-                ? ShellPathStyle.Windows
-                : ShellPathStyle.Posix;
-            if (HasInvalidPersistedCharacter(directory)
-                || !ShellPathRules.TryGetRootRelativeDepth(directory, pathStyle, out _))
-            {
-                return false;
-            }
+            ApprovalEntryValidation.ValidateVersion3(entry);
+            return true;
         }
-
-        return match switch
+        catch (System.Text.Json.JsonException)
         {
-            ApprovalMatchKind.TokenPrefix =>
-                entry.VerbTokens is { Count: > 0 } tokens
-                && string.Equals(entry.Verb, string.Join(" ", tokens), StringComparison.Ordinal),
-            ApprovalMatchKind.LegacyExact => entry.VerbTokens is null,
-            _ => false,
-        };
-    }
-
-    private static bool HasInvalidPersistedCharacter(string value)
-    {
-        for (var index = 0; index < value.Length; index++)
-        {
-            var character = value[index];
-            if (char.IsHighSurrogate(character))
-            {
-                if (index + 1 >= value.Length || !char.IsLowSurrogate(value[index + 1]))
-                    return true;
-
-                index++;
-                continue;
-            }
-
-            if (char.IsLowSurrogate(character)
-                || char.IsControl(character)
-                || character is '\u061c' or '\u200e' or '\u200f'
-                    or >= '\u202a' and <= '\u202e'
-                    or >= '\u2066' and <= '\u2069')
-            {
-                return true;
-            }
+            return false;
         }
-
-        return false;
     }
 }
 

--- a/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
+++ b/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
@@ -1,0 +1,355 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellApprovalEvidence.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+internal sealed class ShellApprovalEvidenceAdapter(IToolApprovalService? approvalService)
+{
+    internal bool IsAvailable => approvalService is not null;
+
+    internal async Task<ShellApprovalMatchResult> MatchAsync(
+        ShellApprovalMatchRequest request,
+        string? cwd,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Candidates.Count == 0 || approvalService is null)
+            return CreateEmptyResult(request.Candidates);
+
+        if (approvalService is IShellApprovalMatchService shellApprovalService)
+        {
+            return await shellApprovalService.MatchShellCandidatesAsync(
+                request,
+                cancellationToken);
+        }
+
+        var compatibilityResult = await approvalService.CheckApprovalAsync(
+            request.SessionId,
+            request.Audience,
+            request.ToolName,
+            request.Candidates.Select(static candidate => candidate.Candidate).ToArray(),
+            cwd,
+            cancellationToken);
+        return ConvertCompatibilityResult(compatibilityResult, request.Candidates);
+    }
+
+    private static ShellApprovalMatchResult ConvertCompatibilityResult(
+        ToolApprovalCheckResult result,
+        IReadOnlyList<ShellGrantCandidate> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        if (result.CandidateChecks is not { } checks)
+        {
+            var aggregateStoreStatus = result.PersistentStoreFailure is { } aggregateFailure
+                ? (PersistentGrantStoreStatus)new PersistentGrantStoreStatus.Unavailable(aggregateFailure)
+                : new PersistentGrantStoreStatus.Ready();
+            return new ShellApprovalMatchResult(
+                aggregateStoreStatus,
+                Array.AsReadOnly(candidates
+                    .Select(static candidate => new ShellGrantCandidateMatch(
+                        candidate.CandidateId,
+                        Match: null,
+                        GrantCoverage: null,
+                        NearMisses: []))
+                    .ToArray()));
+        }
+
+        if (checks.Count != candidates.Count)
+            throw new InvalidOperationException("The approval service returned the wrong candidate count.");
+
+        var matches = new ShellGrantCandidateMatch[checks.Count];
+        var unapprovedPatterns = new List<string>();
+        var approvedMatches = new List<ToolApprovalMatch>();
+        for (var index = 0; index < checks.Count; index++)
+        {
+            var expected = candidates[index];
+            var check = checks[index]
+                ?? throw new InvalidOperationException("The approval service returned a null candidate check.");
+            if (!HasSameCandidateFacts(check.Candidate, expected.Candidate))
+                throw new InvalidOperationException("The approval service changed candidate facts.");
+
+            ShellCoverageKind? grantCoverage = null;
+            if (check.ApprovedMatch is { } approvedMatch)
+            {
+                approvedMatches.Add(approvedMatch);
+                grantCoverage = approvedMatch.Source switch
+                {
+                    "session" => ShellCoverageKind.Session,
+                    "persistent" when approvedMatch.Scope.EndsWith(" anywhere", StringComparison.Ordinal) =>
+                        ShellCoverageKind.PersistentGlobal,
+                    "persistent" => ShellCoverageKind.PersistentFolder,
+                    _ => throw new InvalidOperationException("The approval service returned an unknown grant source."),
+                };
+            }
+            else
+            {
+                unapprovedPatterns.Add(expected.Candidate.Verb);
+            }
+
+            matches[index] = new ShellGrantCandidateMatch(
+                expected.CandidateId,
+                check.ApprovedMatch,
+                grantCoverage,
+                []);
+        }
+
+        if (!unapprovedPatterns.SequenceEqual(
+                result.UnapprovedPatterns,
+                StringComparer.OrdinalIgnoreCase)
+            || !approvedMatches.SequenceEqual(result.ApprovedMatches))
+        {
+            throw new InvalidOperationException("The approval service returned inconsistent aggregates.");
+        }
+
+        var storeStatus = result.PersistentStoreFailure is { } failure
+            ? (PersistentGrantStoreStatus)new PersistentGrantStoreStatus.Unavailable(failure)
+            : new PersistentGrantStoreStatus.Ready();
+        return new ShellApprovalMatchResult(
+            storeStatus,
+            Array.AsReadOnly(matches));
+    }
+
+    private static ShellApprovalMatchResult CreateEmptyResult(
+        IReadOnlyList<ShellGrantCandidate> candidates)
+        => new(
+            new PersistentGrantStoreStatus.Ready(),
+            Array.AsReadOnly(candidates
+                .Select(static candidate => new ShellGrantCandidateMatch(
+                    candidate.CandidateId,
+                    Match: null,
+                    GrantCoverage: null,
+                    NearMisses: []))
+                .ToArray()));
+
+    private static bool HasSameCandidateFacts(
+        ApprovalCandidate first,
+        ApprovalCandidate second) =>
+        string.Equals(first.Verb, second.Verb, StringComparison.Ordinal) &&
+        string.Equals(first.Directory, second.Directory, StringComparison.Ordinal) &&
+        first.Shell == second.Shell &&
+        ((first.VerbTokens is null && second.VerbTokens is null) ||
+         (first.VerbTokens is not null &&
+          second.VerbTokens is not null &&
+          first.VerbTokens.SequenceEqual(second.VerbTokens, StringComparer.Ordinal)));
+}
+
+internal sealed class ValidatedShellGrantEvidence
+{
+    private readonly IReadOnlyList<ValidatedShellGrantCandidateEvidence> _candidateEvidence;
+    private readonly IReadOnlyList<ToolApprovalMatch> _approvalMatches;
+
+    private ValidatedShellGrantEvidence(
+        PersistentGrantStoreStatus persistentStore,
+        ValidatedShellGrantCandidateEvidence[] candidateEvidence,
+        ToolApprovalMatch[] approvalMatches)
+    {
+        PersistentStore = persistentStore;
+        _candidateEvidence = Array.AsReadOnly(candidateEvidence);
+        _approvalMatches = Array.AsReadOnly(approvalMatches);
+    }
+
+    internal PersistentGrantStoreStatus PersistentStore { get; }
+
+    internal IReadOnlyList<ValidatedShellGrantCandidateEvidence> CandidateEvidence => _candidateEvidence;
+
+    internal IReadOnlyList<ToolApprovalMatch> ApprovalMatches => _approvalMatches;
+
+    internal static bool TryCreate(
+        ShellApprovalMatchResult result,
+        IReadOnlyList<ShellPolicyCandidate> candidates,
+        string? cwd,
+        out ValidatedShellGrantEvidence? evidence)
+    {
+        evidence = null;
+        if (result is null
+            || candidates is null
+            || !TryValidateStore(result.PersistentStore, out var storeUnavailable)
+            || result.CandidateMatches is null
+            || result.CandidateMatches.Count != candidates.Count)
+        {
+            return false;
+        }
+
+        var expectedById = candidates.ToDictionary(static candidate => candidate.Id);
+        var seenIds = new HashSet<ShellPolicyCandidateId>();
+        var validated = new ValidatedShellGrantCandidateEvidence[candidates.Count];
+        var approvalMatches = new List<ToolApprovalMatch>(candidates.Count);
+        for (var index = 0; index < result.CandidateMatches.Count; index++)
+        {
+            var candidateMatch = result.CandidateMatches[index];
+            if (candidateMatch is null
+                || !expectedById.TryGetValue(candidateMatch.CandidateId, out var candidate)
+                || !seenIds.Add(candidateMatch.CandidateId)
+                || !TryValidateCandidateEvidence(
+                    candidate,
+                    candidateMatch,
+                    cwd,
+                    storeUnavailable))
+            {
+                return false;
+            }
+
+            var candidateEvidence = CopyCandidateEvidence(candidateMatch);
+            validated[index] = new ValidatedShellGrantCandidateEvidence(candidate, candidateEvidence);
+            if (candidateEvidence.Match is { } match)
+                approvalMatches.Add(match);
+        }
+
+        evidence = new ValidatedShellGrantEvidence(
+            result.PersistentStore,
+            validated,
+            approvalMatches.ToArray());
+        return true;
+    }
+
+    private static bool TryValidateStore(
+        PersistentGrantStoreStatus persistentStore,
+        out bool unavailable)
+    {
+        unavailable = false;
+        switch (persistentStore)
+        {
+            case PersistentGrantStoreStatus.Ready:
+                return true;
+            case PersistentGrantStoreStatus.Unavailable storeUnavailable
+                when Enum.IsDefined(storeUnavailable.Failure):
+                unavailable = true;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryValidateCandidateEvidence(
+        ShellPolicyCandidate candidate,
+        ShellGrantCandidateMatch candidateMatch,
+        string? cwd,
+        bool storeUnavailable)
+    {
+        if (candidateMatch.NearMisses is null)
+            return false;
+
+        if (candidateMatch.Match is null)
+        {
+            return candidateMatch.GrantCoverage is null
+                   && candidateMatch.GrantCreatedAt is null
+                   && candidateMatch.NearMisses.Count <= 1
+                   && (!storeUnavailable || candidateMatch.NearMisses.Count == 0)
+                   && candidateMatch.NearMisses.All(nearMiss =>
+                       IsConsistentNearMiss(candidate.Candidate, nearMiss, cwd));
+        }
+
+        if (candidateMatch.GrantCoverage is not
+            (ShellCoverageKind.Session
+            or ShellCoverageKind.PersistentGlobal
+            or ShellCoverageKind.PersistentFolder)
+            || candidateMatch.NearMisses.Count != 0
+            || (candidateMatch.GrantCoverage == ShellCoverageKind.Session
+                && candidateMatch.GrantCreatedAt is not null)
+            || (storeUnavailable
+                && candidateMatch.GrantCoverage is
+                    (ShellCoverageKind.PersistentGlobal or ShellCoverageKind.PersistentFolder)))
+        {
+            return false;
+        }
+
+        return IsConsistentActorMatch(
+            candidate.Candidate,
+            candidateMatch.Match,
+            candidateMatch.GrantCoverage.Value,
+            cwd);
+    }
+
+    private static ShellGrantCandidateMatch CopyCandidateEvidence(
+        ShellGrantCandidateMatch source)
+        => new(
+            source.CandidateId,
+            source.Match is null
+                ? null
+                : new ToolApprovalMatch(
+                    source.Match.Pattern,
+                    source.Match.Source,
+                    source.Match.Scope),
+            source.GrantCoverage,
+            Array.AsReadOnly(source.NearMisses
+                .Select(static nearMiss => new ShellApprovalNearMiss(
+                    nearMiss.Grant,
+                    nearMiss.Reason))
+                .ToArray()))
+        {
+            GrantCreatedAt = source.GrantCreatedAt
+        };
+
+    private static bool IsConsistentActorMatch(
+        ApprovalCandidate candidate,
+        ToolApprovalMatch match,
+        ShellCoverageKind coverage,
+        string? cwd)
+    {
+        if (match.Pattern is null
+            || match.Source is null
+            || match.Scope is null
+            || !string.Equals(match.Pattern, candidate.Verb, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (coverage == ShellCoverageKind.Session)
+        {
+            return string.Equals(match.Source, "session", StringComparison.Ordinal)
+                   && string.Equals(match.Scope, "this chat", StringComparison.Ordinal);
+        }
+
+        if (coverage is not
+            (ShellCoverageKind.PersistentGlobal or ShellCoverageKind.PersistentFolder)
+            || !string.Equals(match.Source, "persistent", StringComparison.Ordinal)
+            || !ApprovalEntry.TryParseScope(match.Scope, out var entry, out _)
+            || entry.Shell != candidate.Shell
+            || entry.Match is null
+            || (coverage == ShellCoverageKind.PersistentGlobal) != (entry.Directory is null))
+        {
+            return false;
+        }
+
+        return ApprovalPatternMatching.MatchesShellApproval(candidate, cwd, [entry]);
+    }
+
+    private static bool IsConsistentNearMiss(
+        ApprovalCandidate candidate,
+        ShellApprovalNearMiss nearMiss,
+        string? cwd)
+    {
+        if (nearMiss is null || !Enum.IsDefined(nearMiss.Reason) || nearMiss.Grant is null)
+            return false;
+
+        try
+        {
+            var evaluation = ApprovalPatternMatching.EvaluateShellApproval(
+                candidate,
+                cwd,
+                [nearMiss.Grant],
+                maximumNearMisses: 1);
+            return evaluation.MatchedEntry is null
+                   && evaluation.NearMisses.Count == 1
+                   && evaluation.NearMisses[0].Reason == nearMiss.Reason
+                   && ToolApprovalEntryComparer.Equals(
+                       evaluation.NearMisses[0].Grant,
+                       nearMiss.Grant);
+        }
+        catch (Exception exception) when (exception is ArgumentException or IOException)
+        {
+            return false;
+        }
+    }
+}
+
+internal sealed record ValidatedShellGrantCandidateEvidence(
+    ShellPolicyCandidate Candidate,
+    ShellGrantCandidateMatch ActorEvidence);

--- a/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
+++ b/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
@@ -171,32 +171,35 @@ internal sealed class ValidatedShellGrantEvidence
         if (result is null
             || candidates is null
             || !TryValidateStore(result.PersistentStore, out var storeUnavailable)
-            || result.CandidateMatches is null
-            || result.CandidateMatches.Count != candidates.Count)
+            || result.CandidateMatches is null)
         {
             return false;
         }
+
+        var candidateMatches = result.CandidateMatches.ToArray();
+        if (candidateMatches.Length != candidates.Count)
+            return false;
 
         var expectedById = candidates.ToDictionary(static candidate => candidate.Id);
         var seenIds = new HashSet<ShellPolicyCandidateId>();
         var validated = new ValidatedShellGrantCandidateEvidence[candidates.Count];
         var approvalMatches = new List<ToolApprovalMatch>(candidates.Count);
-        for (var index = 0; index < result.CandidateMatches.Count; index++)
+        for (var index = 0; index < candidateMatches.Length; index++)
         {
-            var candidateMatch = result.CandidateMatches[index];
-            if (candidateMatch is null
-                || !expectedById.TryGetValue(candidateMatch.CandidateId, out var candidate)
-                || !seenIds.Add(candidateMatch.CandidateId)
+            var candidateMatch = candidateMatches[index];
+            if (!TryCopyCandidateEvidence(candidateMatch, out var candidateEvidence)
+                || candidateEvidence is null
+                || !expectedById.TryGetValue(candidateEvidence.CandidateId, out var candidate)
+                || !seenIds.Add(candidateEvidence.CandidateId)
                 || !TryValidateCandidateEvidence(
                     candidate,
-                    candidateMatch,
+                    candidateEvidence,
                     cwd,
                     storeUnavailable))
             {
                 return false;
             }
 
-            var candidateEvidence = CopyCandidateEvidence(candidateMatch);
             validated[index] = new ValidatedShellGrantCandidateEvidence(candidate, candidateEvidence);
             if (candidateEvidence.Match is { } match)
                 approvalMatches.Add(match);
@@ -267,9 +270,19 @@ internal sealed class ValidatedShellGrantEvidence
             cwd);
     }
 
-    private static ShellGrantCandidateMatch CopyCandidateEvidence(
-        ShellGrantCandidateMatch source)
-        => new(
+    private static bool TryCopyCandidateEvidence(
+        ShellGrantCandidateMatch? source,
+        out ShellGrantCandidateMatch? snapshot)
+    {
+        snapshot = null;
+        if (source?.NearMisses is null)
+            return false;
+
+        var nearMisses = source.NearMisses.ToArray();
+        if (nearMisses.Any(static nearMiss => nearMiss is null))
+            return false;
+
+        snapshot = new ShellGrantCandidateMatch(
             source.CandidateId,
             source.Match is null
                 ? null
@@ -278,7 +291,7 @@ internal sealed class ValidatedShellGrantEvidence
                     source.Match.Source,
                     source.Match.Scope),
             source.GrantCoverage,
-            Array.AsReadOnly(source.NearMisses
+            Array.AsReadOnly(nearMisses
                 .Select(static nearMiss => new ShellApprovalNearMiss(
                     nearMiss.Grant,
                     nearMiss.Reason))
@@ -286,6 +299,8 @@ internal sealed class ValidatedShellGrantEvidence
         {
             GrantCreatedAt = source.GrantCreatedAt
         };
+        return true;
+    }
 
     private static bool IsConsistentActorMatch(
         ApprovalCandidate candidate,
@@ -311,6 +326,8 @@ internal sealed class ValidatedShellGrantEvidence
             (ShellCoverageKind.PersistentGlobal or ShellCoverageKind.PersistentFolder)
             || !string.Equals(match.Source, "persistent", StringComparison.Ordinal)
             || !ApprovalEntry.TryParseScope(match.Scope, out var entry, out _)
+            || !string.Equals(entry.FormatScope(), match.Scope, StringComparison.Ordinal)
+            || !IsCanonicalShellEntry(entry)
             || entry.Shell != candidate.Shell
             || entry.Match is null
             || (coverage == ShellCoverageKind.PersistentGlobal) != (entry.Directory is null))
@@ -331,6 +348,14 @@ internal sealed class ValidatedShellGrantEvidence
 
         try
         {
+            var scope = nearMiss.Grant.FormatScope();
+            if (!ApprovalEntry.TryParseScope(scope, out var canonicalGrant, out _)
+                || !HasSameEntryFacts(nearMiss.Grant, canonicalGrant)
+                || !IsCanonicalShellEntry(canonicalGrant))
+            {
+                return false;
+            }
+
             var evaluation = ApprovalPatternMatching.EvaluateShellApproval(
                 candidate,
                 cwd,
@@ -347,6 +372,75 @@ internal sealed class ValidatedShellGrantEvidence
         {
             return false;
         }
+    }
+
+    private static bool HasSameEntryFacts(ApprovalEntry first, ApprovalEntry second)
+        => string.Equals(first.Verb, second.Verb, StringComparison.Ordinal)
+           && string.Equals(first.Directory, second.Directory, StringComparison.Ordinal)
+           && first.Shell == second.Shell
+           && first.Match == second.Match
+           && ((first.VerbTokens is null && second.VerbTokens is null)
+               || (first.VerbTokens is not null
+                   && second.VerbTokens is not null
+                   && first.VerbTokens.SequenceEqual(second.VerbTokens, StringComparer.Ordinal)));
+
+    private static bool IsCanonicalShellEntry(ApprovalEntry entry)
+    {
+        if (entry.Shell is not { } shell
+            || !Enum.IsDefined(shell)
+            || entry.Match is not { } match
+            || !Enum.IsDefined(match))
+        {
+            return false;
+        }
+
+        if (entry.Directory is { } directory)
+        {
+            var pathStyle = shell == ApprovalShell.PowerShell
+                ? ShellPathStyle.Windows
+                : ShellPathStyle.Posix;
+            if (HasInvalidPersistedCharacter(directory)
+                || !ShellPathRules.TryGetRootRelativeDepth(directory, pathStyle, out _))
+            {
+                return false;
+            }
+        }
+
+        return match switch
+        {
+            ApprovalMatchKind.TokenPrefix =>
+                entry.VerbTokens is { Count: > 0 } tokens
+                && string.Equals(entry.Verb, string.Join(" ", tokens), StringComparison.Ordinal),
+            ApprovalMatchKind.LegacyExact => entry.VerbTokens is null,
+            _ => false,
+        };
+    }
+
+    private static bool HasInvalidPersistedCharacter(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (char.IsHighSurrogate(character))
+            {
+                if (index + 1 >= value.Length || !char.IsLowSurrogate(value[index + 1]))
+                    return true;
+
+                index++;
+                continue;
+            }
+
+            if (char.IsLowSurrogate(character)
+                || char.IsControl(character)
+                || character is '\u061c' or '\u200e' or '\u200f'
+                    or >= '\u202a' and <= '\u202e'
+                    or >= '\u2066' and <= '\u2069')
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -17,6 +17,8 @@ internal sealed class ShellPolicyCoordinator(
     ToolAccessPolicy policy,
     IToolApprovalService? approvalService)
 {
+    private readonly ShellApprovalEvidenceAdapter _approvalEvidence = new(approvalService);
+
     internal async Task<ShellPolicyAuthorization> EvaluateAsync(
         INetclawTool tool,
         FunctionCallContent toolCall,
@@ -185,7 +187,7 @@ internal sealed class ShellPolicyCoordinator(
 
         var coverage = new ShellCoverageSet(projection.Candidates);
         foreach (var candidate in projection.Candidates.Where(item =>
-                     approvalService is not null
+                     _approvalEvidence.IsAvailable
                      && item.Role == ShellPolicyCandidateRole.Ordinary
                      && ApprovalPatternMatching.IsPureSideEffect(item.Candidate)))
         {
@@ -196,32 +198,50 @@ internal sealed class ShellPolicyCoordinator(
         }
 
         var grantCandidates = projection.GrantCandidates;
-        var actorResult = await MatchCandidatesAsync(
-            tool,
-            context,
-            projection,
-            grantCandidates,
+        var requestCandidates = grantCandidates
+            .Select(candidate => new ShellGrantCandidate(
+                candidate.Id,
+                candidate.Candidate,
+                projection.ApprovalContext.Cwd))
+            .ToArray();
+        var actorResult = await _approvalEvidence.MatchAsync(
+            new ShellApprovalMatchRequest(
+                ToApprovalSessionId(context.SessionId),
+                context.Audience,
+                new ToolName(tool.Name),
+                projection.Environment,
+                Array.AsReadOnly(requestCandidates)),
+            projection.ApprovalContext.Cwd,
             cancellationToken);
-        if (!TryApplyActorResult(
+        if (!ValidatedShellGrantEvidence.TryCreate(
                 actorResult,
                 grantCandidates,
                 projection.ApprovalContext.Cwd,
-                coverage,
-                out var approvalMatches))
+                out var grantEvidence)
+            || grantEvidence is null)
         {
             return CompleteWithTrace(
                 ToolAuthorizationDecision.Deny("internal_policy_failure"),
                 trace);
         }
 
-        foreach (var actorMatch in actorResult.CandidateMatches)
+        foreach (var candidateEvidence in grantEvidence.CandidateEvidence)
         {
-            var candidate = grantCandidates.First(item => item.Id == actorMatch.CandidateId);
-            trace.AddActorEvidence(candidate, actorMatch);
+            var actorMatch = candidateEvidence.ActorEvidence;
+            if (actorMatch.GrantCoverage is { } grantCoverage)
+            {
+                coverage.Cover(
+                    candidateEvidence.Candidate.Id,
+                    grantCoverage,
+                    ToPolicyReason(grantCoverage));
+            }
+
+            trace.AddActorEvidence(candidateEvidence.Candidate, actorMatch);
         }
+        var approvalMatches = grantEvidence.ApprovalMatches;
 
         foreach (var candidate in projection.Candidates.Where(item =>
-                     approvalService is not null
+                     _approvalEvidence.IsAvailable
                      && item.Role == ShellPolicyCandidateRole.Ordinary
                      && ApprovalPatternMatching.IsPureSideEffect(item.Candidate)))
         {
@@ -322,7 +342,7 @@ internal sealed class ShellPolicyCoordinator(
         }
 
         if (uncovered.Count > 0
-            && actorResult.PersistentStore is PersistentGrantStoreStatus.Unavailable)
+            && grantEvidence.PersistentStore is PersistentGrantStoreStatus.Unavailable)
         {
             return CompleteWithTrace(
                 ToolAuthorizationDecision.Deny("approval_store_unavailable"),
@@ -383,236 +403,6 @@ internal sealed class ShellPolicyCoordinator(
             trace);
     }
 
-    private async Task<ShellApprovalMatchResult> MatchCandidatesAsync(
-        INetclawTool tool,
-        ToolExecutionContext context,
-        ShellPolicyProjection projection,
-        IReadOnlyList<ShellPolicyCandidate> candidates,
-        CancellationToken cancellationToken)
-    {
-        if (candidates.Count == 0 || approvalService is null)
-        {
-            return CreateEmptyMatchResult(candidates);
-        }
-
-        var requestCandidates = candidates
-            .Select(candidate => new ShellGrantCandidate(
-                candidate.Id,
-                candidate.Candidate,
-                projection.ApprovalContext.Cwd))
-            .ToArray();
-        if (approvalService is IShellApprovalMatchService shellApprovalService)
-        {
-            return await shellApprovalService.MatchShellCandidatesAsync(
-                new ShellApprovalMatchRequest(
-                    ToApprovalSessionId(context.SessionId),
-                    context.Audience,
-                    new ToolName(tool.Name),
-                    projection.Environment,
-                    Array.AsReadOnly(requestCandidates)),
-                cancellationToken);
-        }
-
-        var compatibilityResult = await approvalService.CheckApprovalAsync(
-            ToApprovalSessionId(context.SessionId),
-            context.Audience,
-            new ToolName(tool.Name),
-            candidates.Select(static candidate => candidate.Candidate).ToArray(),
-            projection.ApprovalContext.Cwd,
-            cancellationToken);
-        return ConvertCompatibilityResult(compatibilityResult, candidates);
-    }
-
-    private static ShellApprovalMatchResult ConvertCompatibilityResult(
-        ToolApprovalCheckResult result,
-        IReadOnlyList<ShellPolicyCandidate> candidates)
-    {
-        if (result.CandidateChecks is not { } checks)
-        {
-            var aggregateStoreStatus = result.PersistentStoreFailure is { } aggregateFailure
-                ? (PersistentGrantStoreStatus)new PersistentGrantStoreStatus.Unavailable(aggregateFailure)
-                : new PersistentGrantStoreStatus.Ready();
-            return new ShellApprovalMatchResult(
-                aggregateStoreStatus,
-                Array.AsReadOnly(candidates
-                    .Select(static candidate => new ShellGrantCandidateMatch(
-                        candidate.Id,
-                        Match: null,
-                        GrantCoverage: null,
-                        NearMisses: []))
-                    .ToArray()));
-        }
-
-        if (checks.Count != candidates.Count)
-            throw new InvalidOperationException("The approval service returned the wrong candidate count.");
-
-        var matches = new ShellGrantCandidateMatch[checks.Count];
-        var unapprovedPatterns = new List<string>();
-        var approvedMatches = new List<ToolApprovalMatch>();
-        for (var index = 0; index < checks.Count; index++)
-        {
-            var expected = candidates[index];
-            var check = checks[index];
-            if (!HasSameCandidateFacts(check.Candidate, expected.Candidate))
-                throw new InvalidOperationException("The approval service changed candidate facts.");
-
-            ShellCoverageKind? grantCoverage = null;
-            if (check.ApprovedMatch is { } approvedMatch)
-            {
-                approvedMatches.Add(approvedMatch);
-                grantCoverage = approvedMatch.Source switch
-                {
-                    "session" => ShellCoverageKind.Session,
-                    "persistent" when approvedMatch.Scope.EndsWith(" anywhere", StringComparison.Ordinal) =>
-                        ShellCoverageKind.PersistentGlobal,
-                    "persistent" => ShellCoverageKind.PersistentFolder,
-                    _ => throw new InvalidOperationException("The approval service returned an unknown grant source."),
-                };
-            }
-            else
-            {
-                unapprovedPatterns.Add(expected.Candidate.Verb);
-            }
-
-            matches[index] = new ShellGrantCandidateMatch(
-                expected.Id,
-                check.ApprovedMatch,
-                grantCoverage,
-                []);
-        }
-
-        if (!unapprovedPatterns.SequenceEqual(
-                result.UnapprovedPatterns,
-                StringComparer.OrdinalIgnoreCase)
-            || !approvedMatches.SequenceEqual(result.ApprovedMatches))
-        {
-            throw new InvalidOperationException("The approval service returned inconsistent aggregates.");
-        }
-
-        var storeStatus = result.PersistentStoreFailure is { } failure
-            ? (PersistentGrantStoreStatus)new PersistentGrantStoreStatus.Unavailable(failure)
-            : new PersistentGrantStoreStatus.Ready();
-        return new ShellApprovalMatchResult(
-            storeStatus,
-            Array.AsReadOnly(matches));
-    }
-
-    private static bool TryApplyActorResult(
-        ShellApprovalMatchResult result,
-        IReadOnlyList<ShellPolicyCandidate> candidates,
-        string? cwd,
-        ShellCoverageSet coverage,
-        out IReadOnlyList<ToolApprovalMatch> approvalMatches)
-    {
-        approvalMatches = [];
-        if (result.PersistentStore is PersistentGrantStoreStatus.Unavailable unavailable
-            && !Enum.IsDefined(unavailable.Failure))
-        {
-            return false;
-        }
-
-        if (result.PersistentStore is not PersistentGrantStoreStatus.Ready
-            && result.PersistentStore is not PersistentGrantStoreStatus.Unavailable)
-        {
-            return false;
-        }
-
-        if (result.CandidateMatches.Count != candidates.Count)
-            return false;
-
-        var expectedIds = candidates.Select(static candidate => candidate.Id).ToHashSet();
-        var seenIds = new HashSet<ShellPolicyCandidateId>();
-        var matches = new List<ToolApprovalMatch>();
-        foreach (var candidateMatch in result.CandidateMatches)
-        {
-            if (!expectedIds.Contains(candidateMatch.CandidateId)
-                || !seenIds.Add(candidateMatch.CandidateId))
-            {
-                return false;
-            }
-
-            if (candidateMatch.Match is null)
-            {
-                if (candidateMatch.GrantCoverage is not null
-                    || candidateMatch.GrantCreatedAt is not null
-                    || candidateMatch.NearMisses.Count > 1
-                    || candidateMatch.NearMisses.Any(static nearMiss =>
-                        !Enum.IsDefined(nearMiss.Reason)))
-                {
-                    return false;
-                }
-
-                continue;
-            }
-
-            if (candidateMatch.GrantCoverage is not
-                (ShellCoverageKind.Session
-                or ShellCoverageKind.PersistentGlobal
-                or ShellCoverageKind.PersistentFolder)
-                || candidateMatch.NearMisses.Count > 0
-                || (candidateMatch.GrantCoverage == ShellCoverageKind.Session
-                    && candidateMatch.GrantCreatedAt is not null))
-            {
-                return false;
-            }
-
-            var candidate = candidates.First(item => item.Id == candidateMatch.CandidateId);
-            if (!IsConsistentActorMatch(
-                    candidate.Candidate,
-                    candidateMatch.Match,
-                    candidateMatch.GrantCoverage.Value,
-                    cwd))
-            {
-                return false;
-            }
-
-            if (result.PersistentStore is PersistentGrantStoreStatus.Unavailable
-                && candidateMatch.GrantCoverage is
-                    (ShellCoverageKind.PersistentGlobal or ShellCoverageKind.PersistentFolder))
-            {
-                return false;
-            }
-
-            coverage.Cover(
-                candidateMatch.CandidateId,
-                candidateMatch.GrantCoverage.Value,
-                ToPolicyReason(candidateMatch.GrantCoverage.Value));
-            matches.Add(candidateMatch.Match);
-        }
-
-        approvalMatches = Array.AsReadOnly(matches.ToArray());
-        return true;
-    }
-
-    private static bool IsConsistentActorMatch(
-        ApprovalCandidate candidate,
-        ToolApprovalMatch match,
-        ShellCoverageKind coverage,
-        string? cwd)
-    {
-        if (!string.Equals(match.Pattern, candidate.Verb, StringComparison.Ordinal))
-            return false;
-
-        if (coverage == ShellCoverageKind.Session)
-        {
-            return string.Equals(match.Source, "session", StringComparison.Ordinal)
-                   && string.Equals(match.Scope, "this chat", StringComparison.Ordinal);
-        }
-
-        if (coverage is not
-            (ShellCoverageKind.PersistentGlobal or ShellCoverageKind.PersistentFolder)
-            || !string.Equals(match.Source, "persistent", StringComparison.Ordinal)
-            || !ApprovalEntry.TryParseScope(match.Scope, out var entry, out _)
-            || entry.Shell != candidate.Shell
-            || entry.Match is null
-            || (coverage == ShellCoverageKind.PersistentGlobal) != (entry.Directory is null))
-        {
-            return false;
-        }
-
-        return ApprovalPatternMatching.MatchesShellApproval(candidate, cwd, [entry]);
-    }
-
     private static IReadOnlyList<ShellPolicyCandidate> GetUncoveredCandidates(
         ShellPolicyProjection projection,
         ShellCoverageSet coverage)
@@ -631,18 +421,6 @@ internal sealed class ShellPolicyCoordinator(
         _ => throw new InvalidOperationException("Invalid actor coverage kind."),
     };
 
-    private static ShellApprovalMatchResult CreateEmptyMatchResult(
-        IReadOnlyList<ShellPolicyCandidate> candidates)
-        => new(
-            new PersistentGrantStoreStatus.Ready(),
-            Array.AsReadOnly(candidates
-                .Select(static candidate => new ShellGrantCandidateMatch(
-                    candidate.Id,
-                    Match: null,
-                    GrantCoverage: null,
-                    NearMisses: []))
-                .ToArray()));
-
     private static ToolAuthorizationDecision CompleteOneTimeOrPrompt(
         string toolName,
         ShellPolicyProjection projection,
@@ -655,17 +433,6 @@ internal sealed class ShellPolicyCoordinator(
             : ToolAuthorizationDecision.RequiresApproval(approvalContext, approvalMatches);
         return CompleteWithTrace(decision, trace);
     }
-
-    private static bool HasSameCandidateFacts(
-        ApprovalCandidate first,
-        ApprovalCandidate second) =>
-        string.Equals(first.Verb, second.Verb, StringComparison.Ordinal) &&
-        string.Equals(first.Directory, second.Directory, StringComparison.Ordinal) &&
-        first.Shell == second.Shell &&
-        ((first.VerbTokens is null && second.VerbTokens is null) ||
-         (first.VerbTokens is not null &&
-          second.VerbTokens is not null &&
-          first.VerbTokens.SequenceEqual(second.VerbTokens, StringComparer.Ordinal)));
 
     private static ToolAuthorizationDecision Complete(
         ToolAccessDecision decision,

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="netclaw" />
     <InternalsVisibleTo Include="netclawd" />
+    <InternalsVisibleTo Include="Netclaw.Actors" />
     <InternalsVisibleTo Include="Netclaw.Configuration.Tests" />
     <InternalsVisibleTo Include="Netclaw.Daemon.Tests" />
     <InternalsVisibleTo Include="Netclaw.Cli.Tests" />


### PR DESCRIPTION
## Summary

- isolate shell compatibility calls behind one typed adapter
- snapshot and validate the complete actor result before any grant changes coverage
- reuse the exact v3 approval-entry validator for persistent scopes and near misses
- remove candidate-result validation and compatibility conversion from the coordinator
- complete tasks 4.1 through 4.6 of the shell policy evaluator refactor

## Security boundaries

Malformed counts, IDs, candidate facts, enums, scopes, timestamps, near misses, and unavailable-store combinations fail closed. A malformed batch cannot apply partial authority or actor trace evidence.

The public approval service remains compatible. Public scope parsing and the approval-store wire format do not change.

## Validation

- focused actor, coordinator, fixture, and disposition tests: 396 passed
- adversarial actor-evidence review: PASS
- strict OpenSpec validation: PASS
- headers, format, and diff checks: PASS
- Slopwatch: no changed-file findings; one unrelated baseline warning remains
- post-rebase patch identity preserved exactly against reviewed commit 2057f3f0