### PR TITLE
Consolidate binding-actor orchestration into shared channel engines

### DIFF
--- a/openspec/changes/consolidate-binding-actor-engines/.openspec.yaml
+++ b/openspec/changes/consolidate-binding-actor-engines/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/consolidate-binding-actor-engines/design.md
+++ b/openspec/changes/consolidate-binding-actor-engines/design.md
@@ -1,0 +1,79 @@
+# Design: consolidate-binding-actor-engines
+
+## Context
+
+The three channel binding actors each own a private copy of the same orchestration algorithms. A structural diff shows Discord and Mattermost are ~78% line-identical; Slack shares the same algorithms with different file organization. PR #2002 already extracted the small shared helpers (`PendingApprovalRequest<TPromptId>`, `PendingApprovalLookup`, `PendingApprovalRecovery`, `MessageChunker`). PR #2004 fixed one drift bug this duplication caused. This change extracts the four remaining large duplicated regions.
+
+Constraints from the constitution: actor boundaries stay transport-agnostic, security dependencies are required (non-nullable), no silent fallbacks, persisted types stay framework-owned and unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One implementation each for gap hydration, approval-response flow, output-completion bookkeeping, and safe transport calls.
+- Zero behavior change, proven by the existing cross-channel contract suite plus new parity tests.
+- Per-channel hooks exist only for genuine transport differences.
+
+**Non-Goals:**
+
+- No shared binding-actor base class. The actors keep their own FSM, persistence handlers, and receive wiring.
+- No change to persisted events (`CursorAdvanced`, `PendingApprovalPromptTracked/Cleared`).
+- No new channel features (Mattermost processing indicator stays a separate product decision).
+- No change to the generic approval API (issue #1944).
+
+## Decisions
+
+### D1: Engines are plain classes, not actors and not a base class
+
+Each engine is a non-actor class in `Netclaw.Channels`, constructed by the binding actor with required dependencies (history fetcher, injection classifier, turn-enqueue callback, logger adapter). Actors call engine methods from inside their existing `CommandAsync` handlers.
+
+Rationale: a base actor class couples lifecycle, persistence, and supervision across transports and violates the transport-agnostic boundary rule. Plain classes keep the actors' Akka semantics untouched and make the algorithms unit-testable without TestKit. Alternative considered: template-method base actor — rejected for the coupling above and because Akka.NET receive registration in a base class hides message wiring from the concrete actor.
+
+### D2: Cursor comparison is an injected comparator; Discord uses length-then-ordinal
+
+The persisted `CursorAdvanced.Cursor` is already a `string` for every channel. Discord's in-memory `ulong` round-trip is the main textual difference blocking hydration consolidation. The engine stores cursors as strings and compares with an injected `IComparer<string>`:
+
+- Mattermost and Slack: ordinal comparison (current behavior).
+- Discord: length-then-ordinal comparison. Plain ordinal is WRONG for snowflakes across digit-length boundaries (`"999..."` 18 digits vs `"1000..."` 19 digits), so Discord SHALL NOT use plain ordinal. Length-then-ordinal equals numeric order for all non-negative integer strings without leading zeros.
+
+A unit test SHALL prove the Discord comparator matches `ulong` comparison, and MUST include cross-digit-length pairs and boundary values (`ulong.MaxValue`, adjacent powers of ten). Alternative considered: keep `ulong` inside Discord and make the engine generic over the cursor type — rejected because it preserves the asymmetry the consolidation exists to remove.
+
+### D3: Approval flow is a shared class with two hooks
+
+`ApprovalResponseFlow` owns text-approval parsing, cold-spawn forwarding, and prompt resolution (via `PendingApprovalLookup` from PR #2002). Hooks:
+
+- `RenderResolvedPromptAsync(...)` — required; each channel redraws its own prompt message.
+- `RespondSynchronously(replyTo, ack)` — optional hook used only by Mattermost, whose interactive-message webhook requires a synchronous HTTP reply. Discord (gateway events) and Slack do not register it.
+
+The requester identity check stays inside the shared flow so it cannot drift per channel.
+
+### D4: Output handling is a shared engine with a channel-output hook
+
+The shared engine owns the `TurnCompleted` bookkeeping (cursor advance, turn-in-flight flag, reminder observer settlement, empty-turn fallback, prompt clearing) and delegates unrecognized or channel-specific outputs (`SessionTitleOutput`, `ProcessingStateOutput`) to a `HandleChannelSpecificOutput` hook. A channel that does not support an output type ignores it in its hook; this is a capability difference, not a silent fallback.
+
+Persistence stays in the actor: the engine returns the events to persist (e.g., cleared prompts); the actor calls `Persist`/`PersistAll` and applies via the PR #2002 recovery helpers. The engine never touches Akka persistence.
+
+### D5: Failure modes keep PR #2004 semantics
+
+Engines do not catch-and-swallow. An exception from an engine method escapes the actor's `CommandAsync` handler, supervision restarts the actor, and recovery re-creates the pipeline. The `Feedback_send_failure_faults_the_actor` contract test pins this. The safe transport-call skeleton records telemetry and calls the delivery-failure notifier exactly as each channel does today.
+
+### D6: Extraction lands in four reviewable steps
+
+Order: (1) Discord cursor stringization + comparator test, (2) gap-hydration engine, (3) approval-response flow, (4) output template + safe-call skeleton. Each step compiles, passes the full `Netclaw.Actors.Tests` suite, and is a separate commit. If a step uncovers a real behavioral difference between channels, the step stops and the difference is surfaced for a decision instead of being silently normalized.
+
+## Risks / Trade-offs
+
+- [Discord cursor ordering breaks on short synthetic IDs in tests] → the comparator test covers cross-digit-length pairs; test fixtures with short numeric IDs order correctly under length-then-ordinal.
+- [Hydration consolidation changes turn-enqueue timing] → the engine is a mechanical transplant; the contract suite's hydration tests (fetch-once, stash-during-hydration, restart-re-runs) run per channel and must stay green at every step.
+- [Approval flow consolidation weakens a per-channel security check] → the requester check already has one shared implementation (`PendingApprovalLookup`, PR #2002); this change only moves its callers. New parity tests assert wrong-requester rejection per channel.
+- [Hidden per-channel differences get normalized away] → D6 stop rule: any discovered difference halts that step and is reported, mirroring how the PR #2004 drift was handled.
+- [Larger blast radius for a single engine bug] → trade-off accepted: one visible bug beats three drifting copies; the cross-channel contract suite runs every scenario against all three channels.
+
+## Migration Plan
+
+No deployment migration: no config, persistence, or wire change. Rollback is a revert of the stacked PR. The four commits in D6 allow partial revert per engine.
+
+## Open Questions
+
+- Mattermost lacks the processing-indicator output handling Slack and Discord have. Feature gap or intentional? Needs a product decision; out of scope here (hook default: ignore).
+- Slack's pending-approval lookup shape differs slightly (`FindIndex`, no call-id-first branch). If step 3 confirms a real semantic difference, Slack keeps its lookup and only shares the outer flow; the difference gets documented in the parity spec.

--- a/openspec/changes/consolidate-binding-actor-engines/proposal.md
+++ b/openspec/changes/consolidate-binding-actor-engines/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: consolidate-binding-actor-engines
+
+## Why
+
+`SlackThreadBindingActor`, `DiscordSessionBindingActor`, and `MattermostSessionBindingActor` copy the same orchestration logic. Discord and Mattermost are ~78% line-identical. This duplication already produced one confirmed drift bug: Discord and Mattermost swallowed feedback-pipe failures that Slack propagated (fixed in PR #2004). Every future fix to hydration, approval flow, or delivery handling must land three times by hand. Each hand copy is a chance to miss a security-relevant path.
+
+Source PRDs: PRD-001 (Netclaw MVP, channel bindings), PRD-002 (gateway security envelope, approval checks), PRD-009 (input adapters and unified input).
+
+## What Changes
+
+- Extract a shared **gap-hydration engine** into `Netclaw.Channels`. It owns the fetch → cursor-filter → injection-classify → adopted-context-merge → turn-enqueue algorithm. The three actors delegate to it. (~600-700 duplicated lines removed.)
+- Extract a shared **approval-response flow**. It owns text approval parsing, cold-spawn approval forwarding, and prompt resolution. Mattermost keeps a synchronous HTTP-reply hook; Discord and Slack do not use it. (~450-550 lines removed.)
+- Extract a shared **output-handling template** for `TurnCompleted`/approval-prompt/reminder-observer bookkeeping, with a channel-specific hook for outputs only some channels support (Discord thread rename, processing indicators). (~70-90 lines removed.)
+- Extract a shared **safe transport-call skeleton** (timing → call → telemetry → failure notify). (~60-80 lines removed.)
+- **Prerequisite**: Discord's internal cursor changes from `ulong` snowflake to `string`, which the persisted `CursorAdvanced` event already stores for every channel. A unit test SHALL prove ordinal string comparison orders real Discord snowflake ranges the same as numeric comparison before the numeric path is removed.
+- Zero behavior change. No persisted-type change. Builds on the `PendingApproval*` helpers from PR #2002.
+
+In scope: the four engine extractions above, the Discord cursor change, and parity tests.
+Out of scope: a shared binding-actor base class that owns the actor FSM; Mattermost processing-indicator support (flagged as a possible feature gap, needs a product decision); the generic approval API rework (issue #1944); SignalR channel extraction (issue #691).
+
+## Capabilities
+
+### New Capabilities
+
+- `channel-binding-parity`: cross-channel guarantee that gap hydration, approval response handling, output-completion bookkeeping, and transport-failure escalation run through single shared implementations, with per-channel hooks limited to genuine transport differences.
+
+### Modified Capabilities
+
+<!-- none: thread-history-backfill and tool-approval-gates requirements are unchanged; this change consolidates their implementations without behavior change -->
+
+## Impact
+
+- Code: `src/Netclaw.Channels` (new engine types), `src/Netclaw.Channels.Slack`, `src/Netclaw.Channels.Discord`, `src/Netclaw.Channels.Mattermost` (delegation), `src/Netclaw.Actors.Tests` (parity contract tests).
+- Security impact: the approval requester check and the prompt-injection gap classification move from three copies to one. A fix in one place reaches all channels. No ACL or policy semantics change. The engines take required (non-nullable) security dependencies per the constitution.
+- Operational impact: none at runtime. Log messages keep their per-channel adapter fields. No config change, no migration, no persisted-format change.
+- Rollout: lands as PR 4 of the refactor stack, stacked on #2004. Revert is a single PR revert; no data migration to unwind.

--- a/openspec/changes/consolidate-binding-actor-engines/specs/channel-binding-parity/spec.md
+++ b/openspec/changes/consolidate-binding-actor-engines/specs/channel-binding-parity/spec.md
@@ -74,6 +74,20 @@ The system SHALL implement turn-completion bookkeeping (cursor advance, turn-in-
 - **THEN** the Discord hook renames the thread
 - **AND** a channel without that capability ignores the output in its hook
 
+#### Scenario: Pipeline reinitialize keeps each channel's cursor discipline
+
+- **GIVEN** a pipeline reinitialize while a turn is in flight
+- **WHEN** the binding actor resets the engine
+- **THEN** Slack discards the pending cursor
+- **AND** Discord and Mattermost keep it, which preserves their current behavior
+
+> Note: the step-4 transplant surfaced this divergence. Slack clears the
+> pending cursor on reinitialize; Discord and Mattermost keep it, so a later
+> `TurnCompleted` can commit the cursor of a turn that the reinitialize
+> abandoned. That is a possible latent defect in the Discord and Mattermost
+> behavior, tracked as a product question outside this change. This change
+> preserves each channel's current behavior via `DiscardPendingCursor()`.
+
 ### Requirement: Transport-failure escalation parity
 
 The safe transport-call skeleton SHALL record telemetry, notify delivery failure, and preserve the fail-loud contract: when the session feedback pipe fails, the error SHALL propagate so supervision restarts the actor and re-creates the pipeline. No channel SHALL swallow a feedback-pipe failure.

--- a/openspec/changes/consolidate-binding-actor-engines/specs/channel-binding-parity/spec.md
+++ b/openspec/changes/consolidate-binding-actor-engines/specs/channel-binding-parity/spec.md
@@ -32,7 +32,7 @@ The shared engine SHALL store cursors as strings, which matches the persisted `C
 
 ### Requirement: Shared approval-response flow
 
-The system SHALL implement text-approval parsing, cold-spawn approval forwarding, and pending-prompt resolution in a single shared flow. The requester identity check SHALL execute inside the shared flow. Per-channel hooks SHALL be limited to prompt rendering and, for Mattermost only, the synchronous webhook reply.
+The system SHALL implement text-approval parsing, cold-spawn approval forwarding, and pending-prompt resolution in a single shared flow. The requester identity check SHALL execute inside the shared flow. Per-channel hooks SHALL be limited to prompt rendering, the pending-approval match order, and, for Mattermost only, the synchronous webhook reply.
 
 #### Scenario: Wrong requester is rejected on every channel
 
@@ -47,6 +47,21 @@ The system SHALL implement text-approval parsing, cold-spawn approval forwarding
 - **WHEN** the shared flow resolves it
 - **THEN** the Mattermost hook sends the synchronous HTTP reply
 - **AND** Discord and Slack register no such hook
+
+#### Scenario: Channel match order picks the same candidate as before
+
+- **GIVEN** two pending approvals that the same sender may approve
+- **WHEN** that sender sends a text approval reply
+- **THEN** Slack resolves the earliest pending approval
+- **AND** Discord and Mattermost resolve the most recent pending approval
+
+> Note: this match order is the one real difference the step-3 stop rule found
+> between the three copies. Slack selected its candidate with `FindIndex`
+> (earliest match); Discord and Mattermost selected it with `LastOrDefault`
+> (most recent match). The shared lookup keeps one requester check and takes the
+> order as a required `ApprovalMatchOrder` input, so each channel keeps the
+> selection it had. Which order is correct is a separate product question,
+> tracked outside this change.
 
 ### Requirement: Shared output-completion bookkeeping
 

--- a/openspec/changes/consolidate-binding-actor-engines/specs/channel-binding-parity/spec.md
+++ b/openspec/changes/consolidate-binding-actor-engines/specs/channel-binding-parity/spec.md
@@ -1,0 +1,71 @@
+# channel-binding-parity Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Shared gap-hydration engine
+
+The system SHALL implement thread gap hydration (fetch history, filter by cursor, classify for prompt-injection risk, merge adopted context, enqueue the turn) in a single engine in the channel abstraction layer. Channel binding actors SHALL delegate hydration to this engine. The engine SHALL take its security-relevant dependencies (injection classifier, sender authorization callback) as required constructor inputs.
+
+#### Scenario: All channels hydrate through one implementation
+
+- **GIVEN** the Slack, Discord, and Mattermost binding actors
+- **WHEN** each performs one-shot hydration at actor start
+- **THEN** each delegates to the shared engine
+- **AND** the per-channel code supplies only transport lookups and the cursor comparator
+
+#### Scenario: Hydration contract behavior is unchanged
+
+- **GIVEN** the existing cross-channel contract suite
+- **WHEN** the hydration tests run (fetch at most once per lifetime, stash during hydration, re-run after supervised restart, adopted-context backfill)
+- **THEN** every test passes for every channel without per-channel test changes
+
+### Requirement: Cursor ordering by injected comparator
+
+The shared engine SHALL store cursors as strings, which matches the persisted `CursorAdvanced` format for every channel. Cursor comparison SHALL use a comparator the channel supplies. The Discord comparator SHALL order numeric snowflake strings identically to unsigned 64-bit numeric comparison. Discord SHALL NOT use plain ordinal string comparison.
+
+#### Scenario: Discord snowflake ordering across digit lengths
+
+- **GIVEN** two snowflake strings with different digit counts, such as an 18-digit and a 19-digit value
+- **WHEN** the Discord comparator orders them
+- **THEN** the result equals the numeric `ulong` ordering
+- **AND** a unit test proves the equivalence for cross-digit-length pairs and for boundary values
+
+### Requirement: Shared approval-response flow
+
+The system SHALL implement text-approval parsing, cold-spawn approval forwarding, and pending-prompt resolution in a single shared flow. The requester identity check SHALL execute inside the shared flow. Per-channel hooks SHALL be limited to prompt rendering and, for Mattermost only, the synchronous webhook reply.
+
+#### Scenario: Wrong requester is rejected on every channel
+
+- **GIVEN** a pending approval requested by user A
+- **WHEN** user B attempts to approve it on any channel
+- **THEN** the shared flow rejects the response
+- **AND** the channel posts its wrong-requester warning
+
+#### Scenario: Mattermost synchronous reply hook
+
+- **GIVEN** a Mattermost interactive-message approval
+- **WHEN** the shared flow resolves it
+- **THEN** the Mattermost hook sends the synchronous HTTP reply
+- **AND** Discord and Slack register no such hook
+
+### Requirement: Shared output-completion bookkeeping
+
+The system SHALL implement turn-completion bookkeeping (cursor advance, turn-in-flight state, reminder delivery settlement, empty-turn fallback, pending-prompt clearing) in a single engine. Persistence calls SHALL remain in the actor: the engine SHALL return the events to persist and SHALL NOT invoke Akka persistence. A channel-specific output hook SHALL handle output types that only some channels support.
+
+#### Scenario: Channel-specific outputs go through the hook
+
+- **GIVEN** a `SessionTitleOutput` for a Discord session
+- **WHEN** the shared engine processes outputs
+- **THEN** the Discord hook renames the thread
+- **AND** a channel without that capability ignores the output in its hook
+
+### Requirement: Transport-failure escalation parity
+
+The safe transport-call skeleton SHALL record telemetry, notify delivery failure, and preserve the fail-loud contract: when the session feedback pipe fails, the error SHALL propagate so supervision restarts the actor and re-creates the pipeline. No channel SHALL swallow a feedback-pipe failure.
+
+#### Scenario: Feedback-pipe failure faults every channel actor
+
+- **GIVEN** a transport post failure whose delivery-failure feedback also fails
+- **WHEN** the binding actor handles it on any channel
+- **THEN** the actor restarts under supervision
+- **AND** the pipeline is re-created, observable as a second pipeline creation

--- a/openspec/changes/consolidate-binding-actor-engines/tasks.md
+++ b/openspec/changes/consolidate-binding-actor-engines/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: consolidate-binding-actor-engines
+
+Working branch: `refactor/binding-engine`, stacked on `refactor/delivery-failure-drift` (PR #2004), worktree `/home/aaronontheweb/repositories/netclaw-dev/netclaw-refactor-cleanup`. Every numbered group ends with the full `Netclaw.Actors.Tests` suite green, `dotnet slopwatch analyze` clean, and header verification clean, and is one commit.
+
+## 1. Discord cursor stringization (prerequisite)
+
+- [ ] 1.1 Add `SnowflakeCursorComparer` (length-then-ordinal) to `Netclaw.Channels` with a unit test proving equivalence to `ulong` ordering: cross-digit-length pairs, adjacent powers of ten, `ulong.MaxValue`, and short synthetic test IDs
+- [ ] 1.2 Replace Discord's internal `ulong` cursor (`_cursorSnowflake`, `AdvanceCursor(ulong)`, `TryParseSnowflake`) with `string` state compared via the comparator; persisted `CursorAdvanced` handling is already string and stays untouched
+- [ ] 1.3 Run Discord contract + cursor tests; verify no persisted-format change with the serialization test suite
+
+## 2. Gap-hydration engine
+
+- [ ] 2.1 Extract the shared engine (fetch → cursor-filter → classify → merge adopted context → enqueue) into `Netclaw.Channels`, transplanting the Mattermost copy as the reference implementation; constructor takes required classifier, authorization callback, history fetcher, and cursor comparator
+- [ ] 2.2 Delegate Mattermost, then Discord, then Slack hydration to the engine; diff each removed region against the transplant to confirm mechanical equivalence; STOP and surface any real semantic difference instead of normalizing it
+- [ ] 2.3 Hydration contract tests green for all three channels (fetch-once, stash-during-hydration, restart re-runs, adopted-context backfill, deferred hydration)
+
+## 3. Approval-response flow
+
+- [ ] 3.1 Extract `ApprovalResponseFlow` (text approval parsing, cold-spawn forwarding, prompt resolution via `PendingApprovalLookup`) with required render hook and optional Mattermost synchronous-reply hook
+- [ ] 3.2 Delegate Discord and Mattermost; verify Slack's lookup shape — if semantically identical, delegate Slack too, otherwise Slack shares the outer flow only and the difference is documented in the parity spec
+- [ ] 3.3 Approval contract tests green per channel, including wrong-requester rejection, cold text approval, pruned option order, and post-turn approval forwarding
+
+## 4. Output template and safe transport calls
+
+- [ ] 4.1 Extract turn-completion bookkeeping engine; engine returns events to persist, actor keeps `Persist`/`PersistAll`; channel-specific outputs (`SessionTitleOutput`, `ProcessingStateOutput`) go through the channel hook
+- [ ] 4.2 Extract the safe transport-call skeleton (timing → call → telemetry → notify) preserving per-channel telemetry categories and the PR #2004 fail-loud contract
+- [ ] 4.3 Contract tests green: delivery-failed feedback, empty-turn fallback, reminder settlement, `Feedback_send_failure_faults_the_actor`
+
+## 5. Finish
+
+- [ ] 5.1 Full solution build with zero warnings; full `Netclaw.Actors.Tests`, `Netclaw.Daemon.Tests` channel suites; slopwatch and header gates
+- [ ] 5.2 Line-count accounting for the PR description (target ~1,200-1,500 lines removed) and parity-spec sync via `/opsx-sync`
+- [ ] 5.3 Submit `refactor/binding-engine` as PR 4 via `gh stack submit`; PR body documents any differences surfaced by the stop rule

--- a/openspec/changes/consolidate-binding-actor-engines/tasks.md
+++ b/openspec/changes/consolidate-binding-actor-engines/tasks.md
@@ -28,6 +28,6 @@ Working branch: `refactor/binding-engine`, stacked on `refactor/delivery-failure
 
 ## 5. Finish
 
-- [ ] 5.1 Full solution build with zero warnings; full `Netclaw.Actors.Tests`, `Netclaw.Daemon.Tests` channel suites; slopwatch and header gates
-- [ ] 5.2 Line-count accounting for the PR description (target ~1,200-1,500 lines removed) and parity-spec sync via `/opsx-sync`
+- [x] 5.1 Full solution build with zero warnings; full `Netclaw.Actors.Tests`, `Netclaw.Daemon.Tests` channel suites; slopwatch and header gates
+- [x] 5.2 Line-count accounting for the PR description (target ~1,200-1,500 lines removed) and parity-spec sync via `/opsx-sync`
 - [ ] 5.3 Submit `refactor/binding-engine` as PR 4 via `gh stack submit`; PR body documents any differences surfaced by the stop rule

--- a/openspec/changes/consolidate-binding-actor-engines/tasks.md
+++ b/openspec/changes/consolidate-binding-actor-engines/tasks.md
@@ -16,9 +16,9 @@ Working branch: `refactor/binding-engine`, stacked on `refactor/delivery-failure
 
 ## 3. Approval-response flow
 
-- [ ] 3.1 Extract `ApprovalResponseFlow` (text approval parsing, cold-spawn forwarding, prompt resolution via `PendingApprovalLookup`) with required render hook and optional Mattermost synchronous-reply hook
-- [ ] 3.2 Delegate Discord and Mattermost; verify Slack's lookup shape — if semantically identical, delegate Slack too, otherwise Slack shares the outer flow only and the difference is documented in the parity spec
-- [ ] 3.3 Approval contract tests green per channel, including wrong-requester rejection, cold text approval, pruned option order, and post-turn approval forwarding
+- [x] 3.1 Extract `ApprovalResponseFlow` (text approval parsing, cold-spawn forwarding, prompt resolution via `PendingApprovalLookup`) with required render hook and optional Mattermost synchronous-reply hook
+- [x] 3.2 Delegate Discord and Mattermost; verify Slack's lookup shape — if semantically identical, delegate Slack too, otherwise Slack shares the outer flow only and the difference is documented in the parity spec
+- [x] 3.3 Approval contract tests green per channel, including wrong-requester rejection, cold text approval, pruned option order, and post-turn approval forwarding
 
 ## 4. Output template and safe transport calls
 

--- a/openspec/changes/consolidate-binding-actor-engines/tasks.md
+++ b/openspec/changes/consolidate-binding-actor-engines/tasks.md
@@ -10,9 +10,9 @@ Working branch: `refactor/binding-engine`, stacked on `refactor/delivery-failure
 
 ## 2. Gap-hydration engine
 
-- [ ] 2.1 Extract the shared engine (fetch → cursor-filter → classify → merge adopted context → enqueue) into `Netclaw.Channels`, transplanting the Mattermost copy as the reference implementation; constructor takes required classifier, authorization callback, history fetcher, and cursor comparator
-- [ ] 2.2 Delegate Mattermost, then Discord, then Slack hydration to the engine; diff each removed region against the transplant to confirm mechanical equivalence; STOP and surface any real semantic difference instead of normalizing it
-- [ ] 2.3 Hydration contract tests green for all three channels (fetch-once, stash-during-hydration, restart re-runs, adopted-context backfill, deferred hydration)
+- [x] 2.1 Extract the shared engine (fetch → cursor-filter → classify → merge adopted context → enqueue) into `Netclaw.Channels`, transplanting the Mattermost copy as the reference implementation; constructor takes required classifier, authorization callback, history fetcher, and cursor comparator
+- [x] 2.2 Delegate Mattermost, then Discord, then Slack hydration to the engine; diff each removed region against the transplant to confirm mechanical equivalence; STOP and surface any real semantic difference instead of normalizing it
+- [x] 2.3 Hydration contract tests green for all three channels (fetch-once, stash-during-hydration, restart re-runs, adopted-context backfill, deferred hydration)
 
 ## 3. Approval-response flow
 

--- a/openspec/changes/consolidate-binding-actor-engines/tasks.md
+++ b/openspec/changes/consolidate-binding-actor-engines/tasks.md
@@ -4,9 +4,9 @@ Working branch: `refactor/binding-engine`, stacked on `refactor/delivery-failure
 
 ## 1. Discord cursor stringization (prerequisite)
 
-- [ ] 1.1 Add `SnowflakeCursorComparer` (length-then-ordinal) to `Netclaw.Channels` with a unit test proving equivalence to `ulong` ordering: cross-digit-length pairs, adjacent powers of ten, `ulong.MaxValue`, and short synthetic test IDs
-- [ ] 1.2 Replace Discord's internal `ulong` cursor (`_cursorSnowflake`, `AdvanceCursor(ulong)`, `TryParseSnowflake`) with `string` state compared via the comparator; persisted `CursorAdvanced` handling is already string and stays untouched
-- [ ] 1.3 Run Discord contract + cursor tests; verify no persisted-format change with the serialization test suite
+- [x] 1.1 Add `SnowflakeCursorComparer` (length-then-ordinal) to `Netclaw.Channels` with a unit test proving equivalence to `ulong` ordering: cross-digit-length pairs, adjacent powers of ten, `ulong.MaxValue`, and short synthetic test IDs
+- [x] 1.2 Replace Discord's internal `ulong` cursor (`_cursorSnowflake`, `AdvanceCursor(ulong)`, `TryParseSnowflake`) with `string` state compared via the comparator; persisted `CursorAdvanced` handling is already string and stays untouched
+- [x] 1.3 Run Discord contract + cursor tests; verify no persisted-format change with the serialization test suite
 
 ## 2. Gap-hydration engine
 

--- a/openspec/changes/consolidate-binding-actor-engines/tasks.md
+++ b/openspec/changes/consolidate-binding-actor-engines/tasks.md
@@ -22,9 +22,9 @@ Working branch: `refactor/binding-engine`, stacked on `refactor/delivery-failure
 
 ## 4. Output template and safe transport calls
 
-- [ ] 4.1 Extract turn-completion bookkeeping engine; engine returns events to persist, actor keeps `Persist`/`PersistAll`; channel-specific outputs (`SessionTitleOutput`, `ProcessingStateOutput`) go through the channel hook
-- [ ] 4.2 Extract the safe transport-call skeleton (timing → call → telemetry → notify) preserving per-channel telemetry categories and the PR #2004 fail-loud contract
-- [ ] 4.3 Contract tests green: delivery-failed feedback, empty-turn fallback, reminder settlement, `Feedback_send_failure_faults_the_actor`
+- [x] 4.1 Extract turn-completion bookkeeping engine; engine returns events to persist, actor keeps `Persist`/`PersistAll`; channel-specific outputs (`SessionTitleOutput`, `ProcessingStateOutput`) go through the channel hook
+- [x] 4.2 Extract the safe transport-call skeleton (timing → call → telemetry → notify) preserving per-channel telemetry categories and the PR #2004 fail-loud contract — Discord and Mattermost delegate; Slack keeps its own by the stop rule (three exception classes, one with `RecordReplyRejected` telemetry no other channel has, plus deferred failure reporting)
+- [x] 4.3 Contract tests green: delivery-failed feedback, empty-turn fallback, reminder settlement, `Feedback_send_failure_faults_the_actor`
 
 ## 5. Finish
 

--- a/openspec/specs/channel-binding-parity/spec.md
+++ b/openspec/specs/channel-binding-parity/spec.md
@@ -1,0 +1,103 @@
+# channel-binding-parity Specification
+
+## Purpose
+
+Guarantee that the Slack, Discord, and Mattermost binding actors run gap hydration, approval response handling, output-completion bookkeeping, and transport-failure escalation through single shared implementations in the channel abstraction layer. Per-channel hooks exist only for genuine transport differences. This prevents the drift class where a fix or a security check lands in one channel and misses the others.
+
+## Requirements
+
+### Requirement: Shared gap-hydration engine
+
+The system SHALL implement thread gap hydration (fetch history, filter by cursor, classify for prompt-injection risk, merge adopted context, enqueue the turn) in a single engine in the channel abstraction layer. Channel binding actors SHALL delegate hydration to this engine. The engine SHALL take its security-relevant dependencies (injection classifier, sender authorization callback) as required constructor inputs.
+
+#### Scenario: All channels hydrate through one implementation
+
+- **GIVEN** the Slack, Discord, and Mattermost binding actors
+- **WHEN** each performs one-shot hydration at actor start
+- **THEN** each delegates to the shared engine
+- **AND** the per-channel code supplies only transport lookups and the cursor comparator
+
+#### Scenario: Hydration contract behavior is unchanged
+
+- **GIVEN** the existing cross-channel contract suite
+- **WHEN** the hydration tests run (fetch at most once per lifetime, stash during hydration, re-run after supervised restart, adopted-context backfill)
+- **THEN** every test passes for every channel without per-channel test changes
+
+### Requirement: Cursor ordering by injected comparator
+
+The shared engine SHALL store cursors as strings, which matches the persisted `CursorAdvanced` format for every channel. Cursor comparison SHALL use a comparator the channel supplies. The Discord comparator SHALL order numeric snowflake strings identically to unsigned 64-bit numeric comparison. Discord SHALL NOT use plain ordinal string comparison.
+
+#### Scenario: Discord snowflake ordering across digit lengths
+
+- **GIVEN** two snowflake strings with different digit counts, such as an 18-digit and a 19-digit value
+- **WHEN** the Discord comparator orders them
+- **THEN** the result equals the numeric `ulong` ordering
+- **AND** a unit test proves the equivalence for cross-digit-length pairs and for boundary values
+
+### Requirement: Shared approval-response flow
+
+The system SHALL implement text-approval parsing, cold-spawn approval forwarding, and pending-prompt resolution in a single shared flow. The requester identity check SHALL execute inside the shared flow. Per-channel hooks SHALL be limited to prompt rendering, the pending-approval match order, and, for Mattermost only, the synchronous webhook reply.
+
+#### Scenario: Wrong requester is rejected on every channel
+
+- **GIVEN** a pending approval requested by user A
+- **WHEN** user B attempts to approve it on any channel
+- **THEN** the shared flow rejects the response
+- **AND** the channel posts its wrong-requester warning
+
+#### Scenario: Mattermost synchronous reply hook
+
+- **GIVEN** a Mattermost interactive-message approval
+- **WHEN** the shared flow resolves it
+- **THEN** the Mattermost hook sends the synchronous HTTP reply
+- **AND** Discord and Slack register no such hook
+
+#### Scenario: Channel match order picks the same candidate as before
+
+- **GIVEN** two pending approvals that the same sender may approve
+- **WHEN** that sender sends a text approval reply
+- **THEN** Slack resolves the earliest pending approval
+- **AND** Discord and Mattermost resolve the most recent pending approval
+
+> Note: this match order is a real difference between the pre-consolidation
+> copies. Slack selected its candidate with `FindIndex` (earliest match);
+> Discord and Mattermost selected it with `LastOrDefault` (most recent match).
+> The shared lookup keeps one requester check and takes the order as a
+> required `ApprovalMatchOrder` input, so each channel keeps the selection it
+> had. Which order is correct is a separate product question, tracked outside
+> the introducing change.
+
+### Requirement: Shared output-completion bookkeeping
+
+The system SHALL implement turn-completion bookkeeping (cursor advance, turn-in-flight state, reminder delivery settlement, empty-turn fallback, pending-prompt clearing) in a single engine. Persistence calls SHALL remain in the actor: the engine SHALL return the events to persist and SHALL NOT invoke Akka persistence. A channel-specific output hook SHALL handle output types that only some channels support.
+
+#### Scenario: Channel-specific outputs go through the hook
+
+- **GIVEN** a `SessionTitleOutput` for a Discord session
+- **WHEN** the shared engine processes outputs
+- **THEN** the Discord hook renames the thread
+- **AND** a channel without that capability ignores the output in its hook
+
+#### Scenario: Pipeline reinitialize keeps each channel's cursor discipline
+
+- **GIVEN** a pipeline reinitialize while a turn is in flight
+- **WHEN** the binding actor resets the engine
+- **THEN** Slack discards the pending cursor
+- **AND** Discord and Mattermost keep it, which preserves their current behavior
+
+> Note: the consolidation surfaced this divergence. Slack clears the pending
+> cursor on reinitialize; Discord and Mattermost keep it, so a later
+> `TurnCompleted` can commit the cursor of a turn that the reinitialize
+> abandoned. That is a possible latent defect in the Discord and Mattermost
+> behavior, tracked as a product question outside the introducing change.
+
+### Requirement: Transport-failure escalation parity
+
+The safe transport-call skeleton SHALL record telemetry, notify delivery failure, and preserve the fail-loud contract: when the session feedback pipe fails, the error SHALL propagate so supervision restarts the actor and re-creates the pipeline. No channel SHALL swallow a feedback-pipe failure.
+
+#### Scenario: Feedback-pipe failure faults every channel actor
+
+- **GIVEN** a transport post failure whose delivery-failure feedback also fails
+- **WHEN** the binding actor handles it on any channel
+- **THEN** the actor restarts under supervision
+- **AND** the pipeline is re-created, observable as a second pipeline creation

--- a/src/Netclaw.Actors.Tests/Channels/SnowflakeCursorComparerTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SnowflakeCursorComparerTests.cs
@@ -1,0 +1,104 @@
+// -----------------------------------------------------------------------
+// <copyright file="SnowflakeCursorComparerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Channels;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+/// <summary>
+/// Proves the string comparer orders snowflake cursors exactly like
+/// <see cref="ulong"/> comparison. The Discord binding actor holds its
+/// cursor as a string and relies on this equivalence.
+/// </summary>
+public sealed class SnowflakeCursorComparerTests
+{
+    // A fixed representative set. It covers short synthetic test IDs, the
+    // adjacent powers of ten where digit length changes, real 18-digit and
+    // 19-digit Discord snowflakes, and the ulong boundary. The set is
+    // deliberately fixed, not random, so a failure always reproduces.
+    private static readonly ulong[] RepresentativeValues =
+    [
+        0UL,
+        1UL,
+        2UL,
+        9UL,
+        10UL,
+        11UL,
+        99UL,
+        100UL,
+        101UL,
+        999UL,
+        1_000UL,
+        99_999_999_999_999_999UL,
+        100_000_000_000_000_000UL,
+        123_456_789_012_345_678UL,
+        900_000_000_000_000_000UL,
+        999_999_999_999_999_999UL,
+        1_000_000_000_000_000_000UL,
+        1_000_000_000_000_000_001UL,
+        1_100_000_000_000_000_000UL,
+        9_999_999_999_999_999_999UL,
+        ulong.MaxValue
+    ];
+
+    [Fact]
+    public void Comparer_matches_numeric_order_for_every_pair()
+    {
+        foreach (var left in RepresentativeValues)
+        {
+            foreach (var right in RepresentativeValues)
+            {
+                var expected = left.CompareTo(right);
+                var actual = SnowflakeCursorComparer.Instance.Compare(
+                    left.ToString(), right.ToString());
+
+                Assert.Equal(expected, Math.Sign(actual));
+            }
+        }
+    }
+
+    [Fact]
+    public void Shorter_snowflake_orders_before_longer_snowflake()
+    {
+        // Plain ordinal comparison fails this pair: '9' sorts after '1'.
+        Assert.True(SnowflakeCursorComparer.Instance.Compare(
+            "999999999999999999", "1000000000000000000") < 0);
+        Assert.True(string.CompareOrdinal("999999999999999999", "1000000000000000000") > 0);
+    }
+
+    [Fact]
+    public void Equal_values_compare_equal()
+    {
+        Assert.Equal(0, SnowflakeCursorComparer.Instance.Compare(
+            "1234567890123456789", "1234567890123456789"));
+        Assert.Equal(0, SnowflakeCursorComparer.Instance.Compare(null, null));
+    }
+
+    [Fact]
+    public void Missing_cursor_orders_before_any_snowflake()
+    {
+        Assert.True(SnowflakeCursorComparer.Instance.Compare(null, "0") < 0);
+        Assert.True(SnowflakeCursorComparer.Instance.Compare("0", null) > 0);
+    }
+
+    [Fact]
+    public void Sorted_string_order_matches_sorted_numeric_order()
+    {
+        // Start from ordinal string order, which is wrong on purpose: the
+        // comparer must repair it into numeric order.
+        var byString = RepresentativeValues
+            .Select(v => v.ToString())
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .OrderBy(v => v, SnowflakeCursorComparer.Instance)
+            .ToArray();
+        var byNumber = RepresentativeValues
+            .OrderBy(v => v)
+            .Select(v => v.ToString())
+            .ToArray();
+
+        Assert.Equal(byNumber, byString);
+    }
+}

--- a/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
+++ b/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
@@ -79,10 +79,4 @@ internal sealed class PendingApprovalRequest : Netclaw.Channels.PendingApprovalR
         : base(callId, requesterSenderId, requesterPrincipal, optionKeys, promptMessageId, toolName, displayText)
     {
     }
-
-    public DiscordMessageId? PromptMessageId
-    {
-        get => PromptId;
-        set => PromptId = value;
-    }
 }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -48,6 +48,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private readonly IPromptInjectionDetector _promptInjectionDetector;
     private readonly SessionPipelineHandle _handle;
     private readonly ILoggingAdapter _log;
+
+    // Null when the gateway supplies no thread-history fetcher. That is a real
+    // runtime state (an instance without history access), not a disabled check:
+    // with no fetcher there is no gap to hydrate, so both hydration paths no-op.
+    private readonly ThreadGapHydrationEngine? _hydrationEngine;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
     // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
@@ -134,6 +139,26 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         _handle = new SessionPipelineHandle(_dependencies.Pipeline, _log, "discord-session");
 
+        if (_dependencies.ThreadHistoryFetcher is { } historyFetcher)
+        {
+            _hydrationEngine = new ThreadGapHydrationEngine(
+                sessionId: _sessionId,
+                channelType: ChannelType.Discord,
+                historyFetcher: historyFetcher,
+                injectionDetector: _promptInjectionDetector,
+                classifierSourceContext: "discord-backfill",
+                cursorComparer: CursorComparer,
+                cursorKeySelector: NormalizeSnowflake,
+                isAuthorizedSender: IsAuthorizedSender,
+                log: _log,
+                readCursor: () => _cursor,
+                readInputQueue: () => _handle.InputQueue,
+                readIngressClosedReason: () => _dependencies.IngressGate?.ClosedReason,
+                warnBackfillDetectorUnavailableAsync: () => SafeReplyAsync(BackfillDetectorWarning),
+                onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
+                setHydrationPending: pending => _hydrationPending = pending);
+        }
+
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
         Recover<PendingApprovalPromptTracked>(ApplyPendingApprovalPromptTracked);
         Recover<PendingApprovalPromptCleared>(ApplyPendingApprovalPromptCleared);
@@ -214,7 +239,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             try
             {
-                await PerformOneShotHydrationAsync();
+                if (_hydrationEngine is { } engine)
+                    await engine.PerformOneShotHydrationAsync();
             }
             catch (Exception ex)
             {
@@ -388,11 +414,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             return;
 
         // Live inbound path is fetch-free. Thread history is hydrated once per
-        // actor lifetime in PerformOneShotHydrationAsync (driven by the
+        // actor lifetime by the hydration engine (driven by the
         // RecoveryCompleted handler); the only exception is a deferred
-        // hydration, which ApplyDeferredHydrationAsync completes on the first
-        // authorized inbound. By the time we get here the session already has
-        // the historical context it needs.
+        // hydration, which the engine completes on the first authorized
+        // inbound. By the time we get here the session already has the
+        // historical context it needs.
         var input = new ChannelInput
         {
             SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value),
@@ -413,7 +439,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         // MentionRequiredInThread the conversation actor forwards only mentions here,
         // so every inbound is a deliberate re-entry. _turnInFlight guards against a
         // re-arm while a prior turn is still processing, preserving the PR #733
-        // no-duplicate invariant; ApplyDeferredHydrationAsync no-ops on an empty gap.
+        // no-duplicate invariant; the deferred hydration no-ops on an empty gap.
         //
         // Two accepted trade-offs of reusing the existing backfill (vs. a new
         // drop-tracking side channel): (1) one thread-history fetch per mention on an
@@ -430,21 +456,20 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _hydrationPending = true;
         }
 
-        if (_hydrationPending && IsAuthorizedSender(message.SenderId.Value))
-            input = await ApplyDeferredHydrationAsync(input, message.EventId.Value, inboundCts.Token);
+        if (_hydrationPending
+            && IsAuthorizedSender(message.SenderId.Value)
+            && _hydrationEngine is { } engine)
+        {
+            input = await engine.ApplyDeferredHydrationAsync(input, message.EventId.Value, inboundCts.Token);
+        }
 
         try
         {
             using var writeCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await writer.WriteAsync(input, writeCts.Token);
-            _turnInFlight = true;
             ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
 
-            if (NormalizeSnowflake(message.EventId.Value) is { } eventCursor)
-            {
-                if (_pendingCursor is not { } pending || CursorComparer.Compare(eventCursor, pending) > 0)
-                    _pendingCursor = eventCursor;
-            }
+            AdvancePendingCursorForEnqueuedTurn(NormalizeSnowflake(message.EventId.Value));
         }
         catch (OperationCanceledException)
         {
@@ -458,336 +483,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
     }
 
-    /// <summary>
-    /// One-shot thread history hydration. Runs once per actor lifetime, in the
-    /// Hydrating behavior immediately after pipeline initialization. Fetches
-    /// thread history, computes the gap relative to the recovered cursor, and
-    /// if there is an authorized message in the gap, synthesizes one backfill
-    /// <see cref="ChannelInput"/> using that message as the trigger and older
-    /// gap messages as adopted context. Hands the synthesized input to the
-    /// session pipeline through the normal input-queue path.
-    /// </summary>
-    private async Task PerformOneShotHydrationAsync()
-    {
-        if (_dependencies.ThreadHistoryFetcher is not { } fetcher)
-            return;
-
-        using var cts = new CancellationTokenSource(InboundProcessingTimeout);
-
-        IReadOnlyList<ChannelInput> history;
-        try
-        {
-            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Warning(ex, "Thread history fetch failed for session {SessionId}", _sessionId.Value);
-            return;
-        }
-
-        if (history.Count == 0)
-        {
-            _log.Info(
-                "Thread history hydration: empty thread, no backfill cursor={Cursor} session={Session}",
-                _cursor ?? "none", _sessionId.Value);
-            return;
-        }
-
-        var cursor = _cursor;
-        var candidates = new List<ChannelInput>(history.Count);
-        foreach (var item in history)
-        {
-            if (NormalizeSnowflake(item.MessageId ?? string.Empty) is not { } itemCursor)
-                continue;
-
-            // Strict: only include messages newer than the cursor. PR #733's
-            // "cursor advances only on TurnCompleted" guarantees that
-            // snowflake == cursor means the session already has that message
-            // persisted — re-including it here on a restart hydration would
-            // duplicate it. The in-flight-crash case is handled too: a turn
-            // that didn't complete leaves the cursor un-advanced, so the
-            // message has snowflake > cursor and is correctly included in the gap.
-            if (cursor is { } c && CursorComparer.Compare(itemCursor, c) <= 0)
-                continue;
-
-            candidates.Add(item);
-        }
-
-        if (candidates.Count == 0)
-        {
-            _log.Info(
-                "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor} session={Session}",
-                history.Count, cursor ?? "none", _sessionId.Value);
-            return;
-        }
-
-        var classified = await ClassifyGapAsync(candidates, cts.Token);
-        var gap = classified.Gap;
-
-        _log.Info(
-            "Thread history hydration fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
-            history.Count, candidates.Count, gap.Count, classified.BlockedForRisk, cursor ?? "none", _sessionId.Value);
-
-        if (classified.DetectorUnavailable)
-            await SafeReplyAsync(BackfillDetectorWarning);
-
-        if (gap.Count == 0)
-            return;
-
-        // Locate the most recent authorized message in the gap — it plays the
-        // role of the "current authorized message" that adopted-context normally
-        // anchors around. Without one we have no authorized trigger to enqueue;
-        // we transition to Active and let the next live authorized inbound be
-        // the trigger.
-        AdoptedContextMessage? trigger = null;
-        for (var i = gap.Count - 1; i >= 0; i--)
-        {
-            if (gap[i].AuthorityAtInclusion == AdoptedMessageAuthority.Authorized)
-            {
-                trigger = gap[i];
-                break;
-            }
-        }
-
-        if (trigger is null)
-        {
-            // Deferred: a non-empty gap with no authorized trigger. The
-            // proactive-thread case — the binding actor's lifetime began when
-            // the agent posted the thread root, so this hydration ran before
-            // any authorized human inbound existed. Re-arm so the first
-            // authorized inbound performs this hydration (adopting the gap,
-            // e.g. the bot-authored root) instead of taking the fetch-free path.
-            _hydrationPending = true;
-            _log.Info("Thread history hydration: no authorized message in gap; re-armed for next authorized inbound session={Session}", _sessionId.Value);
-            return;
-        }
-
-        var adoptedContext = new List<AdoptedContextMessage>();
-        foreach (var item in gap)
-        {
-            if (ReferenceEquals(item, trigger))
-                break;
-            adoptedContext.Add(item);
-        }
-
-        var triggerInput = trigger.Input;
-        var triggerCursor = NormalizeSnowflake(triggerInput.MessageId ?? string.Empty);
-        var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
-
-        if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
-        {
-            _log.Info("Skipping hydration backfill enqueue while restart drain is active: {Reason}", ingressClosedReason);
-            return;
-        }
-
-        var writer = _handle.InputQueue;
-        if (writer is null)
-        {
-            _log.Warning("Input queue is not initialized; skipping hydration backfill");
-            return;
-        }
-
-        try
-        {
-            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
-            writeCts.CancelAfter(TimeSpan.FromSeconds(10));
-            await writer.WriteAsync(backfillInput, writeCts.Token);
-            // A hydration backfill is an in-flight turn too; mirror the live-inbound
-            // enqueue so a mention arriving before this turn completes does not re-arm.
-            _turnInFlight = true;
-
-            if (triggerCursor is { } tc)
-            {
-                if (_pendingCursor is not { } pending || CursorComparer.Compare(tc, pending) > 0)
-                    _pendingCursor = tc;
-            }
-
-            _log.Info(
-                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
-                triggerInput.MessageId, adoptedContext.Count, _sessionId.Value);
-            ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
-        }
-        catch (OperationCanceledException ex)
-        {
-            _log.Warning(ex, "Timed out enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
-        }
-        catch (ChannelClosedException ex)
-        {
-            _log.Warning(ex, "Input queue closed while enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
-        }
-    }
-
-    private Task<Classification> ClassifyGapMessageAsync(ChannelInput input, CancellationToken cancellationToken)
-    {
-        var text = string.Join("\n", input.Contents
-            .OfType<TextContent>()
-            .Select(t => t.Text)
-            .Where(t => !string.IsNullOrWhiteSpace(t)));
-
-        return PromptClassifier.ClassifyAsync(
-            _promptInjectionDetector, text, "discord-backfill", _log, cancellationToken);
-    }
-
     // Discord authorization basis for adopted-context: an empty AllowedUserIds
     // list means the instance is unrestricted; otherwise the sender must be listed.
     private bool IsAuthorizedSender(string senderId)
         => _dependencies.Options.AllowedUserIds.Length == 0
             || _dependencies.Options.AllowedUserIds.Contains(senderId, StringComparer.Ordinal);
-
-    private readonly record struct GapClassification(
-        List<AdoptedContextMessage> Gap,
-        int BlockedForRisk,
-        bool DetectorUnavailable);
-
-    /// <summary>
-    /// Runs prompt-injection classification over candidate gap messages and
-    /// captures each surviving message's authority-at-inclusion. Blocked
-    /// messages are dropped; detector-unavailable messages are also dropped
-    /// and surface a caller-visible flag.
-    /// </summary>
-    private async Task<GapClassification> ClassifyGapAsync(
-        IReadOnlyList<ChannelInput> candidates,
-        CancellationToken cancellationToken)
-    {
-        var classifications = await Task.WhenAll(
-            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
-
-        var gap = new List<AdoptedContextMessage>(candidates.Count);
-        var blockedForRisk = 0;
-        var detectorUnavailable = false;
-        for (var i = 0; i < candidates.Count; i++)
-        {
-            switch (classifications[i].Outcome)
-            {
-                case ClassificationOutcome.Allow:
-                    var authority = IsAuthorizedSender(candidates[i].SenderId.Value)
-                        ? AdoptedMessageAuthority.Authorized
-                        : AdoptedMessageAuthority.Pending;
-                    gap.Add(new AdoptedContextMessage(candidates[i], authority));
-                    break;
-
-                case ClassificationOutcome.Block:
-                    blockedForRisk++;
-                    _log.Warning(
-                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
-                        candidates[i].SenderId,
-                        candidates[i].MessageId ?? "none",
-                        classifications[i].Reason ?? "high-risk pattern detected");
-                    break;
-
-                case ClassificationOutcome.DetectorUnavailable:
-                    blockedForRisk++;
-                    detectorUnavailable = true;
-                    break;
-            }
-        }
-
-        return new GapClassification(gap, blockedForRisk, detectorUnavailable);
-    }
-
-    /// <summary>
-    /// Merges <paramref name="adoptedContext"/> as the adopted-context window
-    /// preceding <paramref name="triggerInput"/> (the executable message) and
-    /// returns the trigger input with adopted-context metadata populated.
-    /// </summary>
-    private static ChannelInput MergeAdoptedContext(
-        ChannelInput triggerInput,
-        List<AdoptedContextMessage> adoptedContext,
-        string? cursor)
-    {
-        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            adoptedContext,
-            triggerInput.Contents,
-            triggerInput.SenderId.Value,
-            triggerInput.ReceivedAt);
-
-        return triggerInput with
-        {
-            Contents = merged.Contents,
-            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(
-                id => !string.Equals(id, triggerInput.SenderId.Value, StringComparison.Ordinal)),
-            AdoptedSpeakerIds = merged.SpeakerIds,
-            AdoptedContextProjection = merged.Projection,
-            AdoptedContextLowerBound = cursor,
-            AdoptedContextUpperBound = triggerInput.MessageId,
-            AdoptedContextEntries = merged.Entries
-        };
-    }
-
-    /// <summary>
-    /// Completes a thread-history hydration that <see cref="PerformOneShotHydrationAsync"/>
-    /// deferred for lack of an authorized trigger (<see cref="_hydrationPending"/>).
-    /// This authorized inbound is the executable trigger; the thread gap strictly
-    /// before it — most importantly a proactively-posted bot-authored root — is
-    /// fetched, classified, and merged as its adopted-context window. On fetch
-    /// failure the turn proceeds un-enriched and hydration stays re-armed so a
-    /// later authorized inbound retries.
-    /// </summary>
-    private async Task<ChannelInput> ApplyDeferredHydrationAsync(
-        ChannelInput baseInput,
-        string liveMessageId,
-        CancellationToken cancellationToken)
-    {
-        if (_dependencies.ThreadHistoryFetcher is not { } fetcher)
-            return baseInput;
-
-        // Without the live message's ordering key the gap below it cannot be
-        // bounded; leave hydration re-armed and take the fetch-free path.
-        if (NormalizeSnowflake(liveMessageId) is not { } liveCursor)
-            return baseInput;
-
-        IReadOnlyList<ChannelInput> history;
-        try
-        {
-            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            // Non-fatal: execute the turn without an adopted window and keep
-            // hydration re-armed so a later authorized inbound retries.
-            _log.Warning(ex, "Re-armed thread history fetch failed for session {SessionId}", _sessionId.Value);
-            return baseInput;
-        }
-
-        // Fetch succeeded: hydration is complete. Only a fetch failure (caught
-        // above) keeps the flag armed — classify/merge outcomes never re-arm.
-        _hydrationPending = false;
-
-        var cursor = _cursor;
-        var candidates = new List<ChannelInput>(history.Count);
-        foreach (var item in history)
-        {
-            if (NormalizeSnowflake(item.MessageId ?? string.Empty) is not { } itemCursor)
-                continue;
-
-            // Strictly above the watermark and strictly below the live inbound:
-            // the live inbound is the executable message, not adopted context.
-            if (cursor is { } c && CursorComparer.Compare(itemCursor, c) <= 0)
-                continue;
-            if (CursorComparer.Compare(itemCursor, liveCursor) >= 0)
-                continue;
-
-            candidates.Add(item);
-        }
-
-        if (candidates.Count == 0)
-            return baseInput;
-
-        var classified = await ClassifyGapAsync(candidates, cancellationToken);
-        if (classified.DetectorUnavailable)
-            await SafeReplyAsync(BackfillDetectorWarning);
-
-        if (classified.Gap.Count == 0)
-            return baseInput;
-
-        _log.Info(
-            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
-            classified.Gap.Count,
-            baseInput.MessageId,
-            _sessionId.Value);
-
-        return MergeAdoptedContext(baseInput, classified.Gap, cursor);
-    }
 
     private async Task<bool> TryHandleTextApprovalResponseAsync(DiscordThreadInbound message)
     {
@@ -1625,6 +1325,23 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     internal static List<string> ChunkMessage(string text) =>
         MessageChunker.Chunk(text, MaxDiscordMessageLength);
 
+    /// <summary>
+    /// Records that a turn went into the input queue. The turn-in-flight flag
+    /// guards the mention re-arm path; the pending cursor keeps the highest
+    /// snowflake of the turn and only becomes the persisted cursor on
+    /// TurnCompleted.
+    /// </summary>
+    private void AdvancePendingCursorForEnqueuedTurn(string? candidateCursor)
+    {
+        _turnInFlight = true;
+
+        if (candidateCursor is null)
+            return;
+
+        if (_pendingCursor is not { } pending || CursorComparer.Compare(candidateCursor, pending) > 0)
+            _pendingCursor = candidateCursor;
+    }
+
     private void AdvanceCursor(string candidateCursor)
     {
         if (_cursor is { } c && CursorComparer.Compare(candidateCursor, c) <= 0)
@@ -1673,7 +1390,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     /// numeric cursor rejected, and it strips a form such as a leading zero
     /// that <see cref="SnowflakeCursorComparer"/> cannot order.
     /// </summary>
-    private static string? NormalizeSnowflake(string value)
+    private static string? NormalizeSnowflake(string? value)
         => ulong.TryParse(value, out var id) ? id.ToString() : null;
 
     private sealed record InitializePipeline

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -55,43 +55,19 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private readonly ThreadGapHydrationEngine? _hydrationEngine;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
     private readonly ApprovalResponseFlow<PendingApprovalRequest, DiscordMessageId> _approvalFlow;
-
-    // Gates the text-approval cold path. The gate rule lives with the cold path
-    // in ApprovalResponseFlow.
-    private bool _hasObservedApprovalRequest;
+    private readonly ChannelOutputEngine<PendingApprovalRequest, DiscordMessageId> _outputEngine;
+    private readonly SafeTransportCall _safeCall;
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan ReinitializeDelay = TimeSpan.FromSeconds(2);
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
-    private bool _deliveredThisTurn;
-    // True when a content post/upload this turn was attempted but failed (the
-    // model produced output, the transport rejected it). Distinct from "nothing
-    // was produced" — it suppresses the empty-turn fallback so a failed post
-    // isn't followed by a misleading "I didn't manage to produce a reply".
-    private bool _postFailedThisTurn;
-    // Reply targets for in-flight reminder delivery confirmations, keyed by
-    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
-    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
-    // Keyed (not a single field) because multiple reminders can target the
-    // same session concurrently — a single field would be clobbered.
-    private readonly Dictionary<ReminderId, IActorRef> _reminderDeliveryObservers = new();
-    private Netclaw.Actors.Protocol.TurnNumber _turnNumber;
     private string? _lastSetThreadName;
     // Snowflake cursors in canonical decimal string form, which is also the
     // persisted CursorAdvanced form. NormalizeSnowflake produces every value,
     // so CursorComparer can order them.
     private static readonly SnowflakeCursorComparer CursorComparer = SnowflakeCursorComparer.Instance;
     private string? _cursor;
-    private string? _pendingCursor;
-
-    // Reliable in-flight-turn signal for the mention re-arm guard: set when the
-    // main inbound is enqueued (unlike _pendingCursor, which is only set
-    // for inbounds with a parseable snowflake), cleared when the turn ends or the
-    // pipeline reinitializes. Without it, a null-snowflake in-flight turn would
-    // leave _pendingCursor unset and let a following mention re-arm
-    // mid-turn — the PR #733 no-duplicate hazard.
-    private bool _turnInFlight;
 
     // Set when PerformOneShotHydrationAsync fetched a non-empty thread gap but
     // found no authorized trigger to anchor a turn. This is the proactive-thread
@@ -134,6 +110,34 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         _handle = new SessionPipelineHandle(_dependencies.Pipeline, _log, "discord-session");
 
+        _safeCall = new SafeTransportCall(
+            ChannelType.Discord,
+            _dependencies.TimeProvider,
+            NotifyDeliveryFailedAsync);
+
+        _outputEngine = new ChannelOutputEngine<PendingApprovalRequest, DiscordMessageId>(
+            channelType: ChannelType.Discord,
+            channelName: "Discord",
+            cursorComparer: CursorComparer,
+            pendingRequests: _pendingApprovalRequests,
+            createPendingRequest: request => new PendingApprovalRequest(request),
+            isApprovalRequest: request => string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase),
+            renderTextOutput: textOutput => textOutput.Text,
+            renderErrorOutput: error => $":warning: {error.Message}",
+            postTextAsync: SafeReplyAsync,
+            uploadFileAsync: SafeUploadFileAsync,
+            postApprovalPromptAsync: SafeReplyWithButtonsAsync,
+            readPromptIdValue: promptMessageId => promptMessageId.Value,
+            onApprovalPromptFailedAsync: request => SendApprovalDenyOnFailureAsync(request.CallId),
+            persistPromptTracked: tracked => Persist(tracked, ApplyPendingApprovalPromptTracked),
+            handleChannelSpecificOutputAsync: HandleChannelSpecificOutputAsync,
+            advanceCursor: AdvanceCursor,
+            postEmptyTurnFallbackAsync: () => SafeReplyAsync(EmptyTurnFallbackText),
+            // Discord reports a delivery failure inline from SafeReplyAsync, so
+            // the session already knows by the time the turn completes.
+            onEmptyTurnSuppressedAsync: _ => Task.CompletedTask,
+            readObservedAtMs: completed => completed.TimestampMs);
+
         if (_dependencies.ThreadHistoryFetcher is { } historyFetcher)
         {
             _hydrationEngine = new ThreadGapHydrationEngine(
@@ -150,7 +154,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 readInputQueue: () => _handle.InputQueue,
                 readIngressClosedReason: () => _dependencies.IngressGate?.ClosedReason,
                 warnBackfillDetectorUnavailableAsync: () => SafeReplyAsync(BackfillDetectorWarning),
-                onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
+                onBackfillEnqueued: _outputEngine.AdvancePendingCursorForEnqueuedTurn,
                 setHydrationPending: pending => _hydrationPending = pending);
         }
 
@@ -162,7 +166,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             operationTimeout: OperationTimeout,
             pendingRequests: _pendingApprovalRequests,
             matchOrder: ApprovalMatchOrder.Newest,
-            hasObservedApprovalRequest: () => _hasObservedApprovalRequest,
+            hasObservedApprovalRequest: () => _outputEngine.HasObservedApprovalRequest,
             postWrongRequesterWarningAsync: () => SafeReplyAsync(WrongRequesterWarning),
             persistPromptCleared: callId => Persist(
                 new PendingApprovalPromptCleared { CallId = callId.Value },
@@ -290,17 +294,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         CommandAsync<ReinitializePipeline>(async msg =>
         {
-            _deliveredThisTurn = false;
-            _postFailedThisTurn = false;
-            // A reinit abandons any in-flight turn before its TurnCompleted; clear
-            // the mention re-arm guard so the next mention can re-hydrate instead of
-            // being blocked by a stuck flag.
-            _turnInFlight = false;
-            // A reinit aborts any in-flight reminder turn before its
-            // TurnCompleted. Report those as not-delivered now so the
-            // execution actor redelivers immediately instead of stalling
-            // until the backstop timeout.
-            FailPendingReminderDeliveries($"Discord pipeline reinitialized: {msg.Reason}");
+            _outputEngine.ResetForPipelineReinitialize(msg.Reason);
             await _handle.ReinitializeAsync(
                 msg.Reason,
                 () => Timers.StartSingleTimer(
@@ -461,7 +455,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         // mention, not this one (and can be skipped if the cursor later advances past
         // it under rapid concurrent mentions).
         if (!_hydrationPending
-            && !_turnInFlight
+            && !_outputEngine.TurnInFlight
             && _dependencies.Options.MentionRequiredInThreadFor(_channelId.Value))
         {
             _hydrationPending = true;
@@ -480,7 +474,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             await writer.WriteAsync(input, writeCts.Token);
             ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
 
-            AdvancePendingCursorForEnqueuedTurn(NormalizeSnowflake(message.EventId.Value));
+            _outputEngine.AdvancePendingCursorForEnqueuedTurn(NormalizeSnowflake(message.EventId.Value));
         }
         catch (OperationCanceledException)
         {
@@ -608,7 +602,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (message.Source.DeliveryObserver is { } deliveryObserver
             && message.Source.ReminderId is { } reminderKey
             && !string.IsNullOrWhiteSpace(reminderKey.Value))
-            _reminderDeliveryObservers[reminderKey] = deliveryObserver;
+            _outputEngine.TrackReminderDeliveryObserver(reminderKey, deliveryObserver);
 
         try
         {
@@ -640,113 +634,27 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
     private async Task HandleOutputReceivedAsync(OutputReceived msg)
     {
-        switch (msg.Output)
+        var clearedPrompts = await _outputEngine.HandleOutputAsync(msg.Output);
+        if (clearedPrompts.Count > 0)
+            PersistAll(clearedPrompts, ApplyPendingApprovalPromptCleared);
+    }
+
+    /// <summary>
+    /// Handles the outputs the shared engine leaves to the channel. Discord
+    /// renames its thread from a session title and renders a processing
+    /// indicator; other output types have no Discord effect.
+    /// </summary>
+    private async Task HandleChannelSpecificOutputAsync(SessionOutput output)
+    {
+        switch (output)
         {
-            case TextOutput textOutput:
-                if (await SafeReplyAsync(textOutput.Text))
-                    _deliveredThisTurn = true;
-                else
-                    _postFailedThisTurn = true;
-                break;
-
-            case ErrorOutput error:
-                if (await SafeReplyAsync($":warning: {error.Message}"))
-                    _deliveredThisTurn = true;
-                else
-                    _postFailedThisTurn = true;
-                break;
-
-            case FileOutput file:
-                if (await SafeUploadFileAsync(file))
-                    _deliveredThisTurn = true;
-                else
-                    _postFailedThisTurn = true;
-                break;
-
             case ProcessingStateOutput processing:
                 await RenderProcessingStateAsync(processing);
-                break;
-
-            case ToolInteractionRequest request when string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase):
-                _hasObservedApprovalRequest = true;
-                var pendingApproval = new PendingApprovalRequest(request);
-                _pendingApprovalRequests.Add(pendingApproval);
-
-                var promptMessageId = await SafeReplyWithButtonsAsync(request);
-                if (promptMessageId is not null)
-                {
-                    pendingApproval.PromptMessageId = promptMessageId;
-                    Persist(new PendingApprovalPromptTracked
-                    {
-                        CallId = pendingApproval.CallId.Value,
-                        RequesterSenderId = pendingApproval.RequesterSenderId,
-                        RequesterPrincipal = pendingApproval.RequesterPrincipal,
-                        OptionKeys = pendingApproval.OptionKeys,
-                        PromptId = promptMessageId.Value.Value,
-                        ToolName = pendingApproval.ToolName,
-                        // Preserve null-vs-set semantics on the wire: Truncate
-                        // returns string.Empty for null input, which would round-
-                        // trip as DisplayText="" with HasDisplayText=true.
-                        DisplayText = string.IsNullOrEmpty(pendingApproval.DisplayText)
-                            ? null
-                            : ApprovalDisplayTextFormatter.Truncate(
-                                pendingApproval.DisplayText,
-                                PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
-                    }, ApplyPendingApprovalPromptTracked);
-                }
-                else
-                {
-                    _pendingApprovalRequests.Remove(pendingApproval);
-                }
                 break;
 
             case SessionTitleOutput titleOutput:
                 if (_threadCreated && titleOutput.Title != _lastSetThreadName)
                     await SafeSetThreadNameAsync(titleOutput.Title);
-                break;
-
-            case TurnCompleted completed:
-                if (completed.Outcome == TurnOutcome.Completed && _pendingCursor is { } pendingCursor)
-                    AdvanceCursor(pendingCursor);
-                _pendingCursor = null;
-                _turnInFlight = false;
-
-                if (completed.SourceReminderId is { } sourceReminderKey
-                    && !string.IsNullOrWhiteSpace(sourceReminderKey.Value)
-                    && _reminderDeliveryObservers.Remove(sourceReminderKey, out var reminderObserver))
-                {
-                    reminderObserver.Tell(new ReminderDeliveryResult(
-                        sourceReminderKey,
-                        ChannelType.Discord,
-                        Delivered: _deliveredThisTurn,
-                        FailureReason: _deliveredThisTurn ? null : "Discord post did not succeed",
-                        ObservedAtMs: completed.TimestampMs));
-                }
-
-                // Only post the empty-turn fallback when the turn genuinely
-                // produced nothing. A failed post already notified the session
-                // (SafeReplyAsync -> NotifyDeliveryFailedAsync); posting "I
-                // didn't manage to produce a reply" on top would be misleading
-                // (a reply WAS produced) and double up with the redelivered one.
-                if (!_deliveredThisTurn && !_postFailedThisTurn)
-                    await SafeReplyAsync(EmptyTurnFallbackText);
-
-                _turnNumber = completed.TurnNumber;
-                var clearedPrompts = _pendingApprovalRequests
-                    .Select(pending => new PendingApprovalPromptCleared
-                    {
-                        CallId = pending.CallId.Value
-                    })
-                    .ToArray();
-                if (clearedPrompts.Length > 0)
-                {
-                    PersistAll(
-                        clearedPrompts,
-                        cleared => ApplyPendingApprovalPromptCleared(cleared));
-                }
-                _pendingApprovalRequests.Clear();
-                _deliveredThisTurn = false;
-                _postFailedThisTurn = false;
                 break;
         }
     }
@@ -813,8 +721,9 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             }
             catch (Exception textEx)
             {
+                // The shared output engine auto-denies the request when this
+                // returns null, so the blocked tool call still unwinds.
                 _log.Error(textEx, "Failed posting text-only approval fallback; auto-denying request");
-                await SendApprovalDenyOnFailureAsync(request.CallId);
                 return null;
             }
         }
@@ -826,32 +735,16 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     /// notifying the session of the delivery failure). Callers that gate
     /// reminder delivery confirmation on real delivery must honor the result.
     /// </summary>
-    private async Task<bool> SafeReplyAsync(string text)
-    {
-        var chunks = ChunkMessage(text);
-        foreach (var chunk in chunks)
-        {
-            var startedAt = _dependencies.TimeProvider.GetTimestamp();
-            try
+    private Task<bool> SafeReplyAsync(string text)
+        => _safeCall.PostChunkedAsync(
+            text,
+            MaxDiscordMessageLength,
+            async chunk =>
             {
-                var postMessage = BuildPostMessage(chunk);
-                var result = await _dependencies.ReplyClient.PostReplyAsync(postMessage);
+                var result = await _dependencies.ReplyClient.PostReplyAsync(BuildPostMessage(chunk));
                 ApplyThreadPromotion(result);
-                var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-                ChannelTelemetry.For(ChannelType.Discord).RecordReplyPosted(duration);
-            }
-            catch (Exception ex)
-            {
-                var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-                _log.Warning(ex, "Failed posting Discord reply for session {0}", _sessionId.Value);
-                ChannelTelemetry.For(ChannelType.Discord).RecordReplyFailed(duration);
-                await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-                return false;
-            }
-        }
-
-        return true;
-    }
+            },
+            ex => _log.Warning(ex, "Failed posting Discord reply for session {0}", _sessionId.Value));
 
     private DiscordPostMessage BuildPostMessage(
         string text,
@@ -875,47 +768,40 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
     private async Task<bool> SafeUploadFileAsync(FileOutput file)
     {
-        var startedAt = _dependencies.TimeProvider.GetTimestamp();
-        try
+        // A missing file never reaches the transport, so it carries no transport
+        // telemetry and a different failure kind.
+        if (!File.Exists(file.FilePath))
         {
-            if (!File.Exists(file.FilePath))
+            _log.Warning("File not found for upload: {Path}", file.FilePath);
+            await NotifyDeliveryFailedAsync(DeliveryFailureKind.Unknown, $"File not found for upload: {file.FilePath}");
+            return false;
+        }
+
+        var uploaded = await _safeCall.InvokeAsync(
+            async () =>
             {
-                _log.Warning("File not found for upload: {Path}", file.FilePath);
-                await NotifyDeliveryFailedAsync(DeliveryFailureKind.Unknown, $"File not found for upload: {file.FilePath}");
-                return false;
-            }
+                using var cts = new CancellationTokenSource(OperationTimeout);
+                await _dependencies.ReplyClient.UploadFileAsync(
+                    new DiscordFileUpload(
+                        _replyChannelId,
+                        file.FilePath,
+                        file.FileName,
+                        $":paperclip: {file.FileName}",
+                        _threadCreated ? null : _rootMessageId),
+                    cts.Token);
+            },
+            ex =>
+            {
+                if (ex is OperationCanceledException)
+                    _log.Error(ex, "Timed out uploading file {FileName} to Discord session", file.FileName);
+                else
+                    _log.Error(ex, "Failed to upload file {FileName} to Discord session", file.FileName);
+            });
 
-            using var cts = new CancellationTokenSource(OperationTimeout);
-            await _dependencies.ReplyClient.UploadFileAsync(
-                new DiscordFileUpload(
-                    _replyChannelId,
-                    file.FilePath,
-                    file.FileName,
-                    $":paperclip: {file.FileName}",
-                    _threadCreated ? null : _rootMessageId),
-                cts.Token);
-
-            var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            ChannelTelemetry.For(ChannelType.Discord).RecordReplyPosted(duration);
+        if (uploaded)
             _log.Info("Uploaded file to Discord session: {FileName}", file.FileName);
-            return true;
-        }
-        catch (OperationCanceledException ex)
-        {
-            var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            _log.Error(ex, "Timed out uploading file {FileName} to Discord session", file.FileName);
-            ChannelTelemetry.For(ChannelType.Discord).RecordReplyFailed(duration);
-            await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            _log.Error(ex, "Failed to upload file {FileName} to Discord session", file.FileName);
-            ChannelTelemetry.For(ChannelType.Discord).RecordReplyFailed(duration);
-            await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-            return false;
-        }
+
+        return uploaded;
     }
 
     private async Task SafeSetThreadNameAsync(string title)
@@ -943,23 +829,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
     }
 
-    /// <summary>
-    /// Tells every in-flight reminder observer that delivery did not happen,
-    /// then clears them. Called when a turn can no longer reach TurnCompleted
-    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
-    /// rather than waiting out its backstop timeout.
-    /// </summary>
-    private void FailPendingReminderDeliveries(string reason)
-    {
-        if (_reminderDeliveryObservers.Count == 0)
-            return;
-
-        foreach (var (key, observer) in _reminderDeliveryObservers)
-            observer.Tell(new ReminderDeliveryResult(key, ChannelType.Discord, Delivered: false, FailureReason: reason));
-
-        _reminderDeliveryObservers.Clear();
-    }
-
     private async Task NotifyDeliveryFailedAsync(DeliveryFailureKind failureKind, string errorMessage)
     {
         try
@@ -967,7 +836,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             await _dependencies.Pipeline.SendFeedbackAsync(new DeliveryFailed
             {
                 SessionId = _sessionId,
-                TurnNumber = _turnNumber,
+                TurnNumber = _outputEngine.LastCompletedTurnNumber,
                 ChannelType = ChannelType.Discord,
                 FailureKind = failureKind,
                 ErrorMessage = errorMessage
@@ -1119,23 +988,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     internal static List<string> ChunkMessage(string text) =>
         MessageChunker.Chunk(text, MaxDiscordMessageLength);
 
-    /// <summary>
-    /// Records that a turn went into the input queue. The turn-in-flight flag
-    /// guards the mention re-arm path; the pending cursor keeps the highest
-    /// snowflake of the turn and only becomes the persisted cursor on
-    /// TurnCompleted.
-    /// </summary>
-    private void AdvancePendingCursorForEnqueuedTurn(string? candidateCursor)
-    {
-        _turnInFlight = true;
-
-        if (candidateCursor is null)
-            return;
-
-        if (_pendingCursor is not { } pending || CursorComparer.Compare(candidateCursor, pending) > 0)
-            _pendingCursor = candidateCursor;
-    }
-
     private void AdvanceCursor(string candidateCursor)
     {
         if (_cursor is { } c && CursorComparer.Compare(candidateCursor, c) <= 0)
@@ -1164,7 +1016,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
     private void ApplyPendingApprovalPromptTracked(PendingApprovalPromptTracked tracked)
     {
-        _hasObservedApprovalRequest = true;
+        _outputEngine.MarkApprovalRequestObserved();
         PendingApprovalRecovery.ApplyTracked<PendingApprovalRequest, DiscordMessageId>(
             _pendingApprovalRequests,
             tracked,

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -78,14 +78,18 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private readonly Dictionary<ReminderId, IActorRef> _reminderDeliveryObservers = new();
     private Netclaw.Actors.Protocol.TurnNumber _turnNumber;
     private string? _lastSetThreadName;
-    private ulong? _cursorSnowflake;
-    private ulong? _pendingCursorSnowflake;
+    // Snowflake cursors in canonical decimal string form, which is also the
+    // persisted CursorAdvanced form. NormalizeSnowflake produces every value,
+    // so CursorComparer can order them.
+    private static readonly SnowflakeCursorComparer CursorComparer = SnowflakeCursorComparer.Instance;
+    private string? _cursor;
+    private string? _pendingCursor;
 
     // Reliable in-flight-turn signal for the mention re-arm guard: set when the
-    // main inbound is enqueued (unlike _pendingCursorSnowflake, which is only set
+    // main inbound is enqueued (unlike _pendingCursor, which is only set
     // for inbounds with a parseable snowflake), cleared when the turn ends or the
     // pipeline reinitializes. Without it, a null-snowflake in-flight turn would
-    // leave _pendingCursorSnowflake unset and let a following mention re-arm
+    // leave _pendingCursor unset and let a following mention re-arm
     // mid-turn — the PR #733 no-duplicate hazard.
     private bool _turnInFlight;
 
@@ -436,10 +440,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _turnInFlight = true;
             ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
 
-            if (TryParseSnowflake(message.EventId.Value) is { } eventSnowflake)
+            if (NormalizeSnowflake(message.EventId.Value) is { } eventCursor)
             {
-                if (_pendingCursorSnowflake is not { } pending || eventSnowflake > pending)
-                    _pendingCursorSnowflake = eventSnowflake;
+                if (_pendingCursor is not { } pending || CursorComparer.Compare(eventCursor, pending) > 0)
+                    _pendingCursor = eventCursor;
             }
         }
         catch (OperationCanceledException)
@@ -485,15 +489,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             _log.Info(
                 "Thread history hydration: empty thread, no backfill cursor={Cursor} session={Session}",
-                _cursorSnowflake?.ToString() ?? "none", _sessionId.Value);
+                _cursor ?? "none", _sessionId.Value);
             return;
         }
 
-        var cursor = _cursorSnowflake;
+        var cursor = _cursor;
         var candidates = new List<ChannelInput>(history.Count);
         foreach (var item in history)
         {
-            if (TryParseSnowflake(item.MessageId ?? string.Empty) is not { } itemSnowflake)
+            if (NormalizeSnowflake(item.MessageId ?? string.Empty) is not { } itemCursor)
                 continue;
 
             // Strict: only include messages newer than the cursor. PR #733's
@@ -503,7 +507,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             // duplicate it. The in-flight-crash case is handled too: a turn
             // that didn't complete leaves the cursor un-advanced, so the
             // message has snowflake > cursor and is correctly included in the gap.
-            if (cursor is { } c && itemSnowflake <= c)
+            if (cursor is { } c && CursorComparer.Compare(itemCursor, c) <= 0)
                 continue;
 
             candidates.Add(item);
@@ -513,7 +517,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             _log.Info(
                 "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor} session={Session}",
-                history.Count, cursor?.ToString() ?? "none", _sessionId.Value);
+                history.Count, cursor ?? "none", _sessionId.Value);
             return;
         }
 
@@ -522,7 +526,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         _log.Info(
             "Thread history hydration fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
-            history.Count, candidates.Count, gap.Count, classified.BlockedForRisk, cursor?.ToString() ?? "none", _sessionId.Value);
+            history.Count, candidates.Count, gap.Count, classified.BlockedForRisk, cursor ?? "none", _sessionId.Value);
 
         if (classified.DetectorUnavailable)
             await SafeReplyAsync(BackfillDetectorWarning);
@@ -567,7 +571,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
 
         var triggerInput = trigger.Input;
-        var triggerSnowflake = TryParseSnowflake(triggerInput.MessageId ?? string.Empty);
+        var triggerCursor = NormalizeSnowflake(triggerInput.MessageId ?? string.Empty);
         var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
 
         if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
@@ -592,10 +596,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             // enqueue so a mention arriving before this turn completes does not re-arm.
             _turnInFlight = true;
 
-            if (triggerSnowflake is { } sn)
+            if (triggerCursor is { } tc)
             {
-                if (_pendingCursorSnowflake is not { } pending || sn > pending)
-                    _pendingCursorSnowflake = sn;
+                if (_pendingCursor is not { } pending || CursorComparer.Compare(tc, pending) > 0)
+                    _pendingCursor = tc;
             }
 
             _log.Info(
@@ -689,7 +693,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static ChannelInput MergeAdoptedContext(
         ChannelInput triggerInput,
         List<AdoptedContextMessage> adoptedContext,
-        ulong? cursor)
+        string? cursor)
     {
         var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
             adoptedContext,
@@ -704,7 +708,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 id => !string.Equals(id, triggerInput.SenderId.Value, StringComparison.Ordinal)),
             AdoptedSpeakerIds = merged.SpeakerIds,
             AdoptedContextProjection = merged.Projection,
-            AdoptedContextLowerBound = cursor?.ToString(),
+            AdoptedContextLowerBound = cursor,
             AdoptedContextUpperBound = triggerInput.MessageId,
             AdoptedContextEntries = merged.Entries
         };
@@ -729,7 +733,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         // Without the live message's ordering key the gap below it cannot be
         // bounded; leave hydration re-armed and take the fetch-free path.
-        if (TryParseSnowflake(liveMessageId) is not { } liveSnowflake)
+        if (NormalizeSnowflake(liveMessageId) is not { } liveCursor)
             return baseInput;
 
         IReadOnlyList<ChannelInput> history;
@@ -749,18 +753,18 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         // above) keeps the flag armed — classify/merge outcomes never re-arm.
         _hydrationPending = false;
 
-        var cursor = _cursorSnowflake;
+        var cursor = _cursor;
         var candidates = new List<ChannelInput>(history.Count);
         foreach (var item in history)
         {
-            if (TryParseSnowflake(item.MessageId ?? string.Empty) is not { } itemSnowflake)
+            if (NormalizeSnowflake(item.MessageId ?? string.Empty) is not { } itemCursor)
                 continue;
 
             // Strictly above the watermark and strictly below the live inbound:
             // the live inbound is the executable message, not adopted context.
-            if (cursor is { } c && itemSnowflake <= c)
+            if (cursor is { } c && CursorComparer.Compare(itemCursor, c) <= 0)
                 continue;
-            if (itemSnowflake >= liveSnowflake)
+            if (CursorComparer.Compare(itemCursor, liveCursor) >= 0)
                 continue;
 
             candidates.Add(item);
@@ -1208,9 +1212,9 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 break;
 
             case TurnCompleted completed:
-                if (completed.Outcome == TurnOutcome.Completed && _pendingCursorSnowflake is { } pendingSnowflake)
-                    AdvanceCursor(pendingSnowflake);
-                _pendingCursorSnowflake = null;
+                if (completed.Outcome == TurnOutcome.Completed && _pendingCursor is { } pendingCursor)
+                    AdvanceCursor(pendingCursor);
+                _pendingCursor = null;
                 _turnInFlight = false;
 
                 if (completed.SourceReminderId is { } sourceReminderKey
@@ -1621,27 +1625,27 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     internal static List<string> ChunkMessage(string text) =>
         MessageChunker.Chunk(text, MaxDiscordMessageLength);
 
-    private void AdvanceCursor(ulong candidateSnowflake)
+    private void AdvanceCursor(string candidateCursor)
     {
-        if (_cursorSnowflake is { } c && candidateSnowflake <= c)
+        if (_cursor is { } c && CursorComparer.Compare(candidateCursor, c) <= 0)
         {
             _log.Debug("Session cursor did not advance session={Session} snowflake={Snowflake}",
-                _sessionId.Value, candidateSnowflake);
+                _sessionId.Value, candidateCursor);
             return;
         }
 
-        Persist(new CursorAdvanced(candidateSnowflake.ToString()), ApplyCursorAdvanced);
+        Persist(new CursorAdvanced(candidateCursor), ApplyCursorAdvanced);
     }
 
     private void ApplyCursorAdvanced(CursorAdvanced advanced)
     {
-        if (!ulong.TryParse(advanced.Cursor, out var snowflake))
+        if (NormalizeSnowflake(advanced.Cursor) is not { } cursor)
         {
             _log.Warning("Corrupt cursor value during recovery, skipping: {Cursor}", advanced.Cursor);
             return;
         }
 
-        _cursorSnowflake = snowflake;
+        _cursor = cursor;
 
         if (!IsRecovering && LastSequenceNr > 1 && LastSequenceNr % 10 == 0)
             DeleteMessages(LastSequenceNr - 1);
@@ -1661,8 +1665,16 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private void ApplyPendingApprovalPromptCleared(PendingApprovalPromptCleared cleared)
         => PendingApprovalRecovery.ApplyCleared<PendingApprovalRequest, DiscordMessageId>(_pendingApprovalRequests, cleared);
 
-    private static ulong? TryParseSnowflake(string value)
-        => ulong.TryParse(value, out var id) ? id : null;
+    /// <summary>
+    /// Returns the canonical decimal form of a Discord snowflake, or null
+    /// when the value is not a snowflake and therefore has no order. The
+    /// <see cref="ulong"/> round-trip is a validation and normalization
+    /// step, not cursor state: it rejects the same inputs the previous
+    /// numeric cursor rejected, and it strips a form such as a leading zero
+    /// that <see cref="SnowflakeCursorComparer"/> cannot order.
+    /// </summary>
+    private static string? NormalizeSnowflake(string value)
+        => ulong.TryParse(value, out var id) ? id.ToString() : null;
 
     private sealed record InitializePipeline
     {

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -54,15 +54,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     // with no fetcher there is no gap to hydrate, so both hydration paths no-op.
     private readonly ThreadGapHydrationEngine? _hydrationEngine;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
+    private readonly ApprovalResponseFlow<PendingApprovalRequest, DiscordMessageId> _approvalFlow;
 
-    // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
-    // A binding that has never observed any ToolInteractionRequest treats an
-    // inbound "A"/"B"/"C" as a possible cold approval reply for a session that
-    // restarted out from under it. Once we've observed at least one prompt,
-    // subsequent ambiguous text from the user is ordinary conversation, not an
-    // approval reply, so the cold path stays off. This does NOT gate button
-    // clicks — those always route to the session, which is the authority on
-    // CallId staleness.
+    // Gates the text-approval cold path. The gate rule lives with the cold path
+    // in ApprovalResponseFlow.
     private bool _hasObservedApprovalRequest;
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
@@ -158,6 +153,22 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
                 setHydrationPending: pending => _hydrationPending = pending);
         }
+
+        _approvalFlow = new ApprovalResponseFlow<PendingApprovalRequest, DiscordMessageId>(
+            sessionId: _sessionId,
+            channelType: ChannelType.Discord,
+            channelName: "Discord",
+            pipeline: _dependencies.Pipeline,
+            operationTimeout: OperationTimeout,
+            pendingRequests: _pendingApprovalRequests,
+            matchOrder: ApprovalMatchOrder.Newest,
+            hasObservedApprovalRequest: () => _hasObservedApprovalRequest,
+            postWrongRequesterWarningAsync: () => SafeReplyAsync(WrongRequesterWarning),
+            persistPromptCleared: callId => Persist(
+                new PendingApprovalPromptCleared { CallId = callId.Value },
+                ApplyPendingApprovalPromptCleared),
+            renderResolvedPromptAsync: TryResolveApprovalPromptAsync,
+            log: _log);
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
         Recover<PendingApprovalPromptTracked>(ApplyPendingApprovalPromptTracked);
@@ -489,229 +500,17 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         => _dependencies.Options.AllowedUserIds.Length == 0
             || _dependencies.Options.AllowedUserIds.Contains(senderId, StringComparer.Ordinal);
 
-    private async Task<bool> TryHandleTextApprovalResponseAsync(DiscordThreadInbound message)
-    {
-        var (result, pending) = ResolvePendingRequest(message.SenderId, callId: null);
+    private Task<bool> TryHandleTextApprovalResponseAsync(DiscordThreadInbound message)
+        => _approvalFlow.TryHandleTextApprovalResponseAsync(message.Text, message.SenderId.Value);
 
-        if (result is ApprovalLookupResult.NotFound)
-        {
-            return !_hasObservedApprovalRequest
-                && await TryHandleColdTextApprovalResponseAsync(message);
-        }
-
-        if (result is ApprovalLookupResult.WrongRequester)
-        {
-            await SafeReplyAsync(WrongRequesterWarning);
-            return true;
-        }
-
-        if (!ToolInteractionResponseParser.TryParseApprovalResponse(
-                message.Text ?? string.Empty,
-                pending!.Options,
-                out var selectedKey)
-            || selectedKey is null)
-        {
-            return false;
-        }
-
-        ISessionResponse feedbackResult;
-        try
-        {
-            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(
-                new ToolInteractionResponse
-                {
-                    SessionId = _sessionId,
-                    CallId = pending!.CallId,
-                    SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(selectedKey),
-                    SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
-                }, feedbackCts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route Discord text approval response for call {CallId}", pending!.CallId);
-            return true;
-        }
-
-        switch (feedbackResult)
-        {
-            case CommandNack nack:
-                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
-                    await SafeReplyAsync(WrongRequesterWarning);
-                _log.Info(
-                    "Session rejected Discord text approval response for call {CallId} reason={Reason}; skipping redraw",
-                    pending!.CallId,
-                    nack.Reason ?? "<none>");
-                return true;
-
-            case not CommandAck:
-                _log.Warning(
-                    "Discord text approval response for call {CallId} returned unexpected feedback result {ResultType}",
-                    pending!.CallId,
-                    feedbackResult.GetType().Name);
-                return true;
-        }
-
-        _pendingApprovalRequests.Remove(pending!);
-        Persist(new PendingApprovalPromptCleared
-        {
-            CallId = pending.CallId.Value
-        }, ApplyPendingApprovalPromptCleared);
-
-        await TryResolveApprovalPromptAsync(
-            pending!.PromptMessageId,
-            pending!.Request,
-            pending!.CallId,
-            selectedKey,
+    // Discord gateway interactions are one-way telemetry from the websocket, so
+    // the flow gets no synchronous-reply hook here.
+    private Task HandleApprovalResponseAsync(DiscordApprovalResponse message)
+        => _approvalFlow.HandleApprovalResponseAsync(
+            message.CallId,
+            message.SelectedKey,
             message.SenderId.Value,
-            persistedToolName: pending.ToolName,
-            persistedDisplayText: pending.DisplayText);
-        return true;
-    }
-
-    private async Task<bool> TryHandleColdTextApprovalResponseAsync(DiscordThreadInbound message)
-    {
-        if (!ToolInteractionResponseParser.LooksLikeApprovalResponse(message.Text ?? string.Empty))
-            return false;
-
-        using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-        try
-        {
-            var reply = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(new ToolInteractionTextResponse
-            {
-                SessionId = _sessionId,
-                Text = message.Text ?? string.Empty,
-                SenderId = new SenderId(message.SenderId.Value)
-            }, feedbackCts.Token);
-
-            if (reply is CommandAck)
-            {
-                _log.Info(
-                    "Forwarded cold Discord text approval response from sender={SenderId} without local pending prompt state",
-                    message.SenderId);
-                return true;
-            }
-
-            // approval_no_history means the session has never had an approval request.
-            // The message was a false-positive from LooksLikeApprovalResponse.
-            // Don't consume — let it fall through to normal LLM ingress. See #1164.
-            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
-                return false;
-
-            return reply is CommandNack;
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route cold Discord text approval response from sender {SenderId}", message.SenderId);
-            return false;
-        }
-    }
-
-    private async Task HandleApprovalResponseAsync(DiscordApprovalResponse message)
-    {
-        var (result, pending) = ResolvePendingRequest(message.SenderId, message.CallId);
-
-        if (result is ApprovalLookupResult.WrongRequester)
-        {
-            await SafeReplyAsync(WrongRequesterWarning);
-            return;
-        }
-
-        // Wait for the session before redrawing. This is the security gate that
-        // prevents (a) a non-requester click destroying the prompt UI on the
-        // cold-spawn path, and (b) a stale re-click overwriting an already-resolved
-        // banner — both surfaced by the #939 code review. The session is the
-        // authority on whether the call is still pending and whether the sender is
-        // allowed. Only redraw on CommandAck.
-        ISessionResponse feedbackResult;
-        try
-        {
-            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(
-                new ToolInteractionResponse
-                {
-                    SessionId = _sessionId,
-                    CallId = message.CallId,
-                    SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
-                    SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
-                }, feedbackCts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route Discord approval response for call {CallId}", message.CallId);
-            return;
-        }
-
-        switch (feedbackResult)
-        {
-            case CommandNack nack:
-                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
-                    await SafeReplyAsync(WrongRequesterWarning);
-                _log.Info(
-                    "Session rejected Discord approval response for call {CallId} reason={Reason}; skipping redraw",
-                    message.CallId,
-                    nack.Reason ?? "<none>");
-                return;
-
-            case CommandAck:
-                break;
-
-            default:
-                _log.Warning(
-                    "Discord approval response for call {CallId} returned unexpected feedback result {ResultType}",
-                    message.CallId,
-                    feedbackResult.GetType().Name);
-                return;
-        }
-
-        if (pending is not null)
-        {
-            _pendingApprovalRequests.Remove(pending);
-            Persist(new PendingApprovalPromptCleared
-            {
-                CallId = pending.CallId.Value
-            }, ApplyPendingApprovalPromptCleared);
-            // Prefer captured message ID; fall back to payload ID when capture failed.
-            var promptMessageId = pending.PromptMessageId ?? message.PromptMessageId;
-            await TryResolveApprovalPromptAsync(
-                promptMessageId,
-                pending.Request,
-                pending.CallId,
-                message.SelectedKey,
-                message.SenderId.Value,
-                persistedToolName: pending.ToolName,
-                persistedDisplayText: pending.DisplayText);
-        }
-        else if (message.PromptMessageId is { } payloadPromptMessageId)
-        {
-            // Cold-spawn redraw — no local pending entry for this CallId (no
-            // PendingApprovalPromptTracked replayed, or the entry was already
-            // cleared). The click payload still carries the prompt's message id
-            // and the session has accepted the response; render the generic
-            // banner so the buttons clear. Pre-0.21 journals that DO replay take
-            // the upper `pending is not null` branch — they render generically
-            // via the !IsNullOrEmpty fallback inside the builder, not here.
-            await TryResolveApprovalPromptAsync(
-                payloadPromptMessageId,
-                request: null,
-                message.CallId,
-                message.SelectedKey,
-                message.SenderId.Value);
-
-            _log.Info(
-                "Forwarded Discord approval response for call {0} to session without local pending entry; redrew prompt via payload messageId={1}",
-                message.CallId,
-                payloadPromptMessageId.Value);
-        }
-        else
-        {
-            // Text-reply on a cold-spawned binding. Remaining #939 gap.
-            _log.Info(
-                "Forwarded Discord approval response for call {0} to session without local pending entry; redraw skipped",
-                message.CallId);
-            ChannelTelemetry.For(ChannelType.Discord).RecordExtra("interactionErrors", "cold_spawn_redraw_skipped");
-        }
-    }
+            message.PromptMessageId);
 
     private async Task TryResolveApprovalPromptAsync(
         DiscordMessageId? promptMessageId,
@@ -838,11 +637,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _channelId.Value,
             _channelId.Value,
             _threadOrMessageId.Value);
-
-    private (ApprovalLookupResult Result, PendingApprovalRequest? Pending) ResolvePendingRequest(
-        DiscordUserId senderId, Netclaw.Tools.ToolCallId? callId)
-        => PendingApprovalLookup.Resolve<PendingApprovalRequest, DiscordMessageId>(
-            _pendingApprovalRequests, senderId.Value, callId);
 
     private async Task HandleOutputReceivedAsync(OutputReceived msg)
     {

--- a/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostIngressMessages.cs
@@ -72,10 +72,4 @@ internal sealed class PendingApprovalRequest : Netclaw.Channels.PendingApprovalR
         : base(callId, requesterSenderId, requesterPrincipal, optionKeys, promptPostId, toolName, displayText)
     {
     }
-
-    public MattermostPostId? PromptPostId
-    {
-        get => PromptId;
-        set => PromptId = value;
-    }
 }

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -54,38 +54,14 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private readonly ThreadGapHydrationEngine? _hydrationEngine;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
     private readonly ApprovalResponseFlow<PendingApprovalRequest, MattermostPostId> _approvalFlow;
-
-    // Gates the text-approval cold path. The gate rule lives with the cold path
-    // in ApprovalResponseFlow.
-    private bool _hasObservedApprovalRequest;
+    private readonly ChannelOutputEngine<PendingApprovalRequest, MattermostPostId> _outputEngine;
+    private readonly SafeTransportCall _safeCall;
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan ReinitializeDelay = TimeSpan.FromSeconds(2);
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
-    private bool _deliveredThisTurn;
-    // True when a content post/upload this turn was attempted but failed (the
-    // model produced output, the transport rejected it). Distinct from "nothing
-    // was produced" — it suppresses the empty-turn fallback so a failed post
-    // isn't followed by a misleading "I didn't manage to produce a reply".
-    private bool _postFailedThisTurn;
-    // Reply targets for in-flight reminder delivery confirmations, keyed by
-    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
-    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
-    // Keyed (not a single field) because multiple reminders can target the
-    // same session concurrently — a single field would be clobbered.
-    private readonly Dictionary<ReminderId, IActorRef> _reminderDeliveryObservers = new();
-    private TurnNumber _turnNumber;
     private string? _cursorPostId;
-    private string? _pendingCursorPostId;
-
-    // Reliable in-flight-turn signal for the mention re-arm guard: set when the
-    // main inbound is enqueued (unlike _pendingCursorPostId, which is only set for
-    // inbounds with a non-empty post id), cleared when the turn ends or the
-    // pipeline reinitializes. Without it, a null-id in-flight turn would leave
-    // _pendingCursorPostId unset and let a following mention re-arm mid-turn —
-    // the PR #733 no-duplicate hazard.
-    private bool _turnInFlight;
 
     // Set when PerformOneShotHydrationAsync fetched a non-empty thread gap but
     // found no authorized trigger to anchor a turn. This is the proactive-thread
@@ -124,6 +100,35 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
 
         _handle = new SessionPipelineHandle(_dependencies.Pipeline, _log, "mattermost-session");
 
+        _safeCall = new SafeTransportCall(
+            ChannelType.Mattermost,
+            _dependencies.TimeProvider,
+            NotifyDeliveryFailedAsync);
+
+        _outputEngine = new ChannelOutputEngine<PendingApprovalRequest, MattermostPostId>(
+            channelType: ChannelType.Mattermost,
+            channelName: "Mattermost",
+            // Mattermost post IDs are lexicographically sortable strings.
+            cursorComparer: StringComparer.Ordinal,
+            pendingRequests: _pendingApprovalRequests,
+            createPendingRequest: request => new PendingApprovalRequest(request),
+            isApprovalRequest: request => string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase),
+            renderTextOutput: textOutput => textOutput.Text,
+            renderErrorOutput: error => $":warning: {error.Message}",
+            postTextAsync: SafeReplyAsync,
+            uploadFileAsync: SafeUploadFileAsync,
+            postApprovalPromptAsync: SafeReplyWithApprovalPromptAsync,
+            readPromptIdValue: promptPostId => promptPostId.Value,
+            onApprovalPromptFailedAsync: request => SendApprovalDenyOnFailureAsync(request.CallId),
+            persistPromptTracked: tracked => Persist(tracked, ApplyPendingApprovalPromptTracked),
+            handleChannelSpecificOutputAsync: HandleChannelSpecificOutputAsync,
+            advanceCursor: AdvanceCursor,
+            postEmptyTurnFallbackAsync: () => SafeReplyAsync(EmptyTurnFallbackText),
+            // Mattermost reports a delivery failure inline from SafeReplyAsync,
+            // so the session already knows by the time the turn completes.
+            onEmptyTurnSuppressedAsync: _ => Task.CompletedTask,
+            readObservedAtMs: completed => completed.TimestampMs);
+
         if (_dependencies.ThreadHistoryFetcher is { } historyFetcher)
         {
             _hydrationEngine = new ThreadGapHydrationEngine(
@@ -141,7 +146,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 readInputQueue: () => _handle.InputQueue,
                 readIngressClosedReason: () => _dependencies.IngressGate?.ClosedReason,
                 warnBackfillDetectorUnavailableAsync: () => SafeReplyAsync(BackfillDetectorWarning),
-                onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
+                onBackfillEnqueued: _outputEngine.AdvancePendingCursorForEnqueuedTurn,
                 setHydrationPending: pending => _hydrationPending = pending);
         }
 
@@ -153,7 +158,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             operationTimeout: OperationTimeout,
             pendingRequests: _pendingApprovalRequests,
             matchOrder: ApprovalMatchOrder.Newest,
-            hasObservedApprovalRequest: () => _hasObservedApprovalRequest,
+            hasObservedApprovalRequest: () => _outputEngine.HasObservedApprovalRequest,
             postWrongRequesterWarningAsync: () => SafeReplyAsync(WrongRequesterWarning),
             persistPromptCleared: callId => Persist(
                 new PendingApprovalPromptCleared { CallId = callId.Value },
@@ -277,17 +282,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
 
         CommandAsync<ReinitializePipeline>(async msg =>
         {
-            _deliveredThisTurn = false;
-            _postFailedThisTurn = false;
-            // A reinit abandons any in-flight turn before its TurnCompleted; clear
-            // the mention re-arm guard so the next mention can re-hydrate instead of
-            // being blocked by a stuck flag.
-            _turnInFlight = false;
-            // A reinit aborts any in-flight reminder turn before its
-            // TurnCompleted. Report those as not-delivered now so the
-            // execution actor redelivers immediately instead of stalling
-            // until the backstop timeout.
-            FailPendingReminderDeliveries($"Mattermost pipeline reinitialized: {msg.Reason}");
+            _outputEngine.ResetForPipelineReinitialize(msg.Reason);
             await _handle.ReinitializeAsync(
                 msg.Reason,
                 () => Timers.StartSingleTimer(
@@ -427,7 +422,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         // mention, not this one (and can be skipped if the cursor later advances past
         // it under rapid concurrent mentions).
         if (!_hydrationPending
-            && !_turnInFlight
+            && !_outputEngine.TurnInFlight
             && _dependencies.Options.MentionRequiredInThreadFor(_channelId.Value))
         {
             _hydrationPending = true;
@@ -447,7 +442,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             ChannelTelemetry.For(ChannelType.Mattermost).RecordMessageEnqueued();
 
             var eventId = message.EventId.Value;
-            AdvancePendingCursorForEnqueuedTurn(string.IsNullOrEmpty(eventId) ? null : eventId);
+            _outputEngine.AdvancePendingCursorForEnqueuedTurn(string.IsNullOrEmpty(eventId) ? null : eventId);
         }
         catch (OperationCanceledException)
         {
@@ -579,7 +574,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         if (message.Source.DeliveryObserver is { } deliveryObserver
             && message.Source.ReminderId is { } reminderKey
             && !string.IsNullOrWhiteSpace(reminderKey.Value))
-            _reminderDeliveryObservers[reminderKey] = deliveryObserver;
+            _outputEngine.TrackReminderDeliveryObserver(reminderKey, deliveryObserver);
 
         try
         {
@@ -611,109 +606,21 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
 
     private async Task HandleOutputReceivedAsync(OutputReceived msg)
     {
-        switch (msg.Output)
-        {
-            case TextOutput textOutput:
-                if (await SafeReplyAsync(textOutput.Text))
-                    _deliveredThisTurn = true;
-                else
-                    _postFailedThisTurn = true;
-                break;
-
-            case ErrorOutput error:
-                if (await SafeReplyAsync($":warning: {error.Message}"))
-                    _deliveredThisTurn = true;
-                else
-                    _postFailedThisTurn = true;
-                break;
-
-            case FileOutput file:
-                if (await SafeUploadFileAsync(file))
-                    _deliveredThisTurn = true;
-                else
-                    _postFailedThisTurn = true;
-                break;
-
-            case ToolInteractionRequest request when string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase):
-                _hasObservedApprovalRequest = true;
-                var pendingApproval = new PendingApprovalRequest(request);
-                _pendingApprovalRequests.Add(pendingApproval);
-
-                var promptPostId = await SafeReplyWithApprovalPromptAsync(request);
-                if (promptPostId is not null)
-                {
-                    pendingApproval.PromptPostId = promptPostId;
-                    Persist(new PendingApprovalPromptTracked
-                    {
-                        CallId = pendingApproval.CallId.Value,
-                        RequesterSenderId = pendingApproval.RequesterSenderId,
-                        RequesterPrincipal = pendingApproval.RequesterPrincipal,
-                        OptionKeys = pendingApproval.OptionKeys,
-                        PromptId = promptPostId.Value.Value,
-                        ToolName = pendingApproval.ToolName,
-                        // Preserve null-vs-set semantics on the wire: Truncate
-                        // returns string.Empty for null input, which would round-
-                        // trip as DisplayText="" with HasDisplayText=true.
-                        DisplayText = string.IsNullOrEmpty(pendingApproval.DisplayText)
-                            ? null
-                            : ApprovalDisplayTextFormatter.Truncate(
-                                pendingApproval.DisplayText,
-                                PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
-                    }, ApplyPendingApprovalPromptTracked);
-                }
-                else
-                {
-                    _pendingApprovalRequests.Remove(pendingApproval);
-                }
-                break;
-
-            // Mattermost threads don't support renaming, so SessionTitleOutput is ignored.
-
-            case TurnCompleted completed:
-                if (completed.Outcome == TurnOutcome.Completed && _pendingCursorPostId is { } pendingCursor)
-                    AdvanceCursor(pendingCursor);
-                _pendingCursorPostId = null;
-                _turnInFlight = false;
-
-                if (completed.SourceReminderId is { } sourceReminderKey
-                    && !string.IsNullOrWhiteSpace(sourceReminderKey.Value)
-                    && _reminderDeliveryObservers.Remove(sourceReminderKey, out var reminderObserver))
-                {
-                    reminderObserver.Tell(new ReminderDeliveryResult(
-                        sourceReminderKey,
-                        ChannelType.Mattermost,
-                        Delivered: _deliveredThisTurn,
-                        FailureReason: _deliveredThisTurn ? null : "Mattermost post did not succeed",
-                        ObservedAtMs: completed.TimestampMs));
-                }
-
-                // Only post the empty-turn fallback when the turn genuinely
-                // produced nothing. A failed post already notified the session
-                // (SafeReplyAsync -> NotifyDeliveryFailedAsync); posting "I
-                // didn't manage to produce a reply" on top would be misleading
-                // (a reply WAS produced) and double up with the redelivered one.
-                if (!_deliveredThisTurn && !_postFailedThisTurn)
-                    await SafeReplyAsync(EmptyTurnFallbackText);
-
-                _turnNumber = completed.TurnNumber;
-                var clearedPrompts = _pendingApprovalRequests
-                    .Select(pending => new PendingApprovalPromptCleared
-                    {
-                        CallId = pending.CallId.Value
-                    })
-                    .ToArray();
-                if (clearedPrompts.Length > 0)
-                {
-                    PersistAll(
-                        clearedPrompts,
-                        cleared => ApplyPendingApprovalPromptCleared(cleared));
-                }
-                _pendingApprovalRequests.Clear();
-                _deliveredThisTurn = false;
-                _postFailedThisTurn = false;
-                break;
-        }
+        var clearedPrompts = await _outputEngine.HandleOutputAsync(msg.Output);
+        if (clearedPrompts.Count > 0)
+            PersistAll(clearedPrompts, ApplyPendingApprovalPromptCleared);
     }
+
+    /// <summary>
+    /// Handles the outputs the shared engine leaves to the channel. Mattermost
+    /// supports none of them, so every one is ignored here. Mattermost threads
+    /// cannot be renamed, so a <c>SessionTitleOutput</c> has no effect, and the
+    /// binding renders no processing indicator. The missing processing
+    /// indicator is a capability difference from Slack and Discord. Whether
+    /// Mattermost should gain one is a product question, recorded as an open
+    /// question in the OpenSpec design for this change.
+    /// </summary>
+    private Task HandleChannelSpecificOutputAsync(SessionOutput output) => Task.CompletedTask;
 
     private async Task<MattermostPostId?> SafeReplyWithApprovalPromptAsync(ToolInteractionRequest request)
     {
@@ -780,9 +687,10 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
         catch (Exception ex)
         {
+            // The shared output engine auto-denies the request when this
+            // returns null, so the blocked tool call still unwinds.
             _log.Error(ex, "Failed posting Mattermost approval prompt; auto-denying request");
             ChannelTelemetry.For(ChannelType.Mattermost).RecordExtra("approvalFallbackActivated", "auto_deny");
-            await SendApprovalDenyOnFailureAsync(request.CallId);
             return null;
         }
     }
@@ -793,31 +701,12 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     /// notifying the session of the delivery failure). Callers that gate
     /// reminder delivery confirmation on real delivery must honor the result.
     /// </summary>
-    private async Task<bool> SafeReplyAsync(string text)
-    {
-        var chunks = ChunkMessage(text);
-        foreach (var chunk in chunks)
-        {
-            var startedAt = _dependencies.TimeProvider.GetTimestamp();
-            try
-            {
-                var postMessage = BuildPostMessage(chunk);
-                await _dependencies.ReplyClient.PostReplyAsync(postMessage);
-                var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-                ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyPosted(duration);
-            }
-            catch (Exception ex)
-            {
-                var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-                _log.Warning(ex, "Failed posting Mattermost reply for session {0}", _sessionId.Value);
-                ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyFailed(duration);
-                await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-                return false;
-            }
-        }
-
-        return true;
-    }
+    private Task<bool> SafeReplyAsync(string text)
+        => _safeCall.PostChunkedAsync(
+            text,
+            MaxMattermostPostLength,
+            chunk => _dependencies.ReplyClient.PostReplyAsync(BuildPostMessage(chunk)),
+            ex => _log.Warning(ex, "Failed posting Mattermost reply for session {0}", _sessionId.Value));
 
     private MattermostPostMessage BuildPostMessage(
         string text,
@@ -832,65 +721,41 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
 
     private async Task<bool> SafeUploadFileAsync(FileOutput file)
     {
-        var startedAt = _dependencies.TimeProvider.GetTimestamp();
-        try
+        // A missing file never reaches the transport, so it carries no transport
+        // telemetry and a different failure kind.
+        if (!File.Exists(file.FilePath))
         {
-            if (!File.Exists(file.FilePath))
+            _log.Warning("File not found for upload: {Path}", file.FilePath);
+            await NotifyDeliveryFailedAsync(DeliveryFailureKind.Unknown, $"File not found for upload: {file.FilePath}");
+            return false;
+        }
+
+        var uploaded = await _safeCall.InvokeAsync(
+            async () =>
             {
-                _log.Warning("File not found for upload: {Path}", file.FilePath);
-                await NotifyDeliveryFailedAsync(DeliveryFailureKind.Unknown, $"File not found for upload: {file.FilePath}");
-                return false;
-            }
+                using var uploadCts = new CancellationTokenSource(OperationTimeout);
+                var fileId = await _dependencies.ReplyClient.UploadFileAsync(
+                    _channelId,
+                    file.FilePath,
+                    file.FileName,
+                    uploadCts.Token);
 
-            using var uploadCts = new CancellationTokenSource(OperationTimeout);
-            var fileId = await _dependencies.ReplyClient.UploadFileAsync(
-                _channelId,
-                file.FilePath,
-                file.FileName,
-                uploadCts.Token);
+                using var postCts = new CancellationTokenSource(OperationTimeout);
+                var postMessage = BuildPostMessage($":paperclip: {file.FileName}", fileIds: [fileId]);
+                await _dependencies.ReplyClient.PostReplyAsync(postMessage, postCts.Token);
+            },
+            ex =>
+            {
+                if (ex is OperationCanceledException)
+                    _log.Error(ex, "Timed out uploading file {FileName} to Mattermost thread", file.FileName);
+                else
+                    _log.Error(ex, "Failed to upload file {FileName} to Mattermost thread", file.FileName);
+            });
 
-            using var postCts = new CancellationTokenSource(OperationTimeout);
-            var postMessage = BuildPostMessage($":paperclip: {file.FileName}", fileIds: [fileId]);
-            await _dependencies.ReplyClient.PostReplyAsync(postMessage, postCts.Token);
-
-            var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyPosted(duration);
+        if (uploaded)
             _log.Info("Uploaded file to Mattermost thread: {FileName}", file.FileName);
-            return true;
-        }
-        catch (OperationCanceledException ex)
-        {
-            var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            _log.Error(ex, "Timed out uploading file {FileName} to Mattermost thread", file.FileName);
-            ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyFailed(duration);
-            await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            _log.Error(ex, "Failed to upload file {FileName} to Mattermost thread", file.FileName);
-            ChannelTelemetry.For(ChannelType.Mattermost).RecordReplyFailed(duration);
-            await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
-            return false;
-        }
-    }
 
-    /// <summary>
-    /// Tells every in-flight reminder observer that delivery did not happen,
-    /// then clears them. Called when a turn can no longer reach TurnCompleted
-    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
-    /// rather than waiting out its backstop timeout.
-    /// </summary>
-    private void FailPendingReminderDeliveries(string reason)
-    {
-        if (_reminderDeliveryObservers.Count == 0)
-            return;
-
-        foreach (var (key, observer) in _reminderDeliveryObservers)
-            observer.Tell(new ReminderDeliveryResult(key, ChannelType.Mattermost, Delivered: false, FailureReason: reason));
-
-        _reminderDeliveryObservers.Clear();
+        return uploaded;
     }
 
     private async Task NotifyDeliveryFailedAsync(DeliveryFailureKind failureKind, string errorMessage)
@@ -900,7 +765,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             await _dependencies.Pipeline.SendFeedbackAsync(new DeliveryFailed
             {
                 SessionId = _sessionId,
-                TurnNumber = _turnNumber,
+                TurnNumber = _outputEngine.LastCompletedTurnNumber,
                 ChannelType = ChannelType.Mattermost,
                 FailureKind = failureKind,
                 ErrorMessage = errorMessage
@@ -1072,24 +937,6 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     internal static List<string> ChunkMessage(string text) =>
         MessageChunker.Chunk(text, MaxMattermostPostLength);
 
-    /// <summary>
-    /// Records that a turn went into the input queue. The turn-in-flight flag
-    /// guards the mention re-arm path; the pending cursor keeps the highest
-    /// post id of the turn and only becomes the persisted cursor on
-    /// TurnCompleted.
-    /// </summary>
-    private void AdvancePendingCursorForEnqueuedTurn(string? candidatePostId)
-    {
-        _turnInFlight = true;
-
-        if (candidatePostId is null)
-            return;
-
-        if (_pendingCursorPostId is null
-            || string.CompareOrdinal(candidatePostId, _pendingCursorPostId) > 0)
-            _pendingCursorPostId = candidatePostId;
-    }
-
     private void AdvanceCursor(string candidatePostId)
     {
         if (_cursorPostId is not null && string.CompareOrdinal(candidatePostId, _cursorPostId) <= 0)
@@ -1112,7 +959,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
 
     private void ApplyPendingApprovalPromptTracked(PendingApprovalPromptTracked tracked)
     {
-        _hasObservedApprovalRequest = true;
+        _outputEngine.MarkApprovalRequestObserved();
         PendingApprovalRecovery.ApplyTracked<PendingApprovalRequest, MattermostPostId>(
             _pendingApprovalRequests,
             tracked,

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -53,15 +53,10 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     // with no fetcher there is no gap to hydrate, so both hydration paths no-op.
     private readonly ThreadGapHydrationEngine? _hydrationEngine;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
+    private readonly ApprovalResponseFlow<PendingApprovalRequest, MattermostPostId> _approvalFlow;
 
-    // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
-    // A binding that has never observed any ToolInteractionRequest treats an
-    // inbound "A"/"B"/"C" as a possible cold approval reply for a session that
-    // restarted out from under it. Once we've observed at least one prompt,
-    // subsequent ambiguous text from the user is ordinary conversation, not an
-    // approval reply, so the cold path stays off. This does NOT gate button
-    // clicks — those always route to the session, which is the authority on
-    // CallId staleness.
+    // Gates the text-approval cold path. The gate rule lives with the cold path
+    // in ApprovalResponseFlow.
     private bool _hasObservedApprovalRequest;
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
@@ -149,6 +144,22 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
                 onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
                 setHydrationPending: pending => _hydrationPending = pending);
         }
+
+        _approvalFlow = new ApprovalResponseFlow<PendingApprovalRequest, MattermostPostId>(
+            sessionId: _sessionId,
+            channelType: ChannelType.Mattermost,
+            channelName: "Mattermost",
+            pipeline: _dependencies.Pipeline,
+            operationTimeout: OperationTimeout,
+            pendingRequests: _pendingApprovalRequests,
+            matchOrder: ApprovalMatchOrder.Newest,
+            hasObservedApprovalRequest: () => _hasObservedApprovalRequest,
+            postWrongRequesterWarningAsync: () => SafeReplyAsync(WrongRequesterWarning),
+            persistPromptCleared: callId => Persist(
+                new PendingApprovalPromptCleared { CallId = callId.Value },
+                ApplyPendingApprovalPromptCleared),
+            renderResolvedPromptAsync: TryResolveApprovalPromptAsync,
+            log: _log);
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
         Recover<PendingApprovalPromptTracked>(ApplyPendingApprovalPromptTracked);
@@ -456,232 +467,21 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         => _dependencies.Options.AllowedUserIds.Length == 0
             || _dependencies.Options.AllowedUserIds.Contains(senderId, StringComparer.Ordinal);
 
-    private async Task<bool> TryHandleTextApprovalResponseAsync(MattermostThreadInbound message)
-    {
-        var (result, pending) = ResolvePendingRequest(message.SenderId, callId: null);
+    private Task<bool> TryHandleTextApprovalResponseAsync(MattermostThreadInbound message)
+        => _approvalFlow.TryHandleTextApprovalResponseAsync(message.Text, message.SenderId.Value);
 
-        if (result is ApprovalLookupResult.NotFound)
-        {
-            return !_hasObservedApprovalRequest
-                && await TryHandleColdTextApprovalResponseAsync(message);
-        }
-
-        if (result is ApprovalLookupResult.WrongRequester)
-        {
-            await SafeReplyAsync(WrongRequesterWarning);
-            return true;
-        }
-
-        if (!ToolInteractionResponseParser.TryParseApprovalResponse(
-                message.Text ?? string.Empty,
-                pending!.Options,
-                out var selectedKey)
-            || selectedKey is null)
-        {
-            return false;
-        }
-
-        ISessionResponse feedbackResult;
-        try
-        {
-            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(new ToolInteractionResponse
-            {
-                SessionId = _sessionId,
-                CallId = pending!.CallId,
-                SelectedKey = new ApprovalOptionKey(selectedKey),
-                SenderId = new SenderId(message.SenderId.Value)
-            }, feedbackCts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route Mattermost text approval response for call {CallId}", pending!.CallId);
-            return true;
-        }
-
-        switch (feedbackResult)
-        {
-            case CommandNack nack:
-                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
-                    await SafeReplyAsync(WrongRequesterWarning);
-                _log.Info(
-                    "Session rejected Mattermost text approval response for call {CallId} reason={Reason}; skipping redraw",
-                    pending!.CallId,
-                    nack.Reason ?? "<none>");
-                return true;
-
-            case not CommandAck:
-                _log.Warning(
-                    "Mattermost text approval response for call {CallId} returned unexpected feedback result {ResultType}",
-                    pending!.CallId,
-                    feedbackResult.GetType().Name);
-                return true;
-        }
-
-        _pendingApprovalRequests.Remove(pending!);
-        Persist(new PendingApprovalPromptCleared
-        {
-            CallId = pending.CallId.Value
-        }, ApplyPendingApprovalPromptCleared);
-
-        await TryResolveApprovalPromptAsync(
-            pending!.PromptPostId,
-            pending!.Request,
-            pending!.CallId,
-            selectedKey,
-            message.SenderId.Value,
-            persistedToolName: pending.ToolName,
-            persistedDisplayText: pending.DisplayText);
-        return true;
-    }
-
-    private async Task<bool> TryHandleColdTextApprovalResponseAsync(MattermostThreadInbound message)
-    {
-        if (!ToolInteractionResponseParser.LooksLikeApprovalResponse(message.Text ?? string.Empty))
-            return false;
-
-        using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-        try
-        {
-            var reply = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(new ToolInteractionTextResponse
-            {
-                SessionId = _sessionId,
-                Text = message.Text ?? string.Empty,
-                SenderId = new SenderId(message.SenderId.Value)
-            }, feedbackCts.Token);
-
-            if (reply is CommandAck)
-            {
-                _log.Info(
-                    "Forwarded cold Mattermost text approval response from sender={SenderId} without local pending prompt state",
-                    message.SenderId);
-                return true;
-            }
-
-            // approval_no_history means the session has never had an approval request.
-            // The message was a false-positive from LooksLikeApprovalResponse.
-            // Don't consume — let it fall through to normal LLM ingress. See #1164.
-            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
-                return false;
-
-            return reply is CommandNack;
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route cold Mattermost text approval response from sender {SenderId}", message.SenderId);
-            return false;
-        }
-    }
-
-    private async Task HandleApprovalResponseAsync(MattermostApprovalResponse message)
+    // The Mattermost interactive-message webhook asks the binding over HTTP and
+    // waits for the session's verdict, so this is the one channel that registers
+    // the synchronous-reply hook.
+    private Task HandleApprovalResponseAsync(MattermostApprovalResponse message)
     {
         var replyTo = Sender;
-        var (result, pending) = ResolvePendingRequest(message.SenderId, message.CallId);
-
-        if (result is ApprovalLookupResult.WrongRequester)
-        {
-            await SafeReplyAsync(WrongRequesterWarning);
-            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, ApprovalNackReasons.WrongRequester));
-            return;
-        }
-
-        ISessionResponse feedbackResult;
-        using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-        try
-        {
-            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(new ToolInteractionResponse
-            {
-                SessionId = _sessionId,
-                CallId = message.CallId,
-                SelectedKey = new ApprovalOptionKey(message.SelectedKey),
-                SenderId = new SenderId(message.SenderId.Value)
-            }, feedbackCts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route Mattermost approval response for call {CallId}", message.CallId);
-            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, ApprovalNackReasons.PersistFailed));
-            return;
-        }
-
-        CommandAck ack;
-        switch (feedbackResult)
-        {
-            case CommandNack nack:
-                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
-                    await SafeReplyAsync(WrongRequesterWarning);
-                ReplyIfExpected(replyTo, nack);
-                return;
-
-            case CommandAck ok:
-                ack = ok;
-                break;
-
-            default:
-                // Unreachable: ISessionResponse is implemented only by CommandAck
-                // and CommandNack. Kept as a defensive guard so an unexpected
-                // future implementer surfaces a structured Nack instead of an
-                // unobservable null reference.
-                _log.Warning(
-                    "Mattermost approval response for call {CallId} returned unexpected feedback result {ResultType}",
-                    message.CallId,
-                    feedbackResult.GetType().Name);
-                ReplyIfExpected(replyTo, CommandNack.For(_sessionId, ApprovalNackReasons.PersistFailed));
-                return;
-        }
-
-        if (pending is not null)
-        {
-            _pendingApprovalRequests.Remove(pending);
-            Persist(new PendingApprovalPromptCleared
-            {
-                CallId = pending.CallId.Value
-            }, ApplyPendingApprovalPromptCleared);
-            // Prefer captured post ID; fall back to payload-provided ID when capture
-            // failed (very narrow race window — see binding's TryPostButtonPromptAsync).
-            var promptPostId = pending.PromptPostId ?? message.PromptPostId;
-            await TryResolveApprovalPromptAsync(
-                promptPostId,
-                pending.Request,
-                pending.CallId,
-                message.SelectedKey,
-                message.SenderId.Value,
-                persistedToolName: pending.ToolName,
-                persistedDisplayText: pending.DisplayText);
-        }
-        else if (message.PromptPostId is { } payloadPromptPostId)
-        {
-            // Cold-spawn path with no local pending entry for this CallId (no
-            // journal record replayed, or the entry was already cleared). The
-            // Mattermost action callback always carries the prompt's post_id;
-            // render the generic banner so the buttons clear. Pre-0.21 journals
-            // that DO replay take the upper `pending is not null` branch — they
-            // render generically via the !IsNullOrEmpty fallback inside the
-            // builder, not here. See issue #939.
-            await TryResolveApprovalPromptAsync(
-                payloadPromptPostId,
-                request: null,
-                message.CallId,
-                message.SelectedKey,
-                message.SenderId.Value);
-
-            _log.Info(
-                "Forwarded Mattermost approval response for call {0} to session without local pending entry; redrew prompt via payload postId={1}",
-                message.CallId,
-                payloadPromptPostId.Value);
-        }
-        else
-        {
-            // Cold-spawn path without payload context (e.g. text-reply A-E in a
-            // thread whose binding has been passivated). Approval still routes;
-            // redraw is not possible. Remaining gap tracked under #939.
-            _log.Info(
-                "Forwarded Mattermost approval response for call {0} to session without local pending entry; redraw skipped",
-                message.CallId);
-            ChannelTelemetry.For(ChannelType.Mattermost).RecordExtra("interactionErrors", "cold_spawn_redraw_skipped");
-        }
-
-        ReplyIfExpected(replyTo, ack);
+        return _approvalFlow.HandleApprovalResponseAsync(
+            message.CallId,
+            message.SelectedKey,
+            message.SenderId.Value,
+            message.PromptPostId,
+            respondSynchronously: response => ReplyIfExpected(replyTo, response));
     }
 
     private async Task TryResolveApprovalPromptAsync(
@@ -808,11 +608,6 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             _channelId.Value,
             _channelId.Value,
             _rootPostId.Value);
-
-    private (ApprovalLookupResult Result, PendingApprovalRequest? Pending) ResolvePendingRequest(
-        MattermostUserId senderId, ToolCallId? callId)
-        => PendingApprovalLookup.Resolve<PendingApprovalRequest, MattermostPostId>(
-            _pendingApprovalRequests, senderId.Value, callId);
 
     private async Task HandleOutputReceivedAsync(OutputReceived msg)
     {

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -47,6 +47,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private readonly IPromptInjectionDetector _promptInjectionDetector;
     private readonly SessionPipelineHandle _handle;
     private readonly ILoggingAdapter _log;
+
+    // Null when the gateway supplies no thread-history fetcher. That is a real
+    // runtime state (an instance without history access), not a disabled check:
+    // with no fetcher there is no gap to hydrate, so both hydration paths no-op.
+    private readonly ThreadGapHydrationEngine? _hydrationEngine;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
     // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
@@ -123,6 +128,27 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             .WithContext("MattermostRootPostId", _rootPostId.Value);
 
         _handle = new SessionPipelineHandle(_dependencies.Pipeline, _log, "mattermost-session");
+
+        if (_dependencies.ThreadHistoryFetcher is { } historyFetcher)
+        {
+            _hydrationEngine = new ThreadGapHydrationEngine(
+                sessionId: _sessionId,
+                channelType: ChannelType.Mattermost,
+                historyFetcher: historyFetcher,
+                injectionDetector: _promptInjectionDetector,
+                classifierSourceContext: "mattermost-backfill",
+                // Mattermost post IDs are lexicographically sortable strings.
+                cursorComparer: StringComparer.Ordinal,
+                cursorKeySelector: messageId => string.IsNullOrEmpty(messageId) ? null : messageId,
+                isAuthorizedSender: IsAuthorizedSender,
+                log: _log,
+                readCursor: () => _cursorPostId,
+                readInputQueue: () => _handle.InputQueue,
+                readIngressClosedReason: () => _dependencies.IngressGate?.ClosedReason,
+                warnBackfillDetectorUnavailableAsync: () => SafeReplyAsync(BackfillDetectorWarning),
+                onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
+                setHydrationPending: pending => _hydrationPending = pending);
+        }
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
         Recover<PendingApprovalPromptTracked>(ApplyPendingApprovalPromptTracked);
@@ -201,7 +227,8 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         {
             try
             {
-                await PerformOneShotHydrationAsync();
+                if (_hydrationEngine is { } engine)
+                    await engine.PerformOneShotHydrationAsync();
             }
             catch (Exception ex)
             {
@@ -353,11 +380,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             return;
 
         // Live inbound path is fetch-free. Thread history is hydrated once per
-        // actor lifetime in PerformOneShotHydrationAsync (driven by the
+        // actor lifetime by the hydration engine (driven by the
         // RecoveryCompleted handler); the only exception is a deferred
-        // hydration, which ApplyDeferredHydrationAsync completes on the first
-        // authorized inbound. By the time we get here the session already has
-        // the historical context it needs.
+        // hydration, which the engine completes on the first authorized
+        // inbound. By the time we get here the session already has the
+        // historical context it needs.
         var input = new ChannelInput
         {
             SenderId = new SenderId(message.SenderId.Value),
@@ -378,7 +405,7 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         // MentionRequiredInThread the conversation actor forwards only mentions here,
         // so every inbound is a deliberate re-entry. _turnInFlight guards against a
         // re-arm while a prior turn is still processing, preserving the PR #733
-        // no-duplicate invariant; ApplyDeferredHydrationAsync no-ops on an empty gap.
+        // no-duplicate invariant; the deferred hydration no-ops on an empty gap.
         //
         // Two accepted trade-offs of reusing the existing backfill (vs. a new
         // drop-tracking side channel): (1) one thread-history fetch per mention on an
@@ -395,23 +422,21 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
             _hydrationPending = true;
         }
 
-        if (_hydrationPending && IsAuthorizedSender(message.SenderId.Value))
-            input = await ApplyDeferredHydrationAsync(input, message.EventId.Value, inboundCts.Token);
+        if (_hydrationPending
+            && IsAuthorizedSender(message.SenderId.Value)
+            && _hydrationEngine is { } engine)
+        {
+            input = await engine.ApplyDeferredHydrationAsync(input, message.EventId.Value, inboundCts.Token);
+        }
 
         try
         {
             using var writeCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await writer.WriteAsync(input, writeCts.Token);
-            _turnInFlight = true;
             ChannelTelemetry.For(ChannelType.Mattermost).RecordMessageEnqueued();
 
             var eventId = message.EventId.Value;
-            if (!string.IsNullOrEmpty(eventId))
-            {
-                if (_pendingCursorPostId is null
-                    || string.CompareOrdinal(eventId, _pendingCursorPostId) > 0)
-                    _pendingCursorPostId = eventId;
-            }
+            AdvancePendingCursorForEnqueuedTurn(string.IsNullOrEmpty(eventId) ? null : eventId);
         }
         catch (OperationCanceledException)
         {
@@ -425,340 +450,11 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         }
     }
 
-    /// <summary>
-    /// One-shot thread history hydration. Runs once per actor lifetime, in the
-    /// Hydrating behavior immediately after pipeline initialization. Fetches
-    /// thread history, computes the gap relative to the recovered cursor, and
-    /// if there is an authorized message in the gap, synthesizes one backfill
-    /// <see cref="ChannelInput"/> using that message as the trigger and older
-    /// gap messages as adopted context. Hands the synthesized input to the
-    /// session pipeline through the normal input-queue path.
-    /// </summary>
-    private async Task PerformOneShotHydrationAsync()
-    {
-        if (_dependencies.ThreadHistoryFetcher is not { } fetcher)
-            return;
-
-        using var cts = new CancellationTokenSource(InboundProcessingTimeout);
-
-        IReadOnlyList<ChannelInput> history;
-        try
-        {
-            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Warning(ex, "Thread history fetch failed for session {SessionId}", _sessionId.Value);
-            return;
-        }
-
-        if (history.Count == 0)
-        {
-            _log.Info(
-                "Thread history hydration: empty thread, no backfill cursor={Cursor} session={Session}",
-                _cursorPostId ?? "none", _sessionId.Value);
-            return;
-        }
-
-        var cursor = _cursorPostId;
-        var candidates = new List<ChannelInput>(history.Count);
-        foreach (var item in history)
-        {
-            var itemId = item.MessageId ?? string.Empty;
-            if (string.IsNullOrEmpty(itemId))
-                continue;
-
-            // Strict: only include messages newer than the cursor. PR #733's
-            // "cursor advances only on TurnCompleted" guarantees that
-            // itemId == cursor means the session already has that message
-            // persisted — re-including it here on a restart hydration would
-            // duplicate it. The in-flight-crash case is handled too: a turn
-            // that didn't complete leaves the cursor un-advanced, so the
-            // message has itemId > cursor and is correctly included in the gap.
-            // Mattermost post IDs are lexicographically sortable strings.
-            if (cursor is not null && string.CompareOrdinal(itemId, cursor) <= 0)
-                continue;
-
-            candidates.Add(item);
-        }
-
-        if (candidates.Count == 0)
-        {
-            _log.Info(
-                "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor} session={Session}",
-                history.Count, cursor ?? "none", _sessionId.Value);
-            return;
-        }
-
-        var classified = await ClassifyGapAsync(candidates, cts.Token);
-        var gap = classified.Gap;
-
-        _log.Info(
-            "Thread history hydration fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
-            history.Count, candidates.Count, gap.Count, classified.BlockedForRisk, cursor ?? "none", _sessionId.Value);
-
-        if (classified.DetectorUnavailable)
-            await SafeReplyAsync(BackfillDetectorWarning);
-
-        if (gap.Count == 0)
-            return;
-
-        // Locate the most recent authorized message in the gap — it plays the
-        // role of the "current authorized message" that adopted-context normally
-        // anchors around. Without one we have no authorized trigger to enqueue;
-        // we transition to Active and let the next live authorized inbound be
-        // the trigger.
-        AdoptedContextMessage? trigger = null;
-        for (var i = gap.Count - 1; i >= 0; i--)
-        {
-            if (gap[i].AuthorityAtInclusion == AdoptedMessageAuthority.Authorized)
-            {
-                trigger = gap[i];
-                break;
-            }
-        }
-
-        if (trigger is null)
-        {
-            // Deferred: a non-empty gap with no authorized trigger. The
-            // proactive-thread case — the binding actor's lifetime began when
-            // the agent posted the thread root, so this hydration ran before
-            // any authorized human inbound existed. Re-arm so the first
-            // authorized inbound performs this hydration (adopting the gap,
-            // e.g. the bot-authored root) instead of taking the fetch-free path.
-            _hydrationPending = true;
-            _log.Info("Thread history hydration: no authorized message in gap; re-armed for next authorized inbound session={Session}", _sessionId.Value);
-            return;
-        }
-
-        var adoptedContext = new List<AdoptedContextMessage>();
-        foreach (var item in gap)
-        {
-            if (ReferenceEquals(item, trigger))
-                break;
-            adoptedContext.Add(item);
-        }
-
-        var triggerInput = trigger.Input;
-        var triggerPostId = triggerInput.MessageId;
-        var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
-
-        if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
-        {
-            _log.Info("Skipping hydration backfill enqueue while restart drain is active: {Reason}", ingressClosedReason);
-            return;
-        }
-
-        var writer = _handle.InputQueue;
-        if (writer is null)
-        {
-            _log.Warning("Input queue is not initialized; skipping hydration backfill");
-            return;
-        }
-
-        try
-        {
-            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
-            writeCts.CancelAfter(TimeSpan.FromSeconds(10));
-            await writer.WriteAsync(backfillInput, writeCts.Token);
-            // A hydration backfill is an in-flight turn too; mirror the live-inbound
-            // enqueue so a mention arriving before this turn completes does not re-arm.
-            _turnInFlight = true;
-
-            if (!string.IsNullOrEmpty(triggerPostId))
-            {
-                if (_pendingCursorPostId is null
-                    || string.CompareOrdinal(triggerPostId, _pendingCursorPostId) > 0)
-                    _pendingCursorPostId = triggerPostId;
-            }
-
-            _log.Info(
-                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
-                triggerInput.MessageId, adoptedContext.Count, _sessionId.Value);
-            ChannelTelemetry.For(ChannelType.Mattermost).RecordMessageEnqueued();
-        }
-        catch (OperationCanceledException ex)
-        {
-            _log.Warning(ex, "Timed out enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
-        }
-        catch (ChannelClosedException ex)
-        {
-            _log.Warning(ex, "Input queue closed while enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
-        }
-    }
-
-    /// <summary>
-    /// Completes a thread-history hydration that <see cref="PerformOneShotHydrationAsync"/>
-    /// deferred for lack of an authorized trigger (<see cref="_hydrationPending"/>).
-    /// This authorized inbound is the executable trigger; the thread gap strictly
-    /// before it — most importantly a proactively-posted bot-authored root — is
-    /// fetched, classified, and merged as its adopted-context window. On fetch
-    /// failure the turn proceeds un-enriched and hydration stays re-armed so a
-    /// later authorized inbound retries.
-    /// </summary>
-    private async Task<ChannelInput> ApplyDeferredHydrationAsync(
-        ChannelInput baseInput,
-        string liveMessageId,
-        CancellationToken cancellationToken)
-    {
-        if (_dependencies.ThreadHistoryFetcher is not { } fetcher)
-            return baseInput;
-
-        // Without the live message's ordering key the gap below it cannot be
-        // bounded; leave hydration re-armed and take the fetch-free path.
-        if (string.IsNullOrEmpty(liveMessageId))
-            return baseInput;
-
-        IReadOnlyList<ChannelInput> history;
-        try
-        {
-            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            // Non-fatal: execute the turn without an adopted window and keep
-            // hydration re-armed so a later authorized inbound retries.
-            _log.Warning(ex, "Re-armed thread history fetch failed for session {SessionId}", _sessionId.Value);
-            return baseInput;
-        }
-
-        // Fetch succeeded: hydration is complete. Only a fetch failure (caught
-        // above) keeps the flag armed — classify/merge outcomes never re-arm.
-        _hydrationPending = false;
-
-        var cursor = _cursorPostId;
-        var candidates = new List<ChannelInput>(history.Count);
-        foreach (var item in history)
-        {
-            var itemId = item.MessageId ?? string.Empty;
-            if (string.IsNullOrEmpty(itemId))
-                continue;
-
-            // Strictly above the watermark and strictly below the live inbound:
-            // the live inbound is the executable message, not adopted context.
-            if (cursor is not null && string.CompareOrdinal(itemId, cursor) <= 0)
-                continue;
-            if (string.CompareOrdinal(itemId, liveMessageId) >= 0)
-                continue;
-
-            candidates.Add(item);
-        }
-
-        if (candidates.Count == 0)
-            return baseInput;
-
-        var classified = await ClassifyGapAsync(candidates, cancellationToken);
-        if (classified.DetectorUnavailable)
-            await SafeReplyAsync(BackfillDetectorWarning);
-
-        if (classified.Gap.Count == 0)
-            return baseInput;
-
-        _log.Info(
-            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
-            classified.Gap.Count,
-            baseInput.MessageId,
-            _sessionId.Value);
-
-        return MergeAdoptedContext(baseInput, classified.Gap, cursor);
-    }
-
-    private Task<Classification> ClassifyGapMessageAsync(ChannelInput input, CancellationToken cancellationToken)
-    {
-        var text = string.Join("\n", input.Contents
-            .OfType<TextContent>()
-            .Select(t => t.Text)
-            .Where(t => !string.IsNullOrWhiteSpace(t)));
-
-        return PromptClassifier.ClassifyAsync(
-            _promptInjectionDetector, text, "mattermost-backfill", _log, cancellationToken);
-    }
-
     // Mattermost authorization basis for adopted-context: an empty AllowedUserIds
     // list means the instance is unrestricted; otherwise the sender must be listed.
     private bool IsAuthorizedSender(string senderId)
         => _dependencies.Options.AllowedUserIds.Length == 0
             || _dependencies.Options.AllowedUserIds.Contains(senderId, StringComparer.Ordinal);
-
-    private readonly record struct GapClassification(
-        List<AdoptedContextMessage> Gap,
-        int BlockedForRisk,
-        bool DetectorUnavailable);
-
-    /// <summary>
-    /// Runs prompt-injection classification over candidate gap messages and
-    /// captures each surviving message's authority-at-inclusion. Blocked
-    /// messages are dropped; detector-unavailable messages are also dropped
-    /// and surface a caller-visible flag.
-    /// </summary>
-    private async Task<GapClassification> ClassifyGapAsync(
-        IReadOnlyList<ChannelInput> candidates,
-        CancellationToken cancellationToken)
-    {
-        var classifications = await Task.WhenAll(
-            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
-
-        var gap = new List<AdoptedContextMessage>(candidates.Count);
-        var blockedForRisk = 0;
-        var detectorUnavailable = false;
-        for (var i = 0; i < candidates.Count; i++)
-        {
-            switch (classifications[i].Outcome)
-            {
-                case ClassificationOutcome.Allow:
-                    var authority = IsAuthorizedSender(candidates[i].SenderId.Value)
-                        ? AdoptedMessageAuthority.Authorized
-                        : AdoptedMessageAuthority.Pending;
-                    gap.Add(new AdoptedContextMessage(candidates[i], authority));
-                    break;
-
-                case ClassificationOutcome.Block:
-                    blockedForRisk++;
-                    _log.Warning(
-                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
-                        candidates[i].SenderId,
-                        candidates[i].MessageId ?? "none",
-                        classifications[i].Reason ?? "high-risk pattern detected");
-                    break;
-
-                case ClassificationOutcome.DetectorUnavailable:
-                    blockedForRisk++;
-                    detectorUnavailable = true;
-                    break;
-            }
-        }
-
-        return new GapClassification(gap, blockedForRisk, detectorUnavailable);
-    }
-
-    /// <summary>
-    /// Merges <paramref name="adoptedContext"/> as the adopted-context window
-    /// preceding <paramref name="triggerInput"/> (the executable message) and
-    /// returns the trigger input with adopted-context metadata populated.
-    /// </summary>
-    private static ChannelInput MergeAdoptedContext(
-        ChannelInput triggerInput,
-        List<AdoptedContextMessage> adoptedContext,
-        string? cursor)
-    {
-        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            adoptedContext,
-            triggerInput.Contents,
-            triggerInput.SenderId.Value,
-            triggerInput.ReceivedAt);
-
-        return triggerInput with
-        {
-            Contents = merged.Contents,
-            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(
-                id => !string.Equals(id, triggerInput.SenderId.Value, StringComparison.Ordinal)),
-            AdoptedSpeakerIds = merged.SpeakerIds,
-            AdoptedContextProjection = merged.Projection,
-            AdoptedContextLowerBound = cursor,
-            AdoptedContextUpperBound = triggerInput.MessageId,
-            AdoptedContextEntries = merged.Entries
-        };
-    }
 
     private async Task<bool> TryHandleTextApprovalResponseAsync(MattermostThreadInbound message)
     {
@@ -1580,6 +1276,24 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
 
     internal static List<string> ChunkMessage(string text) =>
         MessageChunker.Chunk(text, MaxMattermostPostLength);
+
+    /// <summary>
+    /// Records that a turn went into the input queue. The turn-in-flight flag
+    /// guards the mention re-arm path; the pending cursor keeps the highest
+    /// post id of the turn and only becomes the persisted cursor on
+    /// TurnCompleted.
+    /// </summary>
+    private void AdvancePendingCursorForEnqueuedTurn(string? candidatePostId)
+    {
+        _turnInFlight = true;
+
+        if (candidatePostId is null)
+            return;
+
+        if (_pendingCursorPostId is null
+            || string.CompareOrdinal(candidatePostId, _pendingCursorPostId) > 0)
+            _pendingCursorPostId = candidatePostId;
+    }
 
     private void AdvanceCursor(string candidatePostId)
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -59,8 +59,15 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private bool _hasObservedApprovalRequest;
 
     private readonly SessionPipelineHandle _handle;
+    private readonly ThreadGapHydrationEngine _hydrationEngine;
     private SlackEventTs? _cursorTs;
     private SlackEventTs? _pendingCursorTs;
+
+    // A Slack ts is decimal seconds, so two ts values order by numeric value,
+    // not by ordinal text. SlackEventTs.CompareTo owns that rule; the hydration
+    // engine compares cursor keys through this wrapper.
+    private static readonly IComparer<string> CursorComparer =
+        Comparer<string>.Create((x, y) => new SlackEventTs(x).CompareTo(new SlackEventTs(y)));
 
     // Reliable in-flight-turn signal for the mention re-arm guard: set when ANY
     // inbound is enqueued (unlike _pendingCursorTs, which is only set for inbounds
@@ -113,6 +120,24 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             .WithContext(NetclawLogProperties.SessionId, _sessionId.Value)
             .WithContext("SlackChannelId", _channelId)
             .WithContext("SlackThreadTs", _threadTs);
+
+        _hydrationEngine = new ThreadGapHydrationEngine(
+            sessionId: _sessionId,
+            channelType: ChannelType.Slack,
+            historyFetcher: _dependencies.ThreadHistoryFetcher,
+            injectionDetector: _promptInjectionDetector,
+            classifierSourceContext: "slack-backfill",
+            cursorComparer: CursorComparer,
+            cursorKeySelector: messageId => new SlackEventId(messageId ?? string.Empty).TryGetEventTs()?.Value,
+            isAuthorizedSender: senderId =>
+                SlackAclPolicy.IsAllowedUser(new SlackUserId(senderId), _dependencies.Options),
+            log: _log,
+            readCursor: () => _cursorTs?.Value,
+            readInputQueue: () => _handle.InputQueue,
+            readIngressClosedReason: () => _dependencies.IngressGate?.ClosedReason,
+            warnBackfillDetectorUnavailableAsync: () => SafePostAsync(BackfillDetectorWarning),
+            onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
+            setHydrationPending: pending => _hydrationPending = pending);
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
         Recover<PendingApprovalPromptTracked>(ApplyPendingApprovalPromptTracked);
@@ -182,7 +207,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         {
             try
             {
-                await PerformOneShotHydrationAsync();
+                await _hydrationEngine.PerformOneShotHydrationAsync();
             }
             catch (Exception ex)
             {
@@ -414,8 +439,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             // MentionRequiredInThread the conversation actor forwards only mentions here,
             // so every inbound is a deliberate re-entry. _turnInFlight guards against a
             // re-arm while a prior turn is still processing, preserving the PR #733
-            // no-duplicate invariant; BuildInputWithDeferredHydrationAsync no-ops on an
-            // empty gap.
+            // no-duplicate invariant; the deferred hydration no-ops on an empty gap.
             //
             // Two accepted trade-offs of reusing the existing backfill (vs. a new
             // drop-tracking side channel): (1) one thread-history fetch per mention on an
@@ -432,14 +456,13 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 _hydrationPending = true;
             }
 
-            var buildResult = _hydrationPending
-                && SlackAclPolicy.IsAllowedUser(new SlackUserId(message.SenderId.Value), _dependencies.Options)
-                ? await BuildInputWithDeferredHydrationAsync(message, contents, currentTs, inboundCts.Token)
-                : BuildInputForInbound(message, contents);
-            var input = buildResult.Input;
-
-            if (buildResult.BackfillDetectorUnavailable)
-                await SafePostAsync(BackfillDetectorWarning);
+            var input = BuildInputForInbound(message, contents);
+            if (_hydrationPending
+                && SlackAclPolicy.IsAllowedUser(new SlackUserId(message.SenderId.Value), _dependencies.Options))
+            {
+                input = await _hydrationEngine.ApplyDeferredHydrationAsync(
+                    input, message.EventId.Value, inboundCts.Token);
+            }
 
             try
             {
@@ -447,15 +470,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 queueWriteCts.CancelAfter(OperationTimeout);
 
                 await writer.WriteAsync(input, queueWriteCts.Token);
-                _turnInFlight = true;
 
                 // Defer cursor persistence until TurnCompleted confirms durable turn recording,
                 // otherwise a crash between cursor and turn persist loses messages.
-                if (currentTs is { } ts)
-                {
-                    if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
-                        _pendingCursorTs = ts;
-                }
+                AdvancePendingCursorForEnqueuedTurn(currentTs?.Value);
 
                 QueueProcessingIndicatorRefreshIfActive();
             }
@@ -631,7 +649,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             initCts.Token);
     }
 
-    private InboundBuildResult BuildInputForInbound(
+    private ChannelInput BuildInputForInbound(
         SlackThreadInbound triggeringMessage,
         IReadOnlyList<AIContent> liveContents)
     {
@@ -660,7 +678,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             DefaultDeliveryTarget = BuildDefaultDeliveryTarget()
         };
 
-        return new InboundBuildResult(baseInput, false);
+        return baseInput;
     }
 
     private ChannelDeliveryTargetInfo BuildDefaultDeliveryTarget()
@@ -672,326 +690,20 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             _threadTs.Value);
 
     /// <summary>
-    /// One-shot thread history hydration. Runs once per actor lifetime, in the
-    /// Hydrating behavior immediately after pipeline initialization. Fetches
-    /// thread history, computes the gap relative to the recovered cursor, and
-    /// if there is an authorized message in the gap, synthesizes one backfill
-    /// <see cref="ChannelInput"/> using that message as the trigger and older
-    /// gap messages as adopted context. Hands the synthesized input to the
-    /// session pipeline through the normal input-queue path.
+    /// Records that a turn went into the input queue. The turn-in-flight flag
+    /// guards the mention re-arm path; the pending cursor keeps the highest ts
+    /// of the turn and only becomes the persisted cursor on TurnCompleted.
     /// </summary>
-    private async Task PerformOneShotHydrationAsync()
+    private void AdvancePendingCursorForEnqueuedTurn(string? candidateTs)
     {
-        using var cts = new CancellationTokenSource(InboundProcessingTimeout);
+        _turnInFlight = true;
 
-        IReadOnlyList<ChannelInput> history;
-        try
-        {
-            history = await _dependencies.ThreadHistoryFetcher.FetchThreadHistoryAsync(_sessionId, cts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Warning(ex, "Thread history fetch failed for session {SessionId}", _sessionId.Value);
-            return;
-        }
-
-        if (history.Count == 0)
-        {
-            _log.Info("Thread history hydration: empty thread, no backfill cursor={Cursor}", _cursorTs?.Value ?? "none");
-            return;
-        }
-
-        var cursor = _cursorTs;
-        var candidates = new List<ChannelInput>(history.Count);
-        foreach (var item in history)
-        {
-            if (new SlackEventId(item.MessageId ?? string.Empty).TryGetEventTs() is not { } itemTs)
-                continue;
-
-            // Strict: only include messages newer than the cursor. PR #733's
-            // "cursor advances only on TurnCompleted" guarantees that
-            // ts == cursor means the session already has that message persisted
-            // — re-including it here on a restart hydration would duplicate it.
-            // The in-flight-crash case is handled too: a turn that didn't
-            // complete leaves the cursor un-advanced, so the message has
-            // ts > cursor and is correctly included in the gap.
-            if (cursor is { } c && itemTs.CompareTo(c) <= 0)
-                continue;
-
-            candidates.Add(item);
-        }
-
-        if (candidates.Count == 0)
-        {
-            _log.Info(
-                "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor}",
-                history.Count, cursor?.Value ?? "none");
-            return;
-        }
-
-        var classified = await ClassifyGapAsync(candidates, cts.Token);
-        var gap = classified.Gap;
-
-        _log.Info(
-            "Thread history hydration fetched={FetchedCount} gapCount={GapCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor}",
-            history.Count, gap.Count, classified.BlockedForRisk, cursor?.Value ?? "none");
-
-        if (classified.DetectorUnavailable)
-            await SafePostAsync(BackfillDetectorWarning);
-
-        if (gap.Count == 0)
+        if (candidateTs is null)
             return;
 
-        // Locate the most recent authorized message in the gap — it plays the
-        // role of the "current authorized message" that adopted-context normally
-        // anchors around. Without one we have no authorized trigger to enqueue;
-        // we transition to Active and let the next live authorized inbound be
-        // the trigger (the cursor stays put, so staleness still drops anything
-        // already seen).
-        AdoptedContextMessage? trigger = null;
-        for (var i = gap.Count - 1; i >= 0; i--)
-        {
-            if (gap[i].AuthorityAtInclusion == AdoptedMessageAuthority.Authorized)
-            {
-                trigger = gap[i];
-                break;
-            }
-        }
-
-        if (trigger is null)
-        {
-            // Deferred: a non-empty gap with no authorized trigger. The
-            // proactive-thread case — the binding actor's lifetime began when
-            // the agent posted the thread root, so this hydration ran before
-            // any authorized human inbound existed. Re-arm so the first
-            // authorized inbound performs this hydration (adopting the gap,
-            // e.g. the bot-authored root) instead of taking the fetch-free path.
-            _hydrationPending = true;
-            _log.Info("Thread history hydration: no authorized message in gap; re-armed for next authorized inbound");
-            return;
-        }
-
-        var adoptedContext = new List<AdoptedContextMessage>();
-        foreach (var item in gap)
-        {
-            if (ReferenceEquals(item, trigger))
-                break;
-            adoptedContext.Add(item);
-        }
-
-        // Build the synthesized inbound. The trigger's ChannelInput already
-        // carries its own text+attachment contents (loaded by the history
-        // fetcher), so we treat those as the "live" contents for the merge.
-        var triggerInput = trigger.Input;
-        var triggerTs = new SlackEventId(triggerInput.MessageId ?? string.Empty).TryGetEventTs();
-        var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
-
-        if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
-        {
-            _log.Info("Skipping hydration backfill enqueue while restart drain is active: {Reason}", ingressClosedReason);
-            return;
-        }
-
-        var writer = _handle.InputQueue;
-        if (writer is null)
-        {
-            _log.Warning("Input queue is not initialized; skipping hydration backfill");
-            return;
-        }
-
-        try
-        {
-            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
-            writeCts.CancelAfter(OperationTimeout);
-            await writer.WriteAsync(backfillInput, writeCts.Token);
-            // A hydration backfill is an in-flight turn too; mirror the live-inbound
-            // enqueue so a mention arriving before this turn completes does not re-arm.
-            _turnInFlight = true;
-
-            if (triggerTs is { } ts)
-            {
-                if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
-                    _pendingCursorTs = ts;
-            }
-
-            _log.Info(
-                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount}",
-                triggerInput.MessageId,
-                adoptedContext.Count);
-            ChannelTelemetry.For(ChannelType.Slack).RecordMessageEnqueued();
-        }
-        catch (OperationCanceledException ex)
-        {
-            _log.Warning(ex, "Timed out enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
-        }
-        catch (ChannelClosedException ex)
-        {
-            _log.Warning(ex, "Input queue closed while enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
-        }
-    }
-
-    private Task<Classification> ClassifyGapMessageAsync(ChannelInput input, CancellationToken cancellationToken)
-    {
-        var text = string.Join("\n", input.Contents
-            .OfType<TextContent>()
-            .Select(t => t.Text)
-            .Where(t => !string.IsNullOrWhiteSpace(t)));
-
-        return PromptClassifier.ClassifyAsync(
-            _promptInjectionDetector, text, "slack-backfill", _log, cancellationToken);
-    }
-
-    private readonly record struct GapClassification(
-        List<AdoptedContextMessage> Gap,
-        int BlockedForRisk,
-        bool DetectorUnavailable);
-
-    /// <summary>
-    /// Runs prompt-injection classification over candidate gap messages and
-    /// captures each surviving message's authority-at-inclusion. Blocked
-    /// messages are dropped; detector-unavailable messages are also dropped
-    /// and surface a caller-visible flag.
-    /// </summary>
-    private async Task<GapClassification> ClassifyGapAsync(
-        IReadOnlyList<ChannelInput> candidates,
-        CancellationToken cancellationToken)
-    {
-        var classifications = await Task.WhenAll(
-            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
-
-        var gap = new List<AdoptedContextMessage>(candidates.Count);
-        var blockedForRisk = 0;
-        var detectorUnavailable = false;
-        for (var i = 0; i < candidates.Count; i++)
-        {
-            var item = candidates[i];
-            switch (classifications[i].Outcome)
-            {
-                case ClassificationOutcome.Allow:
-                    var authority = SlackAclPolicy.IsAllowedUser(new SlackUserId(item.SenderId.Value), _dependencies.Options)
-                        ? AdoptedMessageAuthority.Authorized
-                        : AdoptedMessageAuthority.Pending;
-                    gap.Add(new AdoptedContextMessage(item, authority));
-                    break;
-
-                case ClassificationOutcome.Block:
-                    blockedForRisk++;
-                    _log.Warning(
-                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
-                        item.SenderId,
-                        item.MessageId ?? "none",
-                        classifications[i].Reason ?? "high-risk pattern detected");
-                    break;
-
-                case ClassificationOutcome.DetectorUnavailable:
-                    blockedForRisk++;
-                    detectorUnavailable = true;
-                    break;
-            }
-        }
-
-        return new GapClassification(gap, blockedForRisk, detectorUnavailable);
-    }
-
-    /// <summary>
-    /// Merges <paramref name="adoptedContext"/> as the adopted-context window
-    /// preceding <paramref name="triggerInput"/> (the executable message) and
-    /// returns the trigger input with adopted-context metadata populated.
-    /// </summary>
-    private static ChannelInput MergeAdoptedContext(
-        ChannelInput triggerInput,
-        List<AdoptedContextMessage> adoptedContext,
-        SlackEventTs? cursor)
-    {
-        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            adoptedContext,
-            triggerInput.Contents,
-            triggerInput.SenderId.Value,
-            triggerInput.ReceivedAt);
-
-        return triggerInput with
-        {
-            Contents = merged.Contents,
-            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(
-                id => !string.Equals(id, triggerInput.SenderId.Value, StringComparison.Ordinal)),
-            AdoptedSpeakerIds = merged.SpeakerIds,
-            AdoptedContextProjection = merged.Projection,
-            AdoptedContextLowerBound = cursor?.Value,
-            AdoptedContextUpperBound = triggerInput.MessageId,
-            AdoptedContextEntries = merged.Entries
-        };
-    }
-
-    /// <summary>
-    /// Completes a thread-history hydration that <see cref="PerformOneShotHydrationAsync"/>
-    /// deferred for lack of an authorized trigger (<see cref="_hydrationPending"/>).
-    /// This authorized inbound is the executable trigger; the thread gap strictly
-    /// before it — most importantly a proactively-posted bot-authored root —
-    /// is fetched, classified, and merged as its adopted-context window. On
-    /// fetch failure the turn proceeds without an adopted window and hydration
-    /// stays re-armed so a later authorized inbound retries.
-    /// </summary>
-    private async Task<InboundBuildResult> BuildInputWithDeferredHydrationAsync(
-        SlackThreadInbound message,
-        IReadOnlyList<AIContent> liveContents,
-        SlackEventTs? liveTs,
-        CancellationToken cancellationToken)
-    {
-        var baseResult = BuildInputForInbound(message, liveContents);
-
-        // Without the live message's ordering key the gap below it cannot be
-        // bounded; leave hydration re-armed and take the fetch-free path.
-        if (liveTs is not { } liveEventTs)
-            return baseResult;
-
-        IReadOnlyList<ChannelInput> history;
-        try
-        {
-            history = await _dependencies.ThreadHistoryFetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            // Non-fatal: execute the turn without an adopted window and keep
-            // hydration re-armed so a later authorized inbound retries.
-            _log.Warning(ex, "Re-armed thread history fetch failed for session {SessionId}", _sessionId.Value);
-            return baseResult;
-        }
-
-        // Fetch succeeded: hydration is complete. Only a fetch failure (caught
-        // above) keeps the flag armed — classify/merge outcomes never re-arm.
-        _hydrationPending = false;
-
-        var cursor = _cursorTs;
-        var candidates = new List<ChannelInput>(history.Count);
-        foreach (var item in history)
-        {
-            if (new SlackEventId(item.MessageId ?? string.Empty).TryGetEventTs() is not { } itemTs)
-                continue;
-
-            // Strictly above the watermark and strictly below the live inbound:
-            // the live inbound is the executable message, not adopted context.
-            if (cursor is { } c && itemTs.CompareTo(c) <= 0)
-                continue;
-            if (itemTs.CompareTo(liveEventTs) >= 0)
-                continue;
-
-            candidates.Add(item);
-        }
-
-        if (candidates.Count == 0)
-            return baseResult;
-
-        var classified = await ClassifyGapAsync(candidates, cancellationToken);
-        if (classified.Gap.Count == 0)
-            return new InboundBuildResult(baseResult.Input, classified.DetectorUnavailable);
-
-        var mergedInput = MergeAdoptedContext(baseResult.Input, classified.Gap, cursor);
-        _log.Info(
-            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId}",
-            classified.Gap.Count,
-            baseResult.Input.MessageId);
-
-        return new InboundBuildResult(mergedInput, classified.DetectorUnavailable);
+        var ts = new SlackEventTs(candidateTs);
+        if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
+            _pendingCursorTs = ts;
     }
 
     private void AdvanceCursor(SlackEventTs candidateTs)
@@ -1042,8 +754,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private void ApplyPendingApprovalPromptCleared(PendingApprovalPromptCleared cleared)
         => PendingApprovalRecovery.ApplyCleared<PendingApprovalRequest, SlackEventTs>(_pendingApprovalRequests, cleared);
-
-    private readonly record struct InboundBuildResult(ChannelInput Input, bool BackfillDetectorUnavailable);
 
     private async Task ReinitializePipelineAsync(string reason)
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -47,15 +47,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     // same session concurrently — a single field would be clobbered.
     private readonly Dictionary<ReminderId, IActorRef> _reminderDeliveryObservers = new();
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
+    private readonly ApprovalResponseFlow<PendingApprovalRequest, SlackEventTs> _approvalFlow;
 
-    // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
-    // A binding that has never observed any ToolInteractionRequest treats an
-    // inbound "A"/"B"/"C" as a possible cold approval reply for a session that
-    // restarted out from under it. Once we've observed at least one prompt,
-    // subsequent ambiguous text from the user is ordinary conversation, not an
-    // approval reply, so the cold path stays off. This does NOT gate button
-    // clicks — those always route to the session, which is the authority on
-    // CallId staleness.
+    // Gates the text-approval cold path. The gate rule lives with the cold path
+    // in ApprovalResponseFlow.
     private bool _hasObservedApprovalRequest;
 
     private readonly SessionPipelineHandle _handle;
@@ -94,6 +89,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private const string BackfillDetectorWarning = ":warning: I couldn't safely analyze some earlier thread messages, so they were excluded from context.";
     private const string LiveDetectorUnavailableWarning = ":warning: I couldn't safely analyze your message — please try again in a moment.";
     private const string LiveInjectionBlockedWarning = ":warning: Message blocked by prompt-injection policy.";
+    private const string WrongRequesterWarning = ":warning: Only the requesting user can approve this tool action.";
 
     public ITimerScheduler Timers { get; set; } = null!;
 
@@ -138,6 +134,25 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             warnBackfillDetectorUnavailableAsync: () => SafePostAsync(BackfillDetectorWarning),
             onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
             setHydrationPending: pending => _hydrationPending = pending);
+
+        _approvalFlow = new ApprovalResponseFlow<PendingApprovalRequest, SlackEventTs>(
+            sessionId: _sessionId,
+            channelType: ChannelType.Slack,
+            channelName: "Slack",
+            pipeline: _dependencies.Pipeline,
+            operationTimeout: OperationTimeout,
+            pendingRequests: _pendingApprovalRequests,
+            // Slack resolves the earliest matching prompt, which is the order its
+            // own lookup used before the extraction. Discord and Mattermost
+            // resolve the most recent one.
+            matchOrder: ApprovalMatchOrder.Oldest,
+            hasObservedApprovalRequest: () => _hasObservedApprovalRequest,
+            postWrongRequesterWarningAsync: () => SafePostAsync(WrongRequesterWarning),
+            persistPromptCleared: callId => Persist(
+                new PendingApprovalPromptCleared { CallId = callId.Value },
+                ApplyPendingApprovalPromptCleared),
+            renderResolvedPromptAsync: TryResolveApprovalPromptAsync,
+            log: _log);
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
         Recover<PendingApprovalPromptTracked>(ApplyPendingApprovalPromptTracked);
@@ -1038,265 +1053,17 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             _threadTs.Value);
     }
 
-    private async Task<bool> TryHandleTextApprovalResponseAsync(SlackThreadInbound message)
-    {
-        if (_pendingApprovalRequests.Count == 0)
-        {
-            return !_hasObservedApprovalRequest
-                && await TryHandleColdTextApprovalResponseAsync(message);
-        }
+    private Task<bool> TryHandleTextApprovalResponseAsync(SlackThreadInbound message)
+        => _approvalFlow.TryHandleTextApprovalResponseAsync(message.Text, message.SenderId.Value);
 
-        var pendingIndex = _pendingApprovalRequests.FindIndex(request =>
-            ApprovalButtonValueCodec.CanApprove(request.RequesterPrincipal, request.RequesterSenderId, message.SenderId.Value));
-
-        if (pendingIndex < 0)
-        {
-            await SafePostAsync(":warning: Only the requesting user can approve this tool action.");
-            return true;
-        }
-
-        var pending = _pendingApprovalRequests[pendingIndex];
-
-        if (!ToolInteractionResponseParser.TryParseApprovalResponse(
-                message.Text ?? string.Empty,
-                pending.Options,
-                out var selectedKey)
-            || selectedKey is null)
-        {
-            return false;
-        }
-
-        try
-        {
-            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-            var feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(
-                new ToolInteractionResponse
-                {
-                    SessionId = _sessionId,
-                    CallId = pending.CallId,
-                    SelectedKey = new Actors.Protocol.ApprovalOptionKey(selectedKey),
-                    SenderId = message.SenderId
-                }, feedbackCts.Token);
-
-            switch (feedbackResult)
-            {
-                case CommandNack nack:
-                    if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
-                        await SafePostAsync(":warning: Only the requesting user can approve this tool action.");
-                    _log.Info(
-                        "Session rejected Slack text approval response for call {CallId} reason={Reason}; skipping redraw",
-                        pending.CallId,
-                        nack.Reason ?? "<none>");
-                    return true;
-
-                case not CommandAck:
-                    _log.Warning(
-                        "Slack text approval response for call {CallId} returned unexpected feedback result {ResultType}",
-                        pending.CallId,
-                        feedbackResult.GetType().Name);
-                    return true;
-            }
-
-            _pendingApprovalRequests.RemoveAt(pendingIndex);
-            Persist(new PendingApprovalPromptCleared
-            {
-                CallId = pending.CallId.Value
-            }, ApplyPendingApprovalPromptCleared);
-
-            await TryResolveApprovalPromptAsync(
-                pending.PromptMessageTs,
-                pending.Request,
-                pending.CallId,
-                selectedKey,
-                message.SenderId.Value,
-                persistedToolName: pending.ToolName,
-                persistedDisplayText: pending.DisplayText);
-
-            _log.Info(
-                "Recorded Slack approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
-                pending.CallId,
-                message.SenderId,
-                selectedKey);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route Slack approval response for call {CallId}", pending.CallId);
-        }
-
-        return true;
-    }
-
-    private async Task<bool> TryHandleColdTextApprovalResponseAsync(SlackThreadInbound message)
-    {
-        if (!ToolInteractionResponseParser.LooksLikeApprovalResponse(message.Text ?? string.Empty))
-            return false;
-
-        using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-        try
-        {
-            var reply = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(new ToolInteractionTextResponse
-            {
-                SessionId = _sessionId,
-                Text = message.Text ?? string.Empty,
-                SenderId = message.SenderId
-            }, feedbackCts.Token);
-
-            if (reply is CommandAck)
-            {
-                _log.Info(
-                    "Forwarded cold Slack text approval response from sender={SenderId} without local pending prompt state",
-                    message.SenderId);
-                return true;
-            }
-
-            // approval_no_history means the session has never had an approval request.
-            // The message was a false-positive from LooksLikeApprovalResponse.
-            // Don't consume — let it fall through to normal LLM ingress. See #1164.
-            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
-                return false;
-
-            return reply is CommandNack;
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route cold Slack text approval response from sender {SenderId}", message.SenderId);
-            return false;
-        }
-    }
-
-    private async Task HandleApprovalResponseAsync(SlackApprovalResponse message)
-    {
-        var pendingIndex = _pendingApprovalRequests.FindIndex(request =>
-            request.CallId == message.CallId);
-        var pending = pendingIndex >= 0 ? _pendingApprovalRequests[pendingIndex] : null;
-
-        // CanApprove fast-path: if the binding still holds the original request we can
-        // post the wrong-requester warning locally without round-tripping through the
-        // session. When the binding has been cold-spawned (no local pending entry) the
-        // session re-runs CanApprove against its own pending-call state, and the wait
-        // below blocks the redraw until the session has actually accepted the click —
-        // see #939 + #979.
-        if (pending is not null && !ApprovalButtonValueCodec.CanApprove(
-                pending.RequesterPrincipal,
-                pending.RequesterSenderId,
-                message.SenderId.Value))
-        {
-            await SafePostAsync(":warning: Only the requesting user can approve this tool action.");
-            return;
-        }
-
-        // Wait for the session before redrawing. This is the security gate that
-        // prevents (a) a non-requester click destroying the prompt UI on the
-        // cold-spawn path, and (b) a stale re-click overwriting an
-        // already-resolved banner — both surfaced by the #939 code review. The
-        // session is the authority on whether the call is still pending and
-        // whether the sender is allowed. Only redraw on CommandAck.
-        ISessionResponse feedbackResult;
-        try
-        {
-            using var feedbackCts = new CancellationTokenSource(OperationTimeout);
-            feedbackResult = await _dependencies.Pipeline.SendFeedbackAndWaitAsync(
-                new ToolInteractionResponse
-                {
-                    SessionId = _sessionId,
-                    CallId = message.CallId,
-                    SelectedKey = new Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
-                    SenderId = message.SenderId
-                }, feedbackCts.Token);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to route Slack button approval response for call {CallId}", message.CallId);
-            return;
-        }
-
-        switch (feedbackResult)
-        {
-            case CommandNack nack:
-                // Session rejected (wrong requester, unknown call, stale resolution).
-                // For wrong-requester surface the warning; for any other reason just
-                // log and DO NOT redraw — the prompt UI must stay consistent with the
-                // session's authoritative state.
-                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
-                    await SafePostAsync(":warning: Only the requesting user can approve this tool action.");
-                _log.Info(
-                    "Session rejected Slack approval response for call {CallId} reason={Reason}; skipping redraw",
-                    message.CallId,
-                    nack.Reason ?? "<none>");
-                return;
-
-            case CommandAck:
-                break;
-
-            default:
-                // ISessionResponse is sealed-by-convention to Ack/Nack. Defensive guard.
-                _log.Warning(
-                    "Slack approval response for call {CallId} returned unexpected feedback result {ResultType}",
-                    message.CallId,
-                    feedbackResult.GetType().Name);
-                return;
-        }
-
-        if (pending is not null)
-        {
-            _pendingApprovalRequests.RemoveAt(pendingIndex);
-            Persist(new PendingApprovalPromptCleared
-            {
-                CallId = pending.CallId.Value
-            }, ApplyPendingApprovalPromptCleared);
-            // Prefer the captured TS, but fall back to the payload's TS when capture
-            // failed (post raced or returned an empty TS). The payload TS is reliable
-            // for a button click since Slack populates it in the envelope.
-            var promptTs = pending.PromptMessageTs ?? message.PromptMessageTs;
-            await TryResolveApprovalPromptAsync(
-                promptTs,
-                pending.Request,
-                pending.CallId,
-                message.SelectedKey,
-                message.SenderId.Value,
-                persistedToolName: pending.ToolName,
-                persistedDisplayText: pending.DisplayText);
-
-            _log.Info(
-                "Recorded Slack button approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
-                pending.CallId,
-                message.SenderId,
-                message.SelectedKey);
-        }
-        else if (message.PromptMessageTs is { } payloadPromptTs)
-        {
-            // Cold-spawn redraw — no local pending entry exists for this CallId
-            // (the journal didn't replay a PendingApprovalPromptTracked event for
-            // it, typically because the binding was re-created without recovery
-            // or the entry was cleared before the click landed). The click
-            // payload still carries the prompt's message TS and the session has
-            // accepted the response; render the generic banner so the buttons
-            // clear. NOTE: pre-0.21 journals that DO replay (with no tool name /
-            // display text) take the upper `pending is not null` branch instead
-            // — they render the generic banner via the !IsNullOrEmpty fallback
-            // inside the builder, not via this branch.
-            await TryResolveApprovalPromptAsync(
-                payloadPromptTs,
-                request: null,
-                message.CallId,
-                message.SelectedKey,
-                message.SenderId.Value);
-
-            _log.Info(
-                "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redrew prompt via payload messageTs={MessageTs}",
-                message.CallId,
-                payloadPromptTs);
-        }
-        else
-        {
-            // Text-reply on a cold-spawned binding: approval routed but no message
-            // TS is available, so the redraw is impossible. Remaining #939 gap.
-            _log.Info(
-                "Forwarded Slack button approval response for call {CallId} to session without local pending entry; redraw skipped",
-                message.CallId);
-            ChannelTelemetry.For(ChannelType.Slack).RecordExtra("interactionErrors", "cold_spawn_redraw_skipped");
-        }
-    }
+    // Slack block actions reach the binding one way through the gateway, so the
+    // flow gets no synchronous-reply hook here.
+    private Task HandleApprovalResponseAsync(SlackApprovalResponse message)
+        => _approvalFlow.HandleApprovalResponseAsync(
+            message.CallId,
+            message.SelectedKey,
+            message.SenderId.Value,
+            message.PromptMessageTs);
 
     private async Task<PostResult> SafePostAsync(string text)
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -37,39 +37,26 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     // Slack subscribes to OutputFilter.Text (final assembled text), not TextStreaming.
     private const string EmptyTurnFallbackText = ":warning: I didn't manage to produce a reply. Please try rephrasing or sending your message again.";
     // No streaming state needed — Slack receives TextOutput only, not TextDeltaOutput.
-    private bool _postedThisTurn;
-    private bool _uploadedFileThisTurn;
+
+    // Slack tells the session about a delivery failure at turn completion, not
+    // at post time, so it keeps the failure descriptor of the last failed post.
+    // The engine's per-turn failure flag gates every read of this field, and
+    // both turn-completion hooks clear it.
     private PostResult? _lastFailedPost;
-    // Reply targets for in-flight reminder delivery confirmations, keyed by
-    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
-    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
-    // Keyed (not a single field) because multiple reminders can target the
-    // same session concurrently — a single field would be clobbered.
-    private readonly Dictionary<ReminderId, IActorRef> _reminderDeliveryObservers = new();
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
     private readonly ApprovalResponseFlow<PendingApprovalRequest, SlackEventTs> _approvalFlow;
-
-    // Gates the text-approval cold path. The gate rule lives with the cold path
-    // in ApprovalResponseFlow.
-    private bool _hasObservedApprovalRequest;
+    private readonly ChannelOutputEngine<PendingApprovalRequest, SlackEventTs> _outputEngine;
 
     private readonly SessionPipelineHandle _handle;
     private readonly ThreadGapHydrationEngine _hydrationEngine;
     private SlackEventTs? _cursorTs;
-    private SlackEventTs? _pendingCursorTs;
 
     // A Slack ts is decimal seconds, so two ts values order by numeric value,
     // not by ordinal text. SlackEventTs.CompareTo owns that rule; the hydration
-    // engine compares cursor keys through this wrapper.
+    // engine and the output engine compare cursor keys through this wrapper.
     private static readonly IComparer<string> CursorComparer =
         Comparer<string>.Create((x, y) => new SlackEventTs(x).CompareTo(new SlackEventTs(y)));
 
-    // Reliable in-flight-turn signal for the mention re-arm guard: set when ANY
-    // inbound is enqueued (unlike _pendingCursorTs, which is only set for inbounds
-    // with a parseable ts), cleared when the turn ends. Without it, a null-ts
-    // in-flight turn would leave _pendingCursorTs unset and let a following mention
-    // re-arm mid-turn — the PR #733 no-duplicate hazard.
-    private bool _turnInFlight;
     private volatile bool _processingIndicatorActive;
     private readonly object _processingIndicatorRenderLock = new();
     private Task _processingIndicatorRenderTail = Task.CompletedTask;
@@ -117,6 +104,33 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             .WithContext("SlackChannelId", _channelId)
             .WithContext("SlackThreadTs", _threadTs);
 
+        _outputEngine = new ChannelOutputEngine<PendingApprovalRequest, SlackEventTs>(
+            channelType: ChannelType.Slack,
+            channelName: "Slack",
+            cursorComparer: CursorComparer,
+            pendingRequests: _pendingApprovalRequests,
+            createPendingRequest: request => new PendingApprovalRequest(request),
+            // Slack renders every interaction request as an approval prompt.
+            // Discord and Mattermost render only Kind == "approval".
+            isApprovalRequest: _ => true,
+            renderTextOutput: textOutput =>
+            {
+                var fullText = textOutput.Text?.Trim();
+                return string.IsNullOrWhiteSpace(fullText) ? null : fullText;
+            },
+            renderErrorOutput: error => $":warning: {error.Message} (ref: {error.CorrelationId.ToString("N")[..8]})",
+            postTextAsync: PostOutputTextAsync,
+            uploadFileAsync: UploadOutputFileAsync,
+            postApprovalPromptAsync: HandleApprovalRequestAsync,
+            readPromptIdValue: promptMessageTs => promptMessageTs.Value,
+            onApprovalPromptFailedAsync: SendApprovalDenyOnFailureAsync,
+            persistPromptTracked: tracked => Persist(tracked, ApplyPendingApprovalPromptTracked),
+            handleChannelSpecificOutputAsync: HandleChannelSpecificOutputAsync,
+            advanceCursor: cursor => AdvanceCursor(new SlackEventTs(cursor)),
+            postEmptyTurnFallbackAsync: PostEmptyTurnFallbackAsync,
+            onEmptyTurnSuppressedAsync: NotifyFailedTurnAsync,
+            readObservedAtMs: _ => _dependencies.TimeProvider.GetUtcNow().ToUnixTimeMilliseconds());
+
         _hydrationEngine = new ThreadGapHydrationEngine(
             sessionId: _sessionId,
             channelType: ChannelType.Slack,
@@ -132,7 +146,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             readInputQueue: () => _handle.InputQueue,
             readIngressClosedReason: () => _dependencies.IngressGate?.ClosedReason,
             warnBackfillDetectorUnavailableAsync: () => SafePostAsync(BackfillDetectorWarning),
-            onBackfillEnqueued: AdvancePendingCursorForEnqueuedTurn,
+            onBackfillEnqueued: _outputEngine.AdvancePendingCursorForEnqueuedTurn,
             setHydrationPending: pending => _hydrationPending = pending);
 
         _approvalFlow = new ApprovalResponseFlow<PendingApprovalRequest, SlackEventTs>(
@@ -146,7 +160,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             // own lookup used before the extraction. Discord and Mattermost
             // resolve the most recent one.
             matchOrder: ApprovalMatchOrder.Oldest,
-            hasObservedApprovalRequest: () => _hasObservedApprovalRequest,
+            hasObservedApprovalRequest: () => _outputEngine.HasObservedApprovalRequest,
             postWrongRequesterWarningAsync: () => SafePostAsync(WrongRequesterWarning),
             persistPromptCleared: callId => Persist(
                 new PendingApprovalPromptCleared { CallId = callId.Value },
@@ -339,7 +353,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         if (message.Source.DeliveryObserver is { } deliveryObserver
             && message.Source.ReminderId is { } reminderKey
             && !string.IsNullOrWhiteSpace(reminderKey.Value))
-            _reminderDeliveryObservers[reminderKey] = deliveryObserver;
+            _outputEngine.TrackReminderDeliveryObserver(reminderKey, deliveryObserver);
 
         try
         {
@@ -465,7 +479,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             // mention, not this one (and can be skipped if the cursor later advances past
             // it under rapid concurrent mentions).
             if (!_hydrationPending
-                && !_turnInFlight
+                && !_outputEngine.TurnInFlight
                 && _dependencies.Options.MentionRequiredInThreadFor(_channelId.Value))
             {
                 _hydrationPending = true;
@@ -488,7 +502,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
                 // Defer cursor persistence until TurnCompleted confirms durable turn recording,
                 // otherwise a crash between cursor and turn persist loses messages.
-                AdvancePendingCursorForEnqueuedTurn(currentTs?.Value);
+                _outputEngine.AdvancePendingCursorForEnqueuedTurn(currentTs?.Value);
 
                 QueueProcessingIndicatorRefreshIfActive();
             }
@@ -704,23 +718,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             _channelId.Value,
             _threadTs.Value);
 
-    /// <summary>
-    /// Records that a turn went into the input queue. The turn-in-flight flag
-    /// guards the mention re-arm path; the pending cursor keeps the highest ts
-    /// of the turn and only becomes the persisted cursor on TurnCompleted.
-    /// </summary>
-    private void AdvancePendingCursorForEnqueuedTurn(string? candidateTs)
-    {
-        _turnInFlight = true;
-
-        if (candidateTs is null)
-            return;
-
-        var ts = new SlackEventTs(candidateTs);
-        if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
-            _pendingCursorTs = ts;
-    }
-
     private void AdvanceCursor(SlackEventTs candidateTs)
     {
         if (_cursorTs is { } c && candidateTs.CompareTo(c) <= 0)
@@ -740,7 +737,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         if (_cursorTs is { } c && ts.CompareTo(c) <= 0)
             return true;
 
-        if (_pendingCursorTs is { } p && ts.CompareTo(p) <= 0)
+        if (_outputEngine.PendingCursor is { } p && ts.CompareTo(new SlackEventTs(p)) <= 0)
             return true;
 
         return false;
@@ -758,7 +755,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private void ApplyPendingApprovalPromptTracked(PendingApprovalPromptTracked tracked)
     {
-        _hasObservedApprovalRequest = true;
+        _outputEngine.MarkApprovalRequestObserved();
         PendingApprovalRecovery.ApplyTracked<PendingApprovalRequest, SlackEventTs>(
             _pendingApprovalRequests,
             tracked,
@@ -773,18 +770,14 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private async Task ReinitializePipelineAsync(string reason)
     {
         QueueProcessingIndicatorClearIfActive();
-        _pendingCursorTs = null;
-        _turnInFlight = false;
-        // Reset per-turn delivery flags: a reinit aborts the in-flight turn,
-        // and a stale _postedThisTurn=true would otherwise leak into the next
+        // Slack drops the cursor key of the abandoned turn; Discord and
+        // Mattermost keep theirs across a reinitialize.
+        _outputEngine.DiscardPendingCursor();
+        // Reset the per-turn delivery state: a reinit aborts the in-flight
+        // turn, and a stale delivered flag would otherwise leak into the next
         // turn and falsely report a later reminder as delivered.
-        _postedThisTurn = false;
-        _uploadedFileThisTurn = false;
         _lastFailedPost = null;
-        // Report any in-flight reminder turn as not-delivered now so the
-        // execution actor redelivers immediately rather than stalling until
-        // the backstop timeout.
-        FailPendingReminderDeliveries($"Slack pipeline reinitialized: {reason}");
+        _outputEngine.ResetForPipelineReinitialize(reason);
         await _handle.ReinitializeAsync(
             reason,
             () => Timers.StartSingleTimer(
@@ -795,133 +788,76 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private async Task HandleOutputAsync(ThreadOutput threadOutput)
     {
-        switch (threadOutput.Output)
+        var clearedPrompts = await _outputEngine.HandleOutputAsync(threadOutput.Output);
+        if (clearedPrompts.Count > 0)
+            PersistAll(clearedPrompts, ApplyPendingApprovalPromptCleared);
+    }
+
+    /// <summary>
+    /// Handles the outputs the shared engine leaves to the channel. Slack
+    /// renders a processing indicator; other output types have no Slack effect.
+    /// BufferFlush and TextDeltaOutput never arrive, because Slack subscribes to
+    /// OutputFilter.Text (final assembled text), not TextStreaming.
+    /// </summary>
+    private async Task HandleChannelSpecificOutputAsync(SessionOutput output)
+    {
+        if (output is ProcessingStateOutput processing)
+            await RenderProcessingStateAsync(processing);
+    }
+
+    /// <summary>
+    /// Posts turn output text for the shared engine. Slack keeps the failure
+    /// descriptor instead of telling the session now, because it reports a
+    /// delivery failure once at turn completion.
+    /// </summary>
+    private async Task<bool> PostOutputTextAsync(string text)
+    {
+        var result = await SafePostAsync(text);
+        if (!result.Success)
+            _lastFailedPost = result;
+        return result.Success;
+    }
+
+    /// <summary>Uploads turn output for the shared engine. See <see cref="PostOutputTextAsync"/>.</summary>
+    private async Task<bool> UploadOutputFileAsync(FileOutput file)
+    {
+        var result = await SafeUploadFileAsync(file);
+        if (!result.Success)
+            _lastFailedPost = result;
+        return result.Success;
+    }
+
+    private async Task PostEmptyTurnFallbackAsync()
+    {
+        _lastFailedPost = null;
+        _log.Warning("Turn completed without visible Slack output; posting fallback reply");
+        await SafePostAsync(EmptyTurnFallbackText);
+    }
+
+    /// <summary>
+    /// Tells the session that the turn produced output the transport rejected.
+    /// Slack defers this report to turn completion and sends it once with the
+    /// completed turn's number. Discord and Mattermost report each failed post
+    /// inline instead, so their engine hook does nothing here.
+    /// </summary>
+    private async Task NotifyFailedTurnAsync(TurnCompleted completed)
+    {
+        var failedPost = _lastFailedPost;
+        _lastFailedPost = null;
+
+        if (failedPost is { ShouldNotifySession: true, FailureKind: { } failureKind, ErrorMessage: { } errorMessage })
         {
-            case TextOutput text:
-            {
-                var fullText = text.Text?.Trim();
-                if (!string.IsNullOrWhiteSpace(fullText))
-                {
-                    var result = await SafePostAsync(fullText);
-                    if (result.Success)
-                        _postedThisTurn = true;
-                    else
-                        _lastFailedPost = result;
-                }
-
-                break;
-            }
-
-            case FileOutput file:
-                var uploadResult = await SafeUploadFileAsync(file);
-                if (!uploadResult.Success)
-                    _lastFailedPost = uploadResult;
-                break;
-
-            case ProcessingStateOutput processing:
-                await RenderProcessingStateAsync(processing);
-                break;
-
-            // BufferFlush and TextDeltaOutput are not received — Slack subscribes
-            // to OutputFilter.Text (final assembled text), not TextStreaming.
-
-            case ToolInteractionRequest interaction:
-                _hasObservedApprovalRequest = true;
-                var pendingApproval = new PendingApprovalRequest(interaction);
-                _pendingApprovalRequests.Add(pendingApproval);
-                var promptMessageTs = await HandleApprovalRequestAsync(interaction);
-                if (promptMessageTs is not null)
-                {
-                    pendingApproval.PromptMessageTs = promptMessageTs;
-                    Persist(new PendingApprovalPromptTracked
-                    {
-                        CallId = pendingApproval.CallId.Value,
-                        RequesterSenderId = pendingApproval.RequesterSenderId,
-                        RequesterPrincipal = pendingApproval.RequesterPrincipal,
-                        OptionKeys = pendingApproval.OptionKeys,
-                        PromptId = promptMessageTs.Value.Value,
-                        ToolName = pendingApproval.ToolName,
-                        // Preserve null-vs-set semantics on the wire: Truncate
-                        // returns string.Empty for null input, which would round-
-                        // trip as DisplayText="" with HasDisplayText=true.
-                        DisplayText = string.IsNullOrEmpty(pendingApproval.DisplayText)
-                            ? null
-                            : ApprovalDisplayTextFormatter.Truncate(
-                                pendingApproval.DisplayText,
-                                PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
-                    }, ApplyPendingApprovalPromptTracked);
-                }
-                else
-                {
-                    // Posting the approval prompt failed. Drop the pending entry and
-                    // route a deny back to the session so the blocked tool task can
-                    // unwind instead of waiting on the infinite-timeout TCS.
-                    _pendingApprovalRequests.Remove(pendingApproval);
-                    await SendApprovalDenyOnFailureAsync(interaction);
-                }
-                break;
-
-            case ErrorOutput err:
-                var refId = err.CorrelationId.ToString("N")[..8];
-                var errorResult = await SafePostAsync($":warning: {err.Message} (ref: {refId})");
-                if (errorResult.Success)
-                    _postedThisTurn = true;
-                else
-                    _lastFailedPost = errorResult;
-                break;
-
-            case TurnCompleted completed:
-                if (completed.Outcome == TurnOutcome.Completed && _pendingCursorTs is { } pendingTs)
-                    AdvanceCursor(pendingTs);
-                _pendingCursorTs = null;
-                _turnInFlight = false;
-
-                if (completed.SourceReminderId is { } sourceReminderKey
-                    && !string.IsNullOrWhiteSpace(sourceReminderKey.Value)
-                    && _reminderDeliveryObservers.Remove(sourceReminderKey, out var reminderObserver))
-                {
-                    var delivered = _postedThisTurn || _uploadedFileThisTurn;
-                    reminderObserver.Tell(new ReminderDeliveryResult(
-                        sourceReminderKey,
-                        ChannelType.Slack,
-                        Delivered: delivered,
-                        FailureReason: delivered ? null : "Slack post did not succeed",
-                        ObservedAtMs: _dependencies.TimeProvider.GetUtcNow().ToUnixTimeMilliseconds()));
-                }
-
-                if (!_postedThisTurn && !_uploadedFileThisTurn)
-                {
-                    if (_lastFailedPost is { ShouldNotifySession: true, FailureKind: { } failureKind, ErrorMessage: { } errorMessage })
-                    {
-                        _log.Warning(
-                            "Turn completed with Slack delivery failure kind={FailureKind}; notifying session",
-                            failureKind);
-                        await NotifyDeliveryFailedAsync(completed.TurnNumber, failureKind, errorMessage);
-                    }
-                    else
-                    {
-                        _log.Warning("Turn completed without visible Slack output; posting fallback reply");
-                        await SafePostAsync(EmptyTurnFallbackText);
-                    }
-                }
-
-                _postedThisTurn = false;
-                _uploadedFileThisTurn = false;
-                _lastFailedPost = null;
-                var clearedPrompts = _pendingApprovalRequests
-                    .Select(pending => new PendingApprovalPromptCleared
-                    {
-                        CallId = pending.CallId.Value
-                    })
-                    .ToArray();
-                if (clearedPrompts.Length > 0)
-                {
-                    PersistAll(
-                        clearedPrompts,
-                        cleared => ApplyPendingApprovalPromptCleared(cleared));
-                }
-                _pendingApprovalRequests.Clear();
-                break;
+            _log.Warning(
+                "Turn completed with Slack delivery failure kind={FailureKind}; notifying session",
+                failureKind);
+            await NotifyDeliveryFailedAsync(completed.TurnNumber, failureKind, errorMessage);
+        }
+        else
+        {
+            // Defensive: a failed post always carries a failure kind, so this
+            // branch is unreachable today. Keep the empty-turn reply as the
+            // safe outcome if that ever stops holding.
+            await PostEmptyTurnFallbackAsync();
         }
     }
 
@@ -1102,23 +1038,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
     }
 
-    /// <summary>
-    /// Tells every in-flight reminder observer that delivery did not happen,
-    /// then clears them. Called when a turn can no longer reach TurnCompleted
-    /// (e.g. pipeline reinit), so the execution actor fails fast and redelivers
-    /// rather than waiting out its backstop timeout.
-    /// </summary>
-    private void FailPendingReminderDeliveries(string reason)
-    {
-        if (_reminderDeliveryObservers.Count == 0)
-            return;
-
-        foreach (var (key, observer) in _reminderDeliveryObservers)
-            observer.Tell(new ReminderDeliveryResult(key, ChannelType.Slack, Delivered: false, FailureReason: reason));
-
-        _reminderDeliveryObservers.Clear();
-    }
-
     private async Task NotifyDeliveryFailedAsync(Actors.Protocol.TurnNumber turnNumber, DeliveryFailureKind failureKind, string errorMessage)
     {
         try
@@ -1282,7 +1201,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 file.FileName,
                 cts.Token);
 
-            _uploadedFileThisTurn = true;
             _log.Info("Uploaded file to Slack thread: {FileName}", file.FileName);
             return PostResult.Ok;
         }
@@ -1326,12 +1244,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             string? displayText = null)
             : base(callId, requesterSenderId, requesterPrincipal, optionKeys, promptMessageTs, toolName, displayText)
         {
-        }
-
-        public SlackEventTs? PromptMessageTs
-        {
-            get => PromptId;
-            set => PromptId = value;
         }
     }
 

--- a/src/Netclaw.Channels/ApprovalResponseFlow.cs
+++ b/src/Netclaw.Channels/ApprovalResponseFlow.cs
@@ -1,0 +1,437 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalResponseFlow.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Event;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
+using Netclaw.Tools;
+using static Netclaw.Actors.Sessions.SessionProtocol;
+
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Redraws a resolved approval prompt on the channel. Each channel supplies
+/// its own renderer because the prompt is a transport-specific message.
+/// </summary>
+/// <param name="promptId">The prompt locator, or <c>null</c> when the binding never captured one.</param>
+/// <param name="request">The original request on the hot path; <c>null</c> on the cold-spawn path.</param>
+/// <param name="callId">The tool call the prompt belongs to.</param>
+/// <param name="selectedKey">The option the sender selected.</param>
+/// <param name="senderId">The sender that resolved the prompt.</param>
+/// <param name="persistedToolName">Tool name from the journal, for the cold-spawn redraw.</param>
+/// <param name="persistedDisplayText">Display text from the journal, for the cold-spawn redraw.</param>
+public delegate Task ResolvedApprovalPromptRenderer<TPromptId>(
+    TPromptId? promptId,
+    ToolInteractionRequest? request,
+    ToolCallId callId,
+    string selectedKey,
+    string senderId,
+    string? persistedToolName,
+    string? persistedDisplayText)
+    where TPromptId : struct;
+
+/// <summary>
+/// Shared approval-response handling for the channel binding actors. The flow
+/// owns text-approval parsing, the cold-spawn text path, pending-prompt
+/// resolution, and the requester identity check. Slack, Discord, and Mattermost
+/// supply the transport effects; the algorithm has one implementation here.
+/// </summary>
+/// <remarks>
+/// The flow holds no Akka state. It does not persist an event and it does not
+/// touch the actor context. Each actor-owned effect (prompt redraw, warning
+/// post, journal write) goes through a callback that the binding actor supplies
+/// at construction. All callbacks run on the actor's own message-processing
+/// path, so they are safe to read and write actor state.
+/// </remarks>
+public sealed class ApprovalResponseFlow<TRequest, TPromptId>
+    where TRequest : PendingApprovalRequest<TPromptId>
+    where TPromptId : struct
+{
+    private readonly SessionId _sessionId;
+    private readonly ChannelType _channelType;
+    private readonly string _channelName;
+    private readonly ISessionPipeline _pipeline;
+    private readonly TimeSpan _operationTimeout;
+    private readonly List<TRequest> _pendingRequests;
+    private readonly ApprovalMatchOrder _matchOrder;
+    private readonly Func<bool> _hasObservedApprovalRequest;
+    private readonly Func<Task> _postWrongRequesterWarningAsync;
+    private readonly Action<ToolCallId> _persistPromptCleared;
+    private readonly ResolvedApprovalPromptRenderer<TPromptId> _renderResolvedPromptAsync;
+    private readonly ILoggingAdapter _log;
+
+    /// <summary>
+    /// Creates the flow. Every dependency is required: the pending-request list
+    /// and the warning poster carry the requester identity check, so the flow
+    /// cannot run with either of them absent.
+    /// </summary>
+    /// <param name="sessionId">The session this binding serves.</param>
+    /// <param name="channelType">Telemetry category for the channel.</param>
+    /// <param name="channelName">Channel name for the log text, for example <c>Slack</c>.</param>
+    /// <param name="pipeline">The session pipeline that carries approval feedback.</param>
+    /// <param name="operationTimeout">Deadline for one feedback round trip.</param>
+    /// <param name="pendingRequests">
+    /// The actor's own pending-approval list. The flow reads it and removes the
+    /// entry it resolves; the actor keeps adding to it and replaying it.
+    /// </param>
+    /// <param name="matchOrder">Which candidate wins when more than one matches.</param>
+    /// <param name="hasObservedApprovalRequest">Reads the cold-path gate.</param>
+    /// <param name="postWrongRequesterWarningAsync">Posts the channel's wrong-requester warning.</param>
+    /// <param name="persistPromptCleared">
+    /// Journals <c>PendingApprovalPromptCleared</c> for the resolved call. The
+    /// actor owns the persistence call; the flow never touches Akka persistence.
+    /// </param>
+    /// <param name="renderResolvedPromptAsync">Redraws the resolved prompt on the channel.</param>
+    /// <param name="log">The binding actor's logger, with its adapter context fields.</param>
+    public ApprovalResponseFlow(
+        SessionId sessionId,
+        ChannelType channelType,
+        string channelName,
+        ISessionPipeline pipeline,
+        TimeSpan operationTimeout,
+        List<TRequest> pendingRequests,
+        ApprovalMatchOrder matchOrder,
+        Func<bool> hasObservedApprovalRequest,
+        Func<Task> postWrongRequesterWarningAsync,
+        Action<ToolCallId> persistPromptCleared,
+        ResolvedApprovalPromptRenderer<TPromptId> renderResolvedPromptAsync,
+        ILoggingAdapter log)
+    {
+        _sessionId = sessionId;
+        _channelType = channelType;
+        _channelName = channelName;
+        _pipeline = pipeline;
+        _operationTimeout = operationTimeout;
+        _pendingRequests = pendingRequests;
+        _matchOrder = matchOrder;
+        _hasObservedApprovalRequest = hasObservedApprovalRequest;
+        _postWrongRequesterWarningAsync = postWrongRequesterWarningAsync;
+        _persistPromptCleared = persistPromptCleared;
+        _renderResolvedPromptAsync = renderResolvedPromptAsync;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Handles an inbound text message that can be an approval reply, for
+    /// example "A" or "deny".
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the flow consumed the message, so the actor must not
+    /// send it to the session as ordinary conversation.
+    /// </returns>
+    public async Task<bool> TryHandleTextApprovalResponseAsync(string? text, string senderId)
+    {
+        var (result, pending) = PendingApprovalLookup.Resolve<TRequest, TPromptId>(
+            _pendingRequests, senderId, callId: null, _matchOrder);
+
+        if (result is ApprovalLookupResult.NotFound)
+        {
+            // The cold path runs only for a binding that has never observed any
+            // ToolInteractionRequest. Such a binding treats an inbound
+            // "A"/"B"/"C" as a possible cold approval reply for a session that
+            // restarted out from under it. Once we've observed at least one
+            // prompt, subsequent ambiguous text from the user is ordinary
+            // conversation, not an approval reply, so the cold path stays off.
+            // This does NOT gate button clicks — those always route to the
+            // session, which is the authority on CallId staleness.
+            return !_hasObservedApprovalRequest()
+                && await TryHandleColdTextApprovalResponseAsync(text, senderId);
+        }
+
+        if (result is ApprovalLookupResult.WrongRequester)
+        {
+            await _postWrongRequesterWarningAsync();
+            return true;
+        }
+
+        if (!ToolInteractionResponseParser.TryParseApprovalResponse(
+                text ?? string.Empty,
+                pending!.Options,
+                out var selectedKey)
+            || selectedKey is null)
+        {
+            return false;
+        }
+
+        ISessionResponse feedbackResult;
+        try
+        {
+            using var feedbackCts = new CancellationTokenSource(_operationTimeout);
+            feedbackResult = await _pipeline.SendFeedbackAndWaitAsync(
+                new ToolInteractionResponse
+                {
+                    SessionId = _sessionId,
+                    CallId = pending.CallId,
+                    SelectedKey = new ApprovalOptionKey(selectedKey),
+                    SenderId = new SenderId(senderId)
+                }, feedbackCts.Token);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to route {Channel} text approval response for call {CallId}", _channelName, pending.CallId);
+            return true;
+        }
+
+        switch (feedbackResult)
+        {
+            case CommandNack nack:
+                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
+                    await _postWrongRequesterWarningAsync();
+                _log.Info(
+                    "Session rejected {Channel} text approval response for call {CallId} reason={Reason}; skipping redraw",
+                    _channelName,
+                    pending.CallId,
+                    nack.Reason ?? "<none>");
+                return true;
+
+            case not CommandAck:
+                _log.Warning(
+                    "{Channel} text approval response for call {CallId} returned unexpected feedback result {ResultType}",
+                    _channelName,
+                    pending.CallId,
+                    feedbackResult.GetType().Name);
+                return true;
+        }
+
+        ClearResolved(pending);
+
+        await _renderResolvedPromptAsync(
+            pending.PromptId,
+            pending.Request,
+            pending.CallId,
+            selectedKey,
+            senderId,
+            pending.ToolName,
+            pending.DisplayText);
+
+        _log.Info(
+            "Recorded {Channel} text approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
+            _channelName,
+            pending.CallId,
+            senderId,
+            selectedKey);
+        return true;
+    }
+
+    /// <summary>
+    /// Handles an interactive approval response, for example a button click.
+    /// </summary>
+    /// <param name="callId">The tool call the response answers.</param>
+    /// <param name="selectedKey">The option the sender selected.</param>
+    /// <param name="senderId">The sender that answered.</param>
+    /// <param name="payloadPromptId">
+    /// The prompt locator carried on the response payload. It is the redraw
+    /// target when the binding holds no pending entry for the call.
+    /// </param>
+    /// <param name="respondSynchronously">
+    /// Mattermost only: its interactive-message webhook asks the binding over
+    /// HTTP and needs the session's verdict back on the same request. Discord
+    /// gateway events and Slack interactions are one-way, so those channels
+    /// pass nothing and the flow sends no synchronous reply.
+    /// </param>
+    public async Task HandleApprovalResponseAsync(
+        ToolCallId callId,
+        string selectedKey,
+        string senderId,
+        TPromptId? payloadPromptId,
+        Action<ISessionResponse>? respondSynchronously = null)
+    {
+        var (result, pending) = PendingApprovalLookup.Resolve<TRequest, TPromptId>(
+            _pendingRequests, senderId, callId, _matchOrder);
+
+        // CanApprove fast-path: if the binding still holds the original request we can
+        // post the wrong-requester warning locally without round-tripping through the
+        // session. When the binding has been cold-spawned (no local pending entry) the
+        // session re-runs CanApprove against its own pending-call state, and the wait
+        // below blocks the redraw until the session has actually accepted the click —
+        // see #939 + #979.
+        if (result is ApprovalLookupResult.WrongRequester)
+        {
+            await _postWrongRequesterWarningAsync();
+            respondSynchronously?.Invoke(CommandNack.For(_sessionId, ApprovalNackReasons.WrongRequester));
+            return;
+        }
+
+        // Wait for the session before redrawing. This is the security gate that
+        // prevents (a) a non-requester click destroying the prompt UI on the
+        // cold-spawn path, and (b) a stale re-click overwriting an already-resolved
+        // banner — both surfaced by the #939 code review. The session is the
+        // authority on whether the call is still pending and whether the sender is
+        // allowed. Only redraw on CommandAck.
+        ISessionResponse feedbackResult;
+        try
+        {
+            using var feedbackCts = new CancellationTokenSource(_operationTimeout);
+            feedbackResult = await _pipeline.SendFeedbackAndWaitAsync(
+                new ToolInteractionResponse
+                {
+                    SessionId = _sessionId,
+                    CallId = callId,
+                    SelectedKey = new ApprovalOptionKey(selectedKey),
+                    SenderId = new SenderId(senderId)
+                }, feedbackCts.Token);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to route {Channel} approval response for call {CallId}", _channelName, callId);
+            respondSynchronously?.Invoke(CommandNack.For(_sessionId, ApprovalNackReasons.PersistFailed));
+            return;
+        }
+
+        CommandAck ack;
+        switch (feedbackResult)
+        {
+            case CommandNack nack:
+                // Session rejected (wrong requester, unknown call, stale resolution).
+                // For wrong-requester surface the warning; for any other reason just
+                // log and DO NOT redraw — the prompt UI must stay consistent with the
+                // session's authoritative state.
+                if (string.Equals(nack.Reason, ApprovalNackReasons.WrongRequester, StringComparison.Ordinal))
+                    await _postWrongRequesterWarningAsync();
+                _log.Info(
+                    "Session rejected {Channel} approval response for call {CallId} reason={Reason}; skipping redraw",
+                    _channelName,
+                    callId,
+                    nack.Reason ?? "<none>");
+                respondSynchronously?.Invoke(nack);
+                return;
+
+            case CommandAck ok:
+                ack = ok;
+                break;
+
+            default:
+                // Unreachable: ISessionResponse is implemented only by CommandAck
+                // and CommandNack. Kept as a defensive guard so an unexpected
+                // future implementer surfaces a structured Nack instead of an
+                // unobservable null reference.
+                _log.Warning(
+                    "{Channel} approval response for call {CallId} returned unexpected feedback result {ResultType}",
+                    _channelName,
+                    callId,
+                    feedbackResult.GetType().Name);
+                respondSynchronously?.Invoke(CommandNack.For(_sessionId, ApprovalNackReasons.PersistFailed));
+                return;
+        }
+
+        if (pending is not null)
+        {
+            ClearResolved(pending);
+            // Prefer the captured prompt locator; fall back to the payload locator
+            // when the capture failed (a narrow race while the prompt was posted).
+            await _renderResolvedPromptAsync(
+                pending.PromptId ?? payloadPromptId,
+                pending.Request,
+                pending.CallId,
+                selectedKey,
+                senderId,
+                pending.ToolName,
+                pending.DisplayText);
+
+            _log.Info(
+                "Recorded {Channel} approval response for call {CallId} sender={SenderId} selection={SelectedKey}",
+                _channelName,
+                pending.CallId,
+                senderId,
+                selectedKey);
+        }
+        else if (payloadPromptId is { } resolvedPayloadPromptId)
+        {
+            // Cold-spawn redraw — no local pending entry exists for this CallId
+            // (the journal didn't replay a PendingApprovalPromptTracked event for
+            // it, typically because the binding was re-created without recovery
+            // or the entry was cleared before the click landed). The response
+            // payload still carries the prompt's locator and the session has
+            // accepted the response; render the generic banner so the buttons
+            // clear. NOTE: pre-0.21 journals that DO replay (with no tool name /
+            // display text) take the upper `pending is not null` branch instead
+            // — they render the generic banner via the !IsNullOrEmpty fallback
+            // inside the builder, not via this branch.
+            await _renderResolvedPromptAsync(
+                resolvedPayloadPromptId,
+                request: null,
+                callId,
+                selectedKey,
+                senderId,
+                persistedToolName: null,
+                persistedDisplayText: null);
+
+            _log.Info(
+                "Forwarded {Channel} approval response for call {CallId} to session without local pending entry; redrew prompt via payload promptId={PromptId}",
+                _channelName,
+                callId,
+                resolvedPayloadPromptId);
+        }
+        else
+        {
+            // Text-reply on a cold-spawned binding: the approval still routes,
+            // but no prompt locator is available, so the redraw is impossible.
+            // Remaining #939 gap.
+            _log.Info(
+                "Forwarded {Channel} approval response for call {CallId} to session without local pending entry; redraw skipped",
+                _channelName,
+                callId);
+            ChannelTelemetry.For(_channelType).RecordExtra("interactionErrors", "cold_spawn_redraw_skipped");
+        }
+
+        respondSynchronously?.Invoke(ack);
+    }
+
+    /// <summary>
+    /// Forwards an approval-shaped text message for a binding that holds no
+    /// prompt state of its own. The session is the authority on whether an
+    /// approval is pending, so the reply decides whether the message is
+    /// consumed or falls through to normal ingress.
+    /// </summary>
+    private async Task<bool> TryHandleColdTextApprovalResponseAsync(string? text, string senderId)
+    {
+        if (!ToolInteractionResponseParser.LooksLikeApprovalResponse(text ?? string.Empty))
+            return false;
+
+        using var feedbackCts = new CancellationTokenSource(_operationTimeout);
+        try
+        {
+            var reply = await _pipeline.SendFeedbackAndWaitAsync(new ToolInteractionTextResponse
+            {
+                SessionId = _sessionId,
+                Text = text ?? string.Empty,
+                SenderId = new SenderId(senderId)
+            }, feedbackCts.Token);
+
+            if (reply is CommandAck)
+            {
+                _log.Info(
+                    "Forwarded cold {Channel} text approval response from sender={SenderId} without local pending prompt state",
+                    _channelName,
+                    senderId);
+                return true;
+            }
+
+            // approval_no_history means the session has never had an approval request.
+            // The message was a false-positive from LooksLikeApprovalResponse.
+            // Don't consume — let it fall through to normal LLM ingress. See #1164.
+            if (reply is CommandNack { Reason: ApprovalNackReasons.NoHistory })
+                return false;
+
+            return reply is CommandNack;
+        }
+        catch (Exception ex)
+        {
+            _log.Error(
+                ex,
+                "Failed to route cold {Channel} text approval response from sender {SenderId}",
+                _channelName,
+                senderId);
+            return false;
+        }
+    }
+
+    private void ClearResolved(TRequest pending)
+    {
+        _pendingRequests.Remove(pending);
+        _persistPromptCleared(pending.CallId);
+    }
+}

--- a/src/Netclaw.Channels/ChannelOutputEngine.cs
+++ b/src/Netclaw.Channels/ChannelOutputEngine.cs
@@ -1,0 +1,392 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChannelOutputEngine.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Actor;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Reminders;
+using static Netclaw.Actors.Sessions.SessionProtocol;
+using static Netclaw.Actors.Reminders.ReminderProtocol;
+
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Shared session-output handling for the channel binding actors. The engine
+/// owns the per-turn delivery bookkeeping: the pending cursor, the
+/// turn-in-flight signal, the reminder delivery observers, the empty-turn
+/// fallback decision, and the pending-approval prompt list. Slack, Discord, and
+/// Mattermost supply the transport effects; the algorithm has one
+/// implementation here.
+/// </summary>
+/// <remarks>
+/// The engine holds no Akka state and never calls Akka persistence. It returns
+/// the <see cref="PendingApprovalPromptCleared"/> events a completed turn
+/// produces, and the binding actor persists them. Each actor-owned effect
+/// (post, upload, prompt redraw, journal write) goes through a callback that
+/// the binding actor supplies at construction. All callbacks run on the actor's
+/// own message-processing path, so they are safe to read and write actor state.
+/// </remarks>
+public sealed class ChannelOutputEngine<TRequest, TPromptId>
+    where TRequest : PendingApprovalRequest<TPromptId>
+    where TPromptId : struct
+{
+    private static readonly PendingApprovalPromptCleared[] NoClearedPrompts = [];
+
+    private readonly ChannelType _channelType;
+    private readonly string _channelName;
+    private readonly IComparer<string> _cursorComparer;
+    private readonly List<TRequest> _pendingRequests;
+    private readonly Func<ToolInteractionRequest, TRequest> _createPendingRequest;
+    private readonly Func<ToolInteractionRequest, bool> _isApprovalRequest;
+    private readonly Func<TextOutput, string?> _renderTextOutput;
+    private readonly Func<ErrorOutput, string> _renderErrorOutput;
+    private readonly Func<string, Task<bool>> _postTextAsync;
+    private readonly Func<FileOutput, Task<bool>> _uploadFileAsync;
+    private readonly Func<ToolInteractionRequest, Task<TPromptId?>> _postApprovalPromptAsync;
+    private readonly Func<TPromptId, string> _readPromptIdValue;
+    private readonly Func<ToolInteractionRequest, Task> _onApprovalPromptFailedAsync;
+    private readonly Action<PendingApprovalPromptTracked> _persistPromptTracked;
+    private readonly Func<SessionOutput, Task> _handleChannelSpecificOutputAsync;
+    private readonly Action<string> _advanceCursor;
+    private readonly Func<Task> _postEmptyTurnFallbackAsync;
+    private readonly Func<TurnCompleted, Task> _onEmptyTurnSuppressedAsync;
+    private readonly Func<TurnCompleted, long?> _readObservedAtMs;
+
+    // Reply targets for in-flight reminder delivery confirmations, keyed by
+    // reminder delivery key. Captured from DeliverTrustedSessionTurn; each is
+    // told a ReminderDeliveryResult on its turn's TurnCompleted and removed.
+    // Keyed (not a single field) because multiple reminders can target the
+    // same session concurrently — a single field would be clobbered.
+    private readonly Dictionary<ReminderId, IActorRef> _reminderDeliveryObservers = new();
+
+    private bool _deliveredThisTurn;
+
+    // True when a content post/upload this turn was attempted but failed (the
+    // model produced output, the transport rejected it). Distinct from "nothing
+    // was produced" — it suppresses the empty-turn fallback so a failed post
+    // isn't followed by a misleading "I didn't manage to produce a reply".
+    private bool _postFailedThisTurn;
+
+    /// <summary>
+    /// Creates the engine. Every dependency is required. The pending-request
+    /// list is the actor's own list, which the approval-response flow also
+    /// reads, so the engine cannot run with it absent.
+    /// </summary>
+    /// <param name="channelType">Telemetry and reminder-result category for the channel.</param>
+    /// <param name="channelName">Channel name for generated text, for example <c>Slack</c>.</param>
+    /// <param name="cursorComparer">Orders two cursor keys of this channel.</param>
+    /// <param name="pendingRequests">
+    /// The actor's own pending-approval list. The engine appends the prompts it
+    /// posts and clears the list when a turn completes.
+    /// </param>
+    /// <param name="createPendingRequest">Creates the channel's pending-approval record.</param>
+    /// <param name="isApprovalRequest">
+    /// Decides whether a <see cref="ToolInteractionRequest"/> is an approval
+    /// prompt this binding renders. Discord and Mattermost require
+    /// <c>Kind == "approval"</c>; Slack accepts every interaction request.
+    /// </param>
+    /// <param name="renderTextOutput">
+    /// Formats a <see cref="TextOutput"/> for the transport. A <c>null</c>
+    /// result means the output carries nothing to post, so the engine skips it
+    /// and records neither a delivery nor a failure.
+    /// </param>
+    /// <param name="renderErrorOutput">Formats an <see cref="ErrorOutput"/> for the transport.</param>
+    /// <param name="postTextAsync">Posts text; returns <c>true</c> when the whole post succeeded.</param>
+    /// <param name="uploadFileAsync">Uploads a file; returns <c>true</c> on success.</param>
+    /// <param name="postApprovalPromptAsync">
+    /// Posts the approval prompt and returns its locator, or <c>null</c> when
+    /// the prompt could not be posted.
+    /// </param>
+    /// <param name="readPromptIdValue">Reads the persisted string form of a prompt locator.</param>
+    /// <param name="onApprovalPromptFailedAsync">
+    /// Handles a prompt that could not be posted. Every channel routes an
+    /// auto-deny so the blocked tool call unwinds instead of waiting forever.
+    /// </param>
+    /// <param name="persistPromptTracked">
+    /// Journals <c>PendingApprovalPromptTracked</c> for a posted prompt. The
+    /// actor owns the persistence call; the engine never touches Akka persistence.
+    /// </param>
+    /// <param name="handleChannelSpecificOutputAsync">
+    /// Handles output types only some channels support, such as
+    /// <see cref="SessionTitleOutput"/> and <see cref="ProcessingStateOutput"/>.
+    /// A channel without the capability ignores the output here.
+    /// </param>
+    /// <param name="advanceCursor">Persists the cursor a completed turn confirmed.</param>
+    /// <param name="postEmptyTurnFallbackAsync">Posts the channel's empty-turn fallback text.</param>
+    /// <param name="onEmptyTurnSuppressedAsync">
+    /// Runs instead of the fallback when the turn produced output that failed
+    /// to post. Discord and Mattermost already told the session inline, so
+    /// their hook does nothing more; Slack tells the session here.
+    /// </param>
+    /// <param name="readObservedAtMs">
+    /// Reads the observation timestamp for the reminder delivery result.
+    /// </param>
+    public ChannelOutputEngine(
+        ChannelType channelType,
+        string channelName,
+        IComparer<string> cursorComparer,
+        List<TRequest> pendingRequests,
+        Func<ToolInteractionRequest, TRequest> createPendingRequest,
+        Func<ToolInteractionRequest, bool> isApprovalRequest,
+        Func<TextOutput, string?> renderTextOutput,
+        Func<ErrorOutput, string> renderErrorOutput,
+        Func<string, Task<bool>> postTextAsync,
+        Func<FileOutput, Task<bool>> uploadFileAsync,
+        Func<ToolInteractionRequest, Task<TPromptId?>> postApprovalPromptAsync,
+        Func<TPromptId, string> readPromptIdValue,
+        Func<ToolInteractionRequest, Task> onApprovalPromptFailedAsync,
+        Action<PendingApprovalPromptTracked> persistPromptTracked,
+        Func<SessionOutput, Task> handleChannelSpecificOutputAsync,
+        Action<string> advanceCursor,
+        Func<Task> postEmptyTurnFallbackAsync,
+        Func<TurnCompleted, Task> onEmptyTurnSuppressedAsync,
+        Func<TurnCompleted, long?> readObservedAtMs)
+    {
+        _channelType = channelType;
+        _channelName = channelName;
+        _cursorComparer = cursorComparer;
+        _pendingRequests = pendingRequests;
+        _createPendingRequest = createPendingRequest;
+        _isApprovalRequest = isApprovalRequest;
+        _renderTextOutput = renderTextOutput;
+        _renderErrorOutput = renderErrorOutput;
+        _postTextAsync = postTextAsync;
+        _uploadFileAsync = uploadFileAsync;
+        _postApprovalPromptAsync = postApprovalPromptAsync;
+        _readPromptIdValue = readPromptIdValue;
+        _onApprovalPromptFailedAsync = onApprovalPromptFailedAsync;
+        _persistPromptTracked = persistPromptTracked;
+        _handleChannelSpecificOutputAsync = handleChannelSpecificOutputAsync;
+        _advanceCursor = advanceCursor;
+        _postEmptyTurnFallbackAsync = postEmptyTurnFallbackAsync;
+        _onEmptyTurnSuppressedAsync = onEmptyTurnSuppressedAsync;
+        _readObservedAtMs = readObservedAtMs;
+    }
+
+    /// <summary>
+    /// True once this binding has seen at least one approval request. The
+    /// text-approval cold path reads it; the actor also sets it during journal
+    /// replay through <see cref="MarkApprovalRequestObserved"/>.
+    /// </summary>
+    public bool HasObservedApprovalRequest { get; private set; }
+
+    /// <summary>
+    /// Reliable in-flight-turn signal for the mention re-arm guard: set when a
+    /// turn is enqueued (unlike the pending cursor, which is only set for
+    /// inbounds with a usable cursor key), cleared when the turn ends or the
+    /// pipeline reinitializes. Without it, a keyless in-flight turn would leave
+    /// the pending cursor unset and let a following mention re-arm mid-turn —
+    /// the PR #733 no-duplicate hazard.
+    /// </summary>
+    public bool TurnInFlight { get; private set; }
+
+    /// <summary>
+    /// The highest cursor key of the turn in flight. It becomes the persisted
+    /// cursor only when the turn completes.
+    /// </summary>
+    public string? PendingCursor { get; private set; }
+
+    /// <summary>
+    /// Turn number of the most recently completed turn. Channels that report a
+    /// delivery failure outside a turn boundary use it as the failure's turn.
+    /// </summary>
+    public TurnNumber LastCompletedTurnNumber { get; private set; }
+
+    /// <summary>Records that the journal replayed an approval prompt.</summary>
+    public void MarkApprovalRequestObserved() => HasObservedApprovalRequest = true;
+
+    /// <summary>
+    /// Records that a turn went into the input queue. The turn-in-flight flag
+    /// guards the mention re-arm path; the pending cursor keeps the highest
+    /// cursor key of the turn.
+    /// </summary>
+    public void AdvancePendingCursorForEnqueuedTurn(string? candidateCursor)
+    {
+        TurnInFlight = true;
+
+        if (candidateCursor is null)
+            return;
+
+        if (PendingCursor is not { } pending || _cursorComparer.Compare(candidateCursor, pending) > 0)
+            PendingCursor = candidateCursor;
+    }
+
+    /// <summary>
+    /// Drops the cursor key of an abandoned turn so a later turn cannot commit
+    /// it. Slack calls this on a pipeline reinitialize; Discord and Mattermost
+    /// keep their pending cursor across a reinitialize.
+    /// </summary>
+    public void DiscardPendingCursor() => PendingCursor = null;
+
+    /// <summary>
+    /// Registers the reply target that waits for a delivery-gated reminder's
+    /// outcome. Keyed by the per-fire reminder delivery id so a second
+    /// concurrent reminder to this session cannot overwrite the first's
+    /// observer before its turn reaches <see cref="TurnCompleted"/>.
+    /// </summary>
+    public void TrackReminderDeliveryObserver(ReminderId reminderKey, IActorRef observer)
+        => _reminderDeliveryObservers[reminderKey] = observer;
+
+    /// <summary>
+    /// Clears the per-turn delivery state after a pipeline reinitialize. The
+    /// reinitialize abandons any in-flight turn before its
+    /// <see cref="TurnCompleted"/>, so the mention re-arm guard is released and
+    /// every waiting reminder observer is told the delivery did not happen. The
+    /// execution actor then redelivers immediately instead of stalling until
+    /// its backstop timeout.
+    /// </summary>
+    public void ResetForPipelineReinitialize(string reason)
+    {
+        _deliveredThisTurn = false;
+        _postFailedThisTurn = false;
+        TurnInFlight = false;
+        FailPendingReminderDeliveries($"{_channelName} pipeline reinitialized: {reason}");
+    }
+
+    /// <summary>
+    /// Handles one session output. Returns the
+    /// <see cref="PendingApprovalPromptCleared"/> events the caller must
+    /// persist; the list is empty for every output except a completed turn that
+    /// still held prompts.
+    /// </summary>
+    public async Task<IReadOnlyList<PendingApprovalPromptCleared>> HandleOutputAsync(SessionOutput output)
+    {
+        switch (output)
+        {
+            case TextOutput textOutput:
+                if (_renderTextOutput(textOutput) is { } text)
+                    RecordDeliveryOutcome(await _postTextAsync(text));
+                break;
+
+            case ErrorOutput errorOutput:
+                RecordDeliveryOutcome(await _postTextAsync(_renderErrorOutput(errorOutput)));
+                break;
+
+            case FileOutput fileOutput:
+                RecordDeliveryOutcome(await _uploadFileAsync(fileOutput));
+                break;
+
+            case ToolInteractionRequest request when _isApprovalRequest(request):
+                await HandleApprovalRequestAsync(request);
+                break;
+
+            case TurnCompleted completed:
+                return await CompleteTurnAsync(completed);
+
+            default:
+                await _handleChannelSpecificOutputAsync(output);
+                break;
+        }
+
+        return NoClearedPrompts;
+    }
+
+    private void RecordDeliveryOutcome(bool succeeded)
+    {
+        if (succeeded)
+            _deliveredThisTurn = true;
+        else
+            _postFailedThisTurn = true;
+    }
+
+    private async Task HandleApprovalRequestAsync(ToolInteractionRequest request)
+    {
+        HasObservedApprovalRequest = true;
+        var pendingApproval = _createPendingRequest(request);
+        _pendingRequests.Add(pendingApproval);
+
+        var promptId = await _postApprovalPromptAsync(request);
+        if (promptId is { } postedPromptId)
+        {
+            pendingApproval.PromptId = postedPromptId;
+            _persistPromptTracked(BuildTracked(pendingApproval, _readPromptIdValue(postedPromptId)));
+            return;
+        }
+
+        // Posting the approval prompt failed. Drop the pending entry and route a
+        // deny back to the session so the blocked tool task can unwind instead
+        // of waiting on the infinite-timeout completion source.
+        _pendingRequests.Remove(pendingApproval);
+        await _onApprovalPromptFailedAsync(request);
+    }
+
+    private async Task<IReadOnlyList<PendingApprovalPromptCleared>> CompleteTurnAsync(TurnCompleted completed)
+    {
+        if (completed.Outcome == TurnOutcome.Completed && PendingCursor is { } pendingCursor)
+            _advanceCursor(pendingCursor);
+        PendingCursor = null;
+        TurnInFlight = false;
+
+        if (completed.SourceReminderId is { } sourceReminderKey
+            && !string.IsNullOrWhiteSpace(sourceReminderKey.Value)
+            && _reminderDeliveryObservers.Remove(sourceReminderKey, out var reminderObserver))
+        {
+            reminderObserver.Tell(new ReminderDeliveryResult(
+                sourceReminderKey,
+                _channelType,
+                Delivered: _deliveredThisTurn,
+                FailureReason: _deliveredThisTurn ? null : $"{_channelName} post did not succeed",
+                ObservedAtMs: _readObservedAtMs(completed)));
+        }
+
+        if (!_deliveredThisTurn)
+        {
+            // Only post the empty-turn fallback when the turn genuinely
+            // produced nothing. A failed post means a reply WAS produced, so
+            // "I didn't manage to produce a reply" would mislead and would
+            // double up with the redelivered one. The channel decides what to
+            // do instead, because the channels differ on when they tell the
+            // session about the failure.
+            if (_postFailedThisTurn)
+                await _onEmptyTurnSuppressedAsync(completed);
+            else
+                await _postEmptyTurnFallbackAsync();
+        }
+
+        LastCompletedTurnNumber = completed.TurnNumber;
+
+        var clearedPrompts = _pendingRequests
+            .Select(pending => new PendingApprovalPromptCleared { CallId = pending.CallId.Value })
+            .ToArray();
+        _pendingRequests.Clear();
+        _deliveredThisTurn = false;
+        _postFailedThisTurn = false;
+        return clearedPrompts;
+    }
+
+    /// <summary>
+    /// Tells every in-flight reminder observer that delivery did not happen,
+    /// then clears them.
+    /// </summary>
+    private void FailPendingReminderDeliveries(string reason)
+    {
+        if (_reminderDeliveryObservers.Count == 0)
+            return;
+
+        foreach (var (key, observer) in _reminderDeliveryObservers)
+            observer.Tell(new ReminderDeliveryResult(key, _channelType, Delivered: false, FailureReason: reason));
+
+        _reminderDeliveryObservers.Clear();
+    }
+
+    private static PendingApprovalPromptTracked BuildTracked(TRequest pending, string promptId)
+        => new()
+        {
+            CallId = pending.CallId.Value,
+            RequesterSenderId = pending.RequesterSenderId,
+            RequesterPrincipal = pending.RequesterPrincipal,
+            OptionKeys = pending.OptionKeys,
+            PromptId = promptId,
+            ToolName = pending.ToolName,
+            // Preserve null-vs-set semantics on the wire: Truncate returns
+            // string.Empty for null input, which would round-trip as
+            // DisplayText="" with HasDisplayText=true.
+            DisplayText = string.IsNullOrEmpty(pending.DisplayText)
+                ? null
+                : ApprovalDisplayTextFormatter.Truncate(
+                    pending.DisplayText,
+                    PendingApprovalPromptTracked.MaxPersistedDisplayTextChars)
+        };
+}

--- a/src/Netclaw.Channels/PendingApprovalLookup.cs
+++ b/src/Netclaw.Channels/PendingApprovalLookup.cs
@@ -11,22 +11,36 @@ namespace Netclaw.Channels;
 public enum ApprovalLookupResult { Matched, WrongRequester, NotFound }
 
 /// <summary>
+/// Selects which candidate wins when more than one pending request matches.
+/// The requester check is the same for both orders; only the tie-break differs.
+/// </summary>
+public enum ApprovalMatchOrder
+{
+    /// <summary>The most recent match wins. Discord and Mattermost use this.</summary>
+    Newest,
+
+    /// <summary>The earliest match wins. Slack uses this.</summary>
+    Oldest
+}
+
+/// <summary>
 /// Finds the pending approval a channel binding actor should act on. A
-/// given call ID takes priority; otherwise the most recent pending
-/// request the sender is allowed to approve wins.
+/// given call ID takes priority; otherwise the pending request the sender
+/// is allowed to approve wins, picked by the channel's match order.
 /// </summary>
 public static class PendingApprovalLookup
 {
     public static (ApprovalLookupResult Result, TRequest? Pending) Resolve<TRequest, TPromptId>(
         IReadOnlyList<TRequest> pendingRequests,
         string approvingSenderId,
-        ToolCallId? callId)
+        ToolCallId? callId,
+        ApprovalMatchOrder matchOrder)
         where TRequest : PendingApprovalRequest<TPromptId>
         where TPromptId : struct
     {
         if (callId is { } resolvedCallId)
         {
-            var byCallId = pendingRequests.LastOrDefault(p => p.CallId == resolvedCallId);
+            var byCallId = Select(pendingRequests, p => p.CallId == resolvedCallId, matchOrder);
             if (byCallId is null)
                 return (ApprovalLookupResult.NotFound, null);
             if (!ApprovalButtonValueCodec.CanApprove(byCallId.RequesterPrincipal, byCallId.RequesterSenderId, approvingSenderId))
@@ -37,10 +51,21 @@ public static class PendingApprovalLookup
         if (pendingRequests.Count == 0)
             return (ApprovalLookupResult.NotFound, null);
 
-        var bySender = pendingRequests.LastOrDefault(p =>
-            ApprovalButtonValueCodec.CanApprove(p.RequesterPrincipal, p.RequesterSenderId, approvingSenderId));
+        var bySender = Select(
+            pendingRequests,
+            p => ApprovalButtonValueCodec.CanApprove(p.RequesterPrincipal, p.RequesterSenderId, approvingSenderId),
+            matchOrder);
         return bySender is not null
             ? (ApprovalLookupResult.Matched, bySender)
             : (ApprovalLookupResult.WrongRequester, null);
     }
+
+    private static TRequest? Select<TRequest>(
+        IReadOnlyList<TRequest> pendingRequests,
+        Func<TRequest, bool> predicate,
+        ApprovalMatchOrder matchOrder)
+        where TRequest : class
+        => matchOrder is ApprovalMatchOrder.Newest
+            ? pendingRequests.LastOrDefault(predicate)
+            : pendingRequests.FirstOrDefault(predicate);
 }

--- a/src/Netclaw.Channels/SafeTransportCall.cs
+++ b/src/Netclaw.Channels/SafeTransportCall.cs
@@ -1,0 +1,97 @@
+// -----------------------------------------------------------------------
+// <copyright file="SafeTransportCall.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
+
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Wraps one outbound transport call in the delivery bookkeeping every channel
+/// binding actor applies to it: measure the call, record reply telemetry for
+/// the channel, and on failure log, record the failure, and tell the session
+/// that delivery did not happen.
+/// </summary>
+/// <remarks>
+/// The delivery-failure notifier is required and its exceptions propagate. A
+/// dead feedback pipe means the session never learns the turn failed, so the
+/// error must reach the actor and let supervision restart it — see PR #2004.
+/// This type therefore never wraps the notifier in a catch of its own.
+/// </remarks>
+public sealed class SafeTransportCall
+{
+    private readonly ChannelType _channelType;
+    private readonly TimeProvider _timeProvider;
+    private readonly Func<DeliveryFailureKind, string, Task> _notifyDeliveryFailedAsync;
+
+    /// <param name="channelType">Telemetry category for the channel.</param>
+    /// <param name="timeProvider">Clock for the call duration.</param>
+    /// <param name="notifyDeliveryFailedAsync">Tells the session that delivery failed.</param>
+    public SafeTransportCall(
+        ChannelType channelType,
+        TimeProvider timeProvider,
+        Func<DeliveryFailureKind, string, Task> notifyDeliveryFailedAsync)
+    {
+        _channelType = channelType;
+        _timeProvider = timeProvider;
+        _notifyDeliveryFailedAsync = notifyDeliveryFailedAsync;
+    }
+
+    /// <summary>
+    /// Runs one transport call. Returns <c>true</c> on success; on failure
+    /// returns <c>false</c> after the session has been told.
+    /// </summary>
+    /// <param name="callAsync">The transport call.</param>
+    /// <param name="logFailure">
+    /// Writes the channel's own failure log line. Each channel keeps its
+    /// wording and its level, so this callback owns the log call.
+    /// </param>
+    public async Task<bool> InvokeAsync(Func<Task> callAsync, Action<Exception> logFailure)
+    {
+        var startedAt = _timeProvider.GetTimestamp();
+        try
+        {
+            await callAsync();
+            ChannelTelemetry.For(_channelType).RecordReplyPosted(ElapsedMs(startedAt));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            var duration = ElapsedMs(startedAt);
+            logFailure(ex);
+            ChannelTelemetry.For(_channelType).RecordReplyFailed(duration);
+            await _notifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into transport-sized chunks and posts
+    /// them in order. Returns <c>true</c> only when every chunk posted; stops at
+    /// the first failed chunk.
+    /// </summary>
+    /// <param name="text">The text to post.</param>
+    /// <param name="maxChunkLength">The transport's message length ceiling.</param>
+    /// <param name="postChunkAsync">Posts one chunk.</param>
+    /// <param name="logFailure">Writes the channel's own failure log line.</param>
+    public async Task<bool> PostChunkedAsync(
+        string text,
+        int maxChunkLength,
+        Func<string, Task> postChunkAsync,
+        Action<Exception> logFailure)
+    {
+        foreach (var chunk in MessageChunker.Chunk(text, maxChunkLength))
+        {
+            if (!await InvokeAsync(() => postChunkAsync(chunk), logFailure))
+                return false;
+        }
+
+        return true;
+    }
+
+    private double ElapsedMs(long startedAt)
+        => _timeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
+}

--- a/src/Netclaw.Channels/SnowflakeCursorComparer.cs
+++ b/src/Netclaw.Channels/SnowflakeCursorComparer.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="SnowflakeCursorComparer.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Orders Discord snowflake cursors that are held as strings. A shorter
+/// digit string is always the smaller number, so the comparison is length
+/// first and then ordinal. Plain ordinal comparison is wrong across a
+/// digit-length boundary: it puts the 18-digit "999999999999999999" after
+/// the 19-digit "1000000000000000000".
+/// </summary>
+/// <remarks>
+/// The comparer expects a canonical unsigned decimal string: digits only,
+/// no sign, no whitespace, and no leading zero. Discord snowflakes have
+/// that form, and the Discord binding actor normalizes every cursor value
+/// through <see cref="ulong"/> before it stores or persists the value. A
+/// non-canonical input has no defined order here.
+/// </remarks>
+public sealed class SnowflakeCursorComparer : IComparer<string>
+{
+    public static readonly SnowflakeCursorComparer Instance = new();
+
+    private SnowflakeCursorComparer()
+    {
+    }
+
+    /// <summary>
+    /// Compares two snowflake cursors. A null value is smaller than any
+    /// non-null value, which matches the framework comparer convention and
+    /// the "no cursor yet" state of a fresh binding.
+    /// </summary>
+    public int Compare(string? x, string? y)
+    {
+        if (ReferenceEquals(x, y))
+            return 0;
+        if (x is null)
+            return -1;
+        if (y is null)
+            return 1;
+
+        if (x.Length != y.Length)
+            return x.Length < y.Length ? -1 : 1;
+
+        return Math.Sign(string.CompareOrdinal(x, y));
+    }
+}

--- a/src/Netclaw.Channels/ThreadGapHydrationEngine.cs
+++ b/src/Netclaw.Channels/ThreadGapHydrationEngine.cs
@@ -1,0 +1,442 @@
+// -----------------------------------------------------------------------
+// <copyright file="ThreadGapHydrationEngine.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Threading.Channels;
+using Akka.Event;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
+using Netclaw.Security;
+
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Shared thread-gap hydration for the channel binding actors. The engine
+/// fetches thread history, filters it against the session cursor, classifies
+/// each candidate for prompt-injection risk, merges the survivors as adopted
+/// context, and enqueues the turn. Slack, Discord, and Mattermost supply the
+/// transport lookups; the algorithm has one implementation here.
+/// </summary>
+/// <remarks>
+/// The engine holds no Akka state. It does not persist an event and it does not
+/// touch the actor context. Each actor-owned effect (cursor read, input-queue
+/// lookup, turn-enqueue bookkeeping, hydration re-arm) goes through a callback
+/// that the binding actor supplies at construction. All callbacks run on the
+/// actor's own message-processing path, so they are safe to read and write
+/// actor state.
+/// </remarks>
+public sealed class ThreadGapHydrationEngine
+{
+    // Both timeouts match what every binding actor used before the extraction:
+    // 30 seconds for the history fetch plus classification, 10 seconds for the
+    // input-queue write.
+    private static readonly TimeSpan HistoryFetchTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan EnqueueTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly SessionId _sessionId;
+    private readonly ChannelType _channelType;
+    private readonly IThreadHistoryFetcher _historyFetcher;
+    private readonly IPromptInjectionDetector _injectionDetector;
+    private readonly string _classifierSourceContext;
+    private readonly IComparer<string> _cursorComparer;
+    private readonly Func<string?, string?> _cursorKeySelector;
+    private readonly Func<string, bool> _isAuthorizedSender;
+    private readonly ILoggingAdapter _log;
+    private readonly Func<string?> _readCursor;
+    private readonly Func<ChannelWriter<ChannelInput>?> _readInputQueue;
+    private readonly Func<string?> _readIngressClosedReason;
+    private readonly Func<Task> _warnBackfillDetectorUnavailableAsync;
+    private readonly Action<string?> _onBackfillEnqueued;
+    private readonly Action<bool> _setHydrationPending;
+
+    /// <summary>
+    /// Creates the engine. Every dependency is required: the injection detector
+    /// and the authorization callback are security inputs, so the engine cannot
+    /// run with either of them absent.
+    /// </summary>
+    /// <param name="sessionId">The session this binding serves.</param>
+    /// <param name="channelType">Telemetry category for the channel.</param>
+    /// <param name="historyFetcher">Transport lookup for thread history.</param>
+    /// <param name="injectionDetector">Prompt-injection detector for gap messages.</param>
+    /// <param name="classifierSourceContext">Detector source tag, for example <c>slack-backfill</c>.</param>
+    /// <param name="cursorComparer">Orders two cursor keys of this channel.</param>
+    /// <param name="cursorKeySelector">
+    /// Maps a raw message id to its cursor key. A <c>null</c> result means the
+    /// message has no usable ordering key, so the engine skips it.
+    /// </param>
+    /// <param name="isAuthorizedSender">Channel authorization basis for adopted context.</param>
+    /// <param name="log">The binding actor's logger, with its adapter context fields.</param>
+    /// <param name="readCursor">Reads the recovered session cursor.</param>
+    /// <param name="readInputQueue">Reads the session pipeline input queue.</param>
+    /// <param name="readIngressClosedReason">Reads the restart-drain reason, or <c>null</c> when ingress is open.</param>
+    /// <param name="warnBackfillDetectorUnavailableAsync">Posts the channel's detector-unavailable warning.</param>
+    /// <param name="onBackfillEnqueued">
+    /// Reports a completed backfill enqueue with the trigger's cursor key. The
+    /// actor marks the turn in flight and advances its pending cursor.
+    /// </param>
+    /// <param name="setHydrationPending">Arms or disarms the deferred-hydration flag.</param>
+    public ThreadGapHydrationEngine(
+        SessionId sessionId,
+        ChannelType channelType,
+        IThreadHistoryFetcher historyFetcher,
+        IPromptInjectionDetector injectionDetector,
+        string classifierSourceContext,
+        IComparer<string> cursorComparer,
+        Func<string?, string?> cursorKeySelector,
+        Func<string, bool> isAuthorizedSender,
+        ILoggingAdapter log,
+        Func<string?> readCursor,
+        Func<ChannelWriter<ChannelInput>?> readInputQueue,
+        Func<string?> readIngressClosedReason,
+        Func<Task> warnBackfillDetectorUnavailableAsync,
+        Action<string?> onBackfillEnqueued,
+        Action<bool> setHydrationPending)
+    {
+        _sessionId = sessionId;
+        _channelType = channelType;
+        _historyFetcher = historyFetcher;
+        _injectionDetector = injectionDetector;
+        _classifierSourceContext = classifierSourceContext;
+        _cursorComparer = cursorComparer;
+        _cursorKeySelector = cursorKeySelector;
+        _isAuthorizedSender = isAuthorizedSender;
+        _log = log;
+        _readCursor = readCursor;
+        _readInputQueue = readInputQueue;
+        _readIngressClosedReason = readIngressClosedReason;
+        _warnBackfillDetectorUnavailableAsync = warnBackfillDetectorUnavailableAsync;
+        _onBackfillEnqueued = onBackfillEnqueued;
+        _setHydrationPending = setHydrationPending;
+    }
+
+    /// <summary>
+    /// One-shot thread history hydration. Runs once per actor lifetime, in the
+    /// Hydrating behavior immediately after pipeline initialization. Fetches
+    /// thread history, computes the gap relative to the recovered cursor, and
+    /// if there is an authorized message in the gap, synthesizes one backfill
+    /// <see cref="ChannelInput"/> using that message as the trigger and older
+    /// gap messages as adopted context. Hands the synthesized input to the
+    /// session pipeline through the normal input-queue path.
+    /// </summary>
+    public async Task PerformOneShotHydrationAsync()
+    {
+        using var cts = new CancellationTokenSource(HistoryFetchTimeout);
+
+        IReadOnlyList<ChannelInput> history;
+        try
+        {
+            history = await _historyFetcher.FetchThreadHistoryAsync(_sessionId, cts.Token);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Thread history fetch failed for session {SessionId}", _sessionId.Value);
+            return;
+        }
+
+        var cursor = _readCursor();
+
+        if (history.Count == 0)
+        {
+            _log.Info(
+                "Thread history hydration: empty thread, no backfill cursor={Cursor} session={Session}",
+                cursor ?? "none", _sessionId.Value);
+            return;
+        }
+
+        var candidates = new List<ChannelInput>(history.Count);
+        foreach (var item in history)
+        {
+            if (_cursorKeySelector(item.MessageId) is not { } itemKey)
+                continue;
+
+            // Strict: only include messages newer than the cursor. PR #733's
+            // "cursor advances only on TurnCompleted" guarantees that
+            // itemKey == cursor means the session already has that message
+            // persisted — re-including it here on a restart hydration would
+            // duplicate it. The in-flight-crash case is handled too: a turn
+            // that didn't complete leaves the cursor un-advanced, so the
+            // message has itemKey > cursor and is correctly included in the gap.
+            if (cursor is { } c && _cursorComparer.Compare(itemKey, c) <= 0)
+                continue;
+
+            candidates.Add(item);
+        }
+
+        if (candidates.Count == 0)
+        {
+            _log.Info(
+                "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor} session={Session}",
+                history.Count, cursor ?? "none", _sessionId.Value);
+            return;
+        }
+
+        var classified = await ClassifyGapAsync(candidates, cts.Token);
+        var gap = classified.Gap;
+
+        _log.Info(
+            "Thread history hydration fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
+            history.Count, candidates.Count, gap.Count, classified.BlockedForRisk, cursor ?? "none", _sessionId.Value);
+
+        if (classified.DetectorUnavailable)
+            await _warnBackfillDetectorUnavailableAsync();
+
+        if (gap.Count == 0)
+            return;
+
+        // Locate the most recent authorized message in the gap — it plays the
+        // role of the "current authorized message" that adopted-context normally
+        // anchors around. Without one we have no authorized trigger to enqueue;
+        // the actor transitions to Active and the next live authorized inbound
+        // becomes the trigger (the cursor stays put, so staleness still drops
+        // anything already seen).
+        AdoptedContextMessage? trigger = null;
+        for (var i = gap.Count - 1; i >= 0; i--)
+        {
+            if (gap[i].AuthorityAtInclusion == AdoptedMessageAuthority.Authorized)
+            {
+                trigger = gap[i];
+                break;
+            }
+        }
+
+        if (trigger is null)
+        {
+            // Deferred: a non-empty gap with no authorized trigger. The
+            // proactive-thread case — the binding actor's lifetime began when
+            // the agent posted the thread root, so this hydration ran before
+            // any authorized human inbound existed. Re-arm so the first
+            // authorized inbound performs this hydration (adopting the gap,
+            // e.g. the bot-authored root) instead of taking the fetch-free path.
+            _setHydrationPending(true);
+            _log.Info(
+                "Thread history hydration: no authorized message in gap; re-armed for next authorized inbound session={Session}",
+                _sessionId.Value);
+            return;
+        }
+
+        var adoptedContext = new List<AdoptedContextMessage>();
+        foreach (var item in gap)
+        {
+            if (ReferenceEquals(item, trigger))
+                break;
+            adoptedContext.Add(item);
+        }
+
+        // Build the synthesized inbound. The trigger's ChannelInput already
+        // carries its own text and attachment contents (loaded by the history
+        // fetcher), so those are the "live" contents for the merge.
+        var triggerInput = trigger.Input;
+        var triggerKey = _cursorKeySelector(triggerInput.MessageId);
+        var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
+
+        if (_readIngressClosedReason() is { } ingressClosedReason)
+        {
+            _log.Info("Skipping hydration backfill enqueue while restart drain is active: {Reason}", ingressClosedReason);
+            return;
+        }
+
+        var writer = _readInputQueue();
+        if (writer is null)
+        {
+            _log.Warning("Input queue is not initialized; skipping hydration backfill");
+            return;
+        }
+
+        try
+        {
+            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+            writeCts.CancelAfter(EnqueueTimeout);
+            await writer.WriteAsync(backfillInput, writeCts.Token);
+            // A hydration backfill is an in-flight turn too; the actor mirrors the
+            // live-inbound enqueue so a mention arriving before this turn completes
+            // does not re-arm.
+            _onBackfillEnqueued(triggerKey);
+
+            _log.Info(
+                "hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
+                triggerInput.MessageId, adoptedContext.Count, _sessionId.Value);
+            ChannelTelemetry.For(_channelType).RecordMessageEnqueued();
+        }
+        catch (OperationCanceledException ex)
+        {
+            _log.Warning(ex, "Timed out enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
+        }
+        catch (ChannelClosedException ex)
+        {
+            _log.Warning(ex, "Input queue closed while enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
+        }
+    }
+
+    /// <summary>
+    /// Completes a thread-history hydration that <see cref="PerformOneShotHydrationAsync"/>
+    /// deferred for lack of an authorized trigger. The caller's authorized inbound
+    /// is the executable trigger; the thread gap strictly before it — most
+    /// importantly a proactively-posted bot-authored root — is fetched,
+    /// classified, and merged as its adopted-context window. On fetch failure the
+    /// turn proceeds un-enriched and hydration stays re-armed, so a later
+    /// authorized inbound retries.
+    /// </summary>
+    /// <param name="baseInput">The live inbound, already built by the actor.</param>
+    /// <param name="liveMessageId">The live inbound's raw message id.</param>
+    /// <param name="cancellationToken">The actor's inbound-processing token.</param>
+    /// <returns>
+    /// The input to enqueue: <paramref name="baseInput"/> when there is nothing
+    /// to adopt, otherwise the same input with its adopted-context window merged.
+    /// </returns>
+    public async Task<ChannelInput> ApplyDeferredHydrationAsync(
+        ChannelInput baseInput,
+        string? liveMessageId,
+        CancellationToken cancellationToken)
+    {
+        // Without the live message's ordering key the gap below it cannot be
+        // bounded; leave hydration re-armed and take the fetch-free path.
+        if (_cursorKeySelector(liveMessageId) is not { } liveKey)
+            return baseInput;
+
+        IReadOnlyList<ChannelInput> history;
+        try
+        {
+            history = await _historyFetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: execute the turn without an adopted window and keep
+            // hydration re-armed so a later authorized inbound retries.
+            _log.Warning(ex, "Re-armed thread history fetch failed for session {SessionId}", _sessionId.Value);
+            return baseInput;
+        }
+
+        // Fetch succeeded: hydration is complete. Only a fetch failure (caught
+        // above) keeps the flag armed — classify/merge outcomes never re-arm.
+        _setHydrationPending(false);
+
+        var cursor = _readCursor();
+        var candidates = new List<ChannelInput>(history.Count);
+        foreach (var item in history)
+        {
+            if (_cursorKeySelector(item.MessageId) is not { } itemKey)
+                continue;
+
+            // Strictly above the watermark and strictly below the live inbound:
+            // the live inbound is the executable message, not adopted context.
+            if (cursor is { } c && _cursorComparer.Compare(itemKey, c) <= 0)
+                continue;
+            if (_cursorComparer.Compare(itemKey, liveKey) >= 0)
+                continue;
+
+            candidates.Add(item);
+        }
+
+        if (candidates.Count == 0)
+            return baseInput;
+
+        var classified = await ClassifyGapAsync(candidates, cancellationToken);
+        if (classified.DetectorUnavailable)
+            await _warnBackfillDetectorUnavailableAsync();
+
+        if (classified.Gap.Count == 0)
+            return baseInput;
+
+        _log.Info(
+            "deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
+            classified.Gap.Count,
+            baseInput.MessageId,
+            _sessionId.Value);
+
+        return MergeAdoptedContext(baseInput, classified.Gap, cursor);
+    }
+
+    private Task<Classification> ClassifyGapMessageAsync(ChannelInput input, CancellationToken cancellationToken)
+    {
+        var text = string.Join("\n", input.Contents
+            .OfType<TextContent>()
+            .Select(t => t.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t)));
+
+        return PromptClassifier.ClassifyAsync(
+            _injectionDetector, text, _classifierSourceContext, _log, cancellationToken);
+    }
+
+    private readonly record struct GapClassification(
+        List<AdoptedContextMessage> Gap,
+        int BlockedForRisk,
+        bool DetectorUnavailable);
+
+    /// <summary>
+    /// Runs prompt-injection classification over candidate gap messages and
+    /// captures each surviving message's authority-at-inclusion. Blocked
+    /// messages are dropped; detector-unavailable messages are also dropped
+    /// and surface a caller-visible flag.
+    /// </summary>
+    private async Task<GapClassification> ClassifyGapAsync(
+        IReadOnlyList<ChannelInput> candidates,
+        CancellationToken cancellationToken)
+    {
+        var classifications = await Task.WhenAll(
+            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
+
+        var gap = new List<AdoptedContextMessage>(candidates.Count);
+        var blockedForRisk = 0;
+        var detectorUnavailable = false;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            switch (classifications[i].Outcome)
+            {
+                case ClassificationOutcome.Allow:
+                    var authority = _isAuthorizedSender(candidates[i].SenderId.Value)
+                        ? AdoptedMessageAuthority.Authorized
+                        : AdoptedMessageAuthority.Pending;
+                    gap.Add(new AdoptedContextMessage(candidates[i], authority));
+                    break;
+
+                case ClassificationOutcome.Block:
+                    blockedForRisk++;
+                    _log.Warning(
+                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
+                        candidates[i].SenderId,
+                        candidates[i].MessageId ?? "none",
+                        classifications[i].Reason ?? "high-risk pattern detected");
+                    break;
+
+                case ClassificationOutcome.DetectorUnavailable:
+                    blockedForRisk++;
+                    detectorUnavailable = true;
+                    break;
+            }
+        }
+
+        return new GapClassification(gap, blockedForRisk, detectorUnavailable);
+    }
+
+    /// <summary>
+    /// Merges <paramref name="adoptedContext"/> as the adopted-context window
+    /// preceding <paramref name="triggerInput"/> (the executable message) and
+    /// returns the trigger input with adopted-context metadata populated.
+    /// </summary>
+    private static ChannelInput MergeAdoptedContext(
+        ChannelInput triggerInput,
+        List<AdoptedContextMessage> adoptedContext,
+        string? cursor)
+    {
+        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
+            adoptedContext,
+            triggerInput.Contents,
+            triggerInput.SenderId.Value,
+            triggerInput.ReceivedAt);
+
+        return triggerInput with
+        {
+            Contents = merged.Contents,
+            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(
+                id => !string.Equals(id, triggerInput.SenderId.Value, StringComparison.Ordinal)),
+            AdoptedSpeakerIds = merged.SpeakerIds,
+            AdoptedContextProjection = merged.Projection,
+            AdoptedContextLowerBound = cursor,
+            AdoptedContextUpperBound = triggerInput.MessageId,
+            AdoptedContextEntries = merged.Entries
+        };
+    }
+}


### PR DESCRIPTION
## What

Phase 4 of the code-reduction stack (on top of #2004), implementing OpenSpec change `consolidate-binding-actor-engines` (proposal, design, parity spec, and tasks are in the PR). The three channel binding actors — previously ~78% line-identical between Discord and Mattermost — now delegate their four big duplicated regions to shared engines in `Netclaw.Channels`:

| Commit | Engine | Actor lines removed |
|---|---|---|
| Discord cursor stringization | `SnowflakeCursorComparer` (length-then-ordinal; proof test vs `ulong` ordering incl. cross-digit-length pairs) | prerequisite |
| Gap hydration | `ThreadGapHydrationEngine` — fetch → cursor-filter → injection-classify → adopted-context merge → enqueue | −859 |
| Approval response | `ApprovalResponseFlow` — text parsing, cold-spawn path, prompt resolution; requester check has one home | −737 |
| Output + transport | `ChannelOutputEngine` (turn-completion state machine) + `SafeTransportCall` | −401 |

**Actor sizes: Slack 1,919→1,263, Discord 1,733→1,057, Mattermost 1,684→989.** This PR net across src: −346 (engines carry ~150 lines of hook XML docs); across the whole stack the src net is **−1,004** with functionality unchanged and coverage strengthened.

## Zero behavior change, with three disclosed exceptions

1. Slack hydration log lines gain `session=`/`allowed=` fields the other channels already log (no test asserts these).
2. Slack's approval text path previously swallowed journal-persist/redraw failures inside a wide try; it now wraps only the feedback send, matching the other channels and the no-silent-fallbacks rule.
3. Prompt-post failure now removes the pending entry before the auto-deny on all three channels (previously order varied; same feedback and list state, removes a Mattermost double-deny risk).

## Real differences found and preserved (the stop rule working)

- **Approval match order**: Slack resolves the *earliest* matching pending approval, Discord/Mattermost the *most recent*. Preserved per channel via a required `ApprovalMatchOrder` on the shared lookup; documented in the parity spec. Which is correct is an open product question.
- **Reinitialize cursor discipline**: Slack discards the pending cursor on pipeline reinitialize, Discord/Mattermost keep it — meaning a later `TurnCompleted` can commit an abandoned turn's cursor. Possible latent defect in the Discord/Mattermost behavior; preserved as-is and documented in the parity spec.
- Slack keeps its own transport wrappers (three-way exception classification + `RecordReplyRejected` don't fit the shared skeleton), delivery-failure report timing (deferred vs inline), reminder observed-at source, text trimming, and error formatting — all per-channel hooks.

## Verification

- Full `Netclaw.Actors.Tests`: 3,447 passed / 0 failed / 1 pre-existing Windows-only skip — run after every channel's delegation in every group, plus a 5× stress run at the end. One intermediate run showed 3 unreproduced failures (names not captured; 5 consecutive clean runs after); flagged here for CI scrutiny given the repo's known racy-test history.
- `Netclaw.Daemon.Tests`: 1,023 passed / 0 failed. FileFlow suites green.
- Persisted formats untouched: `CursorAdvanced` values byte-identical (same `ulong.ToString()` output), journal event types unchanged, no config/schema change.
- `dotnet slopwatch analyze`: 0 issues; header verification passes; zero build warnings.

## Stack

PR 4 of 4 in the current stack. Base: `refactor/delivery-failure-drift` (#2004).