### PR TITLE
Fix Mattermost initial WebSocket connection race

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/MattermostInitialConnectionGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MattermostInitialConnectionGateTests.cs
@@ -1,0 +1,130 @@
+// -----------------------------------------------------------------------
+// <copyright file="MattermostInitialConnectionGateTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Mattermost.Events;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Channels.Mattermost.Transport;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class MattermostInitialConnectionGateTests
+{
+    [Fact]
+    public async Task StartWaitsForConnectedAndRemovesHandler()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var subscription = new ConnectionSubscription();
+        var startCount = 0;
+
+        var start = MattermostInitialConnectionGate.StartAndWaitAsync(
+            cancellationToken =>
+            {
+                Assert.False(cancellationToken.IsCancellationRequested);
+                Assert.NotNull(subscription.Handler);
+                startCount++;
+                return Task.CompletedTask;
+            },
+            subscription.Subscribe,
+            subscription.Unsubscribe,
+            timeProvider,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, startCount);
+        Assert.False(start.IsCompleted);
+
+        subscription.RaiseConnected(timeProvider);
+        await start;
+
+        Assert.Equal(1, subscription.UnsubscribeCount);
+        Assert.Equal(subscription.Handler, subscription.RemovedHandler);
+    }
+
+    [Fact]
+    public async Task TimeoutUsesTimeProviderAndRemovesHandler()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var subscription = new ConnectionSubscription();
+        var start = MattermostInitialConnectionGate.StartAndWaitAsync(
+            _ => Task.CompletedTask,
+            subscription.Subscribe,
+            subscription.Unsubscribe,
+            timeProvider,
+            TestContext.Current.CancellationToken);
+
+        timeProvider.Advance(MattermostInitialConnectionGate.Timeout);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => start);
+        Assert.Equal(1, subscription.UnsubscribeCount);
+        Assert.Equal(subscription.Handler, subscription.RemovedHandler);
+    }
+
+    [Fact]
+    public async Task CancellationRemovesHandler()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var subscription = new ConnectionSubscription();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        var start = MattermostInitialConnectionGate.StartAndWaitAsync(
+            _ => Task.CompletedTask,
+            subscription.Subscribe,
+            subscription.Unsubscribe,
+            timeProvider,
+            cancellation.Token);
+
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => start);
+        Assert.Equal(1, subscription.UnsubscribeCount);
+        Assert.Equal(subscription.Handler, subscription.RemovedHandler);
+    }
+
+    [Fact]
+    public async Task StartFailureRemovesHandler()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var subscription = new ConnectionSubscription();
+        var start = MattermostInitialConnectionGate.StartAndWaitAsync(
+            _ => throw new InvalidOperationException("Start failed."),
+            subscription.Subscribe,
+            subscription.Unsubscribe,
+            timeProvider,
+            TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => start);
+
+        Assert.Equal("Start failed.", exception.Message);
+        Assert.Equal(1, subscription.UnsubscribeCount);
+        Assert.Equal(subscription.Handler, subscription.RemovedHandler);
+    }
+
+    private sealed class ConnectionSubscription
+    {
+        public EventHandler<ConnectionEventArgs>? Handler { get; private set; }
+
+        public EventHandler<ConnectionEventArgs>? RemovedHandler { get; private set; }
+
+        public int UnsubscribeCount { get; private set; }
+
+        public void Subscribe(EventHandler<ConnectionEventArgs> handler) => Handler = handler;
+
+        public void Unsubscribe(EventHandler<ConnectionEventArgs> handler)
+        {
+            RemovedHandler = handler;
+            UnsubscribeCount++;
+        }
+
+        public void RaiseConnected(TimeProvider timeProvider)
+        {
+            Assert.NotNull(Handler);
+            Handler(
+                this,
+                new ConnectionEventArgs(
+                    new Uri("wss://mattermost.test/api/v4/websocket"),
+                    timeProvider.GetUtcNow().UtcDateTime));
+        }
+    }
+}

--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
@@ -195,23 +195,16 @@ internal sealed class MattermostNetGatewayTransport : IMattermostGatewayTranspor
         _logger.LogInformation("Bot identity resolved: {BotUserId} (@{Username})",
             me.Id, me.Username);
 
-        // This seems to be required otherwise it will be trigger a state and
-        // reconnect, so we wait for the OnConnected event or the timeout.
-        var connected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        void HandleInitialConnected(object? sender, ConnectionEventArgs e) => connected.TrySetResult(true);
-        _client.OnConnected += HandleInitialConnected;
+        // Mattermost.NET starts its receiver before the authenticated WebSocket
+        // exists. Preserve the transport contract by waiting for OnConnected.
+        await MattermostInitialConnectionGate.StartAndWaitAsync(
+            _client.StartReceivingAsync,
+            handler => _client.OnConnected += handler,
+            handler => _client.OnConnected -= handler,
+            _timeProvider,
+            cancellationToken);
 
-        try
-        {
-            await _client.StartReceivingAsync(cancellationToken);
-            await connected.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
-
-            return new MattermostBotIdentity(me.Id, me.Username);
-        }
-        finally
-        {
-            _client.OnConnected -= HandleInitialConnected;
-        }
+        return new MattermostBotIdentity(me.Id, me.Username);
     }
 
     public async Task StopAsync()
@@ -412,6 +405,33 @@ internal sealed class MattermostNetGatewayTransport : IMattermostGatewayTranspor
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error handling {Operation}", operation);
+        }
+    }
+}
+
+internal static class MattermostInitialConnectionGate
+{
+    internal static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    public static async Task StartAndWaitAsync(
+        Func<CancellationToken, Task> startReceivingAsync,
+        Action<EventHandler<ConnectionEventArgs>> subscribe,
+        Action<EventHandler<ConnectionEventArgs>> unsubscribe,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void HandleConnected(object? sender, ConnectionEventArgs e) => connected.TrySetResult();
+
+        subscribe(HandleConnected);
+        try
+        {
+            await startReceivingAsync(cancellationToken);
+            await connected.Task.WaitAsync(Timeout, timeProvider, cancellationToken);
+        }
+        finally
+        {
+            unsubscribe(HandleConnected);
         }
     }
 }

--- a/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Mattermost/Transport/MattermostNetGatewayClient.cs
@@ -195,8 +195,23 @@ internal sealed class MattermostNetGatewayTransport : IMattermostGatewayTranspor
         _logger.LogInformation("Bot identity resolved: {BotUserId} (@{Username})",
             me.Id, me.Username);
 
-        await _client.StartReceivingAsync(cancellationToken);
-        return new MattermostBotIdentity(me.Id, me.Username);
+        // This seems to be required otherwise it will be trigger a state and
+        // reconnect, so we wait for the OnConnected event or the timeout.
+        var connected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void HandleInitialConnected(object? sender, ConnectionEventArgs e) => connected.TrySetResult(true);
+        _client.OnConnected += HandleInitialConnected;
+
+        try
+        {
+            await _client.StartReceivingAsync(cancellationToken);
+            await connected.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+            return new MattermostBotIdentity(me.Id, me.Username);
+        }
+        finally
+        {
+            _client.OnConnected -= HandleInitialConnected;
+        }
     }
 
     public async Task StopAsync()


### PR DESCRIPTION
## Summary

- Wait for Mattermost.NET OnConnected before StartAsync returns.
- Use TimeProvider for the initial connection timeout.
- Remove the temporary handler after every exit.
- Add offline tests for success, timeout, cancellation, and start failure.

This PR supersedes #1974.
It preserves commit credit for @TsengSR.

Fixes #1517

## Validation

- Release build: passed
- New connection gate tests: 4 passed
- Mattermost lifecycle tests: 11 passed
- Full Netclaw.Actors.Tests suite: passed
- Real Mattermost container handshake: passed
- Slopwatch: passed with no new violations
- File header check: passed
- Format check: passed

Behavioral evals did not run. This transport-only fix does not affect an eval surface.