### PR TITLE
Extract reviewed-safe shell policy stages

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -39,7 +39,7 @@
 - [x] 5.1 Add one pipeline runner that stops on the first complete or fault result.
 - [x] 5.2 Extract syntax, protected-path, causal-path, and causal-directory stages with no change to precedence.
 - [x] 5.3 Extract actor-evidence and approval-exempt stages with no change to candidate order or request count.
-- [ ] 5.4 Extract reviewed-safe real-scope and intent-scope stages with no change to catalog behavior.
+- [x] 5.4 Extract reviewed-safe real-scope and intent-scope stages with no change to catalog behavior.
 - [ ] 5.5 Extract exact one-time and persistent-store availability stages while their authority owners stay fixed.
 - [ ] 5.6 Extract final correction, prompt, and allow completion into one terminal stage.
 - [ ] 5.7 Add stage-isolation tests and terminal-overlap tests after each extraction.

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -6,6 +6,7 @@
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
+using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
 
@@ -424,7 +425,7 @@ public sealed class ShellPolicyEvaluationTests
     [Fact]
     public async Task Protected_causal_path_stage_denies_before_a_later_stage()
     {
-        var (evaluation, policy) = CreateCausalEvaluation(
+        var (evaluation, policy, _) = CreateCausalEvaluation(
             "cd /tmp && inspect; head private.log",
             ["/tmp/private.log"]);
         var laterStageVisited = false;
@@ -449,7 +450,7 @@ public sealed class ShellPolicyEvaluationTests
     [Fact]
     public async Task Causal_directory_stage_continues_for_eligible_directories()
     {
-        var (evaluation, policy) = CreateCausalEvaluation(
+        var (evaluation, policy, _) = CreateCausalEvaluation(
             "cd /tmp && inspect; head result.log");
 
         var result = await ShellPolicyPipeline.RunAsync(
@@ -472,7 +473,7 @@ public sealed class ShellPolicyEvaluationTests
             var alias = Path.Combine(root.FullName, "alias");
             Directory.CreateDirectory(target);
             Directory.CreateSymbolicLink(alias, target);
-            var (evaluation, policy) = CreateCausalEvaluation(
+            var (evaluation, policy, _) = CreateCausalEvaluation(
                 $"cd {alias} && inspect; head result.log");
 
             var result = Assert.IsType<ShellPolicyStageResult.Complete>(
@@ -655,6 +656,84 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(
             Enum.Parse<ShellCoverageKind>(expectedCoverageName),
             evaluation.CoverageFor(candidate.Id).Kind);
+    }
+
+    [Theory]
+    [InlineData(false, nameof(ShellCoverageKind.Uncovered))]
+    [InlineData(true, nameof(ShellCoverageKind.ReviewedSafePolicy))]
+    public async Task Reviewed_safe_real_scope_stage_requires_interactive_approval(
+        bool interactive,
+        string expectedCoverageName)
+    {
+        var (evaluation, policy, context) = CreateReviewedSafeEvaluation(
+            "head README.md",
+            interactive,
+            "head");
+        var candidate = Assert.Single(evaluation.Candidates);
+
+        var result = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [ShellPolicyReviewedSafeStages.RealScope(policy, context.Invocation)],
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(
+            Enum.Parse<ShellCoverageKind>(expectedCoverageName),
+            evaluation.CoverageFor(candidate.Id).Kind);
+    }
+
+    [SlopwatchSuppress("SW001", "This test pins Bash causal approval intent on POSIX hosts.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only shell directory semantics")]
+    public async Task Reviewed_safe_intent_stage_requires_real_prerequisite_coverage()
+    {
+        var (evaluation, policy, context) = CreateCausalEvaluation(
+            "cd /tmp && inspect; head result.log",
+            safeVerbs: SafeVerbList.FromVerbs(ApprovalShell.Bash, ["head"]));
+        var consumer = Assert.Single(
+            evaluation.Candidates,
+            candidate => candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer);
+        Assert.NotEmpty(consumer.IntentPrerequisites);
+
+        var beforeCoverage = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [ShellPolicyReviewedSafeStages.IntentScope(policy, context.Invocation)],
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(beforeCoverage);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(consumer.Id).Kind);
+
+        foreach (var prerequisiteId in consumer.IntentPrerequisites)
+        {
+            var prerequisite = evaluation.Candidates[prerequisiteId.Value];
+            Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+                prerequisite,
+                ShellCoverageKind.Session,
+                ShellPolicyReason.SessionGrant,
+                ShellScopeRelation.ThisChat));
+        }
+
+        var afterCoverage = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [
+                ShellPolicyReviewedSafeStages.RealScope(policy, context.Invocation),
+                ShellPolicyReviewedSafeStages.IntentScope(policy, context.Invocation)
+            ],
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(afterCoverage);
+        Assert.Equal(
+            ShellCoverageKind.ReviewedSafePolicy,
+            evaluation.CoverageFor(consumer.Id).Kind);
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval)));
+        Assert.Contains(
+            Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace).Rows,
+            row => row is
+            {
+                Stage: ShellPolicyTraceStage.ReviewedSafePolicy,
+                Reason: ShellPolicyTraceReason.ReviewedSafePhrase,
+                ScopeRelation: ShellScopeRelation.UnderIntentRoot
+            });
     }
 
     [Fact]
@@ -997,9 +1076,13 @@ public sealed class ShellPolicyEvaluationTests
         return new ShellPolicyEvaluation(projection);
     }
 
-    private static (ShellPolicyEvaluation Evaluation, ToolAccessPolicy Policy) CreateCausalEvaluation(
+    private static (
+        ShellPolicyEvaluation Evaluation,
+        ToolAccessPolicy Policy,
+        ToolExecutionContext Context) CreateCausalEvaluation(
         string command,
-        IEnumerable<string>? deniedPaths = null)
+        IEnumerable<string>? deniedPaths = null,
+        SafeVerbList? safeVerbs = null)
     {
         var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
         var commandPolicy = new ShellCommandPolicy(environment);
@@ -1013,7 +1096,8 @@ public sealed class ShellPolicyEvaluationTests
                 ShellExecutionMode.HostAllowed,
                 UsedStrictFallback: false),
             commandPolicy,
-            pathPolicy);
+            pathPolicy,
+            safeVerbs: safeVerbs);
         var approvalContext = new ToolApprovalContext(
             ShellTool.ToolName,
             "shell command",
@@ -1040,7 +1124,71 @@ public sealed class ShellPolicyEvaluationTests
         Assert.True(created);
         Assert.NotNull(projection);
         Assert.True(projection.HasCausalIntent);
-        return (new ShellPolicyEvaluation(projection), policy);
+        return (new ShellPolicyEvaluation(projection), policy, context);
+    }
+
+    private static (
+        ShellPolicyEvaluation Evaluation,
+        ToolAccessPolicy Policy,
+        ToolExecutionContext Context) CreateReviewedSafeEvaluation(
+        string command,
+        bool interactive,
+        params string[] safeVerbs)
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+        var commandPolicy = new ShellCommandPolicy(environment);
+        var pathPolicy = new ToolPathPolicy(environment, []);
+        var policy = new ToolAccessPolicy(
+            new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed },
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            commandPolicy,
+            pathPolicy,
+            safeVerbs: SafeVerbList.FromVerbs(ApprovalShell.Bash, safeVerbs));
+        var matcher = new ShellApprovalMatcher(environment);
+        var arguments = ToolInput.Create(
+            "Command",
+            command,
+            "WorkingDirectory",
+            "/work");
+        var execution = commandPolicy.Analyze(command, "/work");
+        var approval = matcher.AnalyzeInvocation(
+            new ToolName(ShellTool.ToolName),
+            arguments,
+            execution);
+        var approvalContext = new ToolApprovalContext(
+            ShellTool.ToolName,
+            approval.DisplayText,
+            approval.Patterns,
+            approval.Candidates.Select(static candidate => candidate.Verb).ToArray(),
+            [],
+            Cwd: "/work",
+            approval.IsMessy,
+            approval.Candidates);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-reviewed-safe-stage",
+            "/work/session",
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                ProjectDirectory = "/work",
+                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(interactive)
+            });
+        var created = ShellPolicyProjection.TryCreate(
+            environment,
+            matcher,
+            execution,
+            approvalContext,
+            context,
+            static _ => false,
+            out var projection);
+
+        Assert.True(created);
+        Assert.NotNull(projection);
+        return (new ShellPolicyEvaluation(projection), policy, context);
     }
 
     private static ApprovalCandidate BashCandidate(string verb) => new(verb, "/work")

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -169,7 +169,9 @@ internal sealed class ShellPolicyCoordinator(
                     ToApprovalSessionId(context.SessionId),
                     context.Audience,
                     new ToolName(tool.Name)),
-                ShellPolicyGrantStages.ApprovalExemptSideEffects(_approvalEvidence.IsAvailable)
+                ShellPolicyGrantStages.ApprovalExemptSideEffects(_approvalEvidence.IsAvailable),
+                ShellPolicyReviewedSafeStages.RealScope(policy, context.Invocation),
+                ShellPolicyReviewedSafeStages.IntentScope(policy, context.Invocation)
             ],
             cancellationToken);
         if (initialResult is not ShellPolicyStageResult.Continue)
@@ -184,56 +186,6 @@ internal sealed class ShellPolicyCoordinator(
 
         var grantCandidates = projection.GrantCandidates;
         var approvalMatches = evaluation.ApprovalMatches;
-
-        var canUseReviewedSafePolicy =
-            projection.RunScope.InteractiveApproval is InteractiveApprovalCapability.Available;
-        foreach (var candidate in grantCandidates.Where(candidate =>
-                     canUseReviewedSafePolicy
-                     && candidate.CanUseRealReviewedSafePolicy
-                     && !evaluation.IsCovered(candidate.Id)))
-        {
-            if (policy.IsReviewedSafeCandidate(
-                    candidate.Candidate,
-                    candidate.SourceOccurrence,
-                    projection.ApprovalContext.Cwd,
-                    context.Invocation))
-            {
-                var coverageResult = evaluation.Cover(
-                    candidate,
-                    ShellCoverageKind.ReviewedSafePolicy,
-                    ShellPolicyReason.ReviewedSafePhrase,
-                    ShellScopeRelation.UnderRealRoot);
-                if (coverageResult is not ShellPolicyStageResult.Continue)
-                    return CompleteEvaluation(evaluation);
-            }
-        }
-
-        foreach (var candidate in projection.Candidates.Where(candidate =>
-                     canUseReviewedSafePolicy
-                     && candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
-                     && !evaluation.IsCovered(candidate.Id)))
-        {
-            if (candidate.IntentDirectory is null
-                || candidate.IntentPrerequisites.Count == 0
-                || candidate.IntentPrerequisites.Any(prerequisite =>
-                    !evaluation.IsCovered(prerequisite))
-                || !policy.IsReviewedSafeIntentCandidate(
-                    candidate.Candidate,
-                    candidate.SourceOccurrence,
-                    candidate.IntentDirectory,
-                    context.Invocation))
-            {
-                continue;
-            }
-
-            var coverageResult = evaluation.Cover(
-                candidate,
-                ShellCoverageKind.ReviewedSafePolicy,
-                ShellPolicyReason.ReviewedSafePhrase,
-                ShellScopeRelation.UnderIntentRoot);
-            if (coverageResult is not ShellPolicyStageResult.Continue)
-                return CompleteEvaluation(evaluation);
-        }
 
         var uncovered = evaluation.UncoveredCandidates;
         var oneTimeApplied = false;

--- a/src/Netclaw.Actors/Tools/ShellPolicyReviewedSafeStages.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyReviewedSafeStages.cs
@@ -1,0 +1,105 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyReviewedSafeStages.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+internal static class ShellPolicyReviewedSafeStages
+{
+    internal static ShellPolicyStage RealScope(
+        ToolAccessPolicy policy,
+        ToolInvocationContext invocation)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(invocation);
+        return (evaluation, _) => ValueTask.FromResult(
+            EvaluateRealScope(evaluation, policy, invocation));
+    }
+
+    internal static ShellPolicyStage IntentScope(
+        ToolAccessPolicy policy,
+        ToolInvocationContext invocation)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(invocation);
+        return (evaluation, _) => ValueTask.FromResult(
+            EvaluateIntentScope(evaluation, policy, invocation));
+    }
+
+    private static ShellPolicyStageResult EvaluateRealScope(
+        ShellPolicyEvaluation evaluation,
+        ToolAccessPolicy policy,
+        ToolInvocationContext invocation)
+    {
+        if (!CanUseReviewedSafePolicy(evaluation))
+            return new ShellPolicyStageResult.Continue();
+
+        foreach (var candidate in evaluation.Projection.GrantCandidates.Where(candidate =>
+                     candidate.CanUseRealReviewedSafePolicy
+                     && !evaluation.IsCovered(candidate.Id)))
+        {
+            if (!policy.IsReviewedSafeCandidate(
+                    candidate.Candidate,
+                    candidate.SourceOccurrence,
+                    evaluation.Projection.ApprovalContext.Cwd,
+                    invocation))
+            {
+                continue;
+            }
+
+            var result = evaluation.Cover(
+                candidate,
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyReason.ReviewedSafePhrase,
+                ShellScopeRelation.UnderRealRoot);
+            if (result is not ShellPolicyStageResult.Continue)
+                return result;
+        }
+
+        return new ShellPolicyStageResult.Continue();
+    }
+
+    private static ShellPolicyStageResult EvaluateIntentScope(
+        ShellPolicyEvaluation evaluation,
+        ToolAccessPolicy policy,
+        ToolInvocationContext invocation)
+    {
+        if (!CanUseReviewedSafePolicy(evaluation))
+            return new ShellPolicyStageResult.Continue();
+
+        foreach (var candidate in evaluation.Candidates.Where(candidate =>
+                     candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
+                     && !evaluation.IsCovered(candidate.Id)))
+        {
+            if (candidate.IntentDirectory is null
+                || candidate.IntentPrerequisites.Count == 0
+                || candidate.IntentPrerequisites.Any(prerequisite =>
+                    !evaluation.IsCovered(prerequisite))
+                || !policy.IsReviewedSafeIntentCandidate(
+                    candidate.Candidate,
+                    candidate.SourceOccurrence,
+                    candidate.IntentDirectory,
+                    invocation))
+            {
+                continue;
+            }
+
+            var result = evaluation.Cover(
+                candidate,
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyReason.ReviewedSafePhrase,
+                ShellScopeRelation.UnderIntentRoot);
+            if (result is not ShellPolicyStageResult.Continue)
+                return result;
+        }
+
+        return new ShellPolicyStageResult.Continue();
+    }
+
+    private static bool CanUseReviewedSafePolicy(ShellPolicyEvaluation evaluation)
+        => evaluation.Projection.RunScope.InteractiveApproval
+            is InteractiveApprovalCapability.Available;
+}


### PR DESCRIPTION
## Summary
- extract ordinary reviewed-safe coverage into an ordered shell policy stage
- extract causal-intent reviewed-safe coverage with prerequisite checks
- preserve interactive-only authority, trace ordering, and existing fixture outcomes

## Validation
- focused actor policy suite: 431 passed
- full Actors suite before exact-identity rebase: 3,380 passed, 1 expected skip
- full solution before exact-identity rebase: 7,387 passed, 15 expected skips
- Release build: 0 warnings and 0 errors
- strict OpenSpec validation
- headers and diff checks
- changed-file Slopwatch: 0 findings
- adversarial review: PASS

The rebase onto current upstream/dev preserved the stable patch ID exactly.