### PR TITLE
Add subagent tool progressive disclosure

### DIFF
--- a/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-subagents/spec.md
@@ -31,8 +31,8 @@ activate deferred tools only in that child actor's ephemeral exposure set.
 ### Requirement: Subagent tool exposure is observable without payloads
 
 Subagent diagnostics SHALL report core, deferred-visible, and dynamically loaded
-tool counts for each run. Logs SHALL NOT include tool argument values, command
-text, file paths, schema bodies, or hidden tool names.
+tool counts for each run. Exposure diagnostics SHALL NOT include tool argument
+values, command text, file paths, schema bodies, or hidden tool names.
 
 #### Scenario: Child startup logs bounded counts
 

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -17,11 +17,11 @@
 
 ## 3. PR 3 - Subagent progressive disclosure
 
-- [ ] 3.1 Seed subagents from the policy-exposed Core set instead of every discoverable registration.
-- [ ] 3.2 Add an ephemeral child exposure cache and intercept successful load_tool results within the child actor.
-- [ ] 3.3 Preserve recursive-spawn denial across child catalog, search, suggestions, load, and dispatch paths.
-- [ ] 3.4 Emit PII-free child core/deferred/loaded counts without tool payloads, paths, schema bodies, or hidden names.
-- [ ] 3.5 Add parent/child parity tests, child-local lease isolation, model-failure eviction, and high-cardinality catalog regression coverage.
+- [x] 3.1 Seed subagents from the policy-exposed Core set instead of every discoverable registration.
+- [x] 3.2 Add an ephemeral child exposure cache and intercept successful load_tool results within the child actor.
+- [x] 3.3 Preserve recursive-spawn denial across child catalog, search, suggestions, load, and dispatch paths.
+- [x] 3.4 Emit PII-free child core/deferred/loaded counts without tool payloads, paths, schema bodies, or hidden names.
+- [x] 3.5 Add parent/child parity tests, child-local lease isolation, model-failure eviction, and high-cardinality catalog regression coverage.
 
 ## 4. PR 4 - Workspace path and outcome foundation
 

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -30,6 +30,7 @@ namespace Netclaw.Actors.Tests.Sessions;
 public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
 {
     private const string ApprovalProbeToolName = "approval_probe";
+    private const string HiddenSpecialtyToolName = "hidden_specialty";
     private const string MainIdentityMarker = "You are a test assistant with subagent support.";
     private const string OperatingRulesMarker = "[embedded agents] Sub-agents inherit operating rules.";
     private const string AgentsLayerMarker = "[agents] This marker should never appear in routed subagent calls.";
@@ -43,6 +44,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
     private readonly ToolRegistry _toolRegistry = new();
     private RecordingContextTool? _recordingFileReadTool;
     private RecordingContextTool? _recordingApprovalTool;
+    private RecordingContextTool? _recordingHiddenTool;
 
     private static FunctionCallContent CreateToolCall(
         string callId,
@@ -159,7 +161,8 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         {
             ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
             {
-                [ApprovalProbeToolName] = ToolApprovalMode.Approval
+                [ApprovalProbeToolName] = ToolApprovalMode.Approval,
+                [HiddenSpecialtyToolName] = ToolApprovalMode.Deny
             }
         };
         var toolAccessPolicy = new ToolAccessPolicy(
@@ -209,10 +212,14 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         // This fixture drives spawn_agent directly from the main model. Mark only that
         // test seam as Core; production registration keeps spawn_agent deferred.
         registry.RegisterCore(new SpawnAgentTool(subAgentRegistry, spawner, subAgentPaths));
+        registry.RegisterCore(new SearchToolsTool(registry, toolAccessPolicy));
+        registry.RegisterCore(new LoadToolTool(registry, toolAccessPolicy));
         _recordingFileReadTool = new RecordingContextTool("file_read", "stub file content", "file");
-        registry.Register(_recordingFileReadTool);
+        registry.RegisterCore(_recordingFileReadTool);
         _recordingApprovalTool = new RecordingContextTool(ApprovalProbeToolName, "approval ok");
         registry.Register(_recordingApprovalTool);
+        _recordingHiddenTool = new RecordingContextTool(HiddenSpecialtyToolName, "hidden result");
+        registry.Register(_recordingHiddenTool);
 
         services.AddSingleton(registry);
         services.AddSingleton(subAgentRegistry);
@@ -263,7 +270,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         var started = await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(SubAgentPhase.Started, started.Phase);
         Assert.Equal("summarizer", started.AgentName.Value);
-        Assert.Equal(2, started.ToolCount);
+        Assert.Equal(4, started.ToolCount);
 
         var completed = await subscriber.ExpectMsgAsync<SubAgentOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(SubAgentPhase.Completed, completed.Phase);
@@ -309,10 +316,19 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Assert.Equal(sessionId.Value, mainOptions.SessionId);
         var subagentOptions = Assert.IsType<SessionScopedChatOptions>(_clientProvider.Compaction.ReceivedOptions[^1]);
         Assert.Equal(sessionId.Value, subagentOptions.SessionId);
+        var mainToolNames = _clientProvider.Main.ReceivedToolNames[0]
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+        var childToolNames = _clientProvider.Compaction.ReceivedToolNames[0]
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+        Assert.Equal(
+            mainToolNames.Where(static name => name != "spawn_agent"),
+            childToolNames);
     }
 
     [Fact]
-    public async Task Final_model_visible_tool_footprints_reduce_main_context_vs_frozen_baseline()
+    public async Task Final_model_visible_child_footprint_reduces_from_frozen_baseline()
     {
         RegisterSyntheticMcpCatalog();
         _clientProvider.Main.ToolCallsOnFirstCall =
@@ -349,23 +365,402 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             TimeSpan.FromSeconds(5),
             TestContext.Current.CancellationToken);
 
-        var mainOptions = Assert.IsType<SessionScopedChatOptions>(_clientProvider.Main.ReceivedOptions[0]);
-        var mainTools = Assert.IsAssignableFrom<IEnumerable<AITool>>(mainOptions.Tools);
         var subagentOptions = Assert.IsType<SessionScopedChatOptions>(_clientProvider.Compaction.ReceivedOptions[0]);
         var subagentTools = Assert.IsAssignableFrom<IEnumerable<AITool>>(subagentOptions.Tools);
 
-        var actual = new ToolFootprintPair(
-            ModelVisibleToolFootprintCalculator.Measure(mainTools),
-            ModelVisibleToolFootprintCalculator.Measure(subagentTools));
+        var actual = ModelVisibleToolFootprintCalculator.Measure(subagentTools);
         var baseline = await ReadToolFootprintBaselineAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, baseline.SchemaVersion);
         Assert.Equal(ToolFootprintScenario, baseline.Scenario);
         Assert.Equal(ToolFootprintMetric, baseline.Metric);
         Assert.Equal(SyntheticMcpToolCount, baseline.SyntheticMcpToolCount);
-        Assert.True(actual.MainCore.Count < baseline.MainCore.Count);
-        Assert.True(actual.MainCore.SerializedDefinitionBytes < baseline.MainCore.SerializedDefinitionBytes);
-        Assert.Equal(baseline.SubagentFull, actual.SubagentFull);
+        Assert.True(actual.Count < baseline.SubagentFull.Count);
+        Assert.True(
+            actual.SerializedDefinitionBytes
+            < baseline.SubagentFull.SerializedDefinitionBytes);
+    }
+
+    [Fact]
+    public async Task Child_loads_one_deferred_tool_without_exposing_the_catalog()
+    {
+        RegisterSyntheticMcpCatalog();
+        _clientProvider.Main.ToolCallsOnFirstCall =
+        [
+            CreateToolCall(
+                "call-progressive-spawn",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Use one synthetic lookup tool."
+                })
+        ];
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-progressive-search",
+                "search_tools",
+                new Dictionary<string, object?>
+                {
+                    ["Query"] = "tool_007"
+                })
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-progressive-load",
+                "load_tool",
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = $"{SyntheticMcpServerName}/tool_007"
+                })
+        ]);
+
+        var sessionId = new SessionId("console/subagent-progressive-disclosure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-progressive-disclosure-events");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use one deferred child tool.",
+            Source = BuildPersonalSource()
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await ExpectTurnCompletedAsync(
+            subscriber,
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        var calls = _clientProvider.Compaction.ReceivedOptions;
+        Assert.True(calls.Count >= 3);
+        var initialNames = Assert.IsAssignableFrom<IEnumerable<AITool>>(calls[0]?.Tools)
+            .OfType<AIFunctionDeclaration>()
+            .Select(static tool => tool.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+        var afterSearchNames = Assert.IsAssignableFrom<IEnumerable<AITool>>(calls[1]?.Tools)
+            .OfType<AIFunctionDeclaration>()
+            .Select(static tool => tool.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+        var loadedNames = Assert.IsAssignableFrom<IEnumerable<AITool>>(calls[2]?.Tools)
+            .OfType<AIFunctionDeclaration>()
+            .Select(static tool => tool.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(["file_read", "load_tool", "search_tools"], initialNames);
+        Assert.Equal(initialNames, afterSearchNames);
+        Assert.Equal(
+            ["file_read", "load_tool", "search_tools", "synthetic_catalog__tool_007"],
+            loadedNames);
+        Assert.DoesNotContain(loadedNames, static name => name == "spawn_agent");
+        var searchResult = GetToolResult(
+            _clientProvider.Compaction.ReceivedMessages[1],
+            "call-progressive-search");
+        Assert.Contains("synthetic_catalog__tool_007", searchResult, StringComparison.Ordinal);
+
+        var firstMessages = _clientProvider.Compaction.ReceivedMessages[0];
+        var system = Assert.Single(
+            firstMessages,
+            static message => message.Role == Microsoft.Extensions.AI.ChatRole.System);
+        Assert.Contains("synthetic_catalog (200 tools)", system.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("spawn_agent", system.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("tool_007", system.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Child_cannot_discover_load_or_dispatch_recursive_or_hidden_tools()
+    {
+        _clientProvider.Main.ToolCallsOnFirstCall =
+        [
+            CreateToolCall(
+                "call-policy-spawn",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Check unavailable capabilities."
+                })
+        ];
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-search-recursive-exact",
+                "search_tools",
+                new Dictionary<string, object?> { ["Query"] = "spawn_agent" }),
+            CreateToolCall(
+                "call-search-recursive-fuzzy",
+                "search_tools",
+                new Dictionary<string, object?> { ["Query"] = "spwn agnt" }),
+            CreateToolCall(
+                "call-load-recursive",
+                "load_tool",
+                new Dictionary<string, object?> { ["Name"] = "spawn_agent" }),
+            CreateToolCall(
+                "call-dispatch-recursive",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Try recursive delegation."
+                }),
+            CreateToolCall(
+                "call-search-hidden",
+                "search_tools",
+                new Dictionary<string, object?> { ["Query"] = HiddenSpecialtyToolName }),
+            CreateToolCall(
+                "call-load-hidden",
+                "load_tool",
+                new Dictionary<string, object?> { ["Name"] = HiddenSpecialtyToolName })
+        ]);
+
+        var sessionId = new SessionId("console/subagent-policy-boundaries");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-policy-boundary-events");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use a child to check unavailable tools.",
+            Source = BuildPersonalSource()
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await ExpectTurnCompletedAsync(
+            subscriber,
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        var resultMessages = _clientProvider.Compaction.ReceivedMessages[1];
+        Assert.StartsWith(
+            "No tools found matching",
+            GetToolResult(resultMessages, "call-search-recursive-exact"),
+            StringComparison.Ordinal);
+        Assert.StartsWith(
+            "No tools found matching",
+            GetToolResult(resultMessages, "call-search-recursive-fuzzy"),
+            StringComparison.Ordinal);
+        Assert.StartsWith(
+            "Tool 'spawn_agent' not found.",
+            GetToolResult(resultMessages, "call-load-recursive"),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            "Unknown tool: spawn_agent",
+            GetToolResult(resultMessages, "call-dispatch-recursive"));
+        Assert.StartsWith(
+            "No tools found matching",
+            GetToolResult(resultMessages, "call-search-hidden"),
+            StringComparison.Ordinal);
+        Assert.StartsWith(
+            $"Tool '{HiddenSpecialtyToolName}' not found.",
+            GetToolResult(resultMessages, "call-load-hidden"),
+            StringComparison.Ordinal);
+
+        Assert.NotNull(_recordingHiddenTool);
+        Assert.False(_recordingHiddenTool!.WasCalled);
+        Assert.All(
+            _clientProvider.Compaction.ReceivedToolNames,
+            names =>
+            {
+                Assert.DoesNotContain("spawn_agent", names);
+                Assert.DoesNotContain(HiddenSpecialtyToolName, names);
+                Assert.Equal(
+                    ["file_read", "load_tool", "search_tools"],
+                    names.OrderBy(static name => name, StringComparer.Ordinal));
+            });
+    }
+
+    [Fact]
+    public async Task Loaded_child_tool_does_not_transfer_to_the_next_child()
+    {
+        RegisterSyntheticMcpCatalog();
+        _clientProvider.Main.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-isolation-spawn-1",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Use one synthetic tool."
+                })
+        ]);
+        _clientProvider.Main.PlannedResponses.Enqueue([new TextContent("First child completed.")]);
+        _clientProvider.Main.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-isolation-spawn-2",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Start without inherited tools."
+                })
+        ]);
+        _clientProvider.Main.PlannedResponses.Enqueue([new TextContent("Second child completed.")]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-isolation-load",
+                "load_tool",
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = $"{SyntheticMcpServerName}/tool_007"
+                })
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue([new TextContent("Loaded child completed.")]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue([new TextContent("Fresh child completed.")]);
+
+        var sessionId = new SessionId("console/subagent-tool-isolation");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-tool-isolation-events");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        foreach (var content in new[] { "Run the first child.", "Run the second child." })
+        {
+            await sessionManager.Ask<CommandAck>(new SendUserMessage
+            {
+                SessionId = sessionId,
+                Content = content,
+                Source = BuildPersonalSource()
+            }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+            await ExpectTurnCompletedAsync(
+                subscriber,
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+        }
+
+        Assert.True(_clientProvider.Compaction.ReceivedToolNames.Count >= 3);
+        Assert.Equal(
+            ["file_read", "load_tool", "search_tools"],
+            _clientProvider.Compaction.ReceivedToolNames[0]
+                .OrderBy(static name => name, StringComparer.Ordinal));
+        Assert.Equal(
+            ["file_read", "load_tool", "search_tools", "synthetic_catalog__tool_007"],
+            _clientProvider.Compaction.ReceivedToolNames[1]
+                .OrderBy(static name => name, StringComparer.Ordinal));
+        Assert.Equal(
+            ["file_read", "load_tool", "search_tools"],
+            _clientProvider.Compaction.ReceivedToolNames[2]
+                .OrderBy(static name => name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task Child_model_failure_discards_loaded_tools_before_a_fresh_child()
+    {
+        const string failureProbeName = "failure_probe";
+        var failureProbe = new RecordingContextTool(
+            failureProbeName,
+            "probe complete",
+            onExecute: _ => _clientProvider.Compaction.PlannedExceptions.Enqueue(
+                new InvalidOperationException("synthetic child model failure")));
+        _toolRegistry.Register(failureProbe);
+
+        _clientProvider.Main.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-failure-spawn-1",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Load the failure probe."
+                })
+        ]);
+        _clientProvider.Main.PlannedResponses.Enqueue([new TextContent("Failure was recorded.")]);
+        _clientProvider.Main.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-failure-spawn-2",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Start with a clean tool set."
+                })
+        ]);
+        _clientProvider.Main.PlannedResponses.Enqueue([new TextContent("Fresh child completed.")]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-failure-load",
+                "load_tool",
+                new Dictionary<string, object?> { ["Name"] = failureProbeName })
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-failure-execute",
+                failureProbeName,
+                new Dictionary<string, object?>())
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue([new TextContent("Fresh child completed.")]);
+
+        var sessionId = new SessionId("console/subagent-failure-isolation");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-failure-isolation-events");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        foreach (var content in new[] { "Run the failing child.", "Run the fresh child." })
+        {
+            await sessionManager.Ask<CommandAck>(new SendUserMessage
+            {
+                SessionId = sessionId,
+                Content = content,
+                Source = BuildPersonalSource()
+            }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+            await ExpectTurnCompletedAsync(
+                subscriber,
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+        }
+
+        Assert.True(failureProbe.WasCalled);
+        Assert.Contains(
+            "synthetic child model failure",
+            GetToolResult(
+                _clientProvider.Main.ReceivedMessages[1],
+                "call-failure-spawn-1"),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            ["file_read", "load_tool", "search_tools"],
+            _clientProvider.Compaction.ReceivedToolNames[0]
+                .OrderBy(static name => name, StringComparer.Ordinal));
+        Assert.Contains(failureProbeName, _clientProvider.Compaction.ReceivedToolNames[1]);
+        Assert.Equal(
+            ["file_read", "load_tool", "search_tools"],
+            _clientProvider.Compaction.ReceivedToolNames[2]
+                .OrderBy(static name => name, StringComparer.Ordinal));
     }
 
     [Fact]
@@ -385,7 +780,17 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
                     ["task"] = "Run the approval probe"
                 })
         ];
-        _clientProvider.Compaction.ToolCallsOnFirstCall =
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-load-approval-probe",
+                "load_tool",
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = ApprovalProbeToolName
+                })
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
         [
             CreateToolCall(
                 childCallId,
@@ -398,7 +803,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
                     // silently dropped the hint).
                     ["_timeout_seconds"] = 1800
                 })
-        ];
+        ]);
 
         var sessionId = new SessionId("console/subagent-approval-integration");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
@@ -458,6 +863,9 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         Assert.NotNull(_recordingApprovalTool);
         Assert.True(_recordingApprovalTool!.WasCalled);
         Assert.Equal(TrustAudience.Personal, _recordingApprovalTool.LastContext?.Audience);
+        Assert.Contains(
+            ApprovalProbeToolName,
+            _clientProvider.Compaction.ReceivedToolNames[1]);
 
         // The sub-agent extracted the meta timeout hint and applied it to the
         // tool context (regression guard for the previously-dropped hint).
@@ -935,15 +1343,20 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
                ?? throw new InvalidOperationException("Tool footprint baseline is empty.");
     }
 
+    private static string GetToolResult(IReadOnlyList<ChatMessage> messages, string callId)
+    {
+        var result = messages
+            .SelectMany(static message => message.Contents.OfType<FunctionResultContent>())
+            .Single(content => content.CallId == callId)
+            .Result;
+        return Assert.IsType<string>(result);
+    }
+
     private sealed record ToolFootprintBaseline(
         int SchemaVersion,
         string Scenario,
         string Metric,
         int SyntheticMcpToolCount,
-        ModelVisibleToolFootprint MainCore,
-        ModelVisibleToolFootprint SubagentFull);
-
-    private sealed record ToolFootprintPair(
         ModelVisibleToolFootprint MainCore,
         ModelVisibleToolFootprint SubagentFull);
 
@@ -956,7 +1369,11 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             => role == ModelRole.Compaction ? Compaction : Main;
     }
 
-    private sealed class RecordingContextTool(string name, string result, string grantCategory = "builtin") : INetclawTool
+    private sealed class RecordingContextTool(
+        string name,
+        string result,
+        string grantCategory = "builtin",
+        Action<ToolInvocationContext>? onExecute = null) : INetclawTool
     {
         public string Name { get; } = name;
         public LlmFacingToolName LlmFacingName { get; } = LlmFacingToolName.FromCanonical(name);
@@ -976,6 +1393,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         {
             WasCalled = true;
             LastContext = context;
+            onExecute?.Invoke(context);
             return Task.FromResult(result);
         }
     }

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
@@ -95,6 +95,30 @@ public sealed class SubAgentObservabilityTests : TestKit
     }
 
     [Fact]
+    public async Task Startup_emits_one_payload_free_tool_exposure_diagnostic()
+    {
+        var core = new FakeNetclawTool("core_marker", "core result");
+        var deferred = new FakeNetclawTool("deferred_marker", "deferred result");
+        var props = SubAgentActor.CreatePropsWithProjectInstructionProvider(
+            CreateDefinition([core, deferred]),
+            new FakeChatClient(),
+            PermissivePolicy(),
+            NullSystemPromptProvider.Instance,
+            coreToolNames: new HashSet<string>([core.Name], StringComparer.Ordinal));
+        var agent = Sys.ActorOf(props);
+
+        await EventFilter.Info(
+            message: "SubAgent tool exposure core=1 deferredVisible=1 loaded=0")
+            .ExpectAsync(1, async () =>
+            {
+                await agent.Ask<SubAgentResult>(
+                    NewRun("Inspect /private/payload-marker.txt"),
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken);
+            }, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task Tool_dispatch_logs_a_tool_start_event_with_call_id()
     {
         var fakeTool = new FakeNetclawTool("greet", "Hello from tool!");

--- a/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
@@ -99,6 +99,23 @@ public class DiscoveredToolCacheTests
         Assert.Empty(cache.AvailableTools);
     }
 
+    [Fact]
+    public void AddIfMissing_deduplicates_source_generated_tool_declarations()
+    {
+        var registry = new ToolRegistry();
+        var tool = new LoadToolTool(
+            registry,
+            TestToolAccessPolicy.Create(new Netclaw.Configuration.ToolConfig()))
+            .ToAITool();
+        var cache = new DiscoveredToolCache();
+        cache.SeedBaseTools([tool]);
+
+        var added = cache.AddIfMissing(tool);
+
+        Assert.False(added);
+        Assert.Single(cache.AvailableTools);
+    }
+
     private static McpToolAdapter RegisterAndRemember(
         ToolRegistry registry,
         DiscoveredToolCache cache,

--- a/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
@@ -137,13 +137,15 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
-    /// Add a tool to the exposed list when no <see cref="AIFunction"/> with the
+    /// Add a tool to the exposed list when no <see cref="AIFunctionDeclaration"/> with the
     /// same name is already present. Returns <c>true</c> if it was added.
     /// </summary>
     public bool AddIfMissing(AITool aiTool)
     {
         if (_availableTools.Any(existing =>
-            existing is AIFunction ef && aiTool is AIFunction nf && ef.Name == nf.Name))
+            existing is AIFunctionDeclaration current
+            && aiTool is AIFunctionDeclaration added
+            && current.Name == added.Name))
         {
             return false;
         }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -78,7 +78,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     // `netclaw stats` instead of vanishing.
     private readonly Telemetry.ISessionMetrics? _sessionMetrics;
     private readonly ToolRegistry _toolRegistry;
+    private readonly DiscoveredToolCache _toolExposure = new();
+    private readonly HashSet<string> _loadedDeferredToolNames = new(StringComparer.Ordinal);
     private IReadOnlyList<AITool> _aiTools = [];
+    private int _coreToolCount;
     private ILoggingAdapter _log;
     private readonly MemoryPolicyEvaluator _policyEvaluator = new();
     private readonly TurnStateTracker _turnState = new();
@@ -172,7 +175,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             NullSystemPromptProvider.Instance,
             approvalService,
             maxToolIterations,
-            sessionMetrics)
+            sessionMetrics,
+            coreToolNames: null)
     {
     }
 
@@ -183,7 +187,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         ISystemPromptProvider promptProvider,
         IToolApprovalService? approvalService,
         int maxToolIterations,
-        Telemetry.ISessionMetrics? sessionMetrics)
+        Telemetry.ISessionMetrics? sessionMetrics,
+        IReadOnlySet<string>? coreToolNames)
     {
         if (maxToolIterations <= 0)
             throw new ArgumentOutOfRangeException(nameof(maxToolIterations), maxToolIterations,
@@ -203,17 +208,48 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _projectInstructions = definition.ProjectInstructions;
         _log = Context.GetLogger();
 
-        // Build a private ToolRegistry for this subagent's tool subset
         _toolRegistry = new ToolRegistry();
+        var hasSearchTools = false;
+        var searchToolsIsCore = false;
+        var hasLoadTool = false;
+        var loadToolIsCore = false;
         foreach (var tool in definition.Tools)
         {
             if (!SubAgentToolPolicy.IsAllowedForSubAgent(tool.Name))
                 continue;
 
-            _toolRegistry.Register(tool);
+            var isCore = coreToolNames is null || coreToolNames.Contains(tool.Name);
+            if (tool is SearchToolsTool)
+            {
+                hasSearchTools = true;
+                searchToolsIsCore = isCore;
+                continue;
+            }
+
+            if (tool is LoadToolTool)
+            {
+                hasLoadTool = true;
+                loadToolIsCore = isCore;
+                continue;
+            }
+
+            RegisterTool(tool, isCore);
         }
 
+        if (hasSearchTools)
+            RegisterTool(new SearchToolsTool(_toolRegistry, _toolAccessPolicy), searchToolsIsCore);
+        if (hasLoadTool)
+            RegisterTool(new LoadToolTool(_toolRegistry, _toolAccessPolicy), loadToolIsCore);
+
         Become(Idle);
+
+        void RegisterTool(INetclawTool tool, bool isCore)
+        {
+            if (isCore)
+                _toolRegistry.RegisterCore(tool);
+            else
+                _toolRegistry.Register(tool);
+        }
     }
 
     public static Props CreateProps(
@@ -240,7 +276,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         ISystemPromptProvider promptProvider,
         IToolApprovalService? approvalService = null,
         int maxToolIterations = DefaultMaxToolIterations,
-        Telemetry.ISessionMetrics? sessionMetrics = null)
+        Telemetry.ISessionMetrics? sessionMetrics = null,
+        IReadOnlySet<string>? coreToolNames = null)
     {
         ArgumentNullException.ThrowIfNull(promptProvider);
         return Props.CreateBy(new SubAgentActorProducer(
@@ -250,7 +287,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             promptProvider,
             approvalService,
             maxToolIterations,
-            sessionMetrics));
+            sessionMetrics,
+            coreToolNames));
     }
 
     private sealed class SubAgentActorProducer(
@@ -260,7 +298,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         ISystemPromptProvider promptProvider,
         IToolApprovalService? approvalService,
         int maxToolIterations,
-        Telemetry.ISessionMetrics? sessionMetrics) : IIndirectActorProducer
+        Telemetry.ISessionMetrics? sessionMetrics,
+        IReadOnlySet<string>? coreToolNames) : IIndirectActorProducer
     {
         public Type ActorType => typeof(SubAgentActor);
 
@@ -272,7 +311,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 promptProvider,
                 approvalService,
                 maxToolIterations,
-                sessionMetrics);
+                sessionMetrics,
+                coreToolNames);
 
         public void Release(ActorBase actor)
         {
@@ -305,6 +345,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _executionCts?.Dispose();
         _externalCts?.Dispose();
         _externalCancellationRegistration.Dispose();
+        _toolExposure.EvictAll();
+        _loadedDeferredToolNames.Clear();
         base.PostStop();
     }
 
@@ -323,7 +365,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 msg.Scope.Authority,
                 ToolExecutionTimeout.Default);
             _fileActivity = new ChildFileActivityTracker(msg.Scope.InitialWorkingSnapshot.WorkingContext);
-            _aiTools = ResolveExposedAiTools();
+            var coreTools = ResolveCoreAiTools();
+            _toolExposure.SeedBaseTools(coreTools);
+            _aiTools = _toolExposure.AvailableTools;
+            _coreToolCount = coreTools.Count;
             _executionCts = new CancellationTokenSource();
             _externalCts = new CancellationTokenSource();
             var self = Self; // Capture before callback — Self requires active actor context
@@ -382,6 +427,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _log.Info("SubAgent [{AgentName}] starting (tools={ToolCount}, prefill={Prefill}, interDelta={InterDelta}, noProgress={NoProgress})",
                 _definition.Name, _aiTools.Count, _prefillBudget, _interDeltaBudget,
                 _noProgressBudget?.ToString() ?? "unbounded");
+            LogToolExposure();
 
             FireLlmCall();
             Become(Processing);
@@ -519,6 +565,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 if (result.ToolCallId is { } callId)
                     _fileActivity.Complete(callId.Value, result.Content);
                 TryApplyProjectDirectory(result);
+                if (result.Name is "load_tool" && result.Content is not null)
+                    TryActivateDiscoveredTool(result.Content.Trim());
                 var preview = result.Content is { Length: > 200 }
                     ? result.Content[..200] + "..."
                     : result.Content ?? "(null)";
@@ -578,6 +626,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         Receive<LlmCallFailed>(msg =>
         {
+            _toolExposure.EvictAll();
+            _loadedDeferredToolNames.Clear();
             _log.Error(msg.Cause, "SubAgent [{AgentName}] LLM call failed callId={CallId}", _definition.Name, msg.CallId);
             Complete(false, $"LLM call failed: {msg.Cause.Message}", SubAgentRunOutcome.Failed, SubAgentOutcomeReason.LlmCallFailed);
         });
@@ -827,13 +877,50 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         _ = InvokeLlmAsync(client, messages, options, self, callId, _executionCts?.Token ?? CancellationToken.None);
     }
 
-    private IReadOnlyList<AITool> ResolveExposedAiTools()
+    private IReadOnlyList<AITool> ResolveCoreAiTools()
     {
-        var tools = _toolRegistry.GetAllRegistrations().Select(r => r.Tool);
+        var tools = _toolRegistry.GetCoreRegistrations().Select(static registration => registration.Tool);
         return _toolAccessPolicy
             .FilterDiscoverableTools(tools, ToolExecutionContext.Invocation)
             .Select(tool => tool.ToAITool())
             .ToList();
+    }
+
+    private bool TryActivateDiscoveredTool(string toolName)
+    {
+        var registration = _toolRegistry.GetRegistrationByToolName(toolName);
+        if (registration is null
+            || !SubAgentToolPolicy.IsAllowedForSubAgent(registration.Tool.Name)
+            || !_toolAccessPolicy.IsToolExposed(registration.Tool, ToolExecutionContext.Invocation))
+        {
+            return false;
+        }
+
+        var tool = registration.Tool;
+        if (_toolRegistry.IsCoreTool(tool.Name))
+            return true;
+
+        if (_toolExposure.AddIfMissing(tool.ToAITool()))
+        {
+            _loadedDeferredToolNames.Add(tool.Name);
+            _log.Info(
+                "SubAgent deferred tool activated loaded={LoadedCount}",
+                _loadedDeferredToolNames.Count);
+        }
+
+        return true;
+    }
+
+    private void LogToolExposure()
+    {
+        var visibleCount = _toolAccessPolicy.FilterDiscoverableTools(
+            _toolRegistry.GetAllRegistrations().Select(static registration => registration.Tool),
+            ToolExecutionContext.Invocation).Count;
+        _log.Info(
+            "SubAgent tool exposure core={CoreCount} deferredVisible={DeferredVisibleCount} loaded={LoadedCount}",
+            _coreToolCount,
+            Math.Max(0, visibleCount - _coreToolCount),
+            _loadedDeferredToolNames.Count);
     }
 
     private bool CanDeclareProjectScope() =>
@@ -1567,7 +1654,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         IReadOnlyList<SerializableMediaReference> ModelInputMediaReferences,
         SessionScratchCorrectionChange? ScratchCorrectionChange);
 
-    private static string BuildSystemPrompt(
+    private string BuildSystemPrompt(
         SubAgentDefinition definition,
         string? projectInstructions,
         bool canDeclareProjectScope)
@@ -1583,6 +1670,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         var rolePrompt = string.IsNullOrWhiteSpace(basePrompt)
             ? definition.SystemPrompt
             : string.Concat(basePrompt.TrimEnd(), "\n\n", definition.SystemPrompt);
+        var toolIndex = _toolRegistry.GenerateCompressedIndex(
+            ToolExecutionContext.Audience,
+            _toolAccessPolicy);
+        var roleWithTools = string.IsNullOrWhiteSpace(toolIndex)
+            ? rolePrompt
+            : string.Concat(rolePrompt.TrimEnd(), "\n\n", toolIndex.TrimEnd());
 
         // Append the headless execution and precedence contract — always at the bottom,
         // after the specialized role prompt it protects from inherited mission conflicts.
@@ -1590,7 +1683,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             ? string.Concat(ProjectScopeDeclarationContract, "\n")
             : string.Empty;
         return string.Concat(
-            rolePrompt.TrimEnd(),
+            roleWithTools.TrimEnd(),
             "\n\n",
             HeadlessExecutionContractPrefix,
             projectScopeContract,

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawnBreadcrumbs.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawnBreadcrumbs.cs
@@ -76,17 +76,6 @@ internal static class SubAgentSpawnBreadcrumbs
                 agentName, runId.Value);
     }
 
-    public static void ToolDenied(ILogger? logger, ToolInvocationContext context, string agentName, string toolName)
-    {
-        // INFO so tool denials are visible in production: a sub-agent missing a tool may be unable
-        // to finish its task. Routed via the SessionId scope like every other breadcrumb (no
-        // hand-rolled (session=…) field), so it lands in the session.log without string drift.
-        using (BeginSessionScope(logger, context.SessionId))
-            logger?.LogInformation(
-                "SubAgent [{AgentName}] tool '{ToolName}' denied by SubAgentToolPolicy",
-                agentName, toolName);
-    }
-
     public static void SpawnRefused(ILogger? logger, ToolInvocationContext context, string agentName, TrustAudience audience, bool subsystemEnabled)
     {
         using (BeginSessionScope(logger, context.SessionId))

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -99,8 +99,8 @@ public sealed class SubAgentSpawner
             };
         }
 
-        var tools = ResolveTools(profile, context);
-        if (tools.Count == 0)
+        var exposure = ResolveTools(context);
+        if (exposure.Tools.Count == 0)
         {
             SubAgentSpawnBreadcrumbs.NoToolsAvailable(_logger, context, profile.Name);
             activitySink?.TryComplete();
@@ -116,7 +116,7 @@ public sealed class SubAgentSpawner
         {
             Name = new AgentName(profile.Name),
             SystemPrompt = AppendSystemPromptOverlay(profile.SystemPrompt, systemPromptOverlay),
-            Tools = tools,
+            Tools = exposure.Tools,
             ModelRole = profile.ModelRole,
             EmitStructuredFindings = profile.EmitStructuredFindings,
             ProjectInstructions = ResolveProjectInstructions(context),
@@ -200,7 +200,7 @@ public sealed class SubAgentSpawner
             RunId = runId,
             AgentName = definition.Name.Value,
             IsStarted = true,
-            ToolCount = tools.Count
+            ToolCount = exposure.Tools.Count
         });
 
         // Spawn as child of the session actor via the context factory
@@ -211,7 +211,8 @@ public sealed class SubAgentSpawner
             _promptProvider,
             _approvalService,
             SubAgentMaxToolIterations,
-            _sessionMetrics);
+            _sessionMetrics,
+            exposure.CoreToolNames);
         var actorName = $"subagent-{definition.Name}-{runId}";
         IActorRef subAgent;
         try
@@ -455,27 +456,26 @@ public sealed class SubAgentSpawner
     private static GitWorkingContextSnapshot? AvailableSnapshot(GitWorkingContextInspection inspection)
         => inspection is GitWorkingContextInspection.Available available ? available.Snapshot : null;
 
-    private IReadOnlyList<INetclawTool> ResolveTools(SubAgentProfile profile, ToolInvocationContext context)
+    private ResolvedSubAgentTools ResolveTools(ToolInvocationContext context)
     {
         // Sub-agents inherit the parent session's runtime tool policy. Agent
         // definition tool metadata is advisory only; the only static
         // sub-agent-specific filter denies recursive spawn_agent delegation.
-        var candidates = _toolRegistry.GetAllRegistrations().Select(r => r.Tool);
-        var tools = new List<INetclawTool>();
-        foreach (var tool in candidates)
-        {
-            if (SubAgentToolPolicy.IsAllowedForSubAgent(tool.Name))
-            {
-                tools.Add(tool);
-            }
-            else
-            {
-                SubAgentSpawnBreadcrumbs.ToolDenied(_logger, context, profile.Name, tool.Name);
-            }
-        }
+        var tools = _toolRegistry.GetAllRegistrations()
+            .Select(static registration => registration.Tool)
+            .Where(static tool => SubAgentToolPolicy.IsAllowedForSubAgent(tool.Name));
 
-        return _toolAccessPolicy.FilterDiscoverableTools(tools, context);
+        var visible = _toolAccessPolicy.FilterDiscoverableTools(tools, context);
+        var coreToolNames = visible
+            .Where(tool => _toolRegistry.IsCoreTool(tool.Name))
+            .Select(static tool => tool.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        return new ResolvedSubAgentTools(visible, coreToolNames);
     }
+
+    private sealed record ResolvedSubAgentTools(
+        IReadOnlyList<INetclawTool> Tools,
+        IReadOnlySet<string> CoreToolNames);
 
     private static void TryStopSubAgent(IActorRef subAgent)
     {

--- a/src/Netclaw.Actors/Tools/LoadToolTool.cs
+++ b/src/Netclaw.Actors/Tools/LoadToolTool.cs
@@ -11,8 +11,8 @@ namespace Netclaw.Actors.Tools;
 /// <summary>
 /// Activates a deferred first-party or MCP tool by name so the LLM can call it.
 /// Tools must first be found via <see cref="SearchToolsTool"/> before loading.
-/// The session actor intercepts this tool by name and reads the tool call
-/// arguments to activate the requested tool — the output is LLM-facing only.
+/// The owning actor intercepts successful results and activates the requested
+/// tool in its private exposure set.
 /// </summary>
 [NetclawTool("load_tool",
     "Activate a tool by name so you can call it. Use search_tools first to find tool names, then load_tool to activate one.",

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -40,7 +40,7 @@ public sealed class ToolRegistry
         public static RegistrySnapshot Empty { get; } = new([], []);
 
         public static RegistrySnapshot Create(RegistryEntry[] entries) =>
-            new(entries, [..entries.Select(static entry => entry.Registration)]);
+            new(entries, [.. entries.Select(static entry => entry.Registration)]);
     }
 
     // Copy-on-write. Registrations change at startup, at MCP reconnect, and at shutdown.
@@ -216,6 +216,20 @@ public sealed class ToolRegistry
             .Where(static entry => entry.ExposureTier == ToolExposureTier.Core)
             .Select(static entry => entry.Registration.Tool.ToAITool())
             .ToList();
+
+    internal IReadOnlyList<ToolRegistration> GetCoreRegistrations() =>
+        GetEntriesSnapshot()
+            .Where(static entry => entry.ExposureTier == ToolExposureTier.Core)
+            .Select(static entry => entry.Registration)
+            .ToList();
+
+    internal bool IsCoreTool(string canonicalName) =>
+        GetEntriesSnapshot().Any(entry =>
+            entry.ExposureTier == ToolExposureTier.Core
+            && string.Equals(
+                entry.Registration.Tool.Name,
+                canonicalName,
+                StringComparison.Ordinal));
 
     /// <summary>
     /// Returns tools that should always be loaded into the LLM context.


### PR DESCRIPTION
## Summary

- Seed child model requests from policy-visible Core tools.
- Bind search and load to each child private registry.
- Keep loaded deferred tools local to one child run.
- Exclude recursive delegation from child catalog and dispatch paths.
- Add count-only exposure diagnostics and deterministic lifecycle tests.

## Stack

This PR depends on #2021. Merge the stack in order.

## Deterministic evaluation evidence

- A child starts from the same policy-visible Core set as its parent, excluding recursive delegation.
- Against the fixed 200-tool synthetic catalog, the child initial footprint is lower than the frozen 202-definition, 133,816-byte baseline.
- Exact search, fuzzy suggestion, load, and direct dispatch cannot reveal or invoke recursive delegation or hidden tools.
- Loading one Deferred tool affects only that child run; a fresh child and a post-failure child do not inherit it.
- The exposure diagnostic contains counts only and omits names, paths, arguments, prompts, and schema bodies.
- No hosted behavioral run was used as evidence for this PR.

## Validation

- Netclaw.Actors.Tests: 3,466 passed; one expected Windows-only skip.
- Focused post-rebase tests: 26 passed.
- Strict OpenSpec validation passed.
- Copyright header validation passed.
- Changed-file formatting passed.
- Slopwatch reported zero issues.
- Diff and BOM checks passed.
