### PR TITLE
Add deterministic agent tool contracts

### DIFF
--- a/openspec/changes/make-agent-tools-pit-of-success/.openspec.yaml
+++ b/openspec/changes/make-agent-tools-pit-of-success/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/make-agent-tools-pit-of-success/design.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/design.md
@@ -1,0 +1,246 @@
+## Context
+
+Netclaw currently treats every non-MCP registration as always loaded. Main
+sessions dynamically load MCP tools, but subagents receive every discoverable
+registration except recursive `spawn_agent`. In the observed deployment this
+meant roughly 220 schemas per subagent. Despite that large choice surface,
+agents repeatedly used approval-gated shell or Python for operations absent from
+the first-party workspace API: recursive search, batch reads, JSON projection,
+image dimensions, and continuation of spilled output.
+
+The file tools also resolve a relative path through the daemon process current
+directory. Recent-file context is reconstructed from authored arguments for all
+tool results, including failures. These behaviors make the less-safe route
+easier and allow a failed operation to influence later model context.
+
+Constraints:
+
+- ACL, audience, approval, path, and MCP grant enforcement remain authoritative.
+- `INetclawTool.ExecuteAsync` is a public string-returning contract and cannot
+  break in this change.
+- Session actors own per-session loaded-tool state and durable working context.
+  Subagent actors own ephemeral child loaded-tool state; neither state is newly
+  persisted.
+- ShellSyntaxTree remains a syntax-fact provider. This design adds no
+  executable-specific policy parsing.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the structured workspace route require fewer decisions than shell.
+- Reduce the default tool-schema surface for main sessions and subagents.
+- Give tools machine-actionable success, failure, and correction semantics while
+  preserving their model-facing string results.
+- Make relative file paths deterministic and scoped to project then session.
+- Turn sanitized live failures into deterministic contract and replay tests.
+
+**Non-Goals:**
+
+- Reclassifying shell commands or widening reviewed-safe command authority.
+- Persisting loaded-tool leases or changing durable session serialization.
+- Parsing arbitrary executable flags, Markdown artifact links, or remote MCP
+  payloads as filesystem authority.
+- Implementing layered configuration provenance from issue #2009.
+- Replacing every existing first-party tool in one step.
+
+## Decisions
+
+### 1. Registration owns an explicit safe-default exposure tier
+
+`ToolRegistry` will distinguish `Core` and `Deferred` registrations. The
+existing registration path will default to `Deferred`; a deliberately named
+core-registration path will be required for the small always-loaded set. This
+makes adding a new tool context-safe by default without adding visibility state
+to the public `INetclawTool` interface.
+
+The initial core set is:
+
+- `search_tools` and `load_tool`;
+- `skill_load` and the resource reader needed by a loaded skill;
+- `set_working_directory`;
+- `file_read`, `file_list`, `file_write`, and `file_edit`;
+- `shell_execute` as the bounded compatibility escape hatch.
+
+Structured workspace tools added by this change are core only when they replace
+a commonly observed shell fallback with a small schema. Reminder, webhook,
+memory-administration, background-job, subagent-administration, web, channel,
+and other specialty tools are deferred. MCP tools remain deferred.
+
+Alternative considered: infer tiers from tool names or grant categories. That
+would couple unrelated security and context concerns and would silently change
+when names/categories evolve. Explicit registration is smaller and auditable.
+
+### 2. One audience-filtered exposure set serves parent and child actors
+
+The existing discovered-tool cache will be generalized around canonical tool
+identity rather than MCP type. Main sessions continue to own lease retention and
+eviction. Each subagent receives a private ephemeral exposure set seeded from
+the same audience-filtered core registrations. Its `search_tools` and
+`load_tool` calls activate deferred tools only for that child run.
+
+Search and load always re-run `ToolAccessPolicy` against the current invocation
+context. Hidden tools do not appear in indexes, search results, suggestions, or
+load errors. Loading never grants execution authority; normal dispatch policy
+still runs on every call.
+
+Alternative considered: provide each subagent a task-specific static tool list.
+Observed models choose unexpected but legitimate workflows, and static lists
+would either recreate overexposure or create brittle missing-tool failures.
+
+### 3. Workspace paths resolve from explicit session-owned roots
+
+First-party filesystem tools will resolve a relative authored path against:
+
+1. the declared project directory when present and valid;
+2. otherwise the immutable session directory;
+3. otherwise fail with `invalid_context`.
+
+The resolved canonical path then enters the existing read/write/attach policy.
+Absolute paths retain their existing policy behavior. Resolution never uses the
+daemon process current directory. A relative path that escapes its selected base
+through traversal is still evaluated as the resulting canonical absolute path
+and denied when outside the applicable roots.
+
+This is implemented once in `ScopedFileAccessPolicy`, not independently in each
+tool.
+
+Alternative considered: require absolute paths forever. Live evidence shows
+models invent `/tmp` or use shell to obtain an absolute path; the requirement
+creates friction without adding authority because a trusted base already exists.
+
+### 4. Add narrow workspace primitives instead of more guidance
+
+The first implementation slice adds:
+
+- recursive literal content/path search with explicit root and bounds;
+- bounded reads of multiple files in one call;
+- JSON projection using a bounded list of RFC 6901 JSON Pointers;
+- image metadata, including dimensions, through the file inspection path;
+- continuation of a spilled result by opaque call id and bounded character
+  window.
+
+Every filesystem operand uses the shared scoped policy. Search does not follow
+directory symlinks, has file/result/byte ceilings, and returns truncation state.
+Batch tools validate the complete batch before reading so a denied member cannot
+produce a partial successful result. The output-continuation tool resolves only
+inside the current session's `tool-calls` directory and never accepts a raw path.
+
+Alternative considered: teach agents preferred shell commands through skills.
+That leaves approvals, executable availability, quoting, and cross-platform
+syntax in the critical path and failed in live use across two model families.
+
+### 5. Internal outcomes drive state; strings remain presentation
+
+An internal append-only invocation receipt will carry one terminal category:
+
+- `success`;
+- `invalid_input`;
+- `access_denied`;
+- `not_found`;
+- `transient_failure`;
+- `recoverable_correction`.
+
+It may also carry canonical successful file activity and a bounded remediation
+code. First-party workspace tools set the receipt before returning their existing
+model-facing string. Dispatcher exceptions and policy denials set it centrally.
+The session pipeline consumes the receipt; it does not parse strings to infer
+success. Only canonical file activity from a successful receipt updates
+`WorkingContext.RecentFiles`. Failed declarations and failed file operations do
+not update project or recent-file state.
+
+The receipt is call-local, never serialized, and is not added to public
+`INetclawTool`. Existing tools without a receipt receive a conservative centrally
+known category; they cannot claim successful file activity.
+
+Alternative considered: standardize JSON in every string result. That would
+break human/model output expectations and tempt downstream code to parse a
+presentation string as authority.
+
+### 6. Conditional schemas are generated from explicit variants
+
+For tools with mutually exclusive modes, the source generator will accept an
+internal variant declaration and emit JSON Schema `oneOf` branches with the
+correct required fields. Dispatch validates the chosen branch before execution.
+The first conversions cover the observed conditional-schema failures; tools with
+a single parameter shape remain unchanged.
+
+Alternative considered: put all fields in one object and explain combinations
+in descriptions. Multiple models ignored or could not satisfy those prose-only
+constraints.
+
+### 7. Tests prove product mechanics deterministically
+
+Tests are layered:
+
+1. schema snapshots and malformed-branch rejection;
+2. audience/search/load/core-tier contracts for parent and child actors;
+3. path, symlink, traversal, bounds, atomic-batch, outcome, and working-context
+   unit/integration tests;
+4. PII-sanitized transcript fixtures replaying the observed intent and asserting
+   the structured tool path remains available without shell approval.
+
+The sanitized corpus stores no session ids, usernames, hostnames, repository
+names, authored content, credentials, or raw paths from production.
+
+## Actor Boundaries and Persistence
+
+- `LlmSessionActor` owns the main exposure cache and applies successful file
+  activity to durable `WorkingContext` through existing events/snapshots.
+- `SubAgentActor` owns an equivalent ephemeral cache and returns only its
+  existing bounded working-context delta to the parent.
+- `ToolRegistry` owns immutable registration metadata and remains daemon scoped.
+- `DispatchingToolExecutor` owns policy enforcement and the call-local outcome
+  receipt. A loaded tool is never an authorization shortcut.
+- No new durable event or snapshot field is required. Recovery reseeds core
+  tools; deferred tools are intentionally rediscovered.
+
+## Failure Modes and Recovery
+
+- Unknown/hidden tool: bounded `not_found` result without revealing hidden
+  names; search can be retried.
+- Tool removed after discovery: load or dispatch returns `not_found`; no stale
+  registration executes.
+- Invalid relative-path context: `invalid_context` correction names the missing
+  declaration/session prerequisite without exposing configured roots.
+- Batch contains denied/invalid member: whole batch fails before content reads.
+- Spill missing/expired: `not_found` names the call id, never probes other paths.
+- Child LLM failure: child exposure state is discarded with the actor.
+- Main LLM failure: existing discovered-tool eviction applies to every deferred
+  tool, not only MCP tools.
+
+## Risks / Trade-offs
+
+- [A deferred tool becomes harder to discover] -> Keep a compressed,
+  audience-filtered index and contract-test representative intents.
+- [Core set grows back into a large catalog] -> Make deferred the registration
+  default and snapshot core names/schema bytes.
+- [Structured tools duplicate mature CLI behavior] -> Implement only generic
+  filesystem/data primitives with strict bounds; keep private executable
+  semantics out.
+- [Cross-platform traversal differs] -> Use .NET filesystem APIs and existing
+  canonical path policy; run native Windows and Linux tests.
+- [Typed outcome adoption becomes a broad rewrite] -> Convert workspace tools
+  first, retain a conservative adapter for untouched tools, and remove legacy
+  argument scraping only after parity tests pass.
+
+## Migration Plan
+
+1. Add exposure metadata and parent/subagent parity while preserving current
+   dispatch authorization.
+2. Add the internal outcome receipt and convert current workspace file tools.
+3. Add bounded workspace primitives and conditional schemas.
+4. Add sanitized replay fixtures and diagnostic counters.
+5. Rebase on `upstream/dev`, run full Linux and native Windows gates, then build
+   a binary for live swap.
+
+Rollback is a normal code rollback. No persisted state or configuration needs
+migration; recovered sessions simply reseed the prior always-loaded catalog.
+
+## Open Questions
+
+- Whether `attach_file` is frequent and small enough to remain core will be
+  decided from schema-byte measurements and sanitized traffic counts.
+- Whether the JSON projection primitive should support only RFC 6901 pointers or
+  a second bounded array-index shorthand will be decided before its schema is
+  frozen; arbitrary query languages remain out of scope.

--- a/openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json
+++ b/openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": 1,
+  "sanitization": {
+    "sourceBoundary": "Raw transcripts remain local. Cases are semantic reconstructions with synthetic identifiers.",
+    "prohibitedRawIdentifierClasses": [
+      "session_id",
+      "tool_call_id",
+      "user_identity",
+      "repository_identity",
+      "host",
+      "url",
+      "exact_timestamp",
+      "credential",
+      "raw_prompt",
+      "raw_response",
+      "raw_log_line"
+    ]
+  },
+  "cases": [
+    {
+      "id": "TF01",
+      "scenario": "RecursiveSearch",
+      "observedFriction": "ApprovalGatedShellSearch",
+      "expectedToolSequence": ["file_search"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": true,
+      "expectedContextEffect": "NoContextChangeRequired"
+    },
+    {
+      "id": "TF02",
+      "scenario": "BatchRead",
+      "observedFriction": "ApprovalGatedShellBatch",
+      "expectedToolSequence": ["file_read_many"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": true,
+      "expectedContextEffect": "RecordTwoCanonicalFiles"
+    },
+    {
+      "id": "TF03",
+      "scenario": "JsonProjection",
+      "observedFriction": "ApprovalGatedInterpreterProjection",
+      "expectedToolSequence": ["json_read"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": true,
+      "expectedContextEffect": "RecordOneCanonicalFile"
+    },
+    {
+      "id": "TF04",
+      "scenario": "ImageMetadata",
+      "observedFriction": "ApprovalGatedInterpreterMetadata",
+      "expectedToolSequence": ["file_read"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": true,
+      "expectedContextEffect": "RecordOneCanonicalFile"
+    },
+    {
+      "id": "TF05",
+      "scenario": "SpillContinuation",
+      "observedFriction": "ApprovalGatedSpillParsing",
+      "expectedToolSequence": ["tool_output_read"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": true,
+      "expectedContextEffect": "NoContextChangeRequired"
+    },
+    {
+      "id": "TF06",
+      "scenario": "FailedFileActivity",
+      "observedFriction": "FailedCallPollutedRecentFiles",
+      "expectedToolSequence": ["file_write"],
+      "expectedOutcome": "access_denied",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": false,
+      "expectedContextEffect": "PreserveRecentFiles"
+    },
+    {
+      "id": "TF07",
+      "scenario": "SubagentCatalogExposure",
+      "observedFriction": "EagerSubagentSchemaCatalog",
+      "expectedToolSequence": ["search_tools", "load_tool"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": false,
+      "expectedContextEffect": "CoreOnlyChildCatalog"
+    }
+  ]
+}

--- a/openspec/changes/make-agent-tools-pit-of-success/evidence/tool-schema-footprint-baseline.json
+++ b/openspec/changes/make-agent-tools-pit-of-success/evidence/tool-schema-footprint-baseline.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "scenario": "personal-session-with-fixed-synthetic-mcp-catalog",
+  "metric": "Compact UTF-8 JSON array of final function names, descriptions, and input schemas in ChatOptions.Tools order.",
+  "syntheticMcpToolCount": 200,
+  "mainCore": {
+    "count": 3,
+    "serializedDefinitionBytes": 1047
+  },
+  "subagentFull": {
+    "count": 202,
+    "serializedDefinitionBytes": 133816
+  }
+}

--- a/openspec/changes/make-agent-tools-pit-of-success/proposal.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/proposal.md
@@ -1,0 +1,91 @@
+## Why
+
+Recent PII-sanitized live-session evidence shows that agents receive hundreds of
+tool schemas yet still fall back to approval-gated shell or Python for routine
+workspace inspection, batch reads, JSON projection, image metadata, and spilled
+result continuation. This undermines PRD-001 outcomes 7 and 9, PRD-006 outcome
+5, and PRD-007 outcomes 3 and 5: the safe, structured route exists in pieces but
+is not the easiest route for either main sessions or subagents.
+
+## What Changes
+
+- Define one audience-filtered progressive-disclosure contract for first-party
+  and MCP tools. A small workspace core remains always visible; specialty tools
+  are discoverable and loadable on demand. Subagents use the same contract
+  instead of receiving nearly the entire discoverable catalog.
+- Make workspace file tools resolve relative paths against the declared project
+  directory, then the immutable session directory, while retaining the existing
+  scoped-access checks. Failed operations do not mutate recent-file context.
+- Add structured, bounded workspace operations for recursive search, batch file
+  reads, JSON projection, image metadata, and continuation of spilled tool
+  output. These operations return machine-actionable outcomes and remediation
+  without requiring shell syntax.
+- Make conditional first-party tool schemas describe valid argument shapes so
+  models cannot select mutually incompatible modes or omit mode-required fields.
+- Replace prompt-only success claims with deterministic schema, authorization,
+  outcome, and PII-sanitized transcript-replay tests.
+
+### In scope for this change
+
+- First-party tool visibility tiers and on-demand loading.
+- Parent-session and subagent parity for tool discovery and audience filtering.
+- Workspace-oriented structured read/search/metadata/result-continuation tools.
+- Relative workspace path ownership and typed recoverable tool outcomes.
+- Sanitized regression fixtures derived from observed failures and approval
+  prompts.
+
+### Out of scope for this change
+
+- Executable-specific shell policy or command-syntax knowledge in Netclaw.
+- ShellSyntaxTree grammar or public API changes.
+- Layered configuration provenance and CLI editing; tracked separately by
+  issue #2009.
+- Weakening ACL, approval, path-containment, audience, or MCP grant checks.
+- Automatically interpreting arbitrary Markdown links as local artifacts.
+- A general tool-runtime rewrite or public `INetclawTool` breaking change.
+
+## Capabilities
+
+### New Capabilities
+
+- `progressive-tool-disclosure`: Defines core versus deferred first-party tools,
+  audience-filtered search/load behavior, and identical parent/subagent loading
+  semantics.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Adds workspace-relative paths, structured workspace
+  operations, machine-actionable outcomes, conditional schemas, and successful
+  file-activity ownership.
+- `bounded-tool-output`: Adds a bounded structured continuation path for spilled
+  results without requiring shell or Python.
+- `netclaw-subagents`: Replaces eager exposure of all discoverable tools with
+  the shared progressive-disclosure contract.
+- `session-cwd`: Makes project-then-session path resolution the explicit default
+  for relative first-party filesystem operations.
+
+## Impact
+
+### Code and APIs
+
+The change affects tool registration and discovery, subagent tool resolution,
+first-party file/result tools, their MEAI schemas, execution-result handling,
+and session file-activity tracking. Public `INetclawTool` and durable session,
+approval, and configuration formats remain compatible; structured outcomes use
+an internal adapter and the existing string result boundary.
+
+### Security
+
+All discovered and loaded tools remain filtered by deployment switches,
+audience allowlists, MCP grants, and existing scoped filesystem authorization.
+Relative paths acquire no ambient process-cwd authority. Unknown tools,
+malformed conditional arguments, missing spill artifacts, and invalid paths fail
+closed with bounded results. No shell allowlist is widened.
+
+### Operations
+
+Tool-definition token load should fall substantially for subagents and modestly
+for main sessions. New diagnostics will report core/deferred/loaded counts and
+structured outcome categories without command contents or PII. Rollout evidence
+will use deterministic tests plus a PII-sanitized replay corpus before a live
+binary swap.

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/bounded-tool-output/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/bounded-tool-output/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Spilled output has an opaque bounded continuation tool
+
+The system SHALL provide a core `tool_output_read` tool that accepts an opaque
+tool call id, start character, and character limit. It SHALL resolve only the
+redacted spill belonging to that call id under the current immutable session
+directory. It SHALL NOT accept a filesystem path, cross a session boundary, or
+return more than the configured limit.
+
+#### Scenario: Agent continues a current-session spill
+
+- **GIVEN** a tool result was spilled under the current session for call id
+  `call_example`
+- **WHEN** `tool_output_read` requests a bounded later window for that id
+- **THEN** the requested redacted window and continuation metadata are returned
+- **AND** no shell or Python command is required
+
+#### Scenario: Path-like call id cannot escape spill directory
+
+- **GIVEN** a model supplies `../other-session/secret` as the call id
+- **WHEN** `tool_output_read` validates the id
+- **THEN** the outcome is `invalid_input`
+- **AND** no path outside the current session spill directory is inspected
+
+#### Scenario: Missing spill is recoverable without probing paths
+
+- **GIVEN** no spill exists for the supplied current-session call id
+- **WHEN** `tool_output_read` executes
+- **THEN** the outcome is `not_found`
+- **AND** the bounded result suggests rerunning or narrowing the originating
+  structured tool

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-subagents/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Subagents use progressive tool disclosure
+
+A subagent SHALL begin with the same policy-exposed core tool set as a main
+session, minus tools prohibited by subagent policy. It SHALL NOT eagerly receive
+every discoverable first-party or MCP tool. `search_tools` and `load_tool` SHALL
+activate deferred tools only in that child actor's ephemeral exposure set.
+
+#### Scenario: Child starts with core rather than full catalog
+
+- **GIVEN** the daemon has more than one hundred policy-visible specialty and
+  MCP tools
+- **WHEN** a subagent starts
+- **THEN** its first model request contains only its allowed core tools
+- **AND** `search_tools` can find allowed deferred capabilities
+
+#### Scenario: Child loads one deferred tool
+
+- **GIVEN** a subagent needs a policy-visible deferred tool
+- **WHEN** it searches for and loads that exact tool
+- **THEN** the next child model request contains the core plus that tool
+- **AND** unrelated deferred schemas remain absent
+
+#### Scenario: Child cannot discover recursive delegation
+
+- **GIVEN** `spawn_agent` is registered for the parent session
+- **WHEN** a subagent searches for or attempts to load it
+- **THEN** the response does not reveal or activate `spawn_agent`
+
+### Requirement: Subagent tool exposure is observable without payloads
+
+Subagent diagnostics SHALL report core, deferred-visible, and dynamically loaded
+tool counts for each run. Logs SHALL NOT include tool argument values, command
+text, file paths, schema bodies, or hidden tool names.
+
+#### Scenario: Child startup logs bounded counts
+
+- **WHEN** a subagent begins a run
+- **THEN** one structured diagnostic records its three tool counts
+- **AND** the event contains no authored payload or path

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-tools/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-tools/spec.md
@@ -1,0 +1,149 @@
+## ADDED Requirements
+
+### Requirement: First-party tool outcomes are machine-actionable
+
+First-party workspace tool execution SHALL produce exactly one call-local
+outcome category: `success`, `invalid_input`, `access_denied`, `not_found`,
+`transient_failure`, or `recoverable_correction`. The category SHALL be separate
+from the model-facing string and SHALL NOT be inferred by parsing that string.
+The outcome MAY carry a bounded remediation code and canonical file activity.
+It SHALL NOT change the public string-returning `INetclawTool` contract.
+
+#### Scenario: Access denial has no successful file activity
+
+- **GIVEN** `file_read` is called for a path outside the current read authority
+- **WHEN** scoped access denies the call
+- **THEN** the outcome category is `access_denied`
+- **AND** the outcome contains no successful file activity
+- **AND** the model receives a bounded denial string
+
+#### Scenario: Recoverable correction stays distinct from failure
+
+- **GIVEN** a workspace tool can continue after the project directory is
+  declared
+- **WHEN** the missing declaration is the only blocker
+- **THEN** the outcome category is `recoverable_correction`
+- **AND** its remediation code identifies `set_working_directory`
+- **AND** no authority is granted by the outcome itself
+
+### Requirement: Working context records successful file activity only
+
+`WorkingContext.RecentFiles` SHALL be updated only from canonical file activity
+reported by a successful tool outcome. Failed, denied, missing, malformed, or
+corrective tool results SHALL NOT update recent files. The session pipeline
+SHALL NOT infer successful file activity solely from authored argument names.
+
+#### Scenario: Failed write does not become recent
+
+- **GIVEN** `file_write` targets a denied path
+- **WHEN** the tool returns an access-denied outcome
+- **THEN** the authored path is absent from `RecentFiles`
+
+#### Scenario: Successful batch read records canonical files
+
+- **GIVEN** `file_read_many` successfully reads two authorized relative paths
+- **WHEN** the session applies the tool receipt
+- **THEN** both canonical resolved paths are added to `RecentFiles`
+- **AND** no authored relative spelling is treated as a separate file
+
+### Requirement: Recursive workspace search is bounded and structured
+
+The system SHALL provide a `file_search` tool for recursive literal file-name
+and text search under one authorized root. The tool SHALL accept explicit
+result, file, and content-byte ceilings; SHALL NOT follow directory symlinks;
+and SHALL report matches, skipped entries, and truncation state. Search SHALL
+use filesystem APIs rather than an external executable.
+
+#### Scenario: Literal content search stays inside the root
+
+- **GIVEN** an authorized project containing text files and a directory symlink
+  to an external tree
+- **WHEN** `file_search` searches for a literal string from the project root
+- **THEN** matching project files are returned with relative paths and line data
+- **AND** the external tree is not traversed
+
+#### Scenario: Search stops at configured ceilings
+
+- **GIVEN** more matching files than the requested result ceiling
+- **WHEN** `file_search` reaches the ceiling
+- **THEN** it stops enumerating further content
+- **AND** the result reports that it was truncated
+
+### Requirement: Batch file reads validate before content access
+
+The system SHALL provide a `file_read_many` tool that accepts a bounded list of
+paths plus per-file and total output ceilings. It SHALL resolve and authorize
+the complete path list before reading file content. If any member is malformed,
+missing, denied, or outside the batch limits, the tool SHALL return a failure
+without content from another member.
+
+#### Scenario: Denied member makes batch atomic
+
+- **GIVEN** a batch contains one authorized file and one denied file
+- **WHEN** `file_read_many` validates the batch
+- **THEN** the outcome is `access_denied`
+- **AND** no content from the authorized file is returned
+- **AND** no file activity is recorded
+
+#### Scenario: Authorized batch returns bounded sections
+
+- **GIVEN** a batch of authorized text files within count limits
+- **WHEN** `file_read_many` reads them
+- **THEN** the result contains one labeled bounded section per file
+- **AND** total output does not exceed the declared ceiling
+
+### Requirement: JSON projection uses bounded data semantics
+
+The system SHALL provide a `json_read` tool that reads one authorized JSON file
+and projects a bounded list of RFC 6901 JSON Pointers. It SHALL parse JSON with
+the repository's System.Text.Json configuration, reject duplicate or invalid
+pointers, and bound input bytes, pointer count, and output characters. It SHALL
+NOT accept executable query languages.
+
+#### Scenario: Selected JSON properties returned without shell
+
+- **GIVEN** an authorized JSON document
+- **WHEN** `json_read` receives pointers `/status` and `/items/0/name`
+- **THEN** it returns the selected values with their pointers
+- **AND** the outcome is `success`
+
+#### Scenario: Invalid pointer fails before partial projection
+
+- **GIVEN** one valid pointer and one malformed pointer
+- **WHEN** `json_read` validates the request
+- **THEN** the outcome is `invalid_input`
+- **AND** no selected value is returned
+
+### Requirement: File inspection exposes bounded image metadata
+
+When `file_read` inspects a supported image, its metadata result SHALL include
+canonical MIME type, byte length, pixel width, and pixel height without decoding
+the full image into an unbounded bitmap. Malformed or unsupported image metadata
+SHALL fail closed without returning raw binary content.
+
+#### Scenario: PNG dimensions are returned
+
+- **GIVEN** an authorized valid PNG file
+- **WHEN** `file_read` inspects it
+- **THEN** the result includes `image/png`, byte length, width, and height
+- **AND** the agent does not need shell or Python to obtain dimensions
+
+### Requirement: Conditional tool schemas expose valid branches
+
+A first-party tool with mutually exclusive execution modes SHALL publish a JSON
+Schema `oneOf` whose branches require the fields for that mode and reject
+fields belonging only to another mode. Native argument validation SHALL reject
+zero or multiple matching branches before the tool executes.
+
+#### Scenario: Reminder mode requires its delivery fields
+
+- **GIVEN** a reminder tool has delivery modes with different required fields
+- **WHEN** its schema is generated
+- **THEN** each mode is a separate `oneOf` branch
+- **AND** a call missing that mode's required field is rejected before dispatch
+
+#### Scenario: Single-shape tool remains compatible
+
+- **GIVEN** `file_list` has one argument shape
+- **WHEN** its schema is generated
+- **THEN** its existing object schema and accepted calls remain unchanged

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/progressive-tool-disclosure/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Tool registrations declare an exposure tier
+
+Every registered tool SHALL have an exposure tier of `Core` or `Deferred`.
+Registration paths that do not explicitly select `Core` SHALL select
+`Deferred`. Exposure tier SHALL NOT replace or widen deployment, audience,
+grant, or invocation policy.
+
+#### Scenario: New first-party tool defaults to deferred
+
+- **GIVEN** a first-party tool is registered without an explicit core selection
+- **WHEN** a session builds its initial model tool set
+- **THEN** the new tool is absent from that initial set
+- **AND** the tool remains discoverable only when current policy exposes it
+
+#### Scenario: Core selection does not grant a tool
+
+- **GIVEN** a core tool is denied by the current audience profile
+- **WHEN** the session builds its initial model tool set
+- **THEN** the denied tool is absent
+- **AND** search and load do not reveal or activate it
+
+### Requirement: Sessions start with a bounded workspace core
+
+The initial model tool set SHALL contain the policy-exposed definitions for
+`search_tools`, `load_tool`, `skill_load`, `skill_read_resource`,
+`set_working_directory`, `file_read`, `file_list`, `file_write`, `file_edit`,
+and `shell_execute`. Other first-party and MCP tools SHALL be deferred unless a
+later specification explicitly adds them to the core.
+
+#### Scenario: Specialty tools are not eagerly exposed
+
+- **GIVEN** reminder, webhook, background-job, web, and MCP tools are registered
+- **WHEN** a new Personal session begins
+- **THEN** their schemas are absent from the initial model request
+- **AND** the policy-exposed tools remain searchable by intent
+
+#### Scenario: Core snapshot stays bounded
+
+- **WHEN** the repository's first-party tool catalog is tested
+- **THEN** the core tool-name snapshot equals the specified core set
+- **AND** registering another first-party tool does not change that snapshot
+
+### Requirement: Search and load apply the complete exposure policy
+
+`search_tools` and `load_tool` SHALL apply deployment switches, audience
+allowlists, MCP server and tool grants, channel restrictions, and subagent tool
+restrictions before returning or activating a tool. Results SHALL NOT reveal a
+hidden tool's name or schema. Loading a tool SHALL add only its definition to the
+current actor's exposure set; normal authorization SHALL still run at dispatch.
+
+#### Scenario: Hidden tool cannot be enumerated or loaded
+
+- **GIVEN** a Team session is not allowed to use a registered specialty tool
+- **WHEN** it searches for the tool by exact name and then attempts to load it
+- **THEN** neither response confirms the hidden tool exists
+- **AND** the model tool set is unchanged
+
+#### Scenario: Loaded tool still requires invocation authority
+
+- **GIVEN** a deferred tool is discoverable and loadable for a session
+- **AND** its invocation requires user approval
+- **WHEN** the model loads and then calls the tool
+- **THEN** the call enters the normal approval pipeline
+- **AND** loading does not satisfy or bypass approval
+
+### Requirement: Deferred exposure is actor-local and recoverable
+
+Loaded deferred tools SHALL be transient actor-owned state. Main-session leases
+SHALL retain and evict any deferred tool using the existing configured limits.
+Subagent-loaded tools SHALL live only for that child run. Recovery SHALL reseed
+the core set and SHALL NOT require a durable schema migration.
+
+#### Scenario: Main model failure evicts deferred first-party tool
+
+- **GIVEN** a main session has loaded a deferred first-party tool
+- **WHEN** an LLM call fails and the discovered-tool cache is reset
+- **THEN** the tool is absent from the next model request
+- **AND** the core set remains available
+
+#### Scenario: Child completion discards loaded tools
+
+- **GIVEN** a subagent loads a deferred tool during its run
+- **WHEN** that subagent stops and another subagent starts
+- **THEN** the new subagent receives only its policy-exposed core set
+- **AND** it does not inherit the prior child tool lease

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/session-cwd/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/session-cwd/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Relative first-party filesystem paths use session-owned bases
+
+First-party filesystem tools SHALL resolve a relative path against the declared
+project directory when one exists; otherwise they SHALL resolve it against the
+immutable session directory. If neither base is available, they SHALL return an
+`invalid_context` correction and SHALL NOT use the daemon process current
+directory. The canonical resolved path SHALL still pass the existing operation-
+specific scoped access and protected-path policies.
+
+#### Scenario: Relative read uses declared project
+
+- **GIVEN** a session with project directory `/workspace/project` and session
+  directory `/session/current`
+- **WHEN** `file_read` receives `src/App.cs`
+- **THEN** it authorizes and reads `/workspace/project/src/App.cs`
+- **AND** it does not resolve the path from the daemon current directory
+
+#### Scenario: Relative write falls back to session scratch
+
+- **GIVEN** a session without a declared project and with session directory
+  `/session/current`
+- **WHEN** `file_write` receives `notes/result.md`
+- **THEN** it resolves `/session/current/notes/result.md`
+- **AND** the existing session-directory write policy decides authorization
+
+#### Scenario: Traversal receives no implicit authority
+
+- **GIVEN** project directory `/workspace/project`
+- **WHEN** a file tool receives `../../outside.txt`
+- **THEN** it canonicalizes the result before policy evaluation
+- **AND** the call is denied when the canonical path is outside authorized roots
+
+#### Scenario: Missing base returns correction
+
+- **GIVEN** a sessionless tool context with no project or session directory
+- **WHEN** a first-party filesystem tool receives a relative path
+- **THEN** it returns `invalid_context`
+- **AND** it performs no filesystem access
+
+### Requirement: Failed filesystem operations do not change project context
+
+A denied or failed `set_working_directory` or filesystem tool call SHALL NOT
+change the declared project directory or recent-file context. Only a validated
+successful project declaration SHALL replace the project directory and reload
+project instructions.
+
+#### Scenario: Denied declaration leaves prior project intact
+
+- **GIVEN** a session already declares `/workspace/old`
+- **WHEN** `set_working_directory` is denied for `/workspace/new`
+- **THEN** the project directory remains `/workspace/old`
+- **AND** project instructions are not reloaded from the denied path

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -1,0 +1,61 @@
+## 1. PR 1 - Contract and sanitized evidence
+
+- [x] 1.1 Add a PII-free fixture schema for observed tool-friction cases, including expected structured tool, outcome, approval requirement, and prohibited raw identifiers.
+- [x] 1.2 Add sanitized cases for recursive search, batch reads, JSON projection, image metadata, spilled output continuation, failed file activity, and subagent catalog overexposure.
+- [x] 1.3 Add deterministic fixture binding, mutation, and PII-audit tests so every policy-relevant field participates in the contract.
+- [x] 1.4 Record the current core schema count/bytes and subagent schema count/bytes as a reproducible baseline without logging schema bodies.
+- [x] 1.5 Validate this OpenSpec change strictly and commit the planning, deterministic fixture, and schema-footprint slice independently.
+
+## 2. PR 2 - Progressive disclosure foundation
+
+- [ ] 2.1 Add explicit Core/Deferred registration metadata with Deferred as the safe default and preserve existing registry lookup identities.
+- [ ] 2.2 Mark the specified workspace/discovery tools Core and leave specialty first-party and MCP tools Deferred.
+- [ ] 2.3 Generalize the discovered-tool cache so leases and eviction apply to deferred first-party tools as well as MCP tools.
+- [ ] 2.4 Extend the compact audience-filtered capability catalog to include deferred first-party tool names and short hints without full schemas.
+- [ ] 2.5 Make search, suggestions, and load apply the same deployment, audience, grant, and feature filters without revealing hidden names.
+- [ ] 2.6 Add snapshots for exact core names, initial schema count/bytes, deferred discovery, load activation, eviction, and authorization-after-load.
+
+## 3. PR 3 - Subagent progressive disclosure
+
+- [ ] 3.1 Seed subagents from the policy-exposed Core set instead of every discoverable registration.
+- [ ] 3.2 Add an ephemeral child exposure cache and intercept successful load_tool results within the child actor.
+- [ ] 3.3 Preserve recursive-spawn denial across child catalog, search, suggestions, load, and dispatch paths.
+- [ ] 3.4 Emit PII-free child core/deferred/loaded counts without tool payloads, paths, schema bodies, or hidden names.
+- [ ] 3.5 Add parent/child parity tests, child-local lease isolation, model-failure eviction, and high-cardinality catalog regression coverage.
+
+## 4. PR 4 - Workspace path and outcome foundation
+
+- [ ] 4.1 Add one shared relative-path resolver using valid project directory then immutable session directory, never process cwd.
+- [ ] 4.2 Route existing first-party read, list, write, edit, and attach paths through the shared resolver before their existing scoped policies.
+- [ ] 4.3 Add the call-local typed outcome receipt and central exception/policy classifications without changing public INetclawTool signatures.
+- [ ] 4.4 Convert first-party workspace tools to report exact success, invalid-input, denial, not-found, transient, or correction outcomes.
+- [ ] 4.5 Replace argument-based RecentFiles inference for workspace tools with canonical successful file activity from the receipt.
+- [ ] 4.6 Prove failed file operations and failed set_working_directory calls cannot change RecentFiles, project scope, or project instructions.
+- [ ] 4.7 Add POSIX and native-Windows tests for relative paths, traversal, missing bases, symlinks, protected paths, and absolute-path compatibility.
+
+## 5. PR 5 - Structured workspace primitives
+
+- [ ] 5.1 Implement bounded file_search with literal name/content modes, scoped root authorization, deterministic ordering, and no directory-symlink traversal.
+- [ ] 5.2 Implement atomic bounded file_read_many with complete prevalidation, per-file ceilings, total ceiling, and canonical successful activity.
+- [ ] 5.3 Implement bounded json_read using System.Text.Json and RFC 6901 pointers with atomic pointer validation.
+- [ ] 5.4 Extend file_read image inspection with bounded PNG/JPEG/GIF/WebP dimensions and malformed-header fail-closed behavior.
+- [ ] 5.5 Register only the small structured workspace schemas as Core and update compact capability hints.
+- [ ] 5.6 Add count/byte/result ceilings, cancellation, access-denial, symlink, binary, encoding, malformed JSON, and cross-platform tests.
+
+## 6. PR 6 - Spill continuation and conditional schemas
+
+- [ ] 6.1 Implement core tool_output_read by opaque call id with bounded windows and current-session-only spill resolution.
+- [ ] 6.2 Make spill creation and continuation share one call-id sanitizer and reject traversal, controls, missing ids, and cross-session access.
+- [ ] 6.3 Add source-generator support for explicit conditional tool variants and oneOf schemas without changing single-shape schemas.
+- [ ] 6.4 Convert the observed mode-dependent first-party tools and reject zero/multiple matching branches before execution.
+- [ ] 6.5 Add schema snapshots, generated-code tests, malformed-branch tests, spill-redaction tests, and public API compatibility checks.
+
+## 7. PR 7 - Replay, documentation, and rollout proof
+
+- [ ] 7.1 Replay every sanitized friction fixture through real registration, policy, dispatch, outcome, and working-context paths.
+- [ ] 7.2 Prove representative structured workflows require no shell approval while equivalent shell/Python fallbacks remain approval-gated.
+- [ ] 7.3 Update embedded operating guidance and repo-owned skills to prefer structured workspace tools and progressive discovery without memorizing command syntax.
+- [ ] 7.4 Add operator diagnostics for core/deferred/loaded counts and outcome categories with PII and payload exclusion tests.
+- [ ] 7.5 Run Release build, full tests, headers, formatting, strict OpenSpec, changed-file Slopwatch, PII audit, and API compatibility gates.
+- [ ] 7.6 Run native Windows and Linux validation.
+- [ ] 7.7 Rebase the final stack on upstream/dev, merge in order, remove merged worktrees, produce a binary-swap build, and harvest a new sanitized live window.

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -42,6 +42,9 @@
     <None Include="../../openspec/changes/reduce-fresh-session-approval-spam/evidence/fresh-session-policy-fixtures.json"
           Link="ApprovalEvidence/fresh-session-policy-fixtures.json"
           CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-schema-footprint-baseline.json"
+          Link="ToolFootprintEvidence/tool-schema-footprint-baseline.json"
+          CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.html" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -5,6 +5,8 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Actors.Channels;
@@ -18,6 +20,7 @@ using Netclaw.Actors.Tools;
 using Netclaw.Actors.Tests.SubAgents;
 using Netclaw.Configuration;
 using Netclaw.Security;
+using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
 using static Netclaw.Actors.Sessions.SessionProtocol;
@@ -30,8 +33,14 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
     private const string MainIdentityMarker = "You are a test assistant with subagent support.";
     private const string OperatingRulesMarker = "[embedded agents] Sub-agents inherit operating rules.";
     private const string AgentsLayerMarker = "[agents] This marker should never appear in routed subagent calls.";
+    private const string ToolFootprintScenario = "personal-session-with-fixed-synthetic-mcp-catalog";
+    private const string ToolFootprintMetric =
+        "Compact UTF-8 JSON array of final function names, descriptions, and input schemas in ChatOptions.Tools order.";
+    private const string SyntheticMcpServerName = "synthetic_catalog";
+    private const int SyntheticMcpToolCount = 200;
 
     private readonly RecordingRoleChatClientProvider _clientProvider = new();
+    private readonly ToolRegistry _toolRegistry = new();
     private RecordingContextTool? _recordingFileReadTool;
     private RecordingContextTool? _recordingApprovalTool;
 
@@ -144,7 +153,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         });
         services.AddSingleton(skillRegistry);
 
-        var registry = new ToolRegistry();
+        var registry = _toolRegistry;
         var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
         toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
         {
@@ -298,6 +307,61 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Assert.Equal(sessionId.Value, mainOptions.SessionId);
         var subagentOptions = Assert.IsType<SessionScopedChatOptions>(_clientProvider.Compaction.ReceivedOptions[^1]);
         Assert.Equal(sessionId.Value, subagentOptions.SessionId);
+    }
+
+    [Fact]
+    public async Task Final_model_visible_tool_footprints_match_frozen_baseline()
+    {
+        RegisterSyntheticMcpCatalog();
+        _clientProvider.Main.ToolCallsOnFirstCall =
+        [
+            CreateToolCall(
+                "call-footprint-spawn",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Summarize the fixed synthetic catalog."
+                })
+        ];
+
+        var sessionId = new SessionId("console/tool-footprint-baseline");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("tool-footprint-events");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use the summarizer.",
+            Source = BuildPersonalSource()
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await ExpectTurnCompletedAsync(
+            subscriber,
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        var mainOptions = Assert.IsType<SessionScopedChatOptions>(_clientProvider.Main.ReceivedOptions[0]);
+        var mainTools = Assert.IsAssignableFrom<IEnumerable<AITool>>(mainOptions.Tools);
+        var subagentOptions = Assert.IsType<SessionScopedChatOptions>(_clientProvider.Compaction.ReceivedOptions[0]);
+        var subagentTools = Assert.IsAssignableFrom<IEnumerable<AITool>>(subagentOptions.Tools);
+
+        var actual = new ToolFootprintPair(
+            ModelVisibleToolFootprintCalculator.Measure(mainTools),
+            ModelVisibleToolFootprintCalculator.Measure(subagentTools));
+        var baseline = await ReadToolFootprintBaselineAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, baseline.SchemaVersion);
+        Assert.Equal(ToolFootprintScenario, baseline.Scenario);
+        Assert.Equal(ToolFootprintMetric, baseline.Metric);
+        Assert.Equal(SyntheticMcpToolCount, baseline.SyntheticMcpToolCount);
+        Assert.Equal(new ToolFootprintPair(baseline.MainCore, baseline.SubagentFull), actual);
     }
 
     [Fact]
@@ -835,6 +899,49 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             Assert.Equal(request.RequesterSenderId?.Value, requesterSenderId);
         }
     }
+
+    private void RegisterSyntheticMcpCatalog()
+    {
+        for (var i = 0; i < SyntheticMcpToolCount; i++)
+        {
+            var toolName = $"tool_{i:D3}";
+            var function = AIFunctionFactory.Create(
+                (string query, int maxResults) => $"unused:{query}:{maxResults}",
+                toolName,
+                "Find synthetic records by query with a bounded result count.");
+            _toolRegistry.Register(new McpToolAdapter(
+                function,
+                SyntheticMcpServerName,
+                toolName));
+        }
+    }
+
+    private static async Task<ToolFootprintBaseline> ReadToolFootprintBaselineAsync(CancellationToken cancellationToken)
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory,
+            "ToolFootprintEvidence",
+            "tool-schema-footprint-baseline.json");
+        var json = await File.ReadAllTextAsync(path, cancellationToken);
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
+        };
+        return JsonSerializer.Deserialize<ToolFootprintBaseline>(json, options)
+               ?? throw new InvalidOperationException("Tool footprint baseline is empty.");
+    }
+
+    private sealed record ToolFootprintBaseline(
+        int SchemaVersion,
+        string Scenario,
+        string Metric,
+        int SyntheticMcpToolCount,
+        ModelVisibleToolFootprint MainCore,
+        ModelVisibleToolFootprint SubagentFull);
+
+    private sealed record ToolFootprintPair(
+        ModelVisibleToolFootprint MainCore,
+        ModelVisibleToolFootprint SubagentFull);
 
     private sealed class RecordingRoleChatClientProvider : IChatClientProvider
     {

--- a/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
+++ b/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
@@ -27,6 +27,9 @@
     <None Include="../../openspec/changes/reduce-fresh-session-approval-spam/evidence/*.json"
           Link="ApprovalEvidence/%(Filename)%(Extension)"
           CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json"
+          Link="ToolFrictionEvidence/tool-friction-fixtures.json"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Security.Tests/ToolFrictionEvidenceContractTests.cs
+++ b/src/Netclaw.Security.Tests/ToolFrictionEvidenceContractTests.cs
@@ -1,0 +1,343 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolFrictionEvidenceContractTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed partial class ToolFrictionEvidenceContractTests
+{
+    private const string FixtureFile = "tool-friction-fixtures.json";
+    private const string FixtureSha256 =
+        "caac85054fd359eef9287b0babeea70e2f6830294e228109fb988942bbe6335c";
+
+    private static readonly string[] ProhibitedRawIdentifierClasses =
+    [
+        "session_id",
+        "tool_call_id",
+        "user_identity",
+        "repository_identity",
+        "host",
+        "url",
+        "exact_timestamp",
+        "credential",
+        "raw_prompt",
+        "raw_response",
+        "raw_log_line"
+    ];
+
+    private static readonly ToolFrictionExpectedCase[] ExpectedCases =
+    [
+        new("TF01", "RecursiveSearch", "ApprovalGatedShellSearch", ["file_search"],
+            "success", false, true, "NoContextChangeRequired"),
+        new("TF02", "BatchRead", "ApprovalGatedShellBatch", ["file_read_many"],
+            "success", false, true, "RecordTwoCanonicalFiles"),
+        new("TF03", "JsonProjection", "ApprovalGatedInterpreterProjection", ["json_read"],
+            "success", false, true, "RecordOneCanonicalFile"),
+        new("TF04", "ImageMetadata", "ApprovalGatedInterpreterMetadata", ["file_read"],
+            "success", false, true, "RecordOneCanonicalFile"),
+        new("TF05", "SpillContinuation", "ApprovalGatedSpillParsing", ["tool_output_read"],
+            "success", false, true, "NoContextChangeRequired"),
+        new("TF06", "FailedFileActivity", "FailedCallPollutedRecentFiles", ["file_write"],
+            "access_denied", false, false, "PreserveRecentFiles"),
+        new("TF07", "SubagentCatalogExposure", "EagerSubagentSchemaCatalog",
+            ["search_tools", "load_tool"], "success", false, false, "CoreOnlyChildCatalog")
+    ];
+
+    [Fact]
+    public void Fixture_binds_the_complete_sanitized_contract()
+    {
+        var bytes = File.ReadAllBytes(FixturePath());
+        var catalog = Deserialize(bytes);
+
+        Assert.Equal(FixtureSha256, ComputeSha256(bytes));
+        Assert.DoesNotContain((byte)'\r', bytes);
+        Assert.Equal(1, catalog.SchemaVersion);
+        Assert.Equal(
+            "Raw transcripts remain local. Cases are semantic reconstructions with synthetic identifiers.",
+            catalog.Sanitization.SourceBoundary);
+        Assert.Equal(
+            ProhibitedRawIdentifierClasses,
+            catalog.Sanitization.ProhibitedRawIdentifierClasses);
+        Assert.Equal(ExpectedCases.Length, catalog.Cases.Count);
+        for (var index = 0; index < ExpectedCases.Length; index++)
+        {
+            var expected = ExpectedCases[index];
+            var actual = ToExpectedCase(catalog.Cases[index]);
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.Scenario, actual.Scenario);
+            Assert.Equal(expected.ObservedFriction, actual.ObservedFriction);
+            Assert.Equal(expected.ExpectedToolSequence, actual.ExpectedToolSequence);
+            Assert.Equal(expected.ExpectedOutcome, actual.ExpectedOutcome);
+            Assert.Equal(expected.ExpectedApprovalRequired, actual.ExpectedApprovalRequired);
+            Assert.Equal(expected.FallbackApprovalRequired, actual.FallbackApprovalRequired);
+            Assert.Equal(expected.ExpectedContextEffect, actual.ExpectedContextEffect);
+        }
+    }
+
+    [Theory]
+    [InlineData("root")]
+    [InlineData("case")]
+    public void Fixture_schema_rejects_unknown_members(string location)
+    {
+        var json = File.ReadAllText(FixturePath());
+        var malformed = location == "root"
+            ? json.Replace(
+                "\"schemaVersion\": 1,",
+                "\"schemaVersion\": 1, \"unexpected\": true,",
+                StringComparison.Ordinal)
+            : json.Replace(
+                "\"id\": \"TF01\",",
+                "\"id\": \"TF01\", \"unexpected\": true,",
+                StringComparison.Ordinal);
+
+        Assert.NotEqual(json, malformed);
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(
+            malformed,
+            ToolFrictionEvidenceJsonContext.Default.ToolFrictionFixtureCatalog));
+    }
+
+    [Theory]
+    [InlineData("schemaVersion")]
+    [InlineData("sourceBoundary")]
+    [InlineData("prohibitedRawIdentifierClasses")]
+    [InlineData("id")]
+    [InlineData("scenario")]
+    [InlineData("observedFriction")]
+    [InlineData("expectedToolSequence")]
+    [InlineData("expectedOutcome")]
+    [InlineData("expectedApprovalRequired")]
+    [InlineData("fallbackApprovalRequired")]
+    [InlineData("expectedContextEffect")]
+    [InlineData("caseOrder")]
+    public void Typed_digest_detects_each_policy_field_mutation(string field)
+    {
+        var catalog = Deserialize(File.ReadAllBytes(FixturePath()));
+        var mutated = Mutate(catalog, field);
+
+        Assert.NotEqual(ComputeContractDigest(catalog), ComputeContractDigest(mutated));
+    }
+
+    [Fact]
+    public void Fixture_contains_no_raw_runtime_identity()
+    {
+        var text = File.ReadAllText(FixturePath());
+
+        Assert.False(ContainsRawIdentity(text));
+    }
+
+    [Theory]
+    [InlineData("D1234567890")]
+    [InlineData("1234567890.123456")]
+    [InlineData("operator@example.com")]
+    [InlineData("/home/private-user/project")]
+    [InlineData(@"C:\Users\private-user\project")]
+    [InlineData("petabridge")]
+    [InlineData("ghp_000000000000000000000000000000000000")]
+    [InlineData("Authorization: Bearer example-credential-value")]
+    [InlineData("api_key=examplecredentialvalue")]
+    [InlineData("https://private.example.com/path")]
+    [InlineData("--repo private-owner/private-project")]
+    [InlineData("call_private")]
+    [InlineData("2026-08-19T01:02:03Z")]
+    [InlineData("01234567-89ab-cdef-0123-456789abcdef")]
+    [InlineData("akka://netclaw/user/session")]
+    [InlineData("[INF] raw daemon line")]
+    [InlineData("\"rawPrompt\":\"private request\"")]
+    [InlineData("\"rawResponse\":\"private result\"")]
+    [InlineData("\"rawLogLine\":\"private log\"")]
+    public void Pii_audit_detects_prohibited_identity_shapes(string value)
+    {
+        Assert.True(ContainsRawIdentity(value));
+    }
+
+    private static ToolFrictionFixtureCatalog Deserialize(byte[] bytes)
+        => JsonSerializer.Deserialize(
+               bytes,
+               ToolFrictionEvidenceJsonContext.Default.ToolFrictionFixtureCatalog)
+           ?? throw new InvalidDataException($"{FixtureFile} has no root object.");
+
+    private static ToolFrictionExpectedCase ToExpectedCase(ToolFrictionCase item)
+        => new(
+            item.Id,
+            item.Scenario,
+            item.ObservedFriction,
+            [.. item.ExpectedToolSequence],
+            item.ExpectedOutcome,
+            item.ExpectedApprovalRequired,
+            item.FallbackApprovalRequired,
+            item.ExpectedContextEffect);
+
+    private static ToolFrictionFixtureCatalog Mutate(
+        ToolFrictionFixtureCatalog catalog,
+        string field)
+    {
+        if (field == "schemaVersion")
+            return catalog with { SchemaVersion = catalog.SchemaVersion + 1 };
+        if (field == "sourceBoundary")
+            return catalog with
+            {
+                Sanitization = catalog.Sanitization with { SourceBoundary = "changed boundary" }
+            };
+        if (field == "prohibitedRawIdentifierClasses")
+            return catalog with
+            {
+                Sanitization = catalog.Sanitization with
+                {
+                    ProhibitedRawIdentifierClasses = ["changed_identifier_class"]
+                }
+            };
+        if (field == "caseOrder")
+            return catalog with { Cases = [.. catalog.Cases.AsEnumerable().Reverse()] };
+
+        var first = catalog.Cases[0];
+        var changed = field switch
+        {
+            "id" => first with { Id = "changed" },
+            "scenario" => first with { Scenario = "ChangedScenario" },
+            "observedFriction" => first with { ObservedFriction = "ChangedFriction" },
+            "expectedToolSequence" => first with { ExpectedToolSequence = ["changed_tool"] },
+            "expectedOutcome" => first with { ExpectedOutcome = "changed_outcome" },
+            "expectedApprovalRequired" => first with
+            {
+                ExpectedApprovalRequired = !first.ExpectedApprovalRequired
+            },
+            "fallbackApprovalRequired" => first with
+            {
+                FallbackApprovalRequired = !first.FallbackApprovalRequired
+            },
+            "expectedContextEffect" => first with
+            {
+                ExpectedContextEffect = "ChangedContextEffect"
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown field.")
+        };
+
+        return catalog with { Cases = [changed, .. catalog.Cases.Skip(1)] };
+    }
+
+    private static string ComputeContractDigest(ToolFrictionFixtureCatalog catalog)
+    {
+        var text = new StringBuilder();
+        Append(text, catalog.SchemaVersion.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Append(text, catalog.Sanitization.SourceBoundary);
+        foreach (var identifierClass in catalog.Sanitization.ProhibitedRawIdentifierClasses)
+            Append(text, identifierClass);
+
+        foreach (var item in catalog.Cases)
+        {
+            Append(text, item.Id);
+            Append(text, item.Scenario);
+            Append(text, item.ObservedFriction);
+            foreach (var tool in item.ExpectedToolSequence)
+                Append(text, tool);
+            Append(text, item.ExpectedOutcome);
+            Append(text, item.ExpectedApprovalRequired ? "true" : "false");
+            Append(text, item.FallbackApprovalRequired ? "true" : "false");
+            Append(text, item.ExpectedContextEffect);
+        }
+
+        return ComputeSha256(Encoding.UTF8.GetBytes(text.ToString()));
+    }
+
+    private static void Append(StringBuilder target, string value)
+        => target.Append(value.Length).Append(':').Append(value).Append('\n');
+
+    private static bool ContainsRawIdentity(string text)
+        => SlackChannelPattern().IsMatch(text)
+           || SlackThreadPattern().IsMatch(text)
+           || EmailPattern().IsMatch(text)
+           || PrivateHomePattern().IsMatch(text)
+           || PrivateWindowsUserPattern().IsMatch(text)
+           || KnownSourceIdentityPattern().IsMatch(text)
+           || AccessTokenPattern().IsMatch(text)
+           || BearerCredentialPattern().IsMatch(text)
+           || CredentialAssignmentPattern().IsMatch(text)
+           || UrlPattern().IsMatch(text)
+           || RemoteRepositoryPattern().IsMatch(text)
+           || CallIdPattern().IsMatch(text)
+           || ExactTimestampPattern().IsMatch(text)
+           || GuidPattern().IsMatch(text)
+           || RawPayloadFieldPattern().IsMatch(text)
+           || text.Contains("akka://", StringComparison.Ordinal)
+           || text.Contains("[INF]", StringComparison.Ordinal);
+
+    private static string ComputeSha256(byte[] bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static string FixturePath()
+        => Path.Combine(AppContext.BaseDirectory, "ToolFrictionEvidence", FixtureFile);
+
+    [GeneratedRegex(@"\bD[A-Z0-9]{10}\b", RegexOptions.CultureInvariant)]
+    private static partial Regex SlackChannelPattern();
+
+    [GeneratedRegex(@"\b\d{10}\.\d{6}\b", RegexOptions.CultureInvariant)]
+    private static partial Regex SlackThreadPattern();
+
+    [GeneratedRegex(@"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", RegexOptions.CultureInvariant)]
+    private static partial Regex EmailPattern();
+
+    [GeneratedRegex(@"/home/(?!user/|test/|foo/|dev/|runner/|gh-actions/|ci/)[a-zA-Z0-9_.-]+/", RegexOptions.CultureInvariant)]
+    private static partial Regex PrivateHomePattern();
+
+    [GeneratedRegex(@"[A-Za-z]:[\\/]Users[\\/](?!user[\\/]|test[\\/]|foo[\\/]|dev[\\/]|runner[\\/]|ci[\\/])[A-Za-z0-9_.-]+[\\/]", RegexOptions.CultureInvariant)]
+    private static partial Regex PrivateWindowsUserPattern();
+
+    [GeneratedRegex(@"petabridge|stannard|testlab|D0AC6", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex KnownSourceIdentityPattern();
+
+    [GeneratedRegex(
+        @"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,})\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AccessTokenPattern();
+
+    [GeneratedRegex(@"\bBearer\s+[A-Za-z0-9._~+/-]{8,}=*", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex BearerCredentialPattern();
+
+    [GeneratedRegex(
+        @"[""']?(?:token|access[_-]?token|api[_-]?key|client[_-]?secret|password)[""']?\s*[:=]\s*[""']?(?!<)[A-Za-z0-9+/=_-]{8,}",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialAssignmentPattern();
+
+    [GeneratedRegex(@"https?://[A-Za-z0-9.-]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex UrlPattern();
+
+    [GeneratedRegex(
+        @"(?:--repo\s+|gh\s+api\s+repos/|api\.github\.com/repos/)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RemoteRepositoryPattern();
+
+    [GeneratedRegex(@"\bcall_[A-Za-z0-9_-]+\b", RegexOptions.CultureInvariant)]
+    private static partial Regex CallIdPattern();
+
+    [GeneratedRegex(
+        @"\b20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex ExactTimestampPattern();
+
+    [GeneratedRegex(
+        @"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex GuidPattern();
+
+    [GeneratedRegex(
+        @"[""'](?:raw)?(?:prompt|response|logLine)[""']\s*:",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RawPayloadFieldPattern();
+
+    private sealed record ToolFrictionExpectedCase(
+        string Id,
+        string Scenario,
+        string ObservedFriction,
+        IReadOnlyList<string> ExpectedToolSequence,
+        string ExpectedOutcome,
+        bool ExpectedApprovalRequired,
+        bool FallbackApprovalRequired,
+        string ExpectedContextEffect);
+}

--- a/src/Netclaw.Security.Tests/ToolFrictionEvidenceModels.cs
+++ b/src/Netclaw.Security.Tests/ToolFrictionEvidenceModels.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolFrictionEvidenceModels.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Security.Tests;
+
+internal sealed record ToolFrictionFixtureCatalog
+{
+    public required int SchemaVersion { get; init; }
+
+    public required ToolFrictionSanitization Sanitization { get; init; }
+
+    public required List<ToolFrictionCase> Cases { get; init; }
+}
+
+internal sealed record ToolFrictionSanitization
+{
+    public required string SourceBoundary { get; init; }
+
+    public required List<string> ProhibitedRawIdentifierClasses { get; init; }
+}
+
+internal sealed record ToolFrictionCase
+{
+    public required string Id { get; init; }
+
+    public required string Scenario { get; init; }
+
+    public required string ObservedFriction { get; init; }
+
+    public required List<string> ExpectedToolSequence { get; init; }
+
+    public required string ExpectedOutcome { get; init; }
+
+    public required bool ExpectedApprovalRequired { get; init; }
+
+    public required bool FallbackApprovalRequired { get; init; }
+
+    public required string ExpectedContextEffect { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow)]
+[JsonSerializable(typeof(ToolFrictionFixtureCatalog))]
+internal sealed partial class ToolFrictionEvidenceJsonContext : JsonSerializerContext;

--- a/src/Netclaw.Tests.Utilities/ModelVisibleToolFootprint.cs
+++ b/src/Netclaw.Tests.Utilities/ModelVisibleToolFootprint.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="ModelVisibleToolFootprint.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Buffers;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Tests.Utilities;
+
+/// <summary>
+/// Aggregate size of the tool definitions sent to a model.
+/// </summary>
+public readonly record struct ModelVisibleToolFootprint(int Count, int SerializedDefinitionBytes);
+
+/// <summary>
+/// Measures model-visible tool definitions without returning or logging their content.
+/// </summary>
+public static class ModelVisibleToolFootprintCalculator
+{
+    /// <summary>
+    /// Serializes each function name, description, and input schema as one compact JSON array.
+    /// The returned value contains only the function count and UTF-8 byte count.
+    /// </summary>
+    public static ModelVisibleToolFootprint Measure(IEnumerable<AITool> tools)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        var count = 0;
+
+        writer.WriteStartArray();
+        foreach (var tool in tools)
+        {
+            if (tool is not AIFunctionDeclaration function)
+                throw new InvalidOperationException("Model-visible tool footprint requires function tools.");
+            if (function.JsonSchema.ValueKind == JsonValueKind.Undefined)
+                throw new InvalidOperationException("Model-visible function schema must be defined.");
+
+            writer.WriteStartObject();
+            writer.WriteString("name", function.Name);
+            writer.WriteString("description", function.Description ?? string.Empty);
+            writer.WritePropertyName("inputSchema");
+            function.JsonSchema.WriteTo(writer);
+            writer.WriteEndObject();
+            count++;
+        }
+
+        writer.WriteEndArray();
+        writer.Flush();
+        return new ModelVisibleToolFootprint(count, buffer.WrittenCount);
+    }
+}


### PR DESCRIPTION
## Summary

- Add the validated OpenSpec plan for safer agent tool use.
- Add a PII-free tool-friction fixture with strict mutation and privacy tests.
- Record the actual parent and subagent schema footprint without schema bodies.

## Scope

This PR defines deterministic contracts only. Product implementation follows in the stacked PRs.

## Deterministic baseline evidence

- A fixed 200-tool synthetic catalog produced 3 parent tool definitions totaling 1,047 serialized UTF-8 bytes.
- The same catalog produced 202 child tool definitions totaling 133,816 serialized UTF-8 bytes.
- The evidence stores aggregate counts and byte sizes only; it contains no schema bodies, raw prompts, logs, paths, session identifiers, or production-derived tool names.
- No hosted behavioral run was used as evidence for this PR.

## Validation

- Tool-friction contract tests: 35 passed.
- Model-visible schema-footprint test: passed.
- Strict OpenSpec validation: passed.
- Header verification: passed.
- Slopwatch: zero issues.
- Diff check: passed.
