### PR TITLE
Simplify shell approval semantics

### DIFF
--- a/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
+++ b/openspec/changes/simplify-shell-policy-evaluator/evidence/refactor-reduction-revision.md
@@ -88,6 +88,20 @@ The coordinator verifies that the outcome agrees with terminal state. Invalid en
 
 The slice removes another 42 production lines without changing the control-flow count. The cumulative footprint uses 8,386 lines and 517 control-flow lines. The complete reduction gate remains open.
 
+## Static shell-semantics slice
+
+This slice replaces one interface, one base class, and two singleton subclasses. One static implementation now takes an explicit shell path style.
+
+The public `ShellTokenizer` surface stays unchanged. Explicit POSIX and Windows tests pin anchored-path and invalid-enum behavior.
+
+The slice removes 171 production lines and 23 control-flow lines. It adds 30 test lines.
+
+The changed footprint now includes three legacy files. Its baseline is 8,972 lines and 635 control-flow lines.
+
+The current footprint uses 9,947 lines and 650 control-flow lines. The gap is 975 lines and 15 control-flow lines.
+
+The complete reduction gate remains open.
+
 ## Preliminary coverage and risk
 
 The audit used `dotnet-coverage` 18.10.0 and `crap4dotnet` 0.1.1.

--- a/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
+++ b/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
@@ -448,6 +448,36 @@ public sealed class ShellTokenizerTests
         Assert.Equal(expected, ShellTokenizer.LooksLikePath(token));
     }
 
+    [Theory]
+    [InlineData("/tmp", ShellPathStyle.Posix, true)]
+    [InlineData("/tmp", ShellPathStyle.Windows, false)]
+    [InlineData(@"C:\work", ShellPathStyle.Posix, false)]
+    [InlineData(@"C:\work", ShellPathStyle.Windows, true)]
+    [InlineData(@"folder\file", ShellPathStyle.Posix, false)]
+    [InlineData(@"folder\file", ShellPathStyle.Windows, true)]
+    public void Explicit_path_style_preserves_legacy_classification(
+        string token,
+        ShellPathStyle pathStyle,
+        bool expected)
+    {
+        Assert.Equal(expected, ShellApprovalSemantics.LooksLikePath(token, pathStyle));
+    }
+
+    [Fact]
+    public void Explicit_path_style_rejects_unknown_values_before_processing()
+    {
+        var invalid = (ShellPathStyle)999;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ShellApprovalSemantics.SplitCompoundCommand(string.Empty, invalid));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ShellApprovalSemantics.ExtractInnerCommands(string.Empty, invalid));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ShellApprovalSemantics.NormalizeApprovalUnit(string.Empty, null, invalid));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ShellApprovalSemantics.NormalizePathToken(string.Empty, null, invalid));
+    }
+
     // ── IsMessyCompoundCommand ──
 
     [Theory]

--- a/src/Netclaw.Security/ShellApprovalSemantics.cs
+++ b/src/Netclaw.Security/ShellApprovalSemantics.cs
@@ -8,53 +8,26 @@ using ShellSyntaxTree;
 
 namespace Netclaw.Security;
 
-internal interface IShellApprovalSemantics
-{
-    IReadOnlyList<string> SplitCompoundCommand(string command);
-
-    string ExtractVerbChain(string command, int maxDepth);
-
-    string? ExtractFirstPathArgument(string command);
-
-    IReadOnlyList<string> ExtractInnerCommands(string command);
-
-    bool LooksLikePath(string token);
-
-    string NormalizeApprovalUnit(string command, string? workingDirectory);
-
-    string? NormalizePathToken(string path, string? workingDirectory);
-}
-
 internal static class ShellApprovalSemantics
 {
-    private static readonly IShellApprovalSemantics Posix = PosixShellApprovalSemantics.Instance;
-    private static readonly IShellApprovalSemantics Windows = WindowsShellApprovalSemantics.Instance;
-
-    public static IShellApprovalSemantics ForPathStyle(ShellPathStyle pathStyle) => pathStyle switch
-    {
-        ShellPathStyle.Posix => Posix,
-        ShellPathStyle.Windows => Windows,
-        _ => throw new ArgumentOutOfRangeException(nameof(pathStyle), pathStyle, "Unknown shell path style.")
-    };
-
-    public static IShellApprovalSemantics ForCommand(string? command)
+    internal static ShellPathStyle ForCommand(string? command)
     {
         if (!OperatingSystem.IsWindows())
-            return Posix;
+            return ShellPathStyle.Posix;
 
         if (string.IsNullOrWhiteSpace(command))
-            return Windows;
+            return ShellPathStyle.Windows;
 
         var tokens = ShellTokenizer.Tokenize(command).ToList();
         if (tokens.Count == 0)
-            return Windows;
+            return ShellPathStyle.Windows;
 
         var first = ShellTokenizer.TrimShellPunctuation(tokens[0]);
-        if (PosixShellApprovalSemantics.IsPosixShellInvoker(first))
-            return Posix;
+        if (IsPosixShellInvoker(first))
+            return ShellPathStyle.Posix;
 
-        if (WindowsShellApprovalSemantics.IsWindowsShellInvoker(first))
-            return Windows;
+        if (IsWindowsShellInvoker(first))
+            return ShellPathStyle.Windows;
 
         foreach (var token in tokens)
         {
@@ -63,205 +36,20 @@ internal static class ShellApprovalSemantics
                 continue;
 
             if (LooksLikePosixCommandPath(trimmed))
-                return Posix;
+                return ShellPathStyle.Posix;
 
-            if (Windows.LooksLikePath(trimmed))
-                return Windows;
+            if (LooksLikePath(trimmed, ShellPathStyle.Windows))
+                return ShellPathStyle.Windows;
         }
 
-        return Windows;
+        return ShellPathStyle.Windows;
     }
 
-    private static bool LooksLikePosixCommandPath(string token)
+    internal static IReadOnlyList<string> SplitCompoundCommand(
+        string command,
+        ShellPathStyle pathStyle)
     {
-        if (token.Contains("://", StringComparison.Ordinal))
-            return false;
-
-        if (token.Equals("/c", StringComparison.OrdinalIgnoreCase)
-            || token.Equals("/k", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return Posix.LooksLikePath(token);
-    }
-}
-
-internal abstract class ShellApprovalSemanticsBase : IShellApprovalSemantics
-{
-    public abstract IReadOnlyList<string> SplitCompoundCommand(string command);
-
-    public abstract IReadOnlyList<string> ExtractInnerCommands(string command);
-
-    public abstract bool LooksLikePath(string token);
-
-    protected abstract bool IsShellSeparator(char ch);
-
-    protected abstract bool IsAnchoredPath(string token);
-
-    public string ExtractVerbChain(string command, int maxDepth)
-    {
-        if (string.IsNullOrWhiteSpace(command))
-            return string.Empty;
-
-        // Greedy verb-chain extraction via ShellSyntaxTree's BashParser:
-        // extends through every "verb-like" token (no slash, no dot, no
-        // flag prefix) until it hits a path or flag. This makes
-        // multi-token CLI subcommands like `freshdesk ticket list`,
-        // `git worktree list`, and `git push origin main` extract their
-        // full chain so the approval prompt and persisted patterns stay
-        // narrow and operator-meaningful.
-        var greedy = TryGreedyExtract(command);
-        if (string.IsNullOrEmpty(greedy))
-            return string.Empty;
-
-        // Apply the path-aware/side-effect short-circuit at depth 1.
-        // BashParser doesn't know that grep/cat/find/ls take a search
-        // pattern or path as their first positional arg (not a
-        // subcommand), so left to its own devices it would bake the
-        // call-specific arg into the verb chain — `grep secret`
-        // instead of `grep`, `echo done` instead of `echo`. The
-        // post-check restores the v2 invariant for these verb
-        // families.
-        var shortCircuited = ShellTokenizer.ApplyVerbShortCircuit(greedy);
-        if (!string.Equals(shortCircuited, greedy, StringComparison.Ordinal))
-            return shortCircuited;
-
-        // Honor the explicit maxDepth cap as a hard upper bound so
-        // callers asking for fewer tokens still get them. Default
-        // callers pass int.MaxValue (effectively "no cap beyond
-        // greedy + path-aware short-circuit").
-        if (maxDepth <= 0)
-            return string.Empty;
-
-        var parts = greedy.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length <= maxDepth)
-            return greedy;
-
-        return string.Join(' ', parts.Take(maxDepth));
-    }
-
-    private static string TryGreedyExtract(string command)
-    {
-        try
-        {
-            var parser = new BashParser();
-            var result = parser.Parse(command);
-            if (result.IsUnparseable || result.Clauses.Count == 0)
-                return string.Empty;
-
-            return result.Clauses[0].Verb.Joined ?? string.Empty;
-        }
-        catch
-        {
-            // Defensive: malformed input that slips past IsUnparseable
-            // shouldn't take down the approval flow. Fail-empty so the
-            // caller treats this as a messy command (no patterns
-            // proposed, Once-only prompt).
-            return string.Empty;
-        }
-    }
-
-    public string? ExtractFirstPathArgument(string command)
-    {
-        // Per the path-extraction spec, only conservatively path-anchored
-        // tokens count: starts with /, ~/, ./, ../ or equals ~, ., ..
-        // Tokens that merely contain a slash (URLs, regexes, docker tags,
-        // git refs) are intentionally NOT extracted — false positives here
-        // would silently expand or contract trust scope.
-        foreach (var token in ShellTokenizer.Tokenize(command))
-        {
-            var trimmed = ShellTokenizer.TrimShellPunctuation(token);
-            if (trimmed.Length == 0)
-                continue;
-            if (trimmed.StartsWith('-'))
-                continue;
-            if (ShellTokenizer.IsPathToken(trimmed))
-                return ShellTokenizer.ApplyFileParentRule(trimmed);
-        }
-
-        return null;
-    }
-
-    public string NormalizeApprovalUnit(string command, string? workingDirectory)
-    {
-        var tokens = ShellTokenizer.Tokenize(command).ToList();
-        if (tokens.Count == 0)
-            return string.Empty;
-
-        var normalizedTokens = new List<string>(tokens.Count);
-        foreach (var token in tokens)
-        {
-            if (!LooksLikePath(token))
-            {
-                normalizedTokens.Add(token);
-                continue;
-            }
-
-            var normalized = NormalizePathToken(token, workingDirectory);
-            normalizedTokens.Add(normalized ?? token);
-        }
-
-        return string.Join(' ', normalizedTokens);
-    }
-
-    public virtual string? NormalizePathToken(string path, string? workingDirectory)
-        => PathUtility.ExpandAndNormalize(path, workingDirectory);
-
-    protected virtual bool LooksLikeArgument(string token)
-    {
-        return ContainsShellPathSeparator(token)
-            || token.StartsWith('~')
-            || token.StartsWith('.')
-            || token.Contains("://", StringComparison.Ordinal)
-            || token.Contains(':', StringComparison.Ordinal)
-            || token.StartsWith('$')
-            || token.StartsWith('%')
-            || token.Contains('*', StringComparison.Ordinal);
-    }
-
-    protected bool ContainsShellPathSeparator(string token)
-    {
-        foreach (var ch in token)
-        {
-            if (IsShellSeparator(ch))
-                return true;
-        }
-
-        return false;
-    }
-
-    protected bool HasTraversalComponent(string token)
-    {
-        return token.Contains("/../", StringComparison.Ordinal)
-            || token.EndsWith("/..", StringComparison.Ordinal)
-            || token.Contains("\\..\\", StringComparison.Ordinal)
-            || token.EndsWith("\\..", StringComparison.Ordinal);
-    }
-
-    protected static bool HasFileExtensionInLastComponent(string token)
-    {
-        var lastComponent = Path.GetFileName(token);
-        if (string.IsNullOrWhiteSpace(lastComponent))
-            return false;
-
-        var ext = Path.GetExtension(lastComponent);
-        return ext.Length > 1;
-    }
-
-    protected int GetFirstShellSeparatorIndex(string token)
-    {
-        for (var i = 0; i < token.Length; i++)
-        {
-            if (IsShellSeparator(token[i]))
-                return i;
-        }
-
-        return -1;
-    }
-
-    protected static IReadOnlyList<string> SplitCompoundCommand(string command, bool splitOnSemicolon, bool splitOnSingleAmpersand)
-    {
+        var splitOnSingleAmpersand = IsWindows(pathStyle);
         if (string.IsNullOrWhiteSpace(command))
             return [];
 
@@ -274,14 +62,14 @@ internal abstract class ShellApprovalSemanticsBase : IShellApprovalSemantics
         {
             var ch = span[i];
 
-            if (quote is null && (ch == '\'' || ch == '"'))
+            if (quote is null && ch is '\'' or '"')
             {
                 quote = ch;
                 current.Append(ch);
                 continue;
             }
 
-            if (quote is not null && ch == quote)
+            if (quote == ch)
             {
                 quote = null;
                 current.Append(ch);
@@ -294,24 +82,14 @@ internal abstract class ShellApprovalSemanticsBase : IShellApprovalSemantics
                 continue;
             }
 
-            if (i + 1 < span.Length)
-            {
-                var twoChar = span.Slice(i, 2);
-                if (twoChar is "&&" or "||")
-                {
-                    FlushSegment(current, segments);
-                    i++;
-                    continue;
-                }
-            }
-
-            if (splitOnSingleAmpersand && ch == '&')
+            if (i + 1 < span.Length && span.Slice(i, 2) is "&&" or "||")
             {
                 FlushSegment(current, segments);
+                i++;
                 continue;
             }
 
-            if (splitOnSemicolon && ch == ';')
+            if (ch == ';' || splitOnSingleAmpersand && ch == '&')
             {
                 FlushSegment(current, segments);
                 continue;
@@ -324,98 +102,170 @@ internal abstract class ShellApprovalSemanticsBase : IShellApprovalSemantics
         return segments;
     }
 
-
-    private static void FlushSegment(StringBuilder current, List<string> segments)
+    internal static string ExtractVerbChain(string command, int maxDepth)
     {
-        var trimmed = current.ToString().Trim();
-        if (trimmed.Length > 0)
-            segments.Add(trimmed);
+        if (string.IsNullOrWhiteSpace(command))
+            return string.Empty;
 
-        current.Clear();
+        var greedy = TryGreedyExtract(command);
+        if (string.IsNullOrEmpty(greedy))
+            return string.Empty;
+
+        var shortCircuited = ShellTokenizer.ApplyVerbShortCircuit(greedy);
+        if (!string.Equals(shortCircuited, greedy, StringComparison.Ordinal))
+            return shortCircuited;
+
+        if (maxDepth <= 0)
+            return string.Empty;
+
+        var parts = greedy.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length <= maxDepth
+            ? greedy
+            : string.Join(' ', parts.Take(maxDepth));
     }
-}
 
-internal sealed class PosixShellApprovalSemantics : ShellApprovalSemanticsBase
-{
-    public static readonly PosixShellApprovalSemantics Instance = new();
-
-    public override IReadOnlyList<string> SplitCompoundCommand(string command)
-        => SplitCompoundCommand(command, splitOnSemicolon: true, splitOnSingleAmpersand: false);
-
-    public override IReadOnlyList<string> ExtractInnerCommands(string command)
+    internal static string? ExtractFirstPathArgument(string command)
     {
+        foreach (var token in ShellTokenizer.Tokenize(command))
+        {
+            var trimmed = ShellTokenizer.TrimShellPunctuation(token);
+            if (trimmed.Length > 0
+                && !trimmed.StartsWith('-')
+                && ShellTokenizer.IsPathToken(trimmed))
+            {
+                return ShellTokenizer.ApplyFileParentRule(trimmed);
+            }
+        }
+
+        return null;
+    }
+
+    internal static IReadOnlyList<string> ExtractInnerCommands(
+        string command,
+        ShellPathStyle pathStyle)
+    {
+        var isWindows = IsWindows(pathStyle);
         var tokens = ShellTokenizer.Tokenize(command).ToList();
         var results = new List<string>();
+        if (!isWindows)
+        {
+            for (var i = 0; i < tokens.Count - 1; i++)
+            {
+                if (!IsPosixShellInvoker(ShellTokenizer.TrimShellPunctuation(tokens[i])))
+                    continue;
+
+                for (var j = i + 1; j < tokens.Count - 1; j++)
+                {
+                    if (!IsPosixCommandFlag(tokens[j]))
+                        continue;
+
+                    results.Add(tokens[j + 1]);
+                    break;
+                }
+            }
+
+            return results;
+        }
 
         for (var i = 0; i < tokens.Count - 1; i++)
         {
             var verb = ShellTokenizer.TrimShellPunctuation(tokens[i]);
-            if (!IsPosixShellInvoker(verb))
-                continue;
-
-            for (var j = i + 1; j < tokens.Count - 1; j++)
+            if (IsCmdInvoker(verb))
             {
-                if (!IsShellCommandFlag(tokens[j]))
-                    continue;
+                if (i + 2 < tokens.Count && IsCmdCommandFlag(tokens[i + 1]))
+                    results.Add(tokens[i + 2]);
 
-                results.Add(tokens[j + 1]);
-                break;
+                continue;
+            }
+
+            if (i + 2 < tokens.Count
+                && IsPowerShellInvoker(verb)
+                && IsPowerShellCommandFlag(tokens[i + 1]))
+            {
+                results.Add(tokens[i + 2]);
             }
         }
 
         return results;
     }
 
-    public override bool LooksLikePath(string token)
+    internal static bool LooksLikePath(string token, ShellPathStyle pathStyle)
     {
-        if (string.IsNullOrWhiteSpace(token) || token.StartsWith('-'))
+        var isWindows = IsWindows(pathStyle);
+        if (string.IsNullOrWhiteSpace(token)
+            || token.StartsWith('-')
+            || token.Contains("://", StringComparison.Ordinal))
+        {
             return false;
+        }
 
-        if (token.Contains("://", StringComparison.Ordinal))
-            return false;
-
-        if (IsAnchoredPath(token))
+        if (IsAnchoredPath(token, isWindows))
             return true;
 
-        if (!ContainsShellPathSeparator(token))
+        var firstSeparator = GetFirstShellSeparatorIndex(token, isWindows);
+        if (firstSeparator < 0)
             return false;
 
-        var firstSlash = GetFirstShellSeparatorIndex(token);
-        if (token.IndexOf(':', StringComparison.Ordinal) is var colonIdx && colonIdx >= 0 && colonIdx < firstSlash)
+        var colonIndex = token.IndexOf(':', StringComparison.Ordinal);
+        if (colonIndex >= 0 && colonIndex < firstSeparator
+            && (!isWindows || colonIndex != 1 || !char.IsAsciiLetter(token[0])))
+        {
             return false;
+        }
 
         if (token.StartsWith('@') && token.IndexOf('/', 1) == token.LastIndexOf('/'))
             return false;
 
-        if ((token.StartsWith("s/", StringComparison.Ordinal) || token.StartsWith("y/", StringComparison.Ordinal))
+        if ((token.StartsWith("s/", StringComparison.Ordinal)
+             || token.StartsWith("y/", StringComparison.Ordinal))
             && CountChar(token, '/') >= 3)
         {
             return false;
         }
 
+        if (isWindows && token.Contains('\\', StringComparison.Ordinal))
+            return true;
+
         return HasTraversalComponent(token) || HasFileExtensionInLastComponent(token);
     }
 
-    public override string? NormalizePathToken(string path, string? workingDirectory)
+    internal static string NormalizeApprovalUnit(
+        string command,
+        string? workingDirectory,
+        ShellPathStyle pathStyle)
     {
-        var expanded = PathUtility.ExpandHome(path);
+        _ = IsWindows(pathStyle);
+        var tokens = ShellTokenizer.Tokenize(command).ToList();
+        if (tokens.Count == 0)
+            return string.Empty;
 
-        if (LooksLikePosixAbsoluteShellPath(expanded))
+        var normalizedTokens = new List<string>(tokens.Count);
+        foreach (var token in tokens)
+        {
+            if (!LooksLikePath(token, pathStyle))
+            {
+                normalizedTokens.Add(token);
+                continue;
+            }
+
+            var normalized = NormalizePathToken(token, workingDirectory, pathStyle);
+            normalizedTokens.Add(normalized ?? token);
+        }
+
+        return string.Join(' ', normalizedTokens);
+    }
+
+    internal static string? NormalizePathToken(
+        string path,
+        string? workingDirectory,
+        ShellPathStyle pathStyle)
+    {
+        var isWindows = IsWindows(pathStyle);
+        var expanded = PathUtility.ExpandHome(path);
+        if (!isWindows && LooksLikePosixAbsoluteShellPath(expanded))
             return NormalizePosixShellPath(expanded);
 
         return PathUtility.ExpandAndNormalize(expanded, workingDirectory);
-    }
-
-    protected override bool IsShellSeparator(char ch) => ch == '/';
-
-    protected override bool IsAnchoredPath(string token)
-    {
-        return token.Length > 0 && token[0] == '/'
-            || token.StartsWith("./", StringComparison.Ordinal)
-            || token.StartsWith("../", StringComparison.Ordinal)
-            || token.StartsWith('~')
-            || token.StartsWith("$HOME", StringComparison.Ordinal)
-            || token.StartsWith("${HOME}", StringComparison.Ordinal);
     }
 
     internal static bool IsPosixShellInvoker(string verb)
@@ -427,12 +277,101 @@ internal sealed class PosixShellApprovalSemantics : ShellApprovalSemanticsBase
             or "/usr/bin/ksh" or "/usr/bin/mksh" or "/usr/bin/zsh";
     }
 
+    private static bool IsWindows(ShellPathStyle pathStyle) => pathStyle switch
+    {
+        ShellPathStyle.Posix => false,
+        ShellPathStyle.Windows => true,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(pathStyle),
+            pathStyle,
+            "Unknown shell path style.")
+    };
+
+    private static string TryGreedyExtract(string command)
+    {
+        try
+        {
+            var result = new BashParser().Parse(command);
+            return result.IsUnparseable || result.Clauses.Count == 0
+                ? string.Empty
+                : result.Clauses[0].Verb.Joined ?? string.Empty;
+        }
+        catch
+        {
+            // The compatibility API must not derive a reusable phrase from malformed input.
+            return string.Empty;
+        }
+    }
+
+    private static void FlushSegment(StringBuilder current, List<string> segments)
+    {
+        var trimmed = current.ToString().Trim();
+        if (trimmed.Length > 0)
+            segments.Add(trimmed);
+
+        current.Clear();
+    }
+
+    private static bool LooksLikePosixCommandPath(string token)
+    {
+        return !token.Contains("://", StringComparison.Ordinal)
+               && !token.Equals("/c", StringComparison.OrdinalIgnoreCase)
+               && !token.Equals("/k", StringComparison.OrdinalIgnoreCase)
+               && LooksLikePath(token, ShellPathStyle.Posix);
+    }
+
+    private static bool IsAnchoredPath(string token, bool isWindows)
+    {
+        return !isWindows && token.Length > 0 && token[0] == '/'
+               || IsPortableAnchoredPath(token)
+               || isWindows
+               && (IsWindowsRootedPath(token)
+                   || token.StartsWith(@".\", StringComparison.Ordinal)
+                   || token.StartsWith(@"..\", StringComparison.Ordinal)
+                   || token.StartsWith("%USERPROFILE%", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsPortableAnchoredPath(string token)
+    {
+        return token.StartsWith("./", StringComparison.Ordinal)
+               || token.StartsWith("../", StringComparison.Ordinal)
+               || token.StartsWith('~')
+               || token.StartsWith("$HOME", StringComparison.Ordinal)
+               || token.StartsWith("${HOME}", StringComparison.Ordinal);
+    }
+
+    private static int GetFirstShellSeparatorIndex(string token, bool isWindows)
+    {
+        for (var i = 0; i < token.Length; i++)
+        {
+            if (token[i] == '/' || isWindows && token[i] == '\\')
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool HasTraversalComponent(string token)
+    {
+        return token.Contains("/../", StringComparison.Ordinal)
+               || token.EndsWith("/..", StringComparison.Ordinal)
+               || token.Contains("\\..\\", StringComparison.Ordinal)
+               || token.EndsWith("\\..", StringComparison.Ordinal);
+    }
+
+    private static bool HasFileExtensionInLastComponent(string token)
+    {
+        var lastComponent = Path.GetFileName(token);
+        return !string.IsNullOrWhiteSpace(lastComponent)
+               && Path.GetExtension(lastComponent).Length > 1;
+    }
+
     private static bool LooksLikePosixAbsoluteShellPath(string path)
     {
         return path.Length > 0 && path[0] == '/'
-            && !path.StartsWith("//", StringComparison.Ordinal)
-            && path.IndexOf('\\', StringComparison.Ordinal) < 0
-            && !path.Contains("://", StringComparison.Ordinal);
+               && !path.StartsWith("//", StringComparison.Ordinal)
+               && path.IndexOf('\\', StringComparison.Ordinal) < 0
+               && !path.Contains("://", StringComparison.Ordinal);
     }
 
     private static string NormalizePosixShellPath(string path)
@@ -458,170 +397,50 @@ internal sealed class PosixShellApprovalSemantics : ShellApprovalSemanticsBase
         return normalized.Count == 0 ? "/" : "/" + string.Join('/', normalized);
     }
 
-    private static bool IsShellCommandFlag(string token)
-    {
-        if (token.Length == 0 || token[0] != '-' || token.StartsWith("--", StringComparison.Ordinal))
-            return false;
+    private static bool IsWindowsShellInvoker(string verb) =>
+        IsCmdInvoker(verb) || IsPowerShellInvoker(verb);
 
-        return token.AsSpan(1).IndexOf('c') >= 0;
-    }
+    private static bool IsCmdInvoker(string verb) =>
+        verb.Equals("cmd", StringComparison.OrdinalIgnoreCase)
+        || verb.Equals("cmd.exe", StringComparison.OrdinalIgnoreCase);
 
-    private static int CountChar(string value, char target)
-    {
-        var count = 0;
-        foreach (var c in value)
-        {
-            if (c == target)
-                count++;
-        }
-
-        return count;
-    }
-}
-
-internal sealed class WindowsShellApprovalSemantics : ShellApprovalSemanticsBase
-{
-    public static readonly WindowsShellApprovalSemantics Instance = new();
-
-    public override IReadOnlyList<string> SplitCompoundCommand(string command)
-        // This legacy tokenizer preserves the historical Windows surface for
-        // public compatibility callers. Runtime authorization uses the selected
-        // PowerShell dialect through ShellCommandAnalyzer instead.
-        => SplitCompoundCommand(command, splitOnSemicolon: true, splitOnSingleAmpersand: true);
-
-    public override IReadOnlyList<string> ExtractInnerCommands(string command)
-    {
-        var tokens = ShellTokenizer.Tokenize(command).ToList();
-        var results = new List<string>();
-
-        for (var i = 0; i < tokens.Count - 1; i++)
-        {
-            var verb = ShellTokenizer.TrimShellPunctuation(tokens[i]);
-            if (IsCmdInvoker(verb))
-            {
-                if (i + 1 < tokens.Count && IsCmdCommandFlag(tokens[i + 1]) && i + 2 < tokens.Count)
-                    results.Add(tokens[i + 2]);
-
-                continue;
-            }
-
-            if (IsPowerShellInvoker(verb)
-                && i + 1 < tokens.Count
-                && IsPowerShellCommandFlag(tokens[i + 1])
-                && i + 2 < tokens.Count)
-            {
-                results.Add(tokens[i + 2]);
-            }
-        }
-
-        return results;
-    }
-
-    public override bool LooksLikePath(string token)
-    {
-        if (string.IsNullOrWhiteSpace(token) || token.StartsWith('-'))
-            return false;
-
-        if (token.Contains("://", StringComparison.Ordinal))
-            return false;
-
-        if (IsAnchoredPath(token))
-            return true;
-
-        if (!ContainsShellPathSeparator(token))
-            return false;
-
-        var firstSeparator = GetFirstShellSeparatorIndex(token);
-        if (token.IndexOf(':', StringComparison.Ordinal) is var colonIdx && colonIdx >= 0 && colonIdx < firstSeparator)
-        {
-            var isDrivePrefix = colonIdx == 1 && char.IsAsciiLetter(token[0]);
-            if (!isDrivePrefix)
-                return false;
-        }
-
-        if (token.StartsWith('@') && token.IndexOf('/', 1) == token.LastIndexOf('/'))
-            return false;
-
-        if ((token.StartsWith("s/", StringComparison.Ordinal) || token.StartsWith("y/", StringComparison.Ordinal))
-            && CountChar(token, '/') >= 3)
-        {
-            return false;
-        }
-
-        if (token.Contains('\\', StringComparison.Ordinal))
-            return true;
-
-        return HasTraversalComponent(token) || HasFileExtensionInLastComponent(token);
-    }
-
-    protected override bool IsShellSeparator(char ch) => ch is '/' or '\\';
-
-    protected override bool IsAnchoredPath(string token)
-    {
-        return IsWindowsRootedPath(token)
-            || token.StartsWith("./", StringComparison.Ordinal)
-            || token.StartsWith("../", StringComparison.Ordinal)
-            || token.StartsWith(@".\", StringComparison.Ordinal)
-            || token.StartsWith(@"..\", StringComparison.Ordinal)
-            || token.StartsWith('~')
-            || token.StartsWith("$HOME", StringComparison.Ordinal)
-            || token.StartsWith("${HOME}", StringComparison.Ordinal)
-            || token.StartsWith("%USERPROFILE%", StringComparison.OrdinalIgnoreCase);
-    }
-
-    public override string? NormalizePathToken(string path, string? workingDirectory)
-    {
-        var expanded = PathUtility.ExpandHome(path);
-
-        return PathUtility.ExpandAndNormalize(expanded, workingDirectory);
-    }
-
-    internal static bool IsWindowsShellInvoker(string verb)
-    {
-        return IsCmdInvoker(verb) || IsPowerShellInvoker(verb);
-    }
-
-    private static bool IsCmdInvoker(string verb)
-        => verb.Equals("cmd", StringComparison.OrdinalIgnoreCase)
-            || verb.Equals("cmd.exe", StringComparison.OrdinalIgnoreCase);
+    private static bool IsPowerShellInvoker(string verb) =>
+        verb.Equals("powershell", StringComparison.OrdinalIgnoreCase)
+        || verb.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase)
+        || verb.Equals("pwsh", StringComparison.OrdinalIgnoreCase)
+        || verb.Equals("pwsh.exe", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsWindowsRootedPath(string token)
     {
-        if (token.StartsWith("\\\\", StringComparison.Ordinal))
-            return true;
-
-        return token.Length >= 3
-            && char.IsAsciiLetter(token[0])
-            && token[1] == ':'
-            && (token[2] == '\\' || token[2] == '/');
+        return token.StartsWith("\\\\", StringComparison.Ordinal)
+               || token.Length >= 3
+               && char.IsAsciiLetter(token[0])
+               && token[1] == ':'
+               && token[2] is '\\' or '/';
     }
 
-    private static bool IsPowerShellInvoker(string verb)
+    private static bool IsPosixCommandFlag(string token)
     {
-        return verb.Equals("powershell", StringComparison.OrdinalIgnoreCase)
-            || verb.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase)
-            || verb.Equals("pwsh", StringComparison.OrdinalIgnoreCase)
-            || verb.Equals("pwsh.exe", StringComparison.OrdinalIgnoreCase);
+        return token.Length > 1
+               && token[0] == '-'
+               && !token.StartsWith("--", StringComparison.Ordinal)
+               && token.AsSpan(1).IndexOf('c') >= 0;
     }
 
-    private static bool IsCmdCommandFlag(string token)
-    {
-        return token.Equals("/c", StringComparison.OrdinalIgnoreCase)
-            || token.Equals("/k", StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool IsCmdCommandFlag(string token) =>
+        token.Equals("/c", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("/k", StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsPowerShellCommandFlag(string token)
-    {
-        return token.Equals("-c", StringComparison.OrdinalIgnoreCase)
-            || token.Equals("-command", StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool IsPowerShellCommandFlag(string token) =>
+        token.Equals("-c", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("-command", StringComparison.OrdinalIgnoreCase);
 
     private static int CountChar(string value, char target)
     {
         var count = 0;
-        foreach (var c in value)
+        foreach (var character in value)
         {
-            if (c == target)
+            if (character == target)
                 count++;
         }
 

--- a/src/Netclaw.Security/ShellCommandAnalysis.cs
+++ b/src/Netclaw.Security/ShellCommandAnalysis.cs
@@ -71,7 +71,9 @@ internal sealed class ShellCommandAnalyzer
             return ShellAnalysisFailure.None;
         }
 
-        var innerCommands = PosixShellApprovalSemantics.Instance.ExtractInnerCommands(command);
+        var innerCommands = ShellApprovalSemantics.ExtractInnerCommands(
+            command,
+            ShellPathStyle.Posix);
         var unexpandedWrappers = parsed.Commands
             .Where(static occurrence => IsUnexpandedWrapperClause(occurrence.Clause))
             .ToList();
@@ -201,7 +203,7 @@ internal sealed class ShellCommandAnalyzer
     }
 
     private static bool IsShellInvokerToken(string token)
-        => PosixShellApprovalSemantics.IsPosixShellInvoker(
+        => ShellApprovalSemantics.IsPosixShellInvoker(
             ShellTokenizer.TrimShellPunctuation(token));
 
     private static bool ContainsBackgroundListOperator(string command)

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -136,7 +136,9 @@ public static class ShellTokenizer
     {
         if (IsMessyCompoundCommand(command))
             return [];
-        return ShellApprovalSemantics.ForCommand(command).SplitCompoundCommand(command);
+        return ShellApprovalSemantics.SplitCompoundCommand(
+            command,
+            ShellApprovalSemantics.ForCommand(command));
     }
 
     private static readonly HashSet<string> BashControlFlowKeywords = new(StringComparer.Ordinal)
@@ -255,7 +257,7 @@ public static class ShellTokenizer
     /// unlimited.
     /// </summary>
     public static string ExtractVerbChain(string command, int maxDepth = int.MaxValue)
-        => ShellApprovalSemantics.ForCommand(command).ExtractVerbChain(command, maxDepth);
+        => ShellApprovalSemantics.ExtractVerbChain(command, maxDepth);
 
     /// <summary>
     /// Returns the first path-like positional argument from a single shell
@@ -271,7 +273,7 @@ public static class ShellTokenizer
     /// operation — no filesystem syscall is performed at extract time.
     /// </remarks>
     public static string? ExtractFirstPathArgument(string command)
-        => ShellApprovalSemantics.ForCommand(command).ExtractFirstPathArgument(command);
+        => ShellApprovalSemantics.ExtractFirstPathArgument(command);
 
     /// <summary>
     /// Conservative path-token classifier. Returns true when the token
@@ -318,28 +320,32 @@ public static class ShellTokenizer
     /// normalized against the working directory. Non-path tokens remain in order.
     /// </summary>
     public static string NormalizeApprovalUnit(string command, string? workingDirectory = null)
-        => ShellApprovalSemantics.ForCommand(command).NormalizeApprovalUnit(command, workingDirectory);
+        => ShellApprovalSemantics.NormalizeApprovalUnit(
+            command,
+            workingDirectory,
+            ShellApprovalSemantics.ForCommand(command));
 
     internal static string NormalizeApprovalUnit(
         string command,
         string? workingDirectory,
         ShellPathStyle pathStyle)
-        => ShellApprovalSemantics.ForPathStyle(pathStyle)
-            .NormalizeApprovalUnit(command, workingDirectory);
+        => ShellApprovalSemantics.NormalizeApprovalUnit(command, workingDirectory, pathStyle);
 
     /// <summary>
     /// Normalizes a path token using the active shell family's path semantics.
     /// Returns null when the token cannot be normalized as a local path.
     /// </summary>
     public static string? NormalizePathToken(string path, string? workingDirectory = null)
-        => ShellApprovalSemantics.ForCommand(path).NormalizePathToken(path, workingDirectory);
+        => ShellApprovalSemantics.NormalizePathToken(
+            path,
+            workingDirectory,
+            ShellApprovalSemantics.ForCommand(path));
 
     internal static string? NormalizePathToken(
         string path,
         string? workingDirectory,
         ShellPathStyle pathStyle)
-        => ShellApprovalSemantics.ForPathStyle(pathStyle)
-            .NormalizePathToken(path, workingDirectory);
+        => ShellApprovalSemantics.NormalizePathToken(path, workingDirectory, pathStyle);
 
     /// <summary>
     /// Extracts inner commands from bash -c / sh -c wrappers. Returns the
@@ -347,7 +353,9 @@ public static class ShellTokenizer
     /// if the command does not use a shell wrapper.
     /// </summary>
     public static IReadOnlyList<string> ExtractInnerCommands(string command)
-        => ShellApprovalSemantics.ForCommand(command).ExtractInnerCommands(command);
+        => ShellApprovalSemantics.ExtractInnerCommands(
+            command,
+            ShellApprovalSemantics.ForCommand(command));
 
     /// <summary>
     /// Returns all command strings that should be evaluated, including the
@@ -381,7 +389,7 @@ public static class ShellTokenizer
     /// on URIs, git refs, docker images, sed expressions, and MIME types.
     /// </summary>
     public static bool LooksLikePath(string token)
-        => ShellApprovalSemantics.ForCommand(token).LooksLikePath(token);
+        => ShellApprovalSemantics.LooksLikePath(token, ShellApprovalSemantics.ForCommand(token));
 
     /// <summary>
     /// Returns true when the pattern is a single-token shell approval for a


### PR DESCRIPTION
## Summary

- replace the internal shell-semantics interface, base class, and two singleton implementations with one static implementation that takes an explicit path style
- preserve the public `ShellTokenizer` surface and existing POSIX/Windows behavior
- add explicit path-style and invalid-enum regressions
- remove 171 production lines and 23 control-flow lines from the cumulative policy footprint

## Verification

- `Netclaw.Security.Tests`: 946 passed
- `Netclaw.Actors.Tests`: 3,443 passed; one expected Windows-only skip
- strict validation passes for both active shell-policy OpenSpec changes
- headers, changed-file formatting, diff check, and changed-file Slopwatch pass