### PR TITLE
Extract shell policy terminal stage

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -41,9 +41,9 @@
 - [x] 5.3 Extract actor-evidence and approval-exempt stages with no change to candidate order or request count.
 - [x] 5.4 Extract reviewed-safe real-scope and intent-scope stages with no change to catalog behavior.
 - [x] 5.5 Extract exact one-time and persistent-store availability stages while their authority owners stay fixed.
-- [ ] 5.6 Extract final correction, prompt, and allow completion into one terminal stage.
-- [ ] 5.7 Add stage-isolation tests and terminal-overlap tests after each extraction.
-- [ ] 5.8 Run exact fixture parity and adversarial review after each production stage slice.
+- [x] 5.6 Extract final correction, prompt, and allow completion into one terminal stage.
+- [x] 5.7 Add stage-isolation tests and terminal-overlap tests after each extraction.
+- [x] 5.8 Run exact fixture parity and adversarial review after each production stage slice.
 
 ## 6. Consolidate policy facts and prompt context
 

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -851,6 +851,101 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     [Fact]
+    public async Task Terminal_stage_prompts_with_only_the_uncovered_candidates()
+    {
+        var evaluation = CreateEvaluation(
+            BashCandidate("git status"),
+            BashCandidate("git push"));
+        var covered = evaluation.Candidates[0];
+        var uncovered = evaluation.Candidates[1];
+        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+            covered,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-terminal-prompt",
+            "/work/session",
+            TrustAudience.Personal);
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(
+                evaluation,
+                [ShellPolicyTerminalStage.Complete(context)],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
+        var prompt = Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext);
+        Assert.Equal([uncovered.Candidate], prompt.Candidates);
+        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(covered.Id).Kind);
+        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(uncovered.Id).Kind);
+    }
+
+    [Fact]
+    public async Task Terminal_stage_preserves_one_time_allow_precedence()
+    {
+        var evaluation = CreateEvaluationWithExactOneTime(
+            isMessy: false,
+            BashCandidate("git status"));
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-terminal-once",
+            "/work/session",
+            TrustAudience.Personal);
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(
+                evaluation,
+                [
+                    ShellPolicyGrantStages.ExactOneTime(
+                        new ToolName(ShellTool.ToolName),
+                        context.SessionDirectory),
+                    ShellPolicyTerminalStage.Complete(context)
+                ],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, result.Decision.Outcome);
+        Assert.Equal(ToolAllowReason.OneTimeApproval, result.Decision.AllowReason);
+    }
+
+    [Fact]
+    public async Task Terminal_stage_records_a_complete_stored_match_decision()
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(evaluation.Candidates);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-terminal-stored",
+            "/work/session",
+            TrustAudience.Personal);
+        var service = new FixedShellApprovalService(_ => new ShellApprovalMatchResult(
+            new PersistentGrantStoreStatus.Ready(),
+            [
+                new ShellGrantCandidateMatch(
+                    candidate.Id,
+                    new ToolApprovalMatch(candidate.Candidate.Verb, "session", "this chat"),
+                    ShellCoverageKind.Session,
+                    NearMisses: [])
+            ]));
+
+        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(
+                evaluation,
+                [
+                    ShellPolicyGrantStages.ActorEvidence(
+                        new ShellApprovalEvidenceAdapter(service),
+                        (ToolApprovalSessionId)"signalr/shell-policy-terminal-stored",
+                        TrustAudience.Personal,
+                        new ToolName(ShellTool.ToolName)),
+                    ShellPolicyTerminalStage.Complete(context)
+                ],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, result.Decision.Outcome);
+        Assert.Equal(ToolAllowReason.StoredApproval, result.Decision.AllowReason);
+        Assert.Equal("PreviouslyApproved", context.Approval.AppliedDecision);
+        Assert.Equal("git status [session: this chat]", context.Approval.AppliedPattern);
+    }
+
+    [Fact]
     public void Coverage_and_trace_change_together()
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -135,7 +135,6 @@ internal sealed class ShellPolicyCoordinator(
                 tool,
                 toolCall,
                 context,
-                projection,
                 evaluation,
                 cancellationToken);
         }
@@ -154,11 +153,10 @@ internal sealed class ShellPolicyCoordinator(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
-        ShellPolicyProjection projection,
         ShellPolicyEvaluation evaluation,
         CancellationToken cancellationToken)
     {
-        var initialResult = await ShellPolicyPipeline.RunAsync(
+        var result = await ShellPolicyPipeline.RunAsync(
             evaluation,
             [
                 ShellPolicyInitialStages.Syntax(toolCall.Name),
@@ -175,68 +173,14 @@ internal sealed class ShellPolicyCoordinator(
                 ShellPolicyGrantStages.ExactOneTime(
                     new ToolName(toolCall.Name),
                     context.SessionDirectory),
-                ShellPolicyGrantStages.PersistentStoreAvailability()
+                ShellPolicyGrantStages.PersistentStoreAvailability(),
+                ShellPolicyTerminalStage.Complete(context)
             ],
             cancellationToken);
-        if (initialResult is not ShellPolicyStageResult.Continue)
-            return CompleteEvaluation(evaluation);
+        if (result is ShellPolicyStageResult.Continue)
+            evaluation.Fault(ShellPolicyFault.InvalidStageResult);
 
-        var grantCandidates = projection.GrantCandidates;
-        var approvalMatches = evaluation.ApprovalMatches;
-
-        var uncovered = evaluation.UncoveredCandidates;
-        if (uncovered.Count > 0)
-        {
-            var promptContext = projection.HasCausalIntent
-                ? projection.ApprovalContext
-                : ToolAccessPolicy.NarrowShellApprovalContext(
-                    projection.ApprovalContext,
-                    uncovered.Select(static candidate => candidate.Candidate).ToArray(),
-                    context.SessionDirectory,
-                    projection.Environment.PathStyle);
-            return CompleteEvaluation(
-                evaluation,
-                ToolAuthorizationDecision.RequiresApproval(promptContext, approvalMatches));
-        }
-
-        if (!evaluation.AllCovered)
-        {
-            return CompleteEvaluation(
-                evaluation,
-                ToolAuthorizationDecision.Deny("internal_policy_failure"));
-        }
-
-        if (evaluation.HasOneTimeCoverage)
-        {
-            return CompleteEvaluation(
-                evaluation,
-                ToolAuthorizationDecision.Allow(
-                    ToolAllowReason.OneTimeApproval,
-                    approvalMatches));
-        }
-
-        if (approvalMatches.Count > 0)
-        {
-            if (approvalMatches.Count == grantCandidates.Count)
-            {
-                context.Approval.ApplyDecision(
-                    "PreviouslyApproved",
-                    FormatApprovalMatches(approvalMatches));
-            }
-
-            return CompleteEvaluation(
-                evaluation,
-                ToolAuthorizationDecision.Allow(
-                    ToolAllowReason.StoredApproval,
-                    approvalMatches));
-        }
-
-        return CompleteEvaluation(
-            evaluation,
-            ToolAuthorizationDecision.Allow(
-                grantCandidates.Count == 0
-                    ? ToolAllowReason.ApprovalExemptShellCandidates
-                    : ToolAllowReason.SafeVerbInTrustedScope));
+        return CompleteEvaluation(evaluation);
     }
 
     private static ToolAuthorizationDecision Complete(
@@ -284,18 +228,6 @@ internal sealed class ShellPolicyCoordinator(
                              ?? throw new InvalidOperationException("Shell policy stage did not complete its trace.");
         return decision.WithShellPolicyTrace(completedTrace);
     }
-
-    private static ToolAuthorizationDecision CompleteEvaluation(
-        ShellPolicyEvaluation evaluation,
-        ToolAuthorizationDecision decision)
-    {
-        evaluation.Complete(decision);
-        return CompleteEvaluation(evaluation);
-    }
-
-    private static string FormatApprovalMatches(IReadOnlyList<ToolApprovalMatch> matches)
-        => string.Join(", ", matches.Select(match =>
-            $"{match.Pattern} [{match.Source}: {match.Scope}]"));
 
     private static ToolApprovalSessionId? ToApprovalSessionId(string? sessionId)
         => sessionId is null ? null : (ToolApprovalSessionId)sessionId;

--- a/src/Netclaw.Actors/Tools/ShellPolicyTerminalStage.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyTerminalStage.cs
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyTerminalStage.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+internal static class ShellPolicyTerminalStage
+{
+    internal static ShellPolicyStage Complete(ToolExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return (evaluation, _) => ValueTask.FromResult(
+            CompleteEvaluation(evaluation, context));
+    }
+
+    private static ShellPolicyStageResult CompleteEvaluation(
+        ShellPolicyEvaluation evaluation,
+        ToolExecutionContext context)
+    {
+        var projection = evaluation.Projection;
+        var approvalMatches = evaluation.ApprovalMatches;
+        var uncovered = evaluation.UncoveredCandidates;
+        if (uncovered.Count > 0)
+        {
+            var promptContext = projection.HasCausalIntent
+                ? projection.ApprovalContext
+                : ToolAccessPolicy.NarrowShellApprovalContext(
+                    projection.ApprovalContext,
+                    uncovered.Select(static candidate => candidate.Candidate).ToArray(),
+                    context.SessionDirectory,
+                    projection.Environment.PathStyle);
+            return evaluation.Complete(
+                ToolAuthorizationDecision.RequiresApproval(promptContext, approvalMatches));
+        }
+
+        if (!evaluation.AllCovered)
+        {
+            return evaluation.Complete(
+                ToolAuthorizationDecision.Deny("internal_policy_failure"));
+        }
+
+        if (evaluation.HasOneTimeCoverage)
+        {
+            return evaluation.Complete(
+                ToolAuthorizationDecision.Allow(
+                    ToolAllowReason.OneTimeApproval,
+                    approvalMatches));
+        }
+
+        var grantCandidates = projection.GrantCandidates;
+        if (approvalMatches.Count > 0)
+        {
+            if (approvalMatches.Count == grantCandidates.Count)
+            {
+                context.Approval.ApplyDecision(
+                    "PreviouslyApproved",
+                    FormatApprovalMatches(approvalMatches));
+            }
+
+            return evaluation.Complete(
+                ToolAuthorizationDecision.Allow(
+                    ToolAllowReason.StoredApproval,
+                    approvalMatches));
+        }
+
+        return evaluation.Complete(
+            ToolAuthorizationDecision.Allow(
+                grantCandidates.Count == 0
+                    ? ToolAllowReason.ApprovalExemptShellCandidates
+                    : ToolAllowReason.SafeVerbInTrustedScope));
+    }
+
+    private static string FormatApprovalMatches(IReadOnlyList<ToolApprovalMatch> matches)
+        => string.Join(", ", matches.Select(match =>
+            $"{match.Pattern} [{match.Source}: {match.Scope}]"));
+}


### PR DESCRIPTION
This slice moves final shell policy completion into one ordered terminal stage.

It preserves correction, prompt, one-time, stored-grant, and reviewed-safe outcomes.

Validation:
- Focused policy tests: 439 passed
- Strict OpenSpec: passed
- Header verification: passed
- Stable patch identity after rebase: exact