### PR TITLE
Share shell uncovered approval context

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -49,7 +49,7 @@
 
 - [ ] 6.1 Project real scopes, intent scopes, fallback scopes, redirects, and authored filesystem values once.
 - [ ] 6.2 Route every filesystem fact through current path policy without command-text rescans.
-- [ ] 6.3 Derive one uncovered-candidate context for exact one-time authority and user prompts.
+- [x] 6.3 Derive one uncovered-candidate context for exact one-time authority and user prompts.
 - [ ] 6.4 Preserve causal full-context, scratch limits, reusable phrases, directory depth, and candidate order.
 - [ ] 6.5 Centralize bounded trace completion and preserve exact redaction and row order.
 - [ ] 6.6 Add path-fact, prompt-context, one-time-key, causal-context, and trace-parity regressions.

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -767,23 +768,91 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     [Fact]
-    public async Task Exact_one_time_stage_leaves_a_different_tool_key_uncovered()
+    public async Task Exact_one_time_and_prompt_share_one_uncovered_context()
     {
         var evaluation = CreateEvaluationWithExactOneTime(
             isMessy: false,
             BashCandidate("git status"));
         var candidate = Assert.Single(evaluation.Candidates);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/shell-policy-shared-context",
+            "/work/session",
+            TrustAudience.Personal);
 
         var result = await ShellPolicyPipeline.RunAsync(
             evaluation,
             [ShellPolicyGrantStages.ExactOneTime(
                 new ToolName("different_tool"),
-                "/work/session")],
+                context.SessionDirectory)],
             TestContext.Current.CancellationToken);
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
         Assert.False(evaluation.HasOneTimeCoverage);
         Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+
+        var oneTimeContext = evaluation.GetUncoveredApprovalContext(context.SessionDirectory);
+        var terminal = Assert.IsType<ShellPolicyStageResult.Complete>(
+            await ShellPolicyPipeline.RunAsync(
+                evaluation,
+                [ShellPolicyTerminalStage.Complete(context)],
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(oneTimeContext, terminal.Decision.ApprovalContext);
+    }
+
+    [Fact]
+    public void Uncovered_context_reprojects_after_candidate_coverage_changes()
+    {
+        var evaluation = CreateEvaluation(
+            BashCandidate("git status"),
+            BashCandidate("git push"));
+        var initial = evaluation.GetUncoveredApprovalContext("/work/session");
+        var candidate = evaluation.Candidates[0];
+        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+            candidate,
+            ShellCoverageKind.Session,
+            ShellPolicyReason.SessionGrant,
+            ShellScopeRelation.ThisChat));
+
+        var reprojected = evaluation.GetUncoveredApprovalContext("/work/session");
+
+        Assert.NotSame(initial, reprojected);
+        Assert.Equal([evaluation.Candidates[1].Candidate], reprojected.Candidates);
+    }
+
+    [Fact]
+    public void Uncovered_context_reprojects_when_session_directory_changes()
+    {
+        var candidate = BashCandidate("git status") with { Directory = "/work/repo" };
+        var evaluation = CreateEvaluation(
+            isMessy: false,
+            hasExactOneTimeApproval: false,
+            cwd: "/work/repo",
+            candidates: [candidate]);
+        var sessionScratch = evaluation.GetUncoveredApprovalContext("/work/repo");
+
+        var ordinaryScope = evaluation.GetUncoveredApprovalContext("/work/session");
+
+        Assert.NotSame(sessionScratch, ordinaryScope);
+        Assert.DoesNotContain(
+            sessionScratch.Options,
+            static option => option.Key == ApprovalOptionKeys.ApproveAlwaysKey);
+        Assert.Contains(
+            ordinaryScope.Options,
+            static option => option.Key == ApprovalOptionKeys.ApproveAlwaysKey);
+    }
+
+    [SlopwatchSuppress("SW001", "This test pins Bash causal approval intent on POSIX hosts.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only shell directory semantics")]
+    public void Causal_uncovered_context_retains_the_complete_approval_context()
+    {
+        var (evaluation, _, context) = CreateCausalEvaluation(
+            "cd /tmp && inspect; head result.log",
+            safeVerbs: SafeVerbList.FromVerbs(ApprovalShell.Bash, ["head"]));
+
+        var uncovered = evaluation.GetUncoveredApprovalContext(context.SessionDirectory);
+
+        Assert.Same(evaluation.Projection.ApprovalContext, uncovered);
     }
 
     [Theory]
@@ -1249,6 +1318,7 @@ public sealed class ShellPolicyEvaluationTests
     private static ShellPolicyEvaluation CreateEvaluation(
         bool isMessy,
         bool hasExactOneTimeApproval,
+        string cwd = "/work",
         params ApprovalCandidate[] candidates)
     {
         var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
@@ -1258,7 +1328,7 @@ public sealed class ShellPolicyEvaluationTests
             candidates.Select(static candidate => candidate.Verb).ToArray(),
             candidates.Select(static candidate => candidate.Verb).ToArray(),
             [],
-            Cwd: "/work",
+            Cwd: cwd,
             IsMessy: isMessy,
             Candidates: candidates);
         var context = TestToolExecutionContext.CreateBound(

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -226,6 +226,7 @@ internal sealed class ShellPolicyEvaluation
     private ShellPolicyDecisionTrace? _completedTrace;
     private ShellPolicyFault? _terminalFault;
     private ValidatedShellGrantEvidence? _grantEvidence;
+    private (string? SessionDirectory, ToolApprovalContext Context)? _uncoveredApprovalContext;
 
     internal ShellPolicyEvaluation(ShellPolicyProjection projection)
     {
@@ -283,6 +284,29 @@ internal sealed class ShellPolicyEvaluation
 
     internal bool HasOneTimeCoverage => _coverage.Any(static item =>
         item.Kind == ShellCoverageKind.OneTime);
+
+    internal ToolApprovalContext GetUncoveredApprovalContext(string? sessionDirectory)
+    {
+        var uncovered = UncoveredCandidates;
+        if (uncovered.Count == 0)
+            throw new InvalidOperationException("No uncovered shell candidates remain.");
+
+        if (_uncoveredApprovalContext is { } cached
+            && string.Equals(cached.SessionDirectory, sessionDirectory, StringComparison.Ordinal))
+        {
+            return cached.Context;
+        }
+
+        var context = Projection.HasCausalIntent
+            ? Projection.ApprovalContext
+            : ToolAccessPolicy.NarrowShellApprovalContext(
+                Projection.ApprovalContext,
+                uncovered.Select(static candidate => candidate.Candidate).ToArray(),
+                sessionDirectory,
+                Projection.Environment.PathStyle);
+        _uncoveredApprovalContext = (sessionDirectory, context);
+        return context;
+    }
 
     internal ToolAuthorizationDecision? TerminalDecision => _terminalDecision;
 
@@ -382,6 +406,7 @@ internal sealed class ShellPolicyEvaluation
             scopeRelation,
             grantTimestamp);
         _coverage[index] = new ShellCandidateCoverage(candidate.Id, coverage, reason);
+        _uncoveredApprovalContext = null;
         return new ShellPolicyStageResult.Continue();
     }
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyGrantStages.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyGrantStages.cs
@@ -115,15 +115,8 @@ internal static class ShellPolicyGrantStages
         if (uncovered.Count == 0)
             return new ShellPolicyStageResult.Continue();
 
-        var projection = evaluation.Projection;
-        var remainingContext = projection.HasCausalIntent
-            ? projection.ApprovalContext
-            : ToolAccessPolicy.NarrowShellApprovalContext(
-                projection.ApprovalContext,
-                uncovered.Select(static candidate => candidate.Candidate).ToArray(),
-                sessionDirectory,
-                projection.Environment.PathStyle);
-        if (!projection.HasExactOneTimeApproval(toolName.Value, remainingContext))
+        var remainingContext = evaluation.GetUncoveredApprovalContext(sessionDirectory);
+        if (!evaluation.Projection.HasExactOneTimeApproval(toolName.Value, remainingContext))
             return new ShellPolicyStageResult.Continue();
 
         foreach (var candidate in uncovered)

--- a/src/Netclaw.Actors/Tools/ShellPolicyTerminalStage.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyTerminalStage.cs
@@ -27,15 +27,10 @@ internal static class ShellPolicyTerminalStage
         var uncovered = evaluation.UncoveredCandidates;
         if (uncovered.Count > 0)
         {
-            var promptContext = projection.HasCausalIntent
-                ? projection.ApprovalContext
-                : ToolAccessPolicy.NarrowShellApprovalContext(
-                    projection.ApprovalContext,
-                    uncovered.Select(static candidate => candidate.Candidate).ToArray(),
-                    context.SessionDirectory,
-                    projection.Environment.PathStyle);
             return evaluation.Complete(
-                ToolAuthorizationDecision.RequiresApproval(promptContext, approvalMatches));
+                ToolAuthorizationDecision.RequiresApproval(
+                    evaluation.GetUncoveredApprovalContext(context.SessionDirectory),
+                    approvalMatches));
         }
 
         if (!evaluation.AllCovered)


### PR DESCRIPTION
## Summary
- centralize uncovered shell candidate and prompt-context projection in `ShellPolicyEvaluation`
- remove duplicate prompt narrowing from grant and terminal stages
- preserve causal, one-time, scratch, and stored-grant behavior

## Validation
- stable patch ID preserved across rebase; range-diff reports exact identity
- focused shell policy evaluation: 59/59
- policy, evidence, and disposition set: 352/352
- strict OpenSpec validation
- copyright headers
- git diff check

Adversarial review passed on the pre-rebase patch; the rebased patch is byte-equivalent by stable patch identity.