### PR TITLE
Complete structured tool rollout proof

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -318,6 +318,13 @@ Done when:
   only Once or Deny and creates no reusable temp authority. Headless behavior,
   Team/Public denial, hard-deny rules, dynamic syntax, protected paths, and
   native PowerShell causal scope stay strict.
+- [x] Seven sanitized tool-friction cases replay through registration, policy,
+  dispatch, typed outcomes, and success-owned working context. Structured
+  search, batch read, JSON selection, image metadata, and spill continuation
+  need no shell approval. Representative interpreter fallbacks still prompt.
+  Parent and child diagnostics report counts and outcome categories only.
+- [ ] Complete the hosted structured-tool comparison, native platform CI, stack
+  merge, binary swap, and a new sanitized live traffic harvest.
 - [ ] Define automated session-directory cleanup in a separate OpenSpec before
   adding retention or deletion behavior.
 - [ ] A constrained executable grammar proves any future safe `sed` form. The

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -323,8 +323,14 @@ Done when:
   search, batch read, JSON selection, image metadata, and spill continuation
   need no shell approval. Representative interpreter fallbacks still prompt.
   Parent and child diagnostics report counts and outcome categories only.
-- [ ] Complete the hosted structured-tool comparison, native platform CI, stack
-  merge, binary swap, and a new sanitized live traffic harvest.
+- [x] The hosted PR 7 comparison ran five trials per selected scenario. Search,
+  batch read, JSON selection, image metadata, and deferred discovery passed
+  25/25 with the intended structured tools and no shell fallback. Spill
+  continuation passed 0/5: all five runs used shell, none loaded or called
+  `tool_output_read`, and one run searched the catalog. Keep this failure as a
+  rollout finding; do not weaken its assertion.
+- [ ] Complete native platform CI, stack merge, binary swap, and a new
+  sanitized live traffic harvest.
 - [ ] Define automated session-directory cleanup in a separate OpenSpec before
   adding retention or deletion behavior.
 - [ ] A constrained executable grammar proves any future safe `sed` form. The

--- a/evals/README.md
+++ b/evals/README.md
@@ -80,7 +80,7 @@ log patterns** (skill loading, memory recall, checkpoint formation).
 | Identity & Self-Awareness | 5 | Bot knows its name, version, repo, session ID, and routes all identity-file concerns without a skill dependency |
 | Skill Discovery and Activation | 20 | Models load relevant file, feed, and MCP prompt skills while they skip unrelated skills |
 | Memory Pipeline | 4 | Memory recall is active, identity-vs-memory routing is correct, explicit saves use memory tools, and automatic checkpointing still fires |
-| Tool Discovery & Use | 13 | Progressive discovery, file-vs-shell selection, web-vs-local search, and timestamped webhook configuration |
+| Tool Discovery & Use | 16 | Progressive discovery, structured workspace selection, web search, and timestamped webhook configuration |
 | Grounding & Alignment | 4 | Uses tools to verify facts, admits uncertainty, and resolves announced attachment paths from the authoritative session root |
 | Autonomy & Execution | 2 | Executes tasks rather than describing them |
 | Deployment Mission | 1 | Applies the disk mission playbook, loads its required skill, and returns reviewed sales email |

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -452,6 +452,12 @@ start_eval_daemon() {
         printf 'ordinary-%s\n' "$i" > "$selection_root/search-target/file-$i.txt"
     done
     printf 'local-search-eval-token\n' > "$selection_root/search-target/nested/match.txt"
+    printf 'batch-first-marker\n' > "$selection_root/batch-first.txt"
+    printf 'batch-second-marker\n' > "$selection_root/batch-second.txt"
+    printf '{"status":"structured-json-ready","ignored":"not-requested"}\n' \
+        > "$selection_root/status.json"
+    printf '\211PNG\r\n\032\n\000\000\000\rIHDR\000\000\000\003\000\000\000\002' \
+        > "$selection_root/dimensions.png"
 
     # Seed the project-root fixture for the set_working_directory evals. The
     # natural prompt requires Git semantics, a project marker, and a build file.
@@ -1457,9 +1463,30 @@ assert_tool_known_file_edit() {
 }
 
 assert_tool_local_repository_search() {
-    stdout_tool_called 'shell_execute' \
+    stdout_tool_called 'file_search' \
+        && ! stdout_tool_called 'shell_execute' \
         && ! stdout_tool_called 'web_search' \
         && stdout_response_contains 'match.txt'
+}
+
+assert_tool_known_batch_read() {
+    stdout_tool_called 'file_read_many' \
+        && ! stdout_tool_called 'shell_execute' \
+        && stdout_response_contains 'batch-first-marker' \
+        && stdout_response_contains 'batch-second-marker'
+}
+
+assert_tool_known_json_projection() {
+    stdout_tool_called 'json_read' \
+        && ! stdout_tool_called 'shell_execute' \
+        && stdout_response_contains 'structured-json-ready' \
+        && ! stdout_response_contains 'not-requested'
+}
+
+assert_tool_known_image_metadata() {
+    stdout_tool_called 'file_read' \
+        && ! stdout_tool_called 'shell_execute' \
+        && stdout_response_contains '3x2'
 }
 
 assert_tool_rationale_contract() {
@@ -2666,8 +2693,17 @@ run_all() {
     run_case tool_known_file_edit "known file edit uses a file tool without shell" \
         "Replace initial-content with edited-content in /home/netclaw/.netclaw/workspaces/file-tool-selection/edit-target.txt, then report completion."
 
-    run_case tool_local_repository_search "local repository search uses shell, not web_search" \
+    run_case tool_local_repository_search "recursive literal search uses file_search without shell" \
         "Search recursively under /home/netclaw/.netclaw/workspaces/file-tool-selection/search-target for the exact text local-search-eval-token and tell me which file contains it."
+
+    run_case tool_known_batch_read "known files use one bounded file_read_many call" \
+        "Read /home/netclaw/.netclaw/workspaces/file-tool-selection/batch-first.txt and /home/netclaw/.netclaw/workspaces/file-tool-selection/batch-second.txt. Return both exact values."
+
+    run_case tool_known_json_projection "known JSON selection uses json_read without an interpreter" \
+        "Read only the /status value from /home/netclaw/.netclaw/workspaces/file-tool-selection/status.json. Do not return other properties."
+
+    run_case tool_known_image_metadata "known image metadata uses file_read without an interpreter" \
+        "Report the exact dimensions of /home/netclaw/.netclaw/workspaces/file-tool-selection/dimensions.png."
 
     run_case --json tool_rationale_contract "all calls retain rationales across two parallel tool iterations" \
         "Use exactly two tool stages. First, call file_list on /home/netclaw/.netclaw/workspaces and list_reminders in one parallel batch. After both results return, call file_read on /home/netclaw/.netclaw/workspaces/netclaw-eval-largefile.txt for lines 1 through 3 and skill_load for netclaw-operations in one parallel batch. Use all four tools, then summarize the results."

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.62.0"
+  version: "2.63.0"
 ---
 
 # Netclaw Operations
@@ -41,6 +41,11 @@ a reference file — load the one matching the user's intent with
 
 When available, use `file_read` for a known local file read.
 When available, use `file_list` for a known local directory listing.
+Use `file_search` for bounded recursive name or literal text search.
+Use `file_read_many` when the paths to read are already known.
+Use `json_read` for bounded JSON pointer selection.
+Use `file_read` for image metadata.
+Use `tool_output_read` to continue a spilled result by call id.
 When available, use `file_write` or `file_edit` for a known local file change.
 When available, use `web_search` for external discovery and `web_fetch` for a known external page.
 When available, use `shell_execute` for local search, VCS, builds, tests, processes, or requested shell behavior.
@@ -48,6 +53,7 @@ Do not substitute shell commands when a listed first-party tool satisfies the ta
 Do not delegate a known file operation that an available file tool can complete.
 After a successful file tool result, do not use shell only to verify it unless the user requests shell behavior.
 For disposable text, use `file_write` then `file_read`; do not attempt a shell redirect first.
+Use `search_tools`, then `load_tool`, before reporting that a specialty tool is unavailable.
 
 Keep shell approval friction bounded:
 

--- a/feeds/skills/.system/files/netclaw-projects/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-projects/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-projects
 description: "How to create, find, and work with project workspaces. Load when the user references a project, asks to organize work, or you need a sustained workspace."
 metadata:
   author: netclaw
-  version: "1.3.0"
+  version: "1.4.0"
 license: MIT
 compatibility: "netclaw >= 0.10.0"
 disable-model-invocation: false
@@ -23,7 +23,7 @@ research initiative, or any sustained body of work.
 Before creating a new project, **always check what already exists**:
 
 ```
-shell_execute("find <workspaces_path> -name AGENTS.md -maxdepth 4 -type f")
+file_search(Root: "<workspaces_path>", Query: "AGENTS.md", Mode: "name")
 ```
 
 Read the `AGENTS.md` of any match to understand its purpose. If a project
@@ -38,12 +38,14 @@ Only create a project when:
 
 Steps:
 1. Choose a descriptive directory name (kebab-case)
-2. `shell_execute("mkdir -p <workspaces_path>/<name> && cd <workspaces_path>/<name> && git init")`
-3. Write an `AGENTS.md` with `file_write` describing:
+2. Create `<workspaces_path>/<name>` with one shell operation.
+3. Set that path with `set_working_directory`.
+4. Initialize version control with one shell operation.
+5. Write an `AGENTS.md` with `file_write` describing:
    - What this project is about
    - Goals and constraints
    - Relevant context (target audience, products, tools, etc.)
-4. `shell_execute("cd <workspaces_path>/<name> && git add -A && git commit -m 'Initial project setup'")`
+6. Stage and commit with separate shell operations.
 
 The `AGENTS.md` is the project's living context document. Update it as the
 project evolves.

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -52,10 +52,10 @@
 
 ## 7. PR 7 - Replay, documentation, and rollout proof
 
-- [ ] 7.1 Replay every sanitized friction fixture through real registration, policy, dispatch, outcome, and working-context paths.
-- [ ] 7.2 Prove representative structured workflows require no shell approval while equivalent shell/Python fallbacks remain approval-gated.
-- [ ] 7.3 Update embedded operating guidance and repo-owned skills to prefer structured workspace tools and progressive discovery without memorizing command syntax.
-- [ ] 7.4 Add operator diagnostics for core/deferred/loaded counts and outcome categories with PII and payload exclusion tests.
+- [x] 7.1 Replay every sanitized friction fixture through real registration, policy, dispatch, outcome, and working-context paths.
+- [x] 7.2 Prove representative structured workflows require no shell approval while equivalent shell/Python fallbacks remain approval-gated.
+- [x] 7.3 Update embedded operating guidance and repo-owned skills to prefer structured workspace tools and progressive discovery without memorizing command syntax.
+- [x] 7.4 Add operator diagnostics for core/deferred/loaded counts and outcome categories with PII and payload exclusion tests.
 - [ ] 7.5 Run Release build, full tests, headers, formatting, strict OpenSpec, changed-file Slopwatch, PII audit, and API compatibility gates.
 - [ ] 7.6 Run native Windows and Linux validation.
 - [ ] 7.7 Rebase the final stack on upstream/dev, merge in order, remove merged worktrees, produce a binary-swap build, and harvest a new sanitized live window.

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -57,5 +57,5 @@
 - [x] 7.3 Update embedded operating guidance and repo-owned skills to prefer structured workspace tools and progressive discovery without memorizing command syntax.
 - [x] 7.4 Add operator diagnostics for core/deferred/loaded counts and outcome categories with PII and payload exclusion tests.
 - [x] 7.5 Run Release build, full tests, headers, formatting, strict OpenSpec, changed-file Slopwatch, PII audit, and API compatibility gates.
-- [ ] 7.6 Run native Windows and Linux validation.
+- [x] 7.6 Run native Windows and Linux validation.
 - [ ] 7.7 Rebase the final stack on upstream/dev, merge in order, remove merged worktrees, produce a binary-swap build, and harvest a new sanitized live window.

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -56,6 +56,6 @@
 - [x] 7.2 Prove representative structured workflows require no shell approval while equivalent shell/Python fallbacks remain approval-gated.
 - [x] 7.3 Update embedded operating guidance and repo-owned skills to prefer structured workspace tools and progressive discovery without memorizing command syntax.
 - [x] 7.4 Add operator diagnostics for core/deferred/loaded counts and outcome categories with PII and payload exclusion tests.
-- [ ] 7.5 Run Release build, full tests, headers, formatting, strict OpenSpec, changed-file Slopwatch, PII audit, and API compatibility gates.
+- [x] 7.5 Run Release build, full tests, headers, formatting, strict OpenSpec, changed-file Slopwatch, PII audit, and API compatibility gates.
 - [ ] 7.6 Run native Windows and Linux validation.
 - [ ] 7.7 Rebase the final stack on upstream/dev, merge in order, remove merged worktrees, produce a binary-swap build, and harvest a new sanitized live window.

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -36,6 +36,8 @@
   <ItemGroup>
     <Compile Include="../Netclaw.Security.Tests/ShellPolicyEvidenceModels.cs"
              Link="Tools/ApprovalEvidence/ShellPolicyEvidenceModels.cs" />
+    <Compile Include="../Netclaw.Security.Tests/ToolFrictionEvidenceModels.cs"
+             Link="Tools/ToolFrictionEvidenceModels.cs" />
     <None Include="../../openspec/changes/archive/2026-08-15-structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json"
           Link="ApprovalEvidence/netclaw-policy-fixtures.json"
           CopyToOutputDirectory="PreserveNewest" />
@@ -44,6 +46,9 @@
           CopyToOutputDirectory="PreserveNewest" />
     <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-schema-footprint-baseline.json"
           Link="ToolFootprintEvidence/tool-schema-footprint-baseline.json"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json"
+          Link="ToolFrictionEvidence/tool-friction-fixtures.json"
           CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.html" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.json" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
+using Akka.Event;
 using Akka.Hosting;
 using Akka.Streams;
 using System.Text.Json;
@@ -77,11 +78,18 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
             AIFunctionFactory.Create((string url) => "ok", "navigate_page", "Navigate to URL"),
             "browser_chrome_devtools",
             "navigate_page"));
-        var toolAccessPolicy = TestToolAccessPolicy.Create(new ToolConfig());
+        var toolConfig = new ToolConfig();
+        toolConfig.AudienceProfiles.Public.AllowedMcpServers.Add("browser_chrome_devtools");
+        toolConfig.AudienceProfiles.Public.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["browser_chrome_devtools"] = ["navigate_page"]
+        };
+        var toolAccessPolicy = TestToolAccessPolicy.Create(toolConfig);
         registry.RegisterCore(new SearchToolsTool(registry, toolAccessPolicy));
         registry.RegisterCore(new LoadToolTool(registry, toolAccessPolicy));
 
         services.AddSingleton(registry);
+        services.AddSingleton(toolAccessPolicy);
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
         services.AddSingleton<TimeProvider>(_timeProvider);
         services.AddSingleton<ISessionLifecycleObserver>(_lifecycleObserver);
@@ -119,6 +127,55 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         Assert.Equal(sessionId, joined.SessionId);
         Assert.Equal(0, joined.TurnCount);
         Assert.Null(joined.Title);
+    }
+
+    [Fact]
+    public async Task Session_emits_one_payload_free_tool_exposure_diagnostic()
+    {
+        var sessionId = new SessionId("signalr/tool-exposure-test");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("tool-exposure-probe");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await EventFilter.Info(
+                message: "Session tool exposure core=2 deferredVisible=1 loaded=0")
+            .ExpectAsync(1, async () =>
+            {
+                await sessionManager.Ask<CommandAck>(new SendUserMessage
+                {
+                    SessionId = sessionId,
+                    Content = "private-payload-marker",
+                    Source = new MessageSource
+                    {
+                        ChannelType = ChannelType.SignalR,
+                        SenderId = new SenderId("synthetic-operator"),
+                        ChannelId = "synthetic-channel",
+                        MessageId = "synthetic-message",
+                        TurnId = new Netclaw.Actors.Protocol.TurnId("synthetic-turn"),
+                        Audience = TrustAudience.Personal,
+                        Boundary = TrustBoundary.Personal,
+                        Principal = PrincipalClassification.Operator,
+                        Provenance = new SourceProvenance(
+                            TransportAuthenticity.Verified,
+                            PayloadTaint.Trusted),
+                        ReceivedAt = _timeProvider.GetUtcNow()
+                    }
+                }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+                await subscriber.ExpectMsgAsync<TextOutput>(
+                    TimeSpan.FromSeconds(3),
+                    cancellationToken: TestContext.Current.CancellationToken);
+                await subscriber.ExpectMsgAsync<TurnCompleted>(
+                    TimeSpan.FromSeconds(3),
+                    cancellationToken: TestContext.Current.CancellationToken);
+            }, cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/SessionToolPipelineTestFixture.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/SessionToolPipelineTestFixture.cs
@@ -47,6 +47,7 @@ internal sealed class SessionToolPipelineTestFixture(
     private IReadOnlyDictionary<string, ApprovalDecision> _decisionOverrides
         = new Dictionary<string, ApprovalDecision>();
     private IReadOnlyList<SessionScratchCorrectionKey> _scratchCorrectionKeys = [];
+    private ILoggingAdapter _logger = NoLogger.Instance;
 
     public SessionToolPipelineTestFixture From(MessageSource source)
     {
@@ -63,6 +64,12 @@ internal sealed class SessionToolPipelineTestFixture(
     public SessionToolPipelineTestFixture WithTimeProvider(TimeProvider timeProvider)
     {
         _timeProvider = timeProvider;
+        return this;
+    }
+
+    public SessionToolPipelineTestFixture WithLogger(ILoggingAdapter logger)
+    {
+        _logger = logger;
         return this;
     }
 
@@ -182,7 +189,7 @@ internal sealed class SessionToolPipelineTestFixture(
         var pipeline = new SessionToolExecutionPipeline(
             executor,
             _timeProvider,
-            NoLogger.Instance);
+            _logger);
         var batch = new SessionToolBatch(turnContext, runEnvironment)
         {
             ToolCalls = toolCalls,

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMessageAssemblerTests.cs
@@ -376,6 +376,7 @@ public sealed class SessionMessageAssemblerTests
         var text = staticBlock.Text ?? string.Empty;
 
         Assert.Contains("session_dir:", text);
+        Assert.Contains(ToolChoiceGuidance.StructuredWorkspaceSelection, text, StringComparison.Ordinal);
         Assert.Contains(ToolChoiceGuidance.DirectorySelectionOrder, text, StringComparison.Ordinal);
         Assert.Contains(ToolChoiceGuidance.ShellCompositionOrder, text, StringComparison.Ordinal);
         Assert.Contains("private scratch for disposable writable non-project artifacts", text);

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -825,6 +825,9 @@ public class SubAgentActorTests : TestKit
             message => message.Text.Contains($"session_dir: {sessionDirectory}", StringComparison.Ordinal));
         Assert.Single(
             client.LastReceivedMessages!,
+            message => message.Text.Contains(ToolChoiceGuidance.StructuredWorkspaceSelection, StringComparison.Ordinal));
+        Assert.Single(
+            client.LastReceivedMessages!,
             message => message.Text.Contains(ToolChoiceGuidance.DirectorySelectionOrder, StringComparison.Ordinal));
         Assert.Single(
             client.LastReceivedMessages!,
@@ -1913,6 +1916,7 @@ public class SubAgentActorTests : TestKit
         var userMessage = fakeClient.LastReceivedMessages![1].Text;
         Assert.Contains("[session]", userMessage);
         Assert.Contains($"session_dir: {sessionDirectory}", userMessage);
+        Assert.Contains(ToolChoiceGuidance.StructuredWorkspaceSelection, userMessage, StringComparison.Ordinal);
         Assert.Contains(ToolChoiceGuidance.DirectorySelectionOrder, userMessage, StringComparison.Ordinal);
         Assert.Contains(ToolChoiceGuidance.ShellCompositionOrder, userMessage, StringComparison.Ordinal);
         Assert.DoesNotContain("always set WorkingDirectory to session_dir", userMessage, StringComparison.OrdinalIgnoreCase);

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentObservabilityTests.cs
@@ -141,6 +141,36 @@ public sealed class SubAgentObservabilityTests : TestKit
         }, cancellationToken: TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Tool_dispatch_emits_only_the_bounded_outcome_category()
+    {
+        var fakeTool = new FakeNetclawTool("greet", "private-result-marker");
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent("private-call-marker", "greet",
+                    new Dictionary<string, object?>
+                    {
+                        ["name"] = "private-argument-marker",
+                        ["_rationale"] = "Exercise the bounded diagnostic."
+                    })
+            ]
+        };
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(
+            CreateDefinition([fakeTool]),
+            fakeClient,
+            PermissivePolicy()));
+
+        await EventFilter.Info(message: "SubAgent tool outcome category=Success").ExpectAsync(1, async () =>
+        {
+            await agent.Ask<SubAgentResult>(
+                NewRun("Use the tool with a private payload marker."),
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+        }, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
     // Regression coverage for issue #1597: sub-agent LLM calls used to discard
     // ChatResponse.Usage entirely — the actor had no ISessionMetrics and never read
     // response.Usage — so every sub-agent's token consumption was invisible to

--- a/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
@@ -50,10 +50,14 @@ public class DiscoveredToolCacheTests
 
         RegisterAndRemember(registry, cache, "notion", "search", retentionTurns: 3, maxCount: 12);
 
+        Assert.Equal(2, cache.BaseToolCount);
+        Assert.Equal(1, cache.LoadedToolCount);
         Assert.Equal(3, cache.AvailableTools.Count);
 
         cache.EvictAll();
 
+        Assert.Equal(2, cache.BaseToolCount);
+        Assert.Equal(0, cache.LoadedToolCount);
         Assert.Equal(2, cache.AvailableTools.Count);
         Assert.Contains(baseTool1, cache.AvailableTools);
         Assert.Contains(baseTool2, cache.AvailableTools);

--- a/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
@@ -1,0 +1,463 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolFrictionReplayTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Immutable;
+using System.Text.Json;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.TestKit;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tests.Sessions.Pipelines;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Security.Tests;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
+using ShellSyntaxTree;
+using Xunit;
+using static Netclaw.Actors.Sessions.SessionProtocol;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    private const string FixtureFile = "tool-friction-fixtures.json";
+
+    protected override void ConfigureAkka(Akka.Hosting.AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Theory]
+    [InlineData("TF01")]
+    [InlineData("TF02")]
+    [InlineData("TF03")]
+    [InlineData("TF04")]
+    [InlineData("TF05")]
+    [InlineData("TF06")]
+    [InlineData("TF07")]
+    public async Task Sanitized_friction_case_replays_through_real_tool_boundaries(string caseId)
+    {
+        var policyCase = LoadCase(caseId);
+        using var temp = new DisposableTempDir();
+        var setup = await CreateScenarioAsync(temp.Path, policyCase, TestContext.Current.CancellationToken);
+        var runtime = CreateRuntime(setup.DeniedPath);
+
+        Assert.Equal(
+            policyCase.ExpectedToolSequence,
+            setup.Calls.Select(static call => call.Name));
+
+        var current = new WorkingContext
+        {
+            ProjectDirectory = setup.ProjectDirectory,
+            RecentFiles = ImmutableList.Create(setup.SeedRecentFile)
+        };
+
+        for (var index = 0; index < setup.Calls.Count; index++)
+        {
+            var call = setup.Calls[index];
+            var registration = runtime.Registry.GetRegistrationByToolName(call.Name);
+            Assert.NotNull(registration);
+            Assert.Equal(call.Name, registration.Tool.Name);
+
+            var authorization = await runtime.Executor.EvaluateAuthorizationAsync(
+                call,
+                CreateContext(setup, current),
+                TestContext.Current.CancellationToken);
+            Assert.Equal(
+                policyCase.ExpectedApprovalRequired,
+                authorization.Outcome == ToolAuthorizationOutcome.RequiresApproval);
+            Assert.Equal(ToolAuthorizationOutcome.Allowed, authorization.Outcome);
+
+            var completed = await ExecuteAsync(
+                runtime.Executor,
+                setup,
+                current,
+                call,
+                $"{caseId.ToLowerInvariant()}-{index}");
+            var receipt = Assert.Single(completed.ToolReceipts).Value;
+            Assert.Equal(ParseOutcome(policyCase.ExpectedOutcome), receipt.Category);
+            current = WorkingContextUpdater.UpdateFromToolReceipts(
+                current,
+                completed.ToolResults,
+                completed.ToolReceipts);
+        }
+
+        if (setup.Fallback is { } fallback)
+        {
+            var fallbackDecision = await runtime.Executor.EvaluateAuthorizationAsync(
+                fallback,
+                CreateContext(setup, current),
+                TestContext.Current.CancellationToken);
+            Assert.Equal(
+                policyCase.FallbackApprovalRequired,
+                fallbackDecision.Outcome == ToolAuthorizationOutcome.RequiresApproval);
+            Assert.Equal(ToolAuthorizationOutcome.RequiresApproval, fallbackDecision.Outcome);
+        }
+        else
+        {
+            Assert.False(policyCase.FallbackApprovalRequired);
+        }
+
+        AssertContextEffect(policyCase.ExpectedContextEffect, setup, current);
+        if (policyCase.ExpectedContextEffect == "CoreOnlyChildCatalog")
+        {
+            Assert.True(runtime.Registry.IsCoreTool("search_tools"));
+            Assert.True(runtime.Registry.IsCoreTool("load_tool"));
+            Assert.False(runtime.Registry.IsCoreTool("attach_file"));
+        }
+    }
+
+    [Fact]
+    public async Task Pipeline_emits_only_the_bounded_outcome_category()
+    {
+        using var temp = new DisposableTempDir();
+        var policyCase = LoadCase("TF01");
+        var setup = await CreateScenarioAsync(temp.Path, policyCase, TestContext.Current.CancellationToken);
+        var runtime = CreateRuntime(setup.DeniedPath);
+        var current = new WorkingContext { ProjectDirectory = setup.ProjectDirectory };
+
+        await EventFilter.Info(message: "Tool outcome category=Success").ExpectAsync(1, async () =>
+        {
+            _ = await ExecuteAsync(runtime.Executor, setup, current, setup.Calls[0], "outcome-log");
+        }, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private async Task<ToolExecutionCompleted> ExecuteAsync(
+        DispatchingToolExecutor executor,
+        ScenarioSetup setup,
+        WorkingContext current,
+        FunctionCallContent call,
+        string suffix)
+    {
+        var sessionId = new SessionId($"signalr/tool-friction-{suffix}");
+        var probe = CreateTestProbe($"tool-friction-{suffix}");
+        var pipeline = new SessionToolPipelineTestFixture(executor, [call], sessionId, probe.Ref)
+            .WithTurnContext(InteractiveTurnContext(sessionId))
+            .InSessionDirectory(setup.SessionDirectory)
+            .InProject(setup.ProjectDirectory, current.RecentFiles)
+            .WithLogger(Logging.GetLogger(Sys, typeof(ToolFrictionReplayTests)))
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(5),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipeline.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        return completed;
+    }
+
+    private static TurnContext InteractiveTurnContext(SessionId sessionId) => new()
+    {
+        SessionId = sessionId,
+        TurnId = new TurnId("tool-friction-turn"),
+        Audience = TrustAudience.Personal,
+        Boundary = TrustBoundary.Personal,
+        ChannelType = ChannelType.SignalR,
+        RequesterSenderId = new SenderId("synthetic-operator"),
+        RequesterPrincipal = PrincipalClassification.Operator,
+        Provenance = new SourceProvenance(
+            TransportAuthenticity.Verified,
+            PayloadTaint.Trusted),
+        SupportsInteractiveApproval = true
+    };
+
+    private static ToolExecutionContext CreateContext(ScenarioSetup setup, WorkingContext current)
+        => TestToolExecutionContext.CreateBound(
+            "signalr/tool-friction-context",
+            setup.SessionDirectory,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                Boundary = TrustBoundary.Personal,
+                ChannelType = ChannelType.SignalR.ToWireValue(),
+                ProjectDirectory = current.ProjectDirectory,
+                RecentFiles = current.RecentFiles
+            });
+
+    private static RuntimeSetup CreateRuntime(string deniedPath)
+    {
+        var environment = ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux);
+        var commandPolicy = new ShellCommandPolicy(environment);
+        var authorizationPathPolicy = new ToolPathPolicy(environment, []);
+        var toolPathPolicy = new ToolPathPolicy(environment, [deniedPath]);
+        var config = new ToolConfig
+        {
+            ShellMode = ShellExecutionMode.HostAllowed,
+            AudienceProfiles = ToolAudienceProfileDefaults.CreateProfilesForPosture(DeploymentPosture.Personal)
+        };
+        var accessPolicy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            commandPolicy,
+            authorizationPathPolicy);
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            toolPathPolicy,
+            commandPolicy,
+            toolAccessPolicy: accessPolicy);
+        return new RuntimeSetup(registry, new DispatchingToolExecutor(registry, accessPolicy));
+    }
+
+    private static async Task<ScenarioSetup> CreateScenarioAsync(
+        string root,
+        ToolFrictionCase policyCase,
+        CancellationToken cancellationToken)
+    {
+        var project = Path.Join(root, "project");
+        var session = Path.Join(root, "sessions", "current");
+        Directory.CreateDirectory(project);
+        Directory.CreateDirectory(session);
+        var seed = Path.Join(project, "seed.txt");
+        var denied = Path.Join(project, "blocked.txt");
+        await File.WriteAllTextAsync(seed, "seed", cancellationToken);
+
+        return policyCase.Id switch
+        {
+            "TF01" => await RecursiveSearchAsync(project, session, seed, denied, cancellationToken),
+            "TF02" => await BatchReadAsync(project, session, seed, denied, cancellationToken),
+            "TF03" => await JsonProjectionAsync(project, session, seed, denied, cancellationToken),
+            "TF04" => await ImageMetadataAsync(project, session, seed, denied, cancellationToken),
+            "TF05" => await SpillContinuationAsync(project, session, seed, denied, cancellationToken),
+            "TF06" => FailedFileActivity(project, session, seed, denied),
+            "TF07" => SubagentCatalogExposure(project, session, seed, denied),
+            _ => throw new InvalidOperationException($"Unsupported fixture case: {policyCase.Id}")
+        };
+    }
+
+    private static async Task<ScenarioSetup> RecursiveSearchAsync(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        CancellationToken cancellationToken)
+    {
+        await File.WriteAllTextAsync(
+            Path.Join(project, "notes.txt"),
+            "fixture-marker",
+            cancellationToken);
+        return Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("search", FileSearchTool.ToolName, "Root", ".", "Query", "fixture-marker", "Mode", "content")],
+            PythonFallback("search-fallback", project, "print('recursive search')"));
+    }
+
+    private static async Task<ScenarioSetup> BatchReadAsync(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        CancellationToken cancellationToken)
+    {
+        var first = Path.Join(project, "first.txt");
+        var second = Path.Join(project, "second.txt");
+        await File.WriteAllTextAsync(first, "first", cancellationToken);
+        await File.WriteAllTextAsync(second, "second", cancellationToken);
+        return Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("batch", FileReadManyTool.ToolName, "Paths", new[] { "first.txt", "second.txt" })],
+            PythonFallback("batch-fallback", project, "print(open('first.txt').read()); print(open('second.txt').read())"),
+            [first, second]);
+    }
+
+    private static async Task<ScenarioSetup> JsonProjectionAsync(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        CancellationToken cancellationToken)
+    {
+        var path = Path.Join(project, "data.json");
+        await File.WriteAllTextAsync(path, "{\"status\":\"ready\"}", cancellationToken);
+        return Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("json", JsonReadTool.ToolName, "Path", "data.json", "Pointers", new[] { "/status" })],
+            PythonFallback("json-fallback", project, "import json; print(json.load(open('data.json'))['status'])"),
+            [path]);
+    }
+
+    private static async Task<ScenarioSetup> ImageMetadataAsync(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        CancellationToken cancellationToken)
+    {
+        var path = Path.Join(project, "image.png");
+        await File.WriteAllBytesAsync(path, PngHeader(3, 2), cancellationToken);
+        return Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("image", FileReadTool.ToolName, "Path", "image.png")],
+            PythonFallback("image-fallback", project, "print('inspect image metadata')"),
+            [path]);
+    }
+
+    private static async Task<ScenarioSetup> SpillContinuationAsync(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        CancellationToken cancellationToken)
+    {
+        const string callId = "fixture-spill";
+        Assert.True(ToolOutputSpillLocation.TryResolve(session, callId, out var directory, out var path));
+        Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(path, new string('x', 256), cancellationToken);
+        return Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("spill", ToolOutputReadTool.ToolName, "CallId", callId, "Start", 0, "Limit", 128)],
+            PythonFallback("spill-fallback", project, "print('continue retained output')"));
+    }
+
+    private static ScenarioSetup FailedFileActivity(
+        string project,
+        string session,
+        string seed,
+        string denied)
+        => Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("denied-write", FileWriteTool.ToolName, "Path", "blocked.txt", "Content", "must not write")],
+            fallback: null);
+
+    private static ScenarioSetup SubagentCatalogExposure(
+        string project,
+        string session,
+        string seed,
+        string denied)
+        => Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [
+                Call("search-tools", "search_tools", "Query", "attach local file"),
+                Call("load-tool", "load_tool", "Name", "attach_file")
+            ],
+            fallback: null);
+
+    private static ScenarioSetup Setup(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        IReadOnlyList<FunctionCallContent> calls,
+        FunctionCallContent? fallback,
+        IReadOnlyList<string>? expectedFiles = null)
+        => new(
+            project,
+            session,
+            seed,
+            denied,
+            calls,
+            fallback,
+            expectedFiles ?? []);
+
+    private static FunctionCallContent PythonFallback(string id, string workingDirectory, string body)
+        => Call(
+            id,
+            ShellTool.ToolName,
+            "Command",
+            $"python -c \"{body}\"",
+            "WorkingDirectory",
+            workingDirectory);
+
+    private static FunctionCallContent Call(string id, string name, params object?[] values)
+    {
+        var arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["_rationale"] = "Replay one sanitized tool-friction case."
+        };
+        for (var index = 0; index < values.Length; index += 2)
+            arguments.Add((string)values[index]!, values[index + 1]);
+        return new FunctionCallContent($"fixture-{id}", name, arguments);
+    }
+
+    private static void AssertContextEffect(
+        string expectedEffect,
+        ScenarioSetup setup,
+        WorkingContext current)
+    {
+        Assert.Equal(setup.ProjectDirectory, current.ProjectDirectory);
+        switch (expectedEffect)
+        {
+            case "RecordOneCanonicalFile":
+            case "RecordTwoCanonicalFiles":
+                Assert.Equal(setup.ExpectedFiles.Count + 1, current.RecentFiles.Count);
+                Assert.All(setup.ExpectedFiles, path => Assert.Contains(path, current.RecentFiles));
+                Assert.Contains(setup.SeedRecentFile, current.RecentFiles);
+                break;
+            case "NoContextChangeRequired":
+            case "PreserveRecentFiles":
+            case "CoreOnlyChildCatalog":
+                Assert.Equal([setup.SeedRecentFile], current.RecentFiles);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported context effect: {expectedEffect}");
+        }
+    }
+
+    private static ToolInvocationOutcomeCategory ParseOutcome(string outcome)
+        => outcome switch
+        {
+            "success" => ToolInvocationOutcomeCategory.Success,
+            "access_denied" => ToolInvocationOutcomeCategory.AccessDenied,
+            _ => throw new InvalidOperationException($"Unsupported outcome: {outcome}")
+        };
+
+    private static ToolFrictionCase LoadCase(string caseId)
+    {
+        var path = Path.Join(AppContext.BaseDirectory, "ToolFrictionEvidence", FixtureFile);
+        var catalog = JsonSerializer.Deserialize(
+                          File.ReadAllBytes(path),
+                          ToolFrictionEvidenceJsonContext.Default.ToolFrictionFixtureCatalog)
+                      ?? throw new InvalidOperationException("Tool-friction evidence must deserialize.");
+        return Assert.Single(catalog.Cases, item => item.Id == caseId);
+    }
+
+    private static byte[] PngHeader(int width, int height) =>
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        (byte)(width >> 24), (byte)(width >> 16), (byte)(width >> 8), (byte)width,
+        (byte)(height >> 24), (byte)(height >> 16), (byte)(height >> 8), (byte)height
+    ];
+
+    private sealed record RuntimeSetup(ToolRegistry Registry, DispatchingToolExecutor Executor);
+
+    private sealed record ScenarioSetup(
+        string ProjectDirectory,
+        string SessionDirectory,
+        string SeedRecentFile,
+        string DeniedPath,
+        IReadOnlyList<FunctionCallContent> Calls,
+        FunctionCallContent? Fallback,
+        IReadOnlyList<string> ExpectedFiles);
+}

--- a/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
@@ -30,6 +30,10 @@ internal sealed class DiscoveredToolCache
     /// </summary>
     public IReadOnlyList<AITool> AvailableTools => _availableTools;
 
+    public int BaseToolCount => _baseToolCount;
+
+    public int LoadedToolCount => Math.Max(0, _availableTools.Count - _baseToolCount);
+
     /// <summary>
     /// Seed the always-loaded base tools once at session start. Everything added
     /// beyond this set is a discovered tool subject to lease-based eviction.

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -96,6 +96,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly TrustContextDeriver? _trustContextDeriver;
     // Owns the exposed tool list (base + discovered) and lease-based eviction.
     private readonly DiscoveredToolCache _discoveredToolCache = new();
+    private (int Core, int DeferredVisible, int Loaded)? _lastToolExposure;
 
     // Last observed input token count from LLM response (for compaction trigger)
     private long _lastInputTokenCount;
@@ -2855,6 +2856,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var client = _chatClient;
 
         var exposedTools = ResolveExposedToolsForCurrentTurn();
+        LogToolExposure(exposedTools.Count);
         // Always carry the session id so the session-agnostic chat-client decorators
         // (logging/retry/routing) can correlate LLM diagnostics — including provider
         // failover/outage — back to this session in Seq. Tools are attached only when
@@ -2992,6 +2994,30 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return availableTools;
 
         return _toolAccessPolicy.FilterExposedTools(availableTools, _fullRegistry, _currentTrustContext);
+    }
+
+    private void LogToolExposure(int exposedCount)
+    {
+        if (_toolAccessPolicy is null || _fullRegistry is null)
+            return;
+
+        var coreCount = _fullRegistry.GetCoreRegistrations().Count(registration =>
+            _toolAccessPolicy.IsToolExposed(registration, _currentTrustContext));
+        var visibleCount = _fullRegistry.GetAllRegistrations().Count(registration =>
+            _toolAccessPolicy.IsToolExposed(registration, _currentTrustContext));
+        var exposure = (
+            Core: coreCount,
+            DeferredVisible: Math.Max(0, visibleCount - coreCount),
+            Loaded: Math.Max(0, exposedCount - coreCount));
+        if (_lastToolExposure == exposure)
+            return;
+
+        _lastToolExposure = exposure;
+        TurnLog().Info(
+            "Session tool exposure core={CoreCount} deferredVisible={DeferredVisibleCount} loaded={LoadedCount}",
+            exposure.Core,
+            exposure.DeferredVisible,
+            exposure.Loaded);
     }
 
     /// <summary>
@@ -3452,7 +3478,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _config.Tuning.DiscoveredToolRetentionTurns,
             _config.Tuning.DiscoveredToolMaxCount);
         if (_discoveredToolCache.AddIfMissing(tool.ToAITool()))
-            _log.Info("Dynamically loaded tool '{ToolName}' into session", canonicalName);
+            _log.Info(
+                "Session deferred tool activated loaded={LoadedCount}",
+                _discoveredToolCache.LoadedToolCount);
         return true;
     }
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -377,6 +377,11 @@ internal sealed class SessionToolExecutionPipeline
                 return result;
             });
             var results = await Task.WhenAll(tasks);
+            foreach (var result in results)
+            {
+                if (result.Receipt is { } receipt)
+                    _logger.Info("Tool outcome category={OutcomeCategory}", receipt.Category);
+            }
 
             if (batch.StreamResults)
             {

--- a/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
@@ -190,6 +190,7 @@ public static class SessionMessageAssembler
         {
             var sessionBlock = $"[session]\nid: {input.SessionId.Value}" +
                                $"\nsession_dir: {sessionDir}" +
+                               $"\n{ToolChoiceGuidance.StructuredWorkspaceSelection}" +
                                $"\n{ToolChoiceGuidance.DirectorySelectionOrder}" +
                                $"\n{ToolChoiceGuidance.ShellCompositionOrder}" +
                                "\nsession_dir is private scratch for disposable writable non-project artifacts. " +

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -567,6 +567,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     msg.ToolReceipts.TryGetValue(callId.Value, out var receipt);
                     _fileActivity.Apply(receipt);
                     TryApplyProjectDirectory(receipt);
+                    if (receipt is not null)
+                        _log.Info("SubAgent tool outcome category={OutcomeCategory}", receipt.Category);
                 }
                 if (result.Name is "load_tool" && result.Content is not null)
                     TryActivateDiscoveredTool(result.Content.Trim());
@@ -1134,6 +1136,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                              || sessionDirectory.Any(char.IsControl)
             ? string.Empty
             : $"[session]\nsession_dir: {sessionDirectory}\n"
+              + ToolChoiceGuidance.StructuredWorkspaceSelection + "\n"
               + ToolChoiceGuidance.DirectorySelectionOrder + "\n"
               + ToolChoiceGuidance.ShellCompositionOrder;
 

--- a/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
+++ b/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
@@ -8,6 +8,17 @@ namespace Netclaw.Actors.Tools;
 
 internal static class ToolChoiceGuidance
 {
+    public const string StructuredWorkspaceSelection = """
+        Prefer structured workspace tools:
+        1. Use file_search for bounded recursive name or literal text search.
+        2. Use file_read_many when the paths to read are already known.
+        3. Use json_read for bounded JSON pointer selection.
+        4. Use file_read for file content and image metadata.
+        5. Use tool_output_read to continue a spilled result by call id.
+        6. Use search_tools, then load_tool, before reporting that a specialty tool is unavailable.
+        7. Use shell or an interpreter only when no structured tool expresses the operation.
+        """;
+
     public const string DirectorySelectionOrder = """
         Choose directories in this order:
         1. For declared-project work, omit WorkingDirectory; the shell uses project_dir.

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -21,6 +21,11 @@
 
 - When available, use `file_read` for a known local file read.
 - When available, use `file_list` for a known local directory listing.
+- Use `file_search` for bounded recursive name or literal text search.
+- Use `file_read_many` when the paths to read are already known.
+- Use `json_read` for bounded JSON pointer selection.
+- Use `file_read` for image metadata.
+- Use `tool_output_read` to continue a spilled result by call id.
 - When available, use `file_write` or `file_edit` for a known local file change.
 - When available, use `web_search` for external discovery and `web_fetch` for a known external page.
 - When available, use `shell_execute` for local search, VCS, builds, tests, processes, or requested shell behavior.
@@ -28,6 +33,7 @@
 - Do not delegate a known file operation that an available file tool can complete.
 - After a successful file tool result, do not use shell only to verify it unless the user requests shell behavior.
 - For disposable text, use `file_write` then `file_read`; do not attempt a shell redirect first.
+- Use `search_tools`, then `load_tool`, before reporting that a specialty tool is unavailable.
 
 Keep shell approval friction bounded:
 

--- a/src/Netclaw.Configuration/Resources/AGENTS.public.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.public.md
@@ -21,6 +21,15 @@
 - Apply this rule to each parallel call and each later tool iteration.
 - If a correction reports a missing rationale, fix every call before the retry.
 
+## Structured Tool Selection
+
+- Use `file_search` for bounded recursive name or literal text search.
+- Use `file_read_many` when the paths to read are already known.
+- Use `json_read` for bounded JSON pointer selection.
+- Use `file_read` for file content and image metadata.
+- Use `tool_output_read` to continue a spilled result by call id.
+- Use `search_tools`, then `load_tool`, before reporting that a specialty tool is unavailable.
+
 ## Grounding Rules
 
 - Never state runtime facts (versions, status, availability) without checking with a tool.


### PR DESCRIPTION
## Summary

- Replay the seven sanitized tool-friction fixtures through real registration, policy, dispatch, typed outcome, and working-context paths.
- Prefer structured workspace tools and progressive discovery in parent and child guidance.
- Add count-only tool exposure diagnostics and outcome-category diagnostics without payloads.
- Extend the behavioral suite for recursive search, bounded batch reads, JSON selection, and image metadata.

This PR is the seventh and final implementation slice in stack #2023. It depends on #2038.

## Hosted behavior comparison

The selected comparison ran five trials per scenario on the production patch now at commit 55f3ff91. Only aggregate results are reported here. Raw transcripts and artifacts are not published.

| Scenario | Result | Observed tool choice |
| --- | ---: | --- |
| Recursive repository search | 5/5 | file_search in every trial; no shell fallback |
| Known batch read | 5/5 | file_read_many in every trial; no shell fallback |
| Known JSON selection | 5/5 | json_read in every trial; no shell fallback |
| Known image metadata | 5/5 | file_read in every trial; no shell fallback |
| Deferred tool discovery | 5/5 | search_tools in every trial; no shell fallback |
| Spilled output continuation | 0/5 | shell used in every trial; catalog searched once; tool_output_read was never loaded or called |

The five structured-selection scenarios passed 25/25. The spill-continuation failure remains recorded as a rollout finding; its assertion was not weakened.

## Validation

- Release build: 0 warnings, 0 errors
- Full solution tests: 7,751 passed; 16 expected platform or external-service skips; 0 failed
- Sanitized friction replay: 8/8 passed
- Strict OpenSpec validation passed
- Copyright-header verification passed
- Changed-file formatting validation passed
- Slopwatch: 0 issues
- Diff check passed
- Added-line privacy scan found no credentials, endpoints, email addresses, URLs, or operator home paths
- No public API or durable wire-format change

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>