### PR TITLE
Remove obsolete shell policy helpers

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -57,9 +57,9 @@
 
 ## 7. Remove obsolete structure
 
-- [ ] 7.1 Remove dead coordinator branches, duplicate coverage mutation, duplicate path helpers, and duplicate prompt-scope logic.
-- [ ] 7.2 Keep the required public compatibility adapter isolated from new typed policy code.
-- [ ] 7.3 Record the separate generic approval API work that can remove the compatibility adapter.
+- [x] 7.1 Remove dead coordinator branches, duplicate coverage mutation, duplicate path helpers, and duplicate prompt-scope logic.
+- [x] 7.2 Keep the required public compatibility adapter isolated from new typed policy code.
+- [x] 7.3 Record the separate generic approval API work that can remove the compatibility adapter ([#1944](https://github.com/netclaw-dev/netclaw/issues/1944)).
 - [ ] 7.4 Verify production policy contains no new executable names or executable-private argument rules.
 - [ ] 7.5 Verify no call-local parser occurrence, command text, path, or secret crosses actor or persistence boundaries.
 - [ ] 7.6 Run API and durable-contract comparisons against the frozen baseline.

--- a/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
@@ -7,6 +7,7 @@ using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
+using ShellSyntaxTree;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Tools;
@@ -333,6 +334,30 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
             new Dictionary<string, object?>
             {
                 ["Command"] = "gh run list --repo example/project",
+                ["WorkingDirectory"] = _projectDir
+            });
+
+        Assert.True(policy.AllShortCircuit(candidates, _projectDir, ctx));
+    }
+
+    [Fact]
+    public void PowerShell_compatibility_paths_use_posix_host_roots()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var policy = new ScopedShellSafeVerbPolicy(
+            SafeVerbList.FromVerbs(ApprovalShell.PowerShell, ["Get-ChildItem"]));
+        var ctx = PersonalContext(projectDir: _projectDir);
+        var matcher = new ShellApprovalMatcher(
+            ShellExecutionEnvironment.CreatePowerShell(
+                "C:\\PowerShell\\pwsh.exe",
+                PwshDialect.PowerShell7));
+        var candidates = matcher.ExtractCandidates(
+            new ToolName("shell_execute"),
+            new Dictionary<string, object?>
+            {
+                ["Command"] = "Get-ChildItem -LiteralPath .\\data.txt",
                 ["WorkingDirectory"] = _projectDir
             });
 

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -438,27 +438,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
     private static ToolAuthorizationDecision CompleteAuthorizationDecision(
         ToolAccessDecision accessDecision,
         IReadOnlyList<ToolApprovalMatch> approvalMatches)
-    {
-        if (accessDecision.NeedsApproval)
-        {
-            return ToolAuthorizationDecision.RequiresApproval(
-                accessDecision.ApprovalContext
-                ?? throw new InvalidOperationException("Approval decision missing approval context."),
-                approvalMatches);
-        }
-
-        if (!accessDecision.Allowed)
-        {
-            return ToolAuthorizationDecision.Deny(
-                accessDecision.DenyReason
-                ?? throw new InvalidOperationException("Denied decision missing a deny reason."));
-        }
-
-        return ToolAuthorizationDecision.Allow(
-            accessDecision.AllowReason
-            ?? throw new InvalidOperationException("Allowed decision missing an allow reason."),
-            approvalMatches);
-    }
+        => ToolAuthorizationDecision.From(accessDecision, approvalMatches);
 
     private static bool TryGetExactUnapprovedCandidates(
         ToolApprovalCheckResult result,

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -316,7 +316,7 @@ internal sealed class ScopedShellSafeVerbPolicy
                     !safeRoots.Any(root => IsSafePath(
                         path.Value,
                         root,
-                        pathStyle))))
+                        path.PathStyle))))
             {
                 return false;
             }
@@ -379,9 +379,9 @@ internal sealed class ScopedShellSafeVerbPolicy
             ?? (occurrence.WorkingDirectory is ShellValueDomain.Exact exact
                 ? exact.Value
                 : null);
-        var pathStyle = shell == ApprovalShell.Bash
-            ? ShellPathStyle.Posix
-            : ShellPathStyle.Windows;
+        var pathStyle = OperatingSystem.IsWindows()
+            ? ShellPathStyle.Windows
+            : ShellPathStyle.Posix;
         return ShellPolicyOccurrencePathFacts.Create(occurrence)
             .Resolve(workingDirectory, pathStyle);
     }

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -97,8 +97,18 @@ internal sealed class ScopedShellSafeVerbPolicy
             .ToArray();
         foreach (var candidate in candidates)
         {
-            if (!IsReviewedDiagnostic(candidate, candidate.SourceOccurrence, prospectiveRoots))
+            var resolvedPaths = ResolveCompatibilityPaths(
+                candidate,
+                candidate.SourceOccurrence,
+                fullCwd);
+            if (!IsReviewedDiagnostic(
+                    candidate,
+                    candidate.SourceOccurrence,
+                    prospectiveRoots,
+                    resolvedPaths))
+            {
                 return false;
+            }
 
             var effectiveDirectory = candidate.Directory ?? fullCwd;
             if (string.IsNullOrWhiteSpace(effectiveDirectory))
@@ -128,50 +138,15 @@ internal sealed class ScopedShellSafeVerbPolicy
         ApprovalCandidate candidate,
         CommandOccurrence? sourceOccurrence,
         IReadOnlyList<string> safeRoots,
-        string? workingDirectoryOverride = null)
-    {
-        if (candidate is not
-            {
-                Shell: { } shell,
-                VerbTokens: { }
-            }
-            || sourceOccurrence is null
-            || ShellRedirectPolicyFacts.HasFileWritingRedirect(sourceOccurrence)
-            || !_safeVerbs.TryMatchReviewedDiagnostic(
-                shell,
-                candidate.VerbTokens,
-                out var matchedTokenCount))
-        {
-            return false;
-        }
-
-        if (sourceOccurrence.Arguments.Any(argument =>
-                argument.Element.PrecedingVerbElementCount < matchedTokenCount))
-        {
-            return false;
-        }
-
-        return AllPossibleAuthoredPathsStayWithinRoots(
-            sourceOccurrence,
-            shell,
-            safeRoots,
-            workingDirectoryOverride);
-    }
-
-    private bool IsReviewedDiagnostic(
-        ApprovalCandidate candidate,
-        ShellPolicyCandidatePathFacts pathFacts,
-        IReadOnlyList<string> safeRoots,
         ShellPolicyResolvedPathView? resolvedPaths)
     {
-        var sourceOccurrence = pathFacts.SourceOccurrence;
         if (candidate is not
             {
                 Shell: { } shell,
                 VerbTokens: { }
             }
             || sourceOccurrence is null
-            || HasFileWritingRedirect(pathFacts)
+            || HasFileWritingRedirect(resolvedPaths)
             || !_safeVerbs.TryMatchReviewedDiagnostic(
                 shell,
                 candidate.VerbTokens,
@@ -214,7 +189,7 @@ internal sealed class ScopedShellSafeVerbPolicy
                 ShellPathStyle.Posix)
             || !IsReviewedDiagnostic(
                 candidate,
-                pathFacts,
+                pathFacts.SourceOccurrence,
                 [intentPath.Value],
                 pathFacts.Intent))
         {
@@ -233,8 +208,9 @@ internal sealed class ScopedShellSafeVerbPolicy
         ToolInvocationContext context)
     {
         var safeRoots = ResolveSafeSpaceRoots(context);
+        var resolvedPaths = ResolveCompatibilityPaths(candidate, sourceOccurrence);
         if (safeRoots.Count == 0
-            || !IsReviewedDiagnostic(candidate, sourceOccurrence, safeRoots))
+            || !IsReviewedDiagnostic(candidate, sourceOccurrence, safeRoots, resolvedPaths))
         {
             return false;
         }
@@ -265,7 +241,7 @@ internal sealed class ScopedShellSafeVerbPolicy
         if (safeRoots.Count == 0
             || !IsReviewedDiagnostic(
                 candidate,
-                pathFacts,
+                pathFacts.SourceOccurrence,
                 safeRoots,
                 pathFacts.Real)
             || pathFacts.RealScope is not
@@ -305,8 +281,8 @@ internal sealed class ScopedShellSafeVerbPolicy
         }
     }
 
-    private static bool HasFileWritingRedirect(ShellPolicyCandidatePathFacts pathFacts)
-        => pathFacts.Real?.Facts.Any(static fact =>
+    private static bool HasFileWritingRedirect(ShellPolicyResolvedPathView? resolvedPaths)
+        => resolvedPaths?.Facts.Any(static fact =>
             fact.Source is
             {
                 Origin: ShellPolicyPathOrigin.Redirect,
@@ -391,12 +367,14 @@ internal sealed class ScopedShellSafeVerbPolicy
         return true;
     }
 
-    private static bool AllPossibleAuthoredPathsStayWithinRoots(
-        CommandOccurrence occurrence,
-        ApprovalShell shell,
-        IReadOnlyList<string> safeRoots,
-        string? workingDirectoryOverride)
+    private static ShellPolicyResolvedPathView? ResolveCompatibilityPaths(
+        ApprovalCandidate candidate,
+        CommandOccurrence? occurrence,
+        string? workingDirectoryOverride = null)
     {
+        if (candidate.Shell is not { } shell || occurrence is null)
+            return null;
+
         var workingDirectory = workingDirectoryOverride
             ?? (occurrence.WorkingDirectory is ShellValueDomain.Exact exact
                 ? exact.Value
@@ -404,43 +382,8 @@ internal sealed class ScopedShellSafeVerbPolicy
         var pathStyle = shell == ApprovalShell.Bash
             ? ShellPathStyle.Posix
             : ShellPathStyle.Windows;
-
-        foreach (var argument in occurrence.Arguments)
-        {
-            if (argument.AuthoredPathShape == ShellPathShape.Unknown)
-                continue;
-            if (argument.AuthoredPathShape == ShellPathShape.Posix
-                    && pathStyle != ShellPathStyle.Posix
-                || argument.AuthoredPathShape == ShellPathShape.Windows
-                    && pathStyle != ShellPathStyle.Windows)
-            {
-                return false;
-            }
-
-            IReadOnlyList<string> possiblePaths = argument.AuthoredValue switch
-            {
-                ShellValueDomain.Exact value => [value.Value],
-                ShellValueDomain.FiniteSet values => values.Values,
-                _ => []
-            };
-            if (possiblePaths.Count == 0)
-                return false;
-
-            foreach (var possiblePath in possiblePaths)
-            {
-                var resolved = ShellTokenizer.NormalizePathToken(
-                    possiblePath,
-                    workingDirectory,
-                    pathStyle);
-                if (string.IsNullOrWhiteSpace(resolved)
-                    || !safeRoots.Any(root => IsSafePath(resolved, root)))
-                {
-                    return false;
-                }
-            }
-        }
-
-        return true;
+        return ShellPolicyOccurrencePathFacts.Create(occurrence)
+            .Resolve(workingDirectory, pathStyle);
     }
 
     private static bool IsSafePath(string path, string root)

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -187,33 +187,9 @@ internal sealed class ShellPolicyCoordinator(
         ToolAccessDecision decision,
         IReadOnlyList<ToolApprovalMatch> approvalMatches,
         ShellPolicyDecisionTraceBuilder trace)
-    {
-        if (decision.NeedsApproval)
-        {
-            return CompleteWithTrace(
-                ToolAuthorizationDecision.RequiresApproval(
-                    decision.ApprovalContext
-                    ?? throw new InvalidOperationException("Approval decision missing approval context."),
-                    approvalMatches),
-                trace);
-        }
-
-        if (!decision.Allowed)
-        {
-            return CompleteWithTrace(
-                ToolAuthorizationDecision.Deny(
-                    decision.DenyReason
-                    ?? throw new InvalidOperationException("Denied decision missing a deny reason.")),
-                trace);
-        }
-
-        return CompleteWithTrace(
-            ToolAuthorizationDecision.Allow(
-                decision.AllowReason
-                ?? throw new InvalidOperationException("Allowed decision missing an allow reason."),
-                approvalMatches),
+        => CompleteWithTrace(
+            ToolAuthorizationDecision.From(decision, approvalMatches),
             trace);
-    }
 
     private static ToolAuthorizationDecision CompleteWithTrace(
         ToolAuthorizationDecision decision,

--- a/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
@@ -115,8 +115,20 @@ internal sealed class ShellPolicyPathFacts
             var sourceFacts = candidate.SourceOccurrence is { } occurrence
                 ? GetOrCreateSourceFacts(sourceCache, occurrence)
                 : null;
-            var realScope = ResolveRealScope(candidate, pathStyle);
-            var realBase = ResolveRealBase(candidate, pathStyle);
+            var occurrenceDirectory = candidate.SourceOccurrence?.WorkingDirectory
+                is ShellValueDomain.Exact exact
+                ? exact.Value
+                : null;
+            var realScope = ResolveScope(
+                ShellPolicyPathBaseKind.Real,
+                baseIndex: 0,
+                candidate.Candidate.Directory ?? occurrenceDirectory,
+                pathStyle);
+            var realBase = ResolveScope(
+                ShellPolicyPathBaseKind.Real,
+                baseIndex: 0,
+                occurrenceDirectory ?? candidate.Candidate.Directory,
+                pathStyle);
             var intentBase = candidate.IntentDirectory is null
                 ? null
                 : ResolveScope(
@@ -160,65 +172,25 @@ internal sealed class ShellPolicyPathFacts
         return new ShellPolicyPathFacts(projected);
     }
 
-    private static ShellPolicyScopePathFact ResolveRealBase(
-        ShellPolicyCandidate candidate,
-        ShellPathStyle pathStyle)
-    {
-        var value = candidate.SourceOccurrence?.WorkingDirectory is ShellValueDomain.Exact exact
-            ? exact.Value
-            : candidate.Candidate.Directory;
-        return ResolveScope(
-            ShellPolicyPathBaseKind.Real,
-            baseIndex: 0,
-            value,
-            pathStyle);
-    }
-
-    private static ShellPolicyScopePathFact ResolveRealScope(
-        ShellPolicyCandidate candidate,
-        ShellPathStyle pathStyle)
-    {
-        var value = candidate.Candidate.Directory
-            ?? (candidate.SourceOccurrence?.WorkingDirectory is ShellValueDomain.Exact exact
-                ? exact.Value
-                : null);
-        return ResolveScope(
-            ShellPolicyPathBaseKind.Real,
-            baseIndex: 0,
-            value,
-            pathStyle);
-    }
-
-    private static ShellPolicyScopePathFact ResolveScope(
+    internal static ShellPolicyScopePathFact ResolveScope(
         ShellPolicyPathBaseKind baseKind,
         int baseIndex,
         string? value,
         ShellPathStyle pathStyle)
     {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return new ShellPolicyScopePathFact(
-                baseKind,
-                baseIndex,
-                value,
-                ShellPolicyPathResolutionState.UnknownDynamic,
-                Path: null);
-        }
-
-        return ShellPathRules.TryNormalize(value, pathStyle, out var normalized)
-               && CanonicalShellPath.TryCreate(normalized, pathStyle, out var path)
-            ? new ShellPolicyScopePathFact(
-                baseKind,
-                baseIndex,
-                value,
-                ShellPolicyPathResolutionState.Known,
-                path)
-            : new ShellPolicyScopePathFact(
-                baseKind,
-                baseIndex,
-                value,
-                ShellPolicyPathResolutionState.InvalidKnownValue,
-                Path: null);
+        CanonicalShellPath path = default;
+        var state = string.IsNullOrWhiteSpace(value)
+            ? ShellPolicyPathResolutionState.UnknownDynamic
+            : ShellPathRules.TryNormalize(value, pathStyle, out var normalized)
+              && CanonicalShellPath.TryCreate(normalized, pathStyle, out path)
+                ? ShellPolicyPathResolutionState.Known
+                : ShellPolicyPathResolutionState.InvalidKnownValue;
+        return new ShellPolicyScopePathFact(
+            baseKind,
+            baseIndex,
+            value,
+            state,
+            state == ShellPolicyPathResolutionState.Known ? path : null);
     }
 
     private static ShellPolicyOccurrencePathFacts GetOrCreateSourceFacts(
@@ -301,6 +273,17 @@ internal sealed class ShellPolicyOccurrencePathFacts
             resolutionBase,
             Array.AsReadOnly(resolved));
     }
+
+    internal ShellPolicyResolvedPathView Resolve(
+        string? resolutionBase,
+        ShellPathStyle pathStyle)
+        => Resolve(
+            ShellPolicyPathFacts.ResolveScope(
+                ShellPolicyPathBaseKind.Real,
+                baseIndex: 0,
+                resolutionBase,
+                pathStyle),
+            pathStyle);
 
     private static ShellPolicySourcePathFact CreateFact(
         ShellPolicyPathOrigin origin,

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -253,6 +253,23 @@ internal sealed record ToolAuthorizationDecision
             [.. approvalMatches]);
     }
 
+    internal static ToolAuthorizationDecision From(
+        ToolAccessDecision decision,
+        IReadOnlyList<ToolApprovalMatch> approvalMatches)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        ArgumentNullException.ThrowIfNull(approvalMatches);
+
+        return decision switch
+        {
+            { NeedsApproval: true, ApprovalContext: { } context } =>
+                RequiresApproval(context, approvalMatches),
+            { Allowed: false, DenyReason: { } reason } => Deny(reason),
+            { Allowed: true, AllowReason: { } reason } => Allow(reason, approvalMatches),
+            _ => throw new InvalidOperationException("Tool access decision is incomplete.")
+        };
+    }
+
     internal ToolAuthorizationDecision WithShellPolicyTrace(ShellPolicyDecisionTrace trace)
     {
         ArgumentNullException.ThrowIfNull(trace);


### PR DESCRIPTION
Removes compatibility-era shell policy helpers now superseded by the typed path-fact projection.

- Routes legacy reviewed-safe checks through the shared occurrence fact resolver.
- Centralizes ToolAccessDecision conversion.
- Preserves typed and compatibility policy boundaries.
- Removes 101 net production lines.

Validation:
- Release build: 0 warnings and 0 errors
- Full runnable suite: 7,431 passed; 15 expected skips
- Focused policy suite: 563 passed
- Fresh adversarial review: PASS
- Strict OpenSpec, headers, formatting, diff check, and changed-file Slopwatch: PASS