### PR TITLE
Make fetched-content filenames collision-proof

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
@@ -733,6 +734,79 @@ public class WebFetchToolTests : IDisposable
             CancellationToken.None);
 
         Assert.DoesNotContain("content truncated", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_same_url_same_frozen_second_saves_two_distinct_files()
+    {
+        // Regression for the filename collision bug: the saved-content
+        // filename used only second-precision time as its unique part. Two
+        // fetches of the same URL within one second built the same filename,
+        // and the second write silently overwrote the first (File.WriteAllText
+        // truncates an existing file; it does not throw). Freeze the clock at
+        // one second and fetch twice to prove both files now survive.
+        var frozenTime = new FakeTimeProvider(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        var handler = new SequencedHttpHandler(
+            ("<html><head><title>First</title></head><body><p>First fetch content.</p></body></html>", "text/html"),
+            ("<html><head><title>Second</title></head><body><p>Second fetch content.</p></body></html>", "text/html"));
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path, timeProvider: frozenTime);
+
+        var firstResult = await tool.ExecuteAsync(
+            ToolInput.Create("Url", "https://example.com/same-page"),
+            TestToolExecutionContext.CreateUnbound(),
+            CancellationToken.None);
+
+        var secondResult = await tool.ExecuteAsync(
+            ToolInput.Create("Url", "https://example.com/same-page"),
+            TestToolExecutionContext.CreateUnbound(),
+            CancellationToken.None);
+
+        var files = Directory.GetFiles(_dir.Path, "*.html");
+        Assert.Equal(2, files.Length);
+
+        var firstPath = ExtractSavedPath(firstResult);
+        var secondPath = ExtractSavedPath(secondResult);
+        Assert.NotEqual(firstPath, secondPath);
+        Assert.True(File.Exists(firstPath));
+        Assert.True(File.Exists(secondPath));
+
+        var firstContent = await File.ReadAllTextAsync(firstPath, TestContext.Current.CancellationToken);
+        var secondContent = await File.ReadAllTextAsync(secondPath, TestContext.Current.CancellationToken);
+        Assert.Contains("First fetch content.", firstContent);
+        Assert.Contains("Second fetch content.", secondContent);
+    }
+
+    private static string ExtractSavedPath(string toolResult)
+    {
+        const string marker = "Saved to: ";
+        var start = toolResult.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        var end = toolResult.IndexOf(" (", start, StringComparison.Ordinal);
+        return toolResult[start..end];
+    }
+
+    private sealed class SequencedHttpHandler : HttpMessageHandler
+    {
+        private readonly (byte[] Bytes, string ContentType)[] _responses;
+        private int _index;
+
+        public SequencedHttpHandler(params (string Content, string ContentType)[] responses)
+        {
+            _responses = [.. responses.Select(r => (Encoding.UTF8.GetBytes(r.Content), r.ContentType))];
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            var (bytes, contentType) = _responses[Math.Min(_index++, _responses.Length - 1)];
+            var content = new ByteArrayContent(bytes);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = content
+            };
+            return Task.FromResult(response);
+        }
     }
 
     private sealed class CountingHttpHandler(string content, string contentType) : HttpMessageHandler

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -266,7 +266,14 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
     {
         Directory.CreateDirectory(directory);
         var sanitized = SanitizeForFilename(uri);
-        var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeSeconds()}{extension}";
+
+        // The second-precision timestamp is for a human to read, not for
+        // uniqueness. Two fetches of the same URL within one second gave the
+        // same filename, and File.WriteAllBytes/WriteAllText overwrote the
+        // first fetch with no warning. The guid segment gives real
+        // uniqueness; the timestamp stays for readability.
+        var uniqueSuffix = Guid.NewGuid().ToString("N")[..8];
+        var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeSeconds()}-{uniqueSuffix}{extension}";
         return Path.Combine(directory, filename);
     }
 

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -267,13 +267,14 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         Directory.CreateDirectory(directory);
         var sanitized = SanitizeForFilename(uri);
 
-        // The second-precision timestamp is for a human to read, not for
-        // uniqueness. Two fetches of the same URL within one second gave the
-        // same filename, and File.WriteAllBytes/WriteAllText overwrote the
-        // first fetch with no warning. The guid segment gives real
-        // uniqueness; the timestamp stays for readability.
+        // The timestamp is for a human to read and sort, not for uniqueness.
+        // Two fetches of the same URL within one second gave the same
+        // filename, and File.WriteAllBytes/WriteAllText overwrote the first
+        // fetch with no warning. The guid segment gives real uniqueness;
+        // millisecond precision keeps same-second fetches in fetch order
+        // when the directory is sorted by name.
         var uniqueSuffix = Guid.NewGuid().ToString("N")[..8];
-        var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeSeconds()}-{uniqueSuffix}{extension}";
+        var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}-{uniqueSuffix}{extension}";
         return Path.Combine(directory, filename);
     }
 


### PR DESCRIPTION
## Bug

WebFetchTool built the saved-content filename from a second-precision
timestamp only (`WebFetchTool.cs:269`). Two fetches of the same URL
inside one second built the same filename.

`File.WriteAllBytes` and `File.WriteAllText` both truncate an existing
file. The second fetch overwrote the first one, silently, with no
error or warning. The first fetch's content was gone, and the tool
result for the first fetch still pointed to a path that now held the
second fetch's content.

This is a sibling of the reminder execution child-name collision fixed
in 30ff5d28 ("Name reminder execution children by sequence, not by
millisecond"): a timestamp collided when two events landed inside one
tick, only there the actor name collision threw, so the bug surfaced
as a crash. Here it fails silently as data loss, which is worse.

## Fix

Add a short random suffix (first 8 hex characters of a guid) to the
saved-content filename. Keep the second-precision timestamp for a
human reading the filename. This matches the established pattern in
`WebhookExecutionService.cs:42`, which appends a full guid segment to
the actor name for the same reason.

## Test

Added `ExecuteAsync_same_url_same_frozen_second_saves_two_distinct_files`
to `WebFetchToolTests`. It freezes the clock at one second with
`FakeTimeProvider` and fetches the same URL twice. Before the fix this
produces one file on disk with only the second fetch's content; after
the fix it produces two distinct files, each holding its own fetch's
content. No sleeps, no bounded waits — the clock is frozen
deterministically.

## Validation

- `dotnet build --nologo -v q` — 0 warnings, 0 errors
- `dotnet test src/Netclaw.Actors.Tests --no-build --nologo --filter "FullyQualifiedName~WebFetchTool"` — 70 passed, 0 failed
- `dotnet slopwatch analyze` — 0 issues
- `pwsh -NoProfile -File ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers