### PR TITLE
Extract shell authority stages

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -40,7 +40,7 @@
 - [x] 5.2 Extract syntax, protected-path, causal-path, and causal-directory stages with no change to precedence.
 - [x] 5.3 Extract actor-evidence and approval-exempt stages with no change to candidate order or request count.
 - [x] 5.4 Extract reviewed-safe real-scope and intent-scope stages with no change to catalog behavior.
-- [ ] 5.5 Extract exact one-time and persistent-store availability stages while their authority owners stay fixed.
+- [x] 5.5 Extract exact one-time and persistent-store availability stages while their authority owners stay fixed.
 - [ ] 5.6 Extract final correction, prompt, and allow completion into one terminal stage.
 - [ ] 5.7 Add stage-isolation tests and terminal-overlap tests after each extraction.
 - [ ] 5.8 Run exact fixture parity and adversarial review after each production stage slice.

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -737,6 +737,120 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     [Fact]
+    public async Task Exact_one_time_stage_covers_the_remaining_candidate_set()
+    {
+        var evaluation = CreateEvaluationWithExactOneTime(
+            isMessy: false,
+            BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+
+        var result = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [ShellPolicyGrantStages.ExactOneTime(
+                new ToolName(ShellTool.ToolName),
+                "/work/session")],
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.True(evaluation.HasOneTimeCoverage);
+        Assert.Equal(ShellCoverageKind.OneTime, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval)));
+        Assert.Collection(
+            Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace).Rows,
+            row =>
+            {
+                Assert.Equal(ShellPolicyTraceStage.OneTimeApproval, row.Stage);
+                Assert.Equal(ShellPolicyTraceReason.OneTimeGrant, row.Reason);
+            },
+            row => Assert.Equal(ShellPolicyTraceStage.Completion, row.Stage));
+    }
+
+    [Fact]
+    public async Task Exact_one_time_stage_leaves_a_different_tool_key_uncovered()
+    {
+        var evaluation = CreateEvaluationWithExactOneTime(
+            isMessy: false,
+            BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+
+        var result = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [ShellPolicyGrantStages.ExactOneTime(
+                new ToolName("different_tool"),
+                "/work/session")],
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.False(evaluation.HasOneTimeCoverage);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task Persistent_store_stage_denies_only_uncovered_candidates(
+        bool coveredBySession,
+        bool expectsDeny)
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        var service = new FixedShellApprovalService(_ => new ShellApprovalMatchResult(
+            new PersistentGrantStoreStatus.Unavailable(ApprovalStoreFailure.IoFailure),
+            [
+                new ShellGrantCandidateMatch(
+                    candidate.Id,
+                    coveredBySession
+                        ? new ToolApprovalMatch(candidate.Candidate.Verb, "session", "this chat")
+                        : null,
+                    coveredBySession ? ShellCoverageKind.Session : null,
+                    NearMisses: [])
+            ]));
+
+        var result = await ShellPolicyPipeline.RunAsync(
+            evaluation,
+            [
+                ShellPolicyGrantStages.ActorEvidence(
+                    new ShellApprovalEvidenceAdapter(service),
+                    (ToolApprovalSessionId)"signalr/shell-policy-store-stage",
+                    TrustAudience.Personal,
+                    new ToolName(ShellTool.ToolName)),
+                ShellPolicyGrantStages.PersistentStoreAvailability()
+            ],
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, service.RequestCount);
+        if (!expectsDeny)
+        {
+            Assert.IsType<ShellPolicyStageResult.Continue>(result);
+            Assert.Null(evaluation.TerminalDecision);
+            Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+        }
+        else
+        {
+            var complete = Assert.IsType<ShellPolicyStageResult.Complete>(result);
+            Assert.Equal(ToolAuthorizationOutcome.Denied, complete.Decision.Outcome);
+            Assert.Equal("approval_store_unavailable", complete.Decision.DenyReason);
+            Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        }
+    }
+
+    [Fact]
+    public async Task Persistent_store_stage_rejects_missing_actor_evidence()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            await ShellPolicyPipeline.RunAsync(
+                evaluation,
+                [ShellPolicyGrantStages.PersistentStoreAvailability()],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, result.Reason);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
     public void Coverage_and_trace_change_together()
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -171,59 +171,20 @@ internal sealed class ShellPolicyCoordinator(
                     new ToolName(tool.Name)),
                 ShellPolicyGrantStages.ApprovalExemptSideEffects(_approvalEvidence.IsAvailable),
                 ShellPolicyReviewedSafeStages.RealScope(policy, context.Invocation),
-                ShellPolicyReviewedSafeStages.IntentScope(policy, context.Invocation)
+                ShellPolicyReviewedSafeStages.IntentScope(policy, context.Invocation),
+                ShellPolicyGrantStages.ExactOneTime(
+                    new ToolName(toolCall.Name),
+                    context.SessionDirectory),
+                ShellPolicyGrantStages.PersistentStoreAvailability()
             ],
             cancellationToken);
         if (initialResult is not ShellPolicyStageResult.Continue)
             return CompleteEvaluation(evaluation);
 
-        var grantEvidence = evaluation.GrantEvidence;
-        if (grantEvidence is null)
-        {
-            evaluation.Fault(ShellPolicyFault.InvalidActorEvidence);
-            return CompleteEvaluation(evaluation);
-        }
-
         var grantCandidates = projection.GrantCandidates;
         var approvalMatches = evaluation.ApprovalMatches;
 
         var uncovered = evaluation.UncoveredCandidates;
-        var oneTimeApplied = false;
-        if (uncovered.Count > 0)
-        {
-            var remainingContext = projection.HasCausalIntent
-                ? projection.ApprovalContext
-                : ToolAccessPolicy.NarrowShellApprovalContext(
-                    projection.ApprovalContext,
-                    uncovered.Select(static candidate => candidate.Candidate).ToArray(),
-                    context.SessionDirectory,
-                    projection.Environment.PathStyle);
-            if (projection.HasExactOneTimeApproval(toolCall.Name, remainingContext))
-            {
-                foreach (var candidate in uncovered)
-                {
-                    var coverageResult = evaluation.Cover(
-                        candidate,
-                        ShellCoverageKind.OneTime,
-                        ShellPolicyReason.OneTimeGrant,
-                        ShellScopeRelation.None);
-                    if (coverageResult is not ShellPolicyStageResult.Continue)
-                        return CompleteEvaluation(evaluation);
-                }
-
-                uncovered = [];
-                oneTimeApplied = true;
-            }
-        }
-
-        if (uncovered.Count > 0
-            && grantEvidence.PersistentStore is PersistentGrantStoreStatus.Unavailable)
-        {
-            return CompleteEvaluation(
-                evaluation,
-                ToolAuthorizationDecision.Deny("approval_store_unavailable"));
-        }
-
         if (uncovered.Count > 0)
         {
             var promptContext = projection.HasCausalIntent
@@ -245,7 +206,7 @@ internal sealed class ShellPolicyCoordinator(
                 ToolAuthorizationDecision.Deny("internal_policy_failure"));
         }
 
-        if (oneTimeApplied)
+        if (evaluation.HasOneTimeCoverage)
         {
             return CompleteEvaluation(
                 evaluation,

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -281,6 +281,9 @@ internal sealed class ShellPolicyEvaluation
     internal IReadOnlyList<ToolApprovalMatch> ApprovalMatches =>
         _grantEvidence?.ApprovalMatches ?? [];
 
+    internal bool HasOneTimeCoverage => _coverage.Any(static item =>
+        item.Kind == ShellCoverageKind.OneTime);
+
     internal ToolAuthorizationDecision? TerminalDecision => _terminalDecision;
 
     internal ShellPolicyDecisionTrace? CompletedTrace => _completedTrace;

--- a/src/Netclaw.Actors/Tools/ShellPolicyGrantStages.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyGrantStages.cs
@@ -32,6 +32,19 @@ internal static class ShellPolicyGrantStages
         => (evaluation, _) => ValueTask.FromResult(
             EvaluateApprovalExemptSideEffects(evaluation, approvalEvidenceAvailable));
 
+    internal static ShellPolicyStage ExactOneTime(
+        ToolName toolName,
+        string? sessionDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName.Value);
+        return (evaluation, _) => ValueTask.FromResult(
+            EvaluateExactOneTime(evaluation, toolName, sessionDirectory));
+    }
+
+    internal static ShellPolicyStage PersistentStoreAvailability()
+        => static (evaluation, _) => ValueTask.FromResult(
+            EvaluatePersistentStoreAvailability(evaluation));
+
     private static async ValueTask<ShellPolicyStageResult> EvaluateActorEvidenceAsync(
         ShellPolicyEvaluation evaluation,
         ShellApprovalEvidenceAdapter approvalEvidence,
@@ -91,5 +104,53 @@ internal static class ShellPolicyGrantStages
         }
 
         return new ShellPolicyStageResult.Continue();
+    }
+
+    private static ShellPolicyStageResult EvaluateExactOneTime(
+        ShellPolicyEvaluation evaluation,
+        ToolName toolName,
+        string? sessionDirectory)
+    {
+        var uncovered = evaluation.UncoveredCandidates;
+        if (uncovered.Count == 0)
+            return new ShellPolicyStageResult.Continue();
+
+        var projection = evaluation.Projection;
+        var remainingContext = projection.HasCausalIntent
+            ? projection.ApprovalContext
+            : ToolAccessPolicy.NarrowShellApprovalContext(
+                projection.ApprovalContext,
+                uncovered.Select(static candidate => candidate.Candidate).ToArray(),
+                sessionDirectory,
+                projection.Environment.PathStyle);
+        if (!projection.HasExactOneTimeApproval(toolName.Value, remainingContext))
+            return new ShellPolicyStageResult.Continue();
+
+        foreach (var candidate in uncovered)
+        {
+            var result = evaluation.Cover(
+                candidate,
+                ShellCoverageKind.OneTime,
+                ShellPolicyReason.OneTimeGrant,
+                ShellScopeRelation.None);
+            if (result is not ShellPolicyStageResult.Continue)
+                return result;
+        }
+
+        return new ShellPolicyStageResult.Continue();
+    }
+
+    private static ShellPolicyStageResult EvaluatePersistentStoreAvailability(
+        ShellPolicyEvaluation evaluation)
+    {
+        if (evaluation.GrantEvidence is null)
+            return new ShellPolicyStageResult.Fault(ShellPolicyFault.InvalidActorEvidence);
+
+        return evaluation.UncoveredCandidates.Count > 0
+               && evaluation.GrantEvidence.PersistentStore
+               is PersistentGrantStoreStatus.Unavailable
+            ? new ShellPolicyStageResult.Complete(
+                ToolAuthorizationDecision.Deny("approval_store_unavailable"))
+            : new ShellPolicyStageResult.Continue();
     }
 }


### PR DESCRIPTION
## Summary
- extract exact one-time authority into an ordered shell policy stage
- extract persistent-store availability into its own terminal boundary
- preserve one-time precedence, actor evidence requirements, and unavailable-store behavior

## Validation
- focused policy parity: 449 passed
- full Actors suite: 3,385 passed, 1 expected skip
- full solution: 7,392 passed, 15 expected skips
- Release build: 0 warnings and 0 errors
- strict OpenSpec validation
- headers, format, and diff checks
- changed-file Slopwatch: 0 findings
- adversarial review: PASS

The rebase onto current upstream/dev preserved the stable patch ID exactly.