### PR TITLE
Serialize MCP smoke child-process spawns to deflake the Windows readiness timeout

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/McpProcessBoundStdioTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpProcessBoundStdioTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
 
+[Collection(McpSmokeChildProcessCollection.Name)]
 public sealed class McpProcessBoundStdioTests
 {
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkCatalogNotificationIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkCatalogNotificationIntegrationTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
 
+[Collection(McpSmokeChildProcessCollection.Name)]
 public sealed class McpSdkCatalogNotificationIntegrationTests(ITestOutputHelper output)
 {
     private static readonly McpServerName ServerName = new("notifications");

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSmokeChildProcessCollection.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSmokeChildProcessCollection.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpSmokeChildProcessCollection.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+/// <summary>
+/// Serializes the MCP test classes that start a real child process — the
+/// deterministic <c>Netclaw.SmokeMcpServer</c> or the python prompt server.
+/// The invariant: a child-process cold start must not share a small CI runner
+/// with another child-process cold start.
+/// <para>
+/// Each spawn pays a full cold start before the server announces readiness: a
+/// new CoreCLR, the DI graph, the MCP reflection scan, and a Kestrel bind for
+/// the HTTP transport. xunit gives one collection per class and runs up to
+/// <c>maxParallelThreads</c> collections together, so six such classes started
+/// six child processes at once on the 4-vCPU Windows runner. The children
+/// starved each other for CPU, and Windows added a Defender scan of the fresh
+/// DLL per spawn.
+/// <c>SmokeMcpServerHttpHeaderTests.ConfiguredHeader_WhenOAuthProbeReturnsMetadata_StillReachesServer</c>
+/// then failed with "Smoke MCP server did not publish a listening URL within 30s".
+/// The readiness signal itself is correct. The runner simply had no CPU left.
+/// </para>
+/// <para>
+/// <c>DisableParallelization</c> changes the schedule only. It runs these
+/// classes one at a time. It does not skip, disable, or weaken any test, and
+/// no timeout value changes. Classes that use fake process doubles, such as
+/// <c>PowerShellHostProbeTests</c>, stay in the default parallel pool.
+/// </para>
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class McpSmokeChildProcessCollection
+{
+    public const string Name = "McpSmokeChildProcess";
+}

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -16,6 +16,7 @@ namespace Netclaw.Daemon.Tests.Mcp;
 /// End-to-end smoke tests that connect to a real MCP server over stdio.
 /// Uses the repository's deterministic MCP smoke server.
 /// </summary>
+[Collection(McpSmokeChildProcessCollection.Name)]
 public class McpStdioSmokeTests : IAsyncDisposable
 {
     private McpClient? _client;

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpPromptSkillTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpPromptSkillTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
 
+[Collection(McpSmokeChildProcessCollection.Name)]
 public sealed class SmokeMcpPromptSkillTests(ITestOutputHelper output)
 {
     [Theory]

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerArgumentCoercionTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerArgumentCoercionTests.cs
@@ -21,6 +21,7 @@ namespace Netclaw.Daemon.Tests.Mcp;
 /// this test proves the wire: that a reconstructed argument actually serializes
 /// over JSON-RPC and is accepted by a real MCP server.
 /// </summary>
+[Collection(McpSmokeChildProcessCollection.Name)]
 public sealed class SmokeMcpServerArgumentCoercionTests(ITestOutputHelper output)
 {
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -29,6 +29,7 @@ namespace Netclaw.Daemon.Tests.Mcp;
 /// configured header → <c>HttpClientTransport.AdditionalHeaders</c> → wire →
 /// server-side capture.
 /// </summary>
+[Collection(McpSmokeChildProcessCollection.Name)]
 public sealed class SmokeMcpServerHttpHeaderTests
 {
     private readonly ITestOutputHelper _output;

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerLocator.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerLocator.cs
@@ -18,7 +18,21 @@ namespace Netclaw.Daemon.Tests.Mcp;
 /// </summary>
 internal static class SmokeMcpServerLocator
 {
-    public static string LocateDll()
+    /// <summary>
+    /// The result cannot change during a test run, so the recursive
+    /// <c>bin/</c> walk runs once per test process instead of once per spawn.
+    /// The walk is expensive on Windows CI, where every spawning test paid for
+    /// it again. <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>
+    /// also caches the failure: a build that produced no DLL is a permanent
+    /// miss, and every test must keep failing with the same assertion.
+    /// </summary>
+    private static readonly Lazy<string> CachedDll = new(
+        LocateDllCore,
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public static string LocateDll() => CachedDll.Value;
+
+    private static string LocateDllCore()
     {
         var projectDir = Path.Combine(LocateRepositoryRoot(), "tests", "Netclaw.SmokeMcpServer");
         var binMarker = $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}";


### PR DESCRIPTION
## Problem

`SmokeMcpServerHttpHeaderTests.ConfiguredHeader_WhenOAuthProbeReturnsMetadata_StillReachesServer`
timed out on Windows CI with:

```
Smoke MCP server did not publish a listening URL within 30s
```

## Root cause: CPU starvation, not a signal defect

Two specialists reviewed the failure and agreed on the cause, with file and
line evidence.

The readiness design is correct:

- the child announces its listening URL on stderr
- the announce completes a `TaskCompletionSource` created with
  `RunContinuationsAsynchronously`
- both pipes are drained, so no pipe buffer can fill and block the child
- the wait separates an early child exit from a real timeout

The failure is CPU oversubscription on the runner. xunit v3 gives one
collection per test class and runs up to `maxParallelThreads` collections at
the same time. The Windows runner has 4 vCPUs. Six classes under
`src/Netclaw.Daemon.Tests/Mcp/` each start their own child process:

- `SmokeMcpServerHttpHeaderTests`
- `McpStdioSmokeTests`
- `SmokeMcpServerArgumentCoercionTests`
- `McpSdkCatalogNotificationIntegrationTests`
- `McpProcessBoundStdioTests`
- `SmokeMcpPromptSkillTests`

Five of them start `dotnet Netclaw.SmokeMcpServer.dll`. The stdio classes
start it through the MCP SDK `StdioClientTransport`, not `Process.Start`.

Each spawn pays a full cold start before the announce: a new CoreCLR, the DI
graph, the MCP reflection scan, and a Kestrel bind for the HTTP transport.
Six concurrent cold starts on 4 cores starve each other. Windows adds a
Defender scan of the fresh DLL, plus a recursive `bin/` walk for every call
to `SmokeMcpServerLocator.LocateDll`.

## The fix

1. New `McpSmokeChildProcessCollection` with
   `[CollectionDefinition(Name, DisableParallelization = true)]`. The six
   classes above join it, so their child-process cold starts never
   co-schedule. The doc comment states the invariant and records the Windows
   evidence.
2. `SmokeMcpServerLocator.LocateDll` now caches its result in a
   `static Lazy<string>` with `LazyThreadSafetyMode.ExecutionAndPublication`.
   The recursive `bin/` walk runs once for each test process instead of once
   for each spawn. The `Lazy` also caches a failure, which is correct here: a
   build that produced no DLL is a permanent miss, and the existing assertion
   message stays the failure for every test. The type doc already states that
   the result cannot change during a run.

`PowerShellHostProbeTests` is in the same assembly but stays out of the
collection. It starts no real process. Every test there drives an
`IPowerShellProbeProcessFactory` double, so it does not compete for spawn
resources.

## No timeout changed

No timeout value changes anywhere in this PR. The 30s readiness budget, the
2-minute per-test budgets, and the connect timeouts are all untouched. The
budget was never too small. The runner had no CPU left to meet it.

## Test count proof

`DisableParallelization` changes the schedule only. It skips, disables, and
weakens nothing. The executed count proves it:

| Run | Command | Result |
|-----|---------|--------|
| Before | `dotnet test src/Netclaw.Daemon.Tests --no-build --nologo --filter "FullyQualifiedName~Mcp"` | Failed: 0, Passed: 182, Skipped: 0, Total: 182 |
| After | same command | Failed: 0, Passed: 182, Skipped: 0, Total: 182 |

Full assembly after the change: Failed: 0, Passed: 1036, Skipped: 0,
Total: 1036.

## Wall-time tradeoff

On a 24-core Linux workstation the full `Netclaw.Daemon.Tests` run goes from
41s to 1m 45s. The serialized MCP set is now the critical path, and the rest
of the assembly still runs in parallel beside it. On the 4-vCPU Windows
runner the old schedule did not win that time anyway: the six children
thrashed one another and one of them missed its readiness budget. Determinism
is worth the cost on a large developer machine.

## Gates

- `dotnet build Netclaw.slnx -warnaserror` — 0 Warning(s), 0 Error(s)
- `dotnet test src/Netclaw.Daemon.Tests --no-build --nologo` — 1036 passed
- `dotnet slopwatch analyze` — `Scan complete: 0 issue(s) found`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — `All files have headers.`
