### PR TITLE
Repair tool rollout contracts

### DIFF
--- a/evals/fixtures/config/tool-approvals.json
+++ b/evals/fixtures/config/tool-approvals.json
@@ -4,6 +4,10 @@
     "personal": {
       "shell_execute": [
         {
+          "verb": "awk",
+          "directory": null
+        },
+        {
           "verb": "git",
           "directory": null
         },

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -89,6 +89,7 @@ NATURALISTIC_PROJECT_ROOT="/home/netclaw/.netclaw/workspaces/netclaw"
 NATURALISTIC_CWD_ROOT="$NATURALISTIC_PROJECT_ROOT/netclaw-worktrees/fix-pwsh-probe-timeout"
 PROJECT_SCOPE_EVAL_ROOT="/home/netclaw/.netclaw/workspaces/eval-project"
 PROJECT_SCOPE_EVAL_MISSING_ROOT="$PROJECT_SCOPE_EVAL_ROOT/missing-project"
+LARGE_OUTPUT_EVAL_COMMAND="awk 'BEGIN{x=1;for(i=1;i<=20000;i++){x=(x*48271)%2147483647;print x}}'"
 
 # Per-prompt state (set by run_prompt, read by assertion helpers)
 STDOUT_FILE=""
@@ -1897,9 +1898,18 @@ assert_complex_diagnose_self() {
 # This shell command produces about 210 KB of output.
 # Line 200 is outside the inline window.
 assert_complex_large_shell_output_spill() {
-    stdout_contains '\[tool:call\] shell_execute' && \
-        stdout_contains '\[tool:call\] tool_output_read' && \
-        stdout_response_contains '872671849'
+    local shell_call
+    local -a shell_calls
+    stdout_json_envelope_valid || return 1
+    mapfile -t shell_calls < <(stdout_json_tool_call_arguments 'shell_execute')
+    [[ "${#shell_calls[@]}" -eq 1 ]] || return 1
+    shell_call="${shell_calls[0]}"
+
+    jq -e --arg expected "$LARGE_OUTPUT_EVAL_COMMAND" \
+        '.Command == $expected and (.WorkingDirectory? == null)' \
+        <<<"$shell_call" >/dev/null \
+        && stdout_json_tool_called 'tool_output_read' \
+        && stdout_response_contains '872671849'
 }
 
 # Large FILE: a pre-seeded ~314 KB file (>256 KB, so file_read returns a bounded
@@ -2801,9 +2811,9 @@ run_all() {
 
     # The prompt gives the goal but does not name the continuation tool.
     # The assertion requires the structured tool and the exact line value.
-    run_case complex_large_shell_output_spill "retrieves a deep line from oversized shell output unaided" \
-        "Run this command with shell_execute and tell me the number it prints on line 200: awk 'BEGIN{x=1;for(i=1;i<=20000;i++){x=(x*48271)%2147483647;print x}}'" \
-        "Using shell_execute, run: awk 'BEGIN{x=1;for(i=1;i<=20000;i++){x=(x*48271)%2147483647;print x}}' — then tell me which number is printed on the 200th line of its output."
+    run_case --json complex_large_shell_output_spill "retrieves a deep line from oversized shell output unaided" \
+        "Run this exact command once with shell_execute, without modifying, piping, filtering, redirecting, or shortening it: $LARGE_OUTPUT_EVAL_COMMAND. Then tell me the number it prints on line 200." \
+        "Using one shell_execute call, run this command exactly as written, with no added pipe, filter, redirect, or argument: $LARGE_OUTPUT_EVAL_COMMAND. Then tell me which number is printed on the 200th line of its output."
 
     # bounded-tool-output: oversized FILE. The prompt states only the goal — read
     # a deep line of a named large file. How to cope with it being too large for

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.64.0"
+  version: "2.65.0"
 ---
 
 # Netclaw Operations
@@ -52,7 +52,8 @@ Do not substitute shell commands when a listed first-party tool satisfies the ta
 Do not delegate a known file operation that an available file tool can complete.
 After a successful file tool result, do not use shell only to verify it unless the user requests shell behavior.
 For disposable text, use `file_write` then `file_read`; do not attempt a shell redirect first.
-Use `search_tools`, then `load_tool`, before reporting that a specialty tool is unavailable.
+Use `load_tool` directly for a known exact tool name.
+Use `search_tools` when the capability is known but its exact tool name is not.
 
 Keep shell approval friction bounded:
 
@@ -158,13 +159,14 @@ view inline plus a pointer to the full output — not the whole thing:
   `check_background_job` returns a tail, and you can `file_read`/`grep` the log for the rest.
   Netclaw deletes a terminal job's definition and logs 24 hours after completion.
 
-Reading a targeted range or grepping is always cheaper than re-running a command or
-re-reading a whole file. Secret-bearing values are redacted from all tool output.
+Use bounded continuation before re-running a command or re-reading a whole file.
+Secret-bearing values are redacted from all tool output.
 
 ## Tool Discovery
 
-Only a core toolset is always loaded. Use `search_tools(query)` to find additional
-or MCP tools by capability before concluding a tool doesn't exist. Full guidance:
+Only a core toolset is always loaded. Use `load_tool(name)` when an exact deferred
+tool name is known. Use `search_tools(query)` to find tools by capability when the
+name is unknown. Full guidance:
 `skill_read_resource('netclaw-operations', 'references/tools.md')`.
 
 MCP servers can also supply workflow skills. These skills use names such as

--- a/feeds/skills/.system/files/netclaw-operations/references/tools.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/tools.md
@@ -4,7 +4,13 @@
 ## Tool Discovery
 
 
-MCP tools are not loaded by default. Use `search_tools` to discover them:
+Deferred tools are not loaded by default. Load a known exact name directly:
+
+```
+load_tool(name: "notion/search")
+```
+
+Use `search_tools` when the exact name is unknown:
 
 ```
 search_tools(query: "servers")                  # list all MCP servers
@@ -12,7 +18,8 @@ search_tools(query: "all", server: "notion")    # browse a server's tools
 search_tools(query: "email")                    # keyword search
 ```
 
-After discovery, matched tools become callable for the session.
+After discovery, call `load_tool` with the selected exact name. Loading exposes
+the schema for the current actor. Normal authorization still runs at dispatch.
 
 ### MCP server state and concurrent callers
 

--- a/openspec/changes/repair-agent-tool-boundaries/tasks.md
+++ b/openspec/changes/repair-agent-tool-boundaries/tasks.md
@@ -27,19 +27,19 @@
 
 ## 3. Repair rollout contracts
 
-- [ ] 3.1 Replace the canonical raw spill path and grep steer with opaque `tool_output_read` guidance.
-- [ ] 3.2 Update runtime and tests so no model-facing spill result reveals a raw path.
-- [ ] 3.3 Clarify that `load_tool` controls schema exposure and never grants execution authority.
-- [ ] 3.4 Tell agents to load a known exact tool name without a prior search.
-- [ ] 3.5 Make the subagent catalog replay create and inspect a real child actor.
-- [ ] 3.6 Keep public evidence aggregate and PII-free.
-- [ ] 3.7 Run focused spill, disclosure, subagent, skill, header, and Slopwatch gates.
+- [x] 3.1 Replace the canonical raw spill path and grep steer with opaque `tool_output_read` guidance.
+- [x] 3.2 Keep runtime and tests from revealing a raw spill path in model-facing results.
+- [x] 3.3 Clarify that `load_tool` controls schema exposure and never grants execution authority.
+- [x] 3.4 Tell agents to load a known exact tool name without a prior search.
+- [x] 3.5 Make the subagent catalog replay create and inspect a real child actor.
+- [x] 3.6 Keep public evidence aggregate and PII-free.
+- [x] 3.7 Run focused spill, disclosure, subagent, skill, header, and Slopwatch gates.
 
 ## 4. Stack and evaluation
 
-- [ ] 4.1 Rebase each branch on its intended parent and verify the stacked patch order.
-- [ ] 4.2 Create three stacked pull requests without auto-merge.
-- [ ] 4.3 Run the deterministic eval harness on the final stacked head.
-- [ ] 4.4 Run the hosted eval matrix on the final stacked head.
-- [ ] 4.5 Publish only PII-free aggregate eval results on the relevant pull request.
-- [ ] 4.6 Run the full build, tests, strict OpenSpec, headers, diff, and Slopwatch gates.
+- [x] 4.1 Rebase each branch on its intended parent and verify the stacked patch order.
+- [x] 4.2 Create three stacked pull requests without auto-merge.
+- [x] 4.3 Run the deterministic eval harness on the final stacked head.
+- [x] 4.4 Run the hosted eval matrix on the final stacked head.
+- [x] 4.5 Publish only PII-free aggregate eval results on the relevant pull request.
+- [x] 4.6 Run the full build, tests, strict OpenSpec, headers, diff, and Slopwatch gates.

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -126,8 +126,10 @@ public class DispatchingToolExecutorTests
             Assert.True(result.Length < 3000);                 // windowed inline, not the full 3000
             Assert.Contains("tool_output_read", result);
             Assert.Contains("CallId='call-spill'", result);
+            Assert.DoesNotContain(sessionDir, result, StringComparison.Ordinal);
             Assert.True(ToolOutputSpillLocation.TryResolve(
                 sessionDir, "call-spill", out _, out var spill));
+            Assert.DoesNotContain(spill, result, StringComparison.Ordinal);
             Assert.True(File.Exists(spill));
             Assert.Contains(new string('x', 100), await File.ReadAllTextAsync(spill, CancellationToken.None));
         }

--- a/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
@@ -12,7 +12,9 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
+using Netclaw.Actors.SubAgents;
 using Netclaw.Actors.Tests.Sessions.Pipelines;
+using Netclaw.Actors.Tests.SubAgents;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -21,6 +23,7 @@ using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using ShellSyntaxTree;
 using Xunit;
+using RecordingChatClient = Netclaw.Actors.Tests.Sessions.FakeChatClient;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
 namespace Netclaw.Actors.Tests.Tools;
@@ -56,6 +59,13 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
             ProjectDirectory = setup.ProjectDirectory,
             RecentFiles = ImmutableList.Create(setup.SeedRecentFile)
         };
+
+        if (policyCase.ExpectedContextEffect == "CoreOnlyChildCatalog")
+        {
+            await AssertChildCatalogAsync(runtime, setup);
+            AssertContextEffect(policyCase.ExpectedContextEffect, setup, current);
+            return;
+        }
 
         for (var index = 0; index < setup.Calls.Count; index++)
         {
@@ -104,12 +114,6 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
         }
 
         AssertContextEffect(policyCase.ExpectedContextEffect, setup, current);
-        if (policyCase.ExpectedContextEffect == "CoreOnlyChildCatalog")
-        {
-            Assert.True(runtime.Registry.IsCoreTool("search_tools"));
-            Assert.True(runtime.Registry.IsCoreTool("load_tool"));
-            Assert.False(runtime.Registry.IsCoreTool("attach_file"));
-        }
     }
 
     [Fact]
@@ -205,7 +209,71 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
             toolPathPolicy,
             commandPolicy,
             toolAccessPolicy: accessPolicy);
-        return new RuntimeSetup(registry, new DispatchingToolExecutor(registry, accessPolicy));
+        return new RuntimeSetup(registry, new DispatchingToolExecutor(registry, accessPolicy), accessPolicy);
+    }
+
+    private async Task AssertChildCatalogAsync(RuntimeSetup runtime, ScenarioSetup setup)
+    {
+        const string attachToolName = "attach_file";
+        var client = new RecordingChatClient();
+        client.PlannedResponses.Enqueue([setup.Calls[0]]);
+        client.PlannedResponses.Enqueue([setup.Calls[1]]);
+        client.PlannedResponses.Enqueue([new TextContent("Catalog replay complete.")]);
+
+        var registrations = runtime.Registry.GetAllRegistrations();
+        var coreNames = runtime.Registry.GetCoreRegistrations()
+            .Select(static registration => registration.Tool.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        var definition = new SubAgentDefinition
+        {
+            Name = new AgentName("fixture-agent"),
+            SystemPrompt = "Replay one sanitized catalog case.",
+            Tools = registrations.Select(static registration => registration.Tool).ToList()
+        };
+        var actor = Sys.ActorOf(SubAgentActor.CreatePropsWithProjectInstructionProvider(
+            definition,
+            client,
+            runtime.AccessPolicy,
+            NullSystemPromptProvider.Instance,
+            coreToolNames: coreNames));
+
+        var result = await actor.Ask<SubAgentProtocol.SubAgentResult>(
+            new SubAgentProtocol.RunSubAgent
+            {
+                Scope = SubAgentTestScope.Create(
+                    scopeId: "signalr/tool-friction/subagent/fixture-agent/run",
+                    sessionDirectory: setup.SessionDirectory,
+                    projectDirectory: setup.ProjectDirectory),
+                Task = "Find and load the deferred attachment tool.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            TimeSpan.FromSeconds(10),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal(3, client.ReceivedToolNames.Count);
+        var expectedCore = coreNames.OrderBy(static name => name, StringComparer.Ordinal).ToList();
+        Assert.Equal(expectedCore, client.ReceivedToolNames[0].OrderBy(static name => name, StringComparer.Ordinal));
+        Assert.Equal(expectedCore, client.ReceivedToolNames[1].OrderBy(static name => name, StringComparer.Ordinal));
+        Assert.DoesNotContain(attachToolName, client.ReceivedToolNames[0]);
+        Assert.DoesNotContain(attachToolName, client.ReceivedToolNames[1]);
+        Assert.Contains(attachToolName, client.ReceivedToolNames[2]);
+        Assert.Contains(
+            attachToolName,
+            GetToolResult(client.ReceivedMessages[1], setup.Calls[0].CallId),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            attachToolName,
+            GetToolResult(client.ReceivedMessages[2], setup.Calls[1].CallId));
+    }
+
+    private static string GetToolResult(IReadOnlyList<ChatMessage> messages, string callId)
+    {
+        var result = messages
+            .SelectMany(static message => message.Contents.OfType<FunctionResultContent>())
+            .Single(content => content.CallId == callId)
+            .Result;
+        return Assert.IsType<string>(result);
     }
 
     private static async Task<ScenarioSetup> CreateScenarioAsync(
@@ -432,7 +500,10 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
         (byte)(height >> 24), (byte)(height >> 16), (byte)(height >> 8), (byte)height
     ];
 
-    private sealed record RuntimeSetup(ToolRegistry Registry, DispatchingToolExecutor Executor);
+    private sealed record RuntimeSetup(
+        ToolRegistry Registry,
+        DispatchingToolExecutor Executor,
+        ToolAccessPolicy AccessPolicy);
 
     private sealed record ScenarioSetup(
         string ProjectDirectory,

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
@@ -15,6 +15,6 @@
   ],
   Footprint: {
     Count: 12,
-    SerializedDefinitionBytes: 15215
+    SerializedDefinitionBytes: 15192
   }
 }

--- a/src/Netclaw.Actors/Tools/LoadToolTool.cs
+++ b/src/Netclaw.Actors/Tools/LoadToolTool.cs
@@ -9,13 +9,12 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Activates a deferred first-party or MCP tool by name so the LLM can call it.
-/// Tools must first be found via <see cref="SearchToolsTool"/> before loading.
-/// The owning actor intercepts successful results and activates the requested
-/// tool in its private exposure set.
+/// Exposes one deferred first-party or MCP tool schema by exact name.
+/// The owning actor intercepts successful results and adds the requested tool
+/// to its private exposure set. Dispatch still runs normal authorization.
 /// </summary>
 [NetclawTool("load_tool",
-    "Activate a tool by name so you can call it. Use search_tools first to find tool names, then load_tool to activate one.",
+    "Expose a known tool schema by exact name. Use search_tools only when the exact name is unknown.",
     Grant = "builtin")]
 public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
 {
@@ -23,7 +22,7 @@ public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
     private readonly ToolAccessPolicy _policy;
 
     public record Params(
-        [property: Description("Full tool name to activate (e.g., 'notion/notion-search'). Use search_tools to find available tool names.")]
+        [property: Description("Exact tool name to expose (e.g., 'notion/notion-search'). Use search_tools only when the name is unknown.")]
         string Name);
 
     public LoadToolTool(ToolRegistry registry, ToolAccessPolicy policy)
@@ -49,9 +48,9 @@ public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
         // Return the LLM-facing alias so the model sees the same form
         // it must emit in a subsequent tool_use call. The session actor
         // intercepts load_tool results and runs the content back through
-        // the registry's two-form lookup to activate the tool. Error
+        // the registry's two-form lookup to expose the schema. Error
         // messages above will not match any registry entry, so only
-        // successful loads trigger activation — no string parsing required.
+        // successful loads change exposure — no string parsing required.
         return Task.FromResult(registration.Tool.LlmFacingName.Value);
     }
 

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -144,7 +144,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
 
         sb.AppendLine();
         sb.AppendLine("To browse one server, call search_tools(query: \"all\", server: \"<server_name>\").");
-        sb.AppendLine("To find tools, call search_tools(query: \"<intent>\", server: \"<server_name>\"), then load_tool(\"<name>\") to activate.");
+        sb.AppendLine("To find tools, call search_tools(query: \"<intent>\", server: \"<server_name>\"), then load_tool(\"<name>\") to expose its schema.");
         if (!string.IsNullOrWhiteSpace(trailingHint))
         {
             sb.AppendLine();
@@ -173,7 +173,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
         }
 
         sb.AppendLine();
-        sb.AppendLine("To use a tool, call load_tool(\"<tool_name>\") to activate it first.");
+        sb.AppendLine("To expose a selected tool schema, call load_tool(\"<tool_name>\"). Normal authorization still runs at dispatch.");
         return sb.ToString();
     }
 

--- a/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
+++ b/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
@@ -14,8 +14,9 @@ internal static class ToolChoiceGuidance
         2. Use file_read for bounded file content and image metadata.
         3. Issue independent file_read calls in parallel when several paths are known.
         4. Use tool_output_read to continue a spilled result by call id.
-        5. Use search_tools, then load_tool, before reporting that a specialty tool is unavailable.
-        6. Use shell or an interpreter only when no structured tool expresses the operation.
+        5. Use load_tool directly when the exact specialty tool name is known.
+        6. Use search_tools when the capability is known but its exact tool name is not.
+        7. Use shell or an interpreter only when no structured tool expresses the operation.
         """;
 
     public const string DirectorySelectionOrder = """

--- a/src/Netclaw.Actors/Tools/ToolOutputSpill.cs
+++ b/src/Netclaw.Actors/Tools/ToolOutputSpill.cs
@@ -62,8 +62,8 @@ internal static class ToolOutputSpill
             return modelFacingResult;
 
         var inline = BoundedOutputReader.Window(modelFacingResult, budget);
-        var spillPath = await TryWriteSpillAsync(spillContent, toolCallId, context, ct);
-        return Compose(inline, spillPath, modelFacingResult.Length, budget);
+        var spillCallId = await TryWriteSpillAsync(spillContent, toolCallId, context, ct);
+        return Compose(inline, spillCallId, modelFacingResult.Length, budget);
     }
 
     private static async Task<string?> TryWriteSpillAsync(

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -143,6 +143,8 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.Contains("After an approval-required result", prompt);
         Assert.Contains("A `Tool access denied:` result is terminal", prompt);
         Assert.Contains("Apply one `Tool execution deferred:` correction unchanged", prompt);
+        Assert.Contains("Use `load_tool` directly for a known exact tool name", prompt);
+        Assert.Contains("Use `search_tools` when the capability is known", prompt);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -1,7 +1,7 @@
 # Operating Rules
 
 - Act autonomously — use available tools to accomplish tasks
-- For MCP capabilities, use progressive discovery: search_tools("servers") -> search_tools("<intent>", server: "<server_name>")
+- Call `load_tool` for a known exact specialty tool name. Use `search_tools` when its name is unknown.
 - For interactive web tasks (clicking, typing, form filling), use browser MCP tools
 - For browser automation, prefer file outputs over inline page dumps
 
@@ -32,7 +32,8 @@
 - Do not delegate a known file operation that an available file tool can complete.
 - After a successful file tool result, do not use shell only to verify it unless the user requests shell behavior.
 - For disposable text, use `file_write` then `file_read`; do not attempt a shell redirect first.
-- Use `search_tools`, then `load_tool`, before reporting that a specialty tool is unavailable.
+- Use `load_tool` directly for a known exact tool name.
+- Use `search_tools` when the capability is known but its exact tool name is not.
 
 Keep shell approval friction bounded:
 
@@ -134,7 +135,7 @@ expect the approval gate to keep it one-time and fail closed.
 
 - Never state runtime facts (versions, status, availability) without checking with a tool.
 - Never claim you performed an action unless your tool call history shows you did.
-- Never claim a tool doesn't exist without calling search_tools first.
+- Never claim a tool doesn't exist without loading its exact name or searching by intent.
 - Never silently substitute a different answer. If you can't complete the actual task,
   say so explicitly. Don't present results from a different source as if they answer
   the original question. Tell the user what failed and ask how to proceed.

--- a/src/Netclaw.Configuration/Resources/AGENTS.public.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.public.md
@@ -1,7 +1,7 @@
 # Operating Rules
 
 - Act autonomously — use available tools to accomplish tasks
-- For MCP capabilities, use progressive discovery: search_tools("servers") -> search_tools("<intent>", server: "<server_name>")
+- Call `load_tool` for a known exact specialty tool name. Use `search_tools` when its name is unknown.
 
 ## Autonomy Rules
 
@@ -27,13 +27,14 @@
 - Use `file_read` for file content and image metadata.
 - Issue independent `file_read` calls in parallel when several paths are known.
 - Use `tool_output_read` to continue a spilled result by call id.
-- Use `search_tools`, then `load_tool`, before reporting that a specialty tool is unavailable.
+- Use `load_tool` directly for a known exact tool name.
+- Use `search_tools` when the capability is known but its exact tool name is not.
 
 ## Grounding Rules
 
 - Never state runtime facts (versions, status, availability) without checking with a tool.
 - Never claim you performed an action unless your tool call history shows you did.
-- Never claim a tool doesn't exist without calling search_tools first.
+- Never claim a tool doesn't exist without loading its exact name or searching by intent.
 - Never silently substitute a different answer. If you can't complete the actual task,
   say so explicitly. Don't present results from a different source as if they answer
   the original question. Tell the user what failed and ask how to proceed.

--- a/src/Netclaw.Configuration/SessionTuning.cs
+++ b/src/Netclaw.Configuration/SessionTuning.cs
@@ -36,8 +36,8 @@ public sealed record SessionTuning
     /// a tool result inlined into conversation history, for tools whose output the
     /// model needs to read in full (file_read, web_fetch, memory recall, MCP).
     /// Oversized results are truncated to a head+tail window by the dispatcher and
-    /// the full (redacted) output is spilled to a session file with a steer to read
-    /// a slice / grep. Verbose tools (shell) override this with a much smaller
+    /// the full (redacted) output is spilled to a session file with an opaque
+    /// <c>tool_output_read</c> continuation. Verbose tools (shell) override this with a much smaller
     /// per-tool budget (<see cref="Netclaw.Tools.INetclawTool.InlineOutputBudgetChars"/>).
     /// </summary>
     public int MaxInlineToolResultChars { get; init; } = 12_000;

--- a/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
+++ b/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
@@ -77,6 +77,8 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
         Assert.Contains("Do not probe a named project path before declaring it", skill, StringComparison.Ordinal);
         Assert.Contains("user-provided fallback before other tools", skill, StringComparison.Ordinal);
         Assert.Contains("Use the task's first project path exactly", skill, StringComparison.Ordinal);
+        Assert.Contains("Use `load_tool` directly for a known exact tool name", skill, StringComparison.Ordinal);
+        Assert.Contains("Use `search_tools` when the capability is known", skill, StringComparison.Ordinal);
 
         var statements = new[]
         {


### PR DESCRIPTION
## Summary

- keep spill files internal and expose only an opaque call id through `tool_output_read`
- describe `load_tool` as schema exposure while retaining normal dispatch authorization
- direct agents to load a known exact tool name without a redundant search
- replay the catalog fixture through a real child actor and inspect its model-visible tools
- preserve the reduced 12-tool core footprint

## Validation

- Release build: 0 warnings, 0 errors
- focused dispatcher, replay, schema, prompt, and skill tests: 153 passed
- strict OpenSpec: passed
- deterministic eval harness checks: passed
- headers: passed
- Slopwatch: 0 findings
- diff check: passed

## Evaluation scope

This PR changes model-visible guidance and spill behavior. The final-head hosted behavioral rerun is still required; only PII-free aggregate evidence will be posted here.

## Stack

This is PR 3 of 3. Its base is PR #2045, now refreshed at `c19edbde`. No merge or auto-merge is enabled.