### PR TITLE
Mattermost: Wait for OnConnected before returning from StartAsync

### DIFF
--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
@@ -195,8 +195,23 @@ internal sealed class MattermostNetGatewayTransport : IMattermostGatewayTranspor
         _logger.LogInformation("Bot identity resolved: {BotUserId} (@{Username})",
             me.Id, me.Username);
 
-        await _client.StartReceivingAsync(cancellationToken);
-        return new MattermostBotIdentity(me.Id, me.Username);
+        // This seems to be required otherwise it will be trigger a state and
+        // reconnect, so we wait for the OnConnected event or the timeout.
+        var connected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void HandleInitialConnected(object? sender, ConnectionEventArgs e) => connected.TrySetResult(true);
+        _client.OnConnected += HandleInitialConnected;
+
+        try
+        {
+            await _client.StartReceivingAsync(cancellationToken);
+            await connected.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+            return new MattermostBotIdentity(me.Id, me.Username);
+        }
+        finally
+        {
+            _client.OnConnected -= HandleInitialConnected;
+        }
     }
 
     public async Task StopAsync()


### PR DESCRIPTION
Fixes #1517 

There seems to have been a race condition between OnConnected and StartAsync that kept the MatterMost transport reconnecting endlessly. The fix waits for the OnConnected event or the timeout before returning from `StartAsync`. 

I had the same issue in my K8s cluster and when running the `Netclaw.Demo.AppHost` locally. The patch made it work. 

It's not very pretty, but works. Suggestions welcome if t here's a better way to place it. Would be nice if it makes in the next release, this has kept pestering me for months