### PR TITLE
Convert the last bounded test handshake to an awaited signal

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
@@ -307,15 +307,13 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         StartFullReset(vm);
         await deleteStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
 
-        using var disposeStarted = new ManualResetEventSlim();
+        var disposeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dispose = Task.Run(() =>
         {
-            disposeStarted.Set();
+            disposeStarted.TrySetResult();
             vm.Dispose();
         }, TestContext.Current.CancellationToken);
-        Assert.True(
-            disposeStarted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken),
-            "Dispose did not start.");
+        await disposeStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
 
         releaseDelete.TrySetResult();
         await dispose.WaitAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
## What

PR 8 of the stack. Result of a full audit of sync-over-async patterns across every test project, per the maintainer directive that TestKit assertions and test orchestration must never block threads (sync-over-async is the root mechanism behind the recent Windows CI dispatch-starvation flakes).

**Audit result: the suites were already async-clean.** Verified:
- 0 sync TestKit assertion calls (`ExpectMsg`/`AwaitAssert`/`ExpectNoMsg`/`Within`/… — all usage is the `*Async` variants)
- 43/43 `.Result` hits are record/DTO **properties** named `Result` (`FunctionResultContent.Result`, `ToolCompletedUpdate.Result`, …), not `Task.Result`
- 3/5 `Thread.Sleep` hits are comment or test-data text

**One genuine conversion** (this PR's diff): `InitExistingInstallViewModelTests.Dispose_WhileDeleteIsRunning_CancelsCompletionNavigation` — a bounded `ManualResetEventSlim.Wait(10s)` handshake becomes an unbounded `TaskCompletionSource` await governed by the test cancellation token. No assertion depends on scheduling latency.

**Deliberate holdouts, each with a recorded reason:**
- `WebhookRouteStoreTests` (5 MRES hits): superseded — the `webhook-route-actor-ownership` OpenSpec change replaces those tests with actor message-order tests
- `DaemonClientReconnectTests:227`: the synchronous block **is the behavior under test** (proves a blocking `IObservable` subscriber cannot stall the async pump)
- `DisposableTempDir.Dispose` retry: sync `IDisposable` constraint; needs an `IAsyncDisposable` migration across all call sites — follow-up pass

## Verification

Full solution build 0 warnings; `Netclaw.Cli.Tests` 1,370/0; slopwatch 0 issues; headers clean.

## Stack

Base: `fix/approval-text-match-order` (#2008).