### PR TITLE
Fail loudly when delivery feedback cannot reach the session

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -825,6 +825,38 @@ public abstract class SessionBindingContractTests : TestKit
         ClearReplyClientThrows();
     }
 
+    [Fact]
+    public async Task Feedback_send_failure_faults_the_actor()
+    {
+        // Contract: when the session feedback pipe itself fails, the binding
+        // actor must fail loudly. A swallowed failure leaves a zombie session
+        // that waits on a delivery report that will never arrive. The loud
+        // path is a supervised restart, which re-creates the pipeline.
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-feedback-fail");
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput("this will fail to post") { SessionId = sid },
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
+        ])
+        {
+            FeedbackException = new InvalidOperationException("feedback pipe down")
+        };
+
+        SetReplyClientThrows(new InvalidOperationException("channel API down"));
+        CreateBindingActor(sid, pipeline, detector);
+
+        // A supervised restart shows up as a second pipeline CreateAsync call.
+        await AwaitAssertAsync(
+            () => Assert.True(
+                pipeline.CreateCount >= 2,
+                $"expected a supervised restart to re-create the pipeline; CreateCount={pipeline.CreateCount}"),
+            cancellationToken: ct);
+
+        ClearReplyClientThrows();
+    }
+
     // --- Pipeline Lifecycle ---
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
@@ -59,12 +59,26 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
     public ConcurrentQueue<ChannelInput> CapturedInputs { get; } = new();
     public Func<IWithSessionId, CancellationToken, Task<ISessionResponse>>? ResponseFactory { get; set; }
 
+    /// <summary>
+    /// Number of <see cref="CreateAsync"/> calls. A supervised actor restart
+    /// re-creates the pipeline, so tests observe a restart as a second call.
+    /// </summary>
+    public int CreateCount => Volatile.Read(ref _createCount);
+    private int _createCount;
+
+    /// <summary>
+    /// When set, <see cref="SendFeedbackAsync"/> throws this exception and
+    /// does not record the feedback. This models a dead session feedback pipe.
+    /// </summary>
+    public Exception? FeedbackException { get; set; }
+
     public Task<MaterializedSession> CreateAsync(
         SessionId sessionId,
         SessionPipelineOptions options,
         IMaterializer? materializer = null,
         CancellationToken cancellationToken = default)
     {
+        Interlocked.Increment(ref _createCount);
         Volatile.Write(ref _capturedOptions, options);
         _created.TrySetResult(options);
 
@@ -131,6 +145,8 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
 
     public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default)
     {
+        if (FeedbackException is { } feedbackException)
+            throw feedbackException;
         lock (_feedbackLock) _recordedFeedback.Add(feedback);
         return Task.CompletedTask;
     }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -1477,7 +1477,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to send delivery feedback to session");
+            // A dead feedback pipe means the session never learns the turn
+            // failed. Rethrow so supervision restarts the actor and
+            // re-creates the pipeline, same as the Slack binding actor.
+            _log.Error(ex, "Failed to send delivery feedback to session; propagating to trigger pipeline reinit");
+            throw;
         }
     }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -1417,7 +1417,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to send delivery feedback to session");
+            // A dead feedback pipe means the session never learns the turn
+            // failed. Rethrow so supervision restarts the actor and
+            // re-creates the pipeline, same as the Slack binding actor.
+            _log.Error(ex, "Failed to send delivery feedback to session; propagating to trigger pipeline reinit");
+            throw;
         }
     }
 


### PR DESCRIPTION
## What

Phase 3 of the code-reduction stack (on top of #2002). Fixes a confirmed behavioral drift between channel binding actors, found while diffing the triplicated code for this refactor series.

**The drift:** `NotifyDeliveryFailedAsync` sends `DeliveryFailed` feedback to the session when a transport post fails. If that feedback send *itself* throws:
- **Slack** logs and rethrows — the exception escapes the `CommandAsync` handler, supervision restarts the actor, and recovery re-creates the pipeline (the comment documents this intent).
- **Discord and Mattermost** logged and swallowed — the session never learns the turn failed and waits forever on a delivery report that will never arrive. A zombie session, and a violation of the repo's no-silent-fallbacks rule.

**The fix:** align Discord and Mattermost with Slack's log-and-rethrow. Blast radius is narrow — the rethrow fires only when the session feedback pipe is already dead. An ordinary transport failure (a post that fails) still takes the normal notify-and-return path.

## Test

New cross-channel contract test `Feedback_send_failure_faults_the_actor` in `SessionBindingContractTests`, which runs against all three channels:
- Drives a transport post failure into a feedback-pipe failure (`RecordingSessionPipeline.FeedbackException`, new test hook)
- Asserts the supervised restart via a second pipeline `CreateAsync` call (new `CreateCount` counter)
- **Before the fix: Slack passed, Discord and Mattermost failed.** After: all three pass.

## Verification

- Full `Netclaw.Actors.Tests`: 3,442 passed, 0 failed, 1 skipped (pre-existing Windows-only skip)
- `dotnet slopwatch analyze`: 0 issues; header verification passes

## Stack

PR 3 of 4. Base: `refactor/channel-warmups` (#2002). Next: binding-actor consolidation (gap-hydration engine + approval flow).