### PR TITLE
Simplify shell policy phase outcomes

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/design.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/design.md
@@ -135,24 +135,22 @@ Why:
 
 Alternative: return a new immutable state after every stage. Rejected because it adds allocation and code without stronger call-local safety.
 
-### 3. Ordered stages return one closed result family
+### 3. Ordered stages return one closed outcome
 
-Each stage returns `ShellPolicyStageResult`:
+Each stage changes state only through `ShellPolicyEvaluation`, then returns a closed outcome:
 
 ```csharp
-internal abstract record ShellPolicyStageResult
+internal enum ShellPolicyStageOutcome
 {
-    internal sealed record Continue : ShellPolicyStageResult;
-
-    internal sealed record Complete(ToolAuthorizationDecision Decision)
-        : ShellPolicyStageResult;
-
-    internal sealed record Fault(ShellPolicyFault Reason)
-        : ShellPolicyStageResult;
+    Invalid = 0,
+    Continue = 1,
+    Complete = 2,
 }
 ```
 
-The sketch omits constructor guards. Production exposes `Complete.ExactOneTime` as the sole uncovered allow marker.
+Coverage, terminal decisions, and typed faults remain owned by the evaluation state. The coordinator verifies that `Continue` has no terminal decision and `Complete` has one. An invalid enum or mismatched outcome fails closed.
+
+The early syntax and causal helpers are the sole callers that may complete an uncovered exact one-time allow.
 
 That marker requires all of these facts:
 
@@ -187,7 +185,7 @@ Synchronous preflight keeps its current order before these stages:
 5. candidate construction;
 6. noninteractive trust zones.
 
-A terminal result stops the pipeline. A later stage cannot revise an earlier deny or prompt.
+A terminal outcome stops the pipeline. A later stage cannot revise an earlier deny or prompt.
 
 Why:
 

--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
@@ -80,6 +80,14 @@ The slice removes another 35 production lines without changing the control-flow 
 
 The cumulative footprint uses 8,428 lines and 517 control-flow lines. The complete reduction gate remains open.
 
+## Closed stage-outcome slice
+
+This slice removes the allocation-backed stage result hierarchy left behind by the deleted delegate pipeline. Stages now mutate only `ShellPolicyEvaluation` and return a closed `Continue` or `Complete` outcome.
+
+The coordinator verifies that the outcome agrees with terminal state. Invalid enums, completion without a terminal decision, and continuation after completion fail closed.
+
+The slice removes another 42 production lines without changing the control-flow count. The cumulative footprint uses 8,386 lines and 517 control-flow lines. The complete reduction gate remains open.
+
 ## Preliminary coverage and risk
 
 The audit used `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.

--- a/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/specs/shell-policy-evaluator-architecture/spec.md
@@ -38,7 +38,7 @@ The state SHALL preserve candidate identity and order for the complete authoriza
 
 ### Requirement: Shell policy stages have one fixed order
 
-The system SHALL execute synchronous preflight and asynchronous completion stages in the documented order. A terminal stage result SHALL stop all later policy stages.
+The system SHALL execute synchronous preflight and asynchronous completion stages in the documented order. A terminal stage outcome SHALL stop all later policy stages.
 
 #### Scenario: Protected path precedes grant and safe policy
 

--- a/openspec/changes/simplify-shell-policy-evaluator/tasks.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/tasks.md
@@ -8,7 +8,7 @@
 
 ## 2. Add call-local policy state
 
-- [x] 2.1 Add internal closed result types for preflight, stage completion, and typed policy faults.
+- [x] 2.1 Add a closed preflight result, closed stage outcome, and typed policy faults.
 - [x] 2.2 Add the internal call-local evaluation state with immutable candidate identity and one coverage slot per candidate.
 - [x] 2.3 Route coverage and its bounded trace row through one atomic state operation.
 - [x] 2.4 Add tests for duplicate coverage, changed candidate facts, invalid candidate IDs, invalid transitions, and multiple terminal results.

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyEvaluationTests.cs
@@ -30,16 +30,17 @@ public sealed class ShellPolicyEvaluationTests
             (_, _) =>
             {
                 laterStageVisited = true;
-                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+                return ValueTask.FromResult(ShellPolicyStageOutcome.Continue);
             }
         ];
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(evaluation, stages, TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(evaluation, stages, TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
+        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, decision.Outcome);
         Assert.False(laterStageVisited);
-        Assert.Single(Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext).Candidates!);
+        Assert.Single(Assert.IsType<ToolApprovalContext>(decision.ApprovalContext).Candidates!);
     }
 
     [Theory]
@@ -50,14 +51,15 @@ public sealed class ShellPolicyEvaluationTests
         var candidate = new ApprovalCandidate("git status", "/work");
         var evaluation = CreateEvaluationWithExactOneTime(isMessy, candidate);
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(
-                evaluation,
-                [SyntaxStage(ShellTool.ToolName)],
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            [SyntaxStage(ShellTool.ToolName)],
+            TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.Allowed, result.Decision.Outcome);
-        Assert.Equal(ToolAllowReason.OneTimeApproval, result.Decision.AllowReason);
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, decision.Outcome);
+        Assert.Equal(ToolAllowReason.OneTimeApproval, decision.AllowReason);
         var trace = Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace);
         var completion = Assert.Single(trace.Rows);
         Assert.Equal(ShellPolicyTraceStage.Completion, completion.Stage);
@@ -79,14 +81,14 @@ public sealed class ShellPolicyEvaluationTests
             (_, _) =>
             {
                 laterStageVisited = true;
-                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+                return ValueTask.FromResult(ShellPolicyStageOutcome.Continue);
             }
         ];
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
-            await RunStagesAsync(evaluation, stages, TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(evaluation, stages, TestContext.Current.CancellationToken);
 
-        Assert.Equal(ShellPolicyFault.InvalidProjection, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidProjection, evaluation.TerminalFault);
         Assert.False(laterStageVisited);
         Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
     }
@@ -104,15 +106,16 @@ public sealed class ShellPolicyEvaluationTests
             (_, _) =>
             {
                 laterStageVisited = true;
-                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+                return ValueTask.FromResult(ShellPolicyStageOutcome.Continue);
             }
         ];
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(evaluation, stages, TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(evaluation, stages, TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.Denied, result.Decision.Outcome);
-        Assert.Equal("shell_references_protected_path", result.Decision.DenyReason);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.Equal("shell_references_protected_path", decision.DenyReason);
         Assert.False(laterStageVisited);
     }
 
@@ -123,14 +126,15 @@ public sealed class ShellPolicyEvaluationTests
             "cd /tmp && inspect; head result.log",
             ["/work/result.log"]);
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(
-                evaluation,
-                [ProtectedCausalPathsStage(policy)],
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            [ProtectedCausalPathsStage(policy)],
+            TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.Denied, result.Decision.Outcome);
-        Assert.Equal("shell_references_protected_path", result.Decision.DenyReason);
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.Equal("shell_references_protected_path", decision.DenyReason);
     }
 
     [Fact]
@@ -215,7 +219,7 @@ public sealed class ShellPolicyEvaluationTests
             [CausalDirectoriesStage(policy, ShellTool.ToolName)],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.Null(evaluation.TerminalDecision);
     }
 
@@ -233,14 +237,15 @@ public sealed class ShellPolicyEvaluationTests
             var (evaluation, policy, _) = CreateCausalEvaluation(
                 $"cd {alias} && inspect; head result.log");
 
-            var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-                await RunStagesAsync(
-                    evaluation,
-                    [CausalDirectoriesStage(policy, ShellTool.ToolName)],
-                    TestContext.Current.CancellationToken));
+            var result = await RunStagesAsync(
+                evaluation,
+                [CausalDirectoriesStage(policy, ShellTool.ToolName)],
+                TestContext.Current.CancellationToken);
+            Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+            var decision = AssertTerminalDecision(evaluation);
 
-            Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
-            Assert.True(Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext).IsMessy);
+            Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, decision.Outcome);
+            Assert.True(Assert.IsType<ToolApprovalContext>(decision.ApprovalContext).IsMessy);
         }
         finally
         {
@@ -277,12 +282,12 @@ public sealed class ShellPolicyEvaluationTests
                 new ToolName(ShellTool.ToolName))],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.Equal(1, service.RequestCount);
         Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         Assert.NotNull(evaluation.GrantEvidence);
         Assert.Single(evaluation.ApprovalMatches);
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(
             ToolAuthorizationDecision.Allow(
                 ToolAllowReason.StoredApproval,
                 evaluation.ApprovalMatches)));
@@ -311,17 +316,17 @@ public sealed class ShellPolicyEvaluationTests
             (_, _) =>
             {
                 laterStageVisited = true;
-                return ValueTask.FromResult<ShellPolicyStageResult>(new ShellPolicyStageResult.Continue());
+                return ValueTask.FromResult(ShellPolicyStageOutcome.Continue);
             }
         ];
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
-            await RunStagesAsync(
-                evaluation,
-                stages,
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            stages,
+            TestContext.Current.CancellationToken);
 
-        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, evaluation.TerminalFault);
         Assert.Equal(1, service.RequestCount);
         Assert.False(laterStageVisited);
         Assert.Null(evaluation.GrantEvidence);
@@ -350,10 +355,10 @@ public sealed class ShellPolicyEvaluationTests
             source.Projection.ApprovalContext.Cwd,
             out var evidence));
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
-            target.ApplyActorEvidence(Assert.IsType<ValidatedShellGrantEvidence>(evidence)));
+        var result = target.ApplyActorEvidence(Assert.IsType<ValidatedShellGrantEvidence>(evidence));
 
-        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, target.TerminalFault);
         Assert.Equal("internal_policy_failure", target.TerminalDecision?.DenyReason);
         Assert.Equal(
             ShellPolicyCoverageSource.Uncovered,
@@ -396,12 +401,12 @@ public sealed class ShellPolicyEvaluationTests
             ],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(grantCandidate.Id));
         Assert.Equal(
             ShellPolicyCoverageSource.ApprovalExemptSideEffect,
             evaluation.CoverageFor(sideEffect.Id));
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(
             ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext)));
         Assert.Collection(
             Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace).Rows,
@@ -440,7 +445,7 @@ public sealed class ShellPolicyEvaluationTests
             ],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.NotNull(evaluation.GrantEvidence);
         Assert.Equal(0, service.RequestCount);
         Assert.Equal(
@@ -466,7 +471,7 @@ public sealed class ShellPolicyEvaluationTests
             [RealScopeStage(policy, context.Invocation)],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.Equal(
             Enum.Parse<ShellPolicyCoverageSource>(expectedCoverageName),
             evaluation.CoverageFor(candidate.Id));
@@ -496,7 +501,7 @@ public sealed class ShellPolicyEvaluationTests
             [RealScopeStage(policy, context.Invocation)],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         var actual = evaluation.Candidates.All(candidate => evaluation.IsCovered(candidate.Id));
         Assert.True(
             actual == allCovered,
@@ -552,7 +557,7 @@ public sealed class ShellPolicyEvaluationTests
             [RealScopeStage(policy, context.Invocation)],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         var candidate = Assert.Single(evaluation.Candidates);
         Assert.True(evaluation.IsCovered(candidate.Id));
     }
@@ -574,13 +579,13 @@ public sealed class ShellPolicyEvaluationTests
             [IntentScopeStage(policy, context.Invocation)],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(beforeCoverage);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, beforeCoverage);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(consumer.Id));
 
         foreach (var prerequisiteId in consumer.IntentPrerequisites)
         {
             var prerequisite = evaluation.Candidates[prerequisiteId.Value];
-            Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+            Assert.Equal(ShellPolicyStageOutcome.Continue, evaluation.Cover(
                 prerequisite,
                 ShellPolicyCoverageSource.Session));
         }
@@ -593,11 +598,11 @@ public sealed class ShellPolicyEvaluationTests
             ],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(afterCoverage);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, afterCoverage);
         Assert.Equal(
             ShellPolicyCoverageSource.ReviewedSafeIntent,
             evaluation.CoverageFor(consumer.Id));
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(
             ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval)));
         Assert.Contains(
             Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace).Rows,
@@ -624,10 +629,10 @@ public sealed class ShellPolicyEvaluationTests
                 "/work/session")],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.True(evaluation.HasOneTimeCoverage);
         Assert.Equal(ShellPolicyCoverageSource.OneTime, evaluation.CoverageFor(candidate.Id));
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(
             ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval)));
         Assert.Collection(
             Assert.IsType<ShellPolicyDecisionTrace>(evaluation.CompletedTrace).Rows,
@@ -658,18 +663,18 @@ public sealed class ShellPolicyEvaluationTests
                 context.SessionDirectory)],
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.False(evaluation.HasOneTimeCoverage);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
 
         var oneTimeContext = evaluation.GetUncoveredApprovalContext(context.SessionDirectory);
-        var terminal = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(
-                evaluation,
-                [CompleteStage(context)],
-                TestContext.Current.CancellationToken));
+        var terminal = await RunStagesAsync(
+            evaluation,
+            [CompleteStage(context)],
+            TestContext.Current.CancellationToken);
 
-        Assert.Same(oneTimeContext, terminal.Decision.ApprovalContext);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, terminal);
+        Assert.Same(oneTimeContext, AssertTerminalDecision(evaluation).ApprovalContext);
     }
 
     [Fact]
@@ -680,7 +685,7 @@ public sealed class ShellPolicyEvaluationTests
             BashCandidate("git push"));
         var initial = evaluation.GetUncoveredApprovalContext("/work/session");
         var candidate = evaluation.Candidates[0];
-        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+        Assert.Equal(ShellPolicyStageOutcome.Continue, evaluation.Cover(
             candidate,
             ShellPolicyCoverageSource.Session));
 
@@ -930,15 +935,16 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(1, service.RequestCount);
         if (!expectsDeny)
         {
-            Assert.IsType<ShellPolicyStageResult.Continue>(result);
+            Assert.Equal(ShellPolicyStageOutcome.Continue, result);
             Assert.Null(evaluation.TerminalDecision);
             Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         }
         else
         {
-            var complete = Assert.IsType<ShellPolicyStageResult.Complete>(result);
-            Assert.Equal(ToolAuthorizationOutcome.Denied, complete.Decision.Outcome);
-            Assert.Equal("approval_store_unavailable", complete.Decision.DenyReason);
+            Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+            var decision = AssertTerminalDecision(evaluation);
+            Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+            Assert.Equal("approval_store_unavailable", decision.DenyReason);
             Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         }
     }
@@ -948,13 +954,13 @@ public sealed class ShellPolicyEvaluationTests
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(
-            await RunStagesAsync(
-                evaluation,
-                [PersistentStoreAvailabilityStage()],
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            [PersistentStoreAvailabilityStage()],
+            TestContext.Current.CancellationToken);
 
-        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidActorEvidence, evaluation.TerminalFault);
         Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
     }
 
@@ -966,7 +972,7 @@ public sealed class ShellPolicyEvaluationTests
             BashCandidate("git push"));
         var covered = evaluation.Candidates[0];
         var uncovered = evaluation.Candidates[1];
-        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+        Assert.Equal(ShellPolicyStageOutcome.Continue, evaluation.Cover(
             covered,
             ShellPolicyCoverageSource.Session));
         var context = TestToolExecutionContext.CreateBound(
@@ -974,14 +980,15 @@ public sealed class ShellPolicyEvaluationTests
             "/work/session",
             TrustAudience.Personal);
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(
-                evaluation,
-                [CompleteStage(context)],
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            [CompleteStage(context)],
+            TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, result.Decision.Outcome);
-        var prompt = Assert.IsType<ToolApprovalContext>(result.Decision.ApprovalContext);
+        Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, decision.Outcome);
+        var prompt = Assert.IsType<ToolApprovalContext>(decision.ApprovalContext);
         Assert.Equal([uncovered.Candidate], prompt.Candidates);
         Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(covered.Id));
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(uncovered.Id));
@@ -998,19 +1005,20 @@ public sealed class ShellPolicyEvaluationTests
             "/work/session",
             TrustAudience.Personal);
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(
-                evaluation,
-                [
-                    ExactOneTimeStage(
-                        new ToolName(ShellTool.ToolName),
-                        context.SessionDirectory),
-                    CompleteStage(context)
-                ],
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            [
+                ExactOneTimeStage(
+                    new ToolName(ShellTool.ToolName),
+                    context.SessionDirectory),
+                CompleteStage(context)
+            ],
+            TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.Allowed, result.Decision.Outcome);
-        Assert.Equal(ToolAllowReason.OneTimeApproval, result.Decision.AllowReason);
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, decision.Outcome);
+        Assert.Equal(ToolAllowReason.OneTimeApproval, decision.AllowReason);
     }
 
     [Fact]
@@ -1032,21 +1040,22 @@ public sealed class ShellPolicyEvaluationTests
                     NearMisses: [])
             ]));
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(
-            await RunStagesAsync(
-                evaluation,
-                [
-                    ActorEvidenceStage(
-                        new ShellApprovalEvidenceAdapter(service),
-                        (ToolApprovalSessionId)"signalr/shell-policy-terminal-stored",
-                        TrustAudience.Personal,
-                        new ToolName(ShellTool.ToolName)),
-                    CompleteStage(context)
-                ],
-                TestContext.Current.CancellationToken));
+        var result = await RunStagesAsync(
+            evaluation,
+            [
+                ActorEvidenceStage(
+                    new ShellApprovalEvidenceAdapter(service),
+                    (ToolApprovalSessionId)"signalr/shell-policy-terminal-stored",
+                    TrustAudience.Personal,
+                    new ToolName(ShellTool.ToolName)),
+                CompleteStage(context)
+            ],
+            TestContext.Current.CancellationToken);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        var decision = AssertTerminalDecision(evaluation);
 
-        Assert.Equal(ToolAuthorizationOutcome.Allowed, result.Decision.Outcome);
-        Assert.Equal(ToolAllowReason.StoredApproval, result.Decision.AllowReason);
+        Assert.Equal(ToolAuthorizationOutcome.Allowed, decision.Outcome);
+        Assert.Equal(ToolAllowReason.StoredApproval, decision.AllowReason);
         Assert.Equal("PreviouslyApproved", context.Approval.AppliedDecision);
         Assert.Equal("git status [session: this chat]", context.Approval.AppliedPattern);
     }
@@ -1063,11 +1072,11 @@ public sealed class ShellPolicyEvaluationTests
             ShellPolicyCoverageSource.PersistentGlobal,
             grantTimestamp);
 
-        Assert.IsType<ShellPolicyStageResult.Continue>(result);
+        Assert.Equal(ShellPolicyStageOutcome.Continue, result);
         Assert.Equal(ShellPolicyCoverageSource.PersistentGlobal, evaluation.CoverageFor(candidate.Id));
 
         var decision = ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval);
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(decision));
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(decision));
         Assert.NotNull(evaluation.CompletedTrace);
         var rows = evaluation.CompletedTrace.Rows;
         Assert.Collection(
@@ -1103,15 +1112,15 @@ public sealed class ShellPolicyEvaluationTests
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));
         var candidate = Assert.Single(evaluation.Candidates);
-        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+        Assert.Equal(ShellPolicyStageOutcome.Continue, evaluation.Cover(
             candidate,
             ShellPolicyCoverageSource.Session));
 
-        var duplicate = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+        var duplicate = evaluation.Cover(
             candidate,
-            ShellPolicyCoverageSource.PersistentGlobal));
+            ShellPolicyCoverageSource.PersistentGlobal);
 
-        Assert.Equal(ShellPolicyFault.CoverageAlreadyAssigned, duplicate.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, duplicate);
         Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.Equal(ShellPolicyFault.CoverageAlreadyAssigned, evaluation.TerminalFault);
@@ -1130,21 +1139,21 @@ public sealed class ShellPolicyEvaluationTests
             Candidate = BashCandidate("git push")
         };
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+        var result = evaluation.Cover(
             changed,
-            ShellPolicyCoverageSource.Session));
+            ShellPolicyCoverageSource.Session);
 
-        Assert.Equal(ShellPolicyFault.CandidateFactsChanged, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.Equal(ShellPolicyFault.CandidateFactsChanged, evaluation.TerminalFault);
         Assert.NotNull(evaluation.CompletedTrace);
         Assert.Single(evaluation.CompletedTrace.Rows);
 
-        var later = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Cover(
+        var later = evaluation.Cover(
             candidate,
-            ShellPolicyCoverageSource.Session));
-        Assert.Same(evaluation.TerminalDecision, later.Decision);
+            ShellPolicyCoverageSource.Session);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, later);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
     }
 
@@ -1157,11 +1166,12 @@ public sealed class ShellPolicyEvaluationTests
             Id = new ShellPolicyCandidateId(7)
         };
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+        var result = evaluation.Cover(
             changed,
-            ShellPolicyCoverageSource.Session));
+            ShellPolicyCoverageSource.Session);
 
-        Assert.Equal(ShellPolicyFault.InvalidCandidateId, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidCandidateId, evaluation.TerminalFault);
         Assert.Single(evaluation.UncoveredCandidates);
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
     }
@@ -1172,11 +1182,12 @@ public sealed class ShellPolicyEvaluationTests
         var evaluation = CreateEvaluation(BashCandidate("git status"));
         var candidate = Assert.Single(evaluation.Candidates);
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+        var result = evaluation.Cover(
             candidate,
-            (ShellPolicyCoverageSource)999));
+            (ShellPolicyCoverageSource)999);
 
-        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, evaluation.TerminalFault);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.NotNull(evaluation.CompletedTrace);
@@ -1189,12 +1200,13 @@ public sealed class ShellPolicyEvaluationTests
         var evaluation = CreateEvaluation(BashCandidate("git status"));
         var candidate = Assert.Single(evaluation.Candidates);
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Cover(
+        var result = evaluation.Cover(
             candidate,
             ShellPolicyCoverageSource.Session,
-            new DateTimeOffset(2026, 8, 14, 0, 0, 0, TimeSpan.Zero)));
+            new DateTimeOffset(2026, 8, 14, 0, 0, 0, TimeSpan.Zero));
 
-        Assert.Equal(ShellPolicyFault.InvalidCoverage, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
+        Assert.Equal(ShellPolicyFault.InvalidCoverage, evaluation.TerminalFault);
         Assert.Equal(ShellPolicyCoverageSource.Uncovered, evaluation.CoverageFor(candidate.Id));
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.NotNull(evaluation.CompletedTrace);
@@ -1208,14 +1220,14 @@ public sealed class ShellPolicyEvaluationTests
         var evaluation = CreateEvaluation(
             BashCandidate("git status"),
             BashCandidate("git diff"));
-        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+        Assert.Equal(ShellPolicyStageOutcome.Continue, evaluation.Cover(
             evaluation.Candidates[0],
             ShellPolicyCoverageSource.Session));
 
-        var result = Assert.IsType<ShellPolicyStageResult.Fault>(evaluation.Complete(
-            ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval)));
+        var result = evaluation.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval));
 
-        Assert.Equal(ShellPolicyFault.InvalidTerminalTransition, result.Reason);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
         Assert.Equal(ToolAuthorizationOutcome.Denied, evaluation.TerminalDecision?.Outcome);
         Assert.Equal(ShellPolicyFault.InvalidTerminalTransition, evaluation.TerminalFault);
         Assert.NotNull(evaluation.CompletedTrace);
@@ -1224,17 +1236,53 @@ public sealed class ShellPolicyEvaluationTests
         Assert.Equal(ShellPolicyTraceOutcome.Deny, evaluation.CompletedTrace.Rows[1].Outcome);
     }
 
+    [Theory]
+    [InlineData(nameof(ShellPolicyStageOutcome.Invalid))]
+    [InlineData("Unknown")]
+    public void Invalid_stage_outcome_fails_closed(string outcomeName)
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        var outcome = outcomeName == nameof(ShellPolicyStageOutcome.Invalid)
+            ? ShellPolicyStageOutcome.Invalid
+            : (ShellPolicyStageOutcome)999;
+
+        Assert.False(evaluation.ApplyStageOutcome(outcome));
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, evaluation.TerminalFault);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
+    [Theory]
+    [InlineData(nameof(ShellPolicyStageOutcome.Continue), true)]
+    [InlineData(nameof(ShellPolicyStageOutcome.Complete), false)]
+    public void Stage_outcome_must_match_terminal_state(
+        string outcomeName,
+        bool precomplete)
+    {
+        var evaluation = CreateEvaluation(BashCandidate("git status"));
+        if (precomplete)
+        {
+            evaluation.Complete(
+                ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext));
+        }
+
+        var outcome = Enum.Parse<ShellPolicyStageOutcome>(outcomeName);
+
+        Assert.False(evaluation.ApplyStageOutcome(outcome));
+        Assert.Equal(ShellPolicyFault.InvalidStageResult, evaluation.TerminalFault);
+        Assert.Equal("internal_policy_failure", evaluation.TerminalDecision?.DenyReason);
+    }
+
     [Fact]
     public void Multiple_terminal_results_return_the_first_terminal_result()
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));
         var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(prompt));
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(prompt));
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(
-            ToolAuthorizationDecision.Deny("internal_policy_failure")));
+        var result = evaluation.Complete(
+            ToolAuthorizationDecision.Deny("internal_policy_failure"));
 
-        Assert.Same(prompt, result.Decision);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
         Assert.Same(prompt, evaluation.TerminalDecision);
         Assert.NotNull(evaluation.CompletedTrace);
         Assert.Single(evaluation.CompletedTrace.Rows);
@@ -1245,17 +1293,17 @@ public sealed class ShellPolicyEvaluationTests
     {
         var evaluation = CreateEvaluation(BashCandidate("git status"));
         var candidate = Assert.Single(evaluation.Candidates);
-        Assert.IsType<ShellPolicyStageResult.Continue>(evaluation.Cover(
+        Assert.Equal(ShellPolicyStageOutcome.Continue, evaluation.Cover(
             candidate,
             ShellPolicyCoverageSource.Session));
         var allow = ToolAuthorizationDecision.Allow(ToolAllowReason.StoredApproval);
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(allow));
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(allow));
 
-        var result = Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Cover(
+        var result = evaluation.Cover(
             candidate,
-            ShellPolicyCoverageSource.PersistentGlobal));
+            ShellPolicyCoverageSource.PersistentGlobal);
 
-        Assert.Same(allow, result.Decision);
+        Assert.Equal(ShellPolicyStageOutcome.Complete, result);
         Assert.Same(allow, evaluation.TerminalDecision);
         Assert.Equal(ShellPolicyCoverageSource.Session, evaluation.CoverageFor(candidate.Id));
         Assert.NotNull(evaluation.CompletedTrace);
@@ -1269,7 +1317,7 @@ public sealed class ShellPolicyEvaluationTests
         var evaluation = CreateEvaluation();
         var prompt = ToolAuthorizationDecision.RequiresApproval(evaluation.Projection.ApprovalContext);
 
-        Assert.IsType<ShellPolicyStageResult.Complete>(evaluation.Complete(prompt));
+        Assert.Equal(ShellPolicyStageOutcome.Complete, evaluation.Complete(prompt));
         Assert.Same(prompt, evaluation.TerminalDecision);
         Assert.NotNull(evaluation.CompletedTrace);
         Assert.Equal(ShellPolicyTraceOutcome.RequiresApproval, evaluation.CompletedTrace.Rows[^1].Outcome);
@@ -1289,11 +1337,11 @@ public sealed class ShellPolicyEvaluationTests
             analysis));
     }
 
-    private delegate ValueTask<ShellPolicyStageResult> TestStage(
+    private delegate ValueTask<ShellPolicyStageOutcome> TestStage(
         ShellPolicyEvaluation evaluation,
         CancellationToken cancellationToken);
 
-    private static async ValueTask<ShellPolicyStageResult> RunStagesAsync(
+    private static async ValueTask<ShellPolicyStageOutcome> RunStagesAsync(
         ShellPolicyEvaluation evaluation,
         IReadOnlyList<TestStage> stages,
         CancellationToken cancellationToken)
@@ -1303,12 +1351,16 @@ public sealed class ShellPolicyEvaluationTests
             cancellationToken.ThrowIfCancellationRequested();
             var result = await stage(evaluation, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            if (!evaluation.ApplyStageResult(result))
+            if (!evaluation.ApplyStageOutcome(result))
                 return result;
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
+
+    private static ToolAuthorizationDecision AssertTerminalDecision(
+        ShellPolicyEvaluation evaluation)
+        => Assert.IsType<ToolAuthorizationDecision>(evaluation.TerminalDecision);
 
     private static TestStage SyntaxStage(string toolName)
         => (evaluation, _) => ValueTask.FromResult(

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -157,10 +157,10 @@ internal sealed class ShellPolicyCoordinator(
         ShellPolicyEvaluation evaluation,
         CancellationToken cancellationToken)
     {
-        bool Continue(ShellPolicyStageResult result)
+        bool Continue(ShellPolicyStageOutcome outcome)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return evaluation.ApplyStageResult(result);
+            return evaluation.ApplyStageOutcome(outcome);
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -243,7 +243,7 @@ internal sealed class ShellPolicyCoordinator(
 
 internal static class ShellPolicyInitialStages
 {
-    internal static ShellPolicyStageResult Syntax(
+    internal static ShellPolicyStageOutcome Syntax(
         ShellPolicyEvaluation evaluation,
         string toolName)
     {
@@ -251,10 +251,10 @@ internal static class ShellPolicyInitialStages
         ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
         var projection = evaluation.Projection;
         if (projection.ApprovalContext.IsMessy && !projection.HasCausalIntent)
-            return CreateOneTimeOrPrompt(projection, toolName);
+            return CreateOneTimeOrPrompt(evaluation, toolName);
 
         if (projection.Candidates.Count == 0)
-            return CreateOneTimeOrPrompt(projection, toolName);
+            return CreateOneTimeOrPrompt(evaluation, toolName);
 
         var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
             ? ApprovalShell.Bash
@@ -263,7 +263,7 @@ internal static class ShellPolicyInitialStages
                 candidate.Candidate.Shell is null
                 || candidate.Candidate.VerbTokens is null))
         {
-            return CreateOneTimeOrPrompt(projection, toolName);
+            return CreateOneTimeOrPrompt(evaluation, toolName);
         }
 
         if (projection.Candidates.Any(candidate =>
@@ -272,13 +272,13 @@ internal static class ShellPolicyInitialStages
                 || candidate.Candidate.VerbTokens.Any(static token =>
                     token.Length == 0 || token.Any(char.IsWhiteSpace))))
         {
-            return new ShellPolicyStageResult.Fault(ShellPolicyFault.InvalidProjection);
+            return evaluation.Fault(ShellPolicyFault.InvalidProjection);
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
-    internal static ShellPolicyStageResult ProtectedCausalPaths(
+    internal static ShellPolicyStageOutcome ProtectedCausalPaths(
         ShellPolicyEvaluation evaluation,
         ToolAccessPolicy policy)
     {
@@ -288,12 +288,12 @@ internal static class ShellPolicyInitialStages
                    candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
                    && policy.CausalIntentReferencesProtectedPath(
                        evaluation.Projection.PathFacts[candidate.Id.Value]))
-            ? new ShellPolicyStageResult.Complete(
+            ? evaluation.Complete(
                 ToolAuthorizationDecision.Deny("shell_references_protected_path"))
-            : new ShellPolicyStageResult.Continue();
+            : ShellPolicyStageOutcome.Continue;
     }
 
-    internal static ShellPolicyStageResult CausalDirectories(
+    internal static ShellPolicyStageOutcome CausalDirectories(
         ShellPolicyEvaluation evaluation,
         ToolAccessPolicy policy,
         string toolName)
@@ -307,23 +307,30 @@ internal static class ShellPolicyInitialStages
                    && !policy.AreCausalIntentDirectoriesEligible(
                        intentDirectory,
                        candidate.IntentFallbackDirectories))
-            ? CreateOneTimeOrPrompt(evaluation.Projection, toolName)
-            : new ShellPolicyStageResult.Continue();
+            ? CreateOneTimeOrPrompt(evaluation, toolName)
+            : ShellPolicyStageOutcome.Continue;
     }
 
-    private static ShellPolicyStageResult CreateOneTimeOrPrompt(
-        ShellPolicyProjection projection,
+    private static ShellPolicyStageOutcome CreateOneTimeOrPrompt(
+        ShellPolicyEvaluation evaluation,
         string toolName)
-        => projection.HasExactOneTimeApproval(toolName, projection.ApprovalContext)
-            ? ShellPolicyStageResult.Complete.ExactOneTime(
-                ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval))
-            : new ShellPolicyStageResult.Complete(
+    {
+        var projection = evaluation.Projection;
+        if (!projection.HasExactOneTimeApproval(toolName, projection.ApprovalContext))
+        {
+            return evaluation.Complete(
                 ToolAuthorizationDecision.RequiresApproval(projection.ApprovalContext));
+        }
+
+        return evaluation.Complete(
+            ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval),
+            allowsUncoveredOneTime: true);
+    }
 }
 
 internal static class ShellPolicyGrantStages
 {
-    internal static async ValueTask<ShellPolicyStageResult> ActorEvidenceAsync(
+    internal static async ValueTask<ShellPolicyStageOutcome> ActorEvidenceAsync(
         ShellPolicyEvaluation evaluation,
         ShellApprovalEvidenceAdapter approvalEvidence,
         ToolApprovalSessionId? sessionId,
@@ -358,19 +365,19 @@ internal static class ShellPolicyGrantStages
                 out var grantEvidence)
             || grantEvidence is null)
         {
-            return new ShellPolicyStageResult.Fault(ShellPolicyFault.InvalidActorEvidence);
+            return evaluation.Fault(ShellPolicyFault.InvalidActorEvidence);
         }
 
         return evaluation.ApplyActorEvidence(grantEvidence);
     }
 
-    internal static ShellPolicyStageResult ApprovalExemptSideEffects(
+    internal static ShellPolicyStageOutcome ApprovalExemptSideEffects(
         ShellPolicyEvaluation evaluation,
         bool approvalEvidenceAvailable)
     {
         ArgumentNullException.ThrowIfNull(evaluation);
         if (!approvalEvidenceAvailable)
-            return new ShellPolicyStageResult.Continue();
+            return ShellPolicyStageOutcome.Continue;
 
         foreach (var candidate in evaluation.Candidates.Where(static item =>
                      item.Role == ShellPolicyCandidateRole.Ordinary
@@ -379,14 +386,14 @@ internal static class ShellPolicyGrantStages
             var result = evaluation.Cover(
                 candidate,
                 ShellPolicyCoverageSource.ApprovalExemptSideEffect);
-            if (result is not ShellPolicyStageResult.Continue)
+            if (result != ShellPolicyStageOutcome.Continue)
                 return result;
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
-    internal static ShellPolicyStageResult ExactOneTime(
+    internal static ShellPolicyStageOutcome ExactOneTime(
         ShellPolicyEvaluation evaluation,
         ToolName toolName,
         string? sessionDirectory)
@@ -395,43 +402,43 @@ internal static class ShellPolicyGrantStages
         ArgumentException.ThrowIfNullOrWhiteSpace(toolName.Value);
         var uncovered = evaluation.UncoveredCandidates;
         if (uncovered.Count == 0)
-            return new ShellPolicyStageResult.Continue();
+            return ShellPolicyStageOutcome.Continue;
 
         var remainingContext = evaluation.GetUncoveredApprovalContext(sessionDirectory);
         if (!evaluation.Projection.HasExactOneTimeApproval(toolName.Value, remainingContext))
-            return new ShellPolicyStageResult.Continue();
+            return ShellPolicyStageOutcome.Continue;
 
         foreach (var candidate in uncovered)
         {
             var result = evaluation.Cover(
                 candidate,
                 ShellPolicyCoverageSource.OneTime);
-            if (result is not ShellPolicyStageResult.Continue)
+            if (result != ShellPolicyStageOutcome.Continue)
                 return result;
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
-    internal static ShellPolicyStageResult PersistentStoreAvailability(
+    internal static ShellPolicyStageOutcome PersistentStoreAvailability(
         ShellPolicyEvaluation evaluation)
     {
         ArgumentNullException.ThrowIfNull(evaluation);
         if (evaluation.GrantEvidence is null)
-            return new ShellPolicyStageResult.Fault(ShellPolicyFault.InvalidActorEvidence);
+            return evaluation.Fault(ShellPolicyFault.InvalidActorEvidence);
 
         return evaluation.UncoveredCandidates.Count > 0
                && evaluation.GrantEvidence.PersistentStore
                is PersistentGrantStoreStatus.Unavailable
-            ? new ShellPolicyStageResult.Complete(
+            ? evaluation.Complete(
                 ToolAuthorizationDecision.Deny("approval_store_unavailable"))
-            : new ShellPolicyStageResult.Continue();
+            : ShellPolicyStageOutcome.Continue;
     }
 }
 
 internal static class ShellPolicyReviewedSafeStages
 {
-    internal static ShellPolicyStageResult RealScope(
+    internal static ShellPolicyStageOutcome RealScope(
         ShellPolicyEvaluation evaluation,
         ToolAccessPolicy policy,
         ToolInvocationContext invocation)
@@ -440,7 +447,7 @@ internal static class ShellPolicyReviewedSafeStages
         ArgumentNullException.ThrowIfNull(policy);
         ArgumentNullException.ThrowIfNull(invocation);
         if (!CanUseReviewedSafePolicy(evaluation))
-            return new ShellPolicyStageResult.Continue();
+            return ShellPolicyStageOutcome.Continue;
 
         foreach (var candidate in evaluation.Projection.GrantCandidates.Where(candidate =>
                      candidate.CanUseRealReviewedSafePolicy
@@ -457,14 +464,14 @@ internal static class ShellPolicyReviewedSafeStages
             var result = evaluation.Cover(
                 candidate,
                 ShellPolicyCoverageSource.ReviewedSafeReal);
-            if (result is not ShellPolicyStageResult.Continue)
+            if (result != ShellPolicyStageOutcome.Continue)
                 return result;
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
-    internal static ShellPolicyStageResult IntentScope(
+    internal static ShellPolicyStageOutcome IntentScope(
         ShellPolicyEvaluation evaluation,
         ToolAccessPolicy policy,
         ToolInvocationContext invocation)
@@ -473,7 +480,7 @@ internal static class ShellPolicyReviewedSafeStages
         ArgumentNullException.ThrowIfNull(policy);
         ArgumentNullException.ThrowIfNull(invocation);
         if (!CanUseReviewedSafePolicy(evaluation))
-            return new ShellPolicyStageResult.Continue();
+            return ShellPolicyStageOutcome.Continue;
 
         foreach (var candidate in evaluation.Candidates.Where(candidate =>
                      candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
@@ -494,11 +501,11 @@ internal static class ShellPolicyReviewedSafeStages
             var result = evaluation.Cover(
                 candidate,
                 ShellPolicyCoverageSource.ReviewedSafeIntent);
-            if (result is not ShellPolicyStageResult.Continue)
+            if (result != ShellPolicyStageOutcome.Continue)
                 return result;
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
     private static bool CanUseReviewedSafePolicy(ShellPolicyEvaluation evaluation)
@@ -508,7 +515,7 @@ internal static class ShellPolicyReviewedSafeStages
 
 internal static class ShellPolicyTerminalStage
 {
-    internal static ShellPolicyStageResult Complete(
+    internal static ShellPolicyStageOutcome Complete(
         ShellPolicyEvaluation evaluation,
         ToolExecutionContext context)
     {

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -74,51 +74,11 @@ internal abstract record ShellPolicyPreflightResult
     }
 }
 
-internal abstract record ShellPolicyStageResult
+internal enum ShellPolicyStageOutcome
 {
-    private ShellPolicyStageResult()
-    {
-    }
-
-    internal sealed record Continue : ShellPolicyStageResult;
-
-    internal sealed record Complete : ShellPolicyStageResult
-    {
-        internal Complete(ToolAuthorizationDecision decision)
-            : this(decision, allowsUncoveredOneTime: false)
-        {
-        }
-
-        private Complete(
-            ToolAuthorizationDecision decision,
-            bool allowsUncoveredOneTime)
-        {
-            ArgumentNullException.ThrowIfNull(decision);
-            Decision = decision;
-            AllowsUncoveredOneTime = allowsUncoveredOneTime;
-        }
-
-        internal ToolAuthorizationDecision Decision { get; }
-
-        internal bool AllowsUncoveredOneTime { get; }
-
-        internal static Complete ExactOneTime(ToolAuthorizationDecision decision)
-        {
-            ArgumentNullException.ThrowIfNull(decision);
-            if (decision.Outcome != ToolAuthorizationOutcome.Allowed
-                || decision.AllowReason != ToolAllowReason.OneTimeApproval)
-            {
-                throw new ArgumentException(
-                    "An uncovered completion requires an exact one-time allow.",
-                    nameof(decision));
-            }
-
-            return new Complete(decision, allowsUncoveredOneTime: true);
-        }
-    }
-
-    internal sealed record Fault(ShellPolicyFault Reason)
-        : ShellPolicyStageResult;
+    Invalid = 0,
+    Continue = 1,
+    Complete = 2,
 }
 
 internal sealed record ShellPolicyAuthorization
@@ -224,11 +184,11 @@ internal sealed class ShellPolicyEvaluation
         return CoverageFor(candidateId) != ShellPolicyCoverageSource.Uncovered;
     }
 
-    internal ShellPolicyStageResult ApplyActorEvidence(ValidatedShellGrantEvidence evidence)
+    internal ShellPolicyStageOutcome ApplyActorEvidence(ValidatedShellGrantEvidence evidence)
     {
         ArgumentNullException.ThrowIfNull(evidence);
         if (_terminalDecision is not null)
-            return new ShellPolicyStageResult.Complete(_terminalDecision);
+            return ShellPolicyStageOutcome.Complete;
 
         if (_grantEvidence is not null
             || !ReferenceEquals(evidence.SourceCandidates, Projection.GrantCandidates))
@@ -244,7 +204,7 @@ internal sealed class ShellPolicyEvaluation
                     candidateEvidence.Candidate,
                     ToCoverageSource(grantCoverage),
                     actorEvidence.GrantCreatedAt);
-                if (result is not ShellPolicyStageResult.Continue)
+                if (result != ShellPolicyStageOutcome.Continue)
                     return result;
             }
             else
@@ -253,10 +213,10 @@ internal sealed class ShellPolicyEvaluation
             }
         }
 
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
-    internal ShellPolicyStageResult Cover(
+    internal ShellPolicyStageOutcome Cover(
         ShellPolicyCandidate candidate,
         ShellPolicyCoverageSource source,
         DateTimeOffset? grantTimestamp = null)
@@ -264,7 +224,7 @@ internal sealed class ShellPolicyEvaluation
         ArgumentNullException.ThrowIfNull(candidate);
 
         if (_terminalDecision is not null)
-            return new ShellPolicyStageResult.Complete(_terminalDecision);
+            return ShellPolicyStageOutcome.Complete;
 
         var index = candidate.Id.Value;
         if ((uint)index >= (uint)Candidates.Count)
@@ -289,17 +249,17 @@ internal sealed class ShellPolicyEvaluation
         _trace.AddCoverage(source, candidate, grantTimestamp);
         _coverage[index] = source;
         _uncoveredApprovalContext = null;
-        return new ShellPolicyStageResult.Continue();
+        return ShellPolicyStageOutcome.Continue;
     }
 
-    internal ShellPolicyStageResult Complete(
+    internal ShellPolicyStageOutcome Complete(
         ToolAuthorizationDecision decision,
         bool allowsUncoveredOneTime = false)
     {
         ArgumentNullException.ThrowIfNull(decision);
 
         if (_terminalDecision is not null)
-            return new ShellPolicyStageResult.Complete(_terminalDecision);
+            return ShellPolicyStageOutcome.Complete;
 
         var mayComplete = decision.Outcome switch
         {
@@ -315,25 +275,16 @@ internal sealed class ShellPolicyEvaluation
 
         _completedTrace = _trace.Complete(decision);
         _terminalDecision = decision;
-        return new ShellPolicyStageResult.Complete(decision);
+        return ShellPolicyStageOutcome.Complete;
     }
 
-    internal bool ApplyStageResult(ShellPolicyStageResult? result)
+    internal bool ApplyStageOutcome(ShellPolicyStageOutcome outcome)
     {
-        switch (result)
+        switch (outcome)
         {
-            case ShellPolicyStageResult.Continue when _terminalDecision is null:
+            case ShellPolicyStageOutcome.Continue when _terminalDecision is null:
                 return true;
-            case ShellPolicyStageResult.Complete complete when _terminalDecision is null:
-                Complete(complete.Decision, complete.AllowsUncoveredOneTime);
-                return false;
-            case ShellPolicyStageResult.Complete complete
-                when ReferenceEquals(_terminalDecision, complete.Decision):
-                return false;
-            case ShellPolicyStageResult.Fault fault when _terminalFault == fault.Reason:
-                return false;
-            case ShellPolicyStageResult.Fault fault when _terminalDecision is null:
-                Fault(fault.Reason);
+            case ShellPolicyStageOutcome.Complete when _terminalDecision is not null:
                 return false;
             default:
                 InvalidateStage(ShellPolicyFault.InvalidStageResult);
@@ -341,26 +292,26 @@ internal sealed class ShellPolicyEvaluation
         }
     }
 
-    internal ShellPolicyStageResult Fault(ShellPolicyFault reason)
+    internal ShellPolicyStageOutcome Fault(ShellPolicyFault reason)
     {
         if (!Enum.IsDefined(reason))
             reason = ShellPolicyFault.InvalidStageResult;
 
-        if (_terminalFault is { } terminalFault)
-            return new ShellPolicyStageResult.Fault(terminalFault);
+        if (_terminalFault is not null)
+            return ShellPolicyStageOutcome.Complete;
 
         if (_terminalDecision is not null)
-            return new ShellPolicyStageResult.Complete(_terminalDecision);
+            return ShellPolicyStageOutcome.Complete;
 
         return Fail(reason);
     }
 
-    internal ShellPolicyStageResult.Fault InvalidateStage(ShellPolicyFault reason) =>
+    internal ShellPolicyStageOutcome InvalidateStage(ShellPolicyFault reason) =>
         Fail(
             Enum.IsDefined(reason) ? reason : ShellPolicyFault.InvalidStageResult,
             replaceCompletion: true);
 
-    private ShellPolicyStageResult.Fault Fail(
+    private ShellPolicyStageOutcome Fail(
         ShellPolicyFault reason,
         bool replaceCompletion = false)
     {
@@ -370,7 +321,7 @@ internal sealed class ShellPolicyEvaluation
             : _trace.Complete(decision);
         _terminalDecision = decision;
         _terminalFault = reason;
-        return new ShellPolicyStageResult.Fault(reason);
+        return ShellPolicyStageOutcome.Complete;
     }
 
     private static ShellPolicyCoverageSource ToCoverageSource(ShellCoverageKind coverage)


### PR DESCRIPTION
## Summary

- Replace allocation-backed phase-result records with one closed enum.
- Preserve coordinator ordering, terminal decisions, and fail-closed validation.
- Remove 42 production lines without changing public or durable contracts.

## Validation

- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --no-restore` (3,443 passed, one expected skip)
- `openspec validate simplify-shell-policy-evaluator --strict`
- `openspec validate structure-shell-approval-policy --strict`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`