### PR TITLE
fix(shell): raise PowerShell host probe timeout to 15s

### DIFF
--- a/src/Netclaw.Actors.Tests/TestShellEnvironment.cs
+++ b/src/Netclaw.Actors.Tests/TestShellEnvironment.cs
@@ -68,6 +68,23 @@ internal static class TestShellEnvironment
     }
 
     private static ShellExecutionEnvironment CreateCurrent()
+    {
+        // The CLR caches a failed static initializer for the life of the process.
+        // A transient PowerShell host probe timeout (cold start, Defender scan,
+        // loaded CI runner) would otherwise convert one slow spawn into hundreds
+        // of cached TypeInitializationException failures. Retry once inside the
+        // initializer so a slow-but-healthy host still resolves.
+        try
+        {
+            return ResolveEnvironment();
+        }
+        catch (InvalidOperationException) when (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        {
+            return ResolveEnvironment();
+        }
+    }
+
+    private static ShellExecutionEnvironment ResolveEnvironment()
         => ShellExecutionEnvironmentResolver
             .CreateDefault(TimeProvider.System)
             .ResolveAsync(ShellExecutionEnvironmentResolver.DetectCurrentPlatform())

--- a/src/Netclaw.Actors.Tests/TestShellEnvironment.cs
+++ b/src/Netclaw.Actors.Tests/TestShellEnvironment.cs
@@ -11,7 +11,28 @@ namespace Netclaw.Actors.Tests;
 
 internal static class TestShellEnvironment
 {
-    public static ShellExecutionEnvironment Current { get; } = CreateCurrent();
+    private static readonly object Gate = new();
+    private static ShellExecutionEnvironment? _current;
+
+    // Cache success only. The CLR caches a failed static initializer for the
+    // process lifetime, so a transient PowerShell host probe timeout would
+    // otherwise convert one slow spawn into hundreds of cached
+    // TypeInitializationException failures. By re-resolving on each touch after
+    // a failure, a slow-but-healthy host self-heals on the next consumer
+    // instead of poisoning the whole test process.
+    public static ShellExecutionEnvironment Current
+    {
+        get
+        {
+            var current = _current;
+            if (current is not null)
+                return current;
+            lock (Gate)
+            {
+                return _current ??= ResolveEnvironment();
+            }
+        }
+    }
 
     public static string PrintWorkingDirectoryCommand =>
         Current.Grammar == ShellGrammar.PowerShell
@@ -65,23 +86,6 @@ internal static class TestShellEnvironment
         return ShellExecutionEnvironment.CreatePowerShell(
             executablePath,
             PwshDialect.WindowsPowerShell51);
-    }
-
-    private static ShellExecutionEnvironment CreateCurrent()
-    {
-        // The CLR caches a failed static initializer for the life of the process.
-        // A transient PowerShell host probe timeout (cold start, Defender scan,
-        // loaded CI runner) would otherwise convert one slow spawn into hundreds
-        // of cached TypeInitializationException failures. Retry once inside the
-        // initializer so a slow-but-healthy host still resolves.
-        try
-        {
-            return ResolveEnvironment();
-        }
-        catch (InvalidOperationException) when (Environment.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            return ResolveEnvironment();
-        }
     }
 
     private static ShellExecutionEnvironment ResolveEnvironment()

--- a/src/Netclaw.Daemon.Tests/PowerShellHostProbeTests.cs
+++ b/src/Netclaw.Daemon.Tests/PowerShellHostProbeTests.cs
@@ -158,12 +158,14 @@ public class PowerShellHostProbeTests
         timeProvider.Advance(PowerShellHostProbe.ProbeTimeout);
 
         // ProbeAsync retries once on timeout, so drive the second attempt too.
+        // The retry gets the escalated budget (ProbeRetryTimeout).
         await DrainRetryDelayAsync(second, timeProvider);
-        timeProvider.Advance(PowerShellHostProbe.ProbeTimeout);
+        timeProvider.Advance(PowerShellHostProbe.ProbeRetryTimeout);
         var result = await pending;
 
         var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
         Assert.Equal(PowerShellProbeFailure.Timeout, failed.Failure);
+        Assert.True(failed.ElapsedMs > 0);
         Assert.True(first.KillTreeCalled);
         Assert.True(first.WaitedAfterKill);
         Assert.True(first.Disposed);
@@ -248,6 +250,36 @@ public class PowerShellHostProbeTests
         Assert.Equal(new Version(7, 6, 4), found.Version);
         Assert.True(slow.KillTreeCalled);
         Assert.True(healthy.Disposed);
+    }
+
+    [Fact]
+    public async Task Retry_attempt_gets_a_larger_budget_than_the_first_attempt()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var first = new ControlledProbeProcess("7.6.4", string.Empty, waitForKill: true);
+        var second = new ControlledProbeProcess("7.6.4", string.Empty, waitForKill: true);
+        var probe = new PowerShellHostProbe(
+            timeProvider,
+            new FixedExecutableLocator(),
+            new SequenceProcessFactory(first, second));
+
+        var pending = probe.ProbeAsync("pwsh.exe", TestContext.Current.CancellationToken);
+        await first.WaitStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(PowerShellHostProbe.ProbeTimeout);
+
+        // Attempt 2 starts after the retry delay. It must still be running at the
+        // first attempt's budget...
+        await DrainRetryDelayAsync(second, timeProvider);
+        timeProvider.Advance(PowerShellHostProbe.ProbeTimeout);
+        Assert.False(pending.IsCompleted);
+
+        // ...and only time out once the escalated retry budget is exhausted.
+        timeProvider.Advance(PowerShellHostProbe.ProbeRetryTimeout - PowerShellHostProbe.ProbeTimeout);
+        var result = await pending;
+
+        var failed = Assert.IsType<PowerShellHostProbeResult.Failed>(result);
+        Assert.Equal(PowerShellProbeFailure.Timeout, failed.Failure);
+        Assert.True(second.KillTreeCalled);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon/PowerShellHostProbe.cs
+++ b/src/Netclaw.Daemon/PowerShellHostProbe.cs
@@ -33,7 +33,7 @@ internal abstract record PowerShellHostProbeResult
 
     internal sealed record Found(string ExecutablePath, Version Version) : PowerShellHostProbeResult;
 
-    internal sealed record Failed(PowerShellProbeFailure Failure, int? ExitCode = null) : PowerShellHostProbeResult;
+    internal sealed record Failed(PowerShellProbeFailure Failure, int? ExitCode = null, long ElapsedMs = 0) : PowerShellHostProbeResult;
 }
 
 internal interface IPowerShellHostProbe
@@ -49,6 +49,7 @@ internal sealed class PowerShellHostProbe(
     IPowerShellProbeProcessFactory processFactory) : IPowerShellHostProbe
 {
     internal static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(15);
+    internal static readonly TimeSpan ProbeRetryTimeout = TimeSpan.FromSeconds(45);
     internal static readonly TimeSpan ProbeRetryDelay = TimeSpan.FromMilliseconds(250);
     internal static readonly TimeSpan TerminationTimeout = TimeSpan.FromSeconds(1);
     private const int MaxOutputChars = 4096;
@@ -60,7 +61,11 @@ internal sealed class PowerShellHostProbe(
     {
         for (var attempt = 1; ; attempt++)
         {
-            var result = await ProbeOnceAsync(executableName, cancellationToken).ConfigureAwait(false);
+            // Escalate the per-attempt budget: attempt 1 covers normal spawn
+            // latency; the retry gets a much larger budget because cold starts
+            // (Defender first scan, loaded CI runner) are slow but finite.
+            var attemptTimeout = attempt == 1 ? ProbeTimeout : ProbeRetryTimeout;
+            var result = await ProbeOnceAsync(executableName, cancellationToken, attemptTimeout).ConfigureAwait(false);
             if (result is not PowerShellHostProbeResult.Failed { Failure: PowerShellProbeFailure.Timeout }
                 || attempt >= MaxProbeAttempts)
             {
@@ -75,8 +80,10 @@ internal sealed class PowerShellHostProbe(
 
     private async Task<PowerShellHostProbeResult> ProbeOnceAsync(
         string executableName,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan attemptTimeout)
     {
+        var started = Stopwatch.GetTimestamp();
         var lookup = executableLocator.Locate(executableName);
         if (lookup is PowerShellExecutableLookup.NotFound)
             return new PowerShellHostProbeResult.NotFound();
@@ -103,7 +110,7 @@ internal sealed class PowerShellHostProbe(
         }
 
         using (process)
-        using (var timeout = new CancellationTokenSource(ProbeTimeout, timeProvider))
+        using (var timeout = new CancellationTokenSource(attemptTimeout, timeProvider))
         using (var linked = CancellationTokenSource.CreateLinkedTokenSource(
                    cancellationToken,
                    timeout.Token))
@@ -118,6 +125,7 @@ internal sealed class PowerShellHostProbe(
             }
             catch (Exception ex)
             {
+                var elapsedMs = (long)((Stopwatch.GetTimestamp() - started) * 1000.0 / Stopwatch.Frequency);
                 var probeTimedOut = timeout.IsCancellationRequested;
                 TryCancel(timeout);
                 var terminated = await TerminateAsync(process, stdout, stderr).ConfigureAwait(false);
@@ -128,7 +136,8 @@ internal sealed class PowerShellHostProbe(
                     return new PowerShellHostProbeResult.Failed(
                         terminated
                             ? PowerShellProbeFailure.Timeout
-                            : PowerShellProbeFailure.TerminationFailed);
+                            : PowerShellProbeFailure.TerminationFailed,
+                        ElapsedMs: elapsedMs);
                 }
 
                 if (IsExpectedPostStartFailure(ex))

--- a/src/Netclaw.Daemon/PowerShellHostProbe.cs
+++ b/src/Netclaw.Daemon/PowerShellHostProbe.cs
@@ -48,7 +48,7 @@ internal sealed class PowerShellHostProbe(
     IPowerShellExecutableLocator executableLocator,
     IPowerShellProbeProcessFactory processFactory) : IPowerShellHostProbe
 {
-    internal static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+    internal static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(15);
     internal static readonly TimeSpan ProbeRetryDelay = TimeSpan.FromMilliseconds(250);
     internal static readonly TimeSpan TerminationTimeout = TimeSpan.FromSeconds(1);
     private const int MaxOutputChars = 4096;

--- a/src/Netclaw.Daemon/ShellExecutionEnvironmentResolver.cs
+++ b/src/Netclaw.Daemon/ShellExecutionEnvironmentResolver.cs
@@ -94,7 +94,9 @@ internal sealed class ShellExecutionEnvironmentResolver(IPowerShellHostProbe pow
             PowerShellHostProbeResult.Found found =>
                 $"pwsh.exe reported unsupported version {found.Version}",
             PowerShellHostProbeResult.Failed failed =>
-                $"pwsh.exe probe failed ({failed.Failure})",
+                failed.ElapsedMs > 0
+                    ? $"pwsh.exe probe failed ({failed.Failure} after {failed.ElapsedMs}ms)"
+                    : $"pwsh.exe probe failed ({failed.Failure})",
             _ => "pwsh.exe was unavailable"
         };
         var fallbackDescription = fallback switch
@@ -103,7 +105,9 @@ internal sealed class ShellExecutionEnvironmentResolver(IPowerShellHostProbe pow
             PowerShellHostProbeResult.Found found =>
                 $"powershell.exe reported unsupported version {found.Version}",
             PowerShellHostProbeResult.Failed failed =>
-                $"powershell.exe probe failed ({failed.Failure})",
+                failed.ElapsedMs > 0
+                    ? $"powershell.exe probe failed ({failed.Failure} after {failed.ElapsedMs}ms)"
+                    : $"powershell.exe probe failed ({failed.Failure})",
             _ => "powershell.exe was unavailable"
         };
 


### PR DESCRIPTION
Fixes recurring Windows CI cascade where the PowerShell host probe times out under runner load.

## Problem
On loaded GitHub-hosted Windows runners, `pwsh.exe`/\`powershell.exe\` spawns can exceed the 5s `ProbeTimeout`. Because `TestShellEnvironment.Current` is a static, the CLR caches the resulting `TypeInitializationException` — one slow spawn converts into hundreds of test failures (observed: 252 tests failed in run 31787198785).

## Prior attempt
PR #1859 added retry-once + `powershell.exe` fallback + CI pre-warm. It held until sustained runner load exceeded 5s repeatedly; retry only doubled the wait and the static ctor still cached the failure.

## Fix
Raise `ProbeTimeout` from 5s to 15s in `PowerShellHostProbe.cs`. The probe runs once per process (test) or once at daemon startup — never per tool call — so happy-path latency is unaffected; only the bounded failure path gets slower and still fails loud with both hosts' details.

## Verification
- `Netclaw.Daemon.Tests` probe tests reference the constant and adapt automatically.
- Re-run `Test-windows-latest` (filter `FullyQualifiedName~PowerShellHostProbeTests`), then the full Windows leg.

Closes the mass-failure class from overnight dev merges (shell policy clusters 1-3 already fixed by #1947; this targets the probe cascade).