### PR TITLE
Prefer typed shell working directories

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -273,6 +273,13 @@ Done when:
   Three failures used `git -C`, and one failure used inline `cd`. The source
   inspection baseline passed 0/5. Each run read the named file, then tried
   shell search before `file_list`.
+- [x] The shell schema and always-loaded rules now separate `Command` from
+  one-call directory selection. The rules do not name an executable syntax.
+  The unchanged worktree status case passed 4/5. Direct typed scope and the
+  deliberate inline-directory case each passed 5/5.
+- [x] The unchanged source-inspection case passed 1/5. Four runs used shell
+  search after `file_read`. This result tracks a separate first-party recursive
+  file-search gap.
 - [x] A sanitized subagent eval proves that a different user-named project is
   declared before the child's first multi-command shell inspection. Absolute
   path operands remain exact scopes, but do not create a safe-space root. The

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.53.0"
+  version: "2.54.0"
 ---
 
 # Netclaw Operations
@@ -54,15 +54,22 @@ allowed roots); the project's identity file (`.netclaw/AGENTS.md`, `CLAUDE.md`,
 `skill_read_resource('netclaw-operations', 'references/projects.md')`.
 
 Use the `shell_execute` `WorkingDirectory` argument for one command in another
-directory. This argument and an absolute path operand provide exact scope, but
-they do not add a safe-space root. Do not add an inline `cd` unless directory
-change is the requested behavior.
+directory. Put the shell operation in `Command`.
+Do not place the named directory in `Command` to choose where the operation runs.
+Program-specific directory options do not replace `WorkingDirectory`.
+Always use this rule for a named child directory or worktree.
+Example: use `Command='inspect'` and `WorkingDirectory='/repo/child'`.
+The argument and an absolute path operand provide exact scope, but
+they do not add a safe-space root. Keep an inline directory change only when
+that change is the requested behavior.
 
 When available, use `set_working_directory` before shell work if several
 commands target another user-named project.
 This rule also applies to subagents and commands with absolute path operands.
 Do not repeat the call when `[working-context]` already names that project. If
 the tool rejects a path, correct the path and retry it before work continues.
+Honor a request to keep the current project unchanged.
+A denied child-directory call does not permit a project change.
 
 For Team and Personal sessions, `[working-context]` is refreshed at the start
 of each new turn. In a Git project it includes the active worktree, branch,

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -48,6 +48,7 @@ public class ShellToolTests
     public void Shell_schema_prefers_file_tools_and_typed_working_directory()
     {
         Assert.Contains("shell semantics", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("Program-specific directory options do not replace it", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Do not use for known file reads", _tool.Description, StringComparison.Ordinal);
 
         var commandDescription = _tool.ParameterSchema
@@ -61,9 +62,10 @@ public class ShellToolTests
             .GetProperty("description")
             .GetString();
 
-        Assert.Equal("The shell command to execute.", commandDescription);
-        Assert.Contains("Prefer this argument", description, StringComparison.Ordinal);
-        Assert.Contains("inline cd", description, StringComparison.Ordinal);
+        Assert.Contains("Command='inspect' and WorkingDirectory='/repo/child'", commandDescription, StringComparison.Ordinal);
+        Assert.Contains("Always use it for one-call work", description, StringComparison.Ordinal);
+        Assert.Contains("named child directory or worktree", description, StringComparison.Ordinal);
+        Assert.Contains("Command='inspect' and WorkingDirectory='/repo/child'", description, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -20,7 +20,7 @@ namespace Netclaw.Actors.Tools;
 /// Captures stdout+stderr, enforces timeout, closes stdin immediately.
 /// </summary>
 [NetclawTool(ToolName,
-    "Execute commands requiring shell semantics. Do not use for known file reads, directory listings, or edits unless shell behavior is requested.",
+    "Execute operations requiring shell semantics. For one-call work in a named directory, set WorkingDirectory. Program-specific directory options do not replace it. Do not use for known file reads, directory listings, or edits unless shell behavior is requested.",
     Grant = "shell")]
 public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 {
@@ -41,9 +41,11 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
     private readonly ShellExecutionEnvironment _environment;
 
     public record Params(
-        [param: Description("The shell command to execute.")] string Command,
         [param: Description(
-            "Run the command in this directory. Prefer this argument to an inline cd. Omit it to use the session project or scratch directory.")]
+            "The shell operation only. For one-call work in a named directory, set WorkingDirectory. Example: use Command='inspect' and WorkingDirectory='/repo/child'.")]
+        string Command,
+        [param: Description(
+            "Run the operation in this directory. Always use it for one-call work in a named child directory or worktree. Example: use Command='inspect' and WorkingDirectory='/repo/child'. Omit it to use the session project or scratch directory.")]
         string? WorkingDirectory = null);
 
     public ShellTool(ToolConfig config, ToolPathPolicy pathPolicy, ShellCommandPolicy commandPolicy)

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -88,6 +88,12 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         var prompt = _provider.GetSystemPrompt(TrustAudience.Personal);
 
         Assert.Contains("`WorkingDirectory` argument", prompt);
+        Assert.Contains("Do not place the named directory in `Command`", prompt);
+        Assert.Contains("Program-specific directory options do not replace `WorkingDirectory`", prompt);
+        Assert.Contains("Always use this rule for a named child directory or worktree", prompt);
+        Assert.Contains("Command='inspect'` and `WorkingDirectory='/repo/child'", prompt);
+        Assert.Contains("Keep the project root unless the user requests", prompt);
+        Assert.Contains("A denied child-directory call does not permit a project change", prompt);
         Assert.Contains("Do not prefix the command with an inline `cd`", prompt);
         Assert.Contains("Path arguments give the approval gate an exact candidate scope", prompt);
         Assert.Contains("safe-space root", prompt);

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -54,6 +54,12 @@ the call when `project_dir` already names the correct project. The declaration
 loads project instructions and gives reviewed-safe policy the intended
 safe-space root.
 
+Do not replace the project root with a child directory or worktree for a
+one-call task. Keep the project root unless the user requests a persistent
+project change.
+Honor a request to keep the current project unchanged.
+A denied child-directory call does not permit a project change.
+
 When NOT to declare scope at all: pure-conversation turns ("what's
 2+2?", "explain X"), sessions where no project has been mentioned, or
 one-shot lookups against external APIs. Calling
@@ -61,8 +67,14 @@ one-shot lookups against external APIs. Calling
 own kind of noise.
 
 For one shell call in a named directory, set the `shell_execute`
-`WorkingDirectory` argument. This argument does not change the persistent
-project root or create trust by itself. Do not prefix the command with an inline `cd`.
+`WorkingDirectory` argument. Put the shell operation in `Command`.
+Do not place the named directory in `Command` to choose where the operation runs.
+Program-specific directory options do not replace `WorkingDirectory`.
+Always use this rule for a named child directory or worktree.
+Example: use `Command='inspect'` and `WorkingDirectory='/repo/child'`.
+The argument does not change the persistent project root or create trust by itself.
+
+Do not prefix the command with an inline `cd`.
 Inline `cd` changes control flow. In `cd <path> && A; B`, command `B` can run
 after a failed `cd`, so approval analysis cannot use the requested directory.
 Keep inline `cd` only when changing directory is itself behavior that the user


### PR DESCRIPTION
## Summary

- Put one-call directory selection in the `WorkingDirectory` tool argument.
- Keep child directories and worktrees from replacing the current project.
- Preserve inline directory changes when the user requests that shell behavior.
- Update the operations skill and contract tests.

The guidance names no executable-specific option or syntax.

## Validation

- Release build: 0 warnings and 0 errors.
- Full runnable tests: 7,450 passed.
- Focused schema and prompt tests passed.
- Worktree status eval: 4/5 passed.
- Direct typed-directory eval: 5/5 passed.
- Deliberate inline-directory eval: 5/5 passed.
- Source-inspection eval: 1/5 passed. Four runs used shell search after `file_read`. This result tracks a separate recursive file-search gap.
- Header verification and diff checks passed.
- Slopwatch found only the existing SW004 at `PowerShellHostProbeTests.cs:311`.
