### PR TITLE
Close shell policy coverage states

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
@@ -42,6 +42,24 @@ The expanded changed-file footprint now uses 7,240 baseline lines and 479 baseli
 
 The current slice uses 8,665 lines and 530 control-flow lines. The complete reduction gate remains open.
 
+## Closed coverage-source slice
+
+This slice replaces the coverage-kind, reason, and scope tuple with one closed internal source. Trace fields now derive from that source once.
+
+Validated actor evidence is bound to its originating candidate snapshot. The evaluation no longer revalidates the same actor batch after the boundary accepts it.
+
+The slice removes another 100 production lines and nine control-flow lines. It also removes 28 redundant state-test lines.
+
+The cumulative footprint uses 8,565 lines and 521 control-flow lines. The complete reduction gate remains open.
+
+## Derived path-metadata slice
+
+This slice removes path-domain tags already expressed by the closed domain type. It also removes base tags already expressed by separate real, intent, and fallback views.
+
+The slice removes another 45 production lines and eight test lines. It does not change the control-flow count.
+
+The cumulative footprint uses 8,520 lines and 521 control-flow lines. The complete reduction gate remains open.
+
 ## Preliminary coverage and risk
 
 The audit used `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -1546,14 +1546,11 @@ public class DispatchingToolExecutorTests
         for (var index = 0; index < 300; index++)
         {
             builder.AddCoverage(
-                ShellPolicyTraceStage.ReviewedSafePolicy,
+                ShellPolicyCoverageSource.ReviewedSafeReal,
                 new ShellPolicyCandidate(
                     new ShellPolicyCandidateId(index),
                     BashCandidate($"/usr/bin/tool-{index}"),
-                    SourceOccurrence: null),
-                ShellCoverageKind.ReviewedSafePolicy,
-                ShellPolicyReason.ReviewedSafePhrase,
-                ShellScopeRelation.UnderRealRoot);
+                    SourceOccurrence: null));
         }
 
         var decision = ToolAuthorizationDecision.Allow(ToolAllowReason.SafeVerbInTrustedScope);
@@ -1605,14 +1602,11 @@ public class DispatchingToolExecutorTests
         var executor = CreateApprovalGatedShellExecutor(logger: logger);
         var builder = new ShellPolicyDecisionTraceBuilder();
         builder.AddCoverage(
-            ShellPolicyTraceStage.ReviewedSafePolicy,
+                ShellPolicyCoverageSource.ReviewedSafeReal,
             new ShellPolicyCandidate(
                 new ShellPolicyCandidateId(0),
                 BashCandidate($"/usr/bin/{secret}\r\n\u202Espoof"),
-                SourceOccurrence: null),
-            ShellCoverageKind.ReviewedSafePolicy,
-            ShellPolicyReason.ReviewedSafePhrase,
-            ShellScopeRelation.UnderRealRoot);
+                SourceOccurrence: null));
         var trace = builder.Complete(
             ToolAuthorizationDecision.Allow(ToolAllowReason.SafeVerbInTrustedScope));
 

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -176,8 +176,6 @@ public sealed class ShellPolicyEvaluationTests
                 .Analyze("Get-Date > $name", @"C:\work")
                 .Commands);
         var resolutionBase = new ShellPolicyScopePathFact(
-            ShellPolicyPathBaseKind.Real,
-            BaseIndex: 0,
             @"C:\work",
             ShellPolicyPathResolutionState.Known,
             CreateCanonicalPath(@"C:\work", ShellPathStyle.Windows));
@@ -279,7 +277,7 @@ public sealed class ShellPolicyEvaluationTests
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
         Assert.Equal(1, service.RequestCount);
-        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         Assert.NotNull(evaluation.GrantEvidence);
         Assert.Single(evaluation.ApprovalMatches);
         Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
@@ -325,8 +323,39 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(1, service.RequestCount);
         Assert.False(laterStageVisited);
         Assert.Null(evaluation.GrantEvidence);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Fact]
+    public void Validated_actor_evidence_remains_bound_to_its_projection()
+    {
+        var source = CreateEvaluation(BashCandidate("git status"));
+        var target = CreateEvaluation(BashCandidate("git status"));
+        var candidate = Assert.Single(source.Projection.GrantCandidates);
+        var actorResult = new ShellApprovalMatchResult(
+            new PersistentGrantStoreStatus.Ready(),
+            [
+                new ShellGrantCandidateMatch(
+                    candidate.Id,
+                    new ToolApprovalMatch(candidate.Candidate.Verb, "session", "this chat"),
+                    ShellCoverageKind.Session,
+                    NearMisses: [])
+            ]);
+        Assert.True(ValidatedShellGrantEvidence.TryCreate(
+            actorResult,
+            source.Projection.GrantCandidates,
+            source.Projection.ApprovalContext.Cwd,
+            out var evidence));
+
+        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
+            target.ApplyActorEvidence(Assert.IsType<ValidatedShellGrantEvidence>(evidence)));
+
+        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, result.Reason);
+        Assert.Equal("internal_policy_failure", target.TerminalDecision?.DenyReason);
+        Assert.Equal(
+            ShellPolicyCoverageSource.Uncovered,
+            target.CoverageFor(Assert.Single(target.Candidates).Id));
     }
 
     [Fact]
@@ -366,8 +395,10 @@ public sealed class ShellPolicyEvaluationTests
             TestContext.Current.CancellationToken);
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(grantCandidate.Id).Kind);
-        Assert.Equal(ShellCoverageKind.ReviewedSafePolicy, evaluation.CoverageFor(sideEffect.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(grantCandidate.Id));
+        Assert.Equal(
+            ShellPolicyCoverageSource.ApprovalExemptSideEffect,
+            evaluation.CoverageFor(sideEffect.Id));
         Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
             ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext)));
         Assert.Collection(
@@ -382,8 +413,8 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     [Theory]
-    [InlineData(false, nameof(ShellCoverageKind.Uncovered))]
-    [InlineData(true, nameof(ShellCoverageKind.ReviewedSafePolicy))]
+    [InlineData(false, nameof(ShellPolicyCoverageSource.Uncovered))]
+    [InlineData(true, nameof(ShellPolicyCoverageSource.ApprovalExemptSideEffect))]
     public async Task Approval_exempt_stage_follows_approval_service_availability(
         bool serviceAvailable,
         string expectedCoverageName)
@@ -411,13 +442,13 @@ public sealed class ShellPolicyEvaluationTests
         Assert.NotNull(evaluation.GrantEvidence);
         Assert.Equal(0, service.RequestCount);
         Assert.Equal(
-            Enum.Parse<ShellCoverageKind>(expectedCoverageName),
-            evaluation.CoverageFor(candidate.Id).Kind);
+            Enum.Parse<ShellPolicyCoverageSource>(expectedCoverageName),
+            evaluation.CoverageFor(candidate.Id));
     }
 
     [Theory]
-    [InlineData(false, nameof(ShellCoverageKind.Uncovered))]
-    [InlineData(true, nameof(ShellCoverageKind.ReviewedSafePolicy))]
+    [InlineData(false, nameof(ShellPolicyCoverageSource.Uncovered))]
+    [InlineData(true, nameof(ShellPolicyCoverageSource.ReviewedSafeReal))]
     public async Task Reviewed_safe_real_scope_stage_requires_interactive_approval(
         bool interactive,
         string expectedCoverageName)
@@ -435,8 +466,8 @@ public sealed class ShellPolicyEvaluationTests
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
         Assert.Equal(
-            Enum.Parse<ShellCoverageKind>(expectedCoverageName),
-            evaluation.CoverageFor(candidate.Id).Kind);
+            Enum.Parse<ShellPolicyCoverageSource>(expectedCoverageName),
+            evaluation.CoverageFor(candidate.Id));
     }
 
     [Theory]
@@ -543,16 +574,14 @@ public sealed class ShellPolicyEvaluationTests
             TestContext.Current.CancellationToken);
 
         Assert.IsType<ShellPolicyStageResult.Continue>(beforeCoverage);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(consumer.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(consumer.Id));
 
         foreach (var prerequisiteId in consumer.IntentPrerequisites)
         {
             var prerequisite = evaluation.Candidates[prerequisiteId.Value];
             Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
                 prerequisite,
-                ShellCoverageKind.Session,
-                ShellPolicyReason.SessionGrant,
-                ShellScopeRelation.ThisChat));
+                ShellPolicyCoverageSource.Session));
         }
 
         var afterCoverage = await RunStagesAsync(
@@ -565,8 +594,8 @@ public sealed class ShellPolicyEvaluationTests
 
         Assert.IsType<ShellPolicyStageResult.Continue>(afterCoverage);
         Assert.Equal(
-            ShellCoverageKind.ReviewedSafePolicy,
-            evaluation.CoverageFor(consumer.Id).Kind);
+            ShellPolicyCoverageSource.ReviewedSafeIntent,
+            evaluation.CoverageFor(consumer.Id));
         Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
             ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval)));
         Assert.Contains(
@@ -596,7 +625,7 @@ public sealed class ShellPolicyEvaluationTests
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
         Assert.True(evaluation.HasOneTimeCoverage);
-        Assert.Equal(ShellCoverageKind.OneTime, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.OneTime, evaluation.CoverageFor(candidate.Id));
         Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
             ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval)));
         Assert.Collection(
@@ -630,7 +659,7 @@ public sealed class ShellPolicyEvaluationTests
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
         Assert.False(evaluation.HasOneTimeCoverage);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
 
         var oneTimeContext = evaluation.GetUncoveredApprovalContext(context.SessionDirectory);
         var terminal = Assert.IsType<ShellPolicyStageResult.Complete>(
@@ -652,9 +681,7 @@ public sealed class ShellPolicyEvaluationTests
         var candidate = evaluation.Candidates[0];
         Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
 
         var reprojected = evaluation.GetUncoveredApprovalContext("/work/session");
 
@@ -715,7 +742,7 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Contains(
             facts.Real.Facts,
             fact => fact.Source.Origin == ShellPolicyPathOrigin.EffectiveArgument
-                    && fact.Source.DomainKind == ShellPolicyPathDomainKind.Exact
+                    && fact.Source.Domain is ShellValueDomain.Exact
                     && fact.State == ShellPolicyPathResolutionState.Known
                     && fact.Paths.Any(path => path.Value == "/work/README.md"));
     }
@@ -737,8 +764,6 @@ public sealed class ShellPolicyEvaluationTests
         var occurrence = Assert.Single(
             new ShellCommandPolicy(environment).Analyze(command, resolutionBase).Commands);
         var scope = new ShellPolicyScopePathFact(
-            ShellPolicyPathBaseKind.Real,
-            BaseIndex: 0,
             resolutionBase,
             ShellPolicyPathResolutionState.Known,
             CreateCanonicalPath(resolutionBase, environment.PathStyle));
@@ -824,8 +849,6 @@ public sealed class ShellPolicyEvaluationTests
         var occurrence = Assert.Single(policy.Analyze("Get-Date > $name", @"C:\work").Commands);
         var source = ShellPolicyOccurrencePathFacts.Create(occurrence);
         var realScope = new ShellPolicyScopePathFact(
-            ShellPolicyPathBaseKind.Real,
-            BaseIndex: 0,
             "C:/work",
             ShellPolicyPathResolutionState.Known,
             CreateCanonicalPath(@"C:\work", ShellPathStyle.Windows));
@@ -838,7 +861,7 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Contains(
             resolved.Facts,
             fact => fact.Source.Origin == ShellPolicyPathOrigin.Redirect
-                    && fact.Source.DomainKind == ShellPolicyPathDomainKind.Unknown
+                    && fact.Source.Domain is ShellValueDomain.Unknown
                     && fact.State == ShellPolicyPathResolutionState.UnknownDynamic);
         Assert.DoesNotContain(
             resolved.Facts,
@@ -846,15 +869,13 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     [Fact]
-    public void Path_facts_retain_redirect_mode_and_domain_kind()
+    public void Path_facts_retain_redirect_mode_and_domain()
     {
         var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
         var policy = new ShellCommandPolicy(environment);
         var occurrence = Assert.Single(policy.Analyze("cat input.txt > output.txt", "/work").Commands);
         var source = ShellPolicyOccurrencePathFacts.Create(occurrence);
         var realScope = new ShellPolicyScopePathFact(
-            ShellPolicyPathBaseKind.Real,
-            BaseIndex: 0,
             "/work",
             ShellPolicyPathResolutionState.Known,
             CreateCanonicalPath("/work", ShellPathStyle.Posix));
@@ -869,7 +890,7 @@ public sealed class ShellPolicyEvaluationTests
 
         Assert.Equal(FileRedirectMode.Output, redirect.Source.RedirectMode);
         Assert.True(redirect.Source.RedirectIsComplete);
-        Assert.Equal(ShellPolicyPathDomainKind.Exact, redirect.Source.DomainKind);
+        Assert.IsType<ShellValueDomain.Exact>(redirect.Source.Domain);
         Assert.Equal(ShellPolicyPathResolutionState.Known, redirect.State);
         Assert.Equal("/work/output.txt", Assert.Single(redirect.Paths).Value);
     }
@@ -912,14 +933,14 @@ public sealed class ShellPolicyEvaluationTests
         {
             Assert.IsType<ShellPolicyStageResult.Continue>(result);
             Assert.Null(evaluation.TerminalDecision);
-            Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+            Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         }
         else
         {
             var complete = Assert.IsType<ShellPolicyStageResult.Complete>(result);
             Assert.Equal(ToolAuthorizationOutcome.Denied, complete.Decision.Outcome);
             Assert.Equal("approval_store_unavailable", complete.Decision.DenyReason);
-            Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+            Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         }
     }
 
@@ -948,9 +969,7 @@ public sealed class ShellPolicyEvaluationTests
         var uncovered = evaluation.Candidates[1];
         Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
             covered,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
         var context = TestToolExecutionContext.CreateBound(
             "signalr/shell-policy-terminal-prompt",
             "/work/session",
@@ -965,8 +984,8 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
         var prompt = Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext);
         Assert.Equal([uncovered.Candidate], prompt.Candidates);
-        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(covered.Id).Kind);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(uncovered.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(covered.Id));
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(uncovered.Id));
     }
 
     [Fact]
@@ -1042,13 +1061,11 @@ public sealed class ShellPolicyEvaluationTests
 
         var result = evaluation.Cover(
             candidate,
-            ShellCoverageKind.PersistentGlobal,
-            ShellPolicyReason.PersistentGlobalGrant,
-            ShellScopeRelation.Global,
+            ShellPolicyCoverageSource.PersistentGlobal,
             grantTimestamp);
 
         Assert.IsType<ShellPolicyStageResult.Continue>(result);
-        Assert.Equal(ShellCoverageKind.PersistentGlobal, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.PersistentGlobal, evaluation.CoverageFor(candidate.Id));
 
         var decision = ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval);
         Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(decision));
@@ -1089,18 +1106,14 @@ public sealed class ShellPolicyEvaluationTests
         var candidate = Assert.Single(evaluation.Candidates);
         Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
 
         var duplicate = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.PersistentGlobal,
-            ShellPolicyReason.PersistentGlobalGrant,
-            ShellScopeRelation.Global));
+            ShellPolicyCoverageSource.PersistentGlobal));
 
         Assert.Equal(ShellPolicyFault.CoverageAlreadyAssigned, duplicate.Reason);
-        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.Equal(ShellPolicyFault.CoverageAlreadyAssigned, evaluation.TerminalFault);
         Assert.NotNull(evaluation.CompletedTrace);
@@ -1120,12 +1133,10 @@ public sealed class ShellPolicyEvaluationTests
 
         var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
             changed,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
 
         Assert.Equal(ShellPolicyFault.CandidateFactsChanged, result.Reason);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.Equal(ShellPolicyFault.CandidateFactsChanged, evaluation.TerminalFault);
         Assert.NotNull(evaluation.CompletedTrace);
@@ -1133,11 +1144,9 @@ public sealed class ShellPolicyEvaluationTests
 
         var later = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
         Assert.Same(evaluation.TerminalDecision, later.Decision);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
     }
 
     [Fact]
@@ -1151,39 +1160,10 @@ public sealed class ShellPolicyEvaluationTests
 
         var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
             changed,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
 
         Assert.Equal(ShellPolicyFault.InvalidCandidateId, result.Reason);
         Assert.Single(evaluation.UncoveredCandidates);
-        Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
-    }
-
-    [Theory]
-    [InlineData(nameof(ShellCoverageKind.Uncovered), nameof(ShellPolicyReason.None), nameof(ShellScopeRelation.None))]
-    [InlineData(nameof(ShellCoverageKind.Denied), nameof(ShellPolicyReason.None), nameof(ShellScopeRelation.None))]
-    [InlineData(nameof(ShellCoverageKind.Session), nameof(ShellPolicyReason.PersistentGlobalGrant), nameof(ShellScopeRelation.ThisChat))]
-    [InlineData(nameof(ShellCoverageKind.Session), nameof(ShellPolicyReason.SessionGrant), nameof(ShellScopeRelation.Global))]
-    public void Invalid_coverage_transition_fails_closed(
-        string coverageName,
-        string reasonName,
-        string scopeRelationName)
-    {
-        var evaluation = CreateEvaluation(BashCandidate("git status"));
-        var candidate = Assert.Single(evaluation.Candidates);
-        var coverage = Enum.Parse<ShellCoverageKind>(coverageName);
-        var reason = Enum.Parse<ShellPolicyReason>(reasonName);
-        var scopeRelation = Enum.Parse<ShellScopeRelation>(scopeRelationName);
-
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
-            candidate,
-            coverage,
-            reason,
-            scopeRelation));
-
-        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
     }
 
@@ -1195,12 +1175,10 @@ public sealed class ShellPolicyEvaluationTests
 
         var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
             candidate,
-            (ShellCoverageKind)999,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            (ShellPolicyCoverageSource)999));
 
         Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.NotNull(evaluation.CompletedTrace);
         Assert.Single(evaluation.CompletedTrace.Rows);
@@ -1214,13 +1192,11 @@ public sealed class ShellPolicyEvaluationTests
 
         var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat,
+            ShellPolicyCoverageSource.Session,
             new DateTimeOffset(2026, 8, 14, 0, 0, 0, TimeSpan.Zero)));
 
         Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
-        Assert.Equal(ShellCoverageKind.Uncovered, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.NotNull(evaluation.CompletedTrace);
         Assert.Single(evaluation.CompletedTrace.Rows);
@@ -1235,9 +1211,7 @@ public sealed class ShellPolicyEvaluationTests
             BashCandidate("git diff"));
         Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
             evaluation.Candidates[0],
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
 
         var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Complete(
             ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval)));
@@ -1274,21 +1248,17 @@ public sealed class ShellPolicyEvaluationTests
         var candidate = Assert.Single(evaluation.Candidates);
         Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.Session,
-            ShellPolicyReason.SessionGrant,
-            ShellScopeRelation.ThisChat));
+            ShellPolicyCoverageSource.Session));
         var allow = ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval);
         Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(allow));
 
         var result = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Cover(
             candidate,
-            ShellCoverageKind.PersistentGlobal,
-            ShellPolicyReason.PersistentGlobalGrant,
-            ShellScopeRelation.Global));
+            ShellPolicyCoverageSource.PersistentGlobal));
 
         Assert.Same(allow, result.Decision);
         Assert.Same(allow, evaluation.TerminalDecision);
-        Assert.Equal(ShellCoverageKind.Session, evaluation.CoverageFor(candidate.Id).Kind);
+        Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         Assert.NotNull(evaluation.CompletedTrace);
         Assert.Equal(2, evaluation.CompletedTrace.Rows.Count);
         Assert.Equal(ShellPolicyTraceOutcome.Allow, evaluation.CompletedTrace.Rows[^1].Outcome);

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -313,8 +313,8 @@ internal sealed class ScopedShellSafeVerbPolicy
                     && pathStyle != ShellPathStyle.Posix
                 || fact.Source.AuthoredPathShape == ShellPathShape.Windows
                     && pathStyle != ShellPathStyle.Windows
-                || fact.Source.DomainKind is not
-                    (ShellPolicyPathDomainKind.Exact or ShellPolicyPathDomainKind.FiniteSet)
+                || fact.Source.Domain is not
+                    (ShellValueDomain.Exact or ShellValueDomain.FiniteSet)
                 || fact.State != ShellPolicyPathResolutionState.Known
                 || fact.Paths.Count == 0
                 || fact.Paths.Any(path =>
@@ -340,8 +340,8 @@ internal sealed class ScopedShellSafeVerbPolicy
         foreach (var fact in resolvedPaths.Facts.Where(static fact =>
                      fact.Source.Origin == ShellPolicyPathOrigin.EffectiveArgument))
         {
-            if (fact.Source.DomainKind is not
-                    (ShellPolicyPathDomainKind.Exact or ShellPolicyPathDomainKind.FiniteSet)
+            if (fact.Source.Domain is not
+                    (ShellValueDomain.Exact or ShellValueDomain.FiniteSet)
                 || fact.State != ShellPolicyPathResolutionState.Known
                 || fact.Paths.Count == 0
                 || fact.Paths.Any(path => !IsSafePath(
@@ -357,7 +357,7 @@ internal sealed class ScopedShellSafeVerbPolicy
                      fact.Source.Origin == ShellPolicyPathOrigin.Redirect))
         {
             if (fact.Source.RedirectMode != FileRedirectMode.Input
-                || fact.Source.DomainKind != ShellPolicyPathDomainKind.Exact
+                || fact.Source.Domain is not ShellValueDomain.Exact
                 || fact.State != ShellPolicyPathResolutionState.Known
                 || fact.Paths.Count != 1
                 || !IsSafePath(

--- a/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
+++ b/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
@@ -147,15 +147,19 @@ internal sealed class ValidatedShellGrantEvidence
 
     private ValidatedShellGrantEvidence(
         PersistentGrantStoreStatus persistentStore,
+        IReadOnlyList<ShellPolicyCandidate> sourceCandidates,
         ValidatedShellGrantCandidateEvidence[] candidateEvidence,
         ToolApprovalMatch[] approvalMatches)
     {
         PersistentStore = persistentStore;
+        SourceCandidates = sourceCandidates;
         _candidateEvidence = Array.AsReadOnly(candidateEvidence);
         _approvalMatches = Array.AsReadOnly(approvalMatches);
     }
 
     internal PersistentGrantStoreStatus PersistentStore { get; }
+
+    internal IReadOnlyList<ShellPolicyCandidate> SourceCandidates { get; }
 
     internal IReadOnlyList<ValidatedShellGrantCandidateEvidence> CandidateEvidence => _candidateEvidence;
 
@@ -207,6 +211,7 @@ internal sealed class ValidatedShellGrantEvidence
 
         evidence = new ValidatedShellGrantEvidence(
             result.PersistentStore,
+            candidates,
             validated,
             approvalMatches.ToArray());
         return true;

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -378,9 +378,7 @@ internal static class ShellPolicyGrantStages
         {
             var result = evaluation.Cover(
                 candidate,
-                ShellCoverageKind.ReviewedSafePolicy,
-                ShellPolicyReason.ApprovalExemptSideEffect,
-                ShellScopeRelation.None);
+                ShellPolicyCoverageSource.ApprovalExemptSideEffect);
             if (result is not ShellPolicyStageResult.Continue)
                 return result;
         }
@@ -407,9 +405,7 @@ internal static class ShellPolicyGrantStages
         {
             var result = evaluation.Cover(
                 candidate,
-                ShellCoverageKind.OneTime,
-                ShellPolicyReason.OneTimeGrant,
-                ShellScopeRelation.None);
+                ShellPolicyCoverageSource.OneTime);
             if (result is not ShellPolicyStageResult.Continue)
                 return result;
         }
@@ -460,9 +456,7 @@ internal static class ShellPolicyReviewedSafeStages
 
             var result = evaluation.Cover(
                 candidate,
-                ShellCoverageKind.ReviewedSafePolicy,
-                ShellPolicyReason.ReviewedSafePhrase,
-                ShellScopeRelation.UnderRealRoot);
+                ShellPolicyCoverageSource.ReviewedSafeReal);
             if (result is not ShellPolicyStageResult.Continue)
                 return result;
         }
@@ -499,9 +493,7 @@ internal static class ShellPolicyReviewedSafeStages
 
             var result = evaluation.Cover(
                 candidate,
-                ShellCoverageKind.ReviewedSafePolicy,
-                ShellPolicyReason.ReviewedSafePhrase,
-                ShellScopeRelation.UnderIntentRoot);
+                ShellPolicyCoverageSource.ReviewedSafeIntent);
             if (result is not ShellPolicyStageResult.Continue)
                 return result;
         }

--- a/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
@@ -133,21 +133,59 @@ internal sealed class ShellPolicyDecisionTraceBuilder
     }
 
     internal void AddCoverage(
-        ShellPolicyTraceStage stage,
+        ShellPolicyCoverageSource source,
         ShellPolicyCandidate candidate,
-        ShellCoverageKind coverage,
-        ShellPolicyReason reason,
-        ShellScopeRelation scopeRelation,
         DateTimeOffset? grantTimestamp = null)
-        => AddDetail(new ShellPolicyTraceRow(
+    {
+        var (stage, coverage, reason, scope) = source switch
+        {
+            ShellPolicyCoverageSource.OneTime => (
+                ShellPolicyTraceStage.OneTimeApproval,
+                ShellCoverageKind.OneTime,
+                ShellPolicyTraceReason.OneTimeGrant,
+                ShellScopeRelation.None),
+            ShellPolicyCoverageSource.Session => (
+                ShellPolicyTraceStage.StoredGrantMatch,
+                ShellCoverageKind.Session,
+                ShellPolicyTraceReason.SessionGrant,
+                ShellScopeRelation.ThisChat),
+            ShellPolicyCoverageSource.PersistentGlobal => (
+                ShellPolicyTraceStage.StoredGrantMatch,
+                ShellCoverageKind.PersistentGlobal,
+                ShellPolicyTraceReason.PersistentGlobalGrant,
+                ShellScopeRelation.Global),
+            ShellPolicyCoverageSource.PersistentFolder => (
+                ShellPolicyTraceStage.StoredGrantMatch,
+                ShellCoverageKind.PersistentFolder,
+                ShellPolicyTraceReason.PersistentFolderGrant,
+                ShellScopeRelation.UnderGrantRoot),
+            ShellPolicyCoverageSource.ReviewedSafeReal => (
+                ShellPolicyTraceStage.ReviewedSafePolicy,
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyTraceReason.ReviewedSafePhrase,
+                ShellScopeRelation.UnderRealRoot),
+            ShellPolicyCoverageSource.ReviewedSafeIntent => (
+                ShellPolicyTraceStage.ReviewedSafePolicy,
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyTraceReason.ReviewedSafePhrase,
+                ShellScopeRelation.UnderIntentRoot),
+            ShellPolicyCoverageSource.ApprovalExemptSideEffect => (
+                ShellPolicyTraceStage.ReviewedSafePolicy,
+                ShellCoverageKind.ReviewedSafePolicy,
+                ShellPolicyTraceReason.ApprovalExemptSideEffect,
+                ShellScopeRelation.None),
+            _ => throw new ArgumentOutOfRangeException(nameof(source))
+        };
+        AddDetail(new ShellPolicyTraceRow(
             stage,
             ShellPolicyTraceOutcome.Covered,
-            ToTraceReason(reason),
+            reason,
             candidate.Id,
             GetExecutableBasename(candidate.Candidate),
             coverage,
-            scopeRelation,
+            scope,
             grantTimestamp));
+    }
 
     internal ShellPolicyDecisionTrace Complete(ToolAuthorizationDecision decision)
     {
@@ -283,17 +321,6 @@ internal sealed class ShellPolicyDecisionTraceBuilder
         ShellCoverageKind.Session => ShellPolicyTraceReason.SessionGrant,
         ShellCoverageKind.PersistentGlobal => ShellPolicyTraceReason.PersistentGlobalGrant,
         ShellCoverageKind.PersistentFolder => ShellPolicyTraceReason.PersistentFolderGrant,
-        _ => ShellPolicyTraceReason.None,
-    };
-
-    private static ShellPolicyTraceReason ToTraceReason(ShellPolicyReason reason) => reason switch
-    {
-        ShellPolicyReason.OneTimeGrant => ShellPolicyTraceReason.OneTimeGrant,
-        ShellPolicyReason.SessionGrant => ShellPolicyTraceReason.SessionGrant,
-        ShellPolicyReason.PersistentGlobalGrant => ShellPolicyTraceReason.PersistentGlobalGrant,
-        ShellPolicyReason.PersistentFolderGrant => ShellPolicyTraceReason.PersistentFolderGrant,
-        ShellPolicyReason.ReviewedSafePhrase => ShellPolicyTraceReason.ReviewedSafePhrase,
-        ShellPolicyReason.ApprovalExemptSideEffect => ShellPolicyTraceReason.ApprovalExemptSideEffect,
         _ => ShellPolicyTraceReason.None,
     };
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -149,7 +149,7 @@ internal sealed class ShellPolicyEvaluation
 {
     private readonly ShellPolicyCandidate[] _candidates;
     private readonly IReadOnlyList<ShellPolicyCandidate> _candidateView;
-    private readonly ShellCandidateCoverage[] _coverage;
+    private readonly ShellPolicyCoverageSource[] _coverage;
     private readonly ShellPolicyDecisionTraceBuilder _trace = new();
     private ToolAuthorizationDecision? _terminalDecision;
     private ShellPolicyDecisionTrace? _completedTrace;
@@ -164,49 +164,26 @@ internal sealed class ShellPolicyEvaluation
         Projection = projection;
         _candidates = projection.Candidates.ToArray();
         _candidateView = Array.AsReadOnly(_candidates);
-        _coverage = new ShellCandidateCoverage[_candidates.Length];
-        for (var index = 0; index < _candidates.Length; index++)
-        {
-            var candidate = _candidates[index];
-            if (candidate.Id.Value != index)
-                throw new InvalidOperationException("Shell candidate IDs must match projection order.");
-
-            _coverage[index] = new ShellCandidateCoverage(
-                candidate.Id,
-                ShellCoverageKind.Uncovered,
-                ShellPolicyReason.None);
-        }
+        _coverage = new ShellPolicyCoverageSource[_candidates.Length];
     }
 
     internal ShellPolicyProjection Projection { get; }
 
     internal IReadOnlyList<ShellPolicyCandidate> Candidates => _candidateView;
 
-    internal bool AllCovered => _coverage.All(static item =>
-        item.Kind is not ShellCoverageKind.Uncovered and not ShellCoverageKind.Denied);
+    internal bool AllCovered => !_coverage.Contains(ShellPolicyCoverageSource.Uncovered);
 
-    internal IReadOnlyList<ShellPolicyCandidate> UncoveredCandidates
-    {
-        get
-        {
-            var uncovered = new List<ShellPolicyCandidate>();
-            for (var index = 0; index < _coverage.Length; index++)
-            {
-                if (_coverage[index].Kind == ShellCoverageKind.Uncovered)
-                    uncovered.Add(_candidates[index]);
-            }
-
-            return Array.AsReadOnly(uncovered.ToArray());
-        }
-    }
+    internal IReadOnlyList<ShellPolicyCandidate> UncoveredCandidates =>
+        Array.AsReadOnly(_candidates
+            .Where((_, index) => _coverage[index] == ShellPolicyCoverageSource.Uncovered)
+            .ToArray());
 
     internal ValidatedShellGrantEvidence? GrantEvidence => _grantEvidence;
 
     internal IReadOnlyList<ToolApprovalMatch> ApprovalMatches =>
         _grantEvidence?.ApprovalMatches ?? [];
 
-    internal bool HasOneTimeCoverage => _coverage.Any(static item =>
-        item.Kind == ShellCoverageKind.OneTime);
+    internal bool HasOneTimeCoverage => _coverage.Contains(ShellPolicyCoverageSource.OneTime);
 
     internal ToolApprovalContext GetUncoveredApprovalContext(string? sessionDirectory)
     {
@@ -237,7 +214,7 @@ internal sealed class ShellPolicyEvaluation
 
     internal ShellPolicyFault? TerminalFault => _terminalFault;
 
-    internal ShellCandidateCoverage CoverageFor(ShellPolicyCandidateId candidateId)
+    internal ShellPolicyCoverageSource CoverageFor(ShellPolicyCandidateId candidateId)
     {
         var index = candidateId.Value;
         if ((uint)index >= (uint)_coverage.Length)
@@ -248,8 +225,7 @@ internal sealed class ShellPolicyEvaluation
 
     internal bool IsCovered(ShellPolicyCandidateId candidateId)
     {
-        var coverage = CoverageFor(candidateId);
-        return coverage.Kind is not ShellCoverageKind.Uncovered and not ShellCoverageKind.Denied;
+        return CoverageFor(candidateId) != ShellPolicyCoverageSource.Uncovered;
     }
 
     internal ShellPolicyStageResult ApplyActorEvidence(ValidatedShellGrantEvidence evidence)
@@ -258,7 +234,8 @@ internal sealed class ShellPolicyEvaluation
         if (_terminalDecision is not null)
             return new ShellPolicyStageResult.Complete(_terminalDecision);
 
-        if (_grantEvidence is not null || !CanApplyActorEvidence(evidence))
+        if (_grantEvidence is not null
+            || !ReferenceEquals(evidence.SourceCandidates, Projection.GrantCandidates))
             return Fail(ShellPolicyFault.InvalidActorEvidence);
 
         _grantEvidence = evidence;
@@ -267,15 +244,9 @@ internal sealed class ShellPolicyEvaluation
             var actorEvidence = candidateEvidence.ActorEvidence;
             if (actorEvidence.GrantCoverage is { } grantCoverage)
             {
-                GetActorCoverageFacts(
-                    grantCoverage,
-                    out var reason,
-                    out var scopeRelation);
                 var result = Cover(
                     candidateEvidence.Candidate,
-                    grantCoverage,
-                    reason,
-                    scopeRelation,
+                    ToCoverageSource(grantCoverage),
                     actorEvidence.GrantCreatedAt);
                 if (result is not ShellPolicyStageResult.Continue)
                     return result;
@@ -291,9 +262,7 @@ internal sealed class ShellPolicyEvaluation
 
     internal ShellPolicyStageResult Cover(
         ShellPolicyCandidate candidate,
-        ShellCoverageKind coverage,
-        ShellPolicyReason reason,
-        ShellScopeRelation scopeRelation,
+        ShellPolicyCoverageSource source,
         DateTimeOffset? grantTimestamp = null)
     {
         ArgumentNullException.ThrowIfNull(candidate);
@@ -308,27 +277,21 @@ internal sealed class ShellPolicyEvaluation
         if (!ReferenceEquals(candidate, _candidates[index]))
             return Fail(ShellPolicyFault.CandidateFactsChanged);
 
-        if (_coverage[index].Kind != ShellCoverageKind.Uncovered)
+        if (_coverage[index] != ShellPolicyCoverageSource.Uncovered)
             return Fail(ShellPolicyFault.CoverageAlreadyAssigned);
 
-        if (!TryGetTraceStage(
-                coverage,
-                reason,
-                scopeRelation,
-                grantTimestamp,
-                out var traceStage))
+        if (!Enum.IsDefined(source)
+            || source == ShellPolicyCoverageSource.Uncovered
+            || grantTimestamp is not null
+            && source is not
+                (ShellPolicyCoverageSource.PersistentGlobal
+                or ShellPolicyCoverageSource.PersistentFolder))
         {
             return Fail(ShellPolicyFault.InvalidCoverage);
         }
 
-        _trace.AddCoverage(
-            traceStage,
-            candidate,
-            coverage,
-            reason,
-            scopeRelation,
-            grantTimestamp);
-        _coverage[index] = new ShellCandidateCoverage(candidate.Id, coverage, reason);
+        _trace.AddCoverage(source, candidate, grantTimestamp);
+        _coverage[index] = source;
         _uncoveredApprovalContext = null;
         return new ShellPolicyStageResult.Continue();
     }
@@ -396,112 +359,30 @@ internal sealed class ShellPolicyEvaluation
         return Fail(reason);
     }
 
-    internal ShellPolicyStageResult.Fault InvalidateStage(ShellPolicyFault reason)
-    {
-        if (!Enum.IsDefined(reason))
-            reason = ShellPolicyFault.InvalidStageResult;
+    internal ShellPolicyStageResult.Fault InvalidateStage(ShellPolicyFault reason) =>
+        Fail(
+            Enum.IsDefined(reason) ? reason : ShellPolicyFault.InvalidStageResult,
+            replaceCompletion: true);
 
+    private ShellPolicyStageResult.Fault Fail(
+        ShellPolicyFault reason,
+        bool replaceCompletion = false)
+    {
         var decision = ToolAuthorizationDecision.Deny("internal_policy_failure");
-        _completedTrace = _trace.ReplaceCompletion(decision);
+        _completedTrace = replaceCompletion
+            ? _trace.ReplaceCompletion(decision)
+            : _trace.Complete(decision);
         _terminalDecision = decision;
         _terminalFault = reason;
         return new ShellPolicyStageResult.Fault(reason);
     }
 
-    private ShellPolicyStageResult.Fault Fail(ShellPolicyFault reason)
-    {
-        var decision = ToolAuthorizationDecision.Deny("internal_policy_failure");
-        _completedTrace = _trace.Complete(decision);
-        _terminalDecision = decision;
-        _terminalFault = reason;
-        return new ShellPolicyStageResult.Fault(reason);
-    }
-
-    private static bool TryGetTraceStage(
-        ShellCoverageKind coverage,
-        ShellPolicyReason reason,
-        ShellScopeRelation scopeRelation,
-        DateTimeOffset? grantTimestamp,
-        out ShellPolicyTraceStage traceStage)
-    {
-        traceStage = coverage switch
+    private static ShellPolicyCoverageSource ToCoverageSource(ShellCoverageKind coverage)
+        => coverage switch
         {
-            ShellCoverageKind.OneTime => ShellPolicyTraceStage.OneTimeApproval,
-            ShellCoverageKind.Session or
-                ShellCoverageKind.PersistentGlobal or
-                ShellCoverageKind.PersistentFolder => ShellPolicyTraceStage.StoredGrantMatch,
-            ShellCoverageKind.ReviewedSafePolicy => ShellPolicyTraceStage.ReviewedSafePolicy,
-            _ => default,
-        };
-
-        return (coverage, reason, scopeRelation, grantTimestamp) switch
-        {
-            (ShellCoverageKind.OneTime, ShellPolicyReason.OneTimeGrant, ShellScopeRelation.None, null) => true,
-            (ShellCoverageKind.Session, ShellPolicyReason.SessionGrant, ShellScopeRelation.ThisChat, null) => true,
-            (ShellCoverageKind.PersistentGlobal, ShellPolicyReason.PersistentGlobalGrant, ShellScopeRelation.Global, _) => true,
-            (ShellCoverageKind.PersistentFolder, ShellPolicyReason.PersistentFolderGrant, ShellScopeRelation.UnderGrantRoot, _) => true,
-            (ShellCoverageKind.ReviewedSafePolicy, ShellPolicyReason.ReviewedSafePhrase,
-                ShellScopeRelation.UnderRealRoot or ShellScopeRelation.UnderIntentRoot, null) => true,
-            (ShellCoverageKind.ReviewedSafePolicy, ShellPolicyReason.ApprovalExemptSideEffect,
-                ShellScopeRelation.None, null) => true,
-            _ => false,
-        };
-    }
-
-    private bool CanApplyActorEvidence(ValidatedShellGrantEvidence evidence)
-    {
-        var grantCandidates = Projection.GrantCandidates;
-        if (evidence.CandidateEvidence.Count != grantCandidates.Count)
-            return false;
-
-        var expectedIds = grantCandidates
-            .Select(static candidate => candidate.Id)
-            .ToHashSet();
-        foreach (var candidateEvidence in evidence.CandidateEvidence)
-        {
-            var candidate = candidateEvidence.Candidate;
-            var index = candidate.Id.Value;
-            if ((uint)index >= (uint)_candidates.Length
-                || !ReferenceEquals(candidate, _candidates[index])
-                || !expectedIds.Remove(candidate.Id)
-                || candidateEvidence.ActorEvidence.CandidateId != candidate.Id)
-            {
-                return false;
-            }
-
-            if (candidateEvidence.ActorEvidence.GrantCoverage is { } coverage
-                && (_coverage[index].Kind != ShellCoverageKind.Uncovered
-                    || !IsActorCoverage(coverage)))
-            {
-                return false;
-            }
-        }
-
-        return expectedIds.Count == 0;
-    }
-
-    private static bool IsActorCoverage(ShellCoverageKind coverage)
-        => coverage is ShellCoverageKind.Session
-            or ShellCoverageKind.PersistentGlobal
-            or ShellCoverageKind.PersistentFolder;
-
-    private static void GetActorCoverageFacts(
-        ShellCoverageKind coverage,
-        out ShellPolicyReason reason,
-        out ShellScopeRelation scopeRelation)
-    {
-        (reason, scopeRelation) = coverage switch
-        {
-            ShellCoverageKind.Session => (
-                ShellPolicyReason.SessionGrant,
-                ShellScopeRelation.ThisChat),
-            ShellCoverageKind.PersistentGlobal => (
-                ShellPolicyReason.PersistentGlobalGrant,
-                ShellScopeRelation.Global),
-            ShellCoverageKind.PersistentFolder => (
-                ShellPolicyReason.PersistentFolderGrant,
-                ShellScopeRelation.UnderGrantRoot),
+            ShellCoverageKind.Session => ShellPolicyCoverageSource.Session,
+            ShellCoverageKind.PersistentGlobal => ShellPolicyCoverageSource.PersistentGlobal,
+            ShellCoverageKind.PersistentFolder => ShellPolicyCoverageSource.PersistentFolder,
             _ => throw new InvalidOperationException("Invalid actor coverage kind."),
         };
-    }
 }

--- a/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
@@ -17,15 +17,6 @@ internal enum ShellPolicyPathOrigin
     Redirect = 3,
 }
 
-internal enum ShellPolicyPathDomainKind
-{
-    Unknown = 0,
-    Exact = 1,
-    FiniteSet = 2,
-    PathPattern = 3,
-    Unsupported = 4,
-}
-
 internal enum ShellPolicyPathResolutionState
 {
     Known = 0,
@@ -33,16 +24,8 @@ internal enum ShellPolicyPathResolutionState
     InvalidKnownValue = 2,
 }
 
-internal enum ShellPolicyPathBaseKind
-{
-    Real = 0,
-    Intent = 1,
-    Fallback = 2,
-}
-
 internal sealed record ShellPolicySourcePathFact(
     ShellPolicyPathOrigin Origin,
-    ShellPolicyPathDomainKind DomainKind,
     ShellValueDomain Domain,
     ShellPathShape AuthoredPathShape)
 {
@@ -57,8 +40,6 @@ internal sealed record ShellPolicyResolvedPathFact(
     IReadOnlyList<CanonicalShellPath> Paths);
 
 internal sealed record ShellPolicyScopePathFact(
-    ShellPolicyPathBaseKind BaseKind,
-    int BaseIndex,
     string? AuthoredValue,
     ShellPolicyPathResolutionState State,
     CanonicalShellPath? Path);
@@ -124,28 +105,18 @@ internal sealed class ShellPolicyPathFacts
                 ? exact.Value
                 : null;
             var realScope = ResolveScope(
-                ShellPolicyPathBaseKind.Real,
-                baseIndex: 0,
                 candidate.Candidate.Directory ?? occurrenceDirectory,
                 pathStyle);
             var realBase = ResolveScope(
-                ShellPolicyPathBaseKind.Real,
-                baseIndex: 0,
                 occurrenceDirectory ?? candidate.Candidate.Directory,
                 pathStyle);
             var intentBase = candidate.IntentDirectory is null
                 ? null
                 : ResolveScope(
-                    ShellPolicyPathBaseKind.Intent,
-                    baseIndex: 0,
                     candidate.IntentDirectory,
                     pathStyle);
             var fallbackScopes = candidate.IntentFallbackDirectories
-                .Select((path, fallbackIndex) => ResolveScope(
-                    ShellPolicyPathBaseKind.Fallback,
-                    fallbackIndex,
-                    path,
-                    pathStyle))
+                .Select(path => ResolveScope(path, pathStyle))
                 .ToArray();
 
             var real = sourceFacts?.Resolve(
@@ -182,8 +153,6 @@ internal sealed class ShellPolicyPathFacts
     }
 
     internal static ShellPolicyScopePathFact ResolveScope(
-        ShellPolicyPathBaseKind baseKind,
-        int baseIndex,
         string? value,
         ShellPathStyle pathStyle)
     {
@@ -195,8 +164,6 @@ internal sealed class ShellPolicyPathFacts
                 ? ShellPolicyPathResolutionState.Known
                 : ShellPolicyPathResolutionState.InvalidKnownValue;
         return new ShellPolicyScopePathFact(
-            baseKind,
-            baseIndex,
             value,
             state,
             state == ShellPolicyPathResolutionState.Known ? path : null);
@@ -331,8 +298,6 @@ internal sealed class ShellPolicyOccurrencePathFacts
         ApprovalShell? shell)
         => Resolve(
             ShellPolicyPathFacts.ResolveScope(
-                ShellPolicyPathBaseKind.Real,
-                baseIndex: 0,
                 resolutionBase,
                 pathStyle),
             pathStyle,
@@ -342,17 +307,7 @@ internal sealed class ShellPolicyOccurrencePathFacts
         ShellPolicyPathOrigin origin,
         ShellValueDomain domain,
         ShellPathShape authoredPathShape)
-        => new(origin, ToDomainKind(domain), domain, authoredPathShape);
-
-    private static ShellPolicyPathDomainKind ToDomainKind(ShellValueDomain domain)
-        => domain switch
-        {
-            ShellValueDomain.Unknown => ShellPolicyPathDomainKind.Unknown,
-            ShellValueDomain.Exact => ShellPolicyPathDomainKind.Exact,
-            ShellValueDomain.FiniteSet => ShellPolicyPathDomainKind.FiniteSet,
-            ShellValueDomain.PathPattern => ShellPolicyPathDomainKind.PathPattern,
-            _ => ShellPolicyPathDomainKind.Unsupported
-        };
+        => new(origin, domain, authoredPathShape);
 
     private static ShellPolicyResolvedPathFact Resolve(
         ShellPolicySourcePathFact fact,

--- a/src/Netclaw.Actors/Tools/ShellPolicyProjection.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyProjection.cs
@@ -21,15 +21,16 @@ internal enum ShellCoverageKind
     Denied = 6,
 }
 
-internal enum ShellPolicyReason
+internal enum ShellPolicyCoverageSource
 {
-    None = 0,
-    OneTimeGrant = 1,
-    SessionGrant = 2,
-    PersistentGlobalGrant = 3,
-    PersistentFolderGrant = 4,
-    ReviewedSafePhrase = 5,
-    ApprovalExemptSideEffect = 6,
+    Uncovered = 0,
+    OneTime = 1,
+    Session = 2,
+    PersistentGlobal = 3,
+    PersistentFolder = 4,
+    ReviewedSafeReal = 5,
+    ReviewedSafeIntent = 6,
+    ApprovalExemptSideEffect = 7,
 }
 
 internal readonly record struct ShellPolicyCandidateId
@@ -68,11 +69,6 @@ internal sealed record ShellPolicyCandidate(
     internal bool CanUseRealReviewedSafePolicy => Role == ShellPolicyCandidateRole.Ordinary;
 }
 
-internal sealed record ShellCandidateCoverage(
-    ShellPolicyCandidateId CandidateId,
-    ShellCoverageKind Kind,
-    ShellPolicyReason Reason);
-
 /// <summary>
 /// The immutable policy-facing projection of one shell approval context.
 /// </summary>
@@ -93,6 +89,11 @@ internal sealed record ShellPolicyProjection
         RunScope = runScope;
         ApprovalContext = approvalContext;
         Candidates = candidates;
+        GrantCandidates = Array.AsReadOnly(candidates
+            .Where(static candidate =>
+                candidate.CanMatchStoredGrant
+                && !ApprovalPatternMatching.IsPureSideEffect(candidate.Candidate))
+            .ToArray());
         PathFacts = pathFacts;
         ApprovedOneTimeKeys = approvedOneTimeKeys;
         ApprovedOneTimeToolName = approvedOneTimeToolName;
@@ -114,13 +115,7 @@ internal sealed record ShellPolicyProjection
 
     internal string? ApprovedOneTimeToolName { get; }
 
-    internal IReadOnlyList<ShellPolicyCandidate> GrantCandidates =>
-        Candidates
-            .Where(static candidate =>
-                candidate.CanMatchStoredGrant
-                &&
-                !ApprovalPatternMatching.IsPureSideEffect(candidate.Candidate))
-            .ToArray();
+    internal IReadOnlyList<ShellPolicyCandidate> GrantCandidates { get; }
 
     internal bool HasCausalIntent => Candidates.Any(static candidate =>
         candidate.Role != ShellPolicyCandidateRole.Ordinary);

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -11,6 +11,7 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
+using ShellSyntaxTree;
 
 namespace Netclaw.Actors.Tools;
 
@@ -401,8 +402,7 @@ public sealed class ToolAccessPolicy
             fact.Source.Origin is ShellPolicyPathOrigin.EffectiveArgument
                 or ShellPolicyPathOrigin.AuthoredArgument
                 or ShellPolicyPathOrigin.Redirect
-            && fact.Source.DomainKind is ShellPolicyPathDomainKind.Exact
-                or ShellPolicyPathDomainKind.FiniteSet
+            && fact.Source.Domain is ShellValueDomain.Exact or ShellValueDomain.FiniteSet
             && (fact.State == ShellPolicyPathResolutionState.InvalidKnownValue
                 || fact.Paths.Any(path =>
                     _toolPathPolicy.IsShellDeniedProjectedPath(path))));


### PR DESCRIPTION
## Summary

- replace the redundant coverage-kind, reason, and scope tuple with one closed internal source
- bind validated actor evidence to the exact projected candidate snapshot
- remove derived path-domain and path-base tags already represented by typed domains and structural views
- preserve every approval outcome, trace row, path boundary, and durable contract

This slice removes 145 production lines and 36 test lines. The cumulative changed footprint is 8,520 production lines and 521 control-flow lines; the complete reduction gate remains open.

## Validation

- focused policy, evidence, and matrix tests: 492 passed
- full Actors suite before patch-identical rebase: 3,438 passed, 1 expected Windows-only skip
- strict OpenSpec validation
- copyright header verification
- git diff check
- Slopwatch: only the existing unrelated PowerShellHostProbeTests timeout warning
- range-diff confirms exact patch identity after rebasing onto PR #1958