### PR TITLE
Consolidate shell policy state

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
@@ -70,6 +70,16 @@ The slice removes another 57 production lines and four control-flow lines. It ad
 
 The cumulative footprint uses 8,463 lines and 517 control-flow lines. The complete reduction gate remains open.
 
+## Consolidated path and actor snapshot slice
+
+This slice removes candidate identity and causal scope copies from path facts. Each intent and fallback view now owns its resolution base, while the candidate remains the sole owner of its ID and parser occurrence.
+
+The actor adapter also reuses one empty-result constructor. Validation snapshots the candidate and near-miss collections without cloning their sealed immutable elements.
+
+The slice removes another 35 production lines without changing the control-flow count. It removes one test line while preserving the mutable-list, malformed-evidence, path-base, and causal-fallback regressions.
+
+The cumulative footprint uses 8,428 lines and 517 control-flow lines. The complete reduction gate remains open.
+
 ## Preliminary coverage and risk
 
 The audit used `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -152,7 +152,7 @@ public sealed class ShellPolicyEvaluationTests
         var invalidFacts = facts with
         {
             Intent = new ShellPolicyResolvedPathView(
-                Assert.IsType<ShellPolicyScopePathFact>(facts.IntentScope),
+                Assert.IsType<ShellPolicyResolvedPathView>(facts.Intent).ResolutionBase,
                 [invalid])
         };
 
@@ -194,9 +194,11 @@ public sealed class ShellPolicyEvaluationTests
         var unknownFacts = facts with
         {
             Intent = new ShellPolicyResolvedPathView(
-                Assert.IsType<ShellPolicyScopePathFact>(facts.IntentScope),
+                Assert.IsType<ShellPolicyResolvedPathView>(facts.Intent).ResolutionBase,
                 [unknown]),
-            Fallbacks = []
+            Fallbacks = facts.Fallbacks
+                .Select(static view => view with { Facts = [] })
+                .ToArray()
         };
 
         Assert.False(policy.CausalIntentReferencesProtectedPath(unknownFacts));
@@ -507,7 +509,7 @@ public sealed class ShellPolicyEvaluationTests
                            + $"directory={candidate.Candidate.Directory}; "
                            + $"sourceCwd={candidate.SourceOccurrence?.WorkingDirectory}; "
                            + $"real={facts.RealScope}; "
-                           + $"facts=[{string.Join(", ", facts.Real?.Facts ?? [])}]";
+                           + $"facts=[{string.Join(", ", facts.Real.Facts)}]";
                 })));
     }
 
@@ -520,14 +522,13 @@ public sealed class ShellPolicyEvaluationTests
             "tr");
         var candidate = Assert.Single(evaluation.Candidates);
         var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
-        var real = Assert.IsType<ShellPolicyResolvedPathView>(facts.Real);
         var invalid = facts with
         {
-            Real = real with { HasUnprovedNonFileSystemSemantics = true }
+            Real = facts.Real with { HasUnprovedNonFileSystemSemantics = true }
         };
 
         Assert.False(policy.IsReviewedSafeCandidate(
-            candidate.Candidate,
+            candidate,
             invalid,
             context.Invocation));
     }
@@ -725,7 +726,7 @@ public sealed class ShellPolicyEvaluationTests
     }
 
     [Fact]
-    public void Path_facts_preserve_candidate_and_real_scope_identity()
+    public void Path_facts_preserve_real_scope_and_source_resolution()
     {
         var (evaluation, _, _) = CreateReviewedSafeEvaluation(
             "head README.md",
@@ -735,10 +736,8 @@ public sealed class ShellPolicyEvaluationTests
 
         var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
 
-        Assert.Same(candidate.SourceOccurrence, facts.SourceOccurrence);
         Assert.Equal(ShellPolicyPathResolutionState.Known, facts.RealScope.State);
         Assert.Equal("/work", facts.RealScope.Path?.Value);
-        Assert.NotNull(facts.Real);
         Assert.Contains(
             facts.Real.Facts,
             fact => fact.Source.Origin == ShellPolicyPathOrigin.EffectiveArgument
@@ -808,9 +807,9 @@ public sealed class ShellPolicyEvaluationTests
         var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
 
         Assert.Equal("/work/sub", facts.RealScope.Path?.Value);
-        Assert.Equal("/work", facts.Real?.ResolutionBase.Path?.Value);
+        Assert.Equal("/work", facts.Real.ResolutionBase.Path?.Value);
         Assert.Contains(
-            Assert.IsType<ShellPolicyResolvedPathView>(facts.Real).Facts,
+            facts.Real.Facts,
             fact => fact.Source.Origin == ShellPolicyPathOrigin.EffectiveArgument
                     && fact.Paths.Any(path => path.Value == "/work/sub/file.txt"));
     }
@@ -827,8 +826,8 @@ public sealed class ShellPolicyEvaluationTests
 
         var facts = evaluation.Projection.PathFacts[candidate.Id.Value];
 
-        Assert.Equal("/tmp", facts.IntentScope?.Path?.Value);
-        Assert.Contains(facts.FallbackScopes, scope => scope.Path?.Value == "/work");
+        Assert.Equal("/tmp", facts.Intent?.ResolutionBase.Path?.Value);
+        Assert.Contains(facts.Fallbacks, view => view.ResolutionBase.Path?.Value == "/work");
         Assert.Contains(
             Assert.IsType<ShellPolicyResolvedPathView>(facts.Intent).Facts,
             fact => fact.Source.Origin == ShellPolicyPathOrigin.EffectiveArgument

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -150,17 +150,18 @@ internal sealed class ScopedShellSafeVerbPolicy
     }
 
     internal bool ShortCircuitsCausalIntent(
-        ApprovalCandidate candidate,
+        ShellPolicyCandidate projected,
         ShellPolicyCandidatePathFacts pathFacts,
         ToolInvocationContext context)
     {
+        var candidate = projected.Candidate;
         if (context.Audience != TrustAudience.Personal
             || candidate is not
             {
                 Shell: ApprovalShell.Bash,
                 VerbTokens: { }
             }
-            || pathFacts.IntentScope is not
+            || pathFacts.Intent?.ResolutionBase is not
             {
                 State: ShellPolicyPathResolutionState.Known,
                 Path: { } intentPath
@@ -171,7 +172,7 @@ internal sealed class ScopedShellSafeVerbPolicy
                 ShellPathStyle.Posix)
             || !IsReviewedDiagnostic(
                 candidate,
-                pathFacts.SourceOccurrence,
+                projected.SourceOccurrence,
                 [intentPath.Value],
                 pathFacts.Intent))
         {
@@ -196,19 +197,20 @@ internal sealed class ScopedShellSafeVerbPolicy
             ? ShellPathStyle.Windows
             : ShellPathStyle.Posix;
         var facts = ShellPolicyPathFacts.Create([projected], pathStyle);
-        return ShortCircuits(projected.Candidate, facts[projected.Id.Value], context);
+        return ShortCircuits(projected, facts[projected.Id.Value], context);
     }
 
     internal bool ShortCircuits(
-        ApprovalCandidate candidate,
+        ShellPolicyCandidate projected,
         ShellPolicyCandidatePathFacts pathFacts,
         ToolInvocationContext context)
     {
+        var candidate = projected.Candidate;
         var safeRoots = ResolveDeclaredSafeSpaceRoots(context);
         if (safeRoots.Count == 0
             || !IsReviewedDiagnostic(
                 candidate,
-                pathFacts.SourceOccurrence,
+                projected.SourceOccurrence,
                 safeRoots,
                 pathFacts.Real)
             || pathFacts.RealScope is not

--- a/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
+++ b/src/Netclaw.Actors/Tools/ShellApprovalEvidence.cs
@@ -21,7 +21,9 @@ internal sealed class ShellApprovalEvidenceAdapter(IToolApprovalService? approva
         ArgumentNullException.ThrowIfNull(request);
 
         if (request.Candidates.Count == 0 || approvalService is null)
-            return CreateEmptyResult(request.Candidates);
+            return CreateEmptyResult(
+                request.Candidates,
+                new PersistentGrantStoreStatus.Ready());
 
         if (approvalService is IShellApprovalMatchService shellApprovalService)
         {
@@ -50,15 +52,7 @@ internal sealed class ShellApprovalEvidenceAdapter(IToolApprovalService? approva
             var aggregateStoreStatus = result.PersistentStoreFailure is { } aggregateFailure
                 ? (PersistentGrantStoreStatus)new PersistentGrantStoreStatus.Unavailable(aggregateFailure)
                 : new PersistentGrantStoreStatus.Ready();
-            return new ShellApprovalMatchResult(
-                aggregateStoreStatus,
-                Array.AsReadOnly(candidates
-                    .Select(static candidate => new ShellGrantCandidateMatch(
-                        candidate.CandidateId,
-                        Match: null,
-                        GrantCoverage: null,
-                        NearMisses: []))
-                    .ToArray()));
+            return CreateEmptyResult(candidates, aggregateStoreStatus);
         }
 
         if (checks.Count != candidates.Count)
@@ -117,9 +111,10 @@ internal sealed class ShellApprovalEvidenceAdapter(IToolApprovalService? approva
     }
 
     private static ShellApprovalMatchResult CreateEmptyResult(
-        IReadOnlyList<ShellGrantCandidate> candidates)
+        IReadOnlyList<ShellGrantCandidate> candidates,
+        PersistentGrantStoreStatus storeStatus)
         => new(
-            new PersistentGrantStoreStatus.Ready(),
+            storeStatus,
             Array.AsReadOnly(candidates
                 .Select(static candidate => new ShellGrantCandidateMatch(
                     candidate.CandidateId,
@@ -142,9 +137,6 @@ internal sealed class ShellApprovalEvidenceAdapter(IToolApprovalService? approva
 
 internal sealed class ValidatedShellGrantEvidence
 {
-    private readonly IReadOnlyList<ValidatedShellGrantCandidateEvidence> _candidateEvidence;
-    private readonly IReadOnlyList<ToolApprovalMatch> _approvalMatches;
-
     private ValidatedShellGrantEvidence(
         PersistentGrantStoreStatus persistentStore,
         IReadOnlyList<ShellPolicyCandidate> sourceCandidates,
@@ -153,17 +145,17 @@ internal sealed class ValidatedShellGrantEvidence
     {
         PersistentStore = persistentStore;
         SourceCandidates = sourceCandidates;
-        _candidateEvidence = Array.AsReadOnly(candidateEvidence);
-        _approvalMatches = Array.AsReadOnly(approvalMatches);
+        CandidateEvidence = Array.AsReadOnly(candidateEvidence);
+        ApprovalMatches = Array.AsReadOnly(approvalMatches);
     }
 
     internal PersistentGrantStoreStatus PersistentStore { get; }
 
     internal IReadOnlyList<ShellPolicyCandidate> SourceCandidates { get; }
 
-    internal IReadOnlyList<ValidatedShellGrantCandidateEvidence> CandidateEvidence => _candidateEvidence;
+    internal IReadOnlyList<ValidatedShellGrantCandidateEvidence> CandidateEvidence { get; }
 
-    internal IReadOnlyList<ToolApprovalMatch> ApprovalMatches => _approvalMatches;
+    internal IReadOnlyList<ToolApprovalMatch> ApprovalMatches { get; }
 
     internal static bool TryCreate(
         ShellApprovalMatchResult result,
@@ -185,7 +177,6 @@ internal sealed class ValidatedShellGrantEvidence
             return false;
 
         var expectedById = candidates.ToDictionary(static candidate => candidate.Id);
-        var seenIds = new HashSet<ShellPolicyCandidateId>();
         var validated = new ValidatedShellGrantCandidateEvidence[candidates.Count];
         var approvalMatches = new List<ToolApprovalMatch>(candidates.Count);
         for (var index = 0; index < candidateMatches.Length; index++)
@@ -193,8 +184,7 @@ internal sealed class ValidatedShellGrantEvidence
             var candidateMatch = candidateMatches[index];
             if (!TryCopyCandidateEvidence(candidateMatch, out var candidateEvidence)
                 || candidateEvidence is null
-                || !expectedById.TryGetValue(candidateEvidence.CandidateId, out var candidate)
-                || !seenIds.Add(candidateEvidence.CandidateId)
+                || !expectedById.Remove(candidateEvidence.CandidateId, out var candidate)
                 || !TryValidateCandidateEvidence(
                     candidate,
                     candidateEvidence,
@@ -287,23 +277,7 @@ internal sealed class ValidatedShellGrantEvidence
         if (nearMisses.Any(static nearMiss => nearMiss is null))
             return false;
 
-        snapshot = new ShellGrantCandidateMatch(
-            source.CandidateId,
-            source.Match is null
-                ? null
-                : new ToolApprovalMatch(
-                    source.Match.Pattern,
-                    source.Match.Source,
-                    source.Match.Scope),
-            source.GrantCoverage,
-            Array.AsReadOnly(nearMisses
-                .Select(static nearMiss => new ShellApprovalNearMiss(
-                    nearMiss.Grant,
-                    nearMiss.Reason))
-                .ToArray()))
-        {
-            GrantCreatedAt = source.GrantCreatedAt
-        };
+        snapshot = source with { NearMisses = Array.AsReadOnly(nearMisses) };
         return true;
     }
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -447,7 +447,7 @@ internal static class ShellPolicyReviewedSafeStages
                      && !evaluation.IsCovered(candidate.Id)))
         {
             if (!policy.IsReviewedSafeCandidate(
-                    candidate.Candidate,
+                    candidate,
                     evaluation.Projection.PathFacts[candidate.Id.Value],
                     invocation))
             {
@@ -484,7 +484,7 @@ internal static class ShellPolicyReviewedSafeStages
                 || candidate.IntentPrerequisites.Any(prerequisite =>
                     !evaluation.IsCovered(prerequisite))
                 || !policy.IsReviewedSafeIntentCandidate(
-                    candidate.Candidate,
+                    candidate,
                     evaluation.Projection.PathFacts[candidate.Id.Value],
                     invocation))
             {

--- a/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyPathFacts.cs
@@ -52,12 +52,8 @@ internal sealed record ShellPolicyResolvedPathView(
 }
 
 internal sealed record ShellPolicyCandidatePathFacts(
-    ShellPolicyCandidateId CandidateId,
-    CommandOccurrence? SourceOccurrence,
     ShellPolicyScopePathFact RealScope,
-    ShellPolicyScopePathFact? IntentScope,
-    IReadOnlyList<ShellPolicyScopePathFact> FallbackScopes,
-    ShellPolicyResolvedPathView? Real,
+    ShellPolicyResolvedPathView Real,
     ShellPolicyResolvedPathView? Intent,
     IReadOnlyList<ShellPolicyResolvedPathView> Fallbacks);
 
@@ -80,7 +76,7 @@ internal static class ShellPolicyPathFacts
 
             var sourceFacts = candidate.SourceOccurrence is { } occurrence
                 ? GetOrCreateSourceFacts(sourceCache, occurrence)
-                : null;
+                : ShellPolicyOccurrencePathFacts.Empty;
             var occurrenceDirectory = candidate.SourceOccurrence?.WorkingDirectory
                 is ShellValueDomain.Exact exact
                 ? exact.Value
@@ -96,35 +92,25 @@ internal static class ShellPolicyPathFacts
                 : ResolveScope(
                     candidate.IntentDirectory,
                     pathStyle);
-            var fallbackScopes = candidate.IntentFallbackDirectories
-                .Select(path => ResolveScope(path, pathStyle))
-                .ToArray();
-
-            var real = sourceFacts?.Resolve(
+            var real = sourceFacts.Resolve(
                 realBase,
                 pathStyle,
                 candidate.Candidate.Shell);
-            var intent = sourceFacts is not null && intentBase is { } intentScope
+            var intent = intentBase is { } intentScope
                 ? sourceFacts.Resolve(
                     intentScope,
                     pathStyle,
                     candidate.Candidate.Shell)
                 : null;
-            var fallbacks = sourceFacts is null
-                ? []
-                : fallbackScopes
-                    .Select(path => sourceFacts.Resolve(
-                        path,
-                        pathStyle,
-                        candidate.Candidate.Shell))
-                    .ToArray();
+            var fallbacks = candidate.IntentFallbackDirectories
+                .Select(path => sourceFacts.Resolve(
+                    ResolveScope(path, pathStyle),
+                    pathStyle,
+                    candidate.Candidate.Shell))
+                .ToArray();
 
             projected[index] = new ShellPolicyCandidatePathFacts(
-                candidate.Id,
-                candidate.SourceOccurrence,
                 realScope,
-                intentBase,
-                Array.AsReadOnly(fallbackScopes),
                 real,
                 intent,
                 Array.AsReadOnly(fallbacks));
@@ -165,6 +151,8 @@ internal static class ShellPolicyPathFacts
 
 internal sealed class ShellPolicyOccurrencePathFacts
 {
+    internal static ShellPolicyOccurrencePathFacts Empty { get; } = new([], false, false);
+
     private readonly IReadOnlyList<ShellPolicySourcePathFact> _facts;
     private readonly bool _hasUnprovedNonFileSystemSemantics;
     private readonly bool _hasUnprovedBashGlobSemantics;

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -344,7 +344,7 @@ public sealed class ToolAccessPolicy
     }
 
     internal bool IsReviewedSafeCandidate(
-        ApprovalCandidate candidate,
+        ShellPolicyCandidate candidate,
         ShellPolicyCandidatePathFacts pathFacts,
         ToolInvocationContext context)
         => _safeVerbPolicy is not null
@@ -354,7 +354,7 @@ public sealed class ToolAccessPolicy
                context);
 
     internal bool IsReviewedSafeIntentCandidate(
-        ApprovalCandidate candidate,
+        ShellPolicyCandidate candidate,
         ShellPolicyCandidatePathFacts pathFacts,
         ToolInvocationContext context)
         => _safeVerbPolicy is not null
@@ -367,15 +367,16 @@ public sealed class ToolAccessPolicy
         ShellPolicyCandidatePathFacts facts)
     {
         ArgumentNullException.ThrowIfNull(facts);
-        if (facts.IntentScope is not { } intent
+        if (facts.Intent?.ResolutionBase is not { } intent
             || string.IsNullOrWhiteSpace(intent.AuthoredValue)
-            || facts.FallbackScopes.Count == 0)
+            || facts.Fallbacks.Count == 0)
         {
             return true;
         }
 
         if (ScopeReferencesProtectedPath(intent)
-            || facts.FallbackScopes.Any(ScopeReferencesProtectedPath))
+            || facts.Fallbacks.Any(fallback =>
+                ScopeReferencesProtectedPath(fallback.ResolutionBase)))
         {
             return true;
         }


### PR DESCRIPTION
## Summary

- Remove duplicate candidate identity and causal scope from path facts.
- Reuse one empty actor result and preserve immutable evidence elements.
- Keep the real candidate scope separate from the occurrence resolution base.
- Remove 35 production lines with no control-flow increase.

## Validation

- `Netclaw.Actors.Tests`: 3,439 passed; one expected Windows-only test skipped.
- Both active shell-policy OpenSpec changes pass strict validation.
- Copyright headers and `git diff --check` pass.
- The stable patch identity stayed unchanged after PR #1961 merged.