### PR TITLE
Add parent tool progressive disclosure

### DIFF
--- a/docs/adr/ADR-003-progressive-tool-disclosure-and-dynamic-discovery.md
+++ b/docs/adr/ADR-003-progressive-tool-disclosure-and-dynamic-discovery.md
@@ -1,4 +1,4 @@
-# ADR-003: Progressive Tool Disclosure with Dynamic MCP Discovery
+# ADR-003: Progressive Tool Disclosure
 
 **Date:** 2026-03-01
 **Status:** Accepted
@@ -8,16 +8,16 @@
 
 Netclaw adopts progressive disclosure for tools:
 
-1. The always-on tool context contains only:
-   - directly callable built-in tools, and
-   - MCP server-level summaries (server name, purpose, tool count).
-2. MCP tools are loaded on demand via `search_tools` and are not directly
-   callable until discovered.
-3. Tool metadata is system-generated to disk as shadow catalogs and used as the
-   dynamic context source:
+1. Each tool registration has an internal `Core` or `Deferred` exposure tier.
+2. Existing registration methods select `Deferred`. Named core methods must select `Core`.
+3. The core contains only the workspace, discovery, skill, and shell compatibility tools.
+4. Deferred first-party and MCP tools load on demand through `search_tools` and `load_tool`.
+5. The live model catalog applies the current audience and feature policy.
+6. Operator metadata is system-generated as complete shadow catalogs:
    - `identity/tooling/shadow/tool-index.md`
    - `identity/tooling/shadow/mcp/<server>.md`
-4. Fuzzy matching remains discovery-only. Suggestion results do not implicitly
+7. Agent file and shell policies deny access to the complete shadow catalogs.
+8. Fuzzy matching remains discovery-only. Suggestion results do not implicitly
    load tools.
 
 ## Context
@@ -49,11 +49,9 @@ without hard-coding domain routers in actor logic.
 
 ### Why file-backed shadow catalogs
 
-Disk-backed catalogs make the tool graph observable and stable across daemon
-restarts. Operators and agents can inspect generated metadata directly instead
-of relying on transient in-memory state. This also creates a clear boundary:
-human-authored identity content remains separate from system-authored tool
-metadata.
+Disk-backed catalogs make the complete tool graph observable across daemon
+restarts. Operators can inspect this metadata outside agent tool paths. The
+model receives a separate live catalog which the current policy filters.
 
 ### Why discovery-only fuzzy matching
 
@@ -63,17 +61,20 @@ named tools and preserves explicit tool loading semantics.
 
 ## Implementation Shape
 
+- `ToolRegistry` stores exposure metadata without changing `ToolRegistration`.
 - `ToolRegistry.GenerateCompressedIndex()` emits:
-  - directly callable built-ins, then
-  - MCP server summaries and explicit discovery instructions.
+  - directly callable core tools,
+  - compact deferred first-party hints, and
+  - MCP server summaries and discovery instructions.
 - `search_tools` supports the progressive flow:
   - `search_tools(query: "servers")`
   - `search_tools(query: "all", server: "<server>")`
   - `search_tools(query: "<intent>", server: "<server>")`
 - `McpShadowCatalogWriter` generates and refreshes shadow catalogs at daemon
   startup after MCP initialization.
-- `FileContextLayerProvider` injects `tool-index.md` into dynamic context
-  layers on each LLM call.
+- `ToolIndexContextLayer` builds the model catalog from the live registry.
+- `ToolAccessPolicy` applies audience, feature, grant, and deny filters.
+- The session exposure cache gives all deferred tools the same bounded lease.
 
 ## Consequences
 
@@ -81,13 +82,14 @@ named tools and preserves explicit tool loading semantics.
 
 - Smaller always-on prompt surface for tooling.
 - Better multi-server navigation for models that struggle with large tool sets.
-- Auditable generated metadata in a predictable filesystem location.
+- Auditable operator metadata in a predictable filesystem location.
+- Hidden tool names stay absent from model catalogs, search, suggestions, and load errors.
 - Fewer accidental calls from fuzzy lookup results.
 
 ### Tradeoffs
 
 - Additional generated files to manage under `identity/tooling/shadow/`.
-- Dynamic tool index freshness is tied to generation/update lifecycle.
+- Loaded tool state is transient and must be rebuilt after actor recovery.
 - Tool accuracy still depends on model quality and memory retrieval quality; the
   disclosure strategy improves routing but does not solve semantic retrieval by
   itself.

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -8,12 +8,12 @@
 
 ## 2. PR 2 - Progressive disclosure foundation
 
-- [ ] 2.1 Add explicit Core/Deferred registration metadata with Deferred as the safe default and preserve existing registry lookup identities.
-- [ ] 2.2 Mark the specified workspace/discovery tools Core and leave specialty first-party and MCP tools Deferred.
-- [ ] 2.3 Generalize the discovered-tool cache so leases and eviction apply to deferred first-party tools as well as MCP tools.
-- [ ] 2.4 Extend the compact audience-filtered capability catalog to include deferred first-party tool names and short hints without full schemas.
-- [ ] 2.5 Make search, suggestions, and load apply the same deployment, audience, grant, and feature filters without revealing hidden names.
-- [ ] 2.6 Add snapshots for exact core names, initial schema count/bytes, deferred discovery, load activation, eviction, and authorization-after-load.
+- [x] 2.1 Add explicit Core/Deferred registration metadata with Deferred as the safe default and preserve existing registry lookup identities.
+- [x] 2.2 Mark the specified workspace/discovery tools Core and leave specialty first-party and MCP tools Deferred.
+- [x] 2.3 Generalize the discovered-tool cache so leases and eviction apply to deferred first-party tools as well as MCP tools.
+- [x] 2.4 Extend the compact audience-filtered capability catalog to include deferred first-party tool names and short hints without full schemas.
+- [x] 2.5 Make search, suggestions, and load apply the same deployment, audience, grant, and feature filters without revealing hidden names.
+- [x] 2.6 Add snapshots for exact core names, initial schema count/bytes, deferred discovery, load activation, eviction, and authorization-after-load.
 
 ## 3. PR 3 - Subagent progressive disclosure
 

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -17,6 +17,7 @@ using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tests.Tools;
 using Netclaw.Actors.Tools;
 using Xunit;
 using static Netclaw.Actors.Sessions.SessionProtocol;
@@ -76,8 +77,9 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
             AIFunctionFactory.Create((string url) => "ok", "navigate_page", "Navigate to URL"),
             "browser_chrome_devtools",
             "navigate_page"));
-        registry.Register(new SearchToolsTool(registry));
-        registry.Register(new LoadToolTool(registry));
+        var toolAccessPolicy = TestToolAccessPolicy.Create(new ToolConfig());
+        registry.RegisterCore(new SearchToolsTool(registry, toolAccessPolicy));
+        registry.RegisterCore(new LoadToolTool(registry, toolAccessPolicy));
 
         services.AddSingleton(registry);
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
@@ -754,6 +756,36 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         Assert.Equal(2, _fakeChatClient.CallCount);
 
         await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Initial_model_call_contains_core_tools_but_not_deferred_tools()
+    {
+        var sessionId = new SessionId("channel-discovery/core-contract");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("core-contract-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use the initial tool set"
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(_fakeChatClient.ReceivedToolNames);
+        Assert.Equal(
+            ["load_tool", "search_tools"],
+            _fakeChatClient.ReceivedToolNames[0].OrderBy(static name => name, StringComparer.Ordinal));
+        Assert.DoesNotContain("browser_chrome_devtools__navigate_page", _fakeChatClient.ReceivedToolNames[0]);
     }
 
     [Fact]
@@ -1888,7 +1920,7 @@ internal sealed class FakeChatClient : IChatClient
         // call and can be non-trivial to enumerate; only the shared-list appends need guarding.
         var messageList = messages.ToList();
         var toolNames = options?.Tools?
-            .Select(t => t is AIFunction f ? f.Name : t.GetType().Name)
+            .Select(t => t is AIFunctionDeclaration f ? f.Name : t.GetType().Name)
             .ToList()
             ?? [];
 

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -52,7 +52,7 @@ public class MaxToolIterationTests : LlmSessionTestBase
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
 
         var registry = new ToolRegistry();
-        registry.Register(
+        registry.RegisterCore(
             AIFunctionFactory.Create(() => "search result", "web_search"),
             "web_search");
         services.AddSingleton(registry);

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -206,7 +206,9 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
                 Microsoft.Extensions.Logging.Abstractions.NullLogger<WorkingContextSnapshotProvider>.Instance),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<SubAgentSpawner>.Instance);
 
-        registry.Register(new SpawnAgentTool(subAgentRegistry, spawner, subAgentPaths));
+        // This fixture drives spawn_agent directly from the main model. Mark only that
+        // test seam as Core; production registration keeps spawn_agent deferred.
+        registry.RegisterCore(new SpawnAgentTool(subAgentRegistry, spawner, subAgentPaths));
         _recordingFileReadTool = new RecordingContextTool("file_read", "stub file content", "file");
         registry.Register(_recordingFileReadTool);
         _recordingApprovalTool = new RecordingContextTool(ApprovalProbeToolName, "approval ok");
@@ -310,7 +312,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
     }
 
     [Fact]
-    public async Task Final_model_visible_tool_footprints_match_frozen_baseline()
+    public async Task Final_model_visible_tool_footprints_reduce_main_context_vs_frozen_baseline()
     {
         RegisterSyntheticMcpCatalog();
         _clientProvider.Main.ToolCallsOnFirstCall =
@@ -361,7 +363,9 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Assert.Equal(ToolFootprintScenario, baseline.Scenario);
         Assert.Equal(ToolFootprintMetric, baseline.Metric);
         Assert.Equal(SyntheticMcpToolCount, baseline.SyntheticMcpToolCount);
-        Assert.Equal(new ToolFootprintPair(baseline.MainCore, baseline.SubagentFull), actual);
+        Assert.True(actual.MainCore.Count < baseline.MainCore.Count);
+        Assert.True(actual.MainCore.SerializedDefinitionBytes < baseline.MainCore.SerializedDefinitionBytes);
+        Assert.Equal(baseline.SubagentFull, actual.SubagentFull);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
@@ -76,6 +76,29 @@ public class DiscoveredToolCacheTests
         Assert.Empty(cache.AvailableTools);
     }
 
+    [Fact]
+    public void Deferred_first_party_tool_uses_the_same_lease_and_eviction_path()
+    {
+        var registry = new ToolRegistry();
+        var cache = new DiscoveredToolCache();
+        var function = AIFunctionFactory.Create(() => "result", "set_reminder", "Schedule a reminder");
+        registry.Register(function, "builtin");
+        var tool = Assert.IsAssignableFrom<Netclaw.Tools.INetclawTool>(registry.GetByName("set_reminder"));
+
+        cache.Remember(tool.Name, tool, leaseTurns: 2, maxCount: 12);
+        cache.AddIfMissing(tool.ToAITool());
+
+        Assert.True(cache.HasTool("set_reminder"));
+        Assert.Contains(
+            cache.AvailableTools,
+            static candidate => candidate is AIFunction functionTool && functionTool.Name == "set_reminder");
+
+        cache.EvictAll();
+
+        Assert.False(cache.HasTool("set_reminder"));
+        Assert.Empty(cache.AvailableTools);
+    }
+
     private static McpToolAdapter RegisterAndRemember(
         ToolRegistry registry,
         DiscoveredToolCache cache,

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -53,7 +53,12 @@ public class DispatchingToolExecutorTests
         var commandPolicy = new ShellCommandPolicy(ShellEnvironment);
         var pathPolicy = new ToolPathPolicy(ShellEnvironment, []);
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(baseConfig, new NetclawPaths(), pathPolicy, commandPolicy);
+        registry.WithFirstPartyTools(
+            baseConfig,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(baseConfig, commandPolicy, pathPolicy));
         _executor = new DispatchingToolExecutor(
             registry,
             new ToolAccessPolicy(
@@ -83,7 +88,11 @@ public class DispatchingToolExecutorTests
             restrictedConfig,
             new NetclawPaths(),
             restrictedPathPolicy,
-            restrictedCommandPolicy);
+            restrictedCommandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(
+                restrictedConfig,
+                restrictedCommandPolicy,
+                restrictedPathPolicy));
         _restrictedExecutor = new DispatchingToolExecutor(
             restrictedRegistry,
             new ToolAccessPolicy(
@@ -416,7 +425,12 @@ public class DispatchingToolExecutorTests
         var commandPolicy = new ShellCommandPolicy(ShellEnvironment);
         var pathPolicy = new ToolPathPolicy(ShellEnvironment, []);
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config, new NetclawPaths(), pathPolicy, commandPolicy);
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
 
         var executor = new DispatchingToolExecutor(
             registry,
@@ -455,7 +469,12 @@ public class DispatchingToolExecutorTests
         var commandPolicy = new ShellCommandPolicy(ShellEnvironment);
         var pathPolicy = new ToolPathPolicy(ShellEnvironment, []);
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config, new NetclawPaths(), pathPolicy, commandPolicy);
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
 
         var executor = new DispatchingToolExecutor(
             registry,
@@ -604,7 +623,8 @@ public class DispatchingToolExecutorTests
             config,
             new NetclawPaths(),
             new ToolPathPolicy([]),
-            new ShellCommandPolicy());
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
         var approvedMatch = new ToolApprovalMatch("git status", "session", "this chat");
         var approvalService = new FixedApprovalService(
             new ToolApprovalCheckResult(["git push"], [approvedMatch]));
@@ -660,7 +680,8 @@ public class DispatchingToolExecutorTests
             config,
             new NetclawPaths(),
             new ToolPathPolicy([]),
-            new ShellCommandPolicy());
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
         var approvedMatch = new ToolApprovalMatch("git status", "session", "this chat");
         var approvedCandidate = BashCandidate("git status");
         var unapprovedCandidate = BashCandidate("git push");
@@ -725,7 +746,12 @@ public class DispatchingToolExecutorTests
             var commandPolicy = new ShellCommandPolicy(ShellEnvironment);
             var pathPolicy = new ToolPathPolicy(ShellEnvironment, []);
             var registry = new ToolRegistry();
-            registry.WithFirstPartyTools(config, new NetclawPaths(), pathPolicy, commandPolicy);
+            registry.WithFirstPartyTools(
+                config,
+                new NetclawPaths(),
+                pathPolicy,
+                commandPolicy,
+                toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
             var approvalService = new FixedShellApprovalService(request =>
             {
                 var matches = request.Candidates.Select(candidate =>
@@ -2145,7 +2171,8 @@ public class DispatchingToolExecutorTests
                 config,
                 new NetclawPaths(),
                 new ToolPathPolicy([]),
-                new ShellCommandPolicy());
+                new ShellCommandPolicy(),
+                toolAccessPolicy: TestToolAccessPolicy.Create(config));
             var approvedScope = ApprovalEntry.CreateTokenPrefix(
                 ApprovalShell.Bash,
                 ["git", "push"],
@@ -2218,7 +2245,8 @@ public class DispatchingToolExecutorTests
             config,
             new NetclawPaths(),
             new ToolPathPolicy([]),
-            new ShellCommandPolicy());
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
         var approvalService = new FixedApprovalService(
             new ToolApprovalCheckResult(
                 ["git push"],
@@ -2274,7 +2302,8 @@ public class DispatchingToolExecutorTests
             config,
             new NetclawPaths(),
             new ToolPathPolicy([]),
-            new ShellCommandPolicy());
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
         var forgedCandidate = new ApprovalCandidate("git status", Directory: null)
         {
             Shell = ApprovalShell.Bash,
@@ -2334,7 +2363,8 @@ public class DispatchingToolExecutorTests
             config,
             new NetclawPaths(),
             new ToolPathPolicy([]),
-            new ShellCommandPolicy());
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
         var approvalService = new FixedApprovalService(
             new ToolApprovalCheckResult(
                 [],
@@ -2795,7 +2825,12 @@ public class DispatchingToolExecutorTests
             };
 
             var registry = new ToolRegistry();
-            registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
+            registry.WithFirstPartyTools(
+                config,
+                new NetclawPaths(),
+                new ToolPathPolicy([]),
+                new ShellCommandPolicy(),
+                toolAccessPolicy: TestToolAccessPolicy.Create(config));
 
             var executor = new DispatchingToolExecutor(
                 registry,
@@ -2938,7 +2973,12 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            new ToolPathPolicy([]),
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
 
         var tempFile = Path.GetTempFileName();
         var system = ActorSystem.Create($"tool-approval-audit-{Guid.NewGuid():N}");
@@ -3017,7 +3057,12 @@ public class DispatchingToolExecutorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config, new NetclawPaths(), new ToolPathPolicy([]), new ShellCommandPolicy());
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            new ToolPathPolicy([]),
+            new ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(config));
 
         var system = ActorSystem.Create($"tool-approval-session-{Guid.NewGuid():N}");
         try
@@ -3564,7 +3609,8 @@ public class DispatchingToolExecutorTests
             config,
             new NetclawPaths(),
             pathPolicy,
-            commandPolicy);
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
         var policy = new ToolAccessPolicy(
             config,
             new EffectivePolicyDefaults(

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
@@ -208,6 +208,58 @@ public sealed class McpToolAudienceGrantsTests
         Assert.DoesNotContain("memorizer__delete", result);
     }
 
+    [Fact]
+    public async Task Hidden_tools_do_not_consume_the_visible_search_result_cap()
+    {
+        var registry = new ToolRegistry();
+        for (var i = 0; i < 12; i++)
+            registry.Register(CreateMcpTool("memorizer", $"archive_hidden_{i}", "Archive records"));
+        registry.Register(CreateMcpTool("memorizer", "archive_visible", "Archive records"));
+
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["archive_visible"]
+        };
+        var tool = new SearchToolsTool(
+            registry,
+            new ToolAccessPolicy(config, Defaults, new ShellCommandPolicy(), new ToolPathPolicy([])));
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Query", "archive"),
+            CreateExecutionContext(TrustAudience.Team),
+            CancellationToken.None);
+
+        Assert.Contains("memorizer__archive_visible", result);
+        Assert.DoesNotContain("archive_hidden", result);
+    }
+
+    [Fact]
+    public async Task Server_catalog_counts_only_tools_visible_to_the_current_audience()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateMcpTool("memorizer", "search_memories", "Find stored memories"));
+        registry.Register(CreateMcpTool("memorizer", "store", "Store a value"));
+        registry.Register(CreateMcpTool("memorizer", "delete", "Delete a memory"));
+
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var tool = new SearchToolsTool(
+            registry,
+            new ToolAccessPolicy(config, Defaults, new ShellCommandPolicy(), new ToolPathPolicy([])));
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Query", "servers"),
+            CreateExecutionContext(TrustAudience.Team),
+            CancellationToken.None);
+
+        Assert.Contains("memorizer (1 tools)", result);
+        Assert.DoesNotContain("memorizer (3 tools)", result);
+    }
+
     // ── FilterExposedTools (session hot path) ──
 
     [Fact]
@@ -249,7 +301,7 @@ public sealed class McpToolAudienceGrantsTests
     // ── load_tool denial ──
 
     [Fact]
-    public async Task LoadTool_DeniesBlockedTool()
+    public async Task LoadTool_HiddenAndMissingToolsHaveTheSameResult()
     {
         var registry = new ToolRegistry();
         registry.Register(CreateMcpTool("memorizer", "search_memories"));
@@ -263,12 +315,21 @@ public sealed class McpToolAudienceGrantsTests
         var policy = new ToolAccessPolicy(config, Defaults, new ShellCommandPolicy(), new ToolPathPolicy([]));
         var tool = new LoadToolTool(registry, policy);
 
-        var result = await tool.ExecuteAsync(
+        var hiddenResult = await tool.ExecuteAsync(
             ToolInput.Create("Name", "memorizer/store"),
             CreateExecutionContext(TrustAudience.Team),
             CancellationToken.None);
 
-        Assert.Contains("not available", result);
+        var missingRegistry = new ToolRegistry();
+        missingRegistry.Register(CreateMcpTool("memorizer", "search_memories"));
+        var missingTool = new LoadToolTool(missingRegistry, policy);
+        var missingResult = await missingTool.ExecuteAsync(
+            ToolInput.Create("Name", "memorizer/store"),
+            CreateExecutionContext(TrustAudience.Team),
+            CancellationToken.None);
+
+        Assert.Equal(missingResult, hiddenResult);
+        Assert.DoesNotContain("not available", hiddenResult, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -294,6 +355,48 @@ public sealed class McpToolAudienceGrantsTests
         // call the tool back using the same form Anthropic surfaces in
         // its tool definitions.
         Assert.Equal("memorizer__search_memories", result);
+    }
+
+    [Fact]
+    public async Task Loading_deferred_tool_does_not_bypass_invocation_approval()
+    {
+        var registry = new ToolRegistry();
+        var deferredTool = CreateMcpTool("memorizer", "store");
+        registry.Register(deferredTool);
+
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["memorizer/store"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            Defaults,
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
+
+        var loadedName = await new LoadToolTool(registry, policy).ExecuteAsync(
+            ToolInput.Create("Name", "memorizer/store"),
+            CreateExecutionContext(TrustAudience.Personal),
+            CancellationToken.None);
+        var decision = policy.AuthorizeInvocation(
+            deferredTool,
+            CreateExecutionContext(TrustAudience.Personal));
+
+        Assert.Equal("memorizer__store", loadedName);
+        Assert.True(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void LoadTool_without_policy_is_rejected()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateMcpTool("memorizer", "search_memories"));
+
+        Assert.Throws<ArgumentNullException>(() => new LoadToolTool(registry, null!));
     }
 
     // ── Public audience ──

--- a/src/Netclaw.Actors.Tests/Tools/MessyCommandOneTimeApprovalTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/MessyCommandOneTimeApprovalTests.cs
@@ -69,7 +69,12 @@ public sealed class MessyCommandOneTimeApprovalTests : TestKit
             new Netclaw.Security.ToolPathPolicy([])));
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(toolConfig, new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]), new Netclaw.Security.ShellCommandPolicy());
+        registry.WithFirstPartyTools(
+            toolConfig,
+            new NetclawPaths(),
+            new Netclaw.Security.ToolPathPolicy([]),
+            new Netclaw.Security.ShellCommandPolicy(),
+            toolAccessPolicy: TestToolAccessPolicy.Create(toolConfig));
         services.AddSingleton(registry);
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/MetaFieldResolutionTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/MetaFieldResolutionTests.cs
@@ -61,8 +61,16 @@ public class MetaFieldResolutionTests
     [Fact]
     public void No_first_party_tool_parameter_collides_with_a_meta_field()
     {
+        var config = new ToolConfig();
+        var pathPolicy = new Netclaw.Security.ToolPathPolicy([]);
+        var commandPolicy = new Netclaw.Security.ShellCommandPolicy();
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(new ToolConfig(), new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]), new Netclaw.Security.ShellCommandPolicy());
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
 
         var collisions = new List<string>();
         foreach (var registration in registry.GetAllRegistrations())

--- a/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
@@ -14,15 +14,21 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public class SearchToolsToolTests
 {
+    private static readonly Netclaw.Tools.ToolExecutionContext PersonalContext =
+        TestToolExecutionContext.CreateUnbound(new TestToolExecutionContextOptions
+        {
+            Audience = TrustAudience.Personal
+        });
+
     [Fact]
     public async Task Search_MatchesByName()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "store"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("memorizer__store", result);
@@ -36,11 +42,11 @@ public class SearchToolsToolTests
             CreateFakeAIFunction("search_memories", "Find stored memories"),
             "memorizer", "search_memories"));
 
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "memories"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("memorizer__search_memories", result);
@@ -50,25 +56,33 @@ public class SearchToolsToolTests
     public async Task Search_NoResults()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "nonexistent_xyz"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("No tools found", result);
     }
 
     [Fact]
+    public void Missing_policy_is_rejected()
+    {
+        var registry = CreateRegistryWithMcpTools();
+
+        Assert.Throws<ArgumentNullException>(() => new SearchToolsTool(registry, null!));
+    }
+
+    [Fact]
     public async Task Search_FiltersServer()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "store", "Server", "github"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         // "github" server has no "store" tool — only memorizer does
@@ -79,11 +93,11 @@ public class SearchToolsToolTests
     public async Task Search_ServerDefault_IsTreatedAsNoFilter()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "store", "Server", "default"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("memorizer__store", result);
@@ -95,11 +109,11 @@ public class SearchToolsToolTests
         var registry = new ToolRegistry();
         registry.Register(CreateFakeToolInRegistry("shell_execute", "Execute shell command"), "shell");
 
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "shell"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         // Without server filter, non-MCP tools are included in search results
@@ -110,7 +124,7 @@ public class SearchToolsToolTests
     public void GrantCategory_IsBuiltin()
     {
         var registry = new ToolRegistry();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         Assert.Equal("builtin", tool.GrantCategory);
     }
@@ -125,10 +139,10 @@ public class SearchToolsToolTests
             AIFunctionFactory.Create((Func<string, int, string>)Navigate, "navigate_page", "Navigate page"),
             "browser", "navigate_page"));
 
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "navigate"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("params: url", result);
@@ -143,11 +157,11 @@ public class SearchToolsToolTests
             "browser_chrome_devtools",
             "navigate_page"));
 
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "navgite pg"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("No exact tools found", result);
@@ -161,11 +175,11 @@ public class SearchToolsToolTests
     public async Task Search_ServersQuery_ReturnsServerCatalog()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "servers"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("Available MCP servers", result);
@@ -177,11 +191,11 @@ public class SearchToolsToolTests
     public async Task Search_AllWithServerFilter_ListsServerTools()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "all", "Server", "memorizer"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("Found 2 tool(s) in server 'memorizer'", result);
@@ -193,11 +207,11 @@ public class SearchToolsToolTests
     public async Task Search_AllWithoutServerFilter_ReturnsServerCatalogHint()
     {
         var registry = CreateRegistryWithMcpTools();
-        var tool = new SearchToolsTool(registry);
+        var tool = CreateSearchTool(registry);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Query", "all"),
-            TestToolExecutionContext.CreateUnbound(),
+            PersonalContext,
             CancellationToken.None);
 
         Assert.Contains("Available MCP servers", result);
@@ -290,6 +304,20 @@ public class SearchToolsToolTests
 
         return registry;
     }
+
+    private static SearchToolsTool CreateSearchTool(ToolRegistry registry) =>
+        new(registry, CreatePersonalPolicy());
+
+    private static ToolAccessPolicy CreatePersonalPolicy() =>
+        new(
+            new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed },
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
 
     private static AIFunction CreateFakeAIFunction(string name, string description)
     {

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalHarness.cs
@@ -177,7 +177,8 @@ internal sealed class ShellApprovalHarness : IAsyncDisposable
             config,
             new NetclawPaths(),
             pathPolicy,
-            commandPolicy);
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
 
         var policy = new ToolAccessPolicy(
             config,

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -651,6 +651,35 @@ public class ShellToolTests
         Assert.Contains("Access denied", result);
     }
 
+    [Fact]
+    public async Task Path_policy_blocks_a_denied_working_directory_before_execution()
+    {
+        var deniedDirectory = Directory.CreateTempSubdirectory("netclaw-shell-cwd-deny-");
+        try
+        {
+            var commandPolicy = new ShellCommandPolicy(ShellEnvironment);
+            var pathPolicy = new ToolPathPolicy(ShellEnvironment, [deniedDirectory.FullName]);
+            var tool = new ShellTool(new ToolConfig(), pathPolicy, commandPolicy);
+            var args = ToolInput.Create(
+                "Command",
+                TestShellEnvironment.PrintWorkingDirectoryCommand,
+                "WorkingDirectory",
+                deniedDirectory.FullName);
+
+            var result = await tool.ExecuteAsync(
+                args,
+                TestToolExecutionContext.CreateUnbound(),
+                TestContext.Current.CancellationToken);
+
+            Assert.Contains("protected file path", result);
+            Assert.Contains("Access denied", result);
+        }
+        finally
+        {
+            deniedDirectory.Delete(recursive: true);
+        }
+    }
+
     [SlopwatchSuppress("SW001", "This test requires native POSIX symbolic-link behavior.")]
     [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only symbolic-link semantics")]
     public async Task Authorized_execution_rechecks_current_symbolic_link_state()

--- a/src/Netclaw.Actors.Tests/Tools/TestToolAccessPolicy.cs
+++ b/src/Netclaw.Actors.Tests/Tools/TestToolAccessPolicy.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestToolAccessPolicy.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Actors.Tools;
+using Netclaw.Security;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+internal static class TestToolAccessPolicy
+{
+    public static ToolAccessPolicy Create(ToolConfig config)
+    {
+        var shellCommandPolicy = new ShellCommandPolicy();
+        var toolPathPolicy = new ToolPathPolicy([]);
+        return Create(config, shellCommandPolicy, toolPathPolicy);
+    }
+
+    public static ToolAccessPolicy Create(
+        ToolConfig config,
+        ShellCommandPolicy shellCommandPolicy,
+        ToolPathPolicy toolPathPolicy) =>
+        new(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            shellCommandPolicy,
+            toolPathPolicy);
+}

--- a/src/Netclaw.Actors.Tests/Tools/ToolArgumentValidatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolArgumentValidatorTests.cs
@@ -38,7 +38,12 @@ public class ToolArgumentValidatorTests
         };
 
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config, new NetclawPaths(), pathPolicy, commandPolicy);
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
         _executor = new DispatchingToolExecutor(
             registry,
             new ToolAccessPolicy(

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
@@ -1,0 +1,18 @@
+﻿{
+  Names: [
+    file_edit,
+    file_list,
+    file_read,
+    file_write,
+    load_tool,
+    search_tools,
+    set_working_directory,
+    shell_execute,
+    skill_load,
+    skill_read_resource
+  ],
+  Footprint: {
+    Count: 10,
+    SerializedDefinitionBytes: 10879
+  }
+}

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.cs
@@ -4,7 +4,13 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Skills;
 using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Security.Skills;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Tools;
@@ -16,6 +22,57 @@ namespace Netclaw.Actors.Tests.Tools;
 /// </summary>
 public class ToolRegistrationExtensionsTests
 {
+    [Fact]
+    public Task Core_tool_names_and_schema_footprint_match_snapshot()
+    {
+        var registry = CreateFullFirstPartyRegistry();
+        var coreTools = registry.GetCoreTools();
+        var names = coreTools
+            .OfType<AIFunctionDeclaration>()
+            .Select(static tool => tool.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var snapshot = new CoreToolSnapshot(
+            names,
+            ModelVisibleToolFootprintCalculator.Measure(coreTools));
+
+        return Verifier.Verify(snapshot);
+    }
+
+    [Fact]
+    public void Registration_defaults_to_deferred_and_core_replacement_is_explicit()
+    {
+        var registry = new ToolRegistry();
+        var deferred = AIFunctionFactory.Create(() => "ok", "specialty_tool", "Specialty action");
+        var core = AIFunctionFactory.Create(() => "ok", "core_tool", "Core action");
+
+        registry.Register(deferred, "builtin");
+        registry.RegisterCore(core, "builtin");
+
+        Assert.Equal(["core_tool"], GetFunctionNames(registry.GetCoreTools()));
+
+        registry.Replace(new FakeTool("core_tool"));
+        Assert.Empty(registry.GetCoreTools());
+
+        registry.ReplaceCore(new FakeTool("core_tool"));
+        Assert.Equal(["core_tool"], GetFunctionNames(registry.GetCoreTools()));
+    }
+
+    [Fact]
+    public void First_party_registration_rejects_missing_access_policy_before_mutation()
+    {
+        var registry = new ToolRegistry();
+        var config = new ToolConfig();
+
+        Assert.Throws<ArgumentNullException>(() => registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            new ToolPathPolicy([]),
+            new ShellCommandPolicy()));
+        Assert.Empty(registry.GetAllRegistrations());
+    }
+
     [Fact]
     public void McpToolAdapter_Truncated_SanitizedAIFunction_UsesClampedDescription()
     {
@@ -31,5 +88,85 @@ public class ToolRegistrationExtensionsTests
 
         // Verify adapter.Description matches what the LLM sees
         Assert.Equal(adapter.Description, aiFunc.Description);
+    }
+
+    private static ToolRegistry CreateFullFirstPartyRegistry()
+    {
+        var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), "netclaw-core-tool-contract"));
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(
+            config,
+            paths,
+            new ToolPathPolicy([]),
+            new ShellCommandPolicy(),
+            toolAccessPolicy: policy);
+
+        var skillRegistry = new SkillRegistry();
+        var scanner = new NoOpSkillContentScanner();
+        var indexPublisher = new SkillIndexPublisher(
+            skillRegistry,
+            new SkillIndexContextLayer(),
+            static (_, _) => true);
+        var refresher = new SkillInventoryRefresher(
+            paths,
+            new SkillFeedsConfig(),
+            [],
+            skillRegistry,
+            indexPublisher);
+        registry.WithSkillTools(
+            skillRegistry,
+            paths,
+            scanner,
+            new UnavailablePromptLoader(),
+            refresher);
+
+        return registry;
+    }
+
+    private static string[] GetFunctionNames(IReadOnlyList<AITool> tools) =>
+        tools
+            .OfType<AIFunctionDeclaration>()
+            .Select(static tool => tool.Name)
+            .ToArray();
+
+    private sealed record CoreToolSnapshot(
+        IReadOnlyList<string> Names,
+        ModelVisibleToolFootprint Footprint);
+
+    private sealed class FakeTool(string name) : INetclawTool
+    {
+        private readonly AIFunction _function = AIFunctionFactory.Create(() => "ok", name, "Replacement");
+
+        public string Name { get; } = name;
+        public LlmFacingToolName LlmFacingName { get; } = LlmFacingToolName.FromCanonical(name);
+        public string Description => "Replacement";
+        public string GrantCategory => "builtin";
+        public System.Text.Json.JsonElement ParameterSchema => default;
+        public AITool ToAITool() => _function;
+
+        public Task<string> ExecuteAsync(
+            IDictionary<string, object?>? arguments,
+            ToolInvocationContext context,
+            CancellationToken ct = default) => Task.FromResult("ok");
+    }
+
+    private sealed class UnavailablePromptLoader : IMcpPromptSkillLoader
+    {
+        public ValueTask<McpPromptSkillLoadResult> LoadAsync(
+            McpPromptSkillSource source,
+            IReadOnlyDictionary<string, string>? arguments,
+            ToolInvocationContext context,
+            CancellationToken cancellationToken) =>
+            ValueTask.FromResult(McpPromptSkillLoadResult.Failed("unavailable"));
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
@@ -79,7 +79,7 @@ public class ToolRegistryTests
     public void GetAlwaysLoadedTools_returns_non_mcp_tools()
     {
         var registry = new ToolRegistry();
-        registry.Register(CreateFakeTool("shell_execute"), "shell");
+        registry.RegisterCore(CreateFakeTool("shell_execute"), "shell");
         registry.Register(CreateFakeTool("search_tools"), "builtin");
         registry.Register(CreateFakeTool("file_read"), "file");
         // MCP tools should be excluded
@@ -158,16 +158,38 @@ public class ToolRegistryTests
             CreateFakeTool("store"), "memorizer", "store"));
         registry.Register(new McpToolAdapter(
             CreateFakeTool("search"), "memorizer", "search"));
-        registry.Register(CreateFakeTool("shell_execute"), "shell");
+        registry.RegisterCore(CreateFakeTool("shell_execute"), "shell");
 
         var index = registry.GenerateCompressedIndex();
 
         Assert.Contains("[MCP capability servers - discover tools with search_tools]", index);
         Assert.Contains("memorizer (2 tools)", index);
         Assert.Contains("search_tools(query: \"all\", server: \"<server_name>\")", index);
+        Assert.Contains("[directly callable core tools]", index);
         Assert.Contains("shell: shell_execute", index);
         Assert.Contains("search_tools", index);
         Assert.DoesNotContain("mcp:memorizer: store, search", index);
+    }
+
+    [Fact]
+    public void GenerateCompressedIndex_lists_deferred_first_party_hint_without_schema()
+    {
+        static string Schedule(string deliveryTarget) => deliveryTarget;
+
+        var registry = new ToolRegistry();
+        registry.Register(
+            AIFunctionFactory.Create(
+                (Func<string, string>)Schedule,
+                "set_reminder",
+                "Schedule a future reminder for a delivery target."),
+            "builtin");
+
+        var index = registry.GenerateCompressedIndex();
+
+        Assert.Contains("[deferred first-party tools - discover with search_tools]", index);
+        Assert.Contains("set_reminder: Schedule a future reminder", index);
+        Assert.DoesNotContain("deliveryTarget", index);
+        Assert.DoesNotContain("inputSchema", index);
     }
 
     [Fact]
@@ -200,7 +222,7 @@ public class ToolRegistryTests
     public void GenerateCompressedIndex_for_public_hides_blocked_capabilities()
     {
         var registry = new ToolRegistry();
-        registry.Register(CreateFakeTool("file_read"), "file");
+        registry.RegisterCore(CreateFakeTool("file_read"), "file");
         registry.Register(CreateFakeTool("set_reminder"), "builtin");
         registry.Register(CreateFakeTool("spawn_agent"), "builtin");
         registry.Register(new McpToolAdapter(
@@ -223,6 +245,34 @@ public class ToolRegistryTests
         Assert.DoesNotContain("set_reminder", index);
         Assert.DoesNotContain("spawn_agent", index);
         Assert.DoesNotContain("memorizer", index);
+    }
+
+    [Fact]
+    public void Approval_deny_hides_first_party_tool_from_compact_catalog()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateFakeTool("specialty_tool"), "builtin");
+        var config = new ToolConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["specialty_tool"] = ToolApprovalMode.Deny
+            }
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
+
+        var index = registry.GenerateCompressedIndex(TrustAudience.Personal, policy);
+
+        Assert.DoesNotContain("specialty_tool", index);
     }
 
     [Fact]
@@ -295,8 +345,15 @@ public class ToolRegistryTests
         // canonical and LLM-facing are the same string. Round-tripping
         // must not mangle them in either direction.
         var config = new ToolConfig();
+        var pathPolicy = new Netclaw.Security.ToolPathPolicy([]);
+        var commandPolicy = new Netclaw.Security.ShellCommandPolicy();
         var registry = new ToolRegistry();
-        registry.WithFirstPartyTools(config, new NetclawPaths(), new Netclaw.Security.ToolPathPolicy([]), new Netclaw.Security.ShellCommandPolicy());
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
 
         Assert.Equal("shell_execute", registry.ToCanonicalName("shell_execute"));
         Assert.Equal("shell_execute", registry.ToLlmFacingName("shell_execute"));

--- a/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
@@ -11,7 +11,7 @@ namespace Netclaw.Actors.Sessions.Handlers;
 
 /// <summary>
 /// Owns the session's exposed tool list — the always-loaded base tools plus the
-/// MCP tools discovered via search_tools — and manages lease-based retention and
+/// deferred tools discovered via search_tools — and manages lease-based retention and
 /// eviction of the discovered set across turns. Because the cache owns the list
 /// it rebuilds, callers seed the base tools once and then drive
 /// <see cref="PrepareForNewTurn"/> / <see cref="EvictAll"/> / <see cref="AddIfMissing"/>
@@ -93,13 +93,10 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
-    /// Remember a discovered MCP tool with a lease for future turns.
+    /// Remember a discovered deferred tool with a lease for future turns.
     /// </summary>
     public void Remember(string toolName, INetclawTool tool, int leaseTurns, int maxCount)
     {
-        if (tool is not McpToolAdapter)
-            return;
-
         if (leaseTurns <= 0 || maxCount <= 0)
             return;
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -262,13 +262,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 services.TimeProvider,
                 NoLogger.Instance);
 
-        // Load all non-MCP tools for initial LLM calls.
-        // MCP tools are loaded dynamically via search_tools and can be retained for a
-        // small number of future turns (configurable lease) to reduce rediscovery churn.
+        // Load only the explicit core for initial LLM calls. Deferred first-party and
+        // MCP tools use search_tools and share the configured discovery lease.
         _fullRegistry = tools?.ToolRegistry;
         if (_fullRegistry is not null)
         {
-            _discoveredToolCache.SeedBaseTools(_fullRegistry.GetAlwaysLoadedTools());
+            _discoveredToolCache.SeedBaseTools(_fullRegistry.GetCoreTools());
         }
 
         // ── Recovery handlers ──

--- a/src/Netclaw.Actors/Tools/LoadToolTool.cs
+++ b/src/Netclaw.Actors/Tools/LoadToolTool.cs
@@ -9,7 +9,7 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Activates a discovered MCP tool by name so the LLM can call it.
+/// Activates a deferred first-party or MCP tool by name so the LLM can call it.
 /// Tools must first be found via <see cref="SearchToolsTool"/> before loading.
 /// The session actor intercepts this tool by name and reads the tool call
 /// arguments to activate the requested tool — the output is LLM-facing only.
@@ -20,14 +20,17 @@ namespace Netclaw.Actors.Tools;
 public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
 {
     private readonly ToolRegistry _registry;
-    private readonly ToolAccessPolicy? _policy;
+    private readonly ToolAccessPolicy _policy;
 
     public record Params(
         [property: Description("Full tool name to activate (e.g., 'notion/notion-search'). Use search_tools to find available tool names.")]
         string Name);
 
-    public LoadToolTool(ToolRegistry registry, ToolAccessPolicy? policy = null)
+    public LoadToolTool(ToolRegistry registry, ToolAccessPolicy policy)
     {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(policy);
+
         _registry = registry;
         _policy = policy;
     }
@@ -40,20 +43,8 @@ public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
             return Task.FromResult("Error: tool name is required.");
 
         var registration = _registry.GetRegistrationByToolName(name);
-        if (registration is null)
-        {
-            var suggestions = _registry.SearchTools(name, null, 3);
-            if (suggestions.Count > 0)
-            {
-                var names = string.Join(", ", suggestions.Select(s => s.Name));
-                return Task.FromResult($"Tool '{name}' not found. Did you mean: {names}?");
-            }
-
-            return Task.FromResult($"Tool '{name}' not found. Use search_tools to find available tools.");
-        }
-
-        if (_policy is not null && !_policy.IsToolExposed(registration.Tool, context))
-            return Task.FromResult($"Tool '{name}' is not available in the current trust context.");
+        if (registration is null || !IsVisible(registration.Tool, context))
+            return Task.FromResult(BuildNotFound(name, context));
 
         // Return the LLM-facing alias so the model sees the same form
         // it must emit in a subsequent tool_use call. The session actor
@@ -64,4 +55,19 @@ public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
         return Task.FromResult(registration.Tool.LlmFacingName.Value);
     }
 
+    private bool IsVisible(INetclawTool tool, ToolInvocationContext context)
+        => _policy.IsToolExposed(tool, context);
+
+    private string BuildNotFound(string authoredName, ToolInvocationContext context)
+    {
+        var suggestions = _registry.SearchTools(authoredName, null, int.MaxValue)
+            .Where(tool => IsVisible(tool, context))
+            .Take(3)
+            .Select(static tool => tool.LlmFacingName.Value)
+            .ToList();
+
+        return suggestions.Count > 0
+            ? $"Tool '{authoredName}' not found. Did you mean: {string.Join(", ", suggestions)}?"
+            : $"Tool '{authoredName}' not found. Use search_tools to find available tools.";
+    }
 }

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -12,7 +12,7 @@ namespace Netclaw.Actors.Tools;
 /// <summary>
 /// Meta-tool that searches the <see cref="ToolRegistry"/> for available tools.
 /// Returns compressed summaries of matching tools so the LLM can decide which
-/// to load dynamically. Used as part of the two-layer discovery architecture.
+/// deferred first-party or MCP tools to load dynamically.
 /// </summary>
 [NetclawTool("search_tools",
     "Search for available tools by keyword. Returns tool names and descriptions — tools are NOT loaded until you call load_tool. "
@@ -21,7 +21,7 @@ namespace Netclaw.Actors.Tools;
 public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params>
 {
     private readonly ToolRegistry _registry;
-    private readonly ToolAccessPolicy? _policy;
+    private readonly ToolAccessPolicy _policy;
     private const int MaxSearchResults = 10;
     private const int MaxServerBrowseResults = 30;
 
@@ -31,8 +31,11 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
         [property: Description("Optional MCP server name to filter results (e.g., 'memorizer')")]
         string? Server = null);
 
-    public SearchToolsTool(ToolRegistry registry, ToolAccessPolicy? policy = null)
+    public SearchToolsTool(ToolRegistry registry, ToolAccessPolicy policy)
     {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(policy);
+
         _registry = registry;
         _policy = policy;
     }
@@ -54,7 +57,11 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
                     "To browse tools, call search_tools(query: \"all\", server: \"<server_name>\")."));
             }
 
-            var serverTools = FilterVisible(_registry.GetToolsForServer(serverFilter.Value, MaxServerBrowseResults), context);
+            var serverTools = FilterVisible(
+                    _registry.GetToolsForServer(serverFilter.Value, int.MaxValue),
+                    context)
+                .Take(MaxServerBrowseResults)
+                .ToList();
             if (serverTools.Count == 0)
             {
                 return Task.FromResult($"No tools found for server '{serverFilter.Value}' in the current trust context.");
@@ -65,11 +72,15 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
                 $"Found {serverTools.Count} tool(s) in server '{serverFilter.Value}':"));
         }
 
-        var results = FilterVisible(_registry.SearchTools(query, serverFilter, MaxSearchResults), context);
+        var results = FilterVisible(_registry.SearchTools(query, serverFilter, int.MaxValue), context)
+            .Take(MaxSearchResults)
+            .ToList();
 
         if (results.Count == 0)
         {
-            var suggestions = FilterVisible(_registry.SuggestTools(query, serverFilter, MaxSearchResults), context);
+            var suggestions = FilterVisible(_registry.SuggestTools(query, serverFilter, int.MaxValue), context)
+                .Take(MaxSearchResults)
+                .ToList();
             if (suggestions.Count == 0)
             {
                 if (serverFilter is null)
@@ -110,7 +121,16 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
     private string BuildServerCatalog(ToolInvocationContext context, string? trailingHint = null)
     {
         var summaries = _registry.GetMcpServerSummaries()
-            .Where(summary => FilterVisible(_registry.GetToolsForServer(new McpServerName(summary.ServerName), int.MaxValue), context).Count > 0)
+            .Select(summary =>
+            {
+                var visibleTools = FilterVisible(
+                    _registry.GetToolsForServer(new McpServerName(summary.ServerName), int.MaxValue),
+                    context);
+                return visibleTools.Count == 0
+                    ? null
+                    : ToolRegistry.SummarizeMcpServer(summary.ServerName, visibleTools);
+            })
+            .OfType<McpServerSummary>()
             .ToList();
         if (summaries.Count == 0)
             return "No MCP servers are currently registered.";
@@ -127,8 +147,6 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
         sb.AppendLine();
         sb.AppendLine("To browse one server, call search_tools(query: \"all\", server: \"<server_name>\").");
         sb.AppendLine("To find tools, call search_tools(query: \"<intent>\", server: \"<server_name>\"), then load_tool(\"<name>\") to activate.");
-        sb.AppendLine("Detailed generated catalogs are on disk at identity/tooling/shadow/mcp/<server>.md.");
-
         if (!string.IsNullOrWhiteSpace(trailingHint))
         {
             sb.AppendLine();
@@ -139,7 +157,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
     }
 
     private IReadOnlyList<INetclawTool> FilterVisible(IReadOnlyList<INetclawTool> tools, ToolInvocationContext context)
-        => _policy?.FilterDiscoverableTools(tools, context) ?? tools;
+        => _policy.FilterDiscoverableTools(tools, context);
 
     private static string BuildToolList(IReadOnlyList<INetclawTool> tools, string heading)
     {

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -152,6 +152,12 @@ public sealed class ToolAccessPolicy
         if (!_profileResolver.IsToolAllowed(new ToolName(tool.Name), audience))
             return false;
 
+        if (_profileResolver.ResolveProfile(audience).ApprovalPolicy?.GetEffectiveMode(tool.Name)
+            == ToolApprovalMode.Deny)
+        {
+            return false;
+        }
+
         if (IsShellCoupledTool(tool))
             return ResolveShellMode() == ShellExecutionMode.HostAllowed && audience == TrustAudience.Personal;
 

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -35,22 +35,24 @@ public static class ToolRegistrationExtensions
         ToolAccessPolicy? toolAccessPolicy = null,
         WebhookRouteStore? webhookRouteStore = null)
     {
-        registry.Register(new ShellTool(config, pathPolicy, shellCommandPolicy));
-        registry.Register(new FileReadTool(config, paths, pathPolicy));
-        registry.Register(new FileListTool(config, paths, pathPolicy));
-        registry.Register(new FileWriteTool(config, paths, pathPolicy));
-        registry.Register(new FileEditTool(config, paths, pathPolicy));
+        ArgumentNullException.ThrowIfNull(toolAccessPolicy);
+
+        registry.RegisterCore(new ShellTool(config, pathPolicy, shellCommandPolicy));
+        registry.RegisterCore(new FileReadTool(config, paths, pathPolicy));
+        registry.RegisterCore(new FileListTool(config, paths, pathPolicy));
+        registry.RegisterCore(new FileWriteTool(config, paths, pathPolicy));
+        registry.RegisterCore(new FileEditTool(config, paths, pathPolicy));
         registry.Register(new AttachFileTool(config, paths, pathPolicy));
         if (webhookRouteStore is not null)
             registry.Register(new ListWebhooksTool(webhookRouteStore));
         if (searchBackend is not null)
             registry.Register(new WebSearchTool(searchBackend));
         registry.Register(new WebFetchTool(config));
-        registry.Register(new SetWorkingDirectoryTool(config, paths));
+        registry.RegisterCore(new SetWorkingDirectoryTool(config, paths));
 
         // Register search_tools and load_tool meta-tools (always loaded, "builtin" grant)
-        registry.Register(new SearchToolsTool(registry, toolAccessPolicy));
-        registry.Register(new LoadToolTool(registry, toolAccessPolicy));
+        registry.RegisterCore(new SearchToolsTool(registry, toolAccessPolicy));
+        registry.RegisterCore(new LoadToolTool(registry, toolAccessPolicy));
 
         return registry;
     }
@@ -73,7 +75,7 @@ public static class ToolRegistrationExtensions
         FileSubAgentDefinitionLoader? subAgentLoader = null,
         ILogger<SkillLoadTool>? skillLoadLogger = null)
     {
-        registry.Register(new SkillLoadTool(
+        registry.RegisterCore(new SkillLoadTool(
             skillRegistry,
             scanner,
             mcpPromptLoader,
@@ -83,7 +85,7 @@ public static class ToolRegistrationExtensions
             skillSyncConfig,
             skillLoadLogger,
             subAgentLoader));
-        registry.Register(new SkillReadResourceTool(skillRegistry, scanner, skillSyncConfig));
+        registry.RegisterCore(new SkillReadResourceTool(skillRegistry, scanner, skillSyncConfig));
         registry.Register(new SkillManageTool(skillRegistry, paths, scanner, inventoryRefresher));
         return registry;
     }

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -21,35 +21,80 @@ public sealed record ToolRegistration(INetclawTool Tool, string GrantCategory);
 /// </summary>
 public sealed record McpServerSummary(string ServerName, string Description, int ToolCount);
 
+internal enum ToolExposureTier
+{
+    Core,
+    Deferred
+}
+
 /// <summary>
 /// Registers <see cref="INetclawTool"/> definitions with grant categories for policy filtering.
 /// Sessions receive only tools whose grant category is in the session's allowed set.
 /// </summary>
 public sealed class ToolRegistry
 {
+    private sealed record RegistryEntry(ToolRegistration Registration, ToolExposureTier ExposureTier);
+
+    private sealed record RegistrySnapshot(RegistryEntry[] Entries, ToolRegistration[] Registrations)
+    {
+        public static RegistrySnapshot Empty { get; } = new([], []);
+
+        public static RegistrySnapshot Create(RegistryEntry[] entries) =>
+            new(entries, [..entries.Select(static entry => entry.Registration)]);
+    }
+
     // Copy-on-write. Registrations change at startup, at MCP reconnect, and at shutdown.
     // Reads happen on every tool call from every concurrent session, so a reader takes no
-    // lock and copies nothing: it reads this field once and works on that array. A writer
+    // lock: it reads this field once and works on that array. A writer
     // holds _writeSync, builds a replacement array, and publishes it in one volatile write,
     // so a reader sees either the old set or the new set and never a partial swap.
-    private volatile ToolRegistration[] _tools = [];
+    private volatile RegistrySnapshot _tools = RegistrySnapshot.Empty;
     private readonly object _writeSync = new();
 
     public void Register(INetclawTool tool)
-    {
-        lock (_writeSync)
-            _tools = [.._tools, new ToolRegistration(tool, tool.GrantCategory)];
-    }
+        => Register(tool, ToolExposureTier.Deferred);
 
-    public void Replace(INetclawTool tool)
+    /// <summary>
+    /// Registers a tool in the small model-visible core set.
+    /// </summary>
+    public void RegisterCore(INetclawTool tool)
+        => Register(tool, ToolExposureTier.Core);
+
+    private void Register(INetclawTool tool, ToolExposureTier exposureTier)
     {
         lock (_writeSync)
         {
-            _tools =
+            var current = _tools;
+            _tools = RegistrySnapshot.Create(
             [
-                .._tools.Where(t => !string.Equals(t.Tool.Name, tool.Name, StringComparison.Ordinal)),
-                new ToolRegistration(tool, tool.GrantCategory),
-            ];
+                ..current.Entries,
+                new RegistryEntry(new ToolRegistration(tool, tool.GrantCategory), exposureTier)
+            ]);
+        }
+    }
+
+    public void Replace(INetclawTool tool)
+        => Replace(tool, ToolExposureTier.Deferred);
+
+    /// <summary>
+    /// Replaces a tool and keeps it in the small model-visible core set.
+    /// </summary>
+    public void ReplaceCore(INetclawTool tool)
+        => Replace(tool, ToolExposureTier.Core);
+
+    private void Replace(INetclawTool tool, ToolExposureTier exposureTier)
+    {
+        lock (_writeSync)
+        {
+            var current = _tools;
+            _tools = RegistrySnapshot.Create(
+            [
+                ..current.Entries.Where(entry => !string.Equals(
+                    entry.Registration.Tool.Name,
+                    tool.Name,
+                    StringComparison.Ordinal)),
+                new RegistryEntry(new ToolRegistration(tool, tool.GrantCategory), exposureTier),
+            ]);
         }
     }
 
@@ -67,12 +112,15 @@ public sealed class ToolRegistry
     {
         lock (_writeSync)
         {
-            _tools =
+            var current = _tools;
+            _tools = RegistrySnapshot.Create(
             [
-                .._tools.Where(t => t.Tool is not McpToolAdapter mcp
+                ..current.Entries.Where(entry => entry.Registration.Tool is not McpToolAdapter mcp
                                     || !string.Equals(mcp.ServerName, serverName, StringComparison.OrdinalIgnoreCase)),
-                ..tools.Select(t => new ToolRegistration(t, t.GrantCategory)),
-            ];
+                ..tools.Select(static tool => new RegistryEntry(
+                    new ToolRegistration(tool, tool.GrantCategory),
+                    ToolExposureTier.Deferred)),
+            ]);
         }
     }
 
@@ -80,9 +128,27 @@ public sealed class ToolRegistry
     /// Register an <see cref="AITool"/> directly (for test fakes that don't implement INetclawTool).
     /// </summary>
     public void Register(AITool tool, string grantCategory)
+        => Register(tool, grantCategory, ToolExposureTier.Deferred);
+
+    /// <summary>
+    /// Registers a test or framework tool in the small model-visible core set.
+    /// </summary>
+    public void RegisterCore(AITool tool, string grantCategory)
+        => Register(tool, grantCategory, ToolExposureTier.Core);
+
+    private void Register(AITool tool, string grantCategory, ToolExposureTier exposureTier)
     {
         lock (_writeSync)
-            _tools = [.._tools, new ToolRegistration(new AIToolAdapter(tool, grantCategory), grantCategory)];
+        {
+            var current = _tools;
+            _tools = RegistrySnapshot.Create(
+            [
+                ..current.Entries,
+                new RegistryEntry(
+                    new ToolRegistration(new AIToolAdapter(tool, grantCategory), grantCategory),
+                    exposureTier)
+            ]);
+        }
     }
 
     /// <summary>All registered tools as AITool for ChatOptions.Tools.</summary>
@@ -132,14 +198,24 @@ public sealed class ToolRegistry
     {
         // One volatile read. Both passes below scan the same array, so a concurrent
         // publication cannot make the canonical pass and the alias pass disagree.
-        var tools = _tools;
-        var direct = tools.FirstOrDefault(t => t.Tool.Name == name);
+        var tools = _tools.Entries;
+        var direct = tools.FirstOrDefault(entry => entry.Registration.Tool.Name == name);
         if (direct is not null)
-            return direct;
-        return tools.FirstOrDefault(t =>
-            t.Tool is McpToolAdapter mcp
-            && string.Equals(mcp.LlmFacingName.Value, name, StringComparison.Ordinal));
+            return direct.Registration;
+        return tools.FirstOrDefault(entry =>
+            entry.Registration.Tool is McpToolAdapter mcp
+            && string.Equals(mcp.LlmFacingName.Value, name, StringComparison.Ordinal))?.Registration;
     }
+
+    /// <summary>
+    /// Returns the small set of tools that a session can expose before discovery.
+    /// Invocation policy still filters this set for each current trust context.
+    /// </summary>
+    public IReadOnlyList<AITool> GetCoreTools() =>
+        GetEntriesSnapshot()
+            .Where(static entry => entry.ExposureTier == ToolExposureTier.Core)
+            .Select(static entry => entry.Registration.Tool.ToAITool())
+            .ToList();
 
     /// <summary>
     /// Returns tools that should always be loaded into the LLM context.
@@ -152,11 +228,10 @@ public sealed class ToolRegistry
             .ToList();
 
     /// <summary>
-    /// Returns all registered tool registrations (for search and dynamic loading).
+    /// Returns a read-only view of all registered tools without copying the snapshot.
     /// </summary>
-    // Wrapped, not copied: callers receive the shared array behind a read-only view so a
-    // cast cannot reach the registry's state.
-    public IReadOnlyList<ToolRegistration> GetAllRegistrations() => Array.AsReadOnly(_tools);
+    public IReadOnlyList<ToolRegistration> GetAllRegistrations() =>
+        Array.AsReadOnly(_tools.Registrations);
 
     /// <summary>
     /// Returns tools discovered from one MCP server.
@@ -193,6 +268,17 @@ public sealed class ToolRegistry
             })
             .OrderBy(x => x.ServerName, StringComparer.Ordinal)
             .ToList();
+    }
+
+    internal static McpServerSummary SummarizeMcpServer(
+        string serverName,
+        IReadOnlyList<INetclawTool> tools)
+    {
+        var mcpTools = tools.OfType<McpToolAdapter>().ToList();
+        return new McpServerSummary(
+            serverName,
+            DescribeServerCapability(serverName, mcpTools),
+            mcpTools.Count);
     }
 
     /// <summary>
@@ -264,12 +350,12 @@ public sealed class ToolRegistry
 
     /// <summary>
     /// Generates a compressed tool index for the system prompt.
-    /// Uses progressive disclosure: list directly-callable tools and MCP servers,
-    /// then route detailed discovery through search_tools.
+    /// Uses progressive disclosure: list directly-callable tools and compact deferred
+    /// capabilities, then route detailed discovery through search_tools.
     /// </summary>
     public string GenerateCompressedIndex()
     {
-        var registrations = GetRegistrationsSnapshot();
+        var registrations = GetEntriesSnapshot();
         if (registrations.Count == 0)
             return string.Empty;
 
@@ -282,32 +368,54 @@ public sealed class ToolRegistry
     /// </summary>
     public string GenerateCompressedIndex(TrustAudience audience, ToolAccessPolicy policy)
     {
-        var visible = GetRegistrationsSnapshot()
-            .Where(t => policy.IsToolExposed(t.Tool, audience))
+        var visible = GetEntriesSnapshot()
+            .Where(entry => policy.IsToolExposed(entry.Registration.Tool, audience))
             .ToList();
 
         return BuildCompressedIndex(visible);
     }
 
-    private static string BuildCompressedIndex(IReadOnlyList<ToolRegistration> registrations)
+    private static string BuildCompressedIndex(IReadOnlyList<RegistryEntry> registrations)
     {
         if (registrations.Count == 0)
             return string.Empty;
 
         var sb = new StringBuilder();
 
-        // Separate always-loaded (directly callable) tools from MCP (dynamic) tools
-        var builtinTools = registrations.Where(t => t.Tool is not McpToolAdapter).ToList();
-        var mcpTools = registrations.Where(t => t.Tool is McpToolAdapter).ToList();
+        var coreTools = registrations
+            .Where(static entry => entry.ExposureTier == ToolExposureTier.Core)
+            .ToList();
+        var deferredFirstPartyTools = registrations
+            .Where(static entry => entry.ExposureTier == ToolExposureTier.Deferred
+                                   && entry.Registration.Tool is not McpToolAdapter)
+            .ToList();
+        var mcpTools = registrations
+            .Where(static entry => entry.Registration.Tool is McpToolAdapter)
+            .ToList();
 
-        if (builtinTools.Count > 0)
+        if (coreTools.Count > 0)
         {
-            sb.AppendLine("[directly callable tools]");
-            var builtinGrouped = builtinTools.GroupBy(t => t.GrantCategory);
+            sb.AppendLine("[directly callable core tools]");
+            var builtinGrouped = coreTools.GroupBy(entry => entry.Registration.GrantCategory);
             foreach (var group in builtinGrouped)
             {
-                var names = group.Select(t => t.Tool.Name);
+                var names = group.Select(entry => entry.Registration.Tool.Name);
                 sb.AppendLine($"{group.Key}: {string.Join(", ", names)}");
+            }
+        }
+
+        if (deferredFirstPartyTools.Count > 0)
+        {
+            if (sb.Length > 0)
+                sb.AppendLine();
+
+            sb.AppendLine("[deferred first-party tools - discover with search_tools]");
+            foreach (var entry in deferredFirstPartyTools.OrderBy(
+                         static entry => entry.Registration.Tool.Name,
+                         StringComparer.Ordinal))
+            {
+                var tool = entry.Registration.Tool;
+                sb.AppendLine($"{tool.Name}: {BuildCompactHint(tool.Description)}");
             }
         }
 
@@ -332,10 +440,10 @@ public sealed class ToolRegistry
         return sb.ToString();
     }
 
-    private static IReadOnlyList<McpServerSummary> GetMcpServerSummaries(IReadOnlyList<ToolRegistration> registrations)
+    private static IReadOnlyList<McpServerSummary> GetMcpServerSummaries(IReadOnlyList<RegistryEntry> registrations)
     {
         return registrations
-            .Select(t => t.Tool)
+            .Select(entry => entry.Registration.Tool)
             .OfType<McpToolAdapter>()
             .GroupBy(t => t.ServerName, StringComparer.OrdinalIgnoreCase)
             .Select(group =>
@@ -347,6 +455,15 @@ public sealed class ToolRegistry
             })
             .OrderBy(x => x.ServerName, StringComparer.Ordinal)
             .ToList();
+    }
+
+    private static string BuildCompactHint(string description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return "No description available.";
+
+        var singleLine = Regex.Replace(description.Trim(), "\\s+", " ");
+        return singleLine.Length <= 80 ? singleLine : singleLine[..77] + "...";
     }
 
     private static string DescribeServerCapability(string serverName, IReadOnlyList<McpToolAdapter> tools)
@@ -473,7 +590,9 @@ public sealed class ToolRegistry
 
     // The published array is never mutated after publication, so a reader can use it
     // directly. This replaces a lock plus a full list copy on every read.
-    private IReadOnlyList<ToolRegistration> GetRegistrationsSnapshot() => _tools;
+    private IReadOnlyList<RegistryEntry> GetEntriesSnapshot() => _tools.Entries;
+
+    private IReadOnlyList<ToolRegistration> GetRegistrationsSnapshot() => _tools.Registrations;
 
     /// <summary>
     /// Adapter to wrap bare <see cref="AITool"/> instances (e.g. test fakes) as <see cref="INetclawTool"/>.

--- a/src/Netclaw.Daemon.Tests/Configuration/DaemonToolPathPolicyFactoryTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/DaemonToolPathPolicyFactoryTests.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonToolPathPolicyFactoryTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Daemon.Configuration;
+using Netclaw.Security;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class DaemonToolPathPolicyFactoryTests
+{
+    [Theory]
+    [InlineData("tool-index.md")]
+    [InlineData("mcp/synthetic-server.md")]
+    public void Operator_tool_catalogs_are_denied_to_read_write_and_shell(string relativePath)
+    {
+        var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), "netclaw-policy-contract"));
+        var policy = DaemonToolPathPolicyFactory.Create(
+            paths,
+            ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux));
+        var catalogPath = Path.Combine(
+            [paths.ToolingShadowDirectory, ..relativePath.Split('/')]);
+
+        Assert.True(policy.IsDenied(catalogPath));
+        Assert.True(policy.IsReadDenied(catalogPath));
+        Assert.True(policy.CommandReferencesDeniedPath($"inspect '{catalogPath}'"));
+        Assert.True(policy.CommandReferencesDeniedPath("find", catalogPath));
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Mcp/McpShadowCatalogWriterTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpShadowCatalogWriterTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Mcp;
+using Netclaw.Security;
 using Netclaw.Tests.Utilities;
 using Xunit;
 
@@ -28,6 +29,10 @@ public sealed class McpShadowCatalogWriterTests
             "memorizer",
             "store"));
         registry.Register(new McpToolAdapter(
+            AIFunctionFactory.Create((string query) => "ok", "search", "Search memory"),
+            "memorizer",
+            "search"));
+        registry.Register(new McpToolAdapter(
             AIFunctionFactory.Create((string url) => "ok", "navigate", "Navigate page"),
             "browser_playwright",
             "navigate"));
@@ -40,8 +45,11 @@ public sealed class McpShadowCatalogWriterTests
         var layer = writer.WriteCatalogs();
 
         Assert.True(File.Exists(paths.ToolIndexShadowPath));
+        Assert.Equal(layer, File.ReadAllText(paths.ToolIndexShadowPath));
         Assert.Contains("[MCP capability servers - discover tools with search_tools]", layer);
         Assert.Contains("[shadow catalogs on disk]", layer);
+        Assert.Contains("memorizer", layer);
+        Assert.Contains("browser_playwright", layer);
 
         var memorizerPath = Path.Combine(paths.McpShadowDirectory, "memorizer.md");
         var browserPath = Path.Combine(paths.McpShadowDirectory, "browser_playwright.md");
@@ -51,7 +59,16 @@ public sealed class McpShadowCatalogWriterTests
 
         var memorizerCatalog = File.ReadAllText(memorizerPath);
         Assert.Contains("Server: memorizer", memorizerCatalog);
+        Assert.Contains("Tool Count: 2", memorizerCatalog);
         Assert.Contains("memorizer/store", memorizerCatalog);
+        Assert.Contains("memorizer/search", memorizerCatalog);
+        Assert.Contains("params: query", memorizerCatalog);
+
+        var browserCatalog = File.ReadAllText(browserPath);
+        Assert.Contains("Server: browser_playwright", browserCatalog);
+        Assert.Contains("Tool Count: 1", browserCatalog);
+        Assert.Contains("browser_playwright/navigate", browserCatalog);
+        Assert.Contains("params: url", browserCatalog);
     }
 
     [Fact]
@@ -79,5 +96,52 @@ public sealed class McpShadowCatalogWriterTests
 
         Assert.False(File.Exists(stalePath));
         Assert.True(File.Exists(Path.Combine(paths.McpShadowDirectory, "memorizer.md")));
+    }
+
+    [Fact]
+    public void Operator_catalog_stays_complete_while_model_index_hides_denied_names()
+    {
+        using var dir = new DisposableTempDir();
+        var paths = new NetclawPaths(dir.Path);
+        paths.EnsureDirectoriesExist();
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            AIFunctionFactory.Create(() => "ok", "search_memories", "Search memory"),
+            "memorizer",
+            "search_memories"));
+        registry.Register(new McpToolAdapter(
+            AIFunctionFactory.Create(() => "ok", "delete_memory", "Delete memory"),
+            "memorizer",
+            "delete_memory"));
+
+        new McpShadowCatalogWriter(
+                paths,
+                registry,
+                NullLogger<McpShadowCatalogWriter>.Instance)
+            .WriteCatalogs();
+
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Team.AllowedMcpServers.Add("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
+
+        var operatorCatalog = File.ReadAllText(Path.Combine(paths.McpShadowDirectory, "memorizer.md"));
+        var modelIndex = new ToolIndexContextLayer(registry, policy).GetContextLayer(TrustAudience.Team);
+
+        Assert.Contains("memorizer/search_memories", operatorCatalog);
+        Assert.Contains("memorizer/delete_memory", operatorCatalog);
+        Assert.Contains("memorizer (1 tools)", modelIndex);
+        Assert.DoesNotContain("delete_memory", modelIndex);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/ToolIndexUpdaterTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/ToolIndexUpdaterTests.cs
@@ -100,7 +100,8 @@ public sealed class ToolIndexUpdaterTests
         await updater.StartAsync(TestContext.Current.CancellationToken);
 
         var publicIndex = toolIndexLayer.GetContextLayer(TrustAudience.Public);
-        Assert.Contains("file: file_read", publicIndex);
+        Assert.Contains("[deferred first-party tools", publicIndex);
+        Assert.Contains("file_read:", publicIndex);
         Assert.DoesNotContain("set_reminder", publicIndex);
         Assert.DoesNotContain("memorizer", publicIndex);
     }

--- a/src/Netclaw.Daemon/Configuration/DaemonToolPathPolicyFactory.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonToolPathPolicyFactory.cs
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------
+// <copyright file="DaemonToolPathPolicyFactory.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Security;
+
+namespace Netclaw.Daemon.Configuration;
+
+internal static class DaemonToolPathPolicyFactory
+{
+    public static ToolPathPolicy Create(
+        NetclawPaths paths,
+        ShellExecutionEnvironment shellEnvironment)
+    {
+        var sqliteSidecars = new[]
+        {
+            paths.SqliteDbPath + "-wal",
+            paths.SqliteDbPath + "-shm",
+            paths.SqliteDbPath + "-journal"
+        };
+        var processControlPaths = new[]
+        {
+            paths.PidFilePath,
+            paths.LockFilePath,
+            paths.RestartManifestPath
+        };
+
+        string[] writeDenyList =
+        [
+            paths.ConfigDirectory,
+            paths.SecretsPath,
+            paths.KeysDirectory,
+            paths.SqliteDbPath,
+            ..sqliteSidecars,
+            ..processControlPaths,
+            paths.SystemSkillsDirectory,
+            paths.ServerFeedsDirectory,
+            paths.ToolingShadowDirectory,
+        ];
+        string[] readDenyList =
+        [
+            paths.SecretsPath,
+            paths.KeysDirectory,
+            paths.WebhooksDirectory,
+            paths.ToolingShadowDirectory,
+        ];
+        string[] shellIndicatorList =
+        [
+            paths.ConfigDirectory,
+            paths.SecretsPath,
+            paths.WebhooksDirectory,
+            paths.KeysDirectory,
+            paths.SqliteDbPath,
+            ..sqliteSidecars,
+            ..processControlPaths,
+            paths.ToolingShadowDirectory,
+        ];
+
+        return new ToolPathPolicy(
+            shellEnvironment,
+            writeDenyList,
+            readDenyList,
+            shellIndicatorList);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
+++ b/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
@@ -40,7 +40,7 @@ internal static class SkillToolRegistration
         var skillSyncConfig = services.GetService<SkillSyncConfig>();
         var loggerFactory = services.GetRequiredService<ILoggerFactory>();
 
-        registry.Replace(new FileReadTool(toolConfig, paths, pathPolicy, skillRegistry, metrics,
+        registry.ReplaceCore(new FileReadTool(toolConfig, paths, pathPolicy, skillRegistry, metrics,
             loggerFactory.CreateLogger<FileReadTool>()));
 
         registry.WithSkillTools(

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -605,65 +605,9 @@ static void ConfigureDaemonServices(
         .Get<SearchConfig>() ?? new SearchConfig();
     var searchBackend = searchConfig.Enabled ? CreateSearchBackend(searchConfig) : null;
 
-    // ConfigDirectory is hard-denied for agent writes and shell access to
-    // close the prompt-injection vector where an injected payload would
-    // instruct the agent to rewrite tool-approvals.json, hard-deny-overrides.json,
-    // or netclaw.json and grant itself global trust. Operators retain agency
-    // by editing config files outside the agent (their own editor) or via
-    // dedicated CLI commands that bypass the agent's tool-call path.
-    // Individual high-sensitivity paths (Secrets, Keys, etc.) are also listed
-    // explicitly for self-documenting intent — ConfigDirectory subsumes them
-    // but the explicit entries make the security purpose obvious to readers.
-    var writeDenyList = new[]
-    {
-        paths.ConfigDirectory,
-        paths.SecretsPath,
-        paths.KeysDirectory,
-        paths.SqliteDbPath,
-        // SQLite sidecars mirror the shell indicator list — they hold the same
-        // raw page data as the DB and must not be writable through tools either.
-        paths.SqliteDbPath + "-wal",
-        paths.SqliteDbPath + "-shm",
-        paths.SqliteDbPath + "-journal",
-        paths.PidFilePath,
-        paths.LockFilePath,
-        paths.RestartManifestPath,
-        // Skill directories managed by the sync service — writes from agent tools
-        // are lost on the next sync cycle and corrupt the sync service's view of
-        // on-disk state. The sync service writes directly via filesystem, not tools.
-        paths.SystemSkillsDirectory,
-        paths.ServerFeedsDirectory,
-    };
-    var readDenyList = new[]
-    {
-        paths.SecretsPath,
-        paths.KeysDirectory,
-        paths.WebhooksDirectory,
-    };
-    var shellIndicatorList = new[]
-    {
-        paths.ConfigDirectory,
-        paths.SecretsPath,
-        paths.WebhooksDirectory,
-        paths.KeysDirectory,
-        paths.SqliteDbPath,
-        // SQLite sidecars hold raw page data (webhook secrets, OAuth tokens)
-        // and are reachable via the read-deny union, so they must be denied
-        // exactly like the DB itself. Shell's substring scan already catches
-        // them (command text contains "netclaw.db"); the path-boundary matcher
-        // in ToolPathPolicy does not, hence the explicit entries (#1724).
-        paths.SqliteDbPath + "-wal",
-        paths.SqliteDbPath + "-shm",
-        paths.SqliteDbPath + "-journal",
-        paths.PidFilePath,
-        paths.LockFilePath,
-        paths.RestartManifestPath,
-    };
-    var toolPathPolicy = new ToolPathPolicy(
-        shellEnvironment,
-        writeDenyList,
-        readDenyList,
-        shellIndicatorList);
+    // Agent tools cannot read or change the control plane. This also protects the
+    // complete operator-only tool catalogs from model-visible name disclosure.
+    var toolPathPolicy = DaemonToolPathPolicyFactory.Create(paths, shellEnvironment);
     services.AddSingleton(toolPathPolicy);
 
     // Load operator-authored hard-deny overrides (additive only — see

--- a/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
@@ -111,6 +111,16 @@ public sealed class ToolPathPolicyTests
     }
 
     [Fact]
+    public void CommandReferencesDeniedPath_checks_the_working_directory()
+    {
+        var policy = new ToolPathPolicy(["/protected/catalog"]);
+
+        Assert.True(policy.CommandReferencesDeniedPath("find", "/protected/catalog"));
+        Assert.True(policy.CommandReferencesDeniedPath("find", "/protected/catalog/mcp"));
+        Assert.False(policy.CommandReferencesDeniedPath("find", "/work"));
+    }
+
+    [Fact]
     public void CommandReferencesDeniedPath_checks_native_power_shell_path()
     {
         var environment = ShellExecutionEnvironment.CreatePowerShell(

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -256,6 +256,12 @@ public sealed class ToolPathPolicy
         var command = analysis.Source;
         var workingDirectory = analysis.WorkingDirectory;
 
+        if (!string.IsNullOrWhiteSpace(workingDirectory)
+            && IsDeniedAgainst(workingDirectory, _shellDeniedPaths))
+        {
+            return true;
+        }
+
         var tokens = ShellTokenizer.Tokenize(command).ToList();
         var slashCommand = command.Replace('\\', '/');
         foreach (var indicator in _commandIndicators)


### PR DESCRIPTION
## Summary

- Add internal Core and Deferred tool exposure tiers.
- Seed parent sessions with exactly ten core tools.
- Lease discovered first-party and MCP tools without granting invocation authority.
- Filter search, load, suggestions, and server summaries before result limits.
- Hide denied tools without revealing whether hidden names exist.
- Protect complete operator shadow catalogs from agent file and shell access.
- Preserve public registry contracts and legacy catalog behavior.

## Stack

- Depends on #2020.
- This is the second pull request in the agent tool pit-of-success stack.

## Deterministic evaluation evidence

- The parent Core snapshot contains 10 tool definitions totaling 10,879 serialized UTF-8 bytes.
- Initial model requests exclude Deferred tool schemas.
- A successful policy-visible load activates one Deferred tool without granting invocation authority.
- Model failure evicts the transient Deferred lease.
- Hidden tools remain absent from exact search, fuzzy suggestions, server summaries, and load responses.
- No hosted behavioral run was used as evidence for this PR.

## Validation

- Actors: 3,460 passed; one expected Windows-only skip.
- Security: 1,052 passed.
- Daemon shadow and path checks: 5 passed.
- Strict OpenSpec validation passed.
- Header and no-BOM checks passed.
- Slopwatch reported zero issues.
- Diff checks passed.
- Independent security and API review passed.
