### PR TITLE
Simplify three duplication hotspots

### DIFF
--- a/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
@@ -1379,205 +1379,11 @@ public sealed class SQLiteMemoryStore
     {
         await WithConnectionAsync(async (conn, ct) =>
         {
-        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
+            await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
 
-        foreach (var operation in operations)
-        {
-            var now = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
-            var resolvedBoundary = string.Equals(operation.Boundary, TrustBoundary.LegacyRestrictedValue, StringComparison.Ordinal)
-                ? TrustBoundary.TrustedInstanceValue
-                : operation.Boundary;
-            var canonicalName = string.IsNullOrWhiteSpace(operation.AnchorCanonicalName)
-                ? operation.Title
-                : operation.AnchorCanonicalName;
-            var anchor = CreateDefaultAnchor(canonicalName) with
-            {
-                AnchorType = operation.AnchorType,
-                Sensitivity = operation.Sensitivity,
-                RecallMode = operation.RecallMode,
-                Confidence = operation.Confidence,
-                FreshnessAtMs = now,
-                CreatedAtMs = now,
-                UpdatedAtMs = now
-            };
+            await ApplyCurationOperationsAsync(conn, tx, operations, ct);
 
-            await EnsureAnchorAsync(conn, tx, anchor, ct);
-
-            if (operation.Kind == MemoryKind.Record.ToWireValue())
-            {
-                var recId = string.IsNullOrWhiteSpace(operation.MemoryId) ? MemoryTypedId.NewRecordId().Value : operation.MemoryId;
-                await using var recordCmd = conn.CreateCommand();
-                recordCmd.Transaction = tx;
-                recordCmd.CommandText = """
-                    INSERT INTO memory_records(
-                      record_id, anchor_id, memory_class, record_type, payload_json, aliases_json, facets_json, slots_json, supersedes_record_id,
-                      update_semantics, boundary, audience, sensitivity, recall_mode, confidence,
-                      freshness_at, expires_at, created_at)
-                    VALUES($id, $anchorId, $memoryClass, $recordType, $payloadJson, $aliasesJson, $facetsJson, $slotsJson, $supersedes,
-                      $semantics, $boundary, $audience, $sensitivity, $recallMode, $confidence,
-                      $freshnessAt, $expiresAt, $createdAt);
-                    """;
-                recordCmd.Parameters.AddWithValue("$id", recId);
-                recordCmd.Parameters.AddWithValue("$anchorId", anchor.AnchorId);
-                recordCmd.Parameters.AddWithValue("$memoryClass", operation.MemoryClass);
-                recordCmd.Parameters.AddWithValue("$recordType", operation.Title);
-                recordCmd.Parameters.AddWithValue("$payloadJson", operation.Content);
-                recordCmd.Parameters.AddWithValue("$aliasesJson", (object?)operation.AliasesJson ?? DBNull.Value);
-                recordCmd.Parameters.AddWithValue("$facetsJson", (object?)operation.FacetsJson ?? DBNull.Value);
-                recordCmd.Parameters.AddWithValue("$slotsJson", (object?)operation.SlotsJson ?? DBNull.Value);
-                recordCmd.Parameters.AddWithValue("$supersedes", (object?)operation.SupersedesRecordId ?? DBNull.Value);
-                recordCmd.Parameters.AddWithValue("$semantics", operation.UpdateSemantics);
-                recordCmd.Parameters.AddWithValue("$boundary", resolvedBoundary);
-                recordCmd.Parameters.AddWithValue("$audience", operation.Audience.ToWireValue());
-                recordCmd.Parameters.AddWithValue("$sensitivity", operation.Sensitivity);
-                recordCmd.Parameters.AddWithValue("$recallMode", operation.RecallMode);
-                recordCmd.Parameters.AddWithValue("$confidence", operation.Confidence);
-                recordCmd.Parameters.AddWithValue("$freshnessAt", (object?)operation.FreshnessAtMs ?? DBNull.Value);
-                recordCmd.Parameters.AddWithValue("$expiresAt", (object?)operation.ExpiresAtMs ?? DBNull.Value);
-                recordCmd.Parameters.AddWithValue("$createdAt", now);
-                await recordCmd.ExecuteNonQueryAsync(ct);
-
-                if (IsSearchableRecallMode(operation.RecallMode))
-                    await UpsertRecordFtsAsync(conn, tx, recId, operation.Title, operation.Content, operation.AliasesJson, operation.FacetsJson, ct);
-
-                continue;
-            }
-
-            var resolvedRecallMode = string.Equals(operation.MemoryClass, MemoryClass.Trace.ToWireValue(), StringComparison.OrdinalIgnoreCase)
-                ? MemoryRecallMode.Never.ToWireValue()
-                : operation.RecallMode;
-
-            // Anchor-based dedup: same logic as ApplyCurationBatchAsync. Reusing an existing
-            // document_id here (documentId set, collision left null) is safe: it means the
-            // operation already carries an explicit target (Update decision). Finding an
-            // existing row via the anchor lookup below (collision set) is a genuine Create
-            // collision — see DedupCollision's remarks — and must append, not overwrite.
-            string documentId;
-            DedupCollision? collision = null;
-            if (!string.IsNullOrWhiteSpace(operation.MemoryId))
-            {
-                documentId = operation.MemoryId;
-            }
-            else if (string.Equals(operation.UpdateSemantics, MemoryUpdateSemantics.MergeDocument.ToWireValue(), StringComparison.OrdinalIgnoreCase))
-            {
-                await using var lookupCmd = conn.CreateCommand();
-                lookupCmd.Transaction = tx;
-                lookupCmd.CommandText = """
-                    SELECT document_id, title, markdown_body, boundary, audience, sensitivity
-                    FROM memory_documents
-                    WHERE anchor_id = $anchorId
-                    ORDER BY updated_at DESC
-                    LIMIT 1;
-                    """;
-                lookupCmd.Parameters.AddWithValue("$anchorId", anchor.AnchorId);
-                await using var lookupReader = await lookupCmd.ExecuteReaderAsync(ct);
-                if (await lookupReader.ReadAsync(ct))
-                {
-                    documentId = lookupReader.GetString(0);
-                    collision = new DedupCollision(
-                        lookupReader.GetString(1),
-                        lookupReader.GetString(2),
-                        lookupReader.IsDBNull(3) ? null : lookupReader.GetString(3),
-                        lookupReader.IsDBNull(4) ? null : lookupReader.GetString(4),
-                        lookupReader.GetString(5));
-                }
-                else
-                {
-                    documentId = MemoryTypedId.NewDocumentId().Value;
-                }
-            }
-            else
-            {
-                documentId = MemoryTypedId.NewDocumentId().Value;
-            }
-
-            if (collision is not null)
-            {
-                // Idempotency guard: a colliding proposal whose content the existing body
-                // already holds verbatim adds nothing — appending it would bloat the
-                // document on every repeat (the inverse failure of the overwrite bug this
-                // path fixes). Logged no-op: the document row stays byte-identical.
-                if (collision.MarkdownBody.Contains(operation.Content, StringComparison.Ordinal))
-                {
-                    _logger.LogInformation(
-                        "curation_dedup_duplicate_skipped anchor={AnchorCanonicalName} targetDoc={DocumentId}",
-                        canonicalName,
-                        documentId);
-                    continue;
-                }
-
-                _logger.LogInformation(
-                    "curation_dedup_append anchor={AnchorCanonicalName} targetDoc={DocumentId}",
-                    canonicalName,
-                    documentId);
-            }
-
-            // Preserve the colliding row's identity/classification; only the body grows
-            // (appended) and update_semantics flips to append-document to record that this
-            // write did not overwrite. Non-collision path is the pre-existing behavior.
-            var effectiveTitle = collision is not null ? collision.Title : operation.Title;
-            var effectiveBody = collision is not null
-                ? BuildDedupAppendedBody(collision.MarkdownBody, operation.Content)
-                : operation.Content;
-            var effectiveBoundary = collision is not null ? collision.Boundary : resolvedBoundary;
-            var effectiveAudience = collision is not null ? collision.Audience : operation.Audience.ToWireValue();
-            var effectiveSensitivity = collision is not null ? collision.Sensitivity : operation.Sensitivity;
-            var effectiveSemantics = collision is not null
-                ? MemoryUpdateSemantics.AppendDocument.ToWireValue()
-                : operation.UpdateSemantics;
-
-            await using var documentCmd = conn.CreateCommand();
-            documentCmd.Transaction = tx;
-            documentCmd.CommandText = """
-                INSERT INTO memory_documents(
-                  document_id, anchor_id, memory_class, title, markdown_body, aliases_json, facets_json, slots_json, update_semantics,
-                  boundary, audience, sensitivity, recall_mode, confidence, freshness_at,
-                  expires_at, created_at, updated_at)
-                VALUES($id, $anchorId, $memoryClass, $title, $body, $aliasesJson, $facetsJson, $slotsJson, $semantics,
-                  $boundary, $audience, $sensitivity, $recallMode, $confidence, $freshnessAt,
-                  $expiresAt, $createdAt, $updatedAt)
-                ON CONFLICT(document_id) DO UPDATE SET
-                  memory_class=excluded.memory_class,
-                  title=excluded.title,
-                  markdown_body=excluded.markdown_body,
-                  aliases_json=excluded.aliases_json,
-                  facets_json=excluded.facets_json,
-                  slots_json=excluded.slots_json,
-                  update_semantics=excluded.update_semantics,
-                  boundary=excluded.boundary,
-                  audience=excluded.audience,
-                  sensitivity=excluded.sensitivity,
-                  recall_mode=excluded.recall_mode,
-                  confidence=excluded.confidence,
-                  freshness_at=excluded.freshness_at,
-                  expires_at=excluded.expires_at,
-                  updated_at=excluded.updated_at;
-                """;
-            documentCmd.Parameters.AddWithValue("$id", documentId);
-            documentCmd.Parameters.AddWithValue("$anchorId", anchor.AnchorId);
-            documentCmd.Parameters.AddWithValue("$memoryClass", operation.MemoryClass);
-            documentCmd.Parameters.AddWithValue("$title", effectiveTitle);
-            documentCmd.Parameters.AddWithValue("$body", effectiveBody);
-            documentCmd.Parameters.AddWithValue("$aliasesJson", (object?)operation.AliasesJson ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$facetsJson", (object?)operation.FacetsJson ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$slotsJson", (object?)operation.SlotsJson ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$semantics", effectiveSemantics);
-            documentCmd.Parameters.AddWithValue("$boundary", (object?)effectiveBoundary ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$audience", (object?)effectiveAudience ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$sensitivity", effectiveSensitivity);
-            documentCmd.Parameters.AddWithValue("$recallMode", resolvedRecallMode);
-            documentCmd.Parameters.AddWithValue("$confidence", operation.Confidence);
-            documentCmd.Parameters.AddWithValue("$freshnessAt", (object?)operation.FreshnessAtMs ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$expiresAt", (object?)operation.ExpiresAtMs ?? DBNull.Value);
-            documentCmd.Parameters.AddWithValue("$createdAt", now);
-            documentCmd.Parameters.AddWithValue("$updatedAt", now);
-            await documentCmd.ExecuteNonQueryAsync(ct);
-
-            if (IsSearchableRecallMode(resolvedRecallMode))
-                await UpsertDocumentFtsAsync(conn, tx, documentId, effectiveTitle, effectiveBody, operation.AliasesJson, operation.FacetsJson, ct);
-        }
-
-        await tx.CommitAsync(ct);
+            await tx.CommitAsync(ct);
         }, ct);
     }
 
@@ -1588,8 +1394,38 @@ public sealed class SQLiteMemoryStore
     {
         await WithConnectionAsync(async (conn, ct) =>
         {
-        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
+            await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
 
+            await ApplyCurationOperationsAsync(conn, tx, operations, ct);
+
+            await using var markDone = conn.CreateCommand();
+            markDone.Transaction = tx;
+            markDone.CommandText = """
+                UPDATE memory_checkpoints
+                SET status = 'completed',
+                    updated_at = $updatedAt
+                WHERE checkpoint_id = $id;
+                """;
+            markDone.Parameters.AddWithValue("$id", checkpointId);
+            markDone.Parameters.AddWithValue("$updatedAt", _timeProvider.GetUtcNow().ToUnixTimeMilliseconds());
+            await markDone.ExecuteNonQueryAsync(ct);
+
+            await tx.CommitAsync(ct);
+        }, ct);
+    }
+
+    /// <summary>
+    /// Shared per-operation write loop for <see cref="ApplyInlineCurationBatchAsync"/> and
+    /// <see cref="ApplyCurationBatchAsync"/>: anchor resolution, record insert, anchor-based
+    /// dedup lookup, document upsert, and FTS upsert. Both callers run this inside their own
+    /// transaction and commit (or add a checkpoint update) afterward.
+    /// </summary>
+    private async Task ApplyCurationOperationsAsync(
+        SqliteConnection conn,
+        SqliteTransaction tx,
+        IReadOnlyList<SQLiteMemoryCurationOperation> operations,
+        CancellationToken ct)
+    {
         foreach (var operation in operations)
         {
             var now = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
@@ -1788,21 +1624,6 @@ public sealed class SQLiteMemoryStore
             if (IsSearchableRecallMode(resolvedRecallMode))
                 await UpsertDocumentFtsAsync(conn, tx, documentId, effectiveTitle, effectiveBody, operation.AliasesJson, operation.FacetsJson, ct);
         }
-
-        await using var markDone = conn.CreateCommand();
-        markDone.Transaction = tx;
-        markDone.CommandText = """
-            UPDATE memory_checkpoints
-            SET status = 'completed',
-                updated_at = $updatedAt
-            WHERE checkpoint_id = $id;
-            """;
-        markDone.Parameters.AddWithValue("$id", checkpointId);
-        markDone.Parameters.AddWithValue("$updatedAt", _timeProvider.GetUtcNow().ToUnixTimeMilliseconds());
-        await markDone.ExecuteNonQueryAsync(ct);
-
-        await tx.CommitAsync(ct);
-        }, ct);
     }
 
     private async Task<T> WithConnectionAsync<T>(

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
@@ -5,14 +5,13 @@
 // -----------------------------------------------------------------------
 using System.Net.Http;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Mcp;
+using Netclaw.Cli.Tests.Tui;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -411,34 +410,16 @@ public sealed class McpToolPermissionsPageTests : IDisposable
     private (VirtualTerminal Terminal, TerminaApplication App, McpToolPermissionsViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input, int width = 120, int height = 40)
     {
-        var terminal = new VirtualTerminal(width, height);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        McpToolPermissionsViewModel? capturedVm = null;
-
         var configuration = new ConfigurationBuilder().Build();
         var daemonApi = new DaemonApi(new FailingHttpClientFactory(), configuration, _paths);
 
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/mcp-tools", builder =>
-        {
-            builder.RegisterRoute<McpToolPermissionsPage, McpToolPermissionsViewModel>(
-                "/mcp-tools",
-                _ => new McpToolPermissionsPage(),
-                _ =>
-                {
-                    capturedVm = new McpToolPermissionsViewModel(_paths, daemonApi);
-                    return capturedVm;
-                });
-        });
-
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
+        return HeadlessTerminaFixture.Create<McpToolPermissionsPage, McpToolPermissionsViewModel>(
+            "/mcp-tools",
+            () => new McpToolPermissionsPage(),
+            () => new McpToolPermissionsViewModel(_paths, daemonApi),
+            out input,
+            width,
+            height);
     }
 
     private static void AssertLineHasBackground(VirtualTerminal terminal, string text, Color expected)

--- a/src/Netclaw.Cli.Tests/Tui/ApprovalsManagerPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ApprovalsManagerPageTests.cs
@@ -3,13 +3,11 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Terminal;
 using Xunit;
@@ -253,31 +251,9 @@ public sealed class ApprovalsManagerPageTests : IDisposable
 
     private (VirtualTerminal Terminal, TerminaApplication App, ApprovalsManagerViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input)
-    {
-        var terminal = new VirtualTerminal(120, 40);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        ApprovalsManagerViewModel? capturedVm = null;
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/approvals", builder =>
-        {
-            builder.RegisterRoute<ApprovalsManagerPage, ApprovalsManagerViewModel>(
-                "/approvals",
-                _ => new ApprovalsManagerPage(),
-                _ =>
-                {
-                    capturedVm = new ApprovalsManagerViewModel(_paths, _time);
-                    return capturedVm;
-                });
-        });
-
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
-    }
+        => HeadlessTerminaFixture.Create<ApprovalsManagerPage, ApprovalsManagerViewModel>(
+            "/approvals",
+            () => new ApprovalsManagerPage(),
+            () => new ApprovalsManagerViewModel(_paths, _time),
+            out input);
 }

--- a/src/Netclaw.Cli.Tests/Tui/Config/ExposureModeConfigPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/ExposureModeConfigPageTests.cs
@@ -3,13 +3,11 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Cli.Tests.Tui;
 using Netclaw.Cli.Tui.Config;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Terminal;
 using Xunit;
@@ -86,31 +84,9 @@ public sealed class ExposureModeConfigPageTests : IDisposable
 
     private (VirtualTerminal Terminal, TerminaApplication App, ExposureModeConfigViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input)
-    {
-        var terminal = new VirtualTerminal(120, 40);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        ExposureModeConfigViewModel? capturedVm = null;
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/exposure", builder =>
-        {
-            builder.RegisterRoute<ExposureModeConfigPage, ExposureModeConfigViewModel>(
-                "/exposure",
-                _ => new ExposureModeConfigPage(),
-                _ =>
-                {
-                    capturedVm = new ExposureModeConfigViewModel(_paths);
-                    return capturedVm;
-                });
-        });
-
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
-    }
+        => HeadlessTerminaFixture.Create<ExposureModeConfigPage, ExposureModeConfigViewModel>(
+            "/exposure",
+            () => new ExposureModeConfigPage(),
+            () => new ExposureModeConfigViewModel(_paths),
+            out input);
 }

--- a/src/Netclaw.Cli.Tests/Tui/Config/SearchConfigEditorPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Config/SearchConfigEditorPageTests.cs
@@ -3,7 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -12,7 +11,6 @@ using Netclaw.Cli.Tui.Config;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Terminal;
 using Xunit;
@@ -99,33 +97,11 @@ public sealed class SearchConfigEditorPageTests : IDisposable
 
     private (VirtualTerminal Terminal, TerminaApplication App, SearchConfigEditorViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input, IHttpClientFactory? httpClientFactory = null)
-    {
-        var terminal = new VirtualTerminal(120, 40);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        SearchConfigEditorViewModel? capturedVm = null;
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/search", builder =>
-        {
-            builder.RegisterRoute<SearchConfigEditorPage, SearchConfigEditorViewModel>(
-                "/search",
-                _ => new SearchConfigEditorPage(),
-                _ =>
-                {
-                    capturedVm = new SearchConfigEditorViewModel(_paths, httpClientFactory);
-                    return capturedVm;
-                });
-        });
-
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
-    }
+        => HeadlessTerminaFixture.Create<SearchConfigEditorPage, SearchConfigEditorViewModel>(
+            "/search",
+            () => new SearchConfigEditorPage(),
+            () => new SearchConfigEditorViewModel(_paths, httpClientFactory),
+            out input);
 
     private sealed class StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
     {

--- a/src/Netclaw.Cli.Tests/Tui/HeadlessTerminaFixture.cs
+++ b/src/Netclaw.Cli.Tests/Tui/HeadlessTerminaFixture.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="HeadlessTerminaFixture.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Reactive;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Shared setup for headless page-level tests that drive a single-route Termina app
+/// through <see cref="VirtualTerminal"/> and <see cref="VirtualInputSource"/>. Covers
+/// the single-page fixture shape used by page test suites (see GitHub issue #929);
+/// multi-route suites (sessions/chat/init-existing-install navigation) keep their own
+/// bespoke setup because they register more than one route.
+/// </summary>
+internal static class HeadlessTerminaFixture
+{
+    public static (VirtualTerminal Terminal, TerminaApplication App, TVm Vm) Create<TPage, TVm>(
+        string route,
+        Func<TPage> createPage,
+        Func<TVm> createViewModel,
+        out VirtualInputSource input,
+        int width = 120,
+        int height = 40)
+        where TPage : ReactivePage<TVm>
+        where TVm : ReactiveViewModel
+    {
+        var terminal = new VirtualTerminal(width, height);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        TVm? capturedVm = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina(route, builder =>
+        {
+            builder.RegisterRoute<TPage, TVm>(
+                route,
+                _ => createPage(),
+                _ =>
+                {
+                    capturedVm = createViewModel();
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/IdentityRedoPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/IdentityRedoPageTests.cs
@@ -3,12 +3,10 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Terminal;
 using Xunit;
@@ -92,31 +90,9 @@ public sealed class IdentityRedoPageTests : IDisposable
 
     private (VirtualTerminal Terminal, TerminaApplication App, IdentityRedoViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input)
-    {
-        var terminal = new VirtualTerminal(120, 40);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        IdentityRedoViewModel? capturedVm = null;
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/identity-redo", builder =>
-        {
-            builder.RegisterRoute<IdentityRedoPage, IdentityRedoViewModel>(
-                "/identity-redo",
-                _ => new IdentityRedoPage(),
-                _ =>
-                {
-                    capturedVm = new IdentityRedoViewModel(_paths);
-                    return capturedVm;
-                });
-        });
-
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
-    }
+        => HeadlessTerminaFixture.Create<IdentityRedoPage, IdentityRedoViewModel>(
+            "/identity-redo",
+            () => new IdentityRedoPage(),
+            () => new IdentityRedoViewModel(_paths),
+            out input);
 }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
@@ -3,7 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
@@ -12,7 +11,6 @@ using Netclaw.Configuration;
 using Netclaw.Providers;
 using Netclaw.Tests.Utilities;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Terminal;
 using Xunit;
@@ -288,37 +286,15 @@ public sealed class InitWizardPageTests : IDisposable
         Assert.Equal(stepId, vm.Orchestrator.CurrentStep?.StepId);
     }
 
+    // Resolving TerminaApplication triggers NavigateTo("/init"), which calls the
+    // factory below and wires the page to the ViewModel.
     private (VirtualTerminal Terminal, TerminaApplication App, InitWizardViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input)
-    {
-        var terminal = new VirtualTerminal(120, 40);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        InitWizardViewModel? capturedVm = null;
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/init", builder =>
-        {
-            builder.RegisterRoute<InitWizardPage, InitWizardViewModel>(
-                "/init",
-                _ => new InitWizardPage(),
-                _ =>
-                {
-                    capturedVm = CreateViewModel();
-                    return capturedVm;
-                });
-        });
-
-        // Resolving TerminaApplication triggers NavigateTo("/init"), which
-        // calls the factory above and wires the page to the ViewModel.
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
-    }
+        => HeadlessTerminaFixture.Create<InitWizardPage, InitWizardViewModel>(
+            "/init",
+            () => new InitWizardPage(),
+            CreateViewModel,
+            out input);
 
     private InitWizardViewModel CreateViewModel()
         => new(_paths, _registry, _fakeProbe, _fakeSlackProbe, _fakeDiscordProbe);

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerPageTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
@@ -12,7 +11,6 @@ using Netclaw.Providers;
 using Netclaw.Providers.OAuth;
 using Netclaw.Tests.Utilities;
 using Termina;
-using Termina.Hosting;
 using Termina.Input;
 using Termina.Terminal;
 using Xunit;
@@ -146,33 +144,11 @@ public sealed class ProviderManagerPageTests : IDisposable
 
     private (VirtualTerminal Terminal, TerminaApplication App, ProviderManagerViewModel Vm)
         CreateHeadlessApp(out VirtualInputSource input)
-    {
-        var terminal = new VirtualTerminal(120, 40);
-        var virtualInput = new VirtualInputSource();
-        input = virtualInput;
-
-        ProviderManagerViewModel? capturedVm = null;
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IAnsiTerminal>(terminal);
-        services.AddTerminaVirtualInput(virtualInput);
-        services.AddTermina("/provider", builder =>
-        {
-            builder.RegisterRoute<ProviderManagerPage, ProviderManagerViewModel>(
-                "/provider",
-                _ => new ProviderManagerPage(),
-                _ =>
-                {
-                    capturedVm = new ProviderManagerViewModel(_paths, _registry, _fakeProbe);
-                    return capturedVm;
-                });
-        });
-
-        var sp = services.BuildServiceProvider();
-        var app = sp.GetRequiredService<TerminaApplication>();
-
-        return (terminal, app, capturedVm!);
-    }
+        => HeadlessTerminaFixture.Create<ProviderManagerPage, ProviderManagerViewModel>(
+            "/provider",
+            () => new ProviderManagerPage(),
+            () => new ProviderManagerViewModel(_paths, _registry, _fakeProbe),
+            out input);
 
     [Fact]
     public async Task DeleteKey_OnSecondRow_RemovesHighlightedProvider()

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -126,8 +126,7 @@ static async Task RunAsync(string[] args)
             }
         }
 
-        var builder = Host.CreateApplicationBuilder(args);
-        ConfigureConfigServices(builder.Services, builder.Configuration);
+        var builder = CreateQuietHostBuilder(args);
         if (mode is "doctor")
         {
             builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
@@ -135,10 +134,6 @@ static async Task RunAsync(string[] args)
             builder.Services.AddHttpClient<IMattermostProbe, MattermostProbe>();
             builder.Services.AddDoctorChecks();
         }
-
-        // Suppress framework console logging
-        builder.Logging.ClearProviders();
-        builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
         if (mode is "init")
         {
@@ -350,11 +345,7 @@ static async Task RunAsync(string[] args)
             return;
         }
 
-        var builder = Host.CreateApplicationBuilder(args);
-        ConfigureConfigServices(builder.Services, builder.Configuration);
-
-        builder.Logging.ClearProviders();
-        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        var builder = CreateQuietHostBuilder(args);
 
         using var host = builder.Build();
         using var scope = host.Services.CreateScope();
@@ -458,11 +449,7 @@ static async Task RunAsync(string[] args)
             return;
         }
 
-        var builder = Host.CreateApplicationBuilder(args);
-        ConfigureConfigServices(builder.Services, builder.Configuration);
-
-        builder.Logging.ClearProviders();
-        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        var builder = CreateQuietHostBuilder(args);
 
         if (statsTui)
         {
@@ -535,10 +522,7 @@ static async Task RunAsync(string[] args)
                     return;
                 }
 
-                var pairBuilder = Host.CreateApplicationBuilder(args);
-                ConfigureConfigServices(pairBuilder.Services, pairBuilder.Configuration);
-                pairBuilder.Logging.ClearProviders();
-                pairBuilder.Logging.SetMinimumLevel(LogLevel.Warning);
+                var pairBuilder = CreateQuietHostBuilder(args);
 
                 using var pairHost = pairBuilder.Build();
                 var pairApi = pairHost.Services.GetRequiredService<DaemonApi>();
@@ -590,10 +574,7 @@ static async Task RunAsync(string[] args)
                     return;
                 }
 
-                var devBuilder = Host.CreateApplicationBuilder(args);
-                ConfigureConfigServices(devBuilder.Services, devBuilder.Configuration);
-                devBuilder.Logging.ClearProviders();
-                devBuilder.Logging.SetMinimumLevel(LogLevel.Warning);
+                var devBuilder = CreateQuietHostBuilder(args);
 
                 using var devHost = devBuilder.Build();
                 var devApi = devHost.Services.GetRequiredService<DaemonApi>();
@@ -672,10 +653,7 @@ static async Task RunAsync(string[] args)
         if ((mcpSubcommand is "tools" or "permissions") && args.Length <= 2)
         {
             // Bare `netclaw mcp tools` or `netclaw mcp permissions` → TUI mode
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            var builder = CreateQuietHostBuilder(args);
             builder.Services.AddSingleton<McpToolPermissionsNavigationState>();
             builder.Services.AddSingleton<TuiNavigation>();
 
@@ -696,10 +674,7 @@ static async Task RunAsync(string[] args)
         if (mcpSubcommand is "auth" or "list" or "tools" or "permissions")
         {
             // auth/list/tools/permissions need the daemon — spin up DI to get DaemonApi
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            var builder = CreateQuietHostBuilder(args);
             using var mcpHost = builder.Build();
             var mcpPaths = mcpHost.Services.GetRequiredService<NetclawPaths>();
             var mcpDaemonApi = mcpHost.Services.GetRequiredService<DaemonApi>();
@@ -725,12 +700,9 @@ static async Task RunAsync(string[] args)
         // Bare invocation → TUI; subcommands → plain CLI
         if (args.Length == 1)
         {
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
+            var builder = CreateQuietHostBuilder(args);
             builder.Services.AddProviderDescriptors();
             builder.Services.AddProviderOAuthServices();
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
             var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-provider-trace.log");
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
@@ -759,11 +731,8 @@ static async Task RunAsync(string[] args)
         // Bare invocation → TUI; subcommands → plain CLI
         if (args.Length == 1)
         {
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
+            var builder = CreateQuietHostBuilder(args);
             builder.Services.AddProviderDescriptors();
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
             var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-model-trace.log");
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
@@ -792,11 +761,8 @@ static async Task RunAsync(string[] args)
         var isTuiInvocation = args.Length == 1 || (args.Length > 1 && args[1] is "tui");
         if (isTuiInvocation)
         {
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
+            var builder = CreateQuietHostBuilder(args);
             builder.Services.AddSingleton(paths);
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
             var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-approvals-trace.log");
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
@@ -821,10 +787,7 @@ static async Task RunAsync(string[] args)
     {
         if (args.Length > 1 && args[1] is "ui" or "tui")
         {
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            var builder = CreateQuietHostBuilder(args);
 
             var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-reminder-trace.log");
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
@@ -848,10 +811,7 @@ static async Task RunAsync(string[] args)
         }
         else
         {
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            var builder = CreateQuietHostBuilder(args);
             using var host = builder.Build();
             Environment.ExitCode = await ReminderCommand.RunAsync(args, host.Services.GetRequiredService<DaemonApi>());
         }
@@ -873,10 +833,7 @@ static async Task RunAsync(string[] args)
             // files, so this path must not make them a new way to crash.
             try
             {
-                var builder = Host.CreateApplicationBuilder(args);
-                ConfigureConfigServices(builder.Services, builder.Configuration);
-                builder.Logging.ClearProviders();
-                builder.Logging.SetMinimumLevel(LogLevel.Warning);
+                var builder = CreateQuietHostBuilder(args);
                 using var skillHost = builder.Build();
                 var skillPaths = skillHost.Services.GetRequiredService<NetclawPaths>();
                 skillPaths.EnsureDirectoriesExist();
@@ -947,10 +904,7 @@ static async Task RunAsync(string[] args)
     // ── Self-update ──
     if (mode is "update")
     {
-        var builder = Host.CreateApplicationBuilder(args);
-        ConfigureConfigServices(builder.Services, builder.Configuration);
-        builder.Logging.ClearProviders();
-        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        var builder = CreateQuietHostBuilder(args);
 
         using var host = builder.Build();
         var paths = host.Services.GetRequiredService<NetclawPaths>();
@@ -983,10 +937,7 @@ static async Task RunAsync(string[] args)
 
         if (onceMode)
         {
-            var builder = Host.CreateApplicationBuilder(args);
-            ConfigureConfigServices(builder.Services, builder.Configuration);
-            builder.Logging.ClearProviders();
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            var builder = CreateQuietHostBuilder(args);
 
             using var host = builder.Build();
             using var scope = host.Services.CreateScope();
@@ -1160,10 +1111,10 @@ static void WriteCrashLog(Exception ex)
 // identical editor (simplify-netclaw-init).
 static async Task RunConfigEditorAsync(string[] args)
 {
-    var builder = Host.CreateApplicationBuilder(args);
-    // ConfigureConfigServices registers NetclawPaths (same paths the caller already
-    // ensured on disk), so no separate paths registration is needed here.
-    ConfigureConfigServices(builder.Services, builder.Configuration);
+    // CreateQuietHostBuilder's ConfigureConfigServices call registers NetclawPaths (same
+    // paths the caller already ensured on disk), so no separate paths registration is
+    // needed here.
+    var builder = CreateQuietHostBuilder(args);
     builder.Services.AddSingleton(new ConfigDashboardNavigationState());
     // Marks this as the embedded config host so the routed Provider/Model managers navigate back
     // to the dashboard (rather than exiting) when backed out — the standalone hosts omit it.
@@ -1181,8 +1132,6 @@ static async Task RunConfigEditorAsync(string[] args)
         .AddSectionEditor<SecurityPostureStepViewModel>()
         .AddSectionEditor<FeatureSelectionStepViewModel>()
         .AddSectionEditor<ExposureModeStepViewModel>();
-    builder.Logging.ClearProviders();
-    builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
     var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-config-trace.log");
     builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
@@ -1216,14 +1165,11 @@ static async Task RunConfigEditorAsync(string[] args)
     if (navigationState.PendingAction == ConfigDashboardAction.RunDoctor)
     {
         var doctorArgs = new[] { "doctor" };
-        var doctorBuilder = Host.CreateApplicationBuilder(doctorArgs);
-        ConfigureConfigServices(doctorBuilder.Services, doctorBuilder.Configuration);
+        var doctorBuilder = CreateQuietHostBuilder(doctorArgs);
         doctorBuilder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
         doctorBuilder.Services.AddHttpClient<IDiscordProbe, DiscordProbe>();
         doctorBuilder.Services.AddHttpClient<IMattermostProbe, MattermostProbe>();
         doctorBuilder.Services.AddDoctorChecks();
-        doctorBuilder.Logging.ClearProviders();
-        doctorBuilder.Logging.SetMinimumLevel(LogLevel.Warning);
 
         using var doctorHost = doctorBuilder.Build();
         using var scope = doctorHost.Services.CreateScope();
@@ -1970,6 +1916,20 @@ static void WriteDailyTable(List<DaemonStats.DailyRow> rows)
 // ═══════════════════════════════════════════════════════════════════════
 // Shared configuration services (all modes)
 // ═══════════════════════════════════════════════════════════════════════
+
+// Builds a HostApplicationBuilder with the shared config chain wired up and framework
+// console logging suppressed to Warning — console output is reserved for CLI/TUI
+// output, not framework log noise. Callers add mode-specific registrations after
+// this returns; the WebApplicationBuilder-based chat/sessions/headless path builds
+// its own builder because it needs a listening HTTP host, not this simpler shape.
+static HostApplicationBuilder CreateQuietHostBuilder(string[] args)
+{
+    var builder = Host.CreateApplicationBuilder(args);
+    ConfigureConfigServices(builder.Services, builder.Configuration);
+    builder.Logging.ClearProviders();
+    builder.Logging.SetMinimumLevel(LogLevel.Warning);
+    return builder;
+}
 
 static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfigurationManager configuration)
 {


### PR DESCRIPTION
## What

Phase 5 of the code-reduction stack (on top of #2005). Three within-file duplication hotspots, **−322 net lines**, zero behavior change:

1. **`SQLiteMemoryStore`** — `ApplyInlineCurationBatchAsync` and `ApplyCurationBatchAsync` ran the same ~190-line per-operation loop (anchor resolution, record insert, dedup lookup, document + FTS upsert) word-for-word. One shared `ApplyCurationOperationsAsync` now serves both; the checkpoint variant keeps its `status='completed'` update before commit. SQL text, parameter names, public signatures, and transaction boundaries unchanged.
2. **TUI test fixtures (issue #929)** — the issue counted three duplicated headless Termina setups; there were seven. One `HeadlessTerminaFixture.Create<TPage,TVm>` helper replaces them, with per-site page/VM lambdas and dimensions preserved. The three multi-route fixtures (Sessions/Chat/InitExistingInstall) intentionally stay as-is.
3. **`Program.cs`** — seventeen mode handlers repeated the same 4-line quiet host-builder setup; one `CreateQuietHostBuilder` helper replaces them. The chat/sessions path uses `WebApplication.CreateBuilder` (hosts a SignalR endpoint) — different builder type, deliberately not converted, documented on the helper.

## Verification

- Memory suites (44), converted TUI page suites (45), full `Netclaw.Cli.Tests` (1,370), full `Netclaw.Actors.Tests` (3,447) — all green
- `dotnet slopwatch analyze`: 0 issues; headers verified; zero build warnings
- No persisted-format, schema, CLI, or API surface change

## Stack

PR 5. Base: `refactor/binding-engine` (#2005).