### PR TITLE
Update Termina to 0.16.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.3.5" />
-    <PackageVersion Include="Termina" Version="0.16.1" />
+    <PackageVersion Include="Termina" Version="0.16.2" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Update Termina from `0.16.1` to `0.16.2`.
- Consume the concurrent `ContainerNode` disposal fix from Termina PR #384.
- Preserve the current Netclaw TUI and package surface.

## Proof

- `dotnet build Netclaw.slnx -c Release --no-restore`: zero warnings and errors.
- `dotnet test Netclaw.slnx -c Release --no-build --no-restore`: 7,445 passed with 15 expected skips.
- `./scripts/smoke/run-smoke.sh tui-cleanup`: passed with both providers preserved.
- Header, diff, and changed-file Slopwatch checks passed.

Evals do not apply because this update changes no model prompt, tool schema, or policy behavior.