### PR TITLE
Steer agents toward file tools for known file work

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -234,6 +234,12 @@ Done when:
   root from one-command `WorkingDirectory` scope, prevent redundant project
   switches, and preserve `cd` when directory mutation is the requested shell
   behavior.
+- [x] Always-loaded guidance, shell metadata, and the operations skill prefer
+  first-party file tools for known reads, listings, and edits. Local repository
+  search, builds, tests, VCS, and process workflows remain shell use cases.
+  External discovery and retrieval remain routed through built-in `web_search`
+  and `web_fetch`. Five-run unaided evals passed 5/5 for read, listing, edit,
+  and local search. Web search passed 4/5 at the required 0.80 threshold.
 - [x] Reviewed-safe shell work beneath an undeclared cwd returns the same
   `set_working_directory` correction in parent sessions and subagents before
   any user prompt. The original tool call remains unchanged. The registered

--- a/evals/README.md
+++ b/evals/README.md
@@ -71,7 +71,7 @@ log patterns** (skill loading, memory recall, checkpoint formation).
 | Identity & Self-Awareness | 5 | Bot knows its name, version, repo, session ID, and routes all identity-file concerns without a skill dependency |
 | Skill Discovery and Activation | 20 | Models load relevant file, feed, and MCP prompt skills while they skip unrelated skills |
 | Memory Pipeline | 4 | Memory recall is active, identity-vs-memory routing is correct, explicit saves use memory tools, and automatic checkpointing still fires |
-| Tool Discovery & Use | 9 | Progressive tool discovery and invocation, including timestamped webhook configuration |
+| Tool Discovery & Use | 13 | Progressive discovery, file-vs-shell selection, web-vs-local search, and timestamped webhook configuration |
 | Grounding & Alignment | 4 | Uses tools to verify facts, admits uncertainty, and resolves announced attachment paths from the authoritative session root |
 | Autonomy & Execution | 2 | Executes tasks rather than describing them |
 | Deployment Mission | 1 | Applies the disk mission playbook, loads its required skill, and returns reviewed sales email |

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -417,6 +417,18 @@ start_eval_daemon() {
     awk 'BEGIN{x=1;for(i=1;i<=30000;i++){x=(x*48271)%2147483647;print x}}' \
         > "$EVAL_HOME/data/workspaces/netclaw-eval-largefile.txt"
 
+    # Seed deterministic local files for unaided file-vs-shell selection evals.
+    # The prompts name goals and paths, never tool names.
+    local selection_root="$EVAL_HOME/data/workspaces/file-tool-selection"
+    mkdir -p "$selection_root/search-target/nested"
+    printf 'first\nexpected-file-read-line\nthird\n' > "$selection_root/read-target.txt"
+    printf 'initial-content\n' > "$selection_root/edit-target.txt"
+    local i
+    for ((i = 1; i <= 20; i++)); do
+        printf 'ordinary-%s\n' "$i" > "$selection_root/search-target/file-$i.txt"
+    done
+    printf 'local-search-eval-token\n' > "$selection_root/search-target/nested/match.txt"
+
     # The eval container runs as the non-root `netclaw` user and needs write
     # access to the bind-mounted identity, logs, skills, and data trees.
     chmod -R ugo+rwX "$EVAL_HOME/identity" "$EVAL_HOME/logs" "$EVAL_HOME/data" "$EVAL_HOME/skills"
@@ -1252,7 +1264,8 @@ assert_tool_shell() {
 }
 
 assert_tool_web_search() {
-    stdout_contains '\[tool:call\] web_search'
+    stdout_tool_called 'web_search' \
+        && ! stdout_tool_called 'shell_execute'
 }
 
 assert_tool_cli_invoke() {
@@ -1260,7 +1273,38 @@ assert_tool_cli_invoke() {
 }
 
 assert_tool_file_list() {
-    stdout_contains '\[tool:call\] file_list'
+    stdout_tool_called 'file_list'
+}
+
+assert_tool_known_file_read() {
+    stdout_tool_called 'file_read' \
+        && ! stdout_tool_called 'shell_execute' \
+        && stdout_response_contains 'expected-file-read-line'
+}
+
+assert_tool_known_directory_list() {
+    stdout_tool_called 'file_list' \
+        && ! stdout_tool_called 'shell_execute' \
+        && stdout_response_contains 'read-target.txt' \
+        && stdout_response_contains 'edit-target.txt'
+}
+
+setup_tool_known_file_edit() {
+    printf 'initial-content\n' \
+        > "$EVAL_HOME/data/workspaces/file-tool-selection/edit-target.txt"
+}
+
+assert_tool_known_file_edit() {
+    (stdout_tool_called 'file_edit' || stdout_tool_called 'file_write') \
+        && ! stdout_tool_called 'shell_execute' \
+        && grep -qx 'edited-content' \
+            "$EVAL_HOME/data/workspaces/file-tool-selection/edit-target.txt"
+}
+
+assert_tool_local_repository_search() {
+    stdout_tool_called 'shell_execute' \
+        && ! stdout_tool_called 'web_search' \
+        && stdout_response_contains 'match.txt'
 }
 
 assert_tool_timestamped_webhook() {
@@ -1823,6 +1867,11 @@ run_case() {
         local prompt
         prompt=$(pick_variant "${prompts[@]}")
 
+        local setup_fn="setup_${case_name}"
+        if declare -f "$setup_fn" >/dev/null 2>&1; then
+            "$setup_fn" "$run"
+        fi
+
         run_prompt "$prompt" "$output_format"
 
         local passed=0
@@ -2028,14 +2077,26 @@ run_all() {
     run_case tool_shell "shell_execute called" \
         "Run 'echo hello' in the shell"
 
-    run_case tool_web_search "web_search called" \
+    run_case tool_web_search "web_search called without shell" \
         "Search the web for today's weather in Columbus Ohio"
 
     run_case tool_cli_invoke "list_reminders called" \
         "List my active reminders"
 
-    run_case tool_file_list "file_list called" \
+    run_case tool_file_list "file_list called without shell" \
         "What files are in my session directory?"
+
+    run_case tool_known_file_read "known file content uses file_read without shell" \
+        "Read line 2 of /home/netclaw/.netclaw/workspaces/file-tool-selection/read-target.txt and tell me its exact value."
+
+    run_case tool_known_directory_list "known directory listing uses file_list without shell" \
+        "List the entries in /home/netclaw/.netclaw/workspaces/file-tool-selection and tell me their names."
+
+    run_case tool_known_file_edit "known file edit uses a file tool without shell" \
+        "Replace initial-content with edited-content in /home/netclaw/.netclaw/workspaces/file-tool-selection/edit-target.txt, then report completion."
+
+    run_case tool_local_repository_search "local repository search uses shell, not web_search" \
+        "Search recursively under /home/netclaw/.netclaw/workspaces/file-tool-selection/search-target for the exact text local-search-eval-token and tell me which file contains it."
 
     run_case tool_timestamped_webhook "set_webhook called with Stripe timestamp verification" \
         "Create a public inbound webhook route named stripe-events for Stripe. Use secret eval-whsec-123 and have it summarize each payment event."

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.51.0"
+  version: "2.52.0"
 ---
 
 # Netclaw Operations
@@ -36,6 +36,15 @@ a reference file — load the one matching the user's intent with
 | Rotate or repair secrets | `skill_read_resource('netclaw-operations', 'references/secrets.md')` |
 | Pair remote devices, manage access | `skill_read_resource('netclaw-operations', 'references/devices.md')` |
 | Kick the tires on Netclaw end-to-end locally | `skill_read_resource('netclaw-operations', 'references/demo-apphost.md')` |
+
+## File and Shell Selection
+
+Prefer file tools for known file reads, directory listings, and edits.
+Do not use shell for those operations unless shell behavior is requested.
+Never use `cat`, `sed`, or `ls` when a file tool can perform the requested operation.
+Use `shell_execute` for local repository search, builds, tests, VCS, or process semantics.
+Use built-in `web_search` for external discovery and `web_fetch` for page retrieval.
+Do not use shell HTTP clients for external search or retrieval.
 
 ## Project Directory
 

--- a/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/structure-shell-approval-policy/specs/tool-approval-gates/spec.md
@@ -709,6 +709,39 @@ unsupported, or contradictory domains SHALL keep reviewed-safe policy strict.
 - **WHEN** the data argument has a positive non-filesystem fact
 - **THEN** the output redirect still prevents reviewed-safe coverage
 
+### Requirement: Guidance distinguishes file operations from shell semantics
+
+Team and Personal guidance SHALL prefer first-party file tools for known file
+reads, directory listings, and edits. It SHALL avoid shell for those operations
+unless shell behavior is requested. Shell guidance SHALL retain
+`shell_execute` for local repository search, builds, tests, VCS, and process
+semantics. External discovery SHALL use built-in `web_search`. Page retrieval
+SHALL use built-in `web_fetch`, not a shell HTTP client.
+
+#### Scenario: Known file content avoids shell approval
+
+- **GIVEN** the agent knows the target file or directory
+- **WHEN** it needs content, a listing, or an edit
+- **THEN** guidance prefers the matching first-party file tool
+- **AND** it does not teach the agent to compose `cat`, `sed`, or `ls` chains
+- **AND** deliberate shell-behavior requests remain shell work
+
+#### Scenario: Shell workflows retain their execution tool
+
+- **GIVEN** the task requires local repository search, build, test, VCS, or process semantics
+- **WHEN** the agent selects a tool
+- **THEN** guidance retains `shell_execute` for that work
+- **AND** no approval-policy exception is added
+
+#### Scenario: External search avoids the local shell
+
+- **GIVEN** the task requires information from external sources
+- **WHEN** the agent selects a search tool
+- **THEN** guidance prefers built-in `web_search`
+- **AND** page retrieval uses built-in `web_fetch`
+- **AND** shell HTTP clients are not used for either operation
+- **AND** it does not classify web search as local shell work
+
 #### Scenario: Exact path scope does not declare a safe root
 
 - **GIVEN** an agent has no declared project root for a user-named project

--- a/openspec/changes/structure-shell-approval-policy/tasks.md
+++ b/openspec/changes/structure-shell-approval-policy/tasks.md
@@ -153,6 +153,13 @@
   subagent eval that proves a different user-named project is declared before
   the child's first shell inspection.
 - [x] 8.6 Update `IMPLEMENTATION_PLAN.md` and canonical OpenSpec requirements.
+- [x] 8.7 Prefer first-party file tools for known reads, listings, and edits in
+  always-loaded guidance, shell metadata, and the operations skill. Retain shell
+  use for local repository search, builds, tests, VCS, and process semantics.
+  Route external discovery through built-in `web_search` and retrieval through
+  `web_fetch`. Add unaided behavioral evals for each tool-selection boundary.
+  Five-run results were 5/5 for read, listing, edit, and local search, and 4/5
+  for web search at the required 0.80 threshold.
 
 ## 9. Validation and staged delivery
 

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -45,8 +45,11 @@ public class ShellToolTests
     }
 
     [Fact]
-    public void Working_directory_schema_prefers_the_typed_argument_to_inline_cd()
+    public void Shell_schema_prefers_file_tools_and_typed_working_directory()
     {
+        Assert.Contains("shell semantics", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("Do not use for known file reads", _tool.Description, StringComparison.Ordinal);
+
         var commandDescription = _tool.ParameterSchema
             .GetProperty("properties")
             .GetProperty("Command")

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -20,7 +20,7 @@ namespace Netclaw.Actors.Tools;
 /// Captures stdout+stderr, enforces timeout, closes stdin immediately.
 /// </summary>
 [NetclawTool(ToolName,
-    "Execute a shell command and return stdout/stderr output with exit code",
+    "Execute commands requiring shell semantics. Do not use for known file reads, directory listings, or edits unless shell behavior is requested.",
     Grant = "shell")]
 public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 {

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -88,6 +88,29 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.Contains("Do not continue with a stale directory", prompt);
     }
 
+    [Theory]
+    [InlineData(TrustAudience.Team)]
+    [InlineData(TrustAudience.Personal)]
+    public void Trusted_audiences_prefer_file_tools_for_known_content(TrustAudience audience)
+    {
+        var prompt = _provider.GetSystemPrompt(audience);
+
+        Assert.Contains("Prefer file tools for known file reads", prompt);
+        Assert.Contains("Do not use shell for those operations", prompt);
+        Assert.Contains("Never use `cat`, `sed`, or `ls`", prompt);
+        Assert.Contains("Use `shell_execute` for local repository search", prompt);
+        Assert.Contains("Use built-in `web_search` for external discovery", prompt);
+        Assert.Contains("Do not use shell HTTP clients", prompt);
+    }
+
+    [Fact]
+    public void Public_audience_omits_shell_selection_guidance()
+    {
+        var prompt = _provider.GetSystemPrompt(TrustAudience.Public);
+
+        Assert.DoesNotContain("Use `shell_execute` for local repository search", prompt);
+    }
+
     [Fact]
     public void Public_audience_does_not_include_tooling()
     {

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -17,6 +17,15 @@
   without attempting at least one fallback.
 - Never say "you can visit..." or "you can call..." — look it up yourself.
 
+## File and Shell Selection
+
+- Prefer file tools for known file reads, directory listings, and edits.
+- Do not use shell for those operations unless shell behavior is requested.
+- Never use `cat`, `sed`, or `ls` when a file tool can perform the requested operation.
+- Use `shell_execute` for local repository search, builds, tests, VCS, or process semantics.
+- Use built-in `web_search` for external discovery and `web_fetch` for page retrieval.
+- Do not use shell HTTP clients for external search or retrieval.
+
 ## Declaring Project Scope (load-bearing for approvals)
 
 Path arguments give the approval gate an exact candidate scope. They do not


### PR DESCRIPTION
## Summary
- prefer first-party file tools for known reads, listings, and edits
- distinguish local repository search via shell_execute from external discovery via web_search and web_fetch
- add deterministic tool-selection evals and synchronize the active OpenSpec plan

This does not change shell authorization, grants, or safe-verb policy.

## Validation
- full Release suite: 7,444 passed; 15 expected skips
- post-rebase focused: Configuration 21/21; Actors 39 passed with 1 expected Windows-only skip
- evals: known read 5/5, directory list 5/5, file edit 5/5, local repository search 5/5, web search 4/5 at the 0.80 threshold
- strict OpenSpec, header verification, Bash syntax, targeted format, diff check, and changed-file Slopwatch passed

## Live verification
The exact rebased commit b45bf8d is running on the local Netclaw instance and reports healthy runtime, SQLite, Slack, TUI, and MCP connector status.