### PR TITLE
Correct the shell policy reduction gate

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -182,6 +182,9 @@ Done when:
 - [ ] The policy pipeline replaces the shell branches in `ToolAccessPolicy`
   and `ShellApprovalMatcher`; any retained legacy scan is deny-only and cannot
   authorize, create candidates, or widen scope.
+  The preliminary complete-footprint audit after PR #1947 found 1,484 added
+  production lines and 52 added control-flow lines. The simplification remains
+  incomplete until the complete footprint is below its frozen baseline.
 - [x] Shell calls pass through one coordinator. It snapshots immutable parser
   and run-scope facts, requests one typed actor batch, and composes grant and
   reviewed-safe coverage per candidate before one final result.

--- a/openspec/changes/simplify-shell-policy-evaluator/design.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/design.md
@@ -310,6 +310,19 @@ This change will not remove the public compatibility interface. A later generic 
 
 The final change must reduce aggregate lines and control-flow lines below 5,136 and 373. The task report will include both counts.
 
+That original-file measure does not count code that moves into a new file. The final audit must also count the complete production footprint.
+
+The complete footprint uses corpus commit `8b4108aa92a229f4727377299d9dd2ed19f70e07` as its baseline. It includes every changed production C# file in these roots:
+
+- `src/Netclaw.Actors/Tools/`
+- `src/Netclaw.Security/`
+
+An added file has zero baseline lines. A removed file has zero final lines. The complete footprint must have fewer final lines and control-flow lines.
+
+The preliminary audit after PR #1947 found a failed reduction gate. The complete footprint changed from 6,680 to 8,164 lines.
+
+It also changed from 452 to 504 control-flow lines. The next slices must remove this displacement before the final audit can pass.
+
 The report will also include method complexity, line coverage, branch coverage, and CRAP risk. It will state the exact tool version and command.
 
 The final review will also inspect:

--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
@@ -1,0 +1,60 @@
+# Shell Policy Reduction Revision
+
+This evidence records the preliminary audit after PR #1947.
+
+## Reason for revision
+
+The original measure covered seven files. Those files changed from 5,136 to 4,589 lines.
+
+They also changed from 373 to 305 control-flow lines. This result did not count code that moved into eight new policy files.
+
+The complete changed production footprint grew. It changed from 6,680 to 8,164 lines.
+
+It also changed from 452 to 504 control-flow lines. The refactor therefore added 1,484 lines and 52 control-flow lines.
+
+The change cannot pass its reduction gate in this state. Task 8.9 required a design revision before more implementation work.
+
+## Revised measure
+
+The final audit uses corpus commit `8b4108aa92a229f4727377299d9dd2ed19f70e07` as its baseline.
+
+It counts every changed production C# file in these roots:
+
+- `src/Netclaw.Actors/Tools/`
+- `src/Netclaw.Security/`
+
+An added file has zero baseline lines. A removed file has zero final lines.
+
+The final state must satisfy both conditions:
+
+- The original seven files remain below 5,136 lines and 373 control-flow lines.
+- The complete changed production footprint has fewer lines and control-flow lines than the baseline.
+
+## Preliminary coverage and risk
+
+The audit used `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.
+
+The actor suite passed 3,411 cases with one expected Windows-only skip. It reported 68.81% line coverage and 45.54% branch coverage.
+
+The security suite passed 927 cases. It reported 62.04% line coverage and 51.99% branch coverage.
+
+The largest new risk values came from these methods:
+
+| File | Method | Complexity | Coverage | CRAP |
+| --- | --- | ---: | ---: | ---: |
+| `ShellPolicyEvaluation.cs` | `RunAsync` | 12 | 0.00%* | 156.00 |
+| `ShellPathRules.cs` | `TryGetWindowsDepth` | 12 | 0.00% | 156.00 |
+| `ShellPolicyCoordinator.cs` | `EvaluateCoreAsync` | 9 | 0.00%* | 90.00 |
+| `ShellPolicyPathFacts.cs` | `Resolve` | 8 | 0.00% | 72.00 |
+
+`crap4dotnet` does not map async state-machine coverage to the source method. The zero values remain repeatable comparison data.
+
+## Commands
+
+```bash
+dotnet-coverage collect 'dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --no-build --no-restore' \
+  -f cobertura -o /tmp/netclaw-final-actors.cobertura.xml
+dotnet-coverage collect 'dotnet test src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj -c Release --no-build --no-restore' \
+  -f cobertura -o /tmp/netclaw-final-security.cobertura.xml
+dotnet-crap analyze SOURCE.cs --coverage COVERAGE.xml --min-crap 0 --output REPORT.json
+```

--- a/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
@@ -187,6 +187,8 @@ It SHALL not add a public API, durable schema, command parser, or duplicate poli
 - **WHEN** all refactor slices are complete
 - **THEN** the task evidence SHALL report before and after production line and control-flow counts
 - **AND** the after counts SHALL be lower than 5,136 lines and 373 control-flow lines
+- **AND** the complete changed production footprint SHALL have fewer lines and control-flow lines than the frozen corpus commit
+- **AND** an added production file SHALL contribute zero lines to the baseline count
 - **AND** the evidence SHALL report method complexity, coverage, and CRAP risk with a versioned command
 
 #### Scenario: Public and durable compatibility

--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -63,6 +63,9 @@
 - [ ] 7.4 Verify production policy contains no new executable names or executable-private argument rules.
 - [ ] 7.5 Verify no call-local parser occurrence, command text, path, or secret crosses actor or persistence boundaries.
 - [ ] 7.6 Run API and durable-contract comparisons against the frozen baseline.
+- [x] 7.7 Audit the complete changed production footprint and revise the reduction gate when file moves hide growth.
+- [ ] 7.8 Remove the displaced production lines and control flow until the complete footprint is below baseline.
+- [ ] 7.9 Run exact parity and adversarial review after each additional reduction slice.
 
 ## 8. Prove equivalence and reduction
 
@@ -72,6 +75,6 @@
 - [ ] 8.4 Confirm channel, reminder, webhook, headless, recovery, and subagent outcomes remain unchanged.
 - [ ] 8.5 Compare public APIs and persisted wire bytes against the frozen baseline.
 - [ ] 8.6 Report final lines, control-flow lines, method complexity, coverage risk, files, largest methods, and duplicate helpers beside the baseline.
-- [ ] 8.7 Require aggregate lines and control-flow lines below 5,136 and 373 while all required checks remain.
+- [ ] 8.7 Require the original-file and complete-footprint reduction gates while all required checks remain.
 - [ ] 8.8 Obtain final adversarial review of authority, precedence, compatibility, test sufficiency, and code reduction.
-- [ ] 8.9 Stop and revise this change if any expected outcome, trace row, authority boundary, or compatibility contract differs.
+- [ ] 8.9 Stop and revise this change if any outcome, trace row, authority boundary, compatibility contract, or reduction gate differs.


### PR DESCRIPTION
## Summary

- count the complete changed production footprint
- treat every added production file as zero baseline lines
- record the failed preliminary reduction audit
- keep the original seven-file threshold as a second gate

## Evidence

- original files: 5,136 to 4,589 lines
- complete footprint: 6,680 to 8,164 lines
- complete control flow: 452 to 504 lines
- actor coverage: 3,411 passed and one expected skip
- security coverage: 927 passed
- strict OpenSpec validation passed
- `git diff --check` passed

This PR changes planning artifacts only. It does not change runtime behavior.