### PR TITLE
Unify reviewed-safe shell path evaluation

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
@@ -60,6 +60,16 @@ The slice removes another 45 production lines and eight test lines. It does not 
 
 The cumulative footprint uses 8,520 lines and 521 control-flow lines. The complete reduction gate remains open.
 
+## Unified reviewed-safe path slice
+
+This slice removes the unused aggregate reviewed-safe route. The compatibility entry now projects candidate-scoped path facts and calls the same reviewed-safe method as the coordinator.
+
+The evaluation also reuses the projection's immutable candidate snapshot, and the path-fact projection returns its immutable candidate list directly instead of wrapping a second indexed container.
+
+The slice removes another 57 production lines and four control-flow lines. It adds 19 test lines while moving the existing direct safe-policy cases onto the shared typed route.
+
+The cumulative footprint uses 8,463 lines and 517 control-flow lines. The complete reduction gate remains open.
+
 ## Preliminary coverage and risk
 
 The audit used `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.

--- a/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ScopedShellSafeVerbPolicyTests.cs
@@ -95,7 +95,19 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         string verb,
         string? cwd,
         ToolInvocationContext context) =>
-        policy.AllShortCircuit([Candidate(verb)], cwd, context);
+        AllShortCircuit(policy, [Candidate(verb)], cwd, context);
+
+    private static bool AllShortCircuit(
+        ScopedShellSafeVerbPolicy policy,
+        IReadOnlyList<ApprovalCandidate> candidates,
+        string? cwd,
+        ToolInvocationContext context)
+    {
+        if (candidates.Count == 0)
+            return false;
+
+        return candidates.All(candidate => policy.ShortCircuits(candidate, cwd, context));
+    }
 
     private ToolInvocationContext PersonalContext(string? projectDir = null, string? sessionDir = null)
         => TestToolExecutionContext.CreateBound("session-1", sessionDir ?? _sessionDir, new TestToolExecutionContextOptions
@@ -191,7 +203,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("grep", "cat"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.False(policy.AllShortCircuit(Candidates("grep", "git push"), _projectDir, ctx));
+        Assert.False(AllShortCircuit(policy, Candidates("grep", "git push"), _projectDir, ctx));
     }
 
     [Fact]
@@ -200,7 +212,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("grep", "cat", "wc"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.True(policy.AllShortCircuit(Candidates("grep", "cat", "wc"), _projectDir, ctx));
+        Assert.True(AllShortCircuit(policy, Candidates("grep", "cat", "wc"), _projectDir, ctx));
     }
 
     [Fact]
@@ -209,7 +221,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("grep"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.False(policy.AllShortCircuit([], _projectDir, ctx));
+        Assert.False(AllShortCircuit(policy, [], _projectDir, ctx));
     }
 
     [Fact]
@@ -244,7 +256,11 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("whoami"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.False(policy.AllShortCircuit(Candidates("whoami", "git push origin main"), _projectDir, ctx));
+        Assert.False(AllShortCircuit(
+            policy,
+            Candidates("whoami", "git push origin main"),
+            _projectDir,
+            ctx));
     }
 
     [Fact]
@@ -253,7 +269,8 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("git ls-tree"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.True(policy.AllShortCircuit(
+        Assert.True(AllShortCircuit(
+            policy,
             [Candidate("git ls-tree feature", _projectDir)],
             _projectDir,
             ctx));
@@ -279,7 +296,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
                 ["WorkingDirectory"] = _projectDir
             });
 
-        Assert.False(policy.AllShortCircuit(candidates, _projectDir, ctx));
+        Assert.False(AllShortCircuit(policy, candidates, _projectDir, ctx));
     }
 
     [Theory]
@@ -302,7 +319,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
                 ["WorkingDirectory"] = _projectDir
             });
 
-        Assert.False(policy.AllShortCircuit(candidates, _projectDir, ctx));
+        Assert.False(AllShortCircuit(policy, candidates, _projectDir, ctx));
     }
 
     [Fact]
@@ -320,7 +337,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
                 ["WorkingDirectory"] = _projectDir
             });
 
-        Assert.True(policy.AllShortCircuit(candidates, _projectDir, ctx));
+        Assert.True(AllShortCircuit(policy, candidates, _projectDir, ctx));
     }
 
     [Fact]
@@ -337,7 +354,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
                 ["WorkingDirectory"] = _projectDir
             });
 
-        Assert.True(policy.AllShortCircuit(candidates, _projectDir, ctx));
+        Assert.True(AllShortCircuit(policy, candidates, _projectDir, ctx));
     }
 
     [Fact]
@@ -361,7 +378,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
                 ["WorkingDirectory"] = _projectDir
             });
 
-        Assert.True(policy.AllShortCircuit(candidates, _projectDir, ctx));
+        Assert.True(AllShortCircuit(policy, candidates, _projectDir, ctx));
     }
 
     [Fact]
@@ -370,7 +387,8 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("git ls-tree"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.False(policy.AllShortCircuit(
+        Assert.False(AllShortCircuit(
+            policy,
             [Candidate("git ls-treex feature", _projectDir)],
             _projectDir,
             ctx));
@@ -383,7 +401,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var ctx = PersonalContext(projectDir: _projectDir);
         var candidate = new ApprovalCandidate("head", _projectDir);
 
-        Assert.False(policy.AllShortCircuit([candidate], _projectDir, ctx));
+        Assert.False(AllShortCircuit(policy, [candidate], _projectDir, ctx));
     }
 
     [Fact]
@@ -392,7 +410,8 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var policy = new ScopedShellSafeVerbPolicy(VerbList("Get-Content"));
         var ctx = PersonalContext(projectDir: _projectDir);
 
-        Assert.False(policy.AllShortCircuit(
+        Assert.False(AllShortCircuit(
+            policy,
             [Candidate("Get-Content", _projectDir, ApprovalShell.PowerShell)],
             _projectDir,
             ctx));
@@ -413,7 +432,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
             var ctx = PersonalContext(projectDir: _projectDir);
             var candidate = Candidate("find", link);
 
-            Assert.False(policy.AllShortCircuit([candidate], _projectDir, ctx));
+            Assert.False(AllShortCircuit(policy, [candidate], _projectDir, ctx));
         }
         finally
         {
@@ -428,7 +447,7 @@ public sealed class ScopedShellSafeVerbPolicyTests : IDisposable
         var ctx = PersonalContext(projectDir: _projectDir);
         var candidates = new[] { Candidate("cat", _outsideDir) };
 
-        Assert.False(policy.AllShortCircuit(candidates, _projectDir, ctx));
+        Assert.False(AllShortCircuit(policy, candidates, _projectDir, ctx));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -141,7 +141,7 @@ public sealed class ShellPolicyEvaluationTests
         var consumer = Assert.Single(
             evaluation.Candidates,
             static candidate => candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer);
-        var facts = evaluation.Projection.PathFacts.For(consumer.Id);
+        var facts = evaluation.Projection.PathFacts[consumer.Id.Value];
         var source = Assert.Single(
             Assert.IsType<ShellPolicyResolvedPathView>(facts.Intent).Facts,
             static fact => fact.Source.Origin == ShellPolicyPathOrigin.EffectiveArgument).Source;
@@ -167,7 +167,7 @@ public sealed class ShellPolicyEvaluationTests
         var consumer = Assert.Single(
             evaluation.Candidates,
             static candidate => candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer);
-        var facts = evaluation.Projection.PathFacts.For(consumer.Id);
+        var facts = evaluation.Projection.PathFacts[consumer.Id.Value];
         var environment = ShellExecutionEnvironment.CreatePowerShell(
             @"C:\Program Files\PowerShell\7\pwsh.exe",
             PwshDialect.PowerShell7);
@@ -502,7 +502,7 @@ public sealed class ShellPolicyEvaluationTests
                 "; ",
                 evaluation.Candidates.Select(candidate =>
                 {
-                    var facts = evaluation.Projection.PathFacts.For(candidate.Id);
+                    var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
                     return $"{candidate.Candidate.Verb}: "
                            + $"directory={candidate.Candidate.Directory}; "
                            + $"sourceCwd={candidate.SourceOccurrence?.WorkingDirectory}; "
@@ -519,7 +519,7 @@ public sealed class ShellPolicyEvaluationTests
             interactive: true,
             "tr");
         var candidate = Assert.Single(evaluation.Candidates);
-        var facts = evaluation.Projection.PathFacts.For(candidate.Id);
+        var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
         var real = Assert.IsType<ShellPolicyResolvedPathView>(facts.Real);
         var invalid = facts with
         {
@@ -733,7 +733,7 @@ public sealed class ShellPolicyEvaluationTests
             "head");
         var candidate = Assert.Single(evaluation.Candidates);
 
-        var facts = evaluation.Projection.PathFacts.For(candidate.Id);
+        var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
 
         Assert.Same(candidate.SourceOccurrence, facts.SourceOccurrence);
         Assert.Equal(ShellPolicyPathResolutionState.Known, facts.RealScope.State);
@@ -805,7 +805,7 @@ public sealed class ShellPolicyEvaluationTests
             evaluation.Candidates,
             static candidate => candidate.Candidate.Directory == "/work/sub");
 
-        var facts = evaluation.Projection.PathFacts.For(candidate.Id);
+        var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
 
         Assert.Equal("/work/sub", facts.RealScope.Path?.Value);
         Assert.Equal("/work", facts.Real?.ResolutionBase.Path?.Value);
@@ -825,7 +825,7 @@ public sealed class ShellPolicyEvaluationTests
             evaluation.Candidates,
             static candidate => candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer);
 
-        var facts = evaluation.Projection.PathFacts.For(candidate.Id);
+        var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
 
         Assert.Equal("/tmp", facts.IntentScope?.Path?.Value);
         Assert.Contains(facts.FallbackScopes, scope => scope.Path?.Value == "/work");

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -36,25 +36,6 @@ internal sealed class ScopedShellSafeVerbPolicy
     }
 
     /// <summary>
-    /// Returns true when each candidate has a safe verb and a safe effective
-    /// directory. The candidate directory takes precedence over the cwd.
-    /// </summary>
-    public bool AllShortCircuit(
-        IReadOnlyList<ApprovalCandidate> candidates,
-        string? cwd,
-        ToolInvocationContext context)
-    {
-        if (candidates.Count == 0)
-            return false;
-
-        return candidates.All(candidate => ShortCircuits(
-            candidate,
-            candidate.SourceOccurrence,
-            cwd,
-            context));
-    }
-
-    /// <summary>
     /// Returns true when declaring <paramref name="cwd"/> as the project root
     /// would make every candidate eligible for the reviewed-safe short circuit.
     /// </summary>
@@ -204,33 +185,18 @@ internal sealed class ScopedShellSafeVerbPolicy
 
     internal bool ShortCircuits(
         ApprovalCandidate candidate,
-        CommandOccurrence? sourceOccurrence,
         string? cwd,
         ToolInvocationContext context)
     {
-        var safeRoots = ResolveSafeSpaceRoots(context);
-        var resolvedPaths = ResolveCompatibilityPaths(candidate, sourceOccurrence);
-        if (safeRoots.Count == 0
-            || !IsReviewedDiagnostic(candidate, sourceOccurrence, safeRoots, resolvedPaths))
-        {
-            return false;
-        }
-
-        var effectiveDirectory = candidate.Directory ?? cwd;
-        if (string.IsNullOrWhiteSpace(effectiveDirectory))
-            return false;
-
-        try
-        {
-            var fullDirectory = Path.GetFullPath(effectiveDirectory);
-            return safeRoots.Any(root => IsSafePath(fullDirectory, root));
-        }
-        catch (Exception ex) when (ex is ArgumentException
-                                      or NotSupportedException
-                                      or PathTooLongException)
-        {
-            return false;
-        }
+        var projected = new ShellPolicyCandidate(
+            new ShellPolicyCandidateId(0),
+            candidate.Directory is null ? candidate with { Directory = cwd } : candidate,
+            candidate.SourceOccurrence);
+        var pathStyle = OperatingSystem.IsWindows()
+            ? ShellPathStyle.Windows
+            : ShellPathStyle.Posix;
+        var facts = ShellPolicyPathFacts.Create([projected], pathStyle);
+        return ShortCircuits(projected.Candidate, facts[projected.Id.Value], context);
     }
 
     internal bool ShortCircuits(

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -287,7 +287,7 @@ internal static class ShellPolicyInitialStages
         return evaluation.Candidates.Any(candidate =>
                    candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
                    && policy.CausalIntentReferencesProtectedPath(
-                       evaluation.Projection.PathFacts.For(candidate.Id)))
+                       evaluation.Projection.PathFacts[candidate.Id.Value]))
             ? new ShellPolicyStageResult.Complete(
                 ToolAuthorizationDecision.Deny("shell_references_protected_path"))
             : new ShellPolicyStageResult.Continue();
@@ -448,7 +448,7 @@ internal static class ShellPolicyReviewedSafeStages
         {
             if (!policy.IsReviewedSafeCandidate(
                     candidate.Candidate,
-                    evaluation.Projection.PathFacts.For(candidate.Id),
+                    evaluation.Projection.PathFacts[candidate.Id.Value],
                     invocation))
             {
                 continue;
@@ -485,7 +485,7 @@ internal static class ShellPolicyReviewedSafeStages
                     !evaluation.IsCovered(prerequisite))
                 || !policy.IsReviewedSafeIntentCandidate(
                     candidate.Candidate,
-                    evaluation.Projection.PathFacts.For(candidate.Id),
+                    evaluation.Projection.PathFacts[candidate.Id.Value],
                     invocation))
             {
                 continue;

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -147,8 +147,6 @@ internal sealed record ShellPolicyAuthorization
 
 internal sealed class ShellPolicyEvaluation
 {
-    private readonly ShellPolicyCandidate[] _candidates;
-    private readonly IReadOnlyList<ShellPolicyCandidate> _candidateView;
     private readonly ShellPolicyCoverageSource[] _coverage;
     private readonly ShellPolicyDecisionTraceBuilder _trace = new();
     private ToolAuthorizationDecision? _terminalDecision;
@@ -162,19 +160,17 @@ internal sealed class ShellPolicyEvaluation
         ArgumentNullException.ThrowIfNull(projection);
 
         Projection = projection;
-        _candidates = projection.Candidates.ToArray();
-        _candidateView = Array.AsReadOnly(_candidates);
-        _coverage = new ShellPolicyCoverageSource[_candidates.Length];
+        _coverage = new ShellPolicyCoverageSource[projection.Candidates.Count];
     }
 
     internal ShellPolicyProjection Projection { get; }
 
-    internal IReadOnlyList<ShellPolicyCandidate> Candidates => _candidateView;
+    internal IReadOnlyList<ShellPolicyCandidate> Candidates => Projection.Candidates;
 
     internal bool AllCovered => !_coverage.Contains(ShellPolicyCoverageSource.Uncovered);
 
     internal IReadOnlyList<ShellPolicyCandidate> UncoveredCandidates =>
-        Array.AsReadOnly(_candidates
+        Array.AsReadOnly(Projection.Candidates
             .Where((_, index) => _coverage[index] == ShellPolicyCoverageSource.Uncovered)
             .ToArray());
 
@@ -271,10 +267,10 @@ internal sealed class ShellPolicyEvaluation
             return new ShellPolicyStageResult.Complete(_terminalDecision);
 
         var index = candidate.Id.Value;
-        if ((uint)index >= (uint)_candidates.Length)
+        if ((uint)index >= (uint)Candidates.Count)
             return Fail(ShellPolicyFault.InvalidCandidateId);
 
-        if (!ReferenceEquals(candidate, _candidates[index]))
+        if (!ReferenceEquals(candidate, Projection.Candidates[index]))
             return Fail(ShellPolicyFault.CandidateFactsChanged);
 
         if (_coverage[index] != ShellPolicyCoverageSource.Uncovered)
@@ -310,7 +306,7 @@ internal sealed class ShellPolicyEvaluation
             ToolAuthorizationOutcome.Allowed => AllCovered
                                                 || allowsUncoveredOneTime
                                                 && decision.AllowReason == ToolAllowReason.OneTimeApproval,
-            ToolAuthorizationOutcome.RequiresApproval => _candidates.Length == 0 || !AllCovered,
+            ToolAuthorizationOutcome.RequiresApproval => Candidates.Count == 0 || !AllCovered,
             ToolAuthorizationOutcome.Denied => true,
             _ => false,
         };

--- a/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
@@ -61,28 +61,9 @@ internal sealed record ShellPolicyCandidatePathFacts(
     ShellPolicyResolvedPathView? Intent,
     IReadOnlyList<ShellPolicyResolvedPathView> Fallbacks);
 
-internal sealed class ShellPolicyPathFacts
+internal static class ShellPolicyPathFacts
 {
-    private readonly ShellPolicyCandidatePathFacts[] _candidates;
-
-    private ShellPolicyPathFacts(ShellPolicyCandidatePathFacts[] candidates)
-    {
-        _candidates = candidates;
-        Candidates = Array.AsReadOnly(candidates);
-    }
-
-    internal IReadOnlyList<ShellPolicyCandidatePathFacts> Candidates { get; }
-
-    internal ShellPolicyCandidatePathFacts For(ShellPolicyCandidateId candidateId)
-    {
-        var index = candidateId.Value;
-        if ((uint)index >= (uint)_candidates.Length)
-            throw new ArgumentOutOfRangeException(nameof(candidateId));
-
-        return _candidates[index];
-    }
-
-    internal static ShellPolicyPathFacts Create(
+    internal static IReadOnlyList<ShellPolicyCandidatePathFacts> Create(
         IReadOnlyList<ShellPolicyCandidate> candidates,
         ShellPathStyle pathStyle)
     {
@@ -149,7 +130,7 @@ internal sealed class ShellPolicyPathFacts
                 Array.AsReadOnly(fallbacks));
         }
 
-        return new ShellPolicyPathFacts(projected);
+        return Array.AsReadOnly(projected);
     }
 
     internal static ShellPolicyScopePathFact ResolveScope(

--- a/src/Netclaw.Actors/Tools/ShellPolicyProjection.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyProjection.cs
@@ -80,7 +80,7 @@ internal sealed record ShellPolicyProjection
         ToolRunScope runScope,
         ToolApprovalContext approvalContext,
         IReadOnlyList<ShellPolicyCandidate> candidates,
-        ShellPolicyPathFacts pathFacts,
+        IReadOnlyList<ShellPolicyCandidatePathFacts> pathFacts,
         IReadOnlySet<string> approvedOneTimeKeys,
         string? approvedOneTimeToolName)
     {
@@ -109,7 +109,7 @@ internal sealed record ShellPolicyProjection
 
     internal IReadOnlyList<ShellPolicyCandidate> Candidates { get; }
 
-    internal ShellPolicyPathFacts PathFacts { get; }
+    internal IReadOnlyList<ShellPolicyCandidatePathFacts> PathFacts { get; }
 
     internal IReadOnlySet<string> ApprovedOneTimeKeys { get; }
 

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -629,8 +629,8 @@ public sealed class ToolAccessPolicy
             if (!deferReviewedSafeCoverage)
             {
                 approvalCandidates = approvalCandidates
-                    .Where(candidate => !_safeVerbPolicy.AllShortCircuit(
-                        [candidate],
+                    .Where(candidate => !_safeVerbPolicy.ShortCircuits(
+                        candidate,
                         context.Approval.Cwd,
                         context.Invocation))
                     .ToList();


### PR DESCRIPTION
## Summary

- route the public compatibility path through the same typed candidate path facts used by the coordinator
- remove the obsolete aggregate reviewed-safe implementation and duplicate candidate/path containers
- preserve the declared-shell typed route and the bounded host-style compatibility behavior
- record the cumulative reduction evidence while leaving the complete reduction gate open

## Reduction

- 57 fewer production lines
- 4 fewer control-flow lines
- no public or durable-contract change

## Validation

- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --no-restore`: 3,439 passed, 1 expected Windows-only skip
- strict OpenSpec validation for `simplify-shell-policy-evaluator` and `structure-shell-approval-policy`
- copyright headers
- `git diff --check`
- changed-file Slopwatch: 0 issues
- stable patch identity preserved across the #1960 squash rebase