### PR TITLE
Extract initial ordered shell policy stages

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/design.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/design.md
@@ -152,6 +152,17 @@ internal abstract record ShellPolicyStageResult
 }
 ```
 
+The sketch omits constructor guards. Production exposes `Complete.ExactOneTime` as the sole uncovered allow marker.
+
+That marker requires all of these facts:
+
+- the exact one-time key matches the tool and complete approval context;
+- syntax or causal eligibility would otherwise return that context as a prompt;
+- the decision uses `OneTimeApproval`;
+- completion adds no invented candidate coverage row.
+
+No session, persistent, reviewed-safe, or other allow reason may bypass candidate coverage.
+
 The pipeline invokes stages in this order:
 
 1. syntax and candidate validation;

--- a/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
@@ -108,6 +108,14 @@ The system SHALL derive one prompt context from the current uncovered candidate 
 - **WHEN** causal intent requires prerequisite and consumer candidates as one unit
 - **THEN** the one-time key and prompt SHALL retain the complete causal context
 
+#### Scenario: Exact retry precedes candidate coverage
+
+- **WHEN** syntax or causal eligibility would prompt before candidate coverage
+- **AND** the exact one-time key matches the same complete approval context
+- **THEN** policy SHALL allow with `OneTimeApproval`
+- **AND** the trace SHALL contain only its completion row
+- **AND** no other allow reason SHALL bypass candidate coverage
+
 ### Requirement: Coverage and trace facts remain atomic
 
 Each coverage change SHALL add its bounded trace fact through the same state operation. Terminal completion SHALL add exactly one completion row.

--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -36,8 +36,8 @@
 
 ## 5. Extract the ordered policy stages
 
-- [ ] 5.1 Add one pipeline runner that stops on the first complete or fault result.
-- [ ] 5.2 Extract syntax, protected-path, causal-path, and causal-directory stages with no change to precedence.
+- [x] 5.1 Add one pipeline runner that stops on the first complete or fault result.
+- [x] 5.2 Extract syntax, protected-path, causal-path, and causal-directory stages with no change to precedence.
 - [ ] 5.3 Extract approval-exempt and actor-evidence stages with no change to candidate order or request count.
 - [ ] 5.4 Extract reviewed-safe real-scope and intent-scope stages with no change to catalog behavior.
 - [ ] 5.5 Extract exact one-time and persistent-store availability stages while their authority owners stay fixed.

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -1219,18 +1219,35 @@ public class DispatchingToolExecutorTests
                     $"cd {alias} && inspect; head result.log",
                     "WorkingDirectory",
                     "/work"));
+            var context = CreateInteractivePersonalContext(
+                "signalr/causal-intent-symlink-target");
 
             var decision = await executor.EvaluateAuthorizationAsync(
                 call,
-                CreateInteractivePersonalContext("signalr/causal-intent-symlink-target"),
+                context,
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, decision.Outcome);
-            Assert.True(Assert.IsType<ToolApprovalContext>(decision.ApprovalContext).IsMessy);
+            var approval = Assert.IsType<ToolApprovalContext>(decision.ApprovalContext);
+            Assert.True(approval.IsMessy);
             Assert.Null(approvalService.LastRequest);
             Assert.DoesNotContain(
                 decision.ShellPolicyTrace.Rows,
                 row => row.ScopeRelation == ShellScopeRelation.UnderIntentRoot);
+
+            context.OneTimeApprovedToolName = call.Name;
+            context.SetOneTimeApprovedPatterns(OneTimeApprovalKeys.Create(approval));
+            var retry = await executor.EvaluateAuthorizationAsync(
+                call,
+                context,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(ToolAuthorizationOutcome.Allowed, retry.Outcome);
+            Assert.Equal(ToolAllowReason.OneTimeApproval, retry.AllowReason);
+            Assert.Null(approvalService.LastRequest);
+            var completion = Assert.Single(retry.ShellPolicyTrace.Rows);
+            Assert.Equal(ShellPolicyTraceStage.Completion, completion.Stage);
+            Assert.Equal(ShellPolicyTraceOutcome.Allow, completion.Outcome);
         }
         finally
         {

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -13,6 +13,8 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public sealed class ShellPolicyEvaluationTests
 {
+    public static bool IsPosix => !OperatingSystem.IsWindows();
+
     [Fact]
     public async Task Pipeline_stops_after_the_first_complete_result()
     {
@@ -125,6 +127,154 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Null(evaluation.CompletedTrace);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Pipeline_propagates_cancellation_before_inspecting_stages(bool hasNullStage)
+    {
+        var evaluation = CreateEvaluation();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        ShellPolicyStage[] stages = hasNullStage ? [null!] : [];
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, cancellation.Token));
+
+        Assert.Null(evaluation.TerminalDecision);
+        Assert.Null(evaluation.CompletedTrace);
+    }
+
+    [Fact]
+    public async Task Pipeline_does_not_invoke_stages_after_a_terminal_decision()
+    {
+        var evaluation = CreateEvaluation();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(prompt));
+        var stageVisited = false;
+        ShellPolicyStage[] stages =
+        [
+            (_, _) =>
+            {
+                stageVisited = true;
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Same(prompt, result.Decision);
+        Assert.False(stageVisited);
+    }
+
+    [Fact]
+    public async Task Pipeline_does_not_invoke_stages_after_a_terminal_fault()
+    {
+        var evaluation = CreateEvaluation();
+        Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Fault(ShellPolicyFault.InvalidCoverage));
+        var stageVisited = false;
+        ShellPolicyStage[] stages =
+        [
+            (_, _) =>
+            {
+                stageVisited = true;
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.False(stageVisited);
+    }
+
+    [Fact]
+    public async Task Pipeline_denies_when_a_stage_completes_then_returns_continue()
+    {
+        var evaluation = CreateEvaluation();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        ShellPolicyStage[] stages =
+        [
+            (state, _) =>
+            {
+                Assert.IsType<ShellPolicyStageResult.Complete>(state.Complete(prompt));
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, result.Reason);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+        Assert.Single(Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace).Rows);
+    }
+
+    [Fact]
+    public async Task Pipeline_denies_when_a_stage_completes_with_a_different_result()
+    {
+        var evaluation = CreateEvaluation();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        var deny = ToolAuthorizationDecision.Deny("shell_references_protected_path");
+        ShellPolicyStage[] stages =
+        [
+            (state, _) =>
+            {
+                Assert.IsType<ShellPolicyStageResult.Complete>(state.Complete(prompt));
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Complete(deny));
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, result.Reason);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
+    public async Task Pipeline_denies_when_a_stage_faults_then_returns_continue()
+    {
+        var evaluation = CreateEvaluation();
+        ShellPolicyStage[] stages =
+        [
+            (state, _) =>
+            {
+                Assert.IsType<ShellPolicyStageResult.Fault>(state.Fault(ShellPolicyFault.InvalidCoverage));
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, result.Reason);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
+    public async Task Pipeline_denies_when_a_stage_completes_then_throws()
+    {
+        var evaluation = CreateEvaluation();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        ShellPolicyStage[] stages =
+        [
+            (state, _) =>
+            {
+                Assert.IsType<ShellPolicyStageResult.Complete>(state.Complete(prompt));
+                throw new InvalidOperationException("stage failed");
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.StageException, result.Reason);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
     [Fact]
     public async Task Pipeline_rejects_an_invalid_fault_enum()
     {
@@ -141,6 +291,33 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(ShellPolicyFault.InvalidStageResult, result.Reason);
         Assert.Equal(ShellPolicyFault.InvalidStageResult, evaluation.TerminalFault);
         Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Pipeline_rejects_null_stages_and_results_before_later_stages(bool nullStage)
+    {
+        var evaluation = CreateEvaluation();
+        var laterStageVisited = false;
+        ShellPolicyStage[] stages =
+        [
+            nullStage
+                ? null!
+                : static (_, _) => ValueTask.FromResult<ShellPolicyStageResult>(null!),
+            (_, _) =>
+            {
+                laterStageVisited = true;
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, result.Reason);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+        Assert.False(laterStageVisited);
     }
 
     [Fact]
@@ -165,6 +342,28 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
         Assert.False(laterStageVisited);
         Assert.Single(Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext).Candidates!);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Syntax_stage_honors_exact_one_time_authority_before_prompting(bool isMessy)
+    {
+        var candidate = new ApprovalCandidate("git status", "/work");
+        var evaluation = CreateEvaluationWithExactOneTime(isMessy, candidate);
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(
+                evaluation,
+                [ShellPolicyInitialStages.Syntax(ShellTool.ToolName)],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, result.Decision.Outcome);
+        Assert.Equal(ToolAllowReason.OneTimeApproval, result.Decision.AllowReason);
+        var trace = Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace);
+        var completion = Assert.Single(trace.Rows);
+        Assert.Equal(ShellPolicyTraceStage.Completion, completion.Stage);
+        Assert.Equal(ShellPolicyTraceOutcome.Allow, completion.Outcome);
     }
 
     [Fact]
@@ -192,6 +391,75 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(ShellPolicyFault.InvalidProjection, result.Reason);
         Assert.False(laterStageVisited);
         Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
+    public async Task Protected_causal_path_stage_denies_before_a_later_stage()
+    {
+        var (evaluation, policy) = CreateCausalEvaluation(
+            "cd /tmp && inspect; head private.log",
+            ["/tmp/private.log"]);
+        var laterStageVisited = false;
+        ShellPolicyStage[] stages =
+        [
+            ShellPolicyInitialStages.ProtectedCausalPaths(policy),
+            (_, _) =>
+            {
+                laterStageVisited = true;
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ToolAuthorizationOutcome.Denied, result.Decision.Outcome);
+        Assert.Equal("shell_references_protected_path", result.Decision.DenyReason);
+        Assert.False(laterStageVisited);
+    }
+
+    [Fact]
+    public async Task Causal_directory_stage_continues_for_eligible_directories()
+    {
+        var (evaluation, policy) = CreateCausalEvaluation(
+            "cd /tmp && inspect; head result.log");
+
+        var result = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [ShellPolicyInitialStages.CausalDirectories(policy, ShellTool.ToolName)],
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Null(evaluation.TerminalDecision);
+    }
+
+    [SlopwatchSuppress("SW001", "This test requires native POSIX symbolic-link behavior.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only symbolic-link semantics")]
+    public async Task Causal_directory_stage_prompts_for_a_symbolic_link_directory()
+    {
+        var root = Directory.CreateTempSubdirectory("netclaw-policy-stage-");
+        try
+        {
+            var target = Path.Combine(root.FullName, "target");
+            var alias = Path.Combine(root.FullName, "alias");
+            Directory.CreateDirectory(target);
+            Directory.CreateSymbolicLink(alias, target);
+            var (evaluation, policy) = CreateCausalEvaluation(
+                $"cd {alias} && inspect; head result.log");
+
+            var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+                await ShellPolicyPipeline.RunAsync(
+                    evaluation,
+                    [ShellPolicyInitialStages.CausalDirectories(policy, ShellTool.ToolName)],
+                    TestContext.Current.CancellationToken));
+
+            Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
+            Assert.True(Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext).IsMessy);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
     }
 
     [Fact]
@@ -482,6 +750,23 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     private static ShellPolicyEvaluation CreateEvaluation(params ApprovalCandidate[] candidates)
+        => CreateEvaluation(
+            isMessy: false,
+            hasExactOneTimeApproval: false,
+            candidates: candidates);
+
+    private static ShellPolicyEvaluation CreateEvaluationWithExactOneTime(
+        bool isMessy,
+        params ApprovalCandidate[] candidates)
+        => CreateEvaluation(
+            isMessy,
+            hasExactOneTimeApproval: true,
+            candidates: candidates);
+
+    private static ShellPolicyEvaluation CreateEvaluation(
+        bool isMessy,
+        bool hasExactOneTimeApproval,
+        params ApprovalCandidate[] candidates)
     {
         var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
         var approvalContext = new ToolApprovalContext(
@@ -491,11 +776,18 @@ public sealed class ShellPolicyEvaluationTests
             candidates.Select(static candidate => candidate.Verb).ToArray(),
             [],
             Cwd: "/work",
+            IsMessy: isMessy,
             Candidates: candidates);
         var context = TestToolExecutionContext.CreateBound(
             "signalr/shell-policy-evaluation",
             "/work/session",
             TrustAudience.Personal);
+        if (hasExactOneTimeApproval)
+        {
+            context.OneTimeApprovedToolName = ShellTool.ToolName;
+            context.SetOneTimeApprovedPatterns(OneTimeApprovalKeys.Create(approvalContext));
+        }
+
         var created = ShellPolicyProjection.TryCreate(
             environment,
             new ShellApprovalMatcher(environment),
@@ -508,6 +800,52 @@ public sealed class ShellPolicyEvaluationTests
         Assert.True(created);
         Assert.NotNull(projection);
         return new ShellPolicyEvaluation(projection);
+    }
+
+    private static (ShellPolicyEvaluation Evaluation, ToolAccessPolicy Policy) CreateCausalEvaluation(
+        string command,
+        IEnumerable<string>? deniedPaths = null)
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+        var commandPolicy = new ShellCommandPolicy(environment);
+        var pathPolicy = new ToolPathPolicy(environment, deniedPaths ?? []);
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            commandPolicy,
+            pathPolicy);
+        var approvalContext = new ToolApprovalContext(
+            ShellTool.ToolName,
+            "shell command",
+            [],
+            [],
+            [],
+            Cwd: "/work",
+            IsMessy: true,
+            Candidates: []);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-causal-stage",
+            "/work/session",
+            TrustAudience.Personal);
+        var execution = commandPolicy.Analyze(command, "/work");
+        var created = ShellPolicyProjection.TryCreate(
+            environment,
+            new ShellApprovalMatcher(environment),
+            execution,
+            approvalContext,
+            context,
+            policy.IsSafePlatformTemporaryPath,
+            out var projection);
+
+        Assert.True(created);
+        Assert.NotNull(projection);
+        Assert.True(projection.HasCausalIntent);
+        return (new ShellPolicyEvaluation(projection), policy);
     }
 
     private static ApprovalCandidate BashCandidate(string verb) => new(verb, "/work")

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -14,6 +14,187 @@ namespace Netclaw.Actors.Tests.Tools;
 public sealed class ShellPolicyEvaluationTests
 {
     [Fact]
+    public async Task Pipeline_stops_after_the_first_complete_result()
+    {
+        var evaluation = CreateEvaluation();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        var visited = new List<int>();
+        ShellPolicyStage[] stages =
+        [
+            (_, _) =>
+            {
+                visited.Add(1);
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            },
+            (_, _) =>
+            {
+                visited.Add(2);
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Complete(prompt));
+            },
+            (_, _) =>
+            {
+                visited.Add(3);
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Same(prompt, result.Decision);
+        Assert.Equal([1, 2], visited);
+        Assert.Same(prompt, evaluation.TerminalDecision);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Single(evaluation.CompletedTrace.Rows);
+    }
+
+    [Fact]
+    public async Task Pipeline_stops_after_a_stage_fault()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var visited = new List<int>();
+        ShellPolicyStage[] stages =
+        [
+            (_, _) =>
+            {
+                visited.Add(1);
+                return ValueTask.FromResult<ShellPolicyStageResult>(
+                    new ShellPolicyStageResult.Fault(ShellPolicyFault.InvalidCoverage));
+            },
+            (_, _) =>
+            {
+                visited.Add(2);
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.Equal([1], visited);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, evaluation.TerminalFault);
+    }
+
+    [Fact]
+    public async Task Pipeline_preserves_coverage_trace_when_a_later_stage_throws()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        ShellPolicyStage[] stages =
+        [
+            (state, _) => ValueTask.FromResult(state.Cover(
+                candidate,
+                ShellCoverageKind.Session,
+                ShellPolicyReason.SessionGrant,
+                ShellScopeRelation.ThisChat)),
+            static (_, _) => throw new InvalidOperationException("stage failed")
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.StageException, result.Reason);
+        Assert.NotNull(evaluation.CompletedTrace);
+        Assert.Collection(
+            evaluation.CompletedTrace.Rows,
+            row => Assert.Equal(ShellPolicyTraceStage.StoredGrantMatch, row.Stage),
+            row =>
+            {
+                Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage);
+                Assert.Equal(ShellPolicyTraceOutcome.Deny, row.Outcome);
+            });
+    }
+
+    [Fact]
+    public async Task Pipeline_propagates_caller_cancellation()
+    {
+        var evaluation = CreateEvaluation();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        ShellPolicyStage[] stages =
+        [
+            static (_, _) => ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue())
+        ];
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, cancellation.Token));
+
+        Assert.Null(evaluation.TerminalDecision);
+        Assert.Null(evaluation.CompletedTrace);
+    }
+
+    [Fact]
+    public async Task Pipeline_rejects_an_invalid_fault_enum()
+    {
+        var evaluation = CreateEvaluation();
+        ShellPolicyStage[] stages =
+        [
+            static (_, _) => ValueTask.FromResult<ShellPolicyStageResult>(
+                new ShellPolicyStageResult.Fault((ShellPolicyFault)999))
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, result.Reason);
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, evaluation.TerminalFault);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
+    public async Task Syntax_stage_prompts_before_a_later_stage_for_untyped_candidates()
+    {
+        var candidate = new ApprovalCandidate("git status", "/work");
+        var evaluation = CreateEvaluation(candidate);
+        var laterStageVisited = false;
+        ShellPolicyStage[] stages =
+        [
+            ShellPolicyInitialStages.Syntax(ShellTool.ToolName),
+            (_, _) =>
+            {
+                laterStageVisited = true;
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
+        Assert.False(laterStageVisited);
+        Assert.Single(Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext).Candidates!);
+    }
+
+    [Fact]
+    public async Task Syntax_stage_faults_before_a_later_stage_for_invalid_tokens()
+    {
+        var candidate = BashCandidate("git status") with
+        {
+            VerbTokens = Array.AsReadOnly(["git status"])
+        };
+        var evaluation = CreateEvaluation(candidate);
+        var laterStageVisited = false;
+        ShellPolicyStage[] stages =
+        [
+            ShellPolicyInitialStages.Syntax(ShellTool.ToolName),
+            (_, _) =>
+            {
+                laterStageVisited = true;
+                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+            }
+        ];
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidProjection, result.Reason);
+        Assert.False(laterStageVisited);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
     public void Coverage_and_trace_change_together()
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -144,6 +144,34 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Null(evaluation.CompletedTrace);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Pipeline_propagates_cancellation_set_by_a_stage(bool throwsAfterCancellation)
+    {
+        var evaluation = CreateEvaluation();
+        using var cancellation = new CancellationTokenSource();
+        var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
+        ShellPolicyStage[] stages =
+        [
+            (_, _) =>
+            {
+                cancellation.Cancel();
+                if (throwsAfterCancellation)
+                    throw new InvalidOperationException("stage failed after cancellation");
+
+                return ValueTask.FromResult<ShellPolicyStageResult>(
+                    new ShellPolicyStageResult.Complete(prompt));
+            }
+        ];
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await ShellPolicyPipeline.RunAsync(evaluation, stages, cancellation.Token));
+
+        Assert.Null(evaluation.TerminalDecision);
+        Assert.Null(evaluation.CompletedTrace);
+    }
+
     [Fact]
     public async Task Pipeline_does_not_invoke_stages_after_a_terminal_decision()
     {

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -130,60 +130,17 @@ internal sealed class ShellPolicyCoordinator(
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
-        if (projection.ApprovalContext.IsMessy && !projection.HasCausalIntent)
-            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, [], trace);
-
-        if (projection.Candidates.Count == 0)
-            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, [], trace);
-
-        var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
-            ? ApprovalShell.Bash
-            : ApprovalShell.PowerShell;
-        if (projection.Candidates.Any(candidate => candidate.Candidate.Shell is null
-                                                    || candidate.Candidate.VerbTokens is null))
-        {
-            return CompleteOneTimeOrPrompt(toolCall.Name, projection, projection.ApprovalContext, [], trace);
-        }
-
-        if (projection.Candidates.Any(candidate =>
-                candidate.Candidate.Shell != expectedShell
-                || candidate.Candidate.VerbTokens!.Count == 0
-                || candidate.Candidate.VerbTokens!.Any(static token =>
-                    token.Length == 0 || token.Any(char.IsWhiteSpace))))
-        {
-            return CompleteWithTrace(
-                ToolAuthorizationDecision.Deny("internal_policy_failure"),
-                trace);
-        }
-
-        if (projection.Candidates.Any(candidate =>
-                candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
-                && candidate.IntentDirectory is { } intentDirectory
-                && candidate.SourceOccurrence is { } sourceOccurrence
-                && policy.CausalIntentReferencesProtectedPath(
-                    sourceOccurrence,
-                    intentDirectory,
-                    candidate.IntentFallbackDirectories)))
-        {
-            return CompleteWithTrace(
-                ToolAuthorizationDecision.Deny("shell_references_protected_path"),
-                trace);
-        }
-
-        if (projection.Candidates.Any(candidate =>
-                candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
-                && candidate.IntentDirectory is { } intentDirectory
-                && !policy.AreCausalIntentDirectoriesEligible(
-                    intentDirectory,
-                    candidate.IntentFallbackDirectories)))
-        {
-            return CompleteOneTimeOrPrompt(
-                toolCall.Name,
-                projection,
-                projection.ApprovalContext,
-                [],
-                trace);
-        }
+        var evaluation = new ShellPolicyEvaluation(projection);
+        var initialResult = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [
+                ShellPolicyInitialStages.Syntax(toolCall.Name),
+                ShellPolicyInitialStages.ProtectedCausalPaths(policy),
+                ShellPolicyInitialStages.CausalDirectories(policy, toolCall.Name)
+            ],
+            cancellationToken);
+        if (initialResult is not ShellPolicyStageResult.Continue)
+            return CompleteEvaluation(evaluation);
 
         var coverage = new ShellCoverageSet(projection.Candidates);
         foreach (var candidate in projection.Candidates.Where(item =>
@@ -421,19 +378,6 @@ internal sealed class ShellPolicyCoordinator(
         _ => throw new InvalidOperationException("Invalid actor coverage kind."),
     };
 
-    private static ToolAuthorizationDecision CompleteOneTimeOrPrompt(
-        string toolName,
-        ShellPolicyProjection projection,
-        ToolApprovalContext approvalContext,
-        IReadOnlyList<ToolApprovalMatch> approvalMatches,
-        ShellPolicyDecisionTraceBuilder trace)
-    {
-        var decision = projection.HasExactOneTimeApproval(toolName, approvalContext)
-            ? ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval, approvalMatches)
-            : ToolAuthorizationDecision.RequiresApproval(approvalContext, approvalMatches);
-        return CompleteWithTrace(decision, trace);
-    }
-
     private static ToolAuthorizationDecision Complete(
         ToolAccessDecision decision,
         IReadOnlyList<ToolApprovalMatch> approvalMatches,
@@ -470,6 +414,15 @@ internal sealed class ShellPolicyCoordinator(
         ToolAuthorizationDecision decision,
         ShellPolicyDecisionTraceBuilder trace)
         => decision.WithShellPolicyTrace(trace.Complete(decision));
+
+    private static ToolAuthorizationDecision CompleteEvaluation(ShellPolicyEvaluation evaluation)
+    {
+        var decision = evaluation.TerminalDecision
+                       ?? throw new InvalidOperationException("Shell policy stage did not set a decision.");
+        var completedTrace = evaluation.CompletedTrace
+                             ?? throw new InvalidOperationException("Shell policy stage did not complete its trace.");
+        return decision.WithShellPolicyTrace(completedTrace);
+    }
 
     private static string FormatApprovalMatches(IReadOnlyList<ToolApprovalMatch> matches)
         => string.Join(", ", matches.Select(match =>

--- a/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
@@ -160,6 +160,17 @@ internal sealed class ShellPolicyDecisionTraceBuilder
         return _completedTrace;
     }
 
+    internal ShellPolicyDecisionTrace ReplaceCompletion(ToolAuthorizationDecision decision)
+    {
+        if (_completedTrace is not null)
+        {
+            _rows.RemoveAt(_rows.Count - 1);
+            _completedTrace = null;
+        }
+
+        return Complete(decision);
+    }
+
     internal static string SanitizeText(string value)
     {
         // A partial private-key block cannot be recognized after truncation.

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -158,9 +158,11 @@ internal static class ShellPolicyPipeline
             }
             catch (Exception)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 return evaluation.InvalidateStage(ShellPolicyFault.StageException);
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             switch (result)
             {
                 case ShellPolicyStageResult.Continue

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -84,12 +84,36 @@ internal abstract record ShellPolicyStageResult
     internal sealed record Complete : ShellPolicyStageResult
     {
         internal Complete(ToolAuthorizationDecision decision)
+            : this(decision, allowsUncoveredOneTime: false)
+        {
+        }
+
+        private Complete(
+            ToolAuthorizationDecision decision,
+            bool allowsUncoveredOneTime)
         {
             ArgumentNullException.ThrowIfNull(decision);
             Decision = decision;
+            AllowsUncoveredOneTime = allowsUncoveredOneTime;
         }
 
         internal ToolAuthorizationDecision Decision { get; }
+
+        internal bool AllowsUncoveredOneTime { get; }
+
+        internal static Complete ExactOneTime(ToolAuthorizationDecision decision)
+        {
+            ArgumentNullException.ThrowIfNull(decision);
+            if (decision.Outcome != ToolAuthorizationOutcome.Allowed
+                || decision.AllowReason != ToolAllowReason.OneTimeApproval)
+            {
+                throw new ArgumentException(
+                    "An uncovered completion requires an exact one-time allow.",
+                    nameof(decision));
+            }
+
+            return new Complete(decision, allowsUncoveredOneTime: true);
+        }
     }
 
     internal sealed record Fault(ShellPolicyFault Reason)
@@ -110,12 +134,19 @@ internal static class ShellPolicyPipeline
         ArgumentNullException.ThrowIfNull(evaluation);
         ArgumentNullException.ThrowIfNull(stages);
 
+        cancellationToken.ThrowIfCancellationRequested();
+        if (evaluation.TerminalFault is { } terminalFault)
+            return new ShellPolicyStageResult.Fault(terminalFault);
+
+        if (evaluation.TerminalDecision is { } terminalDecision)
+            return new ShellPolicyStageResult.Complete(terminalDecision);
+
         foreach (var stage in stages)
         {
-            if (stage is null)
-                return evaluation.Fault(ShellPolicyFault.InvalidStageResult);
-
             cancellationToken.ThrowIfCancellationRequested();
+            if (stage is null)
+                return evaluation.InvalidateStage(ShellPolicyFault.InvalidStageResult);
+
             ShellPolicyStageResult? result;
             try
             {
@@ -127,7 +158,7 @@ internal static class ShellPolicyPipeline
             }
             catch (Exception)
             {
-                return evaluation.Fault(ShellPolicyFault.StageException);
+                return evaluation.InvalidateStage(ShellPolicyFault.StageException);
             }
 
             switch (result)
@@ -137,7 +168,9 @@ internal static class ShellPolicyPipeline
                     continue;
                 case ShellPolicyStageResult.Complete complete
                     when evaluation.TerminalDecision is null:
-                    return evaluation.Complete(complete.Decision);
+                    return evaluation.Complete(
+                        complete.Decision,
+                        complete.AllowsUncoveredOneTime);
                 case ShellPolicyStageResult.Complete complete
                     when ReferenceEquals(evaluation.TerminalDecision, complete.Decision):
                     return complete;
@@ -148,7 +181,7 @@ internal static class ShellPolicyPipeline
                     when evaluation.TerminalDecision is null:
                     return evaluation.Fault(fault.Reason);
                 default:
-                    return evaluation.Fault(ShellPolicyFault.InvalidStageResult);
+                    return evaluation.InvalidateStage(ShellPolicyFault.InvalidStageResult);
             }
         }
 
@@ -282,7 +315,9 @@ internal sealed class ShellPolicyEvaluation
         return new ShellPolicyStageResult.Continue();
     }
 
-    internal ShellPolicyStageResult Complete(ToolAuthorizationDecision decision)
+    internal ShellPolicyStageResult Complete(
+        ToolAuthorizationDecision decision,
+        bool allowsUncoveredOneTime = false)
     {
         ArgumentNullException.ThrowIfNull(decision);
 
@@ -291,7 +326,9 @@ internal sealed class ShellPolicyEvaluation
 
         var mayComplete = decision.Outcome switch
         {
-            ToolAuthorizationOutcome.Allowed => AllCovered,
+            ToolAuthorizationOutcome.Allowed => AllCovered
+                                                || allowsUncoveredOneTime
+                                                && decision.AllowReason == ToolAllowReason.OneTimeApproval,
             ToolAuthorizationOutcome.RequiresApproval => _candidates.Length == 0 || !AllCovered,
             ToolAuthorizationOutcome.Denied => true,
             _ => false,
@@ -316,6 +353,18 @@ internal sealed class ShellPolicyEvaluation
             return new ShellPolicyStageResult.Complete(_terminalDecision);
 
         return Fail(reason);
+    }
+
+    internal ShellPolicyStageResult.Fault InvalidateStage(ShellPolicyFault reason)
+    {
+        if (!Enum.IsDefined(reason))
+            reason = ShellPolicyFault.InvalidStageResult;
+
+        var decision = ToolAuthorizationDecision.Deny("internal_policy_failure");
+        _completedTrace = _trace.ReplaceCompletion(decision);
+        _terminalDecision = decision;
+        _terminalFault = reason;
+        return new ShellPolicyStageResult.Fault(reason);
     }
 
     private ShellPolicyStageResult.Fault Fail(ShellPolicyFault reason)

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -14,6 +14,9 @@ internal enum ShellPolicyFault
     InvalidCoverage = 2,
     CoverageAlreadyAssigned = 3,
     InvalidTerminalTransition = 4,
+    InvalidStageResult = 5,
+    StageException = 6,
+    InvalidProjection = 7,
 }
 
 internal abstract record ShellPolicyPreflightResult
@@ -91,6 +94,66 @@ internal abstract record ShellPolicyStageResult
 
     internal sealed record Fault(ShellPolicyFault Reason)
         : ShellPolicyStageResult;
+}
+
+internal delegate ValueTask<ShellPolicyStageResult> ShellPolicyStage(
+    ShellPolicyEvaluation evaluation,
+    CancellationToken cancellationToken);
+
+internal static class ShellPolicyPipeline
+{
+    internal static async ValueTask<ShellPolicyStageResult> RunAsync(
+        ShellPolicyEvaluation evaluation,
+        IReadOnlyList<ShellPolicyStage> stages,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(evaluation);
+        ArgumentNullException.ThrowIfNull(stages);
+
+        foreach (var stage in stages)
+        {
+            if (stage is null)
+                return evaluation.Fault(ShellPolicyFault.InvalidStageResult);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            ShellPolicyStageResult? result;
+            try
+            {
+                result = await stage(evaluation, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                return evaluation.Fault(ShellPolicyFault.StageException);
+            }
+
+            switch (result)
+            {
+                case ShellPolicyStageResult.Continue
+                    when evaluation.TerminalDecision is null:
+                    continue;
+                case ShellPolicyStageResult.Complete complete
+                    when evaluation.TerminalDecision is null:
+                    return evaluation.Complete(complete.Decision);
+                case ShellPolicyStageResult.Complete complete
+                    when ReferenceEquals(evaluation.TerminalDecision, complete.Decision):
+                    return complete;
+                case ShellPolicyStageResult.Fault fault
+                    when evaluation.TerminalFault == fault.Reason:
+                    return fault;
+                case ShellPolicyStageResult.Fault fault
+                    when evaluation.TerminalDecision is null:
+                    return evaluation.Fault(fault.Reason);
+                default:
+                    return evaluation.Fault(ShellPolicyFault.InvalidStageResult);
+            }
+        }
+
+        return new ShellPolicyStageResult.Continue();
+    }
 }
 
 internal sealed record ShellPolicyAuthorization
@@ -239,6 +302,20 @@ internal sealed class ShellPolicyEvaluation
         _completedTrace = _trace.Complete(decision);
         _terminalDecision = decision;
         return new ShellPolicyStageResult.Complete(decision);
+    }
+
+    internal ShellPolicyStageResult Fault(ShellPolicyFault reason)
+    {
+        if (!Enum.IsDefined(reason))
+            reason = ShellPolicyFault.InvalidStageResult;
+
+        if (_terminalFault is { } terminalFault)
+            return new ShellPolicyStageResult.Fault(terminalFault);
+
+        if (_terminalDecision is not null)
+            return new ShellPolicyStageResult.Complete(_terminalDecision);
+
+        return Fail(reason);
     }
 
     private ShellPolicyStageResult.Fault Fail(ShellPolicyFault reason)

--- a/src/Netclaw.Actors/Tools/ShellPolicyInitialStages.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyInitialStages.cs
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyInitialStages.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+internal static class ShellPolicyInitialStages
+{
+    internal static ShellPolicyStage Syntax(string toolName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+        return (evaluation, _) => ValueTask.FromResult(EvaluateSyntax(evaluation, toolName));
+    }
+
+    internal static ShellPolicyStage ProtectedCausalPaths(ToolAccessPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        return (evaluation, _) => ValueTask.FromResult(EvaluateProtectedCausalPaths(evaluation, policy));
+    }
+
+    internal static ShellPolicyStage CausalDirectories(
+        ToolAccessPolicy policy,
+        string toolName)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+        return (evaluation, _) => ValueTask.FromResult(
+            EvaluateCausalDirectories(evaluation, policy, toolName));
+    }
+
+    private static ShellPolicyStageResult EvaluateSyntax(
+        ShellPolicyEvaluation evaluation,
+        string toolName)
+    {
+        var projection = evaluation.Projection;
+        if (projection.ApprovalContext.IsMessy && !projection.HasCausalIntent)
+            return new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(projection, toolName));
+
+        if (projection.Candidates.Count == 0)
+            return new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(projection, toolName));
+
+        var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
+            ? ApprovalShell.Bash
+            : ApprovalShell.PowerShell;
+        if (projection.Candidates.Any(static candidate =>
+                candidate.Candidate.Shell is null
+                || candidate.Candidate.VerbTokens is null))
+        {
+            return new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(projection, toolName));
+        }
+
+        if (projection.Candidates.Any(candidate =>
+                candidate.Candidate.Shell != expectedShell
+                || candidate.Candidate.VerbTokens!.Count == 0
+                || candidate.Candidate.VerbTokens.Any(static token =>
+                    token.Length == 0 || token.Any(char.IsWhiteSpace))))
+        {
+            return new ShellPolicyStageResult.Fault(ShellPolicyFault.InvalidProjection);
+        }
+
+        return new ShellPolicyStageResult.Continue();
+    }
+
+    private static ShellPolicyStageResult EvaluateProtectedCausalPaths(
+        ShellPolicyEvaluation evaluation,
+        ToolAccessPolicy policy)
+        => evaluation.Candidates.Any(candidate =>
+            candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
+            && candidate.IntentDirectory is { } intentDirectory
+            && candidate.SourceOccurrence is { } sourceOccurrence
+            && policy.CausalIntentReferencesProtectedPath(
+                sourceOccurrence,
+                intentDirectory,
+                candidate.IntentFallbackDirectories))
+            ? new ShellPolicyStageResult.Complete(
+                ToolAuthorizationDecision.Deny("shell_references_protected_path"))
+            : new ShellPolicyStageResult.Continue();
+
+    private static ShellPolicyStageResult EvaluateCausalDirectories(
+        ShellPolicyEvaluation evaluation,
+        ToolAccessPolicy policy,
+        string toolName)
+        => evaluation.Candidates.Any(candidate =>
+            candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
+            && candidate.IntentDirectory is { } intentDirectory
+            && !policy.AreCausalIntentDirectoriesEligible(
+                intentDirectory,
+                candidate.IntentFallbackDirectories))
+            ? new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(evaluation.Projection, toolName))
+            : new ShellPolicyStageResult.Continue();
+
+    private static ToolAuthorizationDecision CreateOneTimeOrPrompt(
+        ShellPolicyProjection projection,
+        string toolName)
+        => projection.HasExactOneTimeApproval(toolName, projection.ApprovalContext)
+            ? ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval)
+            : ToolAuthorizationDecision.RequiresApproval(projection.ApprovalContext);
+}

--- a/src/Netclaw.Actors/Tools/ShellPolicyInitialStages.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyInitialStages.cs
@@ -39,10 +39,10 @@ internal static class ShellPolicyInitialStages
     {
         var projection = evaluation.Projection;
         if (projection.ApprovalContext.IsMessy && !projection.HasCausalIntent)
-            return new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(projection, toolName));
+            return CreateOneTimeOrPrompt(projection, toolName);
 
         if (projection.Candidates.Count == 0)
-            return new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(projection, toolName));
+            return CreateOneTimeOrPrompt(projection, toolName);
 
         var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
             ? ApprovalShell.Bash
@@ -51,7 +51,7 @@ internal static class ShellPolicyInitialStages
                 candidate.Candidate.Shell is null
                 || candidate.Candidate.VerbTokens is null))
         {
-            return new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(projection, toolName));
+            return CreateOneTimeOrPrompt(projection, toolName);
         }
 
         if (projection.Candidates.Any(candidate =>
@@ -91,13 +91,15 @@ internal static class ShellPolicyInitialStages
             && !policy.AreCausalIntentDirectoriesEligible(
                 intentDirectory,
                 candidate.IntentFallbackDirectories))
-            ? new ShellPolicyStageResult.Complete(CreateOneTimeOrPrompt(evaluation.Projection, toolName))
+            ? CreateOneTimeOrPrompt(evaluation.Projection, toolName)
             : new ShellPolicyStageResult.Continue();
 
-    private static ToolAuthorizationDecision CreateOneTimeOrPrompt(
+    private static ShellPolicyStageResult CreateOneTimeOrPrompt(
         ShellPolicyProjection projection,
         string toolName)
         => projection.HasExactOneTimeApproval(toolName, projection.ApprovalContext)
-            ? ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval)
-            : ToolAuthorizationDecision.RequiresApproval(projection.ApprovalContext);
+            ? ShellPolicyStageResult.Complete.ExactOneTime(
+                ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval))
+            : new ShellPolicyStageResult.Complete(
+                ToolAuthorizationDecision.RequiresApproval(projection.ApprovalContext));
 }


### PR DESCRIPTION
## Summary

- add one call-local runner that stops at the first complete or fault result
- extract syntax, protected causal path, and causal directory checks from the coordinator
- preserve exact one-time retry and completion-only trace behavior
- fail closed for malformed stage output while propagating caller cancellation

## Validation

- Release build: 0 warnings, 0 errors
- full local suite: 7,377 passed, 15 expected integration skips
- focused policy contracts: 423 passed
- ShellApprovalEvidenceContractTests: 15 passed
- headers, formatting, strict OpenSpec, diff check, and changed-file Slopwatch passed
- adversarial review: PASS at 20193027856cc351658c564e03f21a99c9979d98

## Scope

This completes OpenSpec tasks 5.1 and 5.2. Later policy stages remain separate bounded slices.