### PR TITLE
test(mcp): surface stdio connect diagnostics in prompt smoke test

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpPromptSkillTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpPromptSkillTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
 
-public sealed class SmokeMcpPromptSkillTests
+public sealed class SmokeMcpPromptSkillTests(ITestOutputHelper output)
 {
     [Theory]
     [InlineData("dotnet")]
@@ -30,10 +30,15 @@ public sealed class SmokeMcpPromptSkillTests
 
         await using var harness = McpSmokeHarness.Create(
             new Dictionary<string, McpServerEntry> { ["smoke"] = entry },
-            new ToolRegistry());
+            new ToolRegistry(),
+            output);
 
         await harness.Manager.StartAsync(cts.Token);
 
+        // Fail with the manager's real connect error instead of an opaque null:
+        // StartAsync swallows TimeoutException into an Unreachable status, so a
+        // bare null-check hides whether the python stdio handshake timed out.
+        harness.AssertConnected("smoke");
         var skill = Assert.IsType<SkillEntry>(harness.SkillRegistry.GetByName(setup.SkillName));
         var source = Assert.IsType<McpPromptSkillSource>(skill.Source);
         Assert.Equal(setup.PromptArgumentNames, source.Arguments.Select(static argument => argument.Name));

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerArgumentCoercionTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerArgumentCoercionTests.cs
@@ -21,7 +21,7 @@ namespace Netclaw.Daemon.Tests.Mcp;
 /// this test proves the wire: that a reconstructed argument actually serializes
 /// over JSON-RPC and is accepted by a real MCP server.
 /// </summary>
-public sealed class SmokeMcpServerArgumentCoercionTests
+public sealed class SmokeMcpServerArgumentCoercionTests(ITestOutputHelper output)
 {
     [Fact]
     public async Task StringifiedArrayArgument_IsReconstructed_OverTheWire()
@@ -39,9 +39,10 @@ public sealed class SmokeMcpServerArgumentCoercionTests
 
         var registry = new ToolRegistry();
         await using var harness = McpSmokeHarness.Create(
-            new Dictionary<string, McpServerEntry> { ["smoke"] = entry }, registry);
+            new Dictionary<string, McpServerEntry> { ["smoke"] = entry }, registry, output);
 
         await harness.Manager.StartAsync(ct);
+        harness.AssertConnected("smoke");
 
         var recordTasks = registry.GetAllRegistrations()
             .Select(r => r.Tool)


### PR DESCRIPTION
Fixes the opaque Windows failure of `SmokeMcpPromptSkillTests.ManagerDiscoversAndLoadsPromptOverStdio(serverKind: \"python\")`.

## Problem
On Windows CI (run 31794198529), the python theory case fails after 1m10s with `Assert.IsType() Failure: Value is null` at line 37. The manager swallows the MCP SDK `TimeoutException` (60s `InitializationTimeout` default) into an `Unreachable` status, and this test never calls `AssertConnected` nor passes an `ITestOutputHelper` — so CI shows only an opaque null and the real startup error goes to `NullLogger`.

## Prior context
- PR #1832 added `AssertConnected` + test logger but applied it only to `SmokeMcpServerHttpHeaderTests`.
- PR #1904 fixed the identical failure shape on `McpSdkCatalogNotificationIntegrationTests` with an explicit note: \"This PR does not prove or fix an underlying production MCP startup defect... the next run will retain the exception needed for a causal follow-up.\" That retention was never applied to this test.

## Fix
Diagnostics-first, per the #1904 pattern — no timeout jiggling:
- Inject `ITestOutputHelper` into the test.
- Call `harness.AssertConnected(\"smoke\")` before the skill lookup, so the next Windows failure names the manager's real exception instead of an opaque null.

This is the prerequisite for a causal fix (expected: python stdio child exceeds the 60s init budget on Windows). If the retained error confirms a timeout, the follow-up is to raise the stdio `InitializationTimeout` in `McpClientManager.BuildClientOptions`.