### PR TITLE
Reuse the JSON pointer token buffer

### DIFF
--- a/src/Netclaw.Actors/Tools/JsonReadTool.cs
+++ b/src/Netclaw.Actors/Tools/JsonReadTool.cs
@@ -190,9 +190,11 @@ public sealed partial class JsonReadTool : NetclawTool<JsonReadTool.Params>
         }
 
         var tokens = new List<string>();
+        var token = new StringBuilder();
         foreach (var encodedToken in source[1..].Split('/'))
         {
-            var token = new StringBuilder(encodedToken.Length);
+            token.Clear();
+            token.EnsureCapacity(encodedToken.Length);
             for (var index = 0; index < encodedToken.Length; index++)
             {
                 if (encodedToken[index] != '~')


### PR DESCRIPTION
## Summary

- Reuse one `StringBuilder` across JSON pointer token decoding.
- Preserve strict RFC 6901 validation and projection behavior.
- Resolve the allocation alert from PR #2037.

## Validation

- `dotnet build Netclaw.slnx -c Release --no-restore`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release --no-build --filter FullyQualifiedName~StructuredWorkspaceToolTests` (18 passed)
- `dotnet slopwatch analyze --fail-on warning`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`

The eval suite was not run. This change does not alter a tool schema or agent behavior.