### PR TITLE
Make workspace tool outcomes authoritative

### DIFF
--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -25,13 +25,13 @@
 
 ## 4. PR 4 - Workspace path and outcome foundation
 
-- [ ] 4.1 Add one shared relative-path resolver using valid project directory then immutable session directory, never process cwd.
-- [ ] 4.2 Route existing first-party read, list, write, edit, and attach paths through the shared resolver before their existing scoped policies.
-- [ ] 4.3 Add the call-local typed outcome receipt and central exception/policy classifications without changing public INetclawTool signatures.
-- [ ] 4.4 Convert first-party workspace tools to report exact success, invalid-input, denial, not-found, transient, or correction outcomes.
-- [ ] 4.5 Replace argument-based RecentFiles inference for workspace tools with canonical successful file activity from the receipt.
-- [ ] 4.6 Prove failed file operations and failed set_working_directory calls cannot change RecentFiles, project scope, or project instructions.
-- [ ] 4.7 Add POSIX and native-Windows tests for relative paths, traversal, missing bases, symlinks, protected paths, and absolute-path compatibility.
+- [x] 4.1 Add one shared relative-path resolver using valid project directory then immutable session directory, never process cwd.
+- [x] 4.2 Route existing first-party read, list, write, edit, and attach paths through the shared resolver before their existing scoped policies.
+- [x] 4.3 Add the call-local typed outcome receipt and central exception/policy classifications without changing public INetclawTool signatures.
+- [x] 4.4 Convert first-party workspace tools to report exact success, invalid-input, denial, not-found, transient, or correction outcomes.
+- [x] 4.5 Replace argument-based RecentFiles inference for workspace tools with canonical successful file activity from the receipt.
+- [x] 4.6 Prove failed file operations and failed set_working_directory calls cannot change RecentFiles, project scope, or project instructions.
+- [x] 4.7 Add POSIX and native-Windows tests for relative paths, traversal, missing bases, symlinks, protected paths, and absolute-path compatibility.
 
 ## 5. PR 5 - Structured workspace primitives
 

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -764,6 +764,10 @@ public class CompactionIntegrationTests : LlmSessionTestBase
                 new Dictionary<string, object?> { ["Path"] = "src/Rect.cs" })
         ];
         _fakeToolExecutor.Results["file_read"] = "public readonly record struct Rect { ... }";
+        var canonicalPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "src", "Rect.cs"));
+        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.Success,
+            [new ToolFileActivity(canonicalPath, ToolFileActivityKind.Read)]);
         _fakeChatClient.UsageOverride = new UsageDetails
         {
             InputTokenCount = 100,
@@ -856,10 +860,10 @@ public class CompactionIntegrationTests : LlmSessionTestBase
 
         var hasWorkingContextBlock = allContent.Any(s =>
             s.Contains("[working-context]", StringComparison.Ordinal)
-            && s.Contains("src/Rect.cs", StringComparison.Ordinal));
+            && s.Contains(canonicalPath, StringComparison.Ordinal));
 
         Assert.True(hasWorkingContextBlock,
-            $"Expected the post-compaction LLM call to include a [working-context] block mentioning src/Rect.cs. All messages:\n{string.Join("\n---\n", allContent)}");
+            $"Expected the post-compaction LLM call to include a [working-context] block mentioning the canonical file. All messages:\n{string.Join("\n---\n", allContent)}");
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -58,6 +58,9 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         registry.Register(
             AIFunctionFactory.Create((string path) => $"contents of {path}", "file_read"),
             "file_read");
+        registry.Register(
+            AIFunctionFactory.Create((string path) => path, "set_working_directory"),
+            "file");
         services.AddSingleton(registry);
     }
 
@@ -272,12 +275,16 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         // and the LLM emits `{"Path": "..."}`. A lowercase "path" here
         // would hide the real-world bug where WorkingContextUpdater's
         // field-name probe misses PascalCase arguments.
+        var canonicalPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "src", "Rect.cs"));
         _fakeChatClient.ToolCallsOnFirstCall =
         [
             new FunctionCallContent("call-1", "file_read",
                 new Dictionary<string, object?> { ["Path"] = "src/Rect.cs" })
         ];
         _fakeToolExecutor.Results["file_read"] = "public readonly record struct Rect { ... }";
+        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.Success,
+            [new ToolFileActivity(canonicalPath, ToolFileActivityKind.Read)]);
 
         var sessionId = new SessionId("console/working-context-populated");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
@@ -325,10 +332,89 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
 
         var hasWorkingContextBlock = allContent.Any(s =>
             s.Contains("[working-context]", StringComparison.Ordinal)
-            && s.Contains("src/Rect.cs", StringComparison.Ordinal));
+            && s.Contains(canonicalPath, StringComparison.Ordinal));
 
         Assert.True(hasWorkingContextBlock,
-            $"Expected turn 2's first LLM call to include a [working-context] block mentioning src/Rect.cs. All messages:\n{string.Join("\n---\n", allContent)}");
+            $"Expected turn 2's first LLM call to include a [working-context] block mentioning the canonical file. All messages:\n{string.Join("\n---\n", allContent)}");
+    }
+
+    [Fact]
+    public async Task Failed_project_declaration_cannot_change_scope_from_successful_looking_text()
+    {
+        var deniedPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "denied-project"));
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-cwd",
+                "set_working_directory",
+                new Dictionary<string, object?> { ["Path"] = deniedPath })
+        ];
+        _fakeToolExecutor.Results["set_working_directory"] = deniedPath;
+        _fakeToolExecutor.Receipts["set_working_directory"] =
+            new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied);
+
+        var nextTurn = await RunToolTurnAndCaptureNextTurnAsync("failed-project-declaration");
+
+        Assert.DoesNotContain(deniedPath, nextTurn, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Successful_project_declaration_uses_receipt_not_presentation_text()
+    {
+        var declaredPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "declared-project"));
+        var misleadingPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "misleading-result"));
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-cwd",
+                "set_working_directory",
+                new Dictionary<string, object?> { ["Path"] = declaredPath })
+        ];
+        _fakeToolExecutor.Results["set_working_directory"] = misleadingPath;
+        _fakeToolExecutor.Receipts["set_working_directory"] = new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.Success,
+            declaredProjectDirectory: declaredPath);
+
+        var nextTurn = await RunToolTurnAndCaptureNextTurnAsync("successful-project-declaration");
+
+        Assert.Contains(declaredPath, nextTurn, StringComparison.Ordinal);
+        Assert.DoesNotContain(misleadingPath, nextTurn, StringComparison.Ordinal);
+    }
+
+    private async Task<string> RunToolTurnAndCaptureNextTurnAsync(string sessionSuffix)
+    {
+        var sessionId = new SessionId($"console/{sessionSuffix}");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe($"{sessionSuffix}-subscriber");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "select the project"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        var previousCalls = _fakeChatClient.ReceivedMessages.Count;
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "what is the project?"
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        return string.Join(
+            "\n",
+            _fakeChatClient.ReceivedMessages[previousCalls].Select(message => message.Text ?? string.Empty));
     }
 }
 
@@ -343,6 +429,8 @@ internal sealed class FakeToolExecutor : IToolExecutor
 
     /// <summary>Tool name → result string.</summary>
     public Dictionary<string, string> Results { get; } = [];
+
+    public Dictionary<string, ToolInvocationReceipt> Receipts { get; } = [];
 
     /// <summary>Tool names that should throw on execution.</summary>
     public HashSet<string> FailForTools { get; } = [];
@@ -365,6 +453,8 @@ internal sealed class FakeToolExecutor : IToolExecutor
         }
 
         var result = Results.GetValueOrDefault(toolCall.Name, $"[fake result for {toolCall.Name}]");
+        if (Receipts.TryGetValue(toolCall.Name, out var receipt))
+            context.Outputs.TryComplete(receipt);
         // Mirror DispatchingToolExecutor's post-processing so integration tests see
         // the same redact + inline-bound + spill the real executor applies. The fake
         // has no tool instance, so it uses the session content budget (per-tool

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
+using Netclaw.Tools;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Sessions;
@@ -12,235 +13,103 @@ namespace Netclaw.Actors.Tests.Sessions;
 public class WorkingContextUpdaterTests
 {
     [Fact]
-    public void TryExtractFilePath_returns_path_from_path_field()
+    public void Successful_receipts_apply_canonical_activity_in_result_order()
     {
-        var ok = WorkingContextUpdater.TryExtractFilePath(
-            """{"path":"src/Rect.cs"}""", out var path);
+        var first = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "receipt-first.txt"));
+        var second = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "receipt-second.txt"));
+        var results = new[]
+        {
+            Result("call-1", "file_read", "presentation is irrelevant"),
+            Result("call-2", "file_edit", "Error-looking presentation is still not authority"),
+            Result("call-3", "file_read", "same file again")
+        };
+        var receipts = new Dictionary<string, ToolInvocationReceipt>(StringComparer.Ordinal)
+        {
+            ["call-1"] = Success(first, ToolFileActivityKind.Read),
+            ["call-2"] = Success(second, ToolFileActivityKind.Changed),
+            ["call-3"] = Success(first, ToolFileActivityKind.Read)
+        };
 
-        Assert.True(ok);
-        Assert.Equal("src/Rect.cs", path);
-    }
+        var updated = WorkingContextUpdater.UpdateFromToolReceipts(
+            WorkingContext.Empty,
+            results,
+            receipts);
 
-    [Fact]
-    public void TryExtractFilePath_returns_path_from_file_path_field()
-    {
-        var ok = WorkingContextUpdater.TryExtractFilePath(
-            """{"file_path":"src/Rect.cs","mode":"r"}""", out var path);
-
-        Assert.True(ok);
-        Assert.Equal("src/Rect.cs", path);
-    }
-
-    [Fact]
-    public void TryExtractFilePath_returns_path_from_camelCase_filePath_field()
-    {
-        var ok = WorkingContextUpdater.TryExtractFilePath(
-            """{"filePath":"src/Rect.cs"}""", out var path);
-
-        Assert.True(ok);
-        Assert.Equal("src/Rect.cs", path);
+        Assert.Equal([first, second], updated.RecentFiles);
     }
 
     [Theory]
-    [InlineData("Path")]
-    [InlineData("FilePath")]
-    [InlineData("File")]
-    [InlineData("FileName")]
-    public void TryExtractFilePath_returns_path_from_PascalCase_field(string fieldName)
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void Failed_or_corrective_receipts_cannot_add_recent_files(int categoryValue)
     {
-        // First-party Netclaw tools (FileReadTool, FileWriteTool, FileEditTool)
-        // use PascalCase parameter names via C# records — NetclawToolGenerator
-        // emits the schema with those names verbatim, so real arguments are
-        // keyed as `{"Path": "..."}`. Missing PascalCase variants would make
-        // WorkingContext a no-op for first-party tools.
-        var json = $$"""{"{{fieldName}}":"src/Rect.cs"}""";
+        var category = (ToolInvocationOutcomeCategory)categoryValue;
+        var result = Result("call-1", "file_read", "successful-looking presentation");
+        var receipt = category == ToolInvocationOutcomeCategory.RecoverableCorrection
+            ? new ToolInvocationReceipt(category, remediationCode: "set_working_directory")
+            : new ToolInvocationReceipt(category);
 
-        var ok = WorkingContextUpdater.TryExtractFilePath(json, out var path);
-
-        Assert.True(ok);
-        Assert.Equal("src/Rect.cs", path);
-    }
-
-    [Fact]
-    public void TryExtractFilePath_returns_false_when_no_path_field_present()
-    {
-        var ok = WorkingContextUpdater.TryExtractFilePath(
-            """{"query":"Rect"}""", out var path);
-
-        Assert.False(ok);
-        Assert.Empty(path);
-    }
-
-    [Fact]
-    public void TryExtractFilePath_returns_false_for_empty_or_null_arguments()
-    {
-        Assert.False(WorkingContextUpdater.TryExtractFilePath(null, out _));
-        Assert.False(WorkingContextUpdater.TryExtractFilePath("", out _));
-        Assert.False(WorkingContextUpdater.TryExtractFilePath("{}", out _));
-    }
-
-    [Fact]
-    public void TryExtractFilePath_returns_false_on_malformed_json()
-    {
-        Assert.False(WorkingContextUpdater.TryExtractFilePath("not valid json", out _));
-        Assert.False(WorkingContextUpdater.TryExtractFilePath("""{"unterminated":""", out _));
-    }
-
-    [Fact]
-    public void UpdateFromToolResults_pushes_path_for_file_read_tool()
-    {
-        var history = new List<SerializableChatMessage>
-        {
-            new()
+        var updated = WorkingContextUpdater.UpdateFromToolReceipts(
+            WorkingContext.Empty,
+            [result],
+            new Dictionary<string, ToolInvocationReceipt>(StringComparer.Ordinal)
             {
-                Role = ChatRole.User,
-                Content = "Read Rect.cs"
-            },
-            new()
-            {
-                Role = ChatRole.Assistant,
-                Content = string.Empty,
-                ToolCalls =
-                [
-                    new SerializableToolCall
-                    {
-                        CallId = new Netclaw.Tools.ToolCallId("call-1"),
-                        Name = new Netclaw.Tools.ToolName("file_read"),
-                        ArgumentsJson = """{"path":"src/Rect.cs"}"""
-                    }
-                ]
-            }
-        };
-
-        var results = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Tool,
-                Name = "file_read",
-                ToolCallId = new Netclaw.Tools.ToolCallId("call-1"),
-                Content = "file contents..."
-            }
-        };
-
-        var updated = WorkingContextUpdater.UpdateFromToolResults(
-            WorkingContext.Empty, history, results);
-
-        Assert.Equal(new[] { "src/Rect.cs" }, updated.RecentFiles);
-    }
-
-    [Fact]
-    public void UpdateFromToolResults_ignores_tools_without_path_arguments()
-    {
-        // shell_execute's args contain `command` but no `path`/`file_path`/
-        // etc. — the field-name probe returns no match, so the tool is
-        // silently skipped. This works for any tool whose arguments don't
-        // look file-path-shaped, regardless of tool name.
-        var history = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Assistant,
-                Content = string.Empty,
-                ToolCalls =
-                [
-                    new SerializableToolCall
-                    {
-                        CallId = new Netclaw.Tools.ToolCallId("call-shell"),
-                        Name = new Netclaw.Tools.ToolName("shell_execute"),
-                        ArgumentsJson = """{"command":"ls"}"""
-                    }
-                ]
-            }
-        };
-
-        var results = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Tool,
-                Name = "shell_execute",
-                ToolCallId = new Netclaw.Tools.ToolCallId("call-shell"),
-                Content = "a.txt b.txt"
-            }
-        };
-
-        var updated = WorkingContextUpdater.UpdateFromToolResults(
-            WorkingContext.Empty, history, results);
+                ["call-1"] = receipt
+            });
 
         Assert.Empty(updated.RecentFiles);
     }
 
     [Fact]
-    public void UpdateFromToolResults_ignores_results_without_matching_call()
+    public void Missing_receipt_cannot_claim_activity_from_arguments_or_result()
     {
-        var history = new List<SerializableChatMessage>();  // empty history
+        var updated = WorkingContextUpdater.UpdateFromToolReceipts(
+            WorkingContext.Empty,
+            [Result("call-1", "mcp_file_tool", "Successfully wrote /outside/file.txt")],
+            new Dictionary<string, ToolInvocationReceipt>(StringComparer.Ordinal));
 
-        var results = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Tool,
-                Name = "file_read",
-                ToolCallId = new Netclaw.Tools.ToolCallId("call-orphan"),
-                Content = "..."
-            }
-        };
-
-        var updated = WorkingContextUpdater.UpdateFromToolResults(
-            WorkingContext.Empty, history, results);
-
-        // Orphan tool result (no matching call in history) — nothing updated
         Assert.Empty(updated.RecentFiles);
     }
 
     [Fact]
-    public void UpdateFromToolResults_dedupes_across_multiple_reads_of_same_file()
+    public void Receipt_is_terminal_and_cannot_be_replaced()
     {
-        var history = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Assistant,
-                Content = string.Empty,
-                ToolCalls =
-                [
-                    new SerializableToolCall
-                    {
-                        CallId = new Netclaw.Tools.ToolCallId("call-1"),
-                        Name = new Netclaw.Tools.ToolName("file_read"),
-                        ArgumentsJson = """{"path":"src/Rect.cs"}"""
-                    },
-                    new SerializableToolCall
-                    {
-                        CallId = new Netclaw.Tools.ToolCallId("call-2"),
-                        Name = new Netclaw.Tools.ToolName("file_read"),
-                        ArgumentsJson = """{"path":"src/Thickness.cs"}"""
-                    },
-                    new SerializableToolCall
-                    {
-                        CallId = new Netclaw.Tools.ToolCallId("call-3"),
-                        Name = new Netclaw.Tools.ToolName("file_read"),
-                        ArgumentsJson = """{"path":"src/Rect.cs"}"""
-                    }
-                ]
-            }
-        };
+        var outputs = new ToolExecutionOutputs();
 
-        var results = new List<SerializableChatMessage>
-        {
-            new() { Role = ChatRole.Tool, Name = "file_read", ToolCallId = new Netclaw.Tools.ToolCallId("call-1"), Content = "..." },
-            new() { Role = ChatRole.Tool, Name = "file_read", ToolCallId = new Netclaw.Tools.ToolCallId("call-2"), Content = "..." },
-            new() { Role = ChatRole.Tool, Name = "file_read", ToolCallId = new Netclaw.Tools.ToolCallId("call-3"), Content = "..." }
-        };
-
-        var updated = WorkingContextUpdater.UpdateFromToolResults(
-            WorkingContext.Empty, history, results);
-
-        // call-3 re-reads Rect.cs, moving it back to front. Dedupe means
-        // only one entry for Rect.cs.
-        Assert.Equal(2, updated.RecentFiles.Count);
-        Assert.Equal("src/Rect.cs", updated.RecentFiles[0]);
-        Assert.Equal("src/Thickness.cs", updated.RecentFiles[1]);
+        Assert.True(outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied)));
+        Assert.False(outputs.TryComplete(Success(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "late.txt")),
+            ToolFileActivityKind.Read)));
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, outputs.Receipt?.Category);
+        Assert.Empty(outputs.Receipt?.FileActivity ?? []);
     }
+
+    [Fact]
+    public void Non_success_receipt_rejects_file_activity()
+    {
+        var path = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "invalid.txt"));
+
+        var exception = Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.AccessDenied,
+            [new ToolFileActivity(path, ToolFileActivityKind.Read)]));
+
+        Assert.Contains("successful", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ToolInvocationReceipt Success(string path, ToolFileActivityKind kind)
+        => new(
+            ToolInvocationOutcomeCategory.Success,
+            [new ToolFileActivity(path, kind)]);
+
+    private static SerializableChatMessage Result(string callId, string name, string content)
+        => new()
+        {
+            Role = ChatRole.Tool,
+            Name = name,
+            ToolCallId = new ToolCallId(callId),
+            Content = content
+        };
 }

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -2030,7 +2030,13 @@ public class SubAgentActorTests : TestKit
     [Fact]
     public async Task Successful_first_party_edit_is_returned_as_confirmed_child_activity()
     {
-        var editTool = new FakeNetclawTool("file_edit", "Successfully edited src/Calculator.cs: replaced 1 occurrence(s)");
+        var changedPath = Path.GetFullPath(Path.Join(MissingProjectDirectory, "src", "Calculator.cs"));
+        var editTool = new FakeNetclawTool(
+            "file_edit",
+            "Successfully edited src/Calculator.cs: replaced 1 occurrence(s)",
+            onExecute: context => context.TryComplete(new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.Success,
+                [new ToolFileActivity(changedPath, ToolFileActivityKind.Changed)])));
         var fakeClient = new FakeChatClient
         {
             ToolCallsOnFirstCall =
@@ -2052,16 +2058,18 @@ public class SubAgentActorTests : TestKit
 
         Assert.True(result.Success);
         Assert.NotNull(result.WorkingContext);
-        Assert.Equal(
-            Path.GetFullPath(Path.Join(MissingProjectDirectory, "src", "Calculator.cs")),
-            Assert.Single(result.WorkingContext.ConfirmedChangedFiles));
+        Assert.Equal(changedPath, Assert.Single(result.WorkingContext.ConfirmedChangedFiles));
         Assert.Empty(result.WorkingContext.ObservedChangedFiles);
     }
 
     [Fact]
     public async Task Denied_first_party_edit_is_not_returned_as_confirmed_child_activity()
     {
-        var editTool = new FakeNetclawTool("file_edit", "Error: Permission denied: src/Calculator.cs");
+        var editTool = new FakeNetclawTool(
+            "file_edit",
+            "Error: Permission denied: src/Calculator.cs",
+            onExecute: context => context.TryComplete(
+                new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied)));
         var fakeClient = new FakeChatClient
         {
             ToolCallsOnFirstCall =

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -22,6 +22,9 @@ namespace Netclaw.Actors.Tests.Tools;
 /// </summary>
 public sealed class AutonomousZoneClampTests : IDisposable
 {
+    public static bool IsWindows => OperatingSystem.IsWindows();
+    public static bool IsPosix => !OperatingSystem.IsWindows();
+
     private readonly DisposableTempDir _dir = new();
     private readonly string _sessionDir;
     private readonly string _projectDir;
@@ -189,5 +192,179 @@ public sealed class AutonomousZoneClampTests : IDisposable
         });
 
         Assert.False(policy.TryResolveWritePath(Path.Join(_outsideDir, "x.txt"), ctx.Invocation, out _, out _));
+    }
+
+    [Fact]
+    public void Relative_path_uses_existing_project_directory()
+    {
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var context = Ctx(TrustAudience.Personal, autonomous: false);
+
+        Assert.True(policy.TryResolveReadPath(
+            Path.Join("src", "App.cs"),
+            context,
+            out var resolved,
+            out var error,
+            out var failure), error);
+        Assert.Equal(Path.GetFullPath(Path.Join(_projectDir, "src", "App.cs")), resolved);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.None, failure);
+    }
+
+    [Fact]
+    public void Relative_path_falls_back_to_session_when_project_is_stale()
+    {
+        var missingProject = Path.Join(_dir.Path, "moved-project");
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/stale-project",
+            _sessionDir,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true),
+                ProjectDirectory = missingProject
+            });
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+
+        Assert.True(policy.TryResolveWritePath(
+            "notes/result.md",
+            context.Invocation,
+            out var resolved,
+            out var error,
+            out var failure), error);
+        Assert.Equal(Path.GetFullPath(Path.Join(_sessionDir, "notes", "result.md")), resolved);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.None, failure);
+    }
+
+    [Fact]
+    public void Relative_path_without_project_or_session_returns_correction()
+    {
+        var context = TestToolExecutionContext.CreateUnbound(new TestToolExecutionContextOptions
+        {
+            Audience = TrustAudience.Personal,
+            InheritedCwd = _projectDir
+        });
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+
+        Assert.False(policy.TryResolveReadPath(
+            "src/App.cs",
+            context.Invocation,
+            out var resolved,
+            out var error,
+            out var failure));
+        Assert.Empty(resolved);
+        Assert.Contains("invalid_context", error, StringComparison.Ordinal);
+        Assert.Contains("set_working_directory", error, StringComparison.Ordinal);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.MissingBase, failure);
+    }
+
+    [Fact]
+    public void Relative_traversal_is_canonicalized_before_scope_denial()
+    {
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var context = Ctx(TrustAudience.Public, autonomous: true, withProject: false);
+
+        Assert.False(policy.TryResolveReadPath(
+            Path.Join("..", "outside.txt"),
+            context,
+            out var resolved,
+            out _,
+            out var failure));
+        Assert.Equal(Path.GetFullPath(Path.Join(_sessionDir, "..", "outside.txt")), resolved);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.AccessDenied, failure);
+    }
+
+    [Fact]
+    public void Absolute_path_retains_existing_resolution()
+    {
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var context = Ctx(TrustAudience.Personal, autonomous: false);
+        var absolute = Path.GetFullPath(Path.Join(_outsideDir, "file.txt"));
+
+        Assert.True(policy.TryResolveReadPath(
+            absolute,
+            context,
+            out var resolved,
+            out var error,
+            out var failure), error);
+        Assert.Equal(absolute, resolved);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.None, failure);
+    }
+
+    [Fact(SkipUnless = nameof(IsWindows), Skip = "Native drive-relative path semantics require Windows.")]
+    [SlopwatchSuppress("SW001", "This regression requires native Windows drive-relative and root-relative path semantics.")]
+    public void Windows_relative_paths_use_project_but_partial_paths_fail_closed()
+    {
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var context = Ctx(TrustAudience.Personal, autonomous: false);
+
+        Assert.True(policy.TryResolveReadPath(
+            @"src\App.cs",
+            context,
+            out var resolved,
+            out var error,
+            out var failure), error);
+        Assert.Equal(Path.GetFullPath(Path.Join(_projectDir, "src", "App.cs")), resolved);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.None, failure);
+
+        var drive = Path.GetPathRoot(_projectDir)![..2];
+        Assert.False(policy.TryResolveReadPath(
+            $@"{drive}src\App.cs",
+            context,
+            out _,
+            out _,
+            out var driveRelativeFailure));
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.InvalidInput, driveRelativeFailure);
+
+        Assert.False(policy.TryResolveReadPath(
+            @"\src\App.cs",
+            context,
+            out _,
+            out _,
+            out var rootRelativeFailure));
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.InvalidInput, rootRelativeFailure);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "Directory symlink creation is privilege-gated on Windows.")]
+    [SlopwatchSuppress("SW001", "This regression requires native POSIX symbolic-link traversal semantics.")]
+    public void Relative_path_through_project_symlink_is_denied()
+    {
+        var link = Path.Join(_projectDir, "escape");
+        Directory.CreateSymbolicLink(link, _outsideDir);
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var context = Ctx(TrustAudience.Personal, autonomous: true);
+
+        Assert.False(policy.TryResolveReadPath(
+            Path.Join("escape", "secret.txt"),
+            context,
+            out _,
+            out _,
+            out var failure));
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.AccessDenied, failure);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "Directory symlink creation is privilege-gated on Windows.")]
+    [SlopwatchSuppress("SW001", "This regression requires native POSIX symbolic-link base semantics.")]
+    public void Symlinked_project_base_falls_back_to_session_directory()
+    {
+        var projectLink = Path.Join(_dir.Path, "project-link");
+        Directory.CreateSymbolicLink(projectLink, _outsideDir);
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), _paths);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/symlink-project-base",
+            _sessionDir,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                ProjectDirectory = projectLink
+            });
+
+        Assert.True(policy.TryResolveReadPath(
+            "secret.txt",
+            context.Invocation,
+            out var resolved,
+            out var error,
+            out var failure), error);
+        Assert.Equal(Path.GetFullPath(Path.Join(_sessionDir, "secret.txt")), resolved);
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.None, failure);
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -381,9 +381,13 @@ public class DispatchingToolExecutorTests
     [Fact]
     public async Task Routes_file_read_missing_file()
     {
+        var missingPath = Path.Combine(
+            Path.GetTempPath(),
+            "netclaw-missing-" + Guid.NewGuid().ToString("N"),
+            "file.txt");
         var toolCall = CreateToolCall(
             "call-2", "file_read",
-            ToolInput.Create("Path", "/nonexistent/file.txt"));
+            ToolInput.Create("Path", missingPath));
 
         var context = TestToolExecutionContext.CreateBound("signalr/thread-1", Path.GetTempPath(), new TestToolExecutionContextOptions
         {

--- a/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
@@ -135,6 +135,76 @@ public class FileWriteToolTests : IDisposable
         Assert.False(File.Exists(filePath));
     }
 
+    [Fact]
+    public async Task Relative_write_uses_project_and_reports_canonical_change()
+    {
+        var projectDir = Path.Join(_dir.Path, "project");
+        Directory.CreateDirectory(projectDir);
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/relative-project",
+            _sessionDir,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                ProjectDirectory = projectDir
+            });
+
+        var result = await _tool.ExecuteAsync(
+            ToolInput.Create("Path", Path.Join("notes", "result.md"), "Content", "done"),
+            context,
+            CancellationToken.None);
+
+        var expected = Path.GetFullPath(Path.Join(projectDir, "notes", "result.md"));
+        Assert.Contains("Successfully wrote", result, StringComparison.Ordinal);
+        Assert.Equal("done", await File.ReadAllTextAsync(expected, TestContext.Current.CancellationToken));
+        Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
+        var activity = Assert.Single(context.Receipt?.FileActivity ?? []);
+        Assert.Equal(expected, activity.CanonicalPath);
+        Assert.Equal(ToolFileActivityKind.Changed, activity.Kind);
+    }
+
+    [Fact]
+    public async Task Relative_write_falls_back_to_session_when_project_was_moved()
+    {
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/stale-project",
+            _sessionDir,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                ProjectDirectory = Path.Join(_dir.Path, "missing-project")
+            });
+
+        var result = await _tool.ExecuteAsync(
+            ToolInput.Create("Path", "result.md", "Content", "session"),
+            context,
+            CancellationToken.None);
+
+        var expected = Path.GetFullPath(Path.Join(_sessionDir, "result.md"));
+        Assert.Contains(expected, result, StringComparison.Ordinal);
+        Assert.Equal("session", await File.ReadAllTextAsync(expected, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Denied_write_reports_no_file_activity()
+    {
+        var filePath = Path.Combine(_dir.Path, "denied.txt");
+        var tool = new FileWriteTool(
+            new ToolConfig(),
+            new NetclawPaths(),
+            new ToolPathPolicy([filePath]));
+        var context = CreatePersonalContext();
+
+        _ = await tool.ExecuteAsync(
+            ToolInput.Create("Path", filePath, "Content", "blocked"),
+            context,
+            CancellationToken.None);
+
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(File.Exists(filePath));
+    }
+
     private ToolExecutionContext CreatePersonalContext()
         => TestToolExecutionContext.CreateBound("signalr/thread-1", _sessionDir, new TestToolExecutionContextOptions
         {

--- a/src/Netclaw.Actors.Tests/Tools/PublicAudienceFileAccessPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/PublicAudienceFileAccessPolicyTests.cs
@@ -119,7 +119,8 @@ public sealed class PublicAudienceFileAccessPolicyTests : IDisposable
         var policy = new ScopedFileAccessPolicy(toolConfig, _paths);
         var publicContext = CreateContext(TrustAudience.Public);
 
-        var allowed = policy.TryResolveWritePath("/some/path", publicContext, out _, out var error);
+        var path = Path.Combine(Path.GetTempPath(), "netclaw-public-denied.txt");
+        var allowed = policy.TryResolveWritePath(path, publicContext, out _, out var error);
 
         Assert.False(allowed);
         Assert.Contains("Public", error);

--- a/src/Netclaw.Actors.Tests/Tools/WorkspaceToolRelativePathTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WorkspaceToolRelativePathTests.cs
@@ -1,0 +1,217 @@
+// -----------------------------------------------------------------------
+// <copyright file="WorkspaceToolRelativePathTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Actors.Tools;
+using Netclaw.Security;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class WorkspaceToolRelativePathTests : IDisposable
+{
+    private readonly DisposableTempDir _temp = new();
+    private readonly string _projectDirectory;
+    private readonly string _sessionDirectory;
+    private readonly ToolConfig _config = new();
+    private readonly ToolPathPolicy _pathPolicy = new([]);
+
+    public WorkspaceToolRelativePathTests()
+    {
+        _projectDirectory = Path.Join(_temp.Path, "project");
+        _sessionDirectory = Path.Join(_temp.Path, "sessions", "current");
+        Directory.CreateDirectory(_projectDirectory);
+        Directory.CreateDirectory(_sessionDirectory);
+    }
+
+    public void Dispose() => _temp.Dispose();
+
+    [Fact]
+    public async Task File_read_resolves_relative_path_from_project()
+    {
+        var path = Path.Join(_projectDirectory, "README.md");
+        await File.WriteAllTextAsync(path, "project read", TestContext.Current.CancellationToken);
+        var context = CreateContext();
+        var tool = new FileReadTool(_config, new NetclawPaths(), _pathPolicy);
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "README.md"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("project read", result);
+        AssertSuccessfulActivity(context, path, ToolFileActivityKind.Read);
+    }
+
+    [Fact]
+    public async Task File_list_resolves_relative_path_without_recording_file_activity()
+    {
+        var directory = Path.Join(_projectDirectory, "src");
+        Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(
+            Path.Join(directory, "App.cs"),
+            "class App {}",
+            TestContext.Current.CancellationToken);
+        var context = CreateContext();
+        var tool = new FileListTool(_config, new NetclawPaths(), _pathPolicy);
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "src"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("App.cs", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
+        Assert.Empty(context.Receipt?.FileActivity ?? []);
+    }
+
+    [Fact]
+    public async Task File_edit_resolves_relative_path_and_reports_change()
+    {
+        var path = Path.Join(_projectDirectory, "settings.json");
+        await File.WriteAllTextAsync(path, "old", TestContext.Current.CancellationToken);
+        var context = CreateContext();
+        var tool = new FileEditTool(_config, new NetclawPaths(), _pathPolicy);
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create(
+                "Path", "settings.json",
+                "OldString", "old",
+                "NewString", "new"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Successfully edited", result, StringComparison.Ordinal);
+        Assert.Equal("new", await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken));
+        AssertSuccessfulActivity(context, path, ToolFileActivityKind.Changed);
+    }
+
+    [Fact]
+    public async Task Attach_file_resolves_relative_source_and_reports_source_read()
+    {
+        var path = Path.Join(_projectDirectory, "report.txt");
+        await File.WriteAllTextAsync(path, "report", TestContext.Current.CancellationToken);
+        var context = CreateContext();
+        var tool = new AttachFileTool(_config, new NetclawPaths(), _pathPolicy);
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "report.txt"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("File attached", result, StringComparison.Ordinal);
+        AssertSuccessfulActivity(context, path, ToolFileActivityKind.Read);
+    }
+
+    [Fact]
+    public async Task Relative_path_still_enters_protected_path_policy()
+    {
+        var path = Path.Join(_projectDirectory, "protected.json");
+        await File.WriteAllTextAsync(path, "secret", TestContext.Current.CancellationToken);
+        var context = CreateContext();
+        var tool = new FileReadTool(_config, new NetclawPaths(), new ToolPathPolicy([path]));
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "protected.json"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Access denied", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.Empty(context.Receipt?.FileActivity ?? []);
+    }
+
+    [Fact]
+    public async Task Control_bearing_relative_path_fails_before_file_access()
+    {
+        var context = CreateContext();
+        var tool = new FileReadTool(_config, new NetclawPaths(), _pathPolicy);
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "bad\nname.txt"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Invalid path", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
+        Assert.Empty(context.Receipt?.FileActivity ?? []);
+    }
+
+    [Fact]
+    public async Task Relative_path_without_owned_base_returns_recoverable_correction()
+    {
+        var context = TestToolExecutionContext.CreateUnbound(new TestToolExecutionContextOptions
+        {
+            Audience = TrustAudience.Personal
+        });
+        var tool = new FileReadTool(_config, new NetclawPaths(), _pathPolicy);
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "README.md"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("invalid_context", result, StringComparison.Ordinal);
+        Assert.Contains("set_working_directory", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.RecoverableCorrection, context.Receipt?.Category);
+        Assert.Equal(ToolOutcomeResults.SetWorkingDirectoryRemediation, context.Receipt?.RemediationCode);
+        Assert.Empty(context.Receipt?.FileActivity ?? []);
+    }
+
+    [Fact]
+    public async Task Set_working_directory_rejects_relative_path_without_state_receipt()
+    {
+        var context = CreateContext();
+        var tool = new SetWorkingDirectoryTool(_config, new NetclawPaths());
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", "other-project"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("must be absolute", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
+        Assert.Null(context.Receipt?.DeclaredProjectDirectory);
+    }
+
+    [Fact]
+    public async Task Set_working_directory_success_reports_validated_project()
+    {
+        var context = CreateContext();
+        var tool = new SetWorkingDirectoryTool(_config, new NetclawPaths());
+
+        var result = await tool.ExecuteAsync(
+            ToolInput.Create("Path", _projectDirectory),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(_projectDirectory, result);
+        Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
+        Assert.Equal(_projectDirectory, context.Receipt?.DeclaredProjectDirectory);
+    }
+
+    private ToolExecutionContext CreateContext()
+        => TestToolExecutionContext.CreateBound(
+            "signalr/relative-tools",
+            _sessionDirectory,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                ProjectDirectory = _projectDirectory
+            });
+
+    private static void AssertSuccessfulActivity(
+        ToolExecutionContext context,
+        string expectedPath,
+        ToolFileActivityKind expectedKind)
+    {
+        Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
+        var activity = Assert.Single(context.Receipt?.FileActivity ?? []);
+        Assert.Equal(Path.GetFullPath(expectedPath), activity.CanonicalPath);
+        Assert.Equal(expectedKind, activity.Kind);
+    }
+}

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -81,6 +81,7 @@ internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeed
     public List<Jobs.ActiveJobInfo> StartedBackgroundJobs { get; init; } = [];
     public List<SessionScratchCorrectionChange> ScratchCorrectionChanges { get; init; } = [];
     public Dictionary<string, string> ToolFailureCodes { get; init; } = new(StringComparer.Ordinal);
+    public Dictionary<string, ToolInvocationReceipt> ToolReceipts { get; init; } = new(StringComparer.Ordinal);
 }
 
 internal sealed record ToolExecutionSingleCompleted(ToolCallResult Result) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -932,13 +932,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         foreach (var change in msg.ScratchCorrectionChanges)
             _sessionScratchCorrections.Apply(change);
 
-        // Processes all results, including failed tool calls. RecentFiles tracks
-        // interaction intent, not successful reads only.
-        var updatedContext = WorkingContextUpdater.UpdateFromToolResults(
+        var updatedContext = WorkingContextUpdater.UpdateFromToolReceipts(
             _state.WorkingContext,
-            _state.History,
             msg.ToolResults,
-            _log);
+            msg.ToolReceipts);
         if (!ReferenceEquals(updatedContext, _state.WorkingContext))
             _state = _state with { WorkingContext = updatedContext };
 
@@ -953,12 +950,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         foreach (var result in msg.ToolResults)
         {
-            if (result.Name is not "set_working_directory" || result.Content is null)
+            if (result.ToolCallId is not { } callId
+                || !msg.ToolReceipts.TryGetValue(callId.Value, out var receipt)
+                || receipt.Category != ToolInvocationOutcomeCategory.Success
+                || receipt.DeclaredProjectDirectory is not { } projectDir)
+            {
                 continue;
-
-            var projectDir = result.Content.Trim();
-            if (!Path.IsPathRooted(projectDir))
-                continue;
+            }
 
             var next = _state.WorkingContext.WithProjectDirectory(projectDir);
             if (ReferenceEquals(next, _state.WorkingContext))
@@ -4719,29 +4717,27 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             FailureCode = result.FailureCode
         }, OutputFilter.ToolCalls);
 
-        var updatedContext = WorkingContextUpdater.UpdateFromToolResults(
+        var updatedContext = WorkingContextUpdater.UpdateFromToolReceipt(
             _state.WorkingContext,
-            _state.History,
-            [toolMessage],
-            _log);
+            result.Receipt);
         if (!ReferenceEquals(updatedContext, _state.WorkingContext))
             _state = _state with { WorkingContext = updatedContext };
 
         if (toolMessage.Name is "load_tool" && toolMessage.Content is not null)
             TryActivateDiscoveredTool(toolMessage.Content.Trim());
 
-        if (toolMessage.Name is "set_working_directory" && toolMessage.Content is not null)
-        {
-            var projectDir = toolMessage.Content.Trim();
-            if (Path.IsPathRooted(projectDir))
+        if (result.Receipt is
             {
-                var next = _state.WorkingContext.WithProjectDirectory(projectDir);
-                if (!ReferenceEquals(next, _state.WorkingContext))
-                {
-                    _state = _state with { WorkingContext = next };
-                    SetSystemPrompt();
-                    _log.Info("Project directory set to {ProjectDir}", projectDir);
-                }
+                Category: ToolInvocationOutcomeCategory.Success,
+                DeclaredProjectDirectory: { } projectDir
+            })
+        {
+            var next = _state.WorkingContext.WithProjectDirectory(projectDir);
+            if (!ReferenceEquals(next, _state.WorkingContext))
+            {
+                _state = _state with { WorkingContext = next };
+                SetSystemPrompt();
+                _log.Info("Project directory set to {ProjectDir}", projectDir);
             }
         }
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -38,7 +38,8 @@ internal sealed record ToolCallResult(
     IReadOnlyList<AcceptedSubAgentFinding> AcceptedSubAgentFindings,
     Jobs.ActiveJobInfo? StartedBackgroundJob = null,
     SessionScratchCorrectionChange? ScratchCorrectionChange = null,
-    string? FailureCode = null);
+    string? FailureCode = null,
+    ToolInvocationReceipt? Receipt = null);
 
 internal abstract record SessionScratchCorrectionChange
 {
@@ -402,6 +403,15 @@ internal sealed class SessionToolExecutionPipeline
                             : throw new InvalidOperationException("A failed tool result requires a call identity."),
                         result => result.FailureCode
                             ?? throw new InvalidOperationException("A failed tool result requires a failure code."),
+                        StringComparer.Ordinal),
+                ToolReceipts = results
+                    .Where(result => result.Receipt is not null)
+                    .ToDictionary<ToolCallResult, string, ToolInvocationReceipt>(
+                        result => result.Message.ToolCallId is { } callId
+                            ? callId.Value
+                            : throw new InvalidOperationException("A tool receipt requires a call identity."),
+                        result => result.Receipt
+                            ?? throw new InvalidOperationException("A selected tool result requires a receipt."),
                         StringComparer.Ordinal)
             });
         }
@@ -450,7 +460,8 @@ internal sealed class SessionToolExecutionPipeline
                 Content = rejection.Message,
                 ToolCallId = new ToolCallId(tc.CallId),
                 Name = tc.Name
-            }, [], [], [], [], FailureCode: rejection.DenyReason);
+            }, [], [], [], [], FailureCode: rejection.DenyReason,
+                Receipt: new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
         }
 
         var meta = interpretation.Meta;
@@ -617,6 +628,7 @@ internal sealed class SessionToolExecutionPipeline
                     [],
                     [],
                     [],
+                    Receipt: new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied),
                     ScratchCorrectionChange: consumedScratchKey is { } deniedConsumed
                         ? new SessionScratchCorrectionChange.Consume(deniedConsumed)
                         : null);
@@ -684,6 +696,9 @@ internal sealed class SessionToolExecutionPipeline
                     ToolCallId = new ToolCallId(tc.CallId),
                     Name = tc.Name
                 }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
+                    Receipt: new ToolInvocationReceipt(
+                        ToolInvocationOutcomeCategory.RecoverableCorrection,
+                        remediationCode: ToolOutcomeResults.UseSessionScratchRemediation),
                     ScratchCorrectionChange: new SessionScratchCorrectionChange.Arm(newCorrectionKey));
             }
 
@@ -703,7 +718,10 @@ internal sealed class SessionToolExecutionPipeline
                     Content = resultText,
                     ToolCallId = new ToolCallId(tc.CallId),
                     Name = tc.Name
-                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings);
+                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
+                    Receipt: new ToolInvocationReceipt(
+                        ToolInvocationOutcomeCategory.RecoverableCorrection,
+                        remediationCode: ToolOutcomeResults.SetWorkingDirectoryRemediation));
             }
 
             if (!CanRequestInteractiveApproval(batch.TurnContext))
@@ -717,7 +735,8 @@ internal sealed class SessionToolExecutionPipeline
                     Content = resultText,
                     ToolCallId = new ToolCallId(tc.CallId),
                     Name = tc.Name
-                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings);
+                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
+                    Receipt: new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
             }
 
             // Mid-turn approval pause: emit request to channel, block on TCS
@@ -827,6 +846,7 @@ internal sealed class SessionToolExecutionPipeline
                     invocation: context.Invocation,
                     canDeclare: batch.CanDeclareWorkingDirectory);
                 resultText = string.IsNullOrEmpty(hint) ? reason : $"{reason}\n{hint}";
+                context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
 
             }
         }
@@ -834,6 +854,7 @@ internal sealed class SessionToolExecutionPipeline
         {
             sw.Stop();
             resultText = $"Tool access denied: {ex.DenyReason}";
+            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
 
         }
         catch (OperationCanceledException) when (batch.CancellationToken.IsCancellationRequested)
@@ -848,6 +869,13 @@ internal sealed class SessionToolExecutionPipeline
         {
             sw.Stop();
             resultText = $"Error executing tool: {ex.Message}";
+            var category = ex switch
+            {
+                UnauthorizedAccessException => ToolInvocationOutcomeCategory.AccessDenied,
+                FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
+                _ => ToolInvocationOutcomeCategory.TransientFailure
+            };
+            context.Outputs.TryComplete(new ToolInvocationReceipt(category));
 
         }
 
@@ -876,6 +904,8 @@ internal sealed class SessionToolExecutionPipeline
             context.Outputs.FileAttachments,
             completedRuns,
             acceptedFindings,
+            Receipt: context.Receipt
+                ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success),
             ScratchCorrectionChange: consumedScratchKey is { } consumed
                 ? new SessionScratchCorrectionChange.Consume(consumed)
                 : null);

--- a/src/Netclaw.Actors/Sessions/WorkingContextUpdater.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextUpdater.cs
@@ -3,206 +3,49 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Text.Json;
-using Akka.Event;
 using Netclaw.Actors.Protocol;
+using Netclaw.Tools;
 
 namespace Netclaw.Actors.Sessions;
 
 /// <summary>
-/// Extracts file paths from tool call arguments and updates
-/// <see cref="WorkingContext.RecentFiles"/>. Lives outside
-/// <see cref="LlmSessionActor"/> so the path-extraction logic is
-/// testable in isolation.
-///
-/// There is no tool-name allowlist. Any tool whose <c>ArgumentsJson</c>
-/// contains a recognizable file-path field (see
-/// <see cref="TryExtractFilePath"/>) has its path tracked. This lets
-/// first-party tools, MCP filesystem tools, and any future path-taking
-/// tool participate without a central registry.
+/// Applies successful, canonical file activity produced by first-party tools.
+/// Presentation strings and authored arguments never establish file activity.
 /// </summary>
 internal static class WorkingContextUpdater
 {
-    // First-party Netclaw tools (FileReadTool, FileWriteTool, FileEditTool)
-    // use PascalCase parameter names via C# records, which NetclawToolGenerator
-    // emits into the tool JSON schema verbatim — so real arguments come in
-    // keyed as `{"Path": "..."}`. MCP tools and other conventions use the
-    // camelCase/snake_case variants. Probe all common forms.
-    private static readonly string[] PathFieldNames =
-    [
-        "Path",
-        "path",
-        "FilePath",
-        "file_path",
-        "filePath",
-        "File",
-        "file",
-        "FileName",
-        "filename",
-        "fileName",
-    ];
-
-    /// <summary>
-    /// Process a batch of tool results that just completed, find each
-    /// result's matching tool call in history, extract any file path
-    /// argument, and return the updated <see cref="WorkingContext"/>.
-    /// Pure — does not mutate inputs. Returns the same instance when no
-    /// result produced a path change.
-    ///
-    /// Optionally takes an <see cref="ILoggingAdapter"/> so the actor can
-    /// emit debug-level observability when a tool call with non-empty
-    /// object arguments is processed but no recognized path field matches
-    /// (signalling potential schema drift — a new tool whose argument
-    /// keys aren't in <see cref="PathFieldNames"/>).
-    /// </summary>
-    public static WorkingContext UpdateFromToolResults(
+    public static WorkingContext UpdateFromToolReceipts(
         WorkingContext current,
-        IReadOnlyList<SerializableChatMessage> history,
-        IReadOnlyList<SerializableChatMessage> results,
-        ILoggingAdapter? log = null)
+        IReadOnlyList<SerializableChatMessage> orderedResults,
+        IReadOnlyDictionary<string, ToolInvocationReceipt> receipts)
     {
-        if (results.Count == 0)
-            return current;
-
-        // Build a lookup from CallId → ArgumentsJson by scanning backward
-        // from the end of history for Assistant messages with tool calls.
-        // Typical turns have one producing assistant message immediately
-        // before the tool-result batch, so the walk exits after a single
-        // match + collecting its calls. In pathological cases where the
-        // batch mixes calls from multiple assistants, we keep walking
-        // until every result's CallId is accounted for.
-        var pendingIds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var r in results)
-        {
-            if (r.ToolCallId is { } id && !string.IsNullOrEmpty(id.Value))
-                pendingIds.Add(id.Value);
-        }
-        if (pendingIds.Count == 0)
-            return current;
-
-        var argsByCallId = new Dictionary<string, string?>(StringComparer.Ordinal);
-        for (var i = history.Count - 1; i >= 0 && pendingIds.Count > 0; i--)
-        {
-            var msg = history[i];
-            if (msg.Role != ChatRole.Assistant || msg.ToolCalls.Count == 0)
-                continue;
-
-            foreach (var tc in msg.ToolCalls)
-            {
-                if (pendingIds.Remove(tc.CallId.Value))
-                    argsByCallId[tc.CallId.Value] = tc.ArgumentsJson;
-            }
-        }
-
         var updated = current;
-        foreach (var result in results)
+        foreach (var result in orderedResults)
         {
-            if (result.ToolCallId is not { } resultCallId
-                || !argsByCallId.TryGetValue(resultCallId.Value, out var argumentsJson))
+            if (result.ToolCallId is not { } callId
+                || !receipts.TryGetValue(callId.Value, out var receipt)
+                || receipt.Category != ToolInvocationOutcomeCategory.Success)
             {
                 continue;
             }
 
-            if (TryExtractFilePath(argumentsJson, out var path))
-            {
-                var next = updated.AddRecentFile(path);
-                if (!ReferenceEquals(next, updated))
-                {
-                    log?.Debug(
-                        "WorkingContext: tracked file {Path} from tool call {CallId} ({ToolName})",
-                        path, result.ToolCallId, result.Name ?? "unknown");
-                }
-                updated = next;
-            }
-            else if (HasStringValuedObjectArgs(argumentsJson))
-            {
-                // The arguments parsed to a non-empty JSON object with at
-                // least one string-valued field, but none of our probe
-                // names matched. This is the schema-drift signal — a new
-                // tool whose path argument uses an unrecognized key, or
-                // a provider that renamed keys in transit. Operators
-                // hunting "why isn't this file showing up in
-                // [working-context]" will see this in debug logs.
-                log?.Debug(
-                    "WorkingContext: tool call {CallId} ({ToolName}) had string-valued arguments but no recognized path field matched (probed: Path/path/FilePath/file_path/filePath/File/file/FileName/filename/fileName); possible schema drift",
-                    result.ToolCallId, result.Name ?? "unknown");
-            }
+            foreach (var activity in receipt.FileActivity)
+                updated = updated.AddRecentFile(activity.CanonicalPath);
         }
+
         return updated;
     }
 
-    /// <summary>
-    /// Returns true when <paramref name="argumentsJson"/> parses to a
-    /// non-empty JSON object that contains at least one string-valued
-    /// property. Used to distinguish "tool has no path arg" (normal,
-    /// quiet) from "tool has string args we didn't recognize" (schema
-    /// drift, worth logging).
-    /// </summary>
-    private static bool HasStringValuedObjectArgs(string? argumentsJson)
+    public static WorkingContext UpdateFromToolReceipt(
+        WorkingContext current,
+        ToolInvocationReceipt? receipt)
     {
-        if (string.IsNullOrWhiteSpace(argumentsJson) || argumentsJson == "{}")
-            return false;
+        if (receipt?.Category != ToolInvocationOutcomeCategory.Success)
+            return current;
 
-        try
-        {
-            using var doc = JsonDocument.Parse(argumentsJson);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object)
-                return false;
-
-            foreach (var prop in doc.RootElement.EnumerateObject())
-            {
-                if (prop.Value.ValueKind == JsonValueKind.String
-                    && !string.IsNullOrWhiteSpace(prop.Value.GetString()))
-                {
-                    return true;
-                }
-            }
-        }
-        catch (JsonException) // slopwatch-ignore: SW003 malformed JSON is benign — see TryExtractFilePath
-        {
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Parse a tool call's <c>ArgumentsJson</c> and extract a file path
-    /// from one of the well-known field names. Returns false when the
-    /// arguments are empty, unparseable, or do not contain a recognized
-    /// path field.
-    /// </summary>
-    public static bool TryExtractFilePath(string? argumentsJson, out string path)
-    {
-        path = string.Empty;
-        if (string.IsNullOrWhiteSpace(argumentsJson) || argumentsJson == "{}")
-            return false;
-
-        try
-        {
-            using var doc = JsonDocument.Parse(argumentsJson);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object)
-                return false;
-
-            foreach (var name in PathFieldNames)
-            {
-                if (doc.RootElement.TryGetProperty(name, out var prop)
-                    && prop.ValueKind == JsonValueKind.String)
-                {
-                    var value = prop.GetString();
-                    if (!string.IsNullOrWhiteSpace(value))
-                    {
-                        path = value;
-                        return true;
-                    }
-                }
-            }
-        }
-        catch (JsonException) // slopwatch-ignore: SW003 malformed LLM-generated JSON is benign — see body comment
-        {
-            // Malformed arguments are treated as "no path" — not worth
-            // failing the actor for.
-        }
-
-        return false;
+        var updated = current;
+        foreach (var activity in receipt.FileActivity)
+            updated = updated.AddRecentFile(activity.CanonicalPath);
+        return updated;
     }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -563,8 +563,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             {
                 _history.Add(ChatMessageConverter.ToAiMessage(result));
                 if (result.ToolCallId is { } callId)
-                    _fileActivity.Complete(callId.Value, result.Content);
-                TryApplyProjectDirectory(result);
+                {
+                    msg.ToolReceipts.TryGetValue(callId.Value, out var receipt);
+                    _fileActivity.Apply(receipt);
+                    TryApplyProjectDirectory(receipt);
+                }
                 if (result.Name is "load_tool" && result.Content is not null)
                     TryActivateDiscoveredTool(result.Content.Trim());
                 var preview = result.Content is { Length: > 200 }
@@ -801,10 +804,6 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 ? JsonSerializer.Serialize(toolCall.Arguments)
                 : null;
             _turnState.TrackToolCall(toolCall.Name, argsJson);
-            if (toolCall.CallId is { Length: > 0 } callId
-                && WorkingContextUpdater.TryExtractFilePath(argsJson, out var path))
-                _fileActivity.Begin(callId, toolCall.Name, path);
-
             // Log tool START event so tool execution spans are visible in Seq
             // (previously only tool results were logged, making it impossible to
             // correlate tool start with tool end when tools take a long time).
@@ -1152,23 +1151,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         return _fileActivity.BuildResult();
     }
 
-    private void TryApplyProjectDirectory(SerializableChatMessage result)
+    private void TryApplyProjectDirectory(ToolInvocationReceipt? receipt)
     {
-        if (result.Name is not SetWorkingDirectoryTool.ToolName
-            || result.Content is null
-            || _toolRegistry.GetByName(SetWorkingDirectoryTool.ToolName) is not SetWorkingDirectoryTool tool)
-        {
-            return;
-        }
-
-        var projectDirectory = result.Content.Trim();
-        var validatedWorkingContext = WorkingContext.Empty.WithProjectDirectory(projectDirectory);
-        if (!string.Equals(
-                validatedWorkingContext.ProjectDirectory,
-                projectDirectory,
-                StringComparison.Ordinal)
-            || !Path.IsPathRooted(projectDirectory)
-            || !tool.CanDeclare(projectDirectory, ToolExecutionContext.Invocation))
+        if (receipt is not
+            {
+                Category: ToolInvocationOutcomeCategory.Success,
+                DeclaredProjectDirectory: { } projectDirectory
+            })
         {
             return;
         }
@@ -1399,7 +1388,11 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 var interpretation = executor.InterpretToolCall(tc);
                 var toolContext = CreatePerToolExecutionContext(executionContext, interpretation.Meta);
                 if (interpretation.Rejection is { } rejection)
+                {
+                    toolContext.Outputs.TryComplete(
+                        new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
                     return BuildToolResult(tc, rejection.Message, toolContext, modelInputBudget);
+                }
 
                 var meta = interpretation.Meta;
                 var cleanedTc = interpretation.Cleaned;
@@ -1443,6 +1436,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         ToolAgentCorrection.SessionScratchSuggested scratchCorrection
                         && scratchCall is { } correctedCall)
                     {
+                        toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
+                            ToolInvocationOutcomeCategory.RecoverableCorrection,
+                            remediationCode: ToolOutcomeResults.UseSessionScratchRemediation));
                         var correctionText = SessionToolExecutionPipeline.BuildSessionScratchCorrection(
                             scratchCorrection.SessionDirectory);
                         var newCorrectionKey = new SessionScratchCorrectionKey(
@@ -1465,6 +1461,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             canDeclareWorkingDirectory);
                     if (!string.IsNullOrEmpty(projectScopeCorrection))
                     {
+                        toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
+                            ToolInvocationOutcomeCategory.RecoverableCorrection,
+                            remediationCode: ToolOutcomeResults.SetWorkingDirectoryRemediation));
                         return BuildToolResult(
                             cleanedTc,
                             projectScopeCorrection,
@@ -1544,6 +1543,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         reason = $"{reason}\n{SessionToolExecutionPipeline.BuildSessionScratchDenialHint(deniedScratchRetry.SessionDirectory)}";
                     }
 
+                    toolContext.Outputs.TryComplete(
+                        new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
+
                     return BuildToolResult(
                         tc,
                         reason,
@@ -1570,6 +1572,13 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (Exception ex)
                 {
+                    var category = ex switch
+                    {
+                        UnauthorizedAccessException => ToolInvocationOutcomeCategory.AccessDenied,
+                        FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
+                        _ => ToolInvocationOutcomeCategory.TransientFailure
+                    };
+                    toolContext.Outputs.TryComplete(new ToolInvocationReceipt(category));
                     return BuildToolResult(
                         tc,
                         $"Error: {ex.Message}",
@@ -1586,7 +1595,16 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             {
                 ToolResults = [.. results.Select(r => r.Message)],
                 ModelInputMediaReferences = [.. results.SelectMany(r => r.ModelInputMediaReferences)],
-                ScratchCorrectionChanges = [.. results.Where(r => r.ScratchCorrectionChange is not null).Select(r => r.ScratchCorrectionChange!)]
+                ScratchCorrectionChanges = [.. results.Where(r => r.ScratchCorrectionChange is not null).Select(r => r.ScratchCorrectionChange!)],
+                ToolReceipts = results
+                    .Where(result => result.Receipt is not null)
+                    .ToDictionary<SubAgentToolCallResult, string, ToolInvocationReceipt>(
+                        result => result.Message.ToolCallId is { } callId
+                            ? callId.Value
+                            : throw new InvalidOperationException("A child tool receipt requires a call identity."),
+                        result => result.Receipt
+                            ?? throw new InvalidOperationException("A selected child tool result requires a receipt."),
+                        StringComparer.Ordinal)
             });
         }
         catch (Exception ex)
@@ -1629,7 +1647,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 Name = toolCall.Name
             },
             materialization.MediaReferences,
-            scratchCorrectionChange);
+            scratchCorrectionChange,
+            toolContext.Receipt ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success));
     }
 
     private static ModelInputMaterializationResult MaterializeModelInputFiles(
@@ -1652,7 +1671,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private sealed record SubAgentToolCallResult(
         SerializableChatMessage Message,
         IReadOnlyList<SerializableMediaReference> ModelInputMediaReferences,
-        SessionScratchCorrectionChange? ScratchCorrectionChange);
+        SessionScratchCorrectionChange? ScratchCorrectionChange,
+        ToolInvocationReceipt? Receipt);
 
     private string BuildSystemPrompt(
         SubAgentDefinition definition,
@@ -1694,7 +1714,6 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     {
         private readonly HashSet<string> _readFiles = new(StringComparer.Ordinal);
         private readonly HashSet<string> _confirmedChangedFiles = new(StringComparer.Ordinal);
-        private readonly Dictionary<string, PendingFileActivity> _pending = new(StringComparer.Ordinal);
         private WorkingContext _workingContext;
 
         public ChildFileActivityTracker(WorkingContext parentSnapshot)
@@ -1702,33 +1721,19 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _workingContext = parentSnapshot;
         }
 
-        public void Begin(string callId, string toolName, string path)
+        public void Apply(ToolInvocationReceipt? receipt)
         {
-            var kind = toolName switch
+            if (receipt?.Category != ToolInvocationOutcomeCategory.Success)
+                return;
+
+            foreach (var activity in receipt.FileActivity)
             {
-                "file_read" => FileActivityKind.Read,
-                "file_write" or "file_edit" => FileActivityKind.Changed,
-                _ => FileActivityKind.None
-            };
-            if (kind == FileActivityKind.None)
-                return;
-
-            var resolvedPath = Path.IsPathRooted(path) || string.IsNullOrWhiteSpace(_workingContext.ProjectDirectory)
-                ? path
-                : Path.GetFullPath(path, _workingContext.ProjectDirectory);
-            _pending[callId] = new PendingFileActivity(resolvedPath, kind);
-        }
-
-        public void Complete(string callId, string? result)
-        {
-            if (!_pending.Remove(callId, out var activity) || !Succeeded(activity.Kind, result))
-                return;
-
-            _workingContext = _workingContext.AddRecentFile(activity.Path);
-            if (activity.Kind == FileActivityKind.Read)
-                _readFiles.Add(activity.Path);
-            else
-                _confirmedChangedFiles.Add(activity.Path);
+                _workingContext = _workingContext.AddRecentFile(activity.CanonicalPath);
+                if (activity.Kind == ToolFileActivityKind.Read)
+                    _readFiles.Add(activity.CanonicalPath);
+                else
+                    _confirmedChangedFiles.Add(activity.CanonicalPath);
+            }
         }
 
         public void SetProjectDirectory(string projectDirectory)
@@ -1742,26 +1747,6 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             ObservedChangedFiles = []
         };
 
-        private static bool Succeeded(FileActivityKind kind, string? result)
-        {
-            if (string.IsNullOrWhiteSpace(result))
-                return false;
-
-            return kind == FileActivityKind.Changed
-                ? result.StartsWith("Successfully ", StringComparison.Ordinal)
-                : !result.StartsWith("Error:", StringComparison.Ordinal)
-                  && !result.StartsWith("Tool access denied:", StringComparison.Ordinal)
-                  && !result.Contains("requires approval", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private sealed record PendingFileActivity(string Path, FileActivityKind Kind);
-
-        private enum FileActivityKind
-        {
-            None,
-            Read,
-            Changed
-        }
     }
 
     private sealed class SubAgentCancelled

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -26,7 +26,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
     private readonly ToolPathPolicy _pathPolicy;
 
     public record Params(
-        [property: Description("Absolute path to the file to attach")] string Path,
+        [property: Description("File path to attach. Relative paths use the current project, then session scratch.")] string Path,
         [property: Description("Optional display name for the file")] string? DisplayName = null);
 
     public AttachFileTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)
@@ -38,19 +38,28 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
     protected override Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return Task.FromResult("Error: 'path' parameter is required.");
+            return Task.FromResult(context.InvalidInput("Error: 'path' parameter is required."));
 
         if (string.IsNullOrWhiteSpace(context.SessionDirectory))
-            return Task.FromResult("Error: No session directory available.");
+            return Task.FromResult(context.RecoverableCorrection(
+                "Error: No session directory available.",
+                ToolOutcomeResults.SetWorkingDirectoryRemediation));
 
-        if (!_fileAccessPolicy.TryResolveAttachPath(args.Path, context, out var requestedPath, out var accessError))
-            return Task.FromResult(accessError);
+        if (!_fileAccessPolicy.TryResolveAttachPath(
+                args.Path,
+                context,
+                out var requestedPath,
+                out var accessError,
+                out var resolutionFailure))
+        {
+            return Task.FromResult(context.PathResolutionFailure(accessError, resolutionFailure));
+        }
 
         // Same hard-deny surface as file_read/file_list: attach must never ship
         // control-plane files (secrets, keys, webhooks, config, sqlite, pid,
         // lock, restart manifest) that shell cannot even reference (#1724).
         if (_pathPolicy.IsReadDenied(requestedPath))
-            return Task.FromResult(FileToolErrors.CredentialReadDenied(requestedPath));
+            return Task.FromResult(context.AccessDenied(FileToolErrors.CredentialReadDenied(requestedPath)));
 
         var sessionDir = PathUtility.Normalize(context.SessionDirectory);
         var sessionRoot = TryGetSessionRootDirectory(sessionDir);
@@ -68,12 +77,12 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
 
         if (!interactivePersonalReach && !requestedInCurrentSession && !requestedInSessionRoot)
         {
-            return Task.FromResult(
-                $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}.");
+            return Task.FromResult(context.AccessDenied(
+                $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}."));
         }
 
         if (!File.Exists(requestedPath))
-            return Task.FromResult($"Error: File not found: {requestedPath}");
+            return Task.FromResult(context.NotFound($"Error: File not found: {requestedPath}"));
 
         var resolvedPath = ResolveFinalPath(requestedPath);
 
@@ -81,15 +90,15 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         // target so any future divergence between requestedPath and resolvedPath
         // cannot widen attach's surface.
         if (_pathPolicy.IsReadDenied(resolvedPath))
-            return Task.FromResult(FileToolErrors.CredentialReadDenied(resolvedPath));
+            return Task.FromResult(context.AccessDenied(FileToolErrors.CredentialReadDenied(resolvedPath)));
 
         var resolvedInCurrentSession = PathUtility.IsWithinRoot(resolvedPath, sessionDir);
         var resolvedInSessionRoot = sessionRoot is not null && PathUtility.IsWithinRoot(resolvedPath, sessionRoot);
 
         if (!interactivePersonalReach && !resolvedInCurrentSession && !resolvedInSessionRoot)
         {
-            return Task.FromResult(
-                $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}.");
+            return Task.FromResult(context.AccessDenied(
+                $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}."));
         }
 
         var attachPath = resolvedInCurrentSession
@@ -97,7 +106,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             : CopyIntoCurrentSession(resolvedPath, sessionDir);
 
         if (!PathUtility.IsWithinRoot(attachPath, sessionDir))
-            return Task.FromResult($"Error: Attach path escaped the session directory ({sessionDir}).");
+            return Task.FromResult(context.AccessDenied($"Error: Attach path escaped the session directory ({sessionDir})."));
 
         var rawFilename = args.DisplayName ?? Path.GetFileName(attachPath);
         var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
@@ -108,7 +117,10 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             ? string.Empty
             : " (copied into current session)";
 
-        return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {attachPath}{copiedText}");
+        return Task.FromResult(context.SuccessFile(
+            $"File attached: {sanitizedFilename} ({mimeType}) at {attachPath}{copiedText}",
+            resolvedPath,
+            ToolFileActivityKind.Read));
     }
 
     private static string ResolveFinalPath(string path)

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -141,6 +141,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         if (_registry.GetByName(toolCall.Name) is null)
         {
             _logger.LogWarning("Unknown tool requested: {ToolName}", toolCall.Name);
+            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.NotFound));
             return $"Unknown tool: {toolCall.Name}";
         }
 
@@ -152,6 +153,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
             _logger.LogWarning(
                 "Rejected tool call ({Reason}): {ToolName} — {Error}",
                 rejection.DenyReason, toolCall.Name, rejection.Message);
+            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
             return rejection.Message;
         }
 
@@ -171,6 +173,8 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
                     shellAnalysis,
                     ct)
                 : await tool.ExecuteAsync(toolCall.Arguments, context.Invocation, ct);
+
+            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success));
 
             var redacted = SecretOutputRedactor.Redact(result);
 
@@ -197,6 +201,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         }
         catch (Exception ex)
         {
+            CompleteExceptionOutcome(context, ex, ct);
             sw.Stop();
             _logger.LogError(ex,
                 "Tool execution failed: {ToolName} ({Duration}ms)",
@@ -227,6 +232,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         if (_registry.GetByName(toolCall.Name) is null)
         {
             _logger.LogWarning("Unknown tool requested: {ToolName}", toolCall.Name);
+            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.NotFound));
             yield return new ToolCompletedUpdate($"Unknown tool: {toolCall.Name}");
             yield break;
         }
@@ -238,6 +244,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
             _logger.LogWarning(
                 "Rejected tool call ({Reason}): {ToolName} — {Error}",
                 rejection.DenyReason, toolCall.Name, rejection.Message);
+            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
             yield return new ToolCompletedUpdate(rejection.Message);
             yield break;
         }
@@ -264,6 +271,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
             {
                 case ToolCompletedUpdate completed:
                     sw.Stop();
+                    context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success));
                     var redacted = SecretOutputRedactor.Redact(completed.Result);
                     var modelResult = tool.SuppressOutputRedaction ? completed.Result : redacted;
                     modelResult = await ToolOutputSpill.BoundAndSpillAsync(
@@ -281,6 +289,24 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
                     break;
             }
         }
+    }
+
+    private static void CompleteExceptionOutcome(
+        ToolExecutionContext context,
+        Exception exception,
+        CancellationToken callerToken)
+    {
+        if (exception is OperationCanceledException && callerToken.IsCancellationRequested)
+            return;
+
+        var category = exception switch
+        {
+            UnauthorizedAccessException => ToolInvocationOutcomeCategory.AccessDenied,
+            FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
+            IOException or TimeoutException => ToolInvocationOutcomeCategory.TransientFailure,
+            _ => ToolInvocationOutcomeCategory.TransientFailure
+        };
+        context.Outputs.TryComplete(new ToolInvocationReceipt(category));
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -31,7 +31,7 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
 
     public record Params(
-        [property: Description("Absolute path to the file")] string Path,
+        [property: Description("File path to edit. Relative paths use the current project, then session scratch.")] string Path,
         [property: Description("The exact text to find in the file (omit when using Content for a full write)")] string? OldString = null,
         [property: Description("The text to replace OldString with (must differ from OldString; use empty string to delete)")] string? NewString = null,
         [property: Description("Replace all occurrences instead of just the first (default: false)")] bool? ReplaceAll = null,
@@ -46,38 +46,46 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
     protected override async Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return "Error: 'Path' parameter is required.";
+            return context.InvalidInput("Error: 'Path' parameter is required.");
 
         // Full-write mode: Content is supplied without OldString
         if (args.Content is not null)
         {
             if (args.OldString is not null || args.NewString is not null || args.ReplaceAll is not null)
-                return "Error: 'Content' and 'OldString'/'NewString'/'ReplaceAll' are mutually exclusive. " +
-                       "Use Content for a full file write, or OldString/NewString for targeted replacement.";
+                return context.InvalidInput(
+                    "Error: 'Content' and 'OldString'/'NewString'/'ReplaceAll' are mutually exclusive. " +
+                    "Use Content for a full file write, or OldString/NewString for targeted replacement.");
 
             return await WriteFileAsync(args.Path, args.Content, context, ct);
         }
 
         // Targeted edit mode: OldString → NewString
         if (string.IsNullOrEmpty(args.OldString))
-            return "Error: either 'OldString' (for targeted edit) or 'Content' (for full write) is required.";
+            return context.InvalidInput("Error: either 'OldString' (for targeted edit) or 'Content' (for full write) is required.");
 
         if (args.NewString is null)
-            return "Error: 'NewString' is required when using OldString for targeted replacement.";
+            return context.InvalidInput("Error: 'NewString' is required when using OldString for targeted replacement.");
 
         if (args.NewString == args.OldString)
-            return "Error: 'NewString' must be different from 'OldString'.";
+            return context.InvalidInput("Error: 'NewString' must be different from 'OldString'.");
 
         return await EditFileAsync(args.Path, args.OldString, args.NewString, args.ReplaceAll == true, context, ct);
     }
 
     internal async Task<string> WriteFileAsync(string path, string content, ToolInvocationContext context, CancellationToken ct)
     {
-        if (!_fileAccessPolicy.TryResolveWritePath(path, context, out var authorizedPath, out var accessError))
-            return accessError;
+        if (!_fileAccessPolicy.TryResolveWritePath(
+                path,
+                context,
+                out var authorizedPath,
+                out var accessError,
+                out var resolutionFailure))
+        {
+            return context.PathResolutionFailure(accessError, resolutionFailure);
+        }
 
         if (_pathPolicy.IsDenied(authorizedPath))
-            return FileToolErrors.ControlPlaneWriteDenied(authorizedPath);
+            return context.AccessDenied(FileToolErrors.ControlPlaneWriteDenied(authorizedPath));
 
         try
         {
@@ -90,29 +98,43 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
             return await FileMutationGate.RunExclusiveAsync(authorizedPath, async () =>
             {
                 await File.WriteAllBytesAsync(authorizedPath, bytes, ct);
-                return $"Successfully wrote {bytes.Length} bytes to {authorizedPath}";
+                return context.SuccessFile(
+                    $"Successfully wrote {bytes.Length} bytes to {authorizedPath}",
+                    authorizedPath,
+                    ToolFileActivityKind.Changed);
             }, ct);
         }
         catch (UnauthorizedAccessException)
         {
-            return $"Error: Permission denied: {authorizedPath}";
+            return context.AccessDenied($"Error: Permission denied: {authorizedPath}");
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return context.NotFound($"Error: Directory not found: {authorizedPath}");
         }
         catch (IOException ex)
         {
-            return $"Error writing file: {ex.Message}";
+            return context.TransientFailure($"Error writing file: {ex.Message}");
         }
     }
 
     private async Task<string> EditFileAsync(string path, string oldString, string newString, bool replaceAll, ToolInvocationContext context, CancellationToken ct)
     {
-        if (!_fileAccessPolicy.TryResolveWritePath(path, context, out var authorizedPath, out var accessError))
-            return accessError;
+        if (!_fileAccessPolicy.TryResolveWritePath(
+                path,
+                context,
+                out var authorizedPath,
+                out var accessError,
+                out var resolutionFailure))
+        {
+            return context.PathResolutionFailure(accessError, resolutionFailure);
+        }
 
         if (_pathPolicy.IsDenied(authorizedPath))
-            return FileToolErrors.ControlPlaneWriteDenied(authorizedPath);
+            return context.AccessDenied(FileToolErrors.ControlPlaneWriteDenied(authorizedPath));
 
         if (!File.Exists(authorizedPath))
-            return $"Error: File not found: {authorizedPath}";
+            return context.NotFound($"Error: File not found: {authorizedPath}");
 
         try
         {
@@ -125,11 +147,15 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
                 var occurrences = CountOccurrences(content, oldString);
 
                 if (occurrences == 0)
-                    return $"Error: The specified text was not found in {authorizedPath}";
+                    return context.RecoverableCorrection(
+                        $"Error: The specified text was not found in {authorizedPath}",
+                        "provide_unique_old_string");
 
                 if (occurrences > 1 && !replaceAll)
-                    return $"Error: OldString matches {occurrences} locations in {authorizedPath}. " +
-                           "Provide more surrounding context to create a unique match, or set ReplaceAll=true.";
+                    return context.RecoverableCorrection(
+                        $"Error: OldString matches {occurrences} locations in {authorizedPath}. " +
+                        "Provide more surrounding context to create a unique match, or set ReplaceAll=true.",
+                        "provide_unique_old_string");
 
                 string newContent;
                 int replacementCount;
@@ -152,16 +178,27 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
                 var bytes = Encoding.UTF8.GetBytes(newContent);
                 await File.WriteAllBytesAsync(authorizedPath, bytes, ct);
 
-                return $"Successfully edited {authorizedPath}: replaced {replacementCount} occurrence(s)";
+                return context.SuccessFile(
+                    $"Successfully edited {authorizedPath}: replaced {replacementCount} occurrence(s)",
+                    authorizedPath,
+                    ToolFileActivityKind.Changed);
             }, ct);
         }
         catch (UnauthorizedAccessException)
         {
-            return $"Error: Permission denied: {authorizedPath}";
+            return context.AccessDenied($"Error: Permission denied: {authorizedPath}");
+        }
+        catch (FileNotFoundException)
+        {
+            return context.NotFound($"Error: File not found: {authorizedPath}");
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return context.NotFound($"Error: File not found: {authorizedPath}");
         }
         catch (IOException ex)
         {
-            return $"Error editing file: {ex.Message}";
+            return context.TransientFailure($"Error editing file: {ex.Message}");
         }
     }
 

--- a/src/Netclaw.Actors/Tools/FileListTool.cs
+++ b/src/Netclaw.Actors/Tools/FileListTool.cs
@@ -31,7 +31,7 @@ public sealed partial class FileListTool : NetclawTool<FileListTool.Params>
     private readonly ToolPathPolicy _pathPolicy;
 
     public record Params(
-        [property: Description("Absolute path to the directory to list")] string Path);
+        [property: Description("Directory path to list. Relative paths use the current project, then session scratch.")] string Path);
 
     public FileListTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)
     {
@@ -42,35 +42,46 @@ public sealed partial class FileListTool : NetclawTool<FileListTool.Params>
     protected override Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return Task.FromResult("Error: 'path' parameter is required.");
+            return Task.FromResult(context.InvalidInput("Error: 'path' parameter is required."));
 
         // Authorize through the read-access policy: this confines the listable
         // directories to the audience's read roots and emits an
         // audience-sanitized error (no configured root paths leaked to Public).
-        if (!_fileAccessPolicy.TryResolveReadPath(args.Path, context, out var authorizedPath, out var accessError))
-            return Task.FromResult(accessError);
+        if (!_fileAccessPolicy.TryResolveReadPath(
+                args.Path,
+                context,
+                out var authorizedPath,
+                out var accessError,
+                out var resolutionFailure))
+        {
+            return Task.FromResult(context.PathResolutionFailure(accessError, resolutionFailure));
+        }
 
         if (_pathPolicy.IsReadDenied(authorizedPath))
-            return Task.FromResult(FileToolErrors.CredentialReadDenied(authorizedPath));
+            return Task.FromResult(context.AccessDenied(FileToolErrors.CredentialReadDenied(authorizedPath)));
 
         if (!Directory.Exists(authorizedPath))
         {
-            return Task.FromResult(File.Exists(authorizedPath)
+            return Task.FromResult(context.NotFound(File.Exists(authorizedPath)
                 ? $"Error: Not a directory (use file_read for files): {authorizedPath}"
-                : $"Error: Directory not found: {authorizedPath}");
+                : $"Error: Directory not found: {authorizedPath}"));
         }
 
         try
         {
-            return Task.FromResult(FormatListing(authorizedPath, _pathPolicy));
+            return Task.FromResult(context.Success(FormatListing(authorizedPath, _pathPolicy)));
         }
         catch (UnauthorizedAccessException)
         {
-            return Task.FromResult($"Error: Permission denied: {authorizedPath}");
+            return Task.FromResult(context.AccessDenied($"Error: Permission denied: {authorizedPath}"));
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Task.FromResult(context.NotFound($"Error: Directory not found: {authorizedPath}"));
         }
         catch (IOException ex)
         {
-            return Task.FromResult($"Error listing directory: {ex.Message}");
+            return Task.FromResult(context.TransientFailure($"Error listing directory: {ex.Message}"));
         }
     }
 

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -46,7 +46,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     private readonly ILogger? _logger;
 
     public record Params(
-        [property: Description("Absolute path to the file to read")] string Path,
+        [property: Description("File path to read. Relative paths use the current project, then session scratch.")] string Path,
         [property: Description("Line number to start reading at, 1-based: the first line is line 1, matching the line numbers shown in this tool's output and in editors/grep/sed. To read line N, pass StartLine=N. Use with Limit to read sections of large files and avoid context window truncation.")] int? StartLine = null,
         [property: Description("Maximum number of lines to read. Use with StartLine to paginate through large files instead of reading the whole file.")] int? Limit = null);
 
@@ -69,16 +69,23 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     protected override async Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return "Error: 'path' parameter is required.";
+            return context.InvalidInput("Error: 'path' parameter is required.");
 
-        if (!_fileAccessPolicy.TryResolveReadPath(args.Path, context, out var authorizedPath, out var accessError))
-            return accessError;
+        if (!_fileAccessPolicy.TryResolveReadPath(
+                args.Path,
+                context,
+                out var authorizedPath,
+                out var accessError,
+                out var resolutionFailure))
+        {
+            return context.PathResolutionFailure(accessError, resolutionFailure);
+        }
 
         if (_pathPolicy.IsReadDenied(authorizedPath))
-            return FileToolErrors.CredentialReadDenied(authorizedPath);
+            return context.AccessDenied(FileToolErrors.CredentialReadDenied(authorizedPath));
 
         if (!File.Exists(authorizedPath))
-            return $"Error: File not found: {authorizedPath}";
+            return context.NotFound($"Error: File not found: {authorizedPath}");
 
         // Treat 0 or negative as "not specified"
         int? startLine = args.StartLine > 0 ? args.StartLine : null;
@@ -88,14 +95,17 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         {
             var inspection = await InspectFileAsync(authorizedPath, ct);
             if (!inspection.IsTextLike)
-                return HandleNonTextFile(authorizedPath, inspection, context);
+                return context.SuccessFile(
+                    HandleNonTextFile(authorizedPath, inspection, context),
+                    authorizedPath,
+                    ToolFileActivityKind.Read);
 
             var encoding = inspection.TextEncoding ?? StrictUtf8;
             if (startLine.HasValue || limit.HasValue)
             {
                 var lines = await ReadLinesAsync(authorizedPath, encoding, startLine ?? 1, limit, _config.MaxOutputChars, ct);
                 RecordSkillReadIfApplicable(authorizedPath);
-                return lines; // redaction + inline bound + spill happen centrally in the dispatcher
+                return context.SuccessFile(lines, authorizedPath, ToolFileActivityKind.Read);
             }
 
             // Bounded head read (not ReadAllTextAsync): a multi-hundred-MB file must
@@ -105,25 +115,37 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             // memory safety and steers past the cap.
             var (content, truncated) = await ReadBoundedHeadAsync(authorizedPath, encoding, _config.MaxOutputChars, ct);
             RecordSkillReadIfApplicable(authorizedPath);
-            return truncated
+            var result = truncated
                 ? content + $"\n[output truncated at {_config.MaxOutputChars} chars — read a specific range with StartLine and Limit, or grep the file, for the rest]"
                 : content;
+            return context.SuccessFile(result, authorizedPath, ToolFileActivityKind.Read);
         }
         catch (DecoderFallbackException)
         {
             var sizeBytes = TryGetFileLength(authorizedPath);
-            return BuildMetadataResponse(
+            return context.SuccessFile(
+                BuildMetadataResponse(
+                    authorizedPath,
+                    new FileInspection(MimeType.Default, AttachmentCategory.Other, sizeBytes, false, null),
+                    "File is not valid in the detected text encoding. Raw binary output is not returned by file_read."),
                 authorizedPath,
-                new FileInspection(MimeType.Default, AttachmentCategory.Other, sizeBytes, false, null),
-                "File is not valid in the detected text encoding. Raw binary output is not returned by file_read.");
+                ToolFileActivityKind.Read);
         }
         catch (UnauthorizedAccessException)
         {
-            return $"Error: Permission denied: {authorizedPath}";
+            return context.AccessDenied($"Error: Permission denied: {authorizedPath}");
+        }
+        catch (FileNotFoundException)
+        {
+            return context.NotFound($"Error: File not found: {authorizedPath}");
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return context.NotFound($"Error: File not found: {authorizedPath}");
         }
         catch (IOException ex)
         {
-            return $"Error reading file: {ex.Message}";
+            return context.TransientFailure($"Error reading file: {ex.Message}");
         }
     }
 

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -29,7 +29,7 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
     private readonly FileEditTool _editTool;
 
     public record Params(
-        [property: Description("Absolute path to the file to write")] string Path,
+        [property: Description("File path to write. Relative paths use the current project, then session scratch.")] string Path,
         [property: Description("Content to write to the file")] string Content);
 
     public FileWriteTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)
@@ -40,7 +40,7 @@ public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
     protected override Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Path))
-            return Task.FromResult("Error: 'Path' parameter is required.");
+            return Task.FromResult(context.InvalidInput("Error: 'Path' parameter is required."));
 
         return _editTool.WriteFileAsync(args.Path, args.Content, context, ct);
     }

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -11,6 +11,14 @@ namespace Netclaw.Actors.Tools;
 
 internal sealed class ScopedFileAccessPolicy
 {
+    internal enum PathResolutionFailure
+    {
+        None,
+        InvalidInput,
+        AccessDenied,
+        MissingBase
+    }
+
     private readonly ToolAudienceProfileResolver _profileResolver;
     private readonly Lazy<IReadOnlyList<string>> _cachedGlobalReadRoots;
     private readonly Lazy<string?> _cachedWorkspacesRoot;
@@ -36,6 +44,14 @@ internal sealed class ScopedFileAccessPolicy
     public bool TryResolveReadPath(string rawPath, ToolInvocationContext context, out string fullPath, out string error)
         => TryResolvePath(rawPath, context, AccessKind.Read, out fullPath, out error);
 
+    internal bool TryResolveReadPath(
+        string rawPath,
+        ToolInvocationContext context,
+        out string fullPath,
+        out string error,
+        out PathResolutionFailure failure)
+        => TryResolvePath(rawPath, context, AccessKind.Read, out fullPath, out error, out failure);
+
     /// <summary>
     /// Resolves a path for <c>set_working_directory</c>. Deliberately does NOT
     /// grant interactive Personal shell-equivalent reach: the working directory
@@ -46,6 +62,21 @@ internal sealed class ScopedFileAccessPolicy
     /// </summary>
     public bool TryResolveWorkingDirectory(string rawPath, ToolInvocationContext context, out string fullPath, out string error)
         => TryResolvePath(rawPath, context, AccessKind.Read, out fullPath, out error, allowInteractivePersonalReach: false);
+
+    internal bool TryResolveWorkingDirectory(
+        string rawPath,
+        ToolInvocationContext context,
+        out string fullPath,
+        out string error,
+        out PathResolutionFailure failure)
+        => TryResolvePath(
+            rawPath,
+            context,
+            AccessKind.Read,
+            out fullPath,
+            out error,
+            out failure,
+            allowInteractivePersonalReach: false);
 
     /// <summary>
     /// True when an interactive Personal-audience session gets shell-equivalent
@@ -61,8 +92,24 @@ internal sealed class ScopedFileAccessPolicy
     public bool TryResolveWritePath(string rawPath, ToolInvocationContext context, out string fullPath, out string error)
         => TryResolvePath(rawPath, context, AccessKind.Write, out fullPath, out error);
 
+    internal bool TryResolveWritePath(
+        string rawPath,
+        ToolInvocationContext context,
+        out string fullPath,
+        out string error,
+        out PathResolutionFailure failure)
+        => TryResolvePath(rawPath, context, AccessKind.Write, out fullPath, out error, out failure);
+
     public bool TryResolveAttachPath(string rawPath, ToolInvocationContext context, out string fullPath, out string error)
         => TryResolvePath(rawPath, context, AccessKind.Attach, out fullPath, out error);
+
+    internal bool TryResolveAttachPath(
+        string rawPath,
+        ToolInvocationContext context,
+        out string fullPath,
+        out string error,
+        out PathResolutionFailure failure)
+        => TryResolvePath(rawPath, context, AccessKind.Attach, out fullPath, out error, out failure);
 
     public IReadOnlyList<string> GetRootsForContext(ToolInvocationContext context, AccessKind accessKind)
     {
@@ -78,15 +125,62 @@ internal sealed class ScopedFileAccessPolicy
         out string fullPath,
         out string error,
         bool allowInteractivePersonalReach = true)
+        => TryResolvePath(
+            rawPath,
+            context,
+            accessKind,
+            out fullPath,
+            out error,
+            out _,
+            allowInteractivePersonalReach);
+
+    private bool TryResolvePath(
+        string rawPath,
+        ToolInvocationContext context,
+        AccessKind accessKind,
+        out string fullPath,
+        out string error,
+        out PathResolutionFailure failure,
+        bool allowInteractivePersonalReach = true)
     {
         try
         {
-            fullPath = Path.GetFullPath(rawPath);
+            if (string.IsNullOrWhiteSpace(rawPath) || rawPath.Any(char.IsControl))
+            {
+                fullPath = string.Empty;
+                error = "Error: Invalid path.";
+                failure = PathResolutionFailure.InvalidInput;
+                return false;
+            }
+
+            if (Path.IsPathFullyQualified(rawPath))
+            {
+                fullPath = Path.GetFullPath(rawPath);
+            }
+            else if (Path.IsPathRooted(rawPath))
+            {
+                fullPath = string.Empty;
+                error = "Error: Invalid path: partially qualified paths are not supported.";
+                failure = PathResolutionFailure.InvalidInput;
+                return false;
+            }
+            else if (TryGetRelativePathBase(context, out var baseDirectory))
+            {
+                fullPath = Path.GetFullPath(rawPath, baseDirectory);
+            }
+            else
+            {
+                fullPath = string.Empty;
+                error = "Error: invalid_context: No project or session directory is available. Call set_working_directory with an absolute project path, then retry.";
+                failure = PathResolutionFailure.MissingBase;
+                return false;
+            }
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
             fullPath = string.Empty;
             error = $"Error: Invalid path: {ex.Message}";
+            failure = PathResolutionFailure.InvalidInput;
             return false;
         }
 
@@ -109,10 +203,13 @@ internal sealed class ScopedFileAccessPolicy
             if (!allowInteractivePersonalReach
                 || context.RunScope.InteractiveApproval is InteractiveApprovalCapability.Unavailable)
             {
-                return TryResolveWithinAutonomousZone(fullPath, context, accessKind, out error);
+                var allowed = TryResolveWithinAutonomousZone(fullPath, context, accessKind, out error);
+                failure = allowed ? PathResolutionFailure.None : PathResolutionFailure.AccessDenied;
+                return allowed;
             }
 
             error = string.Empty;
+            failure = PathResolutionFailure.None;
             return true;
         }
 
@@ -121,6 +218,7 @@ internal sealed class ScopedFileAccessPolicy
         if (access.Mode == ToolFilesystemMode.None)
         {
             error = $"Error: {label} trust context does not allow {accessKind.ToString().ToLowerInvariant()} access to local files.";
+            failure = PathResolutionFailure.AccessDenied;
             return false;
         }
 
@@ -138,6 +236,7 @@ internal sealed class ScopedFileAccessPolicy
             && HasInteractivePersonalReach(context))
         {
             error = string.Empty;
+            failure = PathResolutionFailure.None;
             return true;
         }
 
@@ -146,6 +245,7 @@ internal sealed class ScopedFileAccessPolicy
         if (roots.Count == 0)
         {
             error = $"Error: {label} trust context does not have any configured local file roots for {accessKind.ToString().ToLowerInvariant()} access.";
+            failure = PathResolutionFailure.AccessDenied;
             return false;
         }
 
@@ -157,17 +257,65 @@ internal sealed class ScopedFileAccessPolicy
             if (PathUtility.ContainsSymlinkSegment(root, fullPath))
             {
                 error = $"Error: {label} trust context may not access files through symlinked paths inside the current session directory or configured roots.";
+                failure = PathResolutionFailure.AccessDenied;
                 return false;
             }
 
             error = string.Empty;
+            failure = PathResolutionFailure.None;
             return true;
         }
 
         error = audience == TrustAudience.Public
             ? $"Error: {label} trust context may only access files inside the current session directory."
             : $"Error: {label} trust context may only access files inside the current session directory or configured roots: {string.Join(", ", roots)}.";
+        failure = PathResolutionFailure.AccessDenied;
         return false;
+    }
+
+    private static bool TryGetRelativePathBase(
+        ToolInvocationContext context,
+        out string baseDirectory)
+    {
+        if (TryNormalizeAbsoluteBase(context.ProjectDirectory, requireExistingDirectory: true, out baseDirectory))
+            return true;
+
+        return TryNormalizeAbsoluteBase(context.SessionDirectory, requireExistingDirectory: false, out baseDirectory);
+    }
+
+    private static bool TryNormalizeAbsoluteBase(
+        string? candidate,
+        bool requireExistingDirectory,
+        out string baseDirectory)
+    {
+        baseDirectory = string.Empty;
+        if (string.IsNullOrWhiteSpace(candidate)
+            || candidate.Any(char.IsControl)
+            || !Path.IsPathFullyQualified(candidate))
+            return false;
+
+        try
+        {
+            var normalized = Path.GetFullPath(candidate);
+            if (requireExistingDirectory && !Directory.Exists(normalized))
+                return false;
+            if (Directory.Exists(normalized)
+                && (File.GetAttributes(normalized) & FileAttributes.ReparsePoint) != 0)
+            {
+                return false;
+            }
+
+            baseDirectory = normalized;
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException
+                                   or NotSupportedException
+                                   or PathTooLongException
+                                   or IOException
+                                   or UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     private static ToolFilesystemAccessProfile GetAccessProfile(ToolAudienceProfile profile, AccessKind accessKind) =>

--- a/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
@@ -47,19 +47,29 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
     protected override Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
         if (ContainsInvalidControlCharacter(args.Path))
-            return Task.FromResult("Error: path contains an invalid control character.");
+            return Task.FromResult(context.InvalidInput("Error: path contains an invalid control character."));
 
         var raw = args.Path?.Trim() ?? string.Empty;
         if (string.IsNullOrEmpty(raw))
-            return Task.FromResult("Error: path is required.");
+            return Task.FromResult(context.InvalidInput("Error: path is required."));
 
-        if (!_fileAccessPolicy.TryResolveWorkingDirectory(raw, context, out var fullPath, out var accessError))
-            return Task.FromResult(accessError);
+        if (!Path.IsPathFullyQualified(raw))
+            return Task.FromResult(context.InvalidInput("Error: path must be absolute."));
+
+        if (!_fileAccessPolicy.TryResolveWorkingDirectory(
+                raw,
+                context,
+                out var fullPath,
+                out var accessError,
+                out var resolutionFailure))
+        {
+            return Task.FromResult(context.PathResolutionFailure(accessError, resolutionFailure));
+        }
 
         if (!Directory.Exists(fullPath))
-            return Task.FromResult($"Error: directory does not exist: {fullPath}");
+            return Task.FromResult(context.NotFound($"Error: directory does not exist: {fullPath}"));
 
-        return Task.FromResult(fullPath);
+        return Task.FromResult(context.SuccessProject(fullPath, fullPath));
     }
 
     internal bool CanDeclare(string path, ToolInvocationContext context)

--- a/src/Netclaw.Actors/Tools/ToolOutcomeResults.cs
+++ b/src/Netclaw.Actors/Tools/ToolOutcomeResults.cs
@@ -1,0 +1,85 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolOutcomeResults.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+internal static class ToolOutcomeResults
+{
+    public const string SetWorkingDirectoryRemediation = "set_working_directory";
+    public const string UseSessionScratchRemediation = "use_session_scratch";
+
+    public static string Success(this ToolInvocationContext context, string result)
+        => Complete(context, result, ToolInvocationOutcomeCategory.Success);
+
+    public static string SuccessFile(
+        this ToolInvocationContext context,
+        string result,
+        string canonicalPath,
+        ToolFileActivityKind kind)
+        => Complete(context, result, ToolInvocationOutcomeCategory.Success,
+            [new ToolFileActivity(canonicalPath, kind)]);
+
+    public static string SuccessProject(
+        this ToolInvocationContext context,
+        string result,
+        string canonicalProjectDirectory)
+        => Complete(
+            context,
+            result,
+            ToolInvocationOutcomeCategory.Success,
+            declaredProjectDirectory: canonicalProjectDirectory);
+
+    public static string InvalidInput(this ToolInvocationContext context, string result)
+        => Complete(context, result, ToolInvocationOutcomeCategory.InvalidInput);
+
+    public static string AccessDenied(this ToolInvocationContext context, string result)
+        => Complete(context, result, ToolInvocationOutcomeCategory.AccessDenied);
+
+    public static string NotFound(this ToolInvocationContext context, string result)
+        => Complete(context, result, ToolInvocationOutcomeCategory.NotFound);
+
+    public static string TransientFailure(this ToolInvocationContext context, string result)
+        => Complete(context, result, ToolInvocationOutcomeCategory.TransientFailure);
+
+    public static string RecoverableCorrection(
+        this ToolInvocationContext context,
+        string result,
+        string remediationCode)
+        => Complete(
+            context,
+            result,
+            ToolInvocationOutcomeCategory.RecoverableCorrection,
+            remediationCode: remediationCode);
+
+    public static string PathResolutionFailure(
+        this ToolInvocationContext context,
+        string result,
+        ScopedFileAccessPolicy.PathResolutionFailure failure)
+        => failure switch
+        {
+            ScopedFileAccessPolicy.PathResolutionFailure.MissingBase =>
+                context.RecoverableCorrection(result, SetWorkingDirectoryRemediation),
+            ScopedFileAccessPolicy.PathResolutionFailure.InvalidInput => context.InvalidInput(result),
+            _ => context.AccessDenied(result)
+        };
+
+    private static string Complete(
+        ToolInvocationContext context,
+        string result,
+        ToolInvocationOutcomeCategory category,
+        IReadOnlyList<ToolFileActivity>? fileActivity = null,
+        string? remediationCode = null,
+        string? declaredProjectDirectory = null)
+    {
+        context.TryComplete(new ToolInvocationReceipt(
+            category,
+            fileActivity,
+            remediationCode,
+            declaredProjectDirectory));
+        return result;
+    }
+}

--- a/src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj
+++ b/src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Actors" />
     <InternalsVisibleTo Include="Netclaw.Actors.Tests" />
     <InternalsVisibleTo Include="Netclaw.Daemon.Tests" />
   </ItemGroup>

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -44,9 +44,11 @@ public abstract partial class NetclawTool<TParams> : INetclawTool where TParams 
     /// <inheritdoc />
     public async Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, ToolInvocationContext context, CancellationToken ct = default)
     {
-        return TryParse(arguments, out var error, out var args)
-            ? await ExecuteAsync(args, context, ct)
-            : error;
+        if (TryParse(arguments, out var error, out var args))
+            return await ExecuteAsync(args, context, ct);
+
+        context.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
+        return error;
     }
 
     /// <summary>

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -19,6 +19,97 @@ public sealed record ModelInputFileInfo(string FilePath, string FileName, MimeTy
 /// </summary>
 public sealed record FileAttachmentInfo(string FilePath, string FileName, MimeType MimeType);
 
+internal enum ToolInvocationOutcomeCategory
+{
+    Success,
+    InvalidInput,
+    AccessDenied,
+    NotFound,
+    TransientFailure,
+    RecoverableCorrection
+}
+
+internal enum ToolFileActivityKind
+{
+    Read,
+    Changed
+}
+
+internal sealed record ToolFileActivity
+{
+    public ToolFileActivity(string canonicalPath, ToolFileActivityKind kind)
+    {
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        if (!IsCanonicalAbsolutePath(canonicalPath))
+            throw new ArgumentException("File activity requires a canonical absolute path.", nameof(canonicalPath));
+
+        CanonicalPath = canonicalPath;
+        Kind = kind;
+    }
+
+    public string CanonicalPath { get; }
+    public ToolFileActivityKind Kind { get; }
+
+    private static bool IsCanonicalAbsolutePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)
+            || path.Any(char.IsControl)
+            || !Path.IsPathFullyQualified(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(path, Path.GetFullPath(path), StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+}
+
+internal sealed record ToolInvocationReceipt
+{
+    public ToolInvocationReceipt(
+        ToolInvocationOutcomeCategory category,
+        IReadOnlyList<ToolFileActivity>? fileActivity = null,
+        string? remediationCode = null,
+        string? declaredProjectDirectory = null)
+    {
+        if (!Enum.IsDefined(category))
+            throw new ArgumentOutOfRangeException(nameof(category));
+
+        var activity = fileActivity?.ToArray() ?? [];
+        if (category != ToolInvocationOutcomeCategory.Success
+            && (activity.Length > 0 || declaredProjectDirectory is not null))
+        {
+            throw new ArgumentException("Only successful outcomes may report working-context activity.");
+        }
+
+        if (category != ToolInvocationOutcomeCategory.RecoverableCorrection
+            && remediationCode is not null)
+        {
+            throw new ArgumentException("Only a recoverable correction may report remediation.", nameof(remediationCode));
+        }
+
+        if (declaredProjectDirectory is not null)
+            _ = new ToolFileActivity(declaredProjectDirectory, ToolFileActivityKind.Read);
+
+        Category = category;
+        FileActivity = Array.AsReadOnly(activity);
+        RemediationCode = remediationCode;
+        DeclaredProjectDirectory = declaredProjectDirectory;
+    }
+
+    public ToolInvocationOutcomeCategory Category { get; }
+    public IReadOnlyList<ToolFileActivity> FileActivity { get; }
+    public string? RemediationCode { get; }
+    public string? DeclaredProjectDirectory { get; }
+}
+
 /// <summary>
 /// Machine-readable working-context handoff from an ephemeral subagent run.
 /// Confirmed changes have first-party tool provenance; observed changes are
@@ -240,6 +331,7 @@ public sealed class ToolExecutionOutputs
     private readonly Action<SubAgentNotificationInfo>? _subAgentActivitySink;
     private List<FileAttachmentInfo>? _fileAttachments;
     private List<ModelInputFileInfo>? _modelInputFiles;
+    private ToolInvocationReceipt? _receipt;
 
     public ToolExecutionOutputs()
     {
@@ -257,6 +349,8 @@ public sealed class ToolExecutionOutputs
     public IReadOnlyList<ModelInputFileInfo> ModelInputFiles
         => _modelInputFiles?.AsReadOnly() ?? (IReadOnlyList<ModelInputFileInfo>)[];
 
+    internal ToolInvocationReceipt? Receipt => Volatile.Read(ref _receipt);
+
     public void AddFileAttachment(string filePath, string fileName, MimeType mimeType)
     {
         _fileAttachments ??= [];
@@ -271,6 +365,12 @@ public sealed class ToolExecutionOutputs
 
     public void ReportSubAgentActivity(SubAgentNotificationInfo notification)
         => _subAgentActivitySink?.Invoke(notification);
+
+    internal bool TryComplete(ToolInvocationReceipt receipt)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        return Interlocked.CompareExchange(ref _receipt, receipt, null) is null;
+    }
 
     public ToolExecutionOutputs Fork()
         => _subAgentActivitySink is null ? new ToolExecutionOutputs() : new ToolExecutionOutputs(_subAgentActivitySink);
@@ -532,6 +632,11 @@ public sealed class ToolInvocationContext
     internal void AddModelInputFile(string filePath, string fileName, MimeType mimeType)
         => Outputs.AddModelInputFile(filePath, fileName, mimeType);
 
+    internal ToolInvocationReceipt? Receipt => Outputs.Receipt;
+
+    internal bool TryComplete(ToolInvocationReceipt receipt)
+        => Outputs.TryComplete(receipt);
+
 }
 
 /// <summary>
@@ -576,6 +681,8 @@ public sealed class ToolExecutionContext
     public ModelModality ModelInputModalities => Invocation.ModelInputModalities;
 
     internal IReadOnlyList<FileAttachmentInfo> FileAttachments => Invocation.FileAttachments;
+
+    internal ToolInvocationReceipt? Receipt => Outputs.Receipt;
 
     internal void AddModelInputFile(string filePath, string fileName, string mimeType)
         => Invocation.AddModelInputFile(filePath, fileName, mimeType);


### PR DESCRIPTION
## Summary

- resolve relative first-party workspace paths from the valid project directory, then session scratch, without using process cwd
- add call-local typed outcome receipts so only successful canonical file activity updates working context
- preserve existing scoped and protected-path checks, including traversal, control-character, and symlink boundaries
- prevent failed file operations and failed project declarations from changing recent files or project scope

This is PR 4 of the make-agent-tools-pit-of-success stack.

## Deterministic evaluation evidence

- Relative workspace paths resolve from a valid project directory, then immutable session scratch; process cwd is never used.
- A stale project falls back to session scratch once, while an authorized project-based denial does not retry against a broader base.
- Successful canonical receipts update working context consistently in buffered and streaming flows.
- Failed read, write, edit, attach, and project-declaration calls do not mutate recent files, project scope, or child instructions.
- Absolute-path authorization, protected-path denial, traversal, control-character, and symlink boundaries remain enforced.
- No hosted behavioral run was used as evidence for this PR.

## Validation

- Netclaw.Actors.Tests: 3,493 passed, 2 expected platform skips
- strict OpenSpec validation
- header verification
- Slopwatch: 0 issues
- git diff check
