### PR TITLE
fix(mcp): redact secrets from OAuth failure logs

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerStatusTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerStatusTests.cs
@@ -190,6 +190,35 @@ public sealed class McpClientManagerStatusTests
     }
 
     [Fact]
+    public void LoggedExceptionsNeverIncludeProviderBodySecrets()
+    {
+        var exception = new HttpRequestException(
+            HttpRequestError.Unknown,
+            "invalid_client: client_secret=secret-value token=token-value",
+            null,
+            HttpStatusCode.BadRequest);
+
+        var redacted = McpClientManager.RedactForLogging(exception);
+
+        Assert.DoesNotContain("secret-value", redacted.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("token-value", redacted.ToString(), StringComparison.Ordinal);
+        Assert.Contains("HttpRequestException", redacted.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoggedExceptionsWithoutSecretShapedContentKeepTheOriginalInstance()
+    {
+        // The common case (network errors, cancellations, disposal failures) must keep its
+        // native stack trace and type for diagnostics -- redaction only swaps in a summary
+        // when secret-shaped content is actually detected.
+        var exception = new HttpRequestException("Connection refused");
+
+        var redacted = McpClientManager.RedactForLogging(exception);
+
+        Assert.Same(exception, redacted);
+    }
+
+    [Fact]
     public void WrappedRetiredCredentialWriterIsClassifiedAsCredentialPersistence()
     {
         var exception = new InvalidOperationException(

--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerStatusTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerStatusTests.cs
@@ -190,35 +190,6 @@ public sealed class McpClientManagerStatusTests
     }
 
     [Fact]
-    public void LoggedExceptionsNeverIncludeProviderBodySecrets()
-    {
-        var exception = new HttpRequestException(
-            HttpRequestError.Unknown,
-            "invalid_client: client_secret=secret-value token=token-value",
-            null,
-            HttpStatusCode.BadRequest);
-
-        var redacted = McpClientManager.RedactForLogging(exception);
-
-        Assert.DoesNotContain("secret-value", redacted.ToString(), StringComparison.Ordinal);
-        Assert.DoesNotContain("token-value", redacted.ToString(), StringComparison.Ordinal);
-        Assert.Contains("HttpRequestException", redacted.ToString(), StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void LoggedExceptionsWithoutSecretShapedContentKeepTheOriginalInstance()
-    {
-        // The common case (network errors, cancellations, disposal failures) must keep its
-        // native stack trace and type for diagnostics -- redaction only swaps in a summary
-        // when secret-shaped content is actually detected.
-        var exception = new HttpRequestException("Connection refused");
-
-        var redacted = McpClientManager.RedactForLogging(exception);
-
-        Assert.Same(exception, redacted);
-    }
-
-    [Fact]
     public void WrappedRetiredCredentialWriterIsClassifiedAsCredentialPersistence()
     {
         var exception = new InvalidOperationException(

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -361,7 +361,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 return McpCatalogRefreshResult.Failed;
             }
 
-            _logger.LogWarning(RedactForLogging(ex),
+            _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex),
                 "MCP server '{Name}' catalog refresh failed; keeping generation {Generation} unchanged",
                 current.Name.Value,
                 current.Generation);
@@ -845,7 +845,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             lifecycle.Publish(WithFailureStatus(current, failureStatus));
             if (current.IsConnected)
             {
-                _logger.LogWarning(RedactForLogging(ex),
+                _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex),
                     "MCP server '{Name}' replacement failed; generation {Generation} remains connected",
                     current.Name.Value,
                     current.Generation);
@@ -863,7 +863,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                     _credentialStore.ForgetClientIdentity(current.Name, entry.Url!, CancellationToken.None);
 
                 var error = CreateSafeOAuthError(ex, "connection initialization");
-                _logger.LogError(RedactForLogging(ex),
+                _logger.LogError(SecretOutputRedactor.RedactForLogging(ex),
                     "Explicit MCP OAuth candidate failed for server '{Name}' during {Operation} (provider status {ProviderStatus})",
                     current.Name.Value,
                     error.Operation,
@@ -937,13 +937,13 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             var error = new McpErrorResponse(
                 "Authorization was cancelled or expired. Start a new MCP authorization attempt.",
                 "authorization exchange");
-            _logger.LogWarning(RedactForLogging(ex), "Explicit MCP OAuth flow was cancelled for '{Name}'", flow.ServerName.Value);
+            _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex), "Explicit MCP OAuth flow was cancelled for '{Name}'", flow.ServerName.Value);
             _flowBroker.Fail(flow, error);
         }
         catch (Exception ex)
         {
             var error = CreateSafeOAuthError(ex, "connection initialization");
-            _logger.LogError(RedactForLogging(ex), "Explicit MCP OAuth flow failed for '{Name}'", flow.ServerName.Value);
+            _logger.LogError(SecretOutputRedactor.RedactForLogging(ex), "Explicit MCP OAuth flow failed for '{Name}'", flow.ServerName.Value);
             _flowBroker.Fail(flow, error);
         }
     }
@@ -1001,7 +1001,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         {
             // The replacement is already published and serving; a failed disposal of the
             // old client leaks a connection but must not fail the reconnect.
-            _logger.LogError(RedactForLogging(ex), "Error disposing replaced MCP client '{Name}'", replaced.Name.Value);
+            _logger.LogError(SecretOutputRedactor.RedactForLogging(ex), "Error disposing replaced MCP client '{Name}'", replaced.Name.Value);
         }
     }
 
@@ -1422,7 +1422,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     {
         if (failureStatus.State is McpConnectionState.AwaitingAuth)
         {
-            _logger.LogWarning(RedactForLogging(ex), "MCP server '{Name}' requires OAuth authorization", name.Value);
+            _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex), "MCP server '{Name}' requires OAuth authorization", name.Value);
             EmitAuthAlert(name,
                 $"MCP server '{name.Value}' requires OAuth authorization. Run: netclaw mcp auth {name.Value}",
                 "authorization_required");
@@ -1431,7 +1431,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
         if (failureStatus.State is McpConnectionState.AuthFailed)
         {
-            _logger.LogWarning(RedactForLogging(ex), "MCP server '{Name}' authentication failed", name.Value);
+            _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex), "MCP server '{Name}' authentication failed", name.Value);
             if (hasOAuthRuntimeHints || hasCachedTokens)
             {
                 EmitAuthAlert(name,
@@ -1447,7 +1447,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             return;
         }
 
-        _logger.LogWarning(RedactForLogging(ex), "Failed to connect to MCP server '{Name}'", name.Value);
+        _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex), "Failed to connect to MCP server '{Name}'", name.Value);
         EmitDisconnectedAlert(name,
             $"MCP server '{name.Value}' connection failed: {failureStatus.ErrorMessage}");
     }
@@ -1503,7 +1503,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         var status = CreateAwaitingAuthStatus(current.Name, _timeProvider.GetUtcNow())
             with { ToolCount = current.ToolFunctions.Count };
         lifecycle.Publish(current with { Status = status });
-        _logger.LogWarning(RedactForLogging(ex),
+        _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex),
             "MCP server '{Name}' lost OAuth authorization during catalog refresh; marked AwaitingAuth",
             current.Name.Value);
         EmitAuthAlert(current.Name,
@@ -1612,30 +1612,6 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             : $"MCP OAuth {operation} failed: {statusText}.";
         return new McpErrorResponse(message, operation, status is null ? null : (int)status.Value);
     }
-
-    /// <summary>
-    /// A token/DCR exchange failure can carry the provider's raw HTTP error body inside
-    /// <see cref="Exception.Message"/> or an inner exception, and that body can echo back the
-    /// client secret or token the request sent. <see cref="CreateSafeOAuthError"/> keeps that
-    /// text out of the response sent to callers, but every OAuth failure also reaches
-    /// <see cref="ILogger"/> via the raw exception -- and daemon logs leave the box when OTLP
-    /// export is enabled. Swap in a redacted stand-in only when secret-shaped content is
-    /// actually present, so the overwhelming majority of exceptions (network errors,
-    /// cancellations, disposal failures) keep their full native stack trace.
-    /// </summary>
-    internal static Exception RedactForLogging(Exception ex)
-    {
-        var rendered = ex.ToString();
-        var redacted = SecretOutputRedactor.Redact(rendered);
-        if (string.Equals(redacted, rendered, StringComparison.Ordinal))
-            return ex;
-
-        var typeName = ex.GetType().FullName ?? ex.GetType().Name;
-        return new McpRedactedLoggingException(
-            $"{typeName} (message redacted; matched secret-shaped content): {redacted}");
-    }
-
-    private sealed class McpRedactedLoggingException(string message) : Exception(message);
 
     private static IEnumerable<Exception> EnumerateExceptionTree(Exception root)
     {

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -361,7 +361,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 return McpCatalogRefreshResult.Failed;
             }
 
-            _logger.LogWarning(ex,
+            _logger.LogWarning(RedactForLogging(ex),
                 "MCP server '{Name}' catalog refresh failed; keeping generation {Generation} unchanged",
                 current.Name.Value,
                 current.Generation);
@@ -845,7 +845,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             lifecycle.Publish(WithFailureStatus(current, failureStatus));
             if (current.IsConnected)
             {
-                _logger.LogWarning(ex,
+                _logger.LogWarning(RedactForLogging(ex),
                     "MCP server '{Name}' replacement failed; generation {Generation} remains connected",
                     current.Name.Value,
                     current.Generation);
@@ -863,7 +863,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                     _credentialStore.ForgetClientIdentity(current.Name, entry.Url!, CancellationToken.None);
 
                 var error = CreateSafeOAuthError(ex, "connection initialization");
-                _logger.LogError(ex,
+                _logger.LogError(RedactForLogging(ex),
                     "Explicit MCP OAuth candidate failed for server '{Name}' during {Operation} (provider status {ProviderStatus})",
                     current.Name.Value,
                     error.Operation,
@@ -937,13 +937,13 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             var error = new McpErrorResponse(
                 "Authorization was cancelled or expired. Start a new MCP authorization attempt.",
                 "authorization exchange");
-            _logger.LogWarning(ex, "Explicit MCP OAuth flow was cancelled for '{Name}'", flow.ServerName.Value);
+            _logger.LogWarning(RedactForLogging(ex), "Explicit MCP OAuth flow was cancelled for '{Name}'", flow.ServerName.Value);
             _flowBroker.Fail(flow, error);
         }
         catch (Exception ex)
         {
             var error = CreateSafeOAuthError(ex, "connection initialization");
-            _logger.LogError(ex, "Explicit MCP OAuth flow failed for '{Name}'", flow.ServerName.Value);
+            _logger.LogError(RedactForLogging(ex), "Explicit MCP OAuth flow failed for '{Name}'", flow.ServerName.Value);
             _flowBroker.Fail(flow, error);
         }
     }
@@ -1001,7 +1001,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         {
             // The replacement is already published and serving; a failed disposal of the
             // old client leaks a connection but must not fail the reconnect.
-            _logger.LogError(ex, "Error disposing replaced MCP client '{Name}'", replaced.Name.Value);
+            _logger.LogError(RedactForLogging(ex), "Error disposing replaced MCP client '{Name}'", replaced.Name.Value);
         }
     }
 
@@ -1422,7 +1422,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     {
         if (failureStatus.State is McpConnectionState.AwaitingAuth)
         {
-            _logger.LogWarning(ex, "MCP server '{Name}' requires OAuth authorization", name.Value);
+            _logger.LogWarning(RedactForLogging(ex), "MCP server '{Name}' requires OAuth authorization", name.Value);
             EmitAuthAlert(name,
                 $"MCP server '{name.Value}' requires OAuth authorization. Run: netclaw mcp auth {name.Value}",
                 "authorization_required");
@@ -1431,7 +1431,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
         if (failureStatus.State is McpConnectionState.AuthFailed)
         {
-            _logger.LogWarning(ex, "MCP server '{Name}' authentication failed", name.Value);
+            _logger.LogWarning(RedactForLogging(ex), "MCP server '{Name}' authentication failed", name.Value);
             if (hasOAuthRuntimeHints || hasCachedTokens)
             {
                 EmitAuthAlert(name,
@@ -1447,7 +1447,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             return;
         }
 
-        _logger.LogWarning(ex, "Failed to connect to MCP server '{Name}'", name.Value);
+        _logger.LogWarning(RedactForLogging(ex), "Failed to connect to MCP server '{Name}'", name.Value);
         EmitDisconnectedAlert(name,
             $"MCP server '{name.Value}' connection failed: {failureStatus.ErrorMessage}");
     }
@@ -1503,7 +1503,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         var status = CreateAwaitingAuthStatus(current.Name, _timeProvider.GetUtcNow())
             with { ToolCount = current.ToolFunctions.Count };
         lifecycle.Publish(current with { Status = status });
-        _logger.LogWarning(ex,
+        _logger.LogWarning(RedactForLogging(ex),
             "MCP server '{Name}' lost OAuth authorization during catalog refresh; marked AwaitingAuth",
             current.Name.Value);
         EmitAuthAlert(current.Name,
@@ -1612,6 +1612,30 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             : $"MCP OAuth {operation} failed: {statusText}.";
         return new McpErrorResponse(message, operation, status is null ? null : (int)status.Value);
     }
+
+    /// <summary>
+    /// A token/DCR exchange failure can carry the provider's raw HTTP error body inside
+    /// <see cref="Exception.Message"/> or an inner exception, and that body can echo back the
+    /// client secret or token the request sent. <see cref="CreateSafeOAuthError"/> keeps that
+    /// text out of the response sent to callers, but every OAuth failure also reaches
+    /// <see cref="ILogger"/> via the raw exception -- and daemon logs leave the box when OTLP
+    /// export is enabled. Swap in a redacted stand-in only when secret-shaped content is
+    /// actually present, so the overwhelming majority of exceptions (network errors,
+    /// cancellations, disposal failures) keep their full native stack trace.
+    /// </summary>
+    internal static Exception RedactForLogging(Exception ex)
+    {
+        var rendered = ex.ToString();
+        var redacted = SecretOutputRedactor.Redact(rendered);
+        if (string.Equals(redacted, rendered, StringComparison.Ordinal))
+            return ex;
+
+        var typeName = ex.GetType().FullName ?? ex.GetType().Name;
+        return new McpRedactedLoggingException(
+            $"{typeName} (message redacted; matched secret-shaped content): {redacted}");
+    }
+
+    private sealed class McpRedactedLoggingException(string message) : Exception(message);
 
     private static IEnumerable<Exception> EnumerateExceptionTree(Exception root)
     {

--- a/src/Netclaw.Daemon/Mcp/McpOAuthCredentialStore.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthCredentialStore.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Authentication;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
+using Netclaw.Security;
 using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Mcp;
@@ -483,7 +484,10 @@ internal sealed class McpOAuthCredentialStore
             // one unreadable leaf anywhere in it would otherwise take down daemon startup.
             // Losing cached credentials costs a reauthorization; losing the daemon costs
             // every channel, webhook, and schedule.
-            _logger.LogError(ex,
+            // The secrets file is decrypted before this callback runs, so a malformed-JSON or
+            // decryption exception can in principle echo a fragment of plaintext credential
+            // content. Redact before logging, same as the OAuth HTTP-body-echo case.
+            _logger.LogError(SecretOutputRedactor.RedactForLogging(ex),
                 "Failed to load MCP OAuth credentials from {Path}. " +
                 "Affected MCP servers will require reauthorization.",
                 _paths.SecretsPath);
@@ -517,7 +521,7 @@ internal sealed class McpOAuthCredentialStore
         }
         catch (ArgumentException ex)
         {
-            _logger.LogWarning(ex,
+            _logger.LogWarning(SecretOutputRedactor.RedactForLogging(ex),
                 "Legacy MCP OAuth credentials for '{Name}' have an invalid resource binding",
                 serverName.Value);
             return null;

--- a/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
+++ b/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
@@ -50,6 +50,21 @@ public sealed class SecretOutputRedactorTests
         Assert.DoesNotContain("secret123", redacted, StringComparison.Ordinal);
     }
 
+    // A form-urlencoded OAuth token/DCR error body ("client_secret=...&grant_type=...") uses
+    // compound keys whose secret-bearing fragment is not the first word. These must redact the
+    // same way the JSON key form already does.
+    [Theory]
+    [InlineData("client_secret=super-secret-value-123&grant_type=refresh_token", "super-secret-value-123")]
+    [InlineData("access_token=tok-abc-123&token_type=Bearer", "tok-abc-123")]
+    [InlineData("refresh_token=rt-xyz-456", "rt-xyz-456")]
+    public void Redact_masks_env_style_compound_key_secrets(string input, string secretValue)
+    {
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.Contains("***REDACTED***", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain(secretValue, redacted, StringComparison.Ordinal);
+    }
+
     // ── Authorization header redaction ──
 
     [Fact]

--- a/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
+++ b/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
 using Xunit;
 
 namespace Netclaw.Security.Tests;
@@ -145,5 +146,36 @@ public sealed class SecretOutputRedactorTests
         var redacted = SecretOutputRedactor.Redact(input);
 
         Assert.Equal(input, redacted);
+    }
+
+    // ── Exception redaction for logging ──
+
+    [Fact]
+    public void RedactForLogging_masks_secret_shaped_exception_text()
+    {
+        var exception = new HttpRequestException(
+            HttpRequestError.Unknown,
+            "invalid_client: client_secret=secret-value token=token-value",
+            null,
+            HttpStatusCode.BadRequest);
+
+        var redacted = SecretOutputRedactor.RedactForLogging(exception);
+
+        Assert.DoesNotContain("secret-value", redacted.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("token-value", redacted.ToString(), StringComparison.Ordinal);
+        Assert.Contains("HttpRequestException", redacted.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RedactForLogging_keeps_the_original_instance_when_nothing_matches()
+    {
+        // The common case (network errors, cancellations, disposal failures) must keep its
+        // native stack trace and type for diagnostics -- redaction only swaps in a summary
+        // when secret-shaped content is actually detected.
+        var exception = new HttpRequestException("Connection refused");
+
+        var redacted = SecretOutputRedactor.RedactForLogging(exception);
+
+        Assert.Same(exception, redacted);
     }
 }

--- a/src/Netclaw.Security/SecretOutputRedactor.cs
+++ b/src/Netclaw.Security/SecretOutputRedactor.cs
@@ -83,7 +83,12 @@ public static partial class SecretOutputRedactor
     [GeneratedRegex("\"((?:api[_-]?key|token|secret|password|authorization|access[_-]?token|refresh[_-]?token|client[_-]?secret|signing[_-]?key|private[_-]?key|connection[_-]?string|credential)[^\"]*)\"\\s*:\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase)]
     private static partial Regex JsonSecretValueRegex();
 
-    [GeneratedRegex("\\b((?:api[_-]?key|token|secret|password|authorization|credential)[A-Z0-9_-]*)=([^\\s;]+)", RegexOptions.IgnoreCase)]
+    // Kept in lockstep with JsonSecretValueRegex's key fragments: an OAuth token endpoint's
+    // error body is as likely to arrive form-urlencoded ("client_secret=...&grant_type=...")
+    // as JSON, and a compound key like "client_secret" or "refresh_token" does not match a
+    // bare "secret"/"token" fragment here, since \b only anchors at the start of the whole
+    // key -- "client_secret" has no word boundary before "secret".
+    [GeneratedRegex("\\b((?:api[_-]?key|token|secret|password|authorization|access[_-]?token|refresh[_-]?token|client[_-]?secret|signing[_-]?key|private[_-]?key|connection[_-]?string|credential)[A-Z0-9_-]*)=([^\\s;]+)", RegexOptions.IgnoreCase)]
     private static partial Regex EnvSecretValueRegex();
 
     [GeneratedRegex("(Authorization\\s*:\\s*Bearer\\s+)(\\S+)", RegexOptions.IgnoreCase)]

--- a/src/Netclaw.Security/SecretOutputRedactor.cs
+++ b/src/Netclaw.Security/SecretOutputRedactor.cs
@@ -80,6 +80,30 @@ public static partial class SecretOutputRedactor
         return sanitized;
     }
 
+    /// <summary>
+    /// An exception surfaced from an external call (an OAuth token/DCR exchange, a webhook
+    /// delivery, a subprocess) can carry the far side's raw error body inside
+    /// <see cref="Exception.Message"/> or an inner exception, and that body can echo back a
+    /// secret the request sent. Passing such an exception straight to a logger lets the
+    /// unredacted body reach any log sink, including ones that leave the box (OTLP export).
+    /// This swaps in a redacted stand-in only when secret-shaped content is actually
+    /// present, so the overwhelming majority of exceptions (network errors, cancellations,
+    /// disposal failures) keep their original instance, type, and full native stack trace.
+    /// </summary>
+    public static Exception RedactForLogging(Exception ex)
+    {
+        var rendered = ex.ToString();
+        var redacted = Redact(rendered);
+        if (string.Equals(redacted, rendered, StringComparison.Ordinal))
+            return ex;
+
+        var typeName = ex.GetType().FullName ?? ex.GetType().Name;
+        return new RedactedLoggingException(
+            $"{typeName} (message redacted; matched secret-shaped content): {redacted}");
+    }
+
+    private sealed class RedactedLoggingException(string message) : Exception(message);
+
     [GeneratedRegex("\"((?:api[_-]?key|token|secret|password|authorization|access[_-]?token|refresh[_-]?token|client[_-]?secret|signing[_-]?key|private[_-]?key|connection[_-]?string|credential)[^\"]*)\"\\s*:\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase)]
     private static partial Regex JsonSecretValueRegex();
 


### PR DESCRIPTION
## Problem

A review of #1969 raised a question: could the new OAuth diagnostic logging
print a secret? The new code does not. It logs only booleans and field
names, never the raw token or client secret value.

The review found a separate, pre-existing gap. `McpClientManager` logs nine
OAuth-related exceptions directly through `ILogger`. A token or DCR exchange
failure can carry the provider's raw HTTP error body inside the exception
message, and that body can echo back the client secret or token the request
sent. A log sink prints the full exception text, so a secret could leave the
daemon log. This risk grows when OTLP export sends logs off the box.

A second gap made the fix harder than "add a redact call": `SecretOutputRedactor`
already redacts secrets in JSON key form (`"client_secret": "..."`), but its
env-style regex (`key=value` text) did not match compound keys like
`client_secret` or `refresh_token`. Only the JSON regex matched those keys. A
form-urlencoded OAuth error body (`client_secret=...&grant_type=...`) uses
exactly the compound-key shape the env-style regex missed.

A follow-up check against #1970 (which touches `McpOAuthCredentialStore`)
found the same shape of gap there: its credentials-file load path also logs
a raw exception. The secrets file is decrypted before that callback runs, so
a malformed-JSON or decryption failure could in principle echo a fragment of
plaintext credential content into the log. #1970's own diff adds no logging
and does not introduce this; it is pre-existing in the file it touches.

## Change

- Fix `SecretOutputRedactor`'s env-style regex to match the same compound
  key set the JSON regex already matches.
- Add `SecretOutputRedactor.RedactForLogging`, a shared helper that swaps in
  a redacted summary only when an exception's rendered text matches a secret
  pattern. The common case (network errors, cancellations, disposal
  failures) keeps its original exception instance, type, and full stack
  trace untouched.
- Route all nine `_logger.LogWarning(ex, ...)` / `_logger.LogError(ex, ...)`
  call sites in `McpClientManager.cs` through it, plus the two in
  `McpOAuthCredentialStore.cs`.
- Add regression tests for the redactor gap and the logging helper.