### PR TITLE
Harden workspace paths and complete typed remediation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,19 @@ If you do need to create or modify files under `openspec/`, use the appropriate
 skill above rather than editing them directly. The only exception is updating
 task checkboxes in `openspec/changes/*/tasks.md` during RALPH iterations.
 
+## Specification Review Contract
+
+- Link [the engineering glossary](docs/spec/GLOSSARY.md) for cross-cutting
+  terms. Do not copy its definitions into each specification.
+- Add a glossary term when two or more capabilities need the same meaning.
+- Show an ordered flow with pseudocode or a small diagram when sequence,
+  authority, state, or persistence affects the design.
+- Give at least one concrete positive example and one negative example for each
+  new policy or security boundary.
+- Name the component that owns each decision. State whether its data is
+  call-local, actor-local, or durable.
+- Label pseudocode as schematic when it omits a security gate or runtime step.
+
 ## Discovery Rules
 
 Before coding a capability, discover in this order:

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -146,6 +146,24 @@ Done when:
 - [x] Focused tests and the full repository quality gates pass.
 - [ ] An installed daemon restart confirms the live process uses the durable directory.
 
+### Priority: Complete Tool Remediation
+
+**PRD:** `docs/prd/PRD-006-mcp-tool-integration.md`
+**Spec:** `openspec/changes/complete-tool-remediation/`
+**Surface area:** internal tool receipts and model-facing tool results
+**Verification:** L2
+
+The receipt must drive the next action. The model must not depend on duplicated
+handwritten guidance or an unchecked string code.
+
+Done when:
+
+- [x] Every `RecoverableCorrection` receipt carries one defined internal code.
+- [x] Parent and child paths use one presenter before result delivery.
+- [x] Hidden tools are not named by remediation.
+- [x] Approval authority, scratch retry state, durable messages, and public APIs remain unchanged.
+- [ ] The stacked follow-up handles `attach_file` exposure and native-tool shell mistakes separately.
+
 ### Priority: Reduce Shell Approval Fatigue
 
 **PRDs:** `docs/prd/PRD-002-gateway-security-envelope.md`, `docs/prd/PRD-006-mcp-tool-integration.md`

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -1,0 +1,317 @@
+# Netclaw Engineering Glossary
+
+This glossary defines cross-cutting terms for Netclaw engineering documents.
+PRDs, engineering specs, OpenSpec files, and reviews use these meanings.
+
+A code anchor shows the current implementation owner. It does not freeze the
+class name or prevent a later refactor.
+
+## How to Use This Glossary
+
+- Link to this file instead of copying a definition into another document.
+- Define a local term when only one capability uses it.
+- Add a term here when two or more capabilities need the same meaning.
+- State an explicit exception when a specification narrows a glossary term.
+- Prefer a plain term over an internal class name in descriptive text.
+
+## Tool Call Flow
+
+This flow shows a normal tool return:
+
+```text
+model
+  -> tool call
+  -> dispatcher
+       -> authorization
+       -> optional approval request
+       -> tool implementation
+       -> factual tool result -> redaction and output bound --+
+       -> internal tool receipt ------------------------------+---> correction presenter
+                                                                  -> model-facing result
+
+internal tool receipt
+  -> optional actor working-context update
+```
+
+The result and receipt are sibling outputs of execution. The correction
+presenter can use both to build the final model-facing result. The actor uses a
+successful receipt only when that receipt contains a defined state effect.
+
+A terminal non-cancellation exception follows a different delivery branch:
+
+```text
+dispatcher classifies the receipt and throws
+  -> parent or child actor creates the factual failure result
+  -> correction presenter
+  -> model-facing result
+```
+
+An approval request remains non-terminal, and caller cancellation propagates.
+Neither case creates this terminal receipt and failure result.
+
+## Runtime and Actor Terms
+
+### Actor
+
+An actor owns mutable runtime state and processes one message at a time. Netclaw
+uses actors for sessions, subagents, reminders, and other runtime components.
+
+### Main session
+
+The main session is the actor that owns the user conversation. Some code and
+specs call it the parent session when they compare it with a subagent.
+
+**Code anchor:** `LlmSessionActor`
+
+### Subagent
+
+A subagent is a child actor that performs one delegated task. It has its own
+model requests, tool exposure set, and ephemeral working context.
+
+**Code anchors:** `SubAgentActor`, `SubAgentSpawner`
+
+### Working context
+
+The working context is actor-local state that helps later model turns. It
+contains the optional declared project directory and a bounded list of recently
+used files. The main session persists its `WorkingContext`. A subagent keeps its
+working context only for the child run. Git branch and worktree facts come from
+a separate inspection and are not fields in either working context.
+
+**Code anchors:** `WorkingContext`, `ChildFileActivityTracker`
+
+### Durable and ephemeral
+
+Durable data survives actor restart because Netclaw stores it. Ephemeral data
+exists only in memory for the current call, turn, actor, or process.
+
+Example:
+
+```text
+durable:   a stored tool-role chat message
+ephemeral: the ToolInvocationReceipt for that tool call
+```
+
+## Tool Lifecycle Terms
+
+### Tool definition or tool schema
+
+A tool definition is the name, description, and argument schema that the model
+can see. It tells the model how to author a tool call.
+
+### First-party tool and MCP tool
+
+A first-party tool is implemented and registered by Netclaw. An MCP tool comes
+from an external Model Context Protocol server. Both kinds still pass Netclaw's
+exposure and authorization boundaries.
+
+### Workspace tool
+
+A workspace tool reads, lists, writes, edits, attaches, or selects files and
+directories. It uses the project and session path rules in this glossary.
+
+### Core tool
+
+A core tool is eligible for the initial model-visible tool set. Policy can still
+hide it from a specific audience or session.
+
+### Deferred tool
+
+A deferred tool is registered but absent from the initial model-visible set.
+An allowed actor can find it and load its schema later.
+
+### Schema exposure
+
+Schema exposure means that the model can see a tool definition. Exposure does
+not grant permission to execute the tool.
+
+Example:
+
+```text
+load_tool("list_reminders")
+  -> the next model request can see the list_reminders schema
+  -> a later list_reminders call still runs normal authorization
+```
+
+### Tool call
+
+A tool call is the model-authored tool name, arguments, and call identifier.
+It is a request, not proof that Netclaw executed the tool.
+
+### Dispatcher
+
+The dispatcher is the shared execution boundary for registered tools. It finds
+the registration, runs authorization, invokes the tool, and records an outcome.
+
+**Code anchor:** `DispatchingToolExecutor`
+
+### Authorization
+
+Authorization is the runtime decision that allows, denies, or pauses a tool
+call. It evaluates the current audience, policy, path, and approval state.
+
+### Authority
+
+Authority is the set of actions that the current session is permitted to take.
+Tool exposure, a receipt, and a correction instruction do not add authority.
+
+### Approval
+
+Approval is an operator decision for a call that requires consent. Approval is
+one input to authorization. It is not the same as schema exposure.
+
+Example:
+
+```text
+schema exposed + approval required + no approval
+  -> the model can author the call
+  -> Netclaw does not execute the tool
+```
+
+### Tool result
+
+The tool result is the text that Netclaw returns to the model. Normal dispatcher
+results pass output redaction and bounding before delivery. A result can contain
+data, an error, or a factual explanation of a correctable problem.
+
+### Tool receipt
+
+A tool receipt is trusted internal data about one completed invocation attempt.
+The attempt can end before the tool implementation runs. An actor uses the
+receipt to update state without parsing model-facing text or authored arguments.
+
+**Code anchor:** `ToolInvocationReceipt`
+
+Example:
+
+```text
+result:
+  "README content..."
+
+receipt:
+  category      = Success
+  file activity = Read("/workspace/project/README.md")
+```
+
+### File activity
+
+File activity is a canonical path and an operation kind recorded in a successful
+receipt. The working context uses it instead of guessing paths from authored
+arguments or result text.
+
+### Outcome category
+
+The outcome category is the closed status in a tool receipt. Current categories
+include success, invalid input, access denied, not found, transient failure, and
+recoverable correction.
+
+**Code anchor:** `ToolInvocationOutcomeCategory`
+
+### Remediation code or next-action code
+
+A remediation code is a closed internal value for one bounded correction
+strategy. It contains no path or free-form instruction.
+
+**Code anchor:** `ToolRemediationCode`
+
+Example:
+
+```text
+result:
+  "No project or session directory is available."
+
+receipt:
+  category    = RecoverableCorrection
+  remediation = SetWorkingDirectory
+```
+
+The prose phrase "typed remediation" means that the receipt uses this enum. It
+does not mean that Netclaw executes the action or grants new authority.
+
+### Correction presenter
+
+The correction presenter converts a valid remediation code into one fixed model
+instruction. It does not inspect arguments, execute tools, or grant authority.
+
+**Code anchor:** `ToolRemediationPresenter`
+
+Example:
+
+```text
+input result:  "No project or session directory is available."
+input code:    SetWorkingDirectory
+tool visible:  true
+
+final message:
+  "No project or session directory is available.
+   Next action: call set_working_directory ..."
+```
+
+If the named tool is hidden, the presenter leaves the factual result unchanged.
+This prevents an instruction that the current model cannot follow.
+
+## Filesystem and Output Terms
+
+### Project scope
+
+Project scope is the declared project directory for a main session or subagent
+run. Workspace tools use it as the first base for relative paths.
+
+### Session directory and session scratch
+
+The session directory path is fixed for one session. Its contents are mutable.
+Session scratch means disposable work inside that directory. It is the
+relative-path base when the session has no valid project directory.
+
+### Allowed root
+
+An allowed root is a configured or context-derived directory boundary for a
+specific access type. A path inside one root can still fail another security
+check.
+
+### Canonical path
+
+A canonical path is a fully qualified, normalized path with no unresolved dot
+segments. Canonical form does not by itself grant access.
+
+### Safe, unavailable, and unsafe path bases
+
+These states describe a candidate base for a relative path:
+
+- **Safe:** The base is usable and passes the required authority and link checks.
+- **Unavailable:** The base is absent, not a fully qualified path, or is a
+  missing project directory. Policy can try the next documented base before
+  authorization starts.
+- **Unsafe:** The base is present but normalization or inspection fails, has no
+  owning authority root, or crosses a link boundary. Netclaw denies the call and
+  does not try another base.
+
+Example:
+
+```text
+project missing
+  -> Unavailable
+  -> try the session directory
+
+project ancestor is a link to /outside
+  -> Unsafe
+  -> AccessDenied
+  -> do not try the session directory
+```
+
+**Code anchor:** `ScopedFileAccessPolicy`
+
+### Spill and output continuation
+
+A spill is the full redacted result stored in session-owned output after the
+result exceeds its inline budget. The model receives an opaque call identifier.
+It uses `tool_output_read` to read another bounded window.
+
+```text
+large result
+  -> bounded inline preview
+  -> opaque call id
+  -> tool_output_read(CallId, Start, Limit)
+```
+
+The model does not receive the internal spill path.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -2,6 +2,9 @@
 
 This directory contains implementation-facing specifications derived from PRDs.
 
+Use [GLOSSARY.md](GLOSSARY.md) for cross-cutting engineering terms. A spec can
+narrow a glossary term only when it states the exception.
+
 ## Active Specs
 
 - `SPEC-001-runtime-boundaries.md` (PRD-001, PRD-002)

--- a/openspec/changes/complete-tool-remediation/.openspec.yaml
+++ b/openspec/changes/complete-tool-remediation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/complete-tool-remediation/design.md
+++ b/openspec/changes/complete-tool-remediation/design.md
@@ -1,0 +1,105 @@
+## Context
+
+Workspace tools return model-facing text through the public `INetclawTool`
+contract. They also publish one internal call-local receipt. The receipt now
+stores a free-form remediation string. Parent and child execution paths build
+some correction text separately. No shared component turns the receipt into a
+model instruction.
+
+The receipt is ephemeral. It does not enter actor persistence, protobuf,
+snapshots, or public tool results. This boundary is the right place for trusted
+machine facts. The model-facing result remains a string for compatibility.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace free-form remediation identifiers with a closed internal type.
+- Require every recoverable correction to carry one valid remediation.
+- Generate the final correction instruction through one parent-and-child path.
+- Keep failure detail in the originating tool or policy result.
+- Preserve tool authority, approval behavior, actor persistence, and public APIs.
+
+**Non-Goals:**
+
+- Automatically retry, rewrite, or execute a corrected tool call.
+- Add general advice, output continuation, or successful spill data to remediation.
+- Change tool exposure, shell parsing, or approval policy.
+- Persist remediation across turns or actor recovery.
+- Add a public remediation API or wire format.
+
+## Decisions
+
+### Use a closed remediation code
+
+Add an internal `ToolRemediationCode` enum for the supported actions. Keep
+dynamic paths in the bounded factual result. The receipt carries only the enum.
+
+The first code set is:
+
+- `SetWorkingDirectory`
+- `UseSessionScratch`
+- `ProvideUniqueOldString`
+
+`ToolInvocationReceipt` validates the enum. A `RecoverableCorrection` receipt
+requires one defined code. Every other outcome rejects remediation.
+
+This is safer than a string because new values require a deliberate code change.
+It also avoids a second free-form field that could carry invalid paths or
+instruction-like text.
+
+### Present the correction once
+
+Add one internal presenter in the actor tool-execution layer. It accepts the
+tool-role message, the validated receipt, and whether `set_working_directory`
+is visible. It appends one short action for the remediation code. Parent and
+child paths call it once after execution and before result delivery.
+
+The original result owns the failure facts. The presenter owns only the next
+action. Tools and approval policy therefore stop repeating the action text.
+This keeps the public string result useful for direct tool callers and gives
+both actor paths the same instruction.
+
+The presenter is pure. It does not inspect tool arguments. It suppresses the
+project-declaration action when that tool is hidden. It does not grant
+authority. It does not call another tool. It returns the original result for a
+non-corrective receipt.
+
+### Keep retry state separate
+
+The existing session-scratch correction key remains the loop-control mechanism
+for the shell approval path. The typed remediation does not replace that state.
+It describes the next action only. Project declaration and file-edit corrections
+remain model decisions and do not gain automatic retry state.
+
+### Keep actor and persistence boundaries unchanged
+
+Receipts remain internal call-local data. Batch and streaming messages may carry
+the internal receipt in memory. Durable chat messages still contain only the
+model-facing string. Actor recovery does not restore remediation receipts.
+
+## Risks / Trade-offs
+
+- **Risk: A new correction needs more context.** -> Put bounded facts in the
+  originating result. Keep the receipt closed and do not parse the result.
+- **Risk: The presenter repeats legacy action text.** -> Remove action wording
+  from each updated producer. Keep tests that assert one action in the final
+  parent and child message.
+- **Risk: A producer emits an incomplete corrective receipt.** -> Make the
+  receipt constructor reject `RecoverableCorrection` without remediation.
+- **Risk: Direct tool tests no longer see full guidance.** -> Direct tool results
+  keep the failure reason. Actor integration tests own the final instruction.
+
+## Migration Plan
+
+1. Add the closed remediation enum and strict receipt validation.
+2. Convert all three current string producers.
+3. Add the shared presenter to parent and child result construction.
+4. Remove repeated action text from producers.
+5. Add constructor, direct-tool, parent, and child regressions.
+
+Rollback is a code rollback. There is no stored data to migrate.
+
+## Open Questions
+
+None.

--- a/openspec/changes/complete-tool-remediation/design.md
+++ b/openspec/changes/complete-tool-remediation/design.md
@@ -48,6 +48,11 @@ This is safer than a string because new values require a deliberate code change.
 It also avoids a second free-form field that could carry invalid paths or
 instruction-like text.
 
+Example: a relative `file_read` has no project or session base. The factual
+result explains that no base is available. Its receipt contains only
+`SetWorkingDirectory`; it does not copy a path or instruction into the receipt.
+Creating that corrective receipt without a defined code fails immediately.
+
 ### Present the correction once
 
 Add one internal presenter in the actor tool-execution layer. It accepts the
@@ -65,6 +70,11 @@ project-declaration action when that tool is hidden. It does not grant
 authority. It does not call another tool. It returns the original result for a
 non-corrective receipt.
 
+Example: a parent and child receive the same `UseSessionScratch` receipt. The
+presenter appends the same short next action to both results. If
+`set_working_directory` is hidden, the presenter does not name or recommend it
+for a `SetWorkingDirectory` correction.
+
 ### Keep retry state separate
 
 The existing session-scratch correction key remains the loop-control mechanism
@@ -72,11 +82,19 @@ for the shell approval path. The typed remediation does not replace that state.
 It describes the next action only. Project declaration and file-edit corrections
 remain model decisions and do not gain automatic retry state.
 
+Example: `UseSessionScratch` tells the model where the next call should work.
+It does not execute that call, approve it, or grant scratch authority. The
+existing scratch-correction key still decides whether another retry would loop.
+
 ### Keep actor and persistence boundaries unchanged
 
 Receipts remain internal call-local data. Batch and streaming messages may carry
 the internal receipt in memory. Durable chat messages still contain only the
 model-facing string. Actor recovery does not restore remediation receipts.
+
+Example: after restart, the model can see the correction text already stored in
+chat history. Netclaw does not restore the old receipt or automatically perform
+the suggested action.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/complete-tool-remediation/design.md
+++ b/openspec/changes/complete-tool-remediation/design.md
@@ -1,122 +1,235 @@
 ## Context
 
-Workspace tools return model-facing text through the public `INetclawTool`
-contract. They also publish one internal call-local receipt. The receipt now
-stores a free-form remediation string. Parent and child execution paths build
-some correction text separately. No shared component turns the receipt into a
-model instruction.
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for the
+terms in this design. This document uses "next-action code" for the internal
+`ToolRemediationCode` enum.
 
-The receipt is ephemeral. It does not enter actor persistence, protobuf,
-snapshots, or public tool results. This boundary is the right place for trusted
-machine facts. The model-facing result remains a string for compatibility.
+Before this change, each tool path wrote its own correction instruction. The
+receipt also stored a free-form string that no shared component consumed.
+
+```text
+parent path -> "Error ... call set_working_directory"
+child path  -> separately constructed text
+receipt     -> arbitrary remediation string
+```
+
+This design separates three facts:
+
+```text
+tool result       = factual text about what happened
+tool receipt      = trusted internal outcome for the call
+next-action code  = one closed enum value for a correctable outcome
+```
+
+The receipt is ephemeral. Netclaw does not store it in actor events, snapshots,
+protobuf, or public tool results. The tool result remains a string for public
+API compatibility.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Replace free-form remediation identifiers with a closed internal type.
-- Require every recoverable correction to carry one valid remediation.
-- Generate the final correction instruction through one parent-and-child path.
-- Keep failure detail in the originating tool or policy result.
-- Preserve tool authority, approval behavior, actor persistence, and public APIs.
+- Replace free-form remediation strings with a closed next-action code.
+- Require one valid code for every recoverable correction.
+- Produce the final correction instruction through one shared formatter.
+- Give parent and child sessions the same instruction for the same facts.
+- Preserve tool authority, approval behavior, persistence, and public APIs.
 
 **Non-Goals:**
 
-- Automatically retry, rewrite, or execute a corrected tool call.
-- Add general advice, output continuation, or successful spill data to remediation.
-- Change tool exposure, shell parsing, or approval policy.
-- Persist remediation across turns or actor recovery.
+- Execute or retry the suggested action automatically.
+- Grant file, shell, project, or approval authority.
+- Add output continuation or successful spill data to a correction.
+- Persist the next-action code across actor recovery.
 - Add a public remediation API or wire format.
+
+## End-to-End Example
+
+A relative file call has no project or session directory:
+
+```text
+model call:
+  file_read(Path = "README.md")
+
+tool result:
+  "Error: invalid_context: No project or session directory is available."
+
+internal receipt:
+  category    = RecoverableCorrection
+  remediation = SetWorkingDirectory
+
+final model message when set_working_directory is visible:
+  "Error: invalid_context: No project or session directory is available.
+   Next action: call set_working_directory with an allowed project directory
+   for this task, then retry the failed tool call."
+```
+
+Netclaw does not call `set_working_directory`. The model decides whether to
+make a new tool call. That call still runs normal authorization.
 
 ## Decisions
 
-### Use a closed remediation code
+### Use a closed next-action code
 
-Add an internal `ToolRemediationCode` enum for the supported actions. Keep
-dynamic paths in the bounded factual result. The receipt carries only the enum.
+`ToolRemediationCode` contains the supported corrective actions:
 
-The first code set is:
+```text
+SetWorkingDirectory   A relative tool call has no usable path base.
+UseSessionScratch     A shell call can use the session directory instead of a
+                      shared temporary directory.
+ProvideUniqueOldString
+                      file_edit found zero matches or several ambiguous matches.
+```
 
-- `SetWorkingDirectory`
-- `UseSessionScratch`
-- `ProvideUniqueOldString`
+`ToolInvocationReceipt` enforces these rules:
 
-`ToolInvocationReceipt` validates the enum. A `RecoverableCorrection` receipt
-requires one defined code. Every other outcome rejects remediation.
+```text
+RecoverableCorrection + defined code  -> valid
+RecoverableCorrection + no code       -> reject construction
+Success + remediation code            -> reject construction
+undefined enum value                   -> reject construction
+```
 
-This is safer than a string because new values require a deliberate code change.
-It also avoids a second free-form field that could carry invalid paths or
-instruction-like text.
+The receipt contains no dynamic path or free-form instruction. The factual tool
+result carries details such as a path or match count.
 
-Example: a relative `file_read` has no project or session base. The factual
-result explains that no base is available. Its receipt contains only
-`SetWorkingDirectory`; it does not copy a path or instruction into the receipt.
-Creating that corrective receipt without a defined code fails immediately.
+### Format the correction once
 
-### Present the correction once
+`ToolRemediationPresenter` is a pure formatter. Parent and child execution paths
+call it once before they deliver the tool-role message to the model.
 
-Add one internal presenter in the actor tool-execution layer. It accepts the
-tool-role message, the validated receipt, and whether `set_working_directory`
-is visible. It appends one short action for the remediation code. Parent and
-child paths call it once after execution and before result delivery.
+```text
+formatter inputs:
+  current model-result text
+  validated receipt
+  whether set_working_directory is visible
 
-The original result owns the failure facts. The presenter owns only the next
-action. Tools and approval policy therefore stop repeating the action text.
-This keeps the public string result useful for direct tool callers and gives
-both actor paths the same instruction.
+formatter output:
+  the original result
+  plus one fixed next action when the action is usable
+```
 
-The presenter is pure. It does not inspect tool arguments. It suppresses the
-project-declaration action when that tool is hidden. It does not grant
-authority. It does not call another tool. It returns the original result for a
-non-corrective receipt.
+The formatter does not inspect tool arguments. It does not execute a tool. It
+does not change the receipt or grant authority.
 
-Example: a parent and child receive the same `UseSessionScratch` receipt. The
-presenter appends the same short next action to both results. If
-`set_working_directory` is hidden, the presenter does not name or recommend it
-for a `SetWorkingDirectory` correction.
+### Do not recommend a hidden tool
+
+Some audiences and subagents cannot use `set_working_directory`. Netclaw must
+not tell those models to call a tool that is absent from their tool set.
+
+```text
+receipt remediation = SetWorkingDirectory
+
+set_working_directory visible:
+  append the fixed next action
+
+set_working_directory hidden:
+  return the factual error unchanged
+```
+
+This rule prevents an impossible instruction and avoids disclosure of a hidden
+tool name. It does not turn the correction into another action. The caller can
+still provide a valid absolute path or change the session configuration.
 
 ### Keep retry state separate
 
-The existing session-scratch correction key remains the loop-control mechanism
-for the shell approval path. The typed remediation does not replace that state.
-It describes the next action only. Project declaration and file-edit corrections
-remain model decisions and do not gain automatic retry state.
+The session-scratch correction key prevents a correction loop in the shell
+approval path. The next-action code does not replace that state.
 
-Example: `UseSessionScratch` tells the model where the next call should work.
-It does not execute that call, approve it, or grant scratch authority. The
-existing scratch-correction key still decides whether another retry would loop.
+```text
+first shell call uses a shared temporary path
+  -> result suggests the session directory
+  -> receipt code is UseSessionScratch
+  -> session arms the existing correction key
 
-### Keep actor and persistence boundaries unchanged
+model retries the exact corrected call
+  -> session consumes the key
+  -> normal shell authorization runs again
+```
 
-Receipts remain internal call-local data. Batch and streaming messages may carry
-the internal receipt in memory. Durable chat messages still contain only the
-model-facing string. Actor recovery does not restore remediation receipts.
+Project declaration and file-edit corrections have no automatic retry state.
+The model must author the next call.
 
-Example: after restart, the model can see the correction text already stored in
-chat history. Netclaw does not restore the old receipt or automatically perform
-the suggested action.
+### Keep persistence boundaries unchanged
+
+The main session persists its tool-role message. A subagent keeps its tool-role
+message only for the child run. Neither actor persists the receipt or
+next-action code.
+
+```text
+main session before actor restart:
+  durable chat message = factual result + fixed next action
+  ephemeral receipt    = RecoverableCorrection(SetWorkingDirectory)
+
+main session after actor restart:
+  durable chat message = restored
+  ephemeral receipt    = absent
+  automatic action     = none
+
+subagent after child completion:
+  child chat message = discarded
+  ephemeral receipt  = discarded
+```
+
+## User Stories
+
+### A file call needs a project directory
+
+1. The model calls `file_read` with a relative path.
+2. No project or session base exists.
+3. The tool returns a factual `invalid_context` result.
+4. The receipt uses `RecoverableCorrection(SetWorkingDirectory)`.
+5. The formatter adds one fixed action when the tool is visible.
+6. The model can declare a project and retry.
+
+### A file edit has an ambiguous match
+
+1. The model calls `file_edit` with an `OldString` that matches three locations.
+2. The tool changes no file.
+3. The result reports the match count and canonical file path.
+4. The receipt uses `RecoverableCorrection(ProvideUniqueOldString)`.
+5. The formatter tells the model to use a unique value or `ReplaceAll=true`.
+
+### A shell call should use session scratch
+
+1. The model authors a shell call under a shared temporary directory.
+2. Policy proposes the session directory as the bounded alternative.
+3. The receipt uses `RecoverableCorrection(UseSessionScratch)`.
+4. The formatter tells the model to use the session directory.
+5. A later retry still passes the complete shell authorization policy.
 
 ## Risks / Trade-offs
 
-- **Risk: A new correction needs more context.** -> Put bounded facts in the
-  originating result. Keep the receipt closed and do not parse the result.
-- **Risk: The presenter repeats legacy action text.** -> Remove action wording
-  from each updated producer. Keep tests that assert one action in the final
-  parent and child message.
-- **Risk: A producer emits an incomplete corrective receipt.** -> Make the
-  receipt constructor reject `RecoverableCorrection` without remediation.
-- **Risk: Direct tool tests no longer see full guidance.** -> Direct tool results
-  keep the failure reason. Actor integration tests own the final instruction.
+### A correction needs dynamic detail
+
+Example: `file_edit` must report the number of matches and the file path.
+The tool result carries those facts. The receipt still carries only the enum.
+
+### Old producer text repeats the formatter action
+
+Example: a tool result already says "call set_working_directory." The formatter
+would add the same instruction again. Updated producers therefore return only
+the factual error. Integration tests assert one final action.
+
+### A producer creates an incomplete receipt
+
+Example: a producer creates `RecoverableCorrection` without a code. The receipt
+constructor rejects it before the actor receives it.
+
+### Direct tool tests do not contain the final instruction
+
+Direct tool tests see the factual result and receipt. Parent and child actor
+tests verify the final model message after the shared formatter runs.
 
 ## Migration Plan
 
-1. Add the closed remediation enum and strict receipt validation.
-2. Convert all three current string producers.
-3. Add the shared presenter to parent and child result construction.
-4. Remove repeated action text from producers.
-5. Add constructor, direct-tool, parent, and child regressions.
+1. Add `ToolRemediationCode` with the three supported values.
+2. Convert the path, shell scratch, and `file_edit` producers.
+3. Add `ToolRemediationPresenter` to parent and child message construction.
+4. Remove duplicate action text from those producers.
+5. Add receipt validation and actor integration tests.
 
-Rollback is a code rollback. There is no stored data to migrate.
+Rollback is a code rollback. No stored data requires migration.
 
 ## Open Questions
 

--- a/openspec/changes/complete-tool-remediation/proposal.md
+++ b/openspec/changes/complete-tool-remediation/proposal.md
@@ -6,7 +6,7 @@ Parent and child execution paths therefore depend on separate handwritten result
 
 ## What Changes
 
-- Replace free-form remediation strings with a closed internal code set.
+- Replace free-form remediation strings with a closed next-action code set.
 - Require each recoverable correction to select one known remediation value.
 - Use one shared presenter for parent and child model instructions.
 - Keep remediation separate from tool authority and successful output continuation.
@@ -20,7 +20,7 @@ None.
 
 ### Modified Capabilities
 
-- `netclaw-tools`: Define typed remediation and one shared model instruction path.
+- `netclaw-tools`: Define a closed next-action code and one shared instruction path.
 
 ## Impact
 

--- a/openspec/changes/complete-tool-remediation/proposal.md
+++ b/openspec/changes/complete-tool-remediation/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+PRD-006 requires tools that are simple, secure, and reliable for agents.
+Current receipts store remediation text as an unchecked string, but no shared consumer uses the code.
+Parent and child execution paths therefore depend on separate handwritten result text.
+
+## What Changes
+
+- Replace free-form remediation strings with a closed internal code set.
+- Require each recoverable correction to select one known remediation value.
+- Use one shared presenter for parent and child model instructions.
+- Keep remediation separate from tool authority and successful output continuation.
+- Add regression cases from live behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Define typed remediation and one shared model instruction path.
+
+## Impact
+
+The change affects internal tool receipts, parent and child result presentation, and tests.
+The change adds no public API, durable receipt, configuration property, or approval authority.
+Native-tool exposure and shell affordance corrections remain a separate stacked change.

--- a/openspec/changes/complete-tool-remediation/specs/netclaw-tools/spec.md
+++ b/openspec/changes/complete-tool-remediation/specs/netclaw-tools/spec.md
@@ -1,5 +1,8 @@
 ## MODIFIED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: First-party tool outcomes are machine-actionable
 
 First-party workspace tool execution SHALL produce exactly one call-local
@@ -18,6 +21,25 @@ omit a next action that names a tool hidden from the current audience. It SHALL
 NOT grant authority, execute a tool, rewrite a tool call, or persist the
 remediation.
 
+The following pseudocode shows the required separation:
+
+```text
+tool implementation returns:
+  result  = raw factual text
+  receipt = trusted internal facts for the actor
+
+dispatcher normal-return path:
+  redact and bound the factual text
+
+shared presenter receives:
+  current model-result text
+  receipt.RemediationCode
+  current tool visibility
+
+shared presenter returns:
+  one final tool-role message for the model
+```
+
 #### Scenario: Access denial has no successful file activity
 
 - **GIVEN** `file_read` is called for a path outside the current read authority
@@ -27,9 +49,10 @@ remediation.
 - **AND** the outcome contains no remediation
 - **AND** the model receives a bounded denial string
 
-#### Scenario: Missing declaration has a typed correction
+#### Scenario: Missing declaration has a closed correction code
 
 - **GIVEN** a workspace tool can continue after the project directory is declared
+- **AND** `set_working_directory` is visible to the current model
 - **WHEN** the missing declaration is the only blocker
 - **THEN** the outcome category is `recoverable_correction`
 - **AND** its remediation code is `SetWorkingDirectory`
@@ -49,6 +72,24 @@ remediation.
 - **AND** `set_working_directory` is hidden from the current audience
 - **WHEN** the shared presenter creates the tool-role message
 - **THEN** it does not add an action that names the hidden tool
+- **AND** it returns the factual tool result unchanged
+
+#### Scenario: Ambiguous file edit has one next action
+
+- **GIVEN** `file_edit` finds more than one `OldString` match
+- **WHEN** `ReplaceAll` is false
+- **THEN** the tool changes no file
+- **AND** the result reports the match count
+- **AND** the remediation code is `ProvideUniqueOldString`
+- **AND** the presenter adds one fixed retry action
+
+#### Scenario: Shared temporary path suggests session scratch
+
+- **GIVEN** shell policy proposes the session directory for a shared temporary path
+- **WHEN** the call returns a recoverable correction
+- **THEN** the remediation code is `UseSessionScratch`
+- **AND** the presenter adds one fixed session-scratch action
+- **AND** a later retry still runs normal shell authorization
 
 #### Scenario: Recoverable correction requires a known value
 

--- a/openspec/changes/complete-tool-remediation/specs/netclaw-tools/spec.md
+++ b/openspec/changes/complete-tool-remediation/specs/netclaw-tools/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: First-party tool outcomes are machine-actionable
+
+First-party workspace tool execution SHALL produce exactly one call-local
+outcome category: `success`, `invalid_input`, `access_denied`, `not_found`,
+`transient_failure`, or `recoverable_correction`. The category SHALL be separate
+from the model-facing string. The system SHALL NOT infer it from that string.
+The outcome MAY carry canonical file activity. A `recoverable_correction`
+outcome SHALL carry exactly one closed internal remediation code. Every other
+outcome SHALL reject remediation. Dynamic facts SHALL remain in the bounded
+model-facing result and SHALL NOT become a free-form receipt field. It SHALL NOT
+change the public string-returning `INetclawTool` contract.
+
+The parent and child execution paths SHALL use one shared presenter to turn a
+validated remediation into one model-facing next action. The presenter SHALL
+omit a next action that names a tool hidden from the current audience. It SHALL
+NOT grant authority, execute a tool, rewrite a tool call, or persist the
+remediation.
+
+#### Scenario: Access denial has no successful file activity
+
+- **GIVEN** `file_read` is called for a path outside the current read authority
+- **WHEN** scoped access denies the call
+- **THEN** the outcome category is `access_denied`
+- **AND** the outcome contains no successful file activity
+- **AND** the outcome contains no remediation
+- **AND** the model receives a bounded denial string
+
+#### Scenario: Missing declaration has a typed correction
+
+- **GIVEN** a workspace tool can continue after the project directory is declared
+- **WHEN** the missing declaration is the only blocker
+- **THEN** the outcome category is `recoverable_correction`
+- **AND** its remediation code is `SetWorkingDirectory`
+- **AND** the shared presenter tells the model to call `set_working_directory`
+- **AND** no authority is granted by the outcome itself
+
+#### Scenario: Parent and child present the same correction
+
+- **GIVEN** the same validated recoverable correction reaches a parent and child session
+- **WHEN** each path creates its tool-role message
+- **THEN** both messages contain the same single next action
+- **AND** neither path parses the original result to choose that action
+
+#### Scenario: Hidden declaration tool is not revealed
+
+- **GIVEN** a corrective receipt uses `SetWorkingDirectory`
+- **AND** `set_working_directory` is hidden from the current audience
+- **WHEN** the shared presenter creates the tool-role message
+- **THEN** it does not add an action that names the hidden tool
+
+#### Scenario: Recoverable correction requires a known value
+
+- **WHEN** an internal caller creates a recoverable correction without a remediation
+- **THEN** receipt construction fails closed
+- **AND** an undefined remediation code also fails closed

--- a/openspec/changes/complete-tool-remediation/tasks.md
+++ b/openspec/changes/complete-tool-remediation/tasks.md
@@ -1,0 +1,23 @@
+## 1. Typed remediation contract
+
+- [x] 1.1 Add the closed internal remediation code.
+- [x] 1.2 Require exactly one remediation for each recoverable correction receipt and reject it for other outcomes.
+- [x] 1.3 Convert project declaration, session scratch, and file edit producers from strings to typed remediation.
+- [x] 1.4 Add constructor and producer regressions for valid, missing, undefined, and wrong-category remediations.
+
+## 2. Shared model presentation
+
+- [x] 2.1 Add one pure presenter for all supported remediation values.
+- [x] 2.2 Route parent batch, parent streaming, and child tool-role messages through the presenter without revealing hidden tools.
+- [x] 2.3 Remove duplicate next-action wording from remediation producers while preserving bounded failure detail.
+- [x] 2.4 Add parent-child parity tests that assert one next action and no result-text inference.
+
+## 3. Compatibility
+
+- [x] 3.1 Prove approval authority, session-scratch retry state, public APIs, and durable messages are unchanged.
+
+## 4. Validation
+
+- [x] 4.1 Update `IMPLEMENTATION_PLAN.md` so it records the completed behavior and the separate follow-up affordance change.
+- [x] 4.2 Run focused parent, child, receipt, file-tool, and approval correction tests.
+- [x] 4.3 Run the full Release build and test suite, header verification, strict OpenSpec validation, diff checks, and Slopwatch.

--- a/openspec/changes/complete-tool-remediation/tasks.md
+++ b/openspec/changes/complete-tool-remediation/tasks.md
@@ -1,8 +1,8 @@
-## 1. Typed remediation contract
+## 1. Closed next-action contract
 
 - [x] 1.1 Add the closed internal remediation code.
 - [x] 1.2 Require exactly one remediation for each recoverable correction receipt and reject it for other outcomes.
-- [x] 1.3 Convert project declaration, session scratch, and file edit producers from strings to typed remediation.
+- [x] 1.3 Convert project declaration, session scratch, and file edit producers from free-form strings to the closed next-action code.
 - [x] 1.4 Add constructor and producer regressions for valid, missing, undefined, and wrong-category remediations.
 
 ## 2. Shared model presentation

--- a/openspec/changes/repair-agent-tool-boundaries/.openspec.yaml
+++ b/openspec/changes/repair-agent-tool-boundaries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/repair-agent-tool-boundaries/design.md
+++ b/openspec/changes/repair-agent-tool-boundaries/design.md
@@ -98,6 +98,13 @@ A `ToolApprovalRequiredException` will stay non-terminal. The caller can still c
 
 Workspace tools can set a more exact terminal receipt. The dispatcher will fill a receipt only when the tool has not set one.
 
+The receipt carries the stable category used by actor state. The separate
+bounded result carries the reason presented to the model. For example, a
+dispatcher policy denial can return
+`Tool access denied: tool_not_allowed_for_audience_profile` while the receipt
+remains the closed `AccessDenied` category. Actors never parse that sentence to
+recover the category.
+
 Example:
 
 ```text
@@ -154,8 +161,8 @@ Example:
 
 ```text
 one model response:
-  file_read(Path = "README.md", Offset = 0, Limit = 200)
-  file_read(Path = "CONTRIBUTING.md", Offset = 0, Limit = 200)
+  file_read(Path = "README.md", StartLine = 1, Limit = 200)
+  file_read(Path = "CONTRIBUTING.md", StartLine = 1, Limit = 200)
 
 runtime:
   execute both bounded calls in one tool batch
@@ -175,6 +182,14 @@ Dispatch will still resolve a known registered name and run normal authorization
 
 Guidance will tell an agent to call `load_tool` directly when it knows the exact name. The agent will use `search_tools` only when it knows an intent but not a name.
 
+When retention and maximum-count tuning are positive, main sessions retain a
+loaded schema for the configured number of future user turns, which defaults to
+three. Reloading refreshes the lease. The default maximum is twelve loaded
+schemas; adding another evicts the oldest. Recovery or an LLM failure discards
+the actor-local loaded set. A child has a shorter and simpler lifetime: a loaded
+schema remains for later iterations in that child run and disappears when the
+child ends.
+
 Example:
 
 ```text
@@ -190,6 +205,9 @@ model knows only the intent:
 ```
 
 Alternative: require an activation lease before dispatch. This adds a second authority-like state and does not improve the real approval boundary.
+
+Counterexample: a loaded schema is not durable session state. A recovered main
+session and a newly started child both begin from their policy-filtered core.
 
 ### 6. Spill continuation uses one opaque contract
 
@@ -219,6 +237,11 @@ Alternative: expose the spill file to file tools or shell. This couples continua
 The security PR will add POSIX and native Windows ancestor-link tests. It will also add executor, parent, and child policy-denial receipt tests.
 
 The tool-removal PR will update the core snapshot and remove bulk-tool fixtures. The rollout PR will create a real subagent for the child catalog replay.
+
+The child catalog excludes `spawn_agent` by design, not merely because the
+schema is Deferred. A child cannot recursively create a grandchild. This keeps
+concurrency bounded for self-hosted models and preserves one parent-owned
+`spawn_agent` lifecycle per child.
 
 The final eval run will use the reduced surface. Public evidence will contain aggregate, PII-free results only.
 

--- a/openspec/changes/repair-agent-tool-boundaries/design.md
+++ b/openspec/changes/repair-agent-tool-boundaries/design.md
@@ -1,0 +1,145 @@
+## Context
+
+The prior tool work added relative paths, call-local receipts, progressive disclosure, and several focused tools. Live use and adversarial review exposed three problems.
+
+First, a relative project base can contain an unsafe ancestor link. Second, receipt categories differ between parent and child policy denials. Third, two bulk tools duplicate smaller tools and can consume too much model context.
+
+The canonical spill contract also still describes a raw file path and shell grep. The runtime now exposes an opaque `tool_output_read` route instead.
+
+Constraints:
+
+- ACL, audience, approval, path, and MCP policy remain authoritative.
+- Public durable session and approval formats do not change.
+- No released tag contains `json_read` or `file_read_many`.
+- ShellSyntaxTree remains the owner of shell syntax facts.
+- Netclaw adds no executable-specific command parser.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Close the ancestor-link path escape.
+- Produce one receipt category for the same failure in every actor path.
+- Remove two bulk tools before their first release.
+- Keep the agent tool surface small and composable.
+- Align prompts, skills, fixtures, and canonical specifications.
+- Test a real child catalog instead of a parent substitute.
+
+**Non-Goals:**
+
+- Add search or grep to spilled output.
+- Block a known deferred tool name at dispatch before schema load.
+- Change shell approval authority.
+- Add a durable receipt format.
+- Preserve compatibility for unreleased tool classes.
+
+## Decisions
+
+### 1. The path policy validates the complete selected base chain
+
+`ScopedFileAccessPolicy` will select one relative base. It will validate that base against its owning allowed root before it resolves the authored path.
+
+The validation will reject a link or junction in the base or its ancestors below the owning root. It will preserve the current root, audience, and protected-path checks.
+
+The policy will not retry against session scratch after a project-based denial. A stale project can use the existing session fallback only before path authorization starts.
+
+Alternative: inspect only the final base. This leaves an ancestor-link escape.
+
+### 2. The dispatcher owns terminal receipt classification
+
+The dispatcher will include authorization in its receipt classification boundary. A `ToolAccessDeniedException` will produce `access_denied` for all callers.
+
+A `ToolApprovalRequiredException` will stay non-terminal. The caller can still complete an approval and retry the same call.
+
+Workspace tools can set a more exact terminal receipt. The dispatcher will fill a receipt only when the tool has not set one.
+
+Alternative: keep actor-specific exception maps. That design already caused parent and child drift.
+
+### 3. Only one named tool can declare project scope
+
+Actors will apply `DeclaredProjectDirectory` only for a successful `set_working_directory` receipt. Another tool cannot mutate project scope through the internal receipt seam.
+
+Remediation codes will use a bounded internal value set. They will reject controls and excessive length.
+
+Alternative: trust any internal receipt producer. This makes future tool additions able to widen scope by accident.
+
+### 4. Remove bulk readers and keep composable primitives
+
+The implementation will remove `json_read` and `file_read_many`. It will remove their registration, audience entries, schemas, guidance, tests, and eval cases.
+
+An agent can compose these retained tools:
+
+- `file_search` locates candidate files.
+- `file_read` reads one bounded file window.
+- Parallel tool calls read several known files without one bulk result.
+- `tool_output_read` continues one spilled result by opaque call id.
+
+The replay corpus will not preserve a product expectation for a removed tool. A retained scenario can assert the composed route when that route matches the original intent.
+
+Alternative: keep the bulk tools with lower bounds. The larger schemas and batch results still duplicate simpler calls and invite context floods.
+
+### 5. Loading controls schema exposure only
+
+`load_tool` adds a deferred schema to one actor's model-visible set. It does not grant execution authority.
+
+Dispatch will still resolve a known registered name and run normal authorization. This preserves compatibility with models that recall a name from earlier context.
+
+Guidance will tell an agent to call `load_tool` directly when it knows the exact name. The agent will use `search_tools` only when it knows an intent but not a name.
+
+Alternative: require an activation lease before dispatch. This adds a second authority-like state and does not improve the real approval boundary.
+
+### 6. Spill continuation uses one opaque contract
+
+The dispatcher will not reveal a raw spill path to the model. Its steer will name the call id and `tool_output_read`.
+
+The canonical specification will remove the old `file_read` and shell grep route. A later design can assess search over spilled output.
+
+Alternative: expose the spill file to file tools or shell. This couples continuation to filesystem authority and lower-audience shell access.
+
+### 7. Tests follow actual actor and policy boundaries
+
+The security PR will add POSIX and native Windows ancestor-link tests. It will also add executor, parent, and child policy-denial receipt tests.
+
+The tool-removal PR will update the core snapshot and remove bulk-tool fixtures. The rollout PR will create a real subagent for the child catalog replay.
+
+The final eval run will use the reduced surface. Public evidence will contain aggregate, PII-free results only.
+
+## Actor Boundaries and Persistence
+
+`DispatchingToolExecutor` owns authorization and terminal receipt classification. `LlmSessionActor` and `SubAgentActor` consume the same receipt facts.
+
+Only those actors update their current work context. The main session persists its existing `WorkingContext`. A child keeps its context ephemeral.
+
+This change adds no event, snapshot, protobuf, or configuration field. Recovery behavior stays unchanged.
+
+## Failure Modes and Recovery
+
+- Unsafe project ancestor: return `access_denied`; do not access the file.
+- Policy denial: return or propagate the existing bounded denial with an `access_denied` receipt.
+- Approval request: record no terminal receipt; retry after the approval result.
+- Removed tool name: return the normal hidden or unknown tool result.
+- Missing spill: return `not_found` for the opaque call id.
+- Failed project declaration: keep the previous project and instructions.
+- Eval provider failure: mark infrastructure failure; do not count it as task behavior.
+
+## Risks / Trade-offs
+
+- [Agents may need more file calls] -> Keep parallel `file_read` calls and strict output bounds.
+- [A recalled deferred name can bypass schema load] -> Keep normal authorization and define load as exposure only.
+- [Native link tests need platform support] -> Use deterministic platform tests and explicit skips only when link creation is unavailable.
+- [Corpus changes can erase historical intent] -> Keep sanitized intent and source classification, but remove product expectations for deleted tools.
+- [The stack can drift after a rebase] -> Rebase each branch and compare patch identity before PR publication.
+
+## Migration Plan
+
+1. Merge the path and receipt security fixes.
+2. Remove both unreleased bulk tools and update the tool surface.
+3. Repair the spill, discovery, replay, and eval contracts.
+4. Run deterministic tests on each PR.
+5. Run hosted evals once on the final stacked head.
+
+Rollback uses normal code reversal. No persisted state requires migration.
+
+## Open Questions
+
+The design for search inside spilled output remains open. It requires a separate security and product review.

--- a/openspec/changes/repair-agent-tool-boundaries/design.md
+++ b/openspec/changes/repair-agent-tool-boundaries/design.md
@@ -14,18 +14,32 @@ Constraints:
 - ShellSyntaxTree remains the owner of shell syntax facts.
 - Netclaw adds no executable-specific command parser.
 
-## Terms Used in This Design
+## Vocabulary and Tool Flow
 
-- **Dispatcher** means `DispatchingToolExecutor`. It finds the registered tool,
-  runs authorization, invokes the tool, and records the call-local outcome.
-- **Receipt** means the internal outcome data for one tool call. It is not the
-  text returned to the model and is not stored in the durable chat history.
-- **Project scope** means the declared project directory used to resolve
-  relative workspace paths and build project instructions.
-- **Schema exposure** means that the model can see a tool definition. It does
-  not mean that the model has permission to execute the tool.
-- **Spill** means the full redacted result stored in session-owned output when
-  the result is too large for the inline tool response.
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for the
+cross-cutting terms in this design.
+
+The normal first-party tool-return flow is:
+
+```text
+model
+  -> tool call
+  -> DispatchingToolExecutor
+       -> authorization
+       -> tool implementation
+       -> factual result -> redaction and output bound --+
+       -> ToolInvocationReceipt --------------------------+---> correction presenter
+                                                           -> model-facing result
+
+ToolInvocationReceipt
+  -> optional working-context update in LlmSessionActor or SubAgentActor
+```
+
+An approval request pauses this flow before tool execution. It does not create
+a terminal receipt. Caller cancellation also propagates without a receipt or
+model-facing failure. For another terminal exception, the dispatcher first
+classifies the receipt. The parent or child actor then creates the factual
+failure result and applies the same correction presenter before model delivery.
 
 ## Goals / Non-Goals
 
@@ -56,12 +70,23 @@ The validation will reject a link or junction in the base or its ancestors below
 
 The policy will not retry against session scratch after a project-based denial. A stale project can use the existing session fallback only before path authorization starts.
 
-Example: `/srv/workspaces` is an allowed root and the declared project is
-`/srv/workspaces/team/project`. If `/srv/workspaces/team` is replaced by a link
-to `/outside`, `file_read` with `README.md` returns `access_denied`. It does not
-read through the link or retry the same path under session scratch. By contrast,
-if the declared project no longer exists before authorization starts, the policy
-may select the valid session directory as the relative base.
+Example:
+
+```text
+allowed root     = /srv/workspaces
+declared project = /srv/workspaces/team/project
+authored path    = README.md
+
+/srv/workspaces/team is a link to /outside
+  -> project base state = Unsafe
+  -> result category    = AccessDenied
+  -> file access        = none
+  -> session fallback   = forbidden
+
+/srv/workspaces/team/project does not exist
+  -> project base state = Unavailable
+  -> try the valid session directory before authorization starts
+```
 
 Alternative: inspect only the final base. This leaves an ancestor-link escape.
 
@@ -73,10 +98,18 @@ A `ToolApprovalRequiredException` will stay non-terminal. The caller can still c
 
 Workspace tools can set a more exact terminal receipt. The dispatcher will fill a receipt only when the tool has not set one.
 
-Example: policy denies `file_read` before `FileReadTool` runs. The dispatcher
-records `access_denied` with no successful file activity for both a parent and a
-child actor. If the same call needs approval instead, the dispatcher records no
-terminal receipt. An approved retry enters authorization again and can execute.
+Example:
+
+```text
+policy denies file_read before FileReadTool runs
+  -> parent receipt = AccessDenied
+  -> child receipt  = AccessDenied
+  -> file activity  = empty
+
+policy requires approval
+  -> terminal receipt = none
+  -> approved retry enters authorization again
+```
 
 Alternative: keep actor-specific exception maps. That design already caused parent and child drift.
 
@@ -87,11 +120,20 @@ Actors will apply `DeclaredProjectDirectory` only for a successful `set_working_
 Remediation codes will use a closed internal enum. A corrective receipt must use
 one defined enum value. Every other outcome must reject remediation.
 
-Example: a successful `file_read` receipt that contains a project directory
-cannot replace the current project. A successful `set_working_directory`
-receipt can replace it. If `file_edit` finds several matches, its corrective
-receipt uses `ProvideUniqueOldString`; it cannot insert arbitrary instruction
-text into the remediation field.
+Example:
+
+```text
+file_read + Success + DeclaredProjectDirectory
+  -> actor rejects the project effect
+
+set_working_directory + Success + DeclaredProjectDirectory
+  -> actor replaces the project scope
+
+file_edit finds three matches
+  -> result reports the match count
+  -> receipt = RecoverableCorrection(ProvideUniqueOldString)
+  -> no arbitrary instruction enters the receipt
+```
 
 Alternative: trust any internal receipt producer. This makes future tool additions able to widen scope by accident.
 
@@ -108,10 +150,20 @@ An agent can compose these retained tools:
 
 The replay corpus will not preserve a product expectation for a removed tool. A retained scenario can assert the composed route when that route matches the original intent.
 
-Example: to inspect `README.md` and `CONTRIBUTING.md`, the model issues two
-bounded `file_read` calls in one parallel batch. It does not use
-`file_read_many`. To inspect bounded JSON text, it uses `file_read`; a stable
-domain query should use a purpose-built producer tool instead of `json_read`.
+Example:
+
+```text
+one model response:
+  file_read(Path = "README.md", Offset = 0, Limit = 200)
+  file_read(Path = "CONTRIBUTING.md", Offset = 0, Limit = 200)
+
+runtime:
+  execute both bounded calls in one tool batch
+  return two separate bounded results
+```
+
+For bounded JSON text, the model uses `file_read`. A stable domain query should
+use a purpose-built producer tool.
 
 Alternative: keep the bulk tools with lower bounds. The larger schemas and batch results still duplicate simpler calls and invite context floods.
 
@@ -123,10 +175,19 @@ Dispatch will still resolve a known registered name and run normal authorization
 
 Guidance will tell an agent to call `load_tool` directly when it knows the exact name. The agent will use `search_tools` only when it knows an intent but not a name.
 
-Example: when the model already knows `list_reminders`, it calls `load_tool`
-with that exact name. The next model request can see the schema, but a later
-`list_reminders` call still runs normal authorization. When the model knows only
-that it needs a scheduling tool, it calls `search_tools` first.
+Example:
+
+```text
+model knows the exact name:
+  load_tool(Name = "list_reminders")
+  -> next request includes the list_reminders schema
+  -> later call still runs authorization
+
+model knows only the intent:
+  search_tools(Query = "show scheduled reminders")
+  -> policy-filtered results
+  -> load one exact result
+```
 
 Alternative: require an activation lease before dispatch. This adds a second authority-like state and does not improve the real approval boundary.
 
@@ -136,10 +197,20 @@ The dispatcher will not reveal a raw spill path to the model. Its steer will nam
 
 The canonical specification will remove the old `file_read` and shell grep route. A later design can assess search over spilled output.
 
-Example: a shell call produces 40,000 characters and exceeds the inline limit.
-The response keeps the bounded inline preview and names an opaque call id such
-as `call-example`. The model uses `tool_output_read` with that id to continue.
-It does not receive the spill file path and cannot pass that path to shell.
+Example:
+
+```text
+shell result length = 40,000 characters
+inline budget       = 12,000 characters
+
+model receives:
+  bounded head and tail preview
+  opaque call id = call-example
+  next tool      = tool_output_read
+
+model does not receive:
+  /session/.../tool-calls/call-example.txt
+```
 
 Alternative: expose the spill file to file tools or shell. This couples continuation to filesystem authority and lower-audience shell access.
 
@@ -151,16 +222,26 @@ The tool-removal PR will update the core snapshot and remove bulk-tool fixtures.
 
 The final eval run will use the reduced surface. Public evidence will contain aggregate, PII-free results only.
 
-Example: the child-catalog replay starts a real `SubAgentActor` and inspects the
-first child model request. It does not substitute the parent catalog. The path
-tests create a native link or junction in the selected base chain and verify
-that no file access crosses it.
+Example:
+
+```text
+child catalog test:
+  start SubAgentActor through SubAgentSpawner
+  capture the first child model request
+  assert the allowed core schemas
+  assert hidden schemas are absent
+
+path security test:
+  create a native link or junction in the selected base chain
+  call a relative file tool
+  assert AccessDenied and no file access
+```
 
 ## Actor Boundaries and Persistence
 
 `DispatchingToolExecutor` owns authorization and terminal receipt classification. `LlmSessionActor` and `SubAgentActor` consume the same receipt facts.
 
-Only those actors update their current work context. The main session persists its existing `WorkingContext`. A child keeps its context ephemeral.
+Only those actors update their current working context. The main session persists its existing `WorkingContext`. A child keeps its context ephemeral.
 
 This change adds no event, snapshot, protobuf, or configuration field. Recovery behavior stays unchanged.
 

--- a/openspec/changes/repair-agent-tool-boundaries/design.md
+++ b/openspec/changes/repair-agent-tool-boundaries/design.md
@@ -14,6 +14,19 @@ Constraints:
 - ShellSyntaxTree remains the owner of shell syntax facts.
 - Netclaw adds no executable-specific command parser.
 
+## Terms Used in This Design
+
+- **Dispatcher** means `DispatchingToolExecutor`. It finds the registered tool,
+  runs authorization, invokes the tool, and records the call-local outcome.
+- **Receipt** means the internal outcome data for one tool call. It is not the
+  text returned to the model and is not stored in the durable chat history.
+- **Project scope** means the declared project directory used to resolve
+  relative workspace paths and build project instructions.
+- **Schema exposure** means that the model can see a tool definition. It does
+  not mean that the model has permission to execute the tool.
+- **Spill** means the full redacted result stored in session-owned output when
+  the result is too large for the inline tool response.
+
 ## Goals / Non-Goals
 
 **Goals:**
@@ -43,6 +56,13 @@ The validation will reject a link or junction in the base or its ancestors below
 
 The policy will not retry against session scratch after a project-based denial. A stale project can use the existing session fallback only before path authorization starts.
 
+Example: `/srv/workspaces` is an allowed root and the declared project is
+`/srv/workspaces/team/project`. If `/srv/workspaces/team` is replaced by a link
+to `/outside`, `file_read` with `README.md` returns `access_denied`. It does not
+read through the link or retry the same path under session scratch. By contrast,
+if the declared project no longer exists before authorization starts, the policy
+may select the valid session directory as the relative base.
+
 Alternative: inspect only the final base. This leaves an ancestor-link escape.
 
 ### 2. The dispatcher owns terminal receipt classification
@@ -53,13 +73,25 @@ A `ToolApprovalRequiredException` will stay non-terminal. The caller can still c
 
 Workspace tools can set a more exact terminal receipt. The dispatcher will fill a receipt only when the tool has not set one.
 
+Example: policy denies `file_read` before `FileReadTool` runs. The dispatcher
+records `access_denied` with no successful file activity for both a parent and a
+child actor. If the same call needs approval instead, the dispatcher records no
+terminal receipt. An approved retry enters authorization again and can execute.
+
 Alternative: keep actor-specific exception maps. That design already caused parent and child drift.
 
 ### 3. Only one named tool can declare project scope
 
 Actors will apply `DeclaredProjectDirectory` only for a successful `set_working_directory` receipt. Another tool cannot mutate project scope through the internal receipt seam.
 
-Remediation codes will use a bounded internal value set. They will reject controls and excessive length.
+Remediation codes will use a closed internal enum. A corrective receipt must use
+one defined enum value. Every other outcome must reject remediation.
+
+Example: a successful `file_read` receipt that contains a project directory
+cannot replace the current project. A successful `set_working_directory`
+receipt can replace it. If `file_edit` finds several matches, its corrective
+receipt uses `ProvideUniqueOldString`; it cannot insert arbitrary instruction
+text into the remediation field.
 
 Alternative: trust any internal receipt producer. This makes future tool additions able to widen scope by accident.
 
@@ -76,6 +108,11 @@ An agent can compose these retained tools:
 
 The replay corpus will not preserve a product expectation for a removed tool. A retained scenario can assert the composed route when that route matches the original intent.
 
+Example: to inspect `README.md` and `CONTRIBUTING.md`, the model issues two
+bounded `file_read` calls in one parallel batch. It does not use
+`file_read_many`. To inspect bounded JSON text, it uses `file_read`; a stable
+domain query should use a purpose-built producer tool instead of `json_read`.
+
 Alternative: keep the bulk tools with lower bounds. The larger schemas and batch results still duplicate simpler calls and invite context floods.
 
 ### 5. Loading controls schema exposure only
@@ -86,6 +123,11 @@ Dispatch will still resolve a known registered name and run normal authorization
 
 Guidance will tell an agent to call `load_tool` directly when it knows the exact name. The agent will use `search_tools` only when it knows an intent but not a name.
 
+Example: when the model already knows `list_reminders`, it calls `load_tool`
+with that exact name. The next model request can see the schema, but a later
+`list_reminders` call still runs normal authorization. When the model knows only
+that it needs a scheduling tool, it calls `search_tools` first.
+
 Alternative: require an activation lease before dispatch. This adds a second authority-like state and does not improve the real approval boundary.
 
 ### 6. Spill continuation uses one opaque contract
@@ -93,6 +135,11 @@ Alternative: require an activation lease before dispatch. This adds a second aut
 The dispatcher will not reveal a raw spill path to the model. Its steer will name the call id and `tool_output_read`.
 
 The canonical specification will remove the old `file_read` and shell grep route. A later design can assess search over spilled output.
+
+Example: a shell call produces 40,000 characters and exceeds the inline limit.
+The response keeps the bounded inline preview and names an opaque call id such
+as `call-example`. The model uses `tool_output_read` with that id to continue.
+It does not receive the spill file path and cannot pass that path to shell.
 
 Alternative: expose the spill file to file tools or shell. This couples continuation to filesystem authority and lower-audience shell access.
 
@@ -103,6 +150,11 @@ The security PR will add POSIX and native Windows ancestor-link tests. It will a
 The tool-removal PR will update the core snapshot and remove bulk-tool fixtures. The rollout PR will create a real subagent for the child catalog replay.
 
 The final eval run will use the reduced surface. Public evidence will contain aggregate, PII-free results only.
+
+Example: the child-catalog replay starts a real `SubAgentActor` and inspects the
+first child model request. It does not substitute the parent catalog. The path
+tests create a native link or junction in the selected base chain and verify
+that no file access crosses it.
 
 ## Actor Boundaries and Persistence
 

--- a/openspec/changes/repair-agent-tool-boundaries/proposal.md
+++ b/openspec/changes/repair-agent-tool-boundaries/proposal.md
@@ -28,6 +28,8 @@ This change supports PRD-001 outcomes 7 and 9, PRD-006 outcome 5, and PRD-007 ou
 - Core tool schemas, agent guidance, replay fixtures, and eval cases.
 - Parent and child deferred-tool exposure contracts.
 - Canonical specifications for spilled output.
+- Concrete positive and negative examples for every changed authority, lifetime,
+  state, and output boundary.
 
 ### Out of scope
 

--- a/openspec/changes/repair-agent-tool-boundaries/proposal.md
+++ b/openspec/changes/repair-agent-tool-boundaries/proposal.md
@@ -7,9 +7,10 @@ This change supports PRD-001 outcomes 7 and 9, PRD-006 outcome 5, and PRD-007 ou
 ## What Changes
 
 - Fix relative workspace access when a declared project has a symlink or junction ancestor.
+- Define shared engineering terms and show the tool flow with pseudocode.
 - Classify policy denials at the shared receipt boundary for parent and child sessions.
 - Restrict project-scope receipt effects to `set_working_directory`.
-- Bound receipt remediation codes and keep approval requests non-terminal.
+- Use a closed next-action code and keep approval requests non-terminal.
 - **BREAKING** Remove the unreleased `json_read` tool and its public type.
 - **BREAKING** Remove the unreleased `file_read_many` tool and its public type.
 - Replace their eval cases with composed `file_search` and `file_read` use.
@@ -22,6 +23,7 @@ This change supports PRD-001 outcomes 7 and 9, PRD-006 outcome 5, and PRD-007 ou
 ### In scope
 
 - Workspace path, receipt, and project-scope security boundaries.
+- The shared engineering glossary and examples for these boundaries.
 - Removal of two unreleased bulk tools.
 - Core tool schemas, agent guidance, replay fixtures, and eval cases.
 - Parent and child deferred-tool exposure contracts.

--- a/openspec/changes/repair-agent-tool-boundaries/proposal.md
+++ b/openspec/changes/repair-agent-tool-boundaries/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Live use exposed unsafe path gaps, inconsistent receipt outcomes, and tool choices that can flood model context. The merged contracts also differ from current runtime behavior and from the smallest useful tool surface.
+
+This change supports PRD-001 outcomes 7 and 9, PRD-006 outcome 5, and PRD-007 outcomes 3 and 5.
+
+## What Changes
+
+- Fix relative workspace access when a declared project has a symlink or junction ancestor.
+- Classify policy denials at the shared receipt boundary for parent and child sessions.
+- Restrict project-scope receipt effects to `set_working_directory`.
+- Bound receipt remediation codes and keep approval requests non-terminal.
+- **BREAKING** Remove the unreleased `json_read` tool and its public type.
+- **BREAKING** Remove the unreleased `file_read_many` tool and its public type.
+- Replace their eval cases with composed `file_search` and `file_read` use.
+- Define spilled-output continuation only through an opaque call id and `tool_output_read`.
+- Define deferred-tool load as schema exposure, not execution authority.
+- Tell an agent to load a known exact tool name without a prior search.
+- Make the subagent replay create a real child actor and inspect its catalog.
+- Rerun deterministic and hosted evals after the final tool surface exists.
+
+### In scope
+
+- Workspace path, receipt, and project-scope security boundaries.
+- Removal of two unreleased bulk tools.
+- Core tool schemas, agent guidance, replay fixtures, and eval cases.
+- Parent and child deferred-tool exposure contracts.
+- Canonical specifications for spilled output.
+
+### Out of scope
+
+- A new grep or search feature for spilled output.
+- Executable-specific shell syntax or policy rules.
+- A general tool-runtime rewrite.
+- A new durable receipt or session format.
+- A change to shell approval authority.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Remove bulk read and JSON projection tools, and strengthen receipt ownership.
+- `session-cwd`: Reject a relative base with an unsafe ancestor and preserve explicit fallback rules.
+- `bounded-tool-output`: Make the opaque continuation tool the only model-visible spill route.
+- `netclaw-subagents`: Require a real child-catalog replay and consistent denial outcomes.
+- `progressive-tool-disclosure`: Clarify schema exposure, exact-name loads, and dispatch authorization.
+
+## Impact
+
+### Code and APIs
+
+The change affects workspace tools, path policy, receipt classification, tool registration, prompts, skills, tests, and evals. It removes two public tool classes that no released tag contains. Public durable session and approval formats stay unchanged.
+
+### Security
+
+The path fix closes an ancestor-link escape for relative file access. Receipt checks keep policy denials and project changes consistent across parent and child sessions. Every deferred call still passes normal authorization.
+
+### Operations
+
+The core tool catalog becomes smaller. Existing sessions can no longer call `json_read` or `file_read_many`. Agents use bounded, composable file search and file read calls instead.

--- a/openspec/changes/repair-agent-tool-boundaries/specs/bounded-tool-output/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/bounded-tool-output/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Spill to a session-scoped file with a steer
+
+When a result exceeds its inline budget, the dispatcher SHALL write the full redacted result to an internal file under the current session `tool-calls` directory. The dispatcher SHALL derive the file name from the sanitized call id. It SHALL return the opaque call id and a steer to `tool_output_read`. It SHALL NOT reveal the raw spill path or direct the model to shell, grep, or `file_read`. When no session directory or call id is available, the dispatcher SHALL return the inline window without a spill steer.
+
+#### Scenario: Spill file stays internal
+
+- **WHEN** a result over budget is produced in a session with a directory
+- **THEN** the full redacted result is written under the session `tool-calls` directory
+- **AND** the inline result includes the opaque call id
+- **AND** the steer names `tool_output_read`
+- **AND** the steer contains no filesystem path
+
+#### Scenario: Spilled file is redacted
+
+- **WHEN** a result that contains a secret is spilled
+- **THEN** the internal spill file has the secret redacted
+- **AND** redaction occurs before the spill write
+
+#### Scenario: Call id cannot escape the spill directory
+
+- **WHEN** the call id contains path-traversal characters
+- **THEN** the spill file stays inside the tool-calls directory
+- **AND** the dispatcher reveals no raw path

--- a/openspec/changes/repair-agent-tool-boundaries/specs/bounded-tool-output/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/bounded-tool-output/spec.md
@@ -1,5 +1,8 @@
 ## MODIFIED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Spill to a session-scoped file with a steer
 
 When a result exceeds its inline budget, the dispatcher SHALL write the full redacted result to an internal file under the current session `tool-calls` directory. The dispatcher SHALL derive the file name from the sanitized call id. It SHALL return the opaque call id and a steer to `tool_output_read`. It SHALL NOT reveal the raw spill path or direct the model to shell, grep, or `file_read`. When no session directory or call id is available, the dispatcher SHALL return the inline window without a spill steer.

--- a/openspec/changes/repair-agent-tool-boundaries/specs/bounded-tool-output/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/bounded-tool-output/spec.md
@@ -7,6 +7,38 @@ The terms in this requirement use the
 
 When a result exceeds its inline budget, the dispatcher SHALL write the full redacted result to an internal file under the current session `tool-calls` directory. The dispatcher SHALL derive the file name from the sanitized call id. It SHALL return the opaque call id and a steer to `tool_output_read`. It SHALL NOT reveal the raw spill path or direct the model to shell, grep, or `file_read`. When no session directory or call id is available, the dispatcher SHALL return the inline window without a spill steer.
 
+Concrete result shape:
+
+```text
+tool result size = 40,000 characters
+inline budget    = 12,000 characters
+call id          = call-example
+
+model receives:
+  <bounded head and tail>
+
+  [output truncated to 12000 chars of 40000; continue with
+   tool_output_read using CallId='call-example' and a bounded Start/Limit
+   window instead of re-running]
+
+internal storage may use:
+  <session>/tool-calls/call-example.txt
+
+model never receives:
+  <session>/tool-calls/call-example.txt
+  "run grep on the saved file"
+  "use file_read on the saved file"
+```
+
+Counterexamples:
+
+| Input state | Required behavior |
+|---|---|
+| Result fits the inline budget | Return it without a spill or continuation steer. |
+| Result is oversized but the call id is absent | Return only the bounded inline window. Do not invent an id or reveal a path. |
+| Call id is `../../outside` | Sanitize or reject the spill location; never write outside the session spill directory. |
+| Spill write fails | Preserve the bounded inline result without claiming that continuation exists. |
+
 #### Scenario: Spill file stays internal
 
 - **WHEN** a result over budget is produced in a session with a directory
@@ -26,3 +58,11 @@ When a result exceeds its inline budget, the dispatcher SHALL write the full red
 - **WHEN** the call id contains path-traversal characters
 - **THEN** the spill file stays inside the tool-calls directory
 - **AND** the dispatcher reveals no raw path
+
+#### Scenario: Missing spill identity has no false continuation
+
+- **GIVEN** a result exceeds its inline budget
+- **AND** the invocation has no usable session directory or call id
+- **WHEN** the dispatcher bounds the result
+- **THEN** the model receives the bounded inline window
+- **AND** the result does not claim that `tool_output_read` can continue it

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-subagents/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Subagents use progressive tool disclosure
+
+A subagent SHALL begin with the same policy-exposed core tool set as a main session, minus tools prohibited by subagent policy. It SHALL NOT eagerly receive every discoverable first-party or MCP tool. `search_tools` and `load_tool` SHALL activate deferred schemas only in that child actor's ephemeral exposure set.
+
+A child policy denial SHALL produce the same `access_denied` receipt category as a parent policy denial. A replay that claims child catalog behavior SHALL create a real child actor and inspect that child's model-visible tools.
+
+#### Scenario: Child starts with core rather than full catalog
+
+- **GIVEN** the daemon has more than one hundred visible specialty and MCP tools
+- **WHEN** a subagent starts
+- **THEN** its first model request contains only its allowed core tools
+- **AND** `search_tools` can find allowed deferred capabilities
+
+#### Scenario: Child loads one deferred tool
+
+- **GIVEN** a subagent knows the exact name of a visible deferred tool
+- **WHEN** it loads that exact tool
+- **THEN** the next child request contains the core plus that tool
+- **AND** unrelated deferred schemas remain absent
+
+#### Scenario: Child cannot discover recursive delegation
+
+- **GIVEN** `spawn_agent` is registered for the parent session
+- **WHEN** a subagent searches for or attempts to load it
+- **THEN** the response does not confirm or activate `spawn_agent`
+
+#### Scenario: Child denial matches parent category
+
+- **GIVEN** policy denies the same tool for a parent and a child
+- **WHEN** each actor invokes that tool
+- **THEN** each receipt category is `access_denied`
+- **AND** neither actor records successful activity
+
+#### Scenario: Replay inspects a real child catalog
+
+- **GIVEN** a regression fixture asserts subagent catalog behavior
+- **WHEN** the fixture executes
+- **THEN** it creates a subagent through the production spawn path
+- **AND** it asserts the child model request omits the hidden tool

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-subagents/spec.md
@@ -1,5 +1,8 @@
 ## MODIFIED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Subagents use progressive tool disclosure
 
 A subagent SHALL begin with the same policy-exposed core tool set as a main session, minus tools prohibited by subagent policy. It SHALL NOT eagerly receive every discoverable first-party or MCP tool. `search_tools` and `load_tool` SHALL activate deferred schemas only in that child actor's ephemeral exposure set.

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-subagents/spec.md
@@ -9,6 +9,38 @@ A subagent SHALL begin with the same policy-exposed core tool set as a main sess
 
 A child policy denial SHALL produce the same `access_denied` receipt category as a parent policy denial. A replay that claims child catalog behavior SHALL create a real child actor and inspect that child's model-visible tools.
 
+A schema loaded by a child SHALL remain available for later model iterations in
+that same child run. It SHALL be discarded when the child completes, stops, or
+fails. Child exposure does not use the main session's configurable user-turn
+lease because a child run has no independent sequence of user turns.
+
+Netclaw intentionally prohibits recursive `spawn_agent` calls. A child cannot
+create another child, even when the parent audience can use `spawn_agent`. This
+keeps one parent tool call responsible for one bounded child actor and prevents
+recursive agent trees from multiplying inference requests on self-hosted models
+with limited concurrency.
+
+Concrete exposure examples:
+
+```text
+parent core: [file_read, shell_execute, spawn_agent, ...]
+child core:  [file_read, shell_execute, ...]
+             # spawn_agent is removed by child policy
+
+child calls load_tool(Name = "list_reminders")
+  -> next child model request includes list_reminders
+  -> later iterations in this same child still include list_reminders
+
+child completes; parent starts a fresh child
+  -> the fresh child does not inherit list_reminders
+
+child calls search_tools(Query = "spawn agent")
+  -> response does not confirm spawn_agent exists
+
+child directly calls spawn_agent from recalled text
+  -> dispatch cannot resolve or execute it from the child-private registry
+```
+
 #### Scenario: Child starts with core rather than full catalog
 
 - **GIVEN** the daemon has more than one hundred visible specialty and MCP tools
@@ -21,13 +53,22 @@ A child policy denial SHALL produce the same `access_denied` receipt category as
 - **GIVEN** a subagent knows the exact name of a visible deferred tool
 - **WHEN** it loads that exact tool
 - **THEN** the next child request contains the core plus that tool
+- **AND** later model iterations in the same child retain that tool
 - **AND** unrelated deferred schemas remain absent
+
+#### Scenario: Loaded child schema does not cross child lifetime
+
+- **GIVEN** one child loads an allowed Deferred tool
+- **WHEN** that child completes and the parent starts another child
+- **THEN** the second child's first model request omits the loaded tool
+- **AND** the first child created no durable or parent-owned exposure lease
 
 #### Scenario: Child cannot discover recursive delegation
 
 - **GIVEN** `spawn_agent` is registered for the parent session
 - **WHEN** a subagent searches for or attempts to load it
 - **THEN** the response does not confirm or activate `spawn_agent`
+- **AND** a direct child dispatch cannot start a grandchild
 
 #### Scenario: Child denial matches parent category
 

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
@@ -1,0 +1,75 @@
+## MODIFIED Requirements
+
+### Requirement: First-party tool outcomes are machine-actionable
+
+First-party workspace tool execution SHALL produce exactly one call-local outcome category: `success`, `invalid_input`, `access_denied`, `not_found`, `transient_failure`, or `recoverable_correction`. The category SHALL be separate from the model-facing string. The system SHALL NOT infer it from that string. The outcome MAY carry a bounded remediation code and canonical file activity. A remediation code SHALL reject controls and excessive length. The outcome SHALL NOT change the public string-returning `INetclawTool` contract.
+
+The shared dispatcher SHALL classify a terminal policy denial as `access_denied` for parent and child callers. An approval request SHALL NOT create a terminal receipt before its final decision.
+
+#### Scenario: Access denial has no successful file activity
+
+- **GIVEN** `file_read` is called for a path outside the current read authority
+- **WHEN** scoped access denies the call
+- **THEN** the outcome category is `access_denied`
+- **AND** the outcome contains no successful file activity
+- **AND** the model receives a bounded denial string
+
+#### Scenario: Dispatcher denial has one category
+
+- **GIVEN** policy denies a tool before its implementation runs
+- **WHEN** a parent or child actor invokes the tool
+- **THEN** the receipt category is `access_denied`
+- **AND** neither actor reports `transient_failure`
+
+#### Scenario: Approval request is not terminal
+
+- **GIVEN** a tool requires human approval
+- **WHEN** the dispatcher parks the call for that decision
+- **THEN** no terminal denial receipt is recorded
+- **AND** an approved retry can execute the tool
+
+#### Scenario: Recoverable correction stays distinct from failure
+
+- **GIVEN** a workspace tool can continue after the project directory is declared
+- **WHEN** the missing declaration is the only blocker
+- **THEN** the outcome category is `recoverable_correction`
+- **AND** its remediation code identifies `set_working_directory`
+- **AND** no authority is granted by the outcome itself
+
+### Requirement: Working context records successful file activity only
+
+`WorkingContext.RecentFiles` SHALL update only from canonical file activity in a successful tool outcome. Failed, denied, missing, malformed, or corrective tool results SHALL NOT update recent files. The session pipeline SHALL NOT infer file activity only from authored argument names. Only a successful `set_working_directory` receipt MAY replace the declared project directory.
+
+#### Scenario: Failed write does not become recent
+
+- **GIVEN** `file_write` targets a denied path
+- **WHEN** the tool returns an access-denied outcome
+- **THEN** the authored path is absent from `RecentFiles`
+
+#### Scenario: Parallel reads record bounded canonical activity
+
+- **GIVEN** two authorized files are read by separate `file_read` calls
+- **WHEN** the session applies their successful receipts
+- **THEN** both canonical resolved paths are added to `RecentFiles`
+- **AND** no authored relative spelling becomes a separate file
+
+#### Scenario: Another tool cannot declare a project
+
+- **GIVEN** a successful receipt from a tool other than `set_working_directory`
+- **WHEN** the receipt contains a project directory
+- **THEN** the actor rejects that project effect
+- **AND** the current project directory remains unchanged
+
+## REMOVED Requirements
+
+### Requirement: Batch file reads validate before content access
+
+**Reason**: The tool duplicates parallel bounded `file_read` calls and can create a large combined result.
+
+**Migration**: Use one or more bounded `file_read` calls. A model can issue independent reads in parallel.
+
+### Requirement: JSON projection uses bounded data semantics
+
+**Reason**: The tool duplicates a narrow data query language and lacks a distinct durable product use.
+
+**Migration**: Use `file_read` for bounded JSON content. Use a purpose-built producer tool when structured data needs a stable projection.

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
@@ -1,10 +1,32 @@
 ## MODIFIED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: First-party tool outcomes are machine-actionable
 
 First-party workspace tool execution SHALL produce exactly one call-local outcome category: `success`, `invalid_input`, `access_denied`, `not_found`, `transient_failure`, or `recoverable_correction`. The category SHALL be separate from the model-facing string. The system SHALL NOT infer it from that string. The outcome MAY carry canonical file activity. A `recoverable_correction` outcome SHALL carry exactly one defined internal remediation code. Every other category SHALL reject remediation. The outcome SHALL NOT change the public string-returning `INetclawTool` contract.
 
 The shared dispatcher, `DispatchingToolExecutor`, SHALL classify a terminal policy denial as `access_denied` for parent and child callers. An approval request SHALL NOT create a terminal receipt before its final decision.
+
+Example receipt shapes:
+
+```text
+successful file read:
+  category      = Success
+  file activity = Read("/workspace/project/README.md")
+  remediation   = none
+
+policy denial before tool execution:
+  category      = AccessDenied
+  file activity = empty
+  remediation   = none
+
+correctable missing path base:
+  category      = RecoverableCorrection
+  file activity = empty
+  remediation   = SetWorkingDirectory
+```
 
 #### Scenario: Access denial has no successful file activity
 

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
@@ -9,6 +9,10 @@ First-party workspace tool execution SHALL produce exactly one call-local outcom
 
 The shared dispatcher, `DispatchingToolExecutor`, SHALL classify a terminal policy denial as `access_denied` for parent and child callers. An approval request SHALL NOT create a terminal receipt before its final decision.
 
+The receipt category answers what happened in a stable machine-readable form.
+The separate bounded result explains why to the model. The receipt does not copy
+or parse that text.
+
 Example receipt shapes:
 
 ```text
@@ -21,12 +25,30 @@ policy denial before tool execution:
   category      = AccessDenied
   file activity = empty
   remediation   = none
+  model result  = "Tool access denied: tool_not_allowed_for_audience_profile"
+
+filesystem scope denial inside file_read:
+  category      = AccessDenied
+  file activity = empty
+  remediation   = none
+  model result  = "Error: Team trust context may only access files inside the
+                   current session directory or configured roots: /workspace."
 
 correctable missing path base:
   category      = RecoverableCorrection
   file activity = empty
   remediation   = SetWorkingDirectory
+  model result  = "Error: invalid_context: No project or session directory is available."
 ```
+
+Counterexamples:
+
+| Result | Why it is invalid |
+|---|---|
+| `AccessDenied` plus successful file activity | A denied call did not read or change the file. |
+| `Success` plus `SetWorkingDirectory` remediation | Only a recoverable correction may carry remediation. |
+| Approval request plus terminal `AccessDenied` receipt | Approval is a paused, undecided call rather than a denial. |
+| Inferring `not_found` because the string contains “not found” | The typed receipt, not prose, owns the outcome. |
 
 #### Scenario: Access denial has no successful file activity
 
@@ -42,6 +64,7 @@ correctable missing path base:
 - **WHEN** a parent or child actor invokes the tool
 - **THEN** the receipt category is `access_denied`
 - **AND** neither actor reports `transient_failure`
+- **AND** the separate model-facing result includes the bounded policy reason
 
 #### Scenario: Approval request is not terminal
 
@@ -62,6 +85,28 @@ correctable missing path base:
 
 `WorkingContext.RecentFiles` SHALL update only from canonical file activity in a successful tool outcome. Failed, denied, missing, malformed, or corrective tool results SHALL NOT update recent files. The session pipeline SHALL NOT infer file activity only from authored argument names. Only a successful `set_working_directory` receipt MAY replace the declared project directory.
 
+Concrete activity example:
+
+```text
+project = /workspace/project
+
+file_read(Path = "README.md")
+  -> Success + Read("/workspace/project/README.md")
+
+file_read(Path = "./README.md")
+  -> Success + Read("/workspace/project/README.md")
+
+RecentFiles contains one canonical entry:
+  /workspace/project/README.md
+
+file_write(Path = "../denied.txt") -> AccessDenied
+  -> no RecentFiles entry for ../denied.txt
+
+file_read receipt carries DeclaredProjectDirectory("/outside")
+  -> file activity may be applied when otherwise valid
+  -> project effect is rejected because the producer is not set_working_directory
+```
+
 #### Scenario: Failed write does not become recent
 
 - **GIVEN** `file_write` targets a denied path
@@ -70,9 +115,10 @@ correctable missing path base:
 
 #### Scenario: Parallel reads record bounded canonical activity
 
-- **GIVEN** two authorized files are read by separate `file_read` calls
+- **GIVEN** `README.md` and `docs/guide.md` resolve under `/workspace/project`
+- **AND** separate `file_read` calls read both paths in one tool batch
 - **WHEN** the session applies their successful receipts
-- **THEN** both canonical resolved paths are added to `RecentFiles`
+- **THEN** `/workspace/project/README.md` and `/workspace/project/docs/guide.md` are added to `RecentFiles`
 - **AND** no authored relative spelling becomes a separate file
 
 #### Scenario: Another tool cannot declare a project
@@ -90,8 +136,19 @@ correctable missing path base:
 
 **Migration**: Use one or more bounded `file_read` calls. A model can issue independent reads in parallel.
 
+Example: replace `file_read_many(Paths = ["README.md", "LICENSE"])` with two
+bounded `file_read` calls in one model response. This removal does not remove an
+unrelated Deferred tool; it removes the `file_read_many` registration, schema,
+search result, load result, and dispatch route specifically.
+
 ### Requirement: JSON projection uses bounded data semantics
 
 **Reason**: The tool duplicates a narrow data query language and lacks a distinct durable product use.
 
 **Migration**: Use `file_read` for bounded JSON content. Use a purpose-built producer tool when structured data needs a stable projection.
+
+Example: replace `json_read(Path = "package.json", Pointer = "/version")` with
+a bounded `file_read(Path = "package.json")` when the document itself is the
+required evidence. If a workflow needs a stable domain value rather than file
+content, add a purpose-built producer tool; do not recreate a general JSON query
+language in another generic reader.

--- a/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/netclaw-tools/spec.md
@@ -2,9 +2,9 @@
 
 ### Requirement: First-party tool outcomes are machine-actionable
 
-First-party workspace tool execution SHALL produce exactly one call-local outcome category: `success`, `invalid_input`, `access_denied`, `not_found`, `transient_failure`, or `recoverable_correction`. The category SHALL be separate from the model-facing string. The system SHALL NOT infer it from that string. The outcome MAY carry a bounded remediation code and canonical file activity. A remediation code SHALL reject controls and excessive length. The outcome SHALL NOT change the public string-returning `INetclawTool` contract.
+First-party workspace tool execution SHALL produce exactly one call-local outcome category: `success`, `invalid_input`, `access_denied`, `not_found`, `transient_failure`, or `recoverable_correction`. The category SHALL be separate from the model-facing string. The system SHALL NOT infer it from that string. The outcome MAY carry canonical file activity. A `recoverable_correction` outcome SHALL carry exactly one defined internal remediation code. Every other category SHALL reject remediation. The outcome SHALL NOT change the public string-returning `INetclawTool` contract.
 
-The shared dispatcher SHALL classify a terminal policy denial as `access_denied` for parent and child callers. An approval request SHALL NOT create a terminal receipt before its final decision.
+The shared dispatcher, `DispatchingToolExecutor`, SHALL classify a terminal policy denial as `access_denied` for parent and child callers. An approval request SHALL NOT create a terminal receipt before its final decision.
 
 #### Scenario: Access denial has no successful file activity
 
@@ -33,7 +33,7 @@ The shared dispatcher SHALL classify a terminal policy denial as `access_denied`
 - **GIVEN** a workspace tool can continue after the project directory is declared
 - **WHEN** the missing declaration is the only blocker
 - **THEN** the outcome category is `recoverable_correction`
-- **AND** its remediation code identifies `set_working_directory`
+- **AND** its remediation code is `SetWorkingDirectory`
 - **AND** no authority is granted by the outcome itself
 
 ### Requirement: Working context records successful file activity only

--- a/openspec/changes/repair-agent-tool-boundaries/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/progressive-tool-disclosure/spec.md
@@ -1,5 +1,8 @@
 ## MODIFIED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Sessions start with a bounded workspace core
 
 The initial model tool set SHALL contain policy-exposed definitions for `search_tools`, `load_tool`, `skill_load`, `skill_read_resource`, `set_working_directory`, `file_search`, `file_read`, `file_list`, `file_write`, `file_edit`, `tool_output_read`, and `shell_execute`. Other first-party and MCP tools SHALL be deferred unless a later specification adds them to the core. The core SHALL NOT include `json_read` or `file_read_many`.

--- a/openspec/changes/repair-agent-tool-boundaries/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/progressive-tool-disclosure/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Sessions start with a bounded workspace core
+
+The initial model tool set SHALL contain policy-exposed definitions for `search_tools`, `load_tool`, `skill_load`, `skill_read_resource`, `set_working_directory`, `file_search`, `file_read`, `file_list`, `file_write`, `file_edit`, `tool_output_read`, and `shell_execute`. Other first-party and MCP tools SHALL be deferred unless a later specification adds them to the core. The core SHALL NOT include `json_read` or `file_read_many`.
+
+#### Scenario: Specialty tools are not eagerly exposed
+
+- **GIVEN** specialty and MCP tools are registered
+- **WHEN** a new Personal session begins
+- **THEN** their schemas are absent from the initial set
+- **AND** policy-exposed tools remain searchable by intent
+
+#### Scenario: Core snapshot stays bounded
+
+- **WHEN** the repository first-party catalog is tested
+- **THEN** the core name snapshot equals the specified set
+- **AND** another first-party registration does not change that snapshot
+
+#### Scenario: Removed bulk tools are absent
+
+- **WHEN** a parent or child actor builds its core tool set
+- **THEN** `json_read` and `file_read_many` are absent
+- **AND** `file_read` remains available
+
+### Requirement: Search and load apply the complete exposure policy
+
+`search_tools` and `load_tool` SHALL apply deployment switches, audience allowlists, MCP grants, channel restrictions, and subagent restrictions before they return or activate a tool. Results SHALL NOT reveal a hidden tool name or schema. Loading SHALL add only the definition to the actor exposure set. Normal authorization SHALL still run at dispatch.
+
+Tool guidance SHALL direct an agent to call `load_tool` when it knows the exact tool name. It SHALL direct the agent to call `search_tools` only when it knows an intent but not a name. A known deferred name MAY reach normal dispatch without a prior load, but dispatch SHALL NOT expose its schema or bypass authorization.
+
+#### Scenario: Hidden tool cannot be enumerated or loaded
+
+- **GIVEN** a Team session cannot use a registered specialty tool
+- **WHEN** it searches for and attempts to load the tool
+- **THEN** neither response confirms that the hidden tool exists
+- **AND** the model tool set is unchanged
+
+#### Scenario: Exact known name loads without search
+
+- **GIVEN** the prompt index names an allowed deferred tool
+- **WHEN** the agent needs that exact tool
+- **THEN** guidance directs it to `load_tool` directly
+- **AND** no shell probe is required
+
+#### Scenario: Loaded tool still requires invocation authority
+
+- **GIVEN** a deferred tool is loadable and requires approval
+- **WHEN** the model loads and calls the tool
+- **THEN** the call enters the normal approval pipeline
+- **AND** loading does not satisfy approval
+
+#### Scenario: Recalled deferred name still reaches authorization
+
+- **GIVEN** a model calls an allowed registered deferred name before schema load
+- **WHEN** dispatch resolves that name
+- **THEN** the normal authorization pipeline decides the call
+- **AND** no exposure lease grants authority

--- a/openspec/changes/repair-agent-tool-boundaries/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/progressive-tool-disclosure/spec.md
@@ -7,6 +7,24 @@ The terms in this requirement use the
 
 The initial model tool set SHALL contain policy-exposed definitions for `search_tools`, `load_tool`, `skill_load`, `skill_read_resource`, `set_working_directory`, `file_search`, `file_read`, `file_list`, `file_write`, `file_edit`, `tool_output_read`, and `shell_execute`. Other first-party and MCP tools SHALL be deferred unless a later specification adds them to the core. The core SHALL NOT include `json_read` or `file_read_many`.
 
+`json_read` and `file_read_many` appear here only as negative regression names.
+This change removes their registrations and schemas; it does not defer them.
+
+Core membership example:
+
+```text
+initial core = [search_tools, load_tool, ..., shell_execute]
+
+register ExampleSpecialtyTool with the default Deferred tier
+  -> initial core is unchanged
+  -> search_tools may find ExampleSpecialtyTool when policy allows it
+  -> load_tool may add its schema to one actor
+
+register ExampleCoreTool explicitly as Core
+  -> the exact core snapshot changes
+  -> that change requires a deliberate specification update
+```
+
 #### Scenario: Specialty tools are not eagerly exposed
 
 - **GIVEN** specialty and MCP tools are registered
@@ -25,12 +43,51 @@ The initial model tool set SHALL contain policy-exposed definitions for `search_
 - **WHEN** a parent or child actor builds its core tool set
 - **THEN** `json_read` and `file_read_many` are absent
 - **AND** `file_read` remains available
+- **AND** search, load, and direct dispatch do not resurrect either removed name
 
 ### Requirement: Search and load apply the complete exposure policy
 
 `search_tools` and `load_tool` SHALL apply deployment switches, audience allowlists, MCP grants, channel restrictions, and subagent restrictions before they return or activate a tool. Results SHALL NOT reveal a hidden tool name or schema. Loading SHALL add only the definition to the actor exposure set. Normal authorization SHALL still run at dispatch.
 
 Tool guidance SHALL direct an agent to call `load_tool` when it knows the exact tool name. It SHALL direct the agent to call `search_tools` only when it knows an intent but not a name. A known deferred name MAY reach normal dispatch without a prior load, but dispatch SHALL NOT expose its schema or bypass authorization.
+
+When retention and maximum-count tuning are positive, a main session SHALL
+retain a loaded deferred schema for `Session.Tuning.DiscoveredToolRetentionTurns`
+future user turns. The default is three. Reloading the same tool refreshes that
+lease. A non-positive retention or maximum-count value disables cross-turn
+retention. The default maximum is twelve loaded schemas; exceeding the cap
+evicts the oldest. An LLM failure or session recovery SHALL discard actor-local
+loaded schemas. Subagent exposure follows the separate child-run lifetime in
+the `netclaw-subagents` specification.
+
+Discovery, exposure, and authority examples:
+
+| Model state and action | Required behavior |
+|---|---|
+| Knows exact allowed name `list_reminders`; calls `load_tool(Name = "list_reminders")` | Expose that schema without a preceding search. |
+| Knows only “inspect scheduled tasks”; calls `search_tools(Query = "scheduled tasks")` | Return policy-filtered candidate descriptions, then load one exact result. |
+| Searches for a policy-hidden tool | Return no name, schema, or existence hint. |
+| Loads an allowed tool that still requires approval, then calls it | Enter normal approval; loading grants nothing. |
+| Recalls and directly calls an allowed Deferred name before loading | Dispatch may authorize the call, but the schema does not become loaded merely because dispatch recognized the name. |
+| Loads a tool and then the LLM call fails | Evict the loaded schema instead of carrying a possibly harmful exposure set forward. |
+| Loads a thirteenth tool with the default maximum of twelve | Retain the newest twelve and evict the oldest loaded schema. |
+
+Default lease example:
+
+```text
+user turn 1:
+  load_tool(Name = "list_reminders")
+  -> schema is available to the next model request in turn 1
+
+user turns 2, 3, and 4:
+  -> schema remains available
+
+user turn 5 without another load:
+  -> schema is absent
+
+session recovery or LLM failure before turn 5:
+  -> schema is absent immediately
+```
 
 #### Scenario: Hidden tool cannot be enumerated or loaded
 
@@ -59,3 +116,18 @@ Tool guidance SHALL direct an agent to call `load_tool` when it knows the exact 
 - **WHEN** dispatch resolves that name
 - **THEN** the normal authorization pipeline decides the call
 - **AND** no exposure lease grants authority
+
+#### Scenario: Default loaded-tool lease expires after three future turns
+
+- **GIVEN** the main session uses the default retention value of three
+- **AND** it loads one policy-visible Deferred tool
+- **WHEN** three later user turns complete without another load
+- **THEN** the tool schema is available on those three turns
+- **AND** it is absent from the fourth later user turn
+
+#### Scenario: Zero retention requires activation each turn
+
+- **GIVEN** `DiscoveredToolRetentionTurns` is zero
+- **WHEN** a main session loads a Deferred tool and begins a later user turn
+- **THEN** the later turn does not retain that schema
+- **AND** the earlier load still grants no execution authority

--- a/openspec/changes/repair-agent-tool-boundaries/specs/session-cwd/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/session-cwd/spec.md
@@ -9,6 +9,18 @@ First-party filesystem tools SHALL resolve a relative path against the declared 
 
 The selected base SHALL be a canonical absolute path. A declared project base SHALL remain within an owning allowed root. The system SHALL reject a symlink or junction in that project base or in an ancestor below the owning root. The final canonical path SHALL pass existing scope and protected-path policies. The system SHALL NOT retry another base after a selected base fails authorization.
 
+Resolution examples and counterexamples:
+
+| Authored path and context | Selected path | Result |
+|---|---|---|
+| `src/App.cs`, project `/workspace/project` | `/workspace/project/src/App.cs` | Apply normal read or write policy. |
+| `notes.md`, no project, session `/session/current` | `/session/current/notes.md` | Apply normal session policy. |
+| `notes.md`, stale unavailable project, valid session | `/session/current/notes.md` | Fall back before authorization begins. |
+| `notes.md`, project has a link ancestor | none | `access_denied`; do not try the session base. |
+| `../../outside.txt`, valid project | canonical outside path | Deny if existing scope policy does not authorize it; do not try the session base. |
+| `notes.md`, no project or session | none | `invalid_context`; do not use the daemon current directory. |
+| `/absolute/report.md` | `/absolute/report.md` | Do not select a relative base; apply normal policy directly. |
+
 #### Scenario: Relative read uses declared project
 
 - **GIVEN** a project directory `/workspace/project` and session `/session/current`
@@ -47,6 +59,26 @@ The selected base SHALL be a canonical absolute path. A declared project base SH
 ### Requirement: Failed filesystem operations do not change project context
 
 A denied or failed `set_working_directory` or filesystem call SHALL NOT change the project directory or recent-file context. Only a validated successful `set_working_directory` receipt SHALL replace the project and reload its instructions. Another tool receipt SHALL NOT declare project scope.
+
+Project-effect example:
+
+```text
+current project = /workspace/old
+
+set_working_directory("/workspace/new")
+  -> Success + DeclaredProjectDirectory("/workspace/new")
+  -> project becomes /workspace/new
+  -> project instructions reload
+
+file_read("README.md")
+  -> Success + Read("/workspace/new/README.md")
+  -> RecentFiles changes
+  -> project remains /workspace/new
+
+hypothetical file_read receipt carrying DeclaredProjectDirectory("/outside")
+  -> actor rejects the project effect
+  -> project remains /workspace/new
+```
 
 #### Scenario: Denied declaration leaves prior project intact
 

--- a/openspec/changes/repair-agent-tool-boundaries/specs/session-cwd/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/session-cwd/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Relative first-party filesystem paths use session-owned bases
+
+First-party filesystem tools SHALL resolve a relative path against the declared project directory when one exists. Otherwise, they SHALL use the immutable session directory. If neither base exists, they SHALL return an `invalid_context` correction. They SHALL NOT use the daemon process current directory.
+
+The selected base SHALL be a canonical absolute path. A declared project base SHALL remain within an owning allowed root. The system SHALL reject a symlink or junction in that project base or in an ancestor below the owning root. The final canonical path SHALL pass existing scope and protected-path policies. The system SHALL NOT retry another base after a selected base fails authorization.
+
+#### Scenario: Relative read uses declared project
+
+- **GIVEN** a project directory `/workspace/project` and session `/session/current`
+- **WHEN** `file_read` receives `src/App.cs`
+- **THEN** it authorizes and reads `/workspace/project/src/App.cs`
+- **AND** it does not use the daemon current directory
+
+#### Scenario: Relative write falls back to session scratch
+
+- **GIVEN** no declared project and session directory `/session/current`
+- **WHEN** `file_write` receives `notes/result.md`
+- **THEN** it resolves `/session/current/notes/result.md`
+- **AND** the existing session write policy decides authorization
+
+#### Scenario: Traversal receives no implicit authority
+
+- **GIVEN** project directory `/workspace/project`
+- **WHEN** a file tool receives `../../outside.txt`
+- **THEN** it canonicalizes the result before policy evaluation
+- **AND** it denies the call when the path is outside authorized roots
+
+#### Scenario: Ancestor link rejects the relative base
+
+- **GIVEN** an allowed root contains a link ancestor for the declared project
+- **WHEN** a file tool receives a relative path
+- **THEN** the tool returns `access_denied`
+- **AND** it performs no file access through the link
+
+#### Scenario: Missing base returns correction
+
+- **GIVEN** a tool context has no project or session directory
+- **WHEN** a first-party filesystem tool receives a relative path
+- **THEN** it returns `invalid_context`
+- **AND** it performs no filesystem access
+
+### Requirement: Failed filesystem operations do not change project context
+
+A denied or failed `set_working_directory` or filesystem call SHALL NOT change the project directory or recent-file context. Only a validated successful `set_working_directory` receipt SHALL replace the project and reload its instructions. Another tool receipt SHALL NOT declare project scope.
+
+#### Scenario: Denied declaration leaves prior project intact
+
+- **GIVEN** a session declares `/workspace/old`
+- **WHEN** `set_working_directory` is denied for `/workspace/new`
+- **THEN** the project directory remains `/workspace/old`
+- **AND** project instructions are not loaded from the denied path
+
+#### Scenario: Unrelated receipt cannot replace project
+
+- **GIVEN** a successful file tool receipt contains a project directory
+- **WHEN** the actor applies the receipt
+- **THEN** the actor rejects the project effect
+- **AND** it does not reload project instructions

--- a/openspec/changes/repair-agent-tool-boundaries/specs/session-cwd/spec.md
+++ b/openspec/changes/repair-agent-tool-boundaries/specs/session-cwd/spec.md
@@ -1,5 +1,8 @@
 ## MODIFIED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Relative first-party filesystem paths use session-owned bases
 
 First-party filesystem tools SHALL resolve a relative path against the declared project directory when one exists. Otherwise, they SHALL use the immutable session directory. If neither base exists, they SHALL return an `invalid_context` correction. They SHALL NOT use the daemon process current directory.

--- a/openspec/changes/repair-agent-tool-boundaries/tasks.md
+++ b/openspec/changes/repair-agent-tool-boundaries/tasks.md
@@ -1,3 +1,8 @@
+## 0. Specification clarity
+
+- [x] 0.1 Define shared tool, actor, path, authority, and output terms in the engineering glossary.
+- [x] 0.2 Add end-to-end pseudocode and concrete examples for the path and receipt boundaries.
+
 ## 1. Security and receipt boundaries
 
 - [x] 1.1 Reject a relative project base that has a symlink or junction ancestor below its allowed root.

--- a/openspec/changes/repair-agent-tool-boundaries/tasks.md
+++ b/openspec/changes/repair-agent-tool-boundaries/tasks.md
@@ -1,0 +1,39 @@
+## 1. Security and receipt boundaries
+
+- [x] 1.1 Reject a relative project base that has a symlink or junction ancestor below its allowed root.
+- [x] 1.2 Add POSIX and native Windows tests for ancestor links, direct links, traversal, and stale-project fallback.
+- [x] 1.3 Move terminal authorization classification into the shared dispatcher receipt boundary.
+- [x] 1.4 Prove parent and child policy denials both produce `access_denied` without successful activity.
+- [x] 1.5 Keep approval requests non-terminal and prove that an approved retry can execute.
+- [x] 1.6 Bound remediation codes and reject controls or excessive length.
+- [x] 1.7 Apply a project receipt only when `set_working_directory` produced it successfully.
+- [x] 1.8 Run focused security, dispatcher, parent, child, header, and Slopwatch gates.
+
+## 2. Remove bulk tools
+
+- [ ] 2.1 Remove `JsonReadTool`, `FileReadManyTool`, their schemas, and their registration paths.
+- [ ] 2.2 Remove both tool names from audience profiles, core snapshots, indexes, prompts, and system skills.
+- [ ] 2.3 Replace valid batch intent with parallel bounded `file_read` coverage.
+- [ ] 2.4 Remove JSON projection product fixtures and update all evidence digests.
+- [ ] 2.5 Update tool footprint evidence and schema snapshots for the reduced core.
+- [ ] 2.6 Remove or replace the two tool-specific eval scenarios.
+- [ ] 2.7 Run focused tool, actor, schema, fixture, header, and Slopwatch gates.
+
+## 3. Repair rollout contracts
+
+- [ ] 3.1 Replace the canonical raw spill path and grep steer with opaque `tool_output_read` guidance.
+- [ ] 3.2 Update runtime and tests so no model-facing spill result reveals a raw path.
+- [ ] 3.3 Clarify that `load_tool` controls schema exposure and never grants execution authority.
+- [ ] 3.4 Tell agents to load a known exact tool name without a prior search.
+- [ ] 3.5 Make the subagent catalog replay create and inspect a real child actor.
+- [ ] 3.6 Keep public evidence aggregate and PII-free.
+- [ ] 3.7 Run focused spill, disclosure, subagent, skill, header, and Slopwatch gates.
+
+## 4. Stack and evaluation
+
+- [ ] 4.1 Rebase each branch on its intended parent and verify the stacked patch order.
+- [ ] 4.2 Create three stacked pull requests without auto-merge.
+- [ ] 4.3 Run the deterministic eval harness on the final stacked head.
+- [ ] 4.4 Run the hosted eval matrix on the final stacked head.
+- [ ] 4.5 Publish only PII-free aggregate eval results on the relevant pull request.
+- [ ] 4.6 Run the full build, tests, strict OpenSpec, headers, diff, and Slopwatch gates.

--- a/openspec/changes/repair-agent-tool-boundaries/tasks.md
+++ b/openspec/changes/repair-agent-tool-boundaries/tasks.md
@@ -5,7 +5,7 @@
 - [x] 1.3 Move terminal authorization classification into the shared dispatcher receipt boundary.
 - [x] 1.4 Prove parent and child policy denials both produce `access_denied` without successful activity.
 - [x] 1.5 Keep approval requests non-terminal and prove that an approved retry can execute.
-- [x] 1.6 Bound remediation codes and reject controls or excessive length.
+- [x] 1.6 Replace free-form remediation with a closed enum and reject undefined or wrong-category values.
 - [x] 1.7 Apply a project receipt only when `set_working_directory` produced it successfully.
 - [x] 1.8 Run focused security, dispatcher, parent, child, header, and Slopwatch gates.
 

--- a/openspec/changes/repair-agent-tool-boundaries/tasks.md
+++ b/openspec/changes/repair-agent-tool-boundaries/tasks.md
@@ -2,6 +2,7 @@
 
 - [x] 0.1 Define shared tool, actor, path, authority, and output terms in the engineering glossary.
 - [x] 0.2 Add end-to-end pseudocode and concrete examples for the path and receipt boundaries.
+- [x] 0.3 Add positive examples and counterexamples for every modified specification, including tool leases, recursive-child denial, policy reasons, canonical activity, removed tools, and spill behavior.
 
 ## 1. Security and receipt boundaries
 

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -1,5 +1,8 @@
 # Netclaw OpenSpec Capabilities
 
+Use [the engineering glossary](../../docs/spec/GLOSSARY.md) for cross-cutting
+terms. Define capability-specific terms in the capability specification.
+
 - `netclaw-slack-socket`
 - `netclaw-session`
 - `netclaw-gateway-security`

--- a/openspec/specs/bounded-tool-output/spec.md
+++ b/openspec/specs/bounded-tool-output/spec.md
@@ -98,3 +98,33 @@ single in-memory string before bounding it.
 - **WHEN** a tool reads from a source far larger than the capture ceiling
 - **THEN** peak managed allocation stays on the order of the capture ceiling
 - **AND** the process is not OOM-killed by the capture
+
+### Requirement: Spilled output has an opaque bounded continuation tool
+
+The system SHALL provide a core `tool_output_read` tool that accepts an opaque
+tool call id, start character, and character limit. It SHALL resolve only the
+redacted spill that belongs to that call id under the current immutable session
+directory. It SHALL NOT accept a filesystem path, cross a session boundary, or
+return more than the configured limit.
+
+#### Scenario: Agent continues a current-session spill
+
+- **GIVEN** a tool result was spilled under the current session for call id
+  `call_example`
+- **WHEN** `tool_output_read` requests a bounded later window for that id
+- **THEN** the requested redacted window and continuation metadata are returned
+- **AND** no shell or Python command is required
+
+#### Scenario: Path-like call id cannot escape spill directory
+
+- **GIVEN** a model supplies `../other-session/secret` as the call id
+- **WHEN** `tool_output_read` validates the id
+- **THEN** the outcome is `invalid_input`
+- **AND** no path outside the current session spill directory is inspected
+
+#### Scenario: Missing spill is recoverable without probing paths
+
+- **GIVEN** no spill exists for the supplied current-session call id
+- **WHEN** `tool_output_read` executes
+- **THEN** the outcome is `not_found`
+- **AND** the bounded result suggests a narrower source call

--- a/openspec/specs/netclaw-subagents/spec.md
+++ b/openspec/specs/netclaw-subagents/spec.md
@@ -6,6 +6,45 @@ Define subagent execution contract, timeout enforcement, observability events,
 model role conventions, and context layer awareness for ephemeral autonomous
 LLM actors.
 ## Requirements
+
+### Requirement: Subagents use progressive tool disclosure
+
+A subagent SHALL begin with the same policy-exposed core tool set as a main
+session, minus tools prohibited by subagent policy. It SHALL NOT eagerly receive
+every discoverable first-party or MCP tool. `search_tools` and `load_tool` SHALL
+activate deferred schemas only in that child actor's ephemeral exposure set.
+
+#### Scenario: Child starts with core rather than full catalog
+
+- **GIVEN** the daemon has more than one hundred visible specialty and MCP tools
+- **WHEN** a subagent starts
+- **THEN** its first model request contains only its allowed core tools
+- **AND** `search_tools` can find allowed deferred capabilities
+
+#### Scenario: Child loads one deferred tool
+
+- **GIVEN** a subagent needs a visible deferred tool
+- **WHEN** it searches for and loads that exact tool
+- **THEN** the next child request contains the core plus that tool
+- **AND** unrelated deferred schemas remain absent
+
+#### Scenario: Child cannot discover recursive delegation
+
+- **GIVEN** `spawn_agent` is registered for the parent session
+- **WHEN** a subagent searches for or attempts to load it
+- **THEN** the response does not confirm or activate `spawn_agent`
+
+### Requirement: Subagent tool exposure is observable without payloads
+
+Subagent diagnostics SHALL report core, deferred-visible, and loaded tool counts
+for each run. Exposure diagnostics SHALL NOT include tool argument values,
+command text, file paths, schema bodies, or hidden tool names.
+
+#### Scenario: Child startup logs bounded counts
+
+- **WHEN** a subagent begins a run
+- **THEN** one structured diagnostic records its three tool counts
+- **AND** the event contains no authored payload or path
 ### Requirement: Subagent execution contract
 
 The system SHALL run subagents as ephemeral actors (`SubAgentActor`) that

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -5,6 +5,151 @@
 Define Netclaw's first-party and integrated tool execution behavior, including
 authorization, approval, and filesystem tooling.
 ## Requirements
+
+### Requirement: First-party tool outcomes are machine-actionable
+
+First-party workspace tool execution SHALL produce exactly one call-local
+outcome category: `success`, `invalid_input`, `access_denied`, `not_found`,
+`transient_failure`, or `recoverable_correction`. The category SHALL be separate
+from the model-facing string. The system SHALL NOT infer it from that string.
+The outcome MAY carry a bounded remediation code and canonical file activity.
+It SHALL NOT change the public string-returning `INetclawTool` contract.
+
+#### Scenario: Access denial has no successful file activity
+
+- **GIVEN** `file_read` is called for a path outside the current read authority
+- **WHEN** scoped access denies the call
+- **THEN** the outcome category is `access_denied`
+- **AND** the outcome contains no successful file activity
+- **AND** the model receives a bounded denial string
+
+#### Scenario: Recoverable correction stays distinct from failure
+
+- **GIVEN** a workspace tool can continue after the project directory is declared
+- **WHEN** the missing declaration is the only blocker
+- **THEN** the outcome category is `recoverable_correction`
+- **AND** its remediation code identifies `set_working_directory`
+- **AND** no authority is granted by the outcome itself
+
+### Requirement: Working context records successful file activity only
+
+`WorkingContext.RecentFiles` SHALL update only from canonical file activity in a
+successful tool outcome. Failed, denied, missing, malformed, or corrective tool
+results SHALL NOT update recent files. The session pipeline SHALL NOT infer file
+activity only from authored argument names.
+
+#### Scenario: Failed write does not become recent
+
+- **GIVEN** `file_write` targets a denied path
+- **WHEN** the tool returns an access-denied outcome
+- **THEN** the authored path is absent from `RecentFiles`
+
+#### Scenario: Successful batch read records canonical files
+
+- **GIVEN** `file_read_many` successfully reads two authorized relative paths
+- **WHEN** the session applies the tool receipt
+- **THEN** both canonical resolved paths are added to `RecentFiles`
+- **AND** no authored relative spelling becomes a separate file
+
+### Requirement: Recursive workspace search is bounded and structured
+
+The system SHALL provide a `file_search` tool for recursive literal file-name
+and text search under one authorized root. The tool SHALL accept explicit
+result, file, and content-byte ceilings. It SHALL NOT follow directory symlinks.
+It SHALL report matches, skipped entries, and truncation state. Search SHALL use
+filesystem APIs instead of an external executable.
+
+#### Scenario: Literal content search stays inside the root
+
+- **GIVEN** an authorized project has text files and an external directory link
+- **WHEN** `file_search` searches for a literal string from the project root
+- **THEN** matching project files are returned with relative paths and line data
+- **AND** the external tree is not traversed
+
+#### Scenario: Search stops at configured ceilings
+
+- **GIVEN** more matching files than the requested result ceiling
+- **WHEN** `file_search` reaches the ceiling
+- **THEN** it stops further content enumeration
+- **AND** the result reports that it was truncated
+
+### Requirement: Batch file reads validate before content access
+
+The system SHALL provide a `file_read_many` tool that accepts a bounded path
+list plus per-file and total output ceilings. It SHALL authorize the complete
+path list before it reads content. If one member is malformed, missing, denied,
+or outside the batch limits, the tool SHALL return no content from another
+member.
+
+#### Scenario: Denied member makes batch atomic
+
+- **GIVEN** a batch contains one authorized file and one denied file
+- **WHEN** `file_read_many` validates the batch
+- **THEN** the outcome is `access_denied`
+- **AND** no content from the authorized file is returned
+- **AND** no file activity is recorded
+
+#### Scenario: Authorized batch returns bounded sections
+
+- **GIVEN** a batch of authorized text files within count limits
+- **WHEN** `file_read_many` reads them
+- **THEN** the result contains one labeled bounded section per file
+- **AND** total output does not exceed the declared ceiling
+
+### Requirement: JSON projection uses bounded data semantics
+
+The system SHALL provide a `json_read` tool that reads one authorized JSON file
+and projects a bounded list of RFC 6901 JSON Pointers. It SHALL reject duplicate
+or invalid pointers. It SHALL bound input bytes, pointer count, and output
+characters. It SHALL NOT accept executable query languages.
+
+#### Scenario: Selected JSON properties returned without shell
+
+- **GIVEN** an authorized JSON document
+- **WHEN** `json_read` receives pointers `/status` and `/items/0/name`
+- **THEN** it returns the selected values with their pointers
+- **AND** the outcome is `success`
+
+#### Scenario: Invalid pointer fails before partial projection
+
+- **GIVEN** one valid pointer and one malformed pointer
+- **WHEN** `json_read` validates the request
+- **THEN** the outcome is `invalid_input`
+- **AND** no selected value is returned
+
+### Requirement: File inspection exposes bounded image metadata
+
+When `file_read` inspects a supported image, its metadata result SHALL include
+canonical MIME type, byte length, pixel width, and pixel height. It SHALL NOT
+decode the full image into an unbounded bitmap. Malformed or unsupported image
+metadata SHALL fail closed without returning raw binary content.
+
+#### Scenario: PNG dimensions are returned
+
+- **GIVEN** an authorized valid PNG file
+- **WHEN** `file_read` inspects it
+- **THEN** the result includes `image/png`, byte length, width, and height
+- **AND** the agent does not need shell or Python to obtain dimensions
+
+### Requirement: Conditional tool schemas expose valid branches
+
+A first-party tool with mutually exclusive modes SHALL publish a JSON Schema
+`oneOf`. Each branch SHALL require its mode fields and reject fields that belong
+only to another mode. Native argument validation SHALL reject zero or multiple
+matching branches before tool execution.
+
+#### Scenario: Reminder mode requires its delivery fields
+
+- **GIVEN** a reminder tool has delivery modes with different required fields
+- **WHEN** its schema is generated
+- **THEN** each mode is a separate `oneOf` branch
+- **AND** a call without required mode fields is rejected before dispatch
+
+#### Scenario: Single-shape tool remains compatible
+
+- **GIVEN** `file_list` has one argument shape
+- **WHEN** its schema is generated
+- **THEN** its existing object schema and accepted calls remain unchanged
 ### Requirement: Policy-gated tool invocation
 
 The system SHALL check ACL grants and approval policy before every tool

--- a/openspec/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/specs/progressive-tool-disclosure/spec.md
@@ -1,0 +1,90 @@
+# progressive-tool-disclosure Specification
+
+## Purpose
+
+Define bounded tool schema exposure and actor-local deferred tool activation.
+
+## Requirements
+
+### Requirement: Tool registrations declare an exposure tier
+
+Every registered tool SHALL have a `Core` or `Deferred` exposure tier. A
+registration path that does not select `Core` SHALL select `Deferred`. The tier
+SHALL NOT replace or widen deployment, audience, grant, or invocation policy.
+
+#### Scenario: New first-party tool defaults to deferred
+
+- **GIVEN** a first-party tool is registered without a core selection
+- **WHEN** a session builds its initial model tool set
+- **THEN** the new tool is absent from that initial set
+- **AND** current policy controls whether the tool is discoverable
+
+#### Scenario: Core selection does not grant a tool
+
+- **GIVEN** current audience policy denies a core tool
+- **WHEN** the session builds its initial model tool set
+- **THEN** the denied tool is absent
+- **AND** search and load do not reveal or activate it
+
+### Requirement: Sessions start with a bounded workspace core
+
+The initial model tool set SHALL contain policy-exposed definitions for
+`search_tools`, `load_tool`, `skill_load`, `skill_read_resource`,
+`set_working_directory`, `file_read`, `file_list`, `file_write`, `file_edit`,
+and `shell_execute`. Other first-party and MCP tools SHALL be deferred unless a
+later specification adds them to the core.
+
+#### Scenario: Specialty tools are not eagerly exposed
+
+- **GIVEN** specialty and MCP tools are registered
+- **WHEN** a new Personal session begins
+- **THEN** their schemas are absent from the initial set
+- **AND** policy-exposed tools remain searchable by intent
+
+#### Scenario: Core snapshot stays bounded
+
+- **WHEN** the repository first-party catalog is tested
+- **THEN** the core name snapshot equals the specified set
+- **AND** another first-party registration does not change that snapshot
+
+### Requirement: Search and load apply the complete exposure policy
+
+`search_tools` and `load_tool` SHALL apply deployment switches, audience
+allowlists, MCP grants, channel restrictions, and subagent restrictions before
+they return or activate a tool. Results SHALL NOT reveal a hidden tool name or
+schema. Loading SHALL add only the definition to the actor exposure set. Normal
+authorization SHALL still run at dispatch.
+
+#### Scenario: Hidden tool cannot be enumerated or loaded
+
+- **GIVEN** a Team session cannot use a registered specialty tool
+- **WHEN** it searches for and attempts to load the tool
+- **THEN** neither response confirms that the hidden tool exists
+- **AND** the model tool set is unchanged
+
+#### Scenario: Loaded tool still requires invocation authority
+
+- **GIVEN** a deferred tool is loadable and requires approval
+- **WHEN** the model loads and calls the tool
+- **THEN** the call enters the normal approval pipeline
+- **AND** loading does not satisfy approval
+
+### Requirement: Deferred exposure is actor-local and recoverable
+
+Loaded deferred tools SHALL be transient actor state. Main-session leases SHALL
+use the configured limits. Subagent-loaded tools SHALL exist only for that child
+run. Recovery SHALL reseed the core and SHALL NOT require a durable migration.
+
+#### Scenario: Main model failure evicts deferred first-party tool
+
+- **GIVEN** a main session loaded a deferred first-party tool
+- **WHEN** an LLM call fails and resets the cache
+- **THEN** the next model request omits that tool
+- **AND** the core remains available
+
+#### Scenario: Child completion discards loaded tools
+
+- **GIVEN** a subagent loads a deferred tool
+- **WHEN** that child stops and another child starts
+- **THEN** the new child receives only its policy-exposed core
+- **AND** it does not inherit the prior child lease

--- a/openspec/specs/session-cwd/spec.md
+++ b/openspec/specs/session-cwd/spec.md
@@ -5,6 +5,56 @@ declares it via `set_working_directory`. The project directory is the
 load-bearing input to the approval gate's safe-space root set: declaring
 it expands the trust boundary for shell invocations under that tree.
 ## Requirements
+
+### Requirement: Relative first-party filesystem paths use session-owned bases
+
+First-party filesystem tools SHALL resolve a relative path against the declared
+project directory when one exists. Otherwise, they SHALL use the immutable
+session directory. If neither base exists, they SHALL return an
+`invalid_context` correction. They SHALL NOT use the daemon process current
+directory. The canonical path SHALL pass existing scope and protected-path
+policies.
+
+#### Scenario: Relative read uses declared project
+
+- **GIVEN** a project directory `/workspace/project` and session `/session/current`
+- **WHEN** `file_read` receives `src/App.cs`
+- **THEN** it authorizes and reads `/workspace/project/src/App.cs`
+- **AND** it does not use the daemon current directory
+
+#### Scenario: Relative write falls back to session scratch
+
+- **GIVEN** no declared project and session directory `/session/current`
+- **WHEN** `file_write` receives `notes/result.md`
+- **THEN** it resolves `/session/current/notes/result.md`
+- **AND** the existing session write policy decides authorization
+
+#### Scenario: Traversal receives no implicit authority
+
+- **GIVEN** project directory `/workspace/project`
+- **WHEN** a file tool receives `../../outside.txt`
+- **THEN** it canonicalizes the result before policy evaluation
+- **AND** it denies the call when the path is outside authorized roots
+
+#### Scenario: Missing base returns correction
+
+- **GIVEN** a tool context has no project or session directory
+- **WHEN** a first-party filesystem tool receives a relative path
+- **THEN** it returns `invalid_context`
+- **AND** it performs no filesystem access
+
+### Requirement: Failed filesystem operations do not change project context
+
+A denied or failed `set_working_directory` or filesystem call SHALL NOT change
+the project directory or recent-file context. Only a validated successful
+project declaration SHALL replace the project and reload its instructions.
+
+#### Scenario: Denied declaration leaves prior project intact
+
+- **GIVEN** a session declares `/workspace/old`
+- **WHEN** `set_working_directory` is denied for `/workspace/new`
+- **THEN** the project directory remains `/workspace/old`
+- **AND** project instructions are not loaded from the denied path
 ### Requirement: Session-scoped project directory
 
 Each session SHALL maintain a mutable `ProjectDirectory` in `WorkingContext`
@@ -396,4 +446,3 @@ The system SHALL identify the existing per-session directory as the private scra
 - **WHEN** the current session ends
 - **THEN** this capability does not delete or schedule deletion of that artifact
 - **AND** retention remains unchanged until a separate cleanup capability is specified
-

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineHintTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineHintTests.cs
@@ -172,7 +172,7 @@ public sealed class SessionToolExecutionPipelineHintTests
     }
 
     [Fact]
-    public void Project_scope_correction_preserves_exact_directory_and_retry_intent()
+    public void Project_scope_correction_reports_only_the_failure_reason()
     {
         var context = new ToolApprovalContext(
             ToolName: ShellTool,
@@ -189,9 +189,9 @@ public sealed class SessionToolExecutionPipelineHintTests
             setWorkingDirectoryAvailable: true);
 
         Assert.Contains("working_directory_not_declared", correction);
-        Assert.Contains("set_working_directory", correction);
-        Assert.Contains("/home/user/repos/project", correction);
-        Assert.Contains("exact shell command unchanged", correction);
+        Assert.DoesNotContain("set_working_directory", correction);
+        Assert.Contains("Project directory: '/home/user/repos/project'", correction);
+        Assert.DoesNotContain("Next action", correction);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -1165,8 +1165,9 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             ToolExecutionContext? context = null,
             CancellationToken ct = default)
         {
-            Assert.NotNull(context);
-            context.Outputs.TryComplete(new ToolInvocationReceipt(
+            var requiredContext = context
+                ?? throw new InvalidOperationException("Execution context is required.");
+            requiredContext.Outputs.TryComplete(new ToolInvocationReceipt(
                 ToolInvocationOutcomeCategory.RecoverableCorrection,
                 remediationCode: ToolRemediationCode.SetWorkingDirectory));
             return Task.FromResult("Error: invalid_context: No project or session directory is available.");

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -247,11 +247,77 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
         var result = Assert.Single(completed.ToolResults);
-        Assert.Contains("working_directory_not_declared", result.Content);
-        Assert.Contains("set_working_directory", result.Content);
-        Assert.Contains("/home/user/repos/project", result.Content);
+        Assert.Equal(
+            "Tool execution deferred: working_directory_not_declared\n" +
+            "Project directory: '/home/user/repos/project'.\n" +
+            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            result.Content);
+        Assert.Equal(
+            ToolRemediationCode.SetWorkingDirectory,
+            completed.ToolReceipts["call-1"].RemediationCode);
         Assert.Empty(approvals);
         Assert.Equal(1, executor.Attempts);
+    }
+
+    [Fact]
+    public async Task Streaming_result_is_presented_before_delivery()
+    {
+        var executor = new CorrectiveReceiptExecutor();
+        var probe = CreateTestProbe("streaming-remediation-probe");
+        var call = new FunctionCallContent(
+            "call-streaming-remediation",
+            "file_read",
+            new Dictionary<string, object?> { ["Path"] = "README.md" });
+
+        var pipelineTask = new SessionToolPipelineTestFixture(
+                executor,
+                [call],
+                new SessionId("D1/streaming-remediation"),
+                probe.Ref)
+            .WithSetWorkingDirectoryAvailable()
+            .StreamingResults()
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionSingleCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await probe.ExpectMsgAsync<ToolExecutionBatchCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            "Error: invalid_context: No project or session directory is available.\n" +
+            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            completed.Result.Message.Content);
+        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, completed.Result.Receipt?.RemediationCode);
+    }
+
+    [Fact]
+    public async Task Hidden_working_directory_tool_is_not_named_by_parent_result()
+    {
+        var executor = new CorrectiveReceiptExecutor();
+        var probe = CreateTestProbe("hidden-remediation-probe");
+        var call = new FunctionCallContent(
+            "call-hidden-remediation",
+            "file_read",
+            new Dictionary<string, object?> { ["Path"] = "README.md" });
+
+        var pipelineTask = new SessionToolPipelineTestFixture(
+                executor,
+                [call],
+                new SessionId("D1/hidden-remediation"),
+                probe.Ref)
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(completed.ToolResults);
+        Assert.Equal("Error: invalid_context: No project or session directory is available.", result.Content);
+        Assert.DoesNotContain(SetWorkingDirectoryTool.ToolName, result.Content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -283,7 +349,13 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
         Assert.Equal(2, completed.ToolResults.Count);
         Assert.All(completed.ToolResults, result =>
-            Assert.Contains("shared_temporary_directory", result.Content));
+            Assert.Equal(
+                "Tool execution deferred: shared_temporary_directory\n" +
+                "Session scratch directory: '/home/user/.netclaw/sessions/example'.\n" +
+                "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths.",
+                result.Content));
+        Assert.All(completed.ToolReceipts.Values, receipt =>
+            Assert.Equal(ToolRemediationCode.UseSessionScratch, receipt.RemediationCode));
         Assert.Equal(2, completed.ScratchCorrectionChanges.Count);
         Assert.All(completed.ScratchCorrectionChanges,
             change => Assert.IsType<SessionScratchCorrectionChange.Arm>(change));
@@ -1077,6 +1149,27 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             {
                 SuggestedProjectDirectory = directory
             });
+        }
+    }
+
+    private sealed class CorrectiveReceiptExecutor : IToolExecutor
+    {
+        public Task AuthorizeAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<string> ExecuteAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+        {
+            Assert.NotNull(context);
+            context.Outputs.TryComplete(new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: ToolRemediationCode.SetWorkingDirectory));
+            return Task.FromResult("Error: invalid_context: No project or session directory is available.");
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -250,7 +250,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         Assert.Equal(
             "Tool execution deferred: working_directory_not_declared\n" +
             "Project directory: '/home/user/repos/project'.\n" +
-            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call.",
             result.Content);
         Assert.Equal(
             ToolRemediationCode.SetWorkingDirectory,
@@ -288,7 +288,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
         Assert.Equal(
             "Error: invalid_context: No project or session directory is available.\n" +
-            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call.",
             completed.Result.Message.Content);
         Assert.Equal(ToolRemediationCode.SetWorkingDirectory, completed.Result.Receipt?.RemediationCode);
     }

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -381,6 +381,27 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         Assert.DoesNotContain(misleadingPath, nextTurn, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Another_tool_receipt_cannot_declare_project_scope()
+    {
+        var declaredPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "forged-project"));
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-read",
+                "file_read",
+                new Dictionary<string, object?> { ["Path"] = "README.md" })
+        ];
+        _fakeToolExecutor.Results["file_read"] = "content";
+        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.Success,
+            declaredProjectDirectory: declaredPath);
+
+        var nextTurn = await RunToolTurnAndCaptureNextTurnAsync("forged-project-declaration");
+
+        Assert.DoesNotContain(declaredPath, nextTurn, StringComparison.Ordinal);
+    }
+
     private async Task<string> RunToolTurnAndCaptureNextTurnAsync(string sessionSuffix)
     {
         var sessionId = new SessionId($"console/{sessionSuffix}");

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
@@ -12,6 +12,15 @@ namespace Netclaw.Actors.Tests.Sessions;
 
 public class WorkingContextUpdaterTests
 {
+    public static TheoryData<string> NonSuccessCategories { get; } = new()
+    {
+        nameof(ToolInvocationOutcomeCategory.InvalidInput),
+        nameof(ToolInvocationOutcomeCategory.AccessDenied),
+        nameof(ToolInvocationOutcomeCategory.NotFound),
+        nameof(ToolInvocationOutcomeCategory.TransientFailure),
+        nameof(ToolInvocationOutcomeCategory.RecoverableCorrection)
+    };
+
     [Fact]
     public void Successful_receipts_apply_canonical_activity_in_result_order()
     {
@@ -39,14 +48,10 @@ public class WorkingContextUpdaterTests
     }
 
     [Theory]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(3)]
-    [InlineData(4)]
-    [InlineData(5)]
-    public void Failed_or_corrective_receipts_cannot_add_recent_files(int categoryValue)
+    [MemberData(nameof(NonSuccessCategories))]
+    public void Failed_or_corrective_receipts_cannot_add_recent_files(string categoryName)
     {
-        var category = (ToolInvocationOutcomeCategory)categoryValue;
+        var category = Enum.Parse<ToolInvocationOutcomeCategory>(categoryName);
         var result = Result("call-1", "file_read", "successful-looking presentation");
         var receipt = category == ToolInvocationOutcomeCategory.RecoverableCorrection
             ? new ToolInvocationReceipt(

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
@@ -99,6 +99,17 @@ public class WorkingContextUpdaterTests
         Assert.Contains("successful", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("bad\ncode")]
+    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    public void Recoverable_receipt_rejects_invalid_remediation_code(string code)
+    {
+        Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.RecoverableCorrection,
+            remediationCode: code));
+    }
+
     private static ToolInvocationReceipt Success(string path, ToolFileActivityKind kind)
         => new(
             ToolInvocationOutcomeCategory.Success,

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
@@ -49,7 +49,9 @@ public class WorkingContextUpdaterTests
         var category = (ToolInvocationOutcomeCategory)categoryValue;
         var result = Result("call-1", "file_read", "successful-looking presentation");
         var receipt = category == ToolInvocationOutcomeCategory.RecoverableCorrection
-            ? new ToolInvocationReceipt(category, remediationCode: "set_working_directory")
+            ? new ToolInvocationReceipt(
+                category,
+                remediationCode: ToolRemediationCode.SetWorkingDirectory)
             : new ToolInvocationReceipt(category);
 
         var updated = WorkingContextUpdater.UpdateFromToolReceipts(
@@ -99,15 +101,27 @@ public class WorkingContextUpdaterTests
         Assert.Contains("successful", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("bad\ncode")]
-    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
-    public void Recoverable_receipt_rejects_invalid_remediation_code(string code)
+    [Fact]
+    public void Recoverable_receipt_requires_remediation()
     {
         Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.RecoverableCorrection));
+    }
+
+    [Fact]
+    public void Non_corrective_receipt_rejects_remediation()
+    {
+        Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.AccessDenied,
+            remediationCode: ToolRemediationCode.SetWorkingDirectory));
+    }
+
+    [Fact]
+    public void Remediation_rejects_undefined_code()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ToolInvocationReceipt(
             ToolInvocationOutcomeCategory.RecoverableCorrection,
-            remediationCode: code));
+            remediationCode: (ToolRemediationCode)int.MaxValue));
     }
 
     private static ToolInvocationReceipt Success(string path, ToolFileActivityKind kind)

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -734,7 +734,7 @@ public class SubAgentActorTests : TestKit
         Assert.Equal(
             "Tool execution deferred: working_directory_not_declared\n" +
             $"Project directory: '{scenario.Worktree}'.\n" +
-            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call.",
             correction);
         var preservedCall = scenario.Client.LastReceivedMessages!
             .SelectMany(message => message.Contents.OfType<FunctionCallContent>())

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -704,8 +704,10 @@ public class SubAgentActorTests : TestKit
         Assert.True(result.Success, result.Output);
         Assert.False(fakeTool.WasCalled);
         Assert.Equal(0, approvalBridge.RequestCount);
-        Assert.Contains(
-            "shared_temporary_directory",
+        Assert.Equal(
+            "Tool execution deferred: shared_temporary_directory\n" +
+            "Session scratch directory: '/home/user/.netclaw/sessions/example'.\n" +
+            "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths.",
             GetLastToolResult(fakeClient, "call-scratch-correction"));
     }
 
@@ -729,9 +731,11 @@ public class SubAgentActorTests : TestKit
         Assert.False(scenario.Shell.WasCalled);
         Assert.Equal(0, approvalBridge?.RequestCount ?? 0);
         var correction = GetLastToolResult(scenario.Client, callId);
-        Assert.Contains("working_directory_not_declared", correction, StringComparison.Ordinal);
-        Assert.Contains(scenario.Worktree, correction, StringComparison.Ordinal);
-        Assert.Contains(SetWorkingDirectoryTool.ToolName, correction, StringComparison.Ordinal);
+        Assert.Equal(
+            "Tool execution deferred: working_directory_not_declared\n" +
+            $"Project directory: '{scenario.Worktree}'.\n" +
+            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            correction);
         var preservedCall = scenario.Client.LastReceivedMessages!
             .SelectMany(message => message.Contents.OfType<FunctionCallContent>())
             .Single(call => call.CallId == callId);
@@ -759,6 +763,27 @@ public class SubAgentActorTests : TestKit
         Assert.Equal(scenario.Worktree, approvalBridge.RequestedCwd);
         Assert.DoesNotContain(
             "working_directory_not_declared",
+            GetLastToolResult(scenario.Client, callId),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Subagent_policy_hidden_project_scope_tool_is_not_revealed()
+    {
+        const string callId = "call-project-scope-hidden";
+        var approvalBridge = new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce);
+        var scenario = await RunProjectScopeScenarioAsync(
+            callId,
+            includeScopeTool: true,
+            scopeToolAccepts: true,
+            approvalBridge,
+            hideScopeTool: true);
+
+        Assert.True(scenario.Result.Success, scenario.Result.Output);
+        Assert.True(scenario.Shell.WasCalled);
+        Assert.Equal(1, approvalBridge.RequestCount);
+        Assert.DoesNotContain(
+            SetWorkingDirectoryTool.ToolName,
             GetLastToolResult(scenario.Client, callId),
             StringComparison.Ordinal);
     }
@@ -1359,7 +1384,8 @@ public class SubAgentActorTests : TestKit
         string callId,
         bool includeScopeTool,
         bool scopeToolAccepts,
-        IParentApprovalBridge? approvalBridge)
+        IParentApprovalBridge? approvalBridge,
+        bool hideScopeTool = false)
     {
         var worktree = Path.GetFullPath(AppContext.BaseDirectory);
         var shell = new FakeNetclawTool(ShellTool.ToolName, "approved");
@@ -1381,7 +1407,7 @@ public class SubAgentActorTests : TestKit
         var agent = Sys.ActorOf(SubAgentActor.CreateProps(
             CreateDefinition(tools),
             client,
-            CreateProjectScopeCorrectionPolicy(worktree)));
+            CreateProjectScopeCorrectionPolicy(worktree, hideScopeTool)));
         var result = await agent.Ask<SubAgentResult>(
             new RunSubAgent
             {
@@ -1421,14 +1447,19 @@ public class SubAgentActorTests : TestKit
         public string? GetOperatingRules(TrustAudience audience) => null;
     }
 
-    private static ToolAccessPolicy CreateProjectScopeCorrectionPolicy(string workspacesDirectory)
+    private static ToolAccessPolicy CreateProjectScopeCorrectionPolicy(
+        string workspacesDirectory,
+        bool hideScopeTool = false)
     {
         var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
         toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
         {
             ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
             {
-                [ShellTool.ToolName] = ToolApprovalMode.Approval
+                [ShellTool.ToolName] = ToolApprovalMode.Approval,
+                [SetWorkingDirectoryTool.ToolName] = hideScopeTool
+                    ? ToolApprovalMode.Deny
+                    : ToolApprovalMode.Auto
             }
         };
         var environment = TestShellEnvironment.Current;

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -2098,6 +2098,75 @@ public class SubAgentActorTests : TestKit
         Assert.Empty(result.WorkingContext.ConfirmedChangedFiles);
     }
 
+    [Fact]
+    public async Task Dispatcher_policy_denial_has_access_denied_child_receipt()
+    {
+        var shell = new FakeNetclawTool(ShellTool.ToolName, "should not run");
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                CreateToolCall("call-team-shell", ShellTool.ToolName,
+                    new Dictionary<string, object?> { ["Command"] = "echo denied" })
+            ]
+        };
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(
+            CreateDefinition([shell]),
+            fakeClient,
+            PermissivePolicy()));
+
+        await EventFilter.Info(message: "SubAgent tool outcome category=AccessDenied").ExpectAsync(1, async () =>
+        {
+            var result = await agent.Ask<SubAgentResult>(
+                new RunSubAgent
+                {
+                    Scope = SubAgentTestScope.Create(audience: TrustAudience.Team),
+                    Task = "Run the denied shell tool.",
+                    Timeout = TimeSpan.FromSeconds(5)
+                },
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(result.Success);
+        }, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(shell.WasCalled);
+    }
+
+    [Fact]
+    public async Task Another_child_tool_receipt_cannot_declare_project_scope()
+    {
+        var originalProject = Path.GetFullPath(Path.Join(Path.GetTempPath(), "original-child-project"));
+        var forgedProject = Path.GetFullPath(Path.Join(Path.GetTempPath(), "forged-child-project"));
+        var readTool = new FakeNetclawTool(
+            FileReadTool.ToolName,
+            "content",
+            onExecute: context => context.TryComplete(new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.Success,
+                declaredProjectDirectory: forgedProject)));
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall = [CreateToolCall("call-read", FileReadTool.ToolName)]
+        };
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(
+            CreateDefinition([readTool]),
+            fakeClient,
+            PermissivePolicy()));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Scope = SubAgentTestScope.Create(projectDirectory: originalProject),
+                Task = "Read one file.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal(originalProject, result.WorkingContext?.ProjectDirectory);
+    }
+
     private static readonly string MissingProjectDirectory =
         Path.Join(Path.GetTempPath(), "netclaw-missing-project");
 

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -39,6 +39,25 @@ public class AttachFileToolTests : IDisposable
     }
 
     [Fact]
+    public async Task Missing_session_is_invalid_and_does_not_suggest_project_declaration()
+    {
+        var context = TestToolExecutionContext.CreateUnbound(new TestToolExecutionContextOptions
+        {
+            Audience = TrustAudience.Personal
+        });
+
+        var result = await _tool.ExecuteAsync(
+            ToolInput.Create("Path", "report.png"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("invalid_context", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("set_working_directory", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
+        Assert.Null(context.Receipt?.RemediationCode);
+    }
+
+    [Fact]
     public async Task Path_traversal_attempt_is_rejected()
     {
         // Autonomous Personal: the out-of-session boundary holds for

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -253,7 +253,7 @@ public sealed class AutonomousZoneClampTests : IDisposable
             out var failure));
         Assert.Empty(resolved);
         Assert.Contains("invalid_context", error, StringComparison.Ordinal);
-        Assert.Contains("set_working_directory", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("set_working_directory", error, StringComparison.Ordinal);
         Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.MissingBase, failure);
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AutonomousZoneClampTests.cs
@@ -342,9 +342,9 @@ public sealed class AutonomousZoneClampTests : IDisposable
         Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.AccessDenied, failure);
     }
 
-    [Fact(SkipUnless = nameof(IsPosix), Skip = "Directory symlink creation is privilege-gated on Windows.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "This case uses native POSIX link semantics.")]
     [SlopwatchSuppress("SW001", "This regression requires native POSIX symbolic-link base semantics.")]
-    public void Symlinked_project_base_falls_back_to_session_directory()
+    public void Symlinked_project_base_is_denied()
     {
         var projectLink = Path.Join(_dir.Path, "project-link");
         Directory.CreateSymbolicLink(projectLink, _outsideDir);
@@ -358,13 +358,67 @@ public sealed class AutonomousZoneClampTests : IDisposable
                 ProjectDirectory = projectLink
             });
 
-        Assert.True(policy.TryResolveReadPath(
+        Assert.False(policy.TryResolveReadPath(
             "secret.txt",
             context.Invocation,
-            out var resolved,
-            out var error,
-            out var failure), error);
-        Assert.Equal(Path.GetFullPath(Path.Join(_sessionDir, "secret.txt")), resolved);
-        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.None, failure);
+            out _,
+            out _,
+            out var failure));
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.AccessDenied, failure);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "This case uses native POSIX link semantics.")]
+    [SlopwatchSuppress("SW001", "This regression requires native POSIX ancestor-link semantics.")]
+    public void Posix_project_base_with_link_ancestor_is_denied()
+    {
+        AssertProjectBaseWithLinkAncestorIsDenied(autonomous: true);
+    }
+
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "This case uses native POSIX ancestor-link semantics.")]
+    [SlopwatchSuppress("SW001", "This regression requires native POSIX ancestor-link semantics.")]
+    public void Interactive_project_base_with_link_ancestor_is_denied()
+    {
+        AssertProjectBaseWithLinkAncestorIsDenied(autonomous: false);
+    }
+
+    [Fact(SkipUnless = nameof(IsWindows), Skip = "This case uses native Windows junction semantics.")]
+    [SlopwatchSuppress("SW001", "This regression requires native Windows ancestor-link semantics.")]
+    public void Windows_project_base_with_link_ancestor_is_denied()
+    {
+        AssertProjectBaseWithLinkAncestorIsDenied(autonomous: true);
+    }
+
+    private void AssertProjectBaseWithLinkAncestorIsDenied(bool autonomous)
+    {
+        var workspaces = Path.Join(_dir.Path, "owned-workspaces");
+        var target = Path.Join(_dir.Path, "linked-target");
+        var project = Path.Join(target, "project");
+        Directory.CreateDirectory(workspaces);
+        Directory.CreateDirectory(project);
+
+        var link = Path.Join(workspaces, "linked-parent");
+        Directory.CreateSymbolicLink(link, target);
+        var linkedProject = Path.Join(link, "project");
+        var paths = new NetclawPaths(_dir.Path, workspaces);
+        var policy = new ScopedFileAccessPolicy(new ToolConfig(), paths);
+        var context = TestToolExecutionContext.CreateBound(
+            "reminder/ancestor-link-project",
+            _sessionDir,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                InteractiveApproval = autonomous
+                    ? new InteractiveApprovalCapability.Unavailable()
+                    : new InteractiveApprovalCapability.Available(new TestParentApprovalBridge()),
+                ProjectDirectory = linkedProject
+            });
+
+        Assert.False(policy.TryResolveReadPath(
+            "secret.txt",
+            context.Invocation,
+            out _,
+            out _,
+            out var failure));
+        Assert.Equal(ScopedFileAccessPolicy.PathResolutionFailure.AccessDenied, failure);
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
@@ -81,6 +81,48 @@ public class DiscoveredToolCacheTests
     }
 
     [Fact]
+    public void PrepareForNewTurn_WithZeroRetention_EvictsLoadedTools()
+    {
+        var registry = new ToolRegistry();
+        var cache = new DiscoveredToolCache();
+
+        RegisterAndRemember(registry, cache, "notion", "search", retentionTurns: 3, maxCount: 12);
+        Assert.Single(cache.AvailableTools);
+
+        cache.PrepareForNewTurn(retentionTurns: 0, maxCount: 12, registry);
+
+        Assert.Empty(cache.AvailableTools);
+        Assert.False(cache.HasTool("notion/search"));
+    }
+
+    [Fact]
+    public void PrepareForNewTurn_OverMaximum_EvictsOldestLoadedTool()
+    {
+        var registry = new ToolRegistry();
+        var cache = new DiscoveredToolCache();
+
+        for (var i = 0; i < 13; i++)
+        {
+            RegisterAndRemember(
+                registry,
+                cache,
+                "server",
+                $"tool_{i:D2}",
+                retentionTurns: 3,
+                maxCount: 12);
+        }
+
+        cache.PrepareForNewTurn(retentionTurns: 3, maxCount: 12, registry);
+
+        Assert.Equal(12, cache.LoadedToolCount);
+        Assert.False(cache.HasTool("server/tool_00"));
+        Assert.True(cache.HasTool("server/tool_12"));
+        Assert.DoesNotContain(
+            cache.AvailableTools,
+            static tool => tool is AIFunction function && function.Name == "server/tool_00");
+    }
+
+    [Fact]
     public void Deferred_first_party_tool_uses_the_same_lease_and_eviction_path()
     {
         var registry = new ToolRegistry();

--- a/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
@@ -119,7 +119,7 @@ public class DiscoveredToolCacheTests
         Assert.True(cache.HasTool("server/tool_12"));
         Assert.DoesNotContain(
             cache.AvailableTools,
-            static tool => tool is AIFunction function && function.Name == "server/tool_00");
+            static tool => tool is AIFunction function && function.Name == "server__tool_00");
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -438,6 +438,8 @@ public class DispatchingToolExecutorTests
 
         var ex = await Assert.ThrowsAsync<ToolAccessDeniedException>(() => _restrictedExecutor.ExecuteAsync(toolCall, context, TestContext.Current.CancellationToken));
         Assert.Equal("shell_requires_personal_context", ex.DenyReason);
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.Empty(context.Receipt?.FileActivity ?? []);
     }
 
     [Fact]
@@ -2728,6 +2730,7 @@ public class DispatchingToolExecutorTests
 
             var firstAttempt = await Assert.ThrowsAsync<ToolApprovalRequiredException>(() =>
                 executor.ExecuteAsync(toolCall, context, TestContext.Current.CancellationToken));
+            Assert.Null(context.Receipt);
 
             context.OneTimeApprovedToolName = toolCall.Name;
             context.SetOneTimeApprovedPatterns(OneTimeApprovalKeys.Create(firstAttempt.ApprovalContext));
@@ -2736,6 +2739,7 @@ public class DispatchingToolExecutorTests
             // Output text varies by test environment (git status); meaningful
             // assertion is that no ToolApprovalRequiredException is thrown.
             _ = await executor.ExecuteAsync(toolCall, context, TestContext.Current.CancellationToken);
+            Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
 
             context.OneTimeApprovedToolName = null;
             context.SetOneTimeApprovedPatterns([]);

--- a/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
@@ -62,9 +62,12 @@ public class FileEditToolTests : IDisposable
         var original = "foo bar foo baz foo";
         await File.WriteAllTextAsync(filePath, original, TestContext.Current.CancellationToken);
 
-        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "OldString", "foo", "NewString", "qux"), CreatePersonalContext(), CancellationToken.None);
+        var context = CreatePersonalContext();
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "OldString", "foo", "NewString", "qux"), context, CancellationToken.None);
 
         Assert.Contains("matches 3 locations", result);
+        Assert.DoesNotContain("Next action", result, StringComparison.Ordinal);
+        Assert.Equal(ToolRemediationCode.ProvideUniqueOldString, context.Receipt?.RemediationCode);
         Assert.Equal(original, await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
     }
 
@@ -75,9 +78,11 @@ public class FileEditToolTests : IDisposable
         var original = "hello world";
         await File.WriteAllTextAsync(filePath, original, TestContext.Current.CancellationToken);
 
-        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "OldString", "goodbye", "NewString", "farewell"), CreatePersonalContext(), CancellationToken.None);
+        var context = CreatePersonalContext();
+        var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "OldString", "goodbye", "NewString", "farewell"), context, CancellationToken.None);
 
         Assert.Contains("not found", result);
+        Assert.Equal(ToolRemediationCode.ProvideUniqueOldString, context.Receipt?.RemediationCode);
         Assert.Equal(original, await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
@@ -168,6 +168,8 @@ public class SearchToolsToolTests
         Assert.Contains("Did you mean", result);
         Assert.Contains("browser_chrome_devtools__navigate_page", result);
         Assert.Contains("Suggestions are not loaded yet", result);
+        Assert.Contains("Call load_tool with one of the exact tool names above", result);
+        Assert.DoesNotContain("Call search_tools again", result);
         Assert.DoesNotContain("browser_chrome_devtools__navigate_page —", result);
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolRemediationPresenterTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tools;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class ToolRemediationPresenterTests
+{
+    private static readonly (ToolRemediationCode Code, string ExpectedAction)[] SupportedRemediations =
+    {
+        (
+            ToolRemediationCode.SetWorkingDirectory,
+            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call."
+        ),
+        (
+            ToolRemediationCode.UseSessionScratch,
+            "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths."
+        ),
+        (
+            ToolRemediationCode.ProvideUniqueOldString,
+            "Next action: retry file_edit with a unique OldString, or set ReplaceAll=true when every match should change."
+        )
+    };
+
+    [Fact]
+    public void Presenter_appends_one_action_for_each_supported_remediation()
+    {
+        foreach (var (code, expectedAction) in SupportedRemediations)
+        {
+            var receipt = new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: code);
+
+            var result = ToolRemediationPresenter.Present(
+                Message("bounded failure"),
+                receipt,
+                setWorkingDirectoryAvailable: true);
+
+            Assert.Equal($"bounded failure\n{expectedAction}", result.Content);
+            Assert.Equal(1, CountOccurrences(result.Content, "Next action:"));
+        }
+    }
+
+    [Fact]
+    public void Presenter_suppresses_hidden_working_directory_tool()
+    {
+        var receipt = new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.RecoverableCorrection,
+            remediationCode: ToolRemediationCode.SetWorkingDirectory);
+
+        var result = ToolRemediationPresenter.Present(
+            Message("bounded failure"),
+            receipt,
+            setWorkingDirectoryAvailable: false);
+
+        Assert.Equal("bounded failure", result.Content);
+        Assert.DoesNotContain("set_working_directory", result.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Presenter_leaves_non_corrective_result_unchanged()
+    {
+        var message = Message("denied");
+        var receipt = new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied);
+
+        Assert.Same(message, ToolRemediationPresenter.Present(message, receipt, true));
+        Assert.Same(message, ToolRemediationPresenter.Present(message, null, true));
+    }
+
+    private static SerializableChatMessage Message(string content)
+        => new() { Role = ChatRole.Tool, Content = content };
+
+    private static int CountOccurrences(string value, string term)
+        => value.Split(term, StringSplitOptions.None).Length - 1;
+}

--- a/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
@@ -12,39 +12,40 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public class ToolRemediationPresenterTests
 {
-    private static readonly (ToolRemediationCode Code, string ExpectedAction)[] SupportedRemediations =
+    public static TheoryData<string, string> SupportedRemediations { get; } = new()
     {
-        (
-            ToolRemediationCode.SetWorkingDirectory,
+        {
+            nameof(ToolRemediationCode.SetWorkingDirectory),
             "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call."
-        ),
-        (
-            ToolRemediationCode.UseSessionScratch,
+        },
+        {
+            nameof(ToolRemediationCode.UseSessionScratch),
             "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths."
-        ),
-        (
-            ToolRemediationCode.ProvideUniqueOldString,
+        },
+        {
+            nameof(ToolRemediationCode.ProvideUniqueOldString),
             "Next action: retry file_edit with a unique OldString, or set ReplaceAll=true when every match should change."
-        )
+        }
     };
 
-    [Fact]
-    public void Presenter_appends_one_action_for_each_supported_remediation()
+    [Theory]
+    [MemberData(nameof(SupportedRemediations))]
+    public void Presenter_appends_one_action_for_supported_remediation(
+        string codeName,
+        string expectedAction)
     {
-        foreach (var (code, expectedAction) in SupportedRemediations)
-        {
-            var receipt = new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.RecoverableCorrection,
-                remediationCode: code);
+        var code = Enum.Parse<ToolRemediationCode>(codeName);
+        var receipt = new ToolInvocationReceipt(
+            ToolInvocationOutcomeCategory.RecoverableCorrection,
+            remediationCode: code);
 
-            var result = ToolRemediationPresenter.Present(
-                Message("bounded failure"),
-                receipt,
-                setWorkingDirectoryAvailable: true);
+        var result = ToolRemediationPresenter.Present(
+            Message("bounded failure"),
+            receipt,
+            setWorkingDirectoryAvailable: true);
 
-            Assert.Equal($"bounded failure\n{expectedAction}", result.Content);
-            Assert.Equal(1, CountOccurrences(result.Content, "Next action:"));
-        }
+        Assert.Equal($"bounded failure\n{expectedAction}", result.Content);
+        Assert.Equal(1, CountOccurrences(result.Content, "Next action:"));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
@@ -16,7 +16,7 @@ public class ToolRemediationPresenterTests
     {
         {
             nameof(ToolRemediationCode.SetWorkingDirectory),
-            "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call."
+            "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call."
         },
         {
             nameof(ToolRemediationCode.UseSessionScratch),

--- a/src/Netclaw.Actors.Tests/Tools/WorkspaceToolRelativePathTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WorkspaceToolRelativePathTests.cs
@@ -156,9 +156,9 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
             TestContext.Current.CancellationToken);
 
         Assert.Contains("invalid_context", result, StringComparison.Ordinal);
-        Assert.Contains("set_working_directory", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("set_working_directory", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.RecoverableCorrection, context.Receipt?.Category);
-        Assert.Equal(ToolOutcomeResults.SetWorkingDirectoryRemediation, context.Receipt?.RemediationCode);
+        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, context.Receipt?.RemediationCode);
         Assert.Empty(context.Receipt?.FileActivity ?? []);
     }
 

--- a/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
@@ -11,8 +11,8 @@ namespace Netclaw.Actors.Sessions.Handlers;
 
 /// <summary>
 /// Owns the session's exposed tool list — the always-loaded base tools plus the
-/// deferred tools discovered via search_tools — and manages lease-based retention and
-/// eviction of the discovered set across turns. Because the cache owns the list
+/// deferred tools activated through load_tool — and manages lease-based retention and
+/// eviction of the loaded set across turns. Because the cache owns the list
 /// it rebuilds, callers seed the base tools once and then drive
 /// <see cref="PrepareForNewTurn"/> / <see cref="EvictAll"/> / <see cref="AddIfMissing"/>
 /// without passing the list around. Transient and actor-owned; never persisted.
@@ -26,7 +26,7 @@ internal sealed class DiscoveredToolCache
 
     /// <summary>
     /// The tools currently exposed to the model this turn: the base tools
-    /// followed by any discovered tools with an active lease.
+    /// followed by any loaded Deferred tools with an active lease.
     /// </summary>
     public IReadOnlyList<AITool> AvailableTools => _availableTools;
 
@@ -36,7 +36,7 @@ internal sealed class DiscoveredToolCache
 
     /// <summary>
     /// Seed the always-loaded base tools once at session start. Everything added
-    /// beyond this set is a discovered tool subject to lease-based eviction.
+    /// beyond this set is a loaded Deferred tool subject to lease-based eviction.
     /// </summary>
     public void SeedBaseTools(IReadOnlyList<AITool> alwaysLoadedTools)
     {
@@ -50,7 +50,7 @@ internal sealed class DiscoveredToolCache
     /// and rebuild the available tools list from the cache.
     /// </summary>
     /// <param name="retentionTurns">Configured retention turns (0 or negative disables caching).</param>
-    /// <param name="maxCount">Maximum discovered tools to retain.</param>
+    /// <param name="maxCount">Maximum loaded Deferred tools to retain.</param>
     /// <param name="registry">Tool registry for resolving tool instances.</param>
     public void PrepareForNewTurn(int retentionTurns, int maxCount, ToolRegistry? registry)
     {
@@ -97,7 +97,7 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
-    /// Remember a discovered deferred tool with a lease for future turns.
+    /// Remember a loaded Deferred tool with a lease for future turns.
     /// </summary>
     public void Remember(string toolName, INetclawTool tool, int leaseTurns, int maxCount)
     {
@@ -121,7 +121,7 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
-    /// Evict all discovered tools and trim the available tools list back to the
+    /// Evict all loaded Deferred tools and trim the available tools list back to the
     /// base tools. Used when an LLM call fails to prevent a bad tool set from
     /// poisoning subsequent turns.
     /// </summary>
@@ -133,7 +133,7 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
-    /// Check whether the cache contains a tool with an active lease.
+    /// Check whether the cache contains a loaded tool with an active lease.
     /// </summary>
     public bool HasTool(string toolName)
     {
@@ -159,7 +159,7 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
-    /// Rebuild the available tools list from the discovered tool cache.
+    /// Rebuild the available tools list from the loaded-tool cache.
     /// </summary>
     private void RebuildFromCache(ToolRegistry registry)
     {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -951,7 +951,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         foreach (var result in msg.ToolResults)
         {
-            if (result.ToolCallId is not { } callId
+            if (!string.Equals(result.Name, SetWorkingDirectoryTool.ToolName, StringComparison.Ordinal)
+                || result.ToolCallId is not { } callId
                 || !msg.ToolReceipts.TryGetValue(callId.Value, out var receipt)
                 || receipt.Category != ToolInvocationOutcomeCategory.Success
                 || receipt.DeclaredProjectDirectory is not { } projectDir)
@@ -4754,7 +4755,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (toolMessage.Name is "load_tool" && toolMessage.Content is not null)
             TryActivateDiscoveredTool(toolMessage.Content.Trim());
 
-        if (result.Receipt is
+        if (string.Equals(toolMessage.Name, SetWorkingDirectoryTool.ToolName, StringComparison.Ordinal)
+            && result.Receipt is
             {
                 Category: ToolInvocationOutcomeCategory.Success,
                 DeclaredProjectDirectory: { } projectDir

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -264,7 +264,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 NoLogger.Instance);
 
         // Load only the explicit core for initial LLM calls. Deferred first-party and
-        // MCP tools use search_tools and share the configured discovery lease.
+        // MCP tools are discovered through search_tools, activated through load_tool,
+        // and share the configured loaded-tool lease.
         _fullRegistry = tools?.ToolRegistry;
         if (_fullRegistry is not null)
         {
@@ -668,7 +669,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // the failure reaches here, so a failed turn is terminal.
             TurnLog().Error(msg.Cause, "turn_llm_call_failed");
 
-            // Evict discovered tools to prevent a poisoned tool set from cascading
+            // Evict loaded Deferred tools to prevent a poisoned tool set from cascading
             // across turns (e.g., oversized Notion schemas causing repeated 502s).
             _discoveredToolCache.EvictAll();
             TurnLog().Info("turn_discovered_tools_evicted — tool list reset to base tools after LLM call failure");
@@ -3456,7 +3457,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     /// <summary>
-    /// Attempt to activate a single discovered tool by name.
+    /// Attempt to activate a single Deferred tool by name.
     /// Checks registry, access policy, and adds to the available tools cache.
     /// </summary>
     private bool TryActivateDiscoveredTool(string toolName)

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -372,6 +372,13 @@ internal sealed class SessionToolExecutionPipeline
                         ? scratchDirectory
                         : null,
                     modelInputBudget);
+                result = result with
+                {
+                    Message = ToolRemediationPresenter.Present(
+                        result.Message,
+                        result.Receipt,
+                        batch.SetWorkingDirectoryAvailable)
+                };
                 if (batch.StreamResults)
                     batch.ReplyTo.Tell(new ToolExecutionSingleCompleted(result));
                 return result;
@@ -693,6 +700,9 @@ internal sealed class SessionToolExecutionPipeline
                     correctedCall,
                     scratchCorrection.TemporaryRoot,
                     scratchCorrection.SessionDirectory);
+                var correctionReceipt = new ToolInvocationReceipt(
+                    ToolInvocationOutcomeCategory.RecoverableCorrection,
+                    remediationCode: ToolRemediationCode.UseSessionScratch);
 
                 return new ToolCallResult(new SerializableChatMessage
                 {
@@ -701,9 +711,7 @@ internal sealed class SessionToolExecutionPipeline
                     ToolCallId = new ToolCallId(tc.CallId),
                     Name = tc.Name
                 }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
-                    Receipt: new ToolInvocationReceipt(
-                        ToolInvocationOutcomeCategory.RecoverableCorrection,
-                        remediationCode: ToolOutcomeResults.UseSessionScratchRemediation),
+                    Receipt: correctionReceipt,
                     ScratchCorrectionChange: new SessionScratchCorrectionChange.Arm(newCorrectionKey));
             }
 
@@ -717,6 +725,9 @@ internal sealed class SessionToolExecutionPipeline
                 sw.Stop();
                 resultText = projectScopeCorrection;
 
+                var correctionReceipt = new ToolInvocationReceipt(
+                    ToolInvocationOutcomeCategory.RecoverableCorrection,
+                    remediationCode: ToolRemediationCode.SetWorkingDirectory);
                 return new ToolCallResult(new SerializableChatMessage
                 {
                     Role = Protocol.ChatRole.Tool,
@@ -724,9 +735,7 @@ internal sealed class SessionToolExecutionPipeline
                     ToolCallId = new ToolCallId(tc.CallId),
                     Name = tc.Name
                 }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
-                    Receipt: new ToolInvocationReceipt(
-                        ToolInvocationOutcomeCategory.RecoverableCorrection,
-                        remediationCode: ToolOutcomeResults.SetWorkingDirectoryRemediation));
+                    Receipt: correctionReceipt);
             }
 
             if (!CanRequestInteractiveApproval(batch.TurnContext))
@@ -894,6 +903,8 @@ internal sealed class SessionToolExecutionPipeline
                 resultText,
                 modelInputMaterialization.RequestedCount - modelInputMaterialization.MediaReferences.Count);
 
+        var receipt = context.Receipt
+            ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success);
         var message = new SerializableChatMessage
         {
             Role = Protocol.ChatRole.Tool,
@@ -909,8 +920,7 @@ internal sealed class SessionToolExecutionPipeline
             context.Outputs.FileAttachments,
             completedRuns,
             acceptedFindings,
-            Receipt: context.Receipt
-                ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success),
+            Receipt: receipt,
             ScratchCorrectionChange: consumedScratchKey is { } consumed
                 ? new SessionScratchCorrectionChange.Consume(consumed)
                 : null);
@@ -1327,8 +1337,7 @@ internal sealed class SessionToolExecutionPipeline
 
     internal static string BuildSessionScratchCorrection(string sessionDirectory)
         => "Tool execution deferred: shared_temporary_directory\n" +
-           $"Use the private session scratch directory '{sessionDirectory}' for disposable artifacts. " +
-           "Author a replacement shell call there. If this exact platform path is required, retry the original call unchanged.";
+           $"Session scratch directory: '{sessionDirectory}'.";
 
     /// <summary>
     /// Builds the agent-facing correction for reviewed-safe shell work whose
@@ -1350,7 +1359,7 @@ internal sealed class SessionToolExecutionPipeline
         }
 
         return "Tool execution deferred: working_directory_not_declared\n" +
-               $"Call set_working_directory with '{context.SuggestedProjectDirectory}', then retry this exact shell command unchanged.";
+               $"Project directory: '{context.SuggestedProjectDirectory}'.";
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -823,7 +823,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         var setWorkingDirectoryTool =
             _toolRegistry.GetByName(SetWorkingDirectoryTool.ToolName) as SetWorkingDirectoryTool;
         Func<string, ToolInvocationContext, bool>? canDeclareWorkingDirectory =
-            setWorkingDirectoryTool is null ? null : setWorkingDirectoryTool.CanDeclare;
+            setWorkingDirectoryTool is null
+            || !_toolAccessPolicy.IsToolExposed(
+                setWorkingDirectoryTool,
+                ToolExecutionContext.Invocation)
+                ? null
+                : setWorkingDirectoryTool.CanDeclare;
         _toolExecutionWatchdogState = _approvalBridge is null
             ? ToolExecutionWatchdogState.None
             : ToolExecutionWatchdogState.RunningApprovalCapableTools;
@@ -1442,7 +1447,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     {
                         toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
                             ToolInvocationOutcomeCategory.RecoverableCorrection,
-                            remediationCode: ToolOutcomeResults.UseSessionScratchRemediation));
+                            remediationCode: ToolRemediationCode.UseSessionScratch));
                         var correctionText = SessionToolExecutionPipeline.BuildSessionScratchCorrection(
                             scratchCorrection.SessionDirectory);
                         var newCorrectionKey = new SessionScratchCorrectionKey(
@@ -1467,7 +1472,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     {
                         toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
                             ToolInvocationOutcomeCategory.RecoverableCorrection,
-                            remediationCode: ToolOutcomeResults.SetWorkingDirectoryRemediation));
+                            remediationCode: ToolRemediationCode.SetWorkingDirectory));
                         return BuildToolResult(
                             cleanedTc,
                             projectScopeCorrection,
@@ -1596,6 +1601,17 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             });
 
             var results = await Task.WhenAll(tasks);
+            for (var i = 0; i < results.Length; i++)
+            {
+                var result = results[i];
+                results[i] = result with
+                {
+                    Message = ToolRemediationPresenter.Present(
+                        result.Message,
+                        result.Receipt,
+                        canDeclareWorkingDirectory is not null)
+                };
+            }
             self.Tell(new ToolExecutionCompleted
             {
                 ToolResults = [.. results.Select(r => r.Message)],
@@ -1643,6 +1659,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 materialization.RequestedCount - materialization.MediaReferences.Count);
         }
 
+        var receipt = toolContext.Receipt
+            ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success);
         return new SubAgentToolCallResult(
             new SerializableChatMessage
             {
@@ -1653,7 +1671,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             },
             materialization.MediaReferences,
             scratchCorrectionChange,
-            toolContext.Receipt ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success));
+            receipt);
     }
 
     private static ModelInputMaterializationResult MaterializeModelInputFiles(

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -566,7 +566,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 {
                     msg.ToolReceipts.TryGetValue(callId.Value, out var receipt);
                     _fileActivity.Apply(receipt);
-                    TryApplyProjectDirectory(receipt);
+                    TryApplyProjectDirectory(result.Name, receipt);
                     if (receipt is not null)
                         _log.Info("SubAgent tool outcome category={OutcomeCategory}", receipt.Category);
                 }
@@ -1154,9 +1154,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         return _fileActivity.BuildResult();
     }
 
-    private void TryApplyProjectDirectory(ToolInvocationReceipt? receipt)
+    private void TryApplyProjectDirectory(string? toolName, ToolInvocationReceipt? receipt)
     {
-        if (receipt is not
+        if (!string.Equals(toolName, SetWorkingDirectoryTool.ToolName, StringComparison.Ordinal)
+            || receipt is not
             {
                 Category: ToolInvocationOutcomeCategory.Success,
                 DeclaredProjectDirectory: { } projectDirectory
@@ -1577,6 +1578,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 {
                     var category = ex switch
                     {
+                        ToolAccessDeniedException => ToolInvocationOutcomeCategory.AccessDenied,
                         UnauthorizedAccessException => ToolInvocationOutcomeCategory.AccessDenied,
                         FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
                         _ => ToolInvocationOutcomeCategory.TransientFailure

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -41,9 +41,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             return Task.FromResult(context.InvalidInput("Error: 'path' parameter is required."));
 
         if (string.IsNullOrWhiteSpace(context.SessionDirectory))
-            return Task.FromResult(context.RecoverableCorrection(
-                "Error: No session directory available.",
-                ToolOutcomeResults.SetWorkingDirectoryRemediation));
+            return Task.FromResult(context.InvalidInput("Error: invalid_context: No session directory available."));
 
         if (!_fileAccessPolicy.TryResolveAttachPath(
                 args.Path,

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -159,12 +159,11 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
 
         toolCall = interpretation.Cleaned;
 
-        var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
-        var tool = authorized.Tool;
-
         var sw = Stopwatch.StartNew();
         try
         {
+            var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
+            var tool = authorized.Tool;
             var result = tool is ShellTool shellTool
                          && authorized.AuthorizedAnalysis is { } shellAnalysis
                 ? await shellTool.ExecuteAuthorizedAsync(
@@ -251,10 +250,17 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
 
         toolCall = interpretation.Cleaned;
 
-        // Authorization throws (ToolApprovalRequiredException / ToolAccessDeniedException)
-        // before the first item is produced; the tool-execution pipeline handles
-        // those exactly as it does for the non-streaming path.
-        var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
+        (INetclawTool Tool, ShellCommandAnalysis? AuthorizedAnalysis) authorized;
+        try
+        {
+            authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
+        }
+        catch (Exception ex)
+        {
+            CompleteExceptionOutcome(context, ex, ct);
+            throw;
+        }
+
         var tool = authorized.Tool;
         var updates = tool is ShellTool shellTool
                       && authorized.AuthorizedAnalysis is { } shellAnalysis
@@ -299,8 +305,12 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         if (exception is OperationCanceledException && callerToken.IsCancellationRequested)
             return;
 
+        if (exception is ToolApprovalRequiredException)
+            return;
+
         var category = exception switch
         {
+            ToolAccessDeniedException => ToolInvocationOutcomeCategory.AccessDenied,
             UnauthorizedAccessException => ToolInvocationOutcomeCategory.AccessDenied,
             FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
             IOException or TimeoutException => ToolInvocationOutcomeCategory.TransientFailure,

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -149,13 +149,12 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
                 if (occurrences == 0)
                     return context.RecoverableCorrection(
                         $"Error: The specified text was not found in {authorizedPath}",
-                        "provide_unique_old_string");
+                        ToolRemediationCode.ProvideUniqueOldString);
 
                 if (occurrences > 1 && !replaceAll)
                     return context.RecoverableCorrection(
-                        $"Error: OldString matches {occurrences} locations in {authorizedPath}. " +
-                        "Provide more surrounding context to create a unique match, or set ReplaceAll=true.",
-                        "provide_unique_old_string");
+                        $"Error: OldString matches {occurrences} locations in {authorizedPath}.",
+                        ToolRemediationCode.ProvideUniqueOldString);
 
                 string newContent;
                 int replacementCount;

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -181,7 +181,7 @@ internal sealed class ScopedFileAccessPolicy
                     }
                     else
                     {
-                        error = "Error: invalid_context: No project or session directory is available. Call set_working_directory with an absolute project path, then retry.";
+                        error = "Error: invalid_context: No project or session directory is available.";
                         failure = PathResolutionFailure.MissingBase;
                     }
 

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -164,16 +164,29 @@ internal sealed class ScopedFileAccessPolicy
                 failure = PathResolutionFailure.InvalidInput;
                 return false;
             }
-            else if (TryGetRelativePathBase(context, out var baseDirectory))
-            {
-                fullPath = Path.GetFullPath(rawPath, baseDirectory);
-            }
             else
             {
-                fullPath = string.Empty;
-                error = "Error: invalid_context: No project or session directory is available. Call set_working_directory with an absolute project path, then retry.";
-                failure = PathResolutionFailure.MissingBase;
-                return false;
+                var baseResult = TryGetRelativePathBase(context, accessKind, out var baseDirectory);
+                if (baseResult == RelativePathBaseResult.Safe)
+                {
+                    fullPath = Path.GetFullPath(rawPath, baseDirectory);
+                }
+                else
+                {
+                    fullPath = string.Empty;
+                    if (baseResult == RelativePathBaseResult.Unsafe)
+                    {
+                        error = "Error: The project or session directory contains an unsafe filesystem link.";
+                        failure = PathResolutionFailure.AccessDenied;
+                    }
+                    else
+                    {
+                        error = "Error: invalid_context: No project or session directory is available. Call set_working_directory with an absolute project path, then retry.";
+                        failure = PathResolutionFailure.MissingBase;
+                    }
+
+                    return false;
+                }
             }
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
@@ -273,17 +286,74 @@ internal sealed class ScopedFileAccessPolicy
         return false;
     }
 
-    private static bool TryGetRelativePathBase(
+    private RelativePathBaseResult TryGetRelativePathBase(
         ToolInvocationContext context,
+        AccessKind accessKind,
         out string baseDirectory)
     {
-        if (TryNormalizeAbsoluteBase(context.ProjectDirectory, requireExistingDirectory: true, out baseDirectory))
-            return true;
+        var projectResult = TryNormalizeAbsoluteBase(
+            context.ProjectDirectory,
+            requireExistingDirectory: true,
+            out baseDirectory);
+        if (projectResult == RelativePathBaseResult.Safe)
+        {
+            var authorityRoot = GetProjectAuthorityRootResult(baseDirectory, context, accessKind);
+            if (authorityRoot == ProjectAuthorityRootResult.Safe
+                || (authorityRoot == ProjectAuthorityRootResult.Unavailable
+                    && HasInteractivePersonalReach(context)))
+            {
+                return RelativePathBaseResult.Safe;
+            }
+
+            baseDirectory = string.Empty;
+            return RelativePathBaseResult.Unsafe;
+        }
+
+        if (projectResult == RelativePathBaseResult.Unsafe)
+            return RelativePathBaseResult.Unsafe;
 
         return TryNormalizeAbsoluteBase(context.SessionDirectory, requireExistingDirectory: false, out baseDirectory);
     }
 
-    private static bool TryNormalizeAbsoluteBase(
+    private ProjectAuthorityRootResult GetProjectAuthorityRootResult(
+        string projectDirectory,
+        ToolInvocationContext context,
+        AccessKind accessKind)
+    {
+        var roots = new List<string>();
+        if (!string.IsNullOrWhiteSpace(context.SessionDirectory))
+            roots.Add(context.SessionDirectory);
+
+        var profile = _profileResolver.ResolveProfile(context);
+        roots.AddRange(_profileResolver.ResolveRoots(profile.ReadFiles, context));
+        roots.AddRange(_cachedGlobalReadRoots.Value);
+        if (accessKind is not AccessKind.Read && _cachedWorkspacesRoot.Value is { } workspacesRoot)
+            roots.Add(workspacesRoot);
+
+        foreach (var candidate in roots)
+        {
+            string root;
+            try
+            {
+                root = Path.GetFullPath(candidate);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                continue;
+            }
+
+            if (!PathUtility.IsWithinRoot(projectDirectory, root))
+                continue;
+
+            return PathUtility.ContainsSymlinkSegment(root, projectDirectory)
+                ? ProjectAuthorityRootResult.Unsafe
+                : ProjectAuthorityRootResult.Safe;
+        }
+
+        return ProjectAuthorityRootResult.Unavailable;
+    }
+
+    private static RelativePathBaseResult TryNormalizeAbsoluteBase(
         string? candidate,
         bool requireExistingDirectory,
         out string baseDirectory)
@@ -292,21 +362,21 @@ internal sealed class ScopedFileAccessPolicy
         if (string.IsNullOrWhiteSpace(candidate)
             || candidate.Any(char.IsControl)
             || !Path.IsPathFullyQualified(candidate))
-            return false;
+            return RelativePathBaseResult.Unavailable;
 
         try
         {
             var normalized = Path.GetFullPath(candidate);
             if (requireExistingDirectory && !Directory.Exists(normalized))
-                return false;
+                return RelativePathBaseResult.Unavailable;
             if (Directory.Exists(normalized)
                 && (File.GetAttributes(normalized) & FileAttributes.ReparsePoint) != 0)
             {
-                return false;
+                return RelativePathBaseResult.Unsafe;
             }
 
             baseDirectory = normalized;
-            return true;
+            return RelativePathBaseResult.Safe;
         }
         catch (Exception ex) when (ex is ArgumentException
                                    or NotSupportedException
@@ -314,8 +384,22 @@ internal sealed class ScopedFileAccessPolicy
                                    or IOException
                                    or UnauthorizedAccessException)
         {
-            return false;
+            return RelativePathBaseResult.Unsafe;
         }
+    }
+
+    private enum RelativePathBaseResult
+    {
+        Unavailable,
+        Safe,
+        Unsafe
+    }
+
+    private enum ProjectAuthorityRootResult
+    {
+        Unavailable,
+        Safe,
+        Unsafe
     }
 
     private static ToolFilesystemAccessProfile GetAccessProfile(ToolAudienceProfile profile, AccessKind accessKind) =>

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -109,7 +109,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
 
             suggestionBuilder.AppendLine();
             suggestionBuilder.AppendLine(
-                "Suggestions are not loaded yet. Call search_tools again with one of the exact tool names above.");
+                "Suggestions are not loaded yet. Call load_tool with one of the exact tool names above.");
             return Task.FromResult(suggestionBuilder.ToString());
         }
 

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -102,10 +102,8 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
                     : tool.Description;
                 var parameterHint = GetParameterHint(tool);
 
-                // NOTE: Keep suggestions in a distinct format so LlmSessionActor doesn't
-                // auto-load them as discovered tools. Auto-loading is only for exact matches.
-                // Emit the LLM-facing alias so what the model reads here
-                // matches what it must emit in a tool_use call.
+                // Keep suggestions distinct from exact search results. Emit the
+                // LLM-facing alias so the model can pass that exact name to load_tool.
                 suggestionBuilder.AppendLine($"  ? {tool.LlmFacingName} :: {desc}{parameterHint}");
             }
 

--- a/src/Netclaw.Actors/Tools/ToolOutcomeResults.cs
+++ b/src/Netclaw.Actors/Tools/ToolOutcomeResults.cs
@@ -9,9 +9,6 @@ namespace Netclaw.Actors.Tools;
 
 internal static class ToolOutcomeResults
 {
-    public const string SetWorkingDirectoryRemediation = "set_working_directory";
-    public const string UseSessionScratchRemediation = "use_session_scratch";
-
     public static string Success(this ToolInvocationContext context, string result)
         => Complete(context, result, ToolInvocationOutcomeCategory.Success);
 
@@ -59,7 +56,7 @@ internal static class ToolOutcomeResults
     public static string RecoverableCorrection(
         this ToolInvocationContext context,
         string result,
-        string remediationCode)
+        ToolRemediationCode remediationCode)
         => Complete(
             context,
             result,
@@ -73,7 +70,9 @@ internal static class ToolOutcomeResults
         => failure switch
         {
             ScopedFileAccessPolicy.PathResolutionFailure.MissingBase =>
-                context.RecoverableCorrection(result, SetWorkingDirectoryRemediation),
+                context.RecoverableCorrection(
+                    result,
+                    ToolRemediationCode.SetWorkingDirectory),
             ScopedFileAccessPolicy.PathResolutionFailure.InvalidInput => context.InvalidInput(result),
             _ => context.AccessDenied(result)
         };
@@ -83,7 +82,7 @@ internal static class ToolOutcomeResults
         string result,
         ToolInvocationOutcomeCategory category,
         IReadOnlyList<ToolFileActivity>? fileActivity = null,
-        string? remediationCode = null,
+        ToolRemediationCode? remediationCode = null,
         string? declaredProjectDirectory = null)
     {
         context.TryComplete(new ToolInvocationReceipt(

--- a/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
+++ b/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
@@ -21,7 +21,7 @@ internal static class ToolRemediationPresenter
         var action = remediationCode switch
         {
             ToolRemediationCode.SetWorkingDirectory when setWorkingDirectoryAvailable =>
-                "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+                "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call.",
             ToolRemediationCode.SetWorkingDirectory => null,
             ToolRemediationCode.UseSessionScratch =>
                 "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths.",

--- a/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
+++ b/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolRemediationPresenter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Tools;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Actors.Tools;
+
+internal static class ToolRemediationPresenter
+{
+    public static SerializableChatMessage Present(
+        SerializableChatMessage message,
+        ToolInvocationReceipt? receipt,
+        bool setWorkingDirectoryAvailable)
+    {
+        if (receipt?.RemediationCode is not { } remediationCode)
+            return message;
+
+        var action = remediationCode switch
+        {
+            ToolRemediationCode.SetWorkingDirectory when setWorkingDirectoryAvailable =>
+                "Next action: call set_working_directory with the project directory from this result, then retry the failed tool call.",
+            ToolRemediationCode.SetWorkingDirectory => null,
+            ToolRemediationCode.UseSessionScratch =>
+                "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths.",
+            ToolRemediationCode.ProvideUniqueOldString =>
+                "Next action: retry file_edit with a unique OldString, or set ReplaceAll=true when every match should change.",
+            _ => throw new InvalidOperationException("Unsupported tool remediation code.")
+        };
+
+        if (action is null)
+            return message;
+
+        var content = string.IsNullOrWhiteSpace(message.Content)
+            ? action
+            : $"{message.Content}\n{action}";
+        return message with { Content = content };
+    }
+}

--- a/src/Netclaw.Configuration/SessionTuning.cs
+++ b/src/Netclaw.Configuration/SessionTuning.cs
@@ -43,15 +43,16 @@ public sealed record SessionTuning
     public int MaxInlineToolResultChars { get; init; } = 12_000;
 
     /// <summary>
-    /// Number of future user turns that dynamically discovered MCP tools remain
-    /// available without re-running <c>search_tools</c>. Set to 0 to require
-    /// discovery on every user turn.
+    /// Number of future user turns that dynamically loaded deferred first-party
+    /// or MCP tools remain available without another load. Set to 0 to require
+    /// activation again on every user turn.
     /// </summary>
     public int DiscoveredToolRetentionTurns { get; init; } = 3;
 
     /// <summary>
-    /// Maximum number of discovered MCP tools retained across turns.
-    /// Oldest discovered tools are evicted first when the cap is exceeded.
+    /// Maximum number of loaded deferred first-party or MCP tools retained
+    /// across turns. Oldest loaded tools are evicted first when the cap is
+    /// exceeded.
     /// </summary>
     public int DiscoveredToolMaxCount { get; init; } = 12;
 

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -29,6 +29,13 @@ internal enum ToolInvocationOutcomeCategory
     RecoverableCorrection
 }
 
+internal enum ToolRemediationCode
+{
+    SetWorkingDirectory,
+    UseSessionScratch,
+    ProvideUniqueOldString
+}
+
 internal enum ToolFileActivityKind
 {
     Read,
@@ -73,12 +80,10 @@ internal sealed record ToolFileActivity
 
 internal sealed record ToolInvocationReceipt
 {
-    private const int MaxRemediationCodeLength = 64;
-
     public ToolInvocationReceipt(
         ToolInvocationOutcomeCategory category,
         IReadOnlyList<ToolFileActivity>? fileActivity = null,
-        string? remediationCode = null,
+        ToolRemediationCode? remediationCode = null,
         string? declaredProjectDirectory = null)
     {
         if (!Enum.IsDefined(category))
@@ -97,13 +102,14 @@ internal sealed record ToolInvocationReceipt
             throw new ArgumentException("Only a recoverable correction may report remediation.", nameof(remediationCode));
         }
 
-        if (remediationCode is not null
-            && (string.IsNullOrWhiteSpace(remediationCode)
-                || remediationCode.Length > MaxRemediationCodeLength
-                || remediationCode.Any(char.IsControl)))
+        if (category == ToolInvocationOutcomeCategory.RecoverableCorrection
+            && remediationCode is null)
         {
-            throw new ArgumentException("The remediation code is invalid.", nameof(remediationCode));
+            throw new ArgumentException("A recoverable correction requires remediation.", nameof(remediationCode));
         }
+
+        if (remediationCode is { } code && !Enum.IsDefined(code))
+            throw new ArgumentOutOfRangeException(nameof(remediationCode));
 
         if (declaredProjectDirectory is not null)
             _ = new ToolFileActivity(declaredProjectDirectory, ToolFileActivityKind.Read);
@@ -116,7 +122,7 @@ internal sealed record ToolInvocationReceipt
 
     public ToolInvocationOutcomeCategory Category { get; }
     public IReadOnlyList<ToolFileActivity> FileActivity { get; }
-    public string? RemediationCode { get; }
+    public ToolRemediationCode? RemediationCode { get; }
     public string? DeclaredProjectDirectory { get; }
 }
 

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -73,6 +73,8 @@ internal sealed record ToolFileActivity
 
 internal sealed record ToolInvocationReceipt
 {
+    private const int MaxRemediationCodeLength = 64;
+
     public ToolInvocationReceipt(
         ToolInvocationOutcomeCategory category,
         IReadOnlyList<ToolFileActivity>? fileActivity = null,
@@ -93,6 +95,14 @@ internal sealed record ToolInvocationReceipt
             && remediationCode is not null)
         {
             throw new ArgumentException("Only a recoverable correction may report remediation.", nameof(remediationCode));
+        }
+
+        if (remediationCode is not null
+            && (string.IsNullOrWhiteSpace(remediationCode)
+                || remediationCode.Length > MaxRemediationCodeLength
+                || remediationCode.Any(char.IsControl)))
+        {
+            throw new ArgumentException("The remediation code is invalid.", nameof(remediationCode));
         }
 
         if (declaredProjectDirectory is not null)

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -48,7 +48,7 @@ internal sealed record ToolFileActivity
     {
         if (!Enum.IsDefined(kind))
             throw new ArgumentOutOfRangeException(nameof(kind));
-        if (!IsCanonicalAbsolutePath(canonicalPath))
+        if (!ToolInvocationReceipt.IsCanonicalAbsolutePath(canonicalPath))
             throw new ArgumentException("File activity requires a canonical absolute path.", nameof(canonicalPath));
 
         CanonicalPath = canonicalPath;
@@ -57,25 +57,6 @@ internal sealed record ToolFileActivity
 
     public string CanonicalPath { get; }
     public ToolFileActivityKind Kind { get; }
-
-    private static bool IsCanonicalAbsolutePath(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path)
-            || path.Any(char.IsControl)
-            || !Path.IsPathFullyQualified(path))
-        {
-            return false;
-        }
-
-        try
-        {
-            return string.Equals(path, Path.GetFullPath(path), StringComparison.Ordinal);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            return false;
-        }
-    }
 }
 
 internal sealed record ToolInvocationReceipt
@@ -111,8 +92,13 @@ internal sealed record ToolInvocationReceipt
         if (remediationCode is { } code && !Enum.IsDefined(code))
             throw new ArgumentOutOfRangeException(nameof(remediationCode));
 
-        if (declaredProjectDirectory is not null)
-            _ = new ToolFileActivity(declaredProjectDirectory, ToolFileActivityKind.Read);
+        if (declaredProjectDirectory is not null
+            && !IsCanonicalAbsolutePath(declaredProjectDirectory))
+        {
+            throw new ArgumentException(
+                "Declared project directory requires a canonical absolute path.",
+                nameof(declaredProjectDirectory));
+        }
 
         Category = category;
         FileActivity = Array.AsReadOnly(activity);
@@ -124,6 +110,25 @@ internal sealed record ToolInvocationReceipt
     public IReadOnlyList<ToolFileActivity> FileActivity { get; }
     public ToolRemediationCode? RemediationCode { get; }
     public string? DeclaredProjectDirectory { get; }
+
+    internal static bool IsCanonicalAbsolutePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)
+            || path.Any(char.IsControl)
+            || !Path.IsPathFullyQualified(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(path, Path.GetFullPath(path), StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

### Workspace and receipt boundaries

- Reject a declared project base that contains a symlink or junction below its owning root.
- Classify terminal authorization denials the same way for parent and child callers.
- Keep approval requests non-terminal until the user resolves them.
- Accept project-scope changes only from a successful `set_working_directory` receipt.

### Typed remediation

- Replace free-form remediation strings with a closed internal code set.
- Give parent and child agents the same bounded recovery instruction.
- Hide `set_working_directory` guidance when the active policy hides that tool.
- Reuse one canonical-path validator for file activity and project declarations.

### Authority boundary

Remediation gives guidance only. It does not approve, grant, execute, or retry a tool call.

A session does not need a project unless its task uses project files.

## Validation

- Release solution build: 0 warnings and 0 errors.
- Full actor suite: 3,576 passed and 3 platform tests skipped.
- Focused remediation and receipt suite: 53 passed.
- Strict OpenSpec validation: passed for both active changes.
- File headers: passed.
- Changed-file format check: passed.
- Slopwatch: 0 issues.
- Diff check: passed.

## Evaluation scope

No hosted eval ran for this internal receipt and correction slice.

Deterministic parent and child tests cover the model-visible correction text and its authority limits.

## Stack

This is PR 1 of 4.

1. #2044 hardens workspace paths and completes typed remediation.
2. #2045 removes two unreleased bulk workspace tools.
3. #2046 repairs the related rollout contracts.
4. #2050 adds bounded recovery for native tool names sent through the shell.

This update does not merge the PR or enable auto-merge.