### PR TITLE
Deflake CI: shared-timeout sizing, plus a runner-handshake diagnosis

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -201,8 +201,10 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         // Idle timeout with the recovered approval still pending: the session
         // passivates (approval state is journaled) instead of deferring forever.
         var escapedId = Uri.EscapeDataString(sessionId.Value);
+        // The resolve budget bounds the session spawn and recovery under a
+        // starved CI scheduler. It does not measure correctness.
         var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}")
-            .ResolveOne(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            .ResolveOne(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
         Watch(child);
         child.Tell(new LeaveSession(rejoinProbe) { SessionId = sessionId });
         child.Tell(ReceiveTimeout.Instance);
@@ -1516,8 +1518,10 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
         await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
 
         var escapedId = Uri.EscapeDataString(sessionId.Value);
+        // The resolve budget bounds the session spawn and recovery under a
+        // starved CI scheduler. It does not measure correctness.
         var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}")
-            .ResolveOne(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            .ResolveOne(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
         Watch(child);
 
         // Drop the subscriber and force the idle timeout so the session enters
@@ -1550,8 +1554,13 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
     private async Task ColdRespawnAsync(SessionId sessionId)
     {
         var escapedId = Uri.EscapeDataString(sessionId.Value);
+        // The resolve waits for the session child to finish its spawn and its
+        // Akka.Persistence recovery. The budget bounds that multi-hop startup
+        // under a starved CI scheduler. It does not measure correctness. About
+        // twenty cold-respawn tests call this helper, so a short budget makes
+        // the whole group flake at once.
         var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}")
-            .ResolveOne(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            .ResolveOne(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
         Watch(child);
         Sys.Stop(child);
         await ExpectTerminatedAsync(child, cancellationToken: TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,15 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// </summary>
 public sealed class ErrorCorrelationTests(ITestOutputHelper output) : LlmSessionTestBase(output)
 {
+    // LlmSessionTestBase seals ConfigureAkka, so the raise goes through the
+    // Config property seam instead. The stock single-expect-default is 3
+    // seconds. That value measures scheduler load on a starved CI runner. It
+    // does not measure correctness. Production allows 30 seconds for a
+    // comparable ack-after-work handshake — see
+    // ProactiveSendFormatting.ProactiveThreadAckTimeout.
+    protected override Config? Config =>
+        ConfigurationFactory.ParseString("akka.test.single-expect-default = 15s");
+
     private readonly FailingChatClient _chatClient = new();
 
     protected override void ConfigureSessionServices(IServiceCollection services)
@@ -67,7 +77,7 @@ public sealed class ErrorCorrelationTests(ITestOutputHelper output) : LlmSession
             Content = "trigger error"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
         Assert.NotEqual(Guid.Empty, error.CorrelationId);
@@ -95,7 +105,7 @@ public sealed class ErrorCorrelationTests(ITestOutputHelper output) : LlmSession
             Content = "first"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        var firstError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var firstError = await subscriber.ExpectMsgAsync<ErrorOutput>(cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -104,7 +114,7 @@ public sealed class ErrorCorrelationTests(ITestOutputHelper output) : LlmSession
             Content = "second"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        var secondError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var secondError = await subscriber.ExpectMsgAsync<ErrorOutput>(cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotEqual(firstError.CorrelationId, secondError.CorrelationId);
@@ -134,7 +144,7 @@ public sealed class ErrorCorrelationTests(ITestOutputHelper output) : LlmSession
             Content = "trigger timeout"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ErrorCategory.Timeout, error.Category);
         Assert.NotEqual(Guid.Empty, error.CorrelationId);

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -1012,7 +1012,7 @@ public class SubAgentActorTests : TestKit
                 Task = "Run the same approval-gated tool twice",
                 Timeout = TimeSpan.FromSeconds(5)
             },
-            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            ApprovalAskTimeout, TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.Equal(2, approvalBridge.RequestCount);

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
@@ -142,7 +142,12 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
 
         if (persistentSeeds.Count > 0)
         {
-            await approvalActor.GracefulStop(TimeSpan.FromSeconds(5));
+            // The stop waits for a persistence flush and the actor teardown.
+            // The budget bounds a multi-hop shutdown under a starved CI
+            // scheduler. It does not measure correctness. Every shell-approval
+            // test goes through this shared harness, so a short budget makes a
+            // whole suite flake at once.
+            await approvalActor.GracefulStop(TimeSpan.FromSeconds(15));
             approvalActor = CreateApprovalActor(actorSystem, store);
             approvalService = CreateApprovalService(approvalActor);
         }
@@ -295,7 +300,9 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await _approvalActor.GracefulStop(TimeSpan.FromSeconds(5));
+        // Same reason as the seed-phase stop above: the budget bounds a
+        // multi-hop teardown under a starved CI scheduler, not correctness.
+        await _approvalActor.GracefulStop(TimeSpan.FromSeconds(15));
         if (Directory.Exists(_rootDirectory))
             Directory.Delete(_rootDirectory, recursive: true);
     }


### PR DESCRIPTION
Consolidates the remaining CI deflake items into one PR, in the shape of #2001.

## Doctrine

Every raise here is environment sizing, not a correctness change. A short
budget on a multi-hop actor operation measures scheduler load on a starved
CI runner. It does not measure the property under test. Production code is
untouched, and a green test pays no added time — the raise only slows
failure reporting.

Ask literals stay explicit. `Ask` falls back to `akka.actor.ask-timeout`,
which is infinite by default. Deletion of an Ask timeout would trade a
flaky wait for a hang.

## 1. SubAgent Ask literal inconsistency

`SubAgentActorTests.Approve_once_does_not_leak_between_subagent_tool_calls`
used a 5-second literal on its outer `Ask`. Every sibling approval test in
the file uses the class constant `ApprovalAskTimeout`, which is 30 seconds.

This test drives two sequential approval round-trips. It makes more hops
than any sibling, so it tolerates a 5-second budget least. It flaked on
Windows CI. The literal now uses the class constant.

## 2. ErrorCorrelation leftovers

`ErrorCorrelationTests` held four 5-second literals on
`ExpectMsgAsync<ErrorOutput>`. Each waits for a full provider-failure turn:
actor spawn, Akka.Persistence recovery, a failed stream, and the error
classification.

This commit adds the same `Config`-property raise that #2014 applies to this
class, then drops the four literals so they inherit it.
`LlmSessionTestBase` seals `ConfigureAkka`, so the `Config` property is the
only seam. The comment text matches #2014 word for word.

Merge note for #2014: the `Config` property is byte-identical on both
branches, so it merges clean. Two hunks in
`Each_error_turn_gets_a_distinct_CorrelationId` will conflict, because this
PR edits the `ErrorOutput` line and #2014 edits the `TurnCompleted` line
directly under it. No line separates them, so git cannot merge the pair.
The resolution is the union: keep both deletions. This conflict is
unavoidable in either order of merge.

## 3. Shared-infrastructure raises

Two shared helpers held 5-second budgets. A short budget on a shared helper
makes a whole group of tests flake at once.

- `ShellApprovalHarness` stops the approval actor twice — once to prove a
  persistent grant survives a restart, once on dispose. Both stops wait for
  a persistence flush and an actor teardown. Every shell-approval test runs
  through this harness. Both budgets move to 15 seconds.
- `ApprovalRehydrationTests` resolves the session child at three sites, one
  of them the shared `ColdRespawnAsync` helper. The resolve waits for the
  actor spawn and the Akka.Persistence recovery. About twenty cold-respawn
  tests depend on it. All three budgets move to 15 seconds.

Each site carries a comment that names what the budget bounds.

## 4. Demo.AppHost xUnit v3 handshake corruption — diagnosed, not fixed

Incident:

```
Netclaw.Demo.AppHost.IntegrationTests: Catastrophic failure:
System.InvalidOperationException: Test process did not return valid JSON (non-object)
```

The mechanism is now proven from the runner code, and it is not ours:

1. The VSTest adapter probes the test executable with a single argument,
   `-assemblyInfo`
   (`TestProcessLauncherAdapter.GetAssemblyInfo`, xunit.runner.visualstudio
   3.1.5). It then reads **all** of stdout and parses it as one JSON object.
2. `ConsoleRunner.PrintAssemblyInfo` writes that one JSON object and returns.
3. `ConsoleRunner.Run` (xunit.v3.runner.inproc.console 3.2.2) queues a
   watchdog. One second after the entry point returns, if the process still
   lives, it writes to stdout:
   `Console.WriteLine("Waiting 10 seconds for foreground threads to exit...")`.
   The plain-text branch runs because `-assemblyInfo` is not automated mode;
   the automated branch would emit a JSON diagnostic instead.
4. The adapter reads the JSON object plus that line, and the parse fails
   with `non-object`.

No Netclaw code writes to stdout on this path. The only `Console.WriteLine`
in the suite sits inside the opt-in test body, which is skipped without
`NETCLAW_RUN_DEMO_SMOKE=1`. The assembly has one module initializer, and it
only sets an environment variable. A local `-assemblyInfo` probe on Linux
returns clean JSON and exits in 72 ms. The trigger is process-exit latency
above one second on the Windows runner.

No fix is applied, because the minimal fix is not in our code. Two options
for a follow-up, both maintainer calls:

- Exclude `samples/Netclaw.Demo.AppHost.IntegrationTests` from the
  `pr_validation` sweep. Every test in it is opt-in and skips without Docker
  and `NETCLAW_RUN_DEMO_SMOKE=1`, so the sweep buys no coverage and pays a
  fragile process probe. `demo_smoke.yml` already runs the suite on its own.
- Report the watchdog race upstream to xunit. The `-assemblyInfo` probe
  should not write plain text to a stdout channel it defines as JSON.

Related but separate: `skunkworks/json-stdout-hygiene` covers the Netclaw
CLI `--json` envelope, not the xUnit runner handshake. It does not apply
here.

## Gates

- `dotnet build --nologo -v q` — 0 warnings, 0 errors
- `SubAgentActorTests` — 66 passed
- `ErrorCorrelationTests` — 3 passed
- `ApprovalRehydrationTests` — 20 passed
- `ShellPolicyEvidenceFixtureTests` + `ShellApprovalDispositionMatrixTests` — 332 passed
- `dotnet slopwatch analyze` — 0 issues
- `./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
