### PR TITLE
Prevent native tools from falling through to shell

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -172,7 +172,7 @@ Done when:
 - [x] Specify parser-owned exact executable matching without executable-private argument parsing.
 - [x] Return a typed correction before shell approval or execution and expose one deferred schema actor-locally.
 - [x] Prove parent/child, hard-deny, hidden-tool, and eventual-authorization boundaries.
-- [ ] Refresh deterministic and hosted PII-free behavioral evidence.
+- [x] Refresh deterministic and hosted PII-free behavioral evidence.
 - [ ] Complete Release, OpenSpec, header, formatting, Slopwatch, and adversarial-review gates before opening the stacked PR.
 
 ### Priority: Reduce Shell Approval Fatigue

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Netclaw Implementation Plan
 
-Last updated: 2026-08-14
+Last updated: 2026-08-21
 
 This is the execution plan for Netclaw. Autonomous agents and RALPH-style loops
 SHALL work from `NOW` by default. `NEXT` and `LATER` work belongs in
@@ -173,7 +173,7 @@ Done when:
 - [x] Return a typed correction before shell approval or execution and expose one deferred schema actor-locally.
 - [x] Prove parent/child, hard-deny, hidden-tool, and eventual-authorization boundaries.
 - [x] Refresh deterministic and hosted PII-free behavioral evidence.
-- [ ] Complete Release, OpenSpec, header, formatting, Slopwatch, and adversarial-review gates before opening the stacked PR.
+- [x] Complete Release, OpenSpec, header, formatting, Slopwatch, and adversarial-review gates before opening the stacked PR.
 
 ### Priority: Reduce Shell Approval Fatigue
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -164,6 +164,17 @@ Done when:
 - [x] Approval authority, scratch retry state, durable messages, and public APIs remain unchanged.
 - [ ] The stacked follow-up handles `attach_file` exposure and native-tool shell mistakes separately.
 
+### Priority: Prevent Native-Tool Shell Mistakes
+
+**Stack parent:** PR #2046 (`fix/repair-tool-rollout-contracts`).
+
+- [x] Specify `attach_file` as a policy-filtered Core tool that accepts the authorized source path directly.
+- [x] Specify parser-owned exact executable matching without executable-private argument parsing.
+- [x] Return a typed correction before shell approval or execution and expose one deferred schema actor-locally.
+- [x] Prove parent/child, hard-deny, hidden-tool, and eventual-authorization boundaries.
+- [ ] Refresh deterministic and hosted PII-free behavioral evidence.
+- [ ] Complete Release, OpenSpec, header, formatting, Slopwatch, and adversarial-review gates before opening the stacked PR.
+
 ### Priority: Reduce Shell Approval Fatigue
 
 **PRDs:** `docs/prd/PRD-002-gateway-security-envelope.md`, `docs/prd/PRD-006-mcp-tool-integration.md`

--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -179,7 +179,7 @@ findings into clear, well-organized summaries.
 - Cross-reference multiple sources when possible.
 - Always cite your sources with URLs.
 - Use file_read for local reference material when needed.
-- Use attach_file if the parent session should deliver an existing file.
+- Return each authorized file path that the parent session should deliver.
 - Be thorough but concise — focus on facts and actionable information.
 ```
 

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -105,6 +105,48 @@ A first-party tool is implemented and registered by Netclaw. An MCP tool comes
 from an external Model Context Protocol server. Both kinds still pass Netclaw's
 exposure and authorization boundaries.
 
+### Policy-visible tool
+
+A policy-visible tool passes `ToolAccessPolicy.IsToolExposed` for the current
+audience. This check applies feature gates, audience rules, approval-mode
+denies, and shell-coupled limits. MCP registrations also apply MCP server and
+tool rules. A policy-visible tool can still be Deferred and absent from the
+current model request. Policy visibility does not grant execution authority.
+
+Example:
+
+```text
+list_reminders passes ToolAccessPolicy.IsToolExposed
+  -> policy-visible
+  -> still absent until the actor loads its Deferred schema
+  -> normal authorization still controls a later call
+```
+
+**Code anchor:** `ToolAccessPolicy.IsToolExposed`
+
+### Native Netclaw tool
+
+A native Netclaw tool is a first-party structured tool in `ToolRegistry`. In
+this phrase, native does not mean a host executable or a native binary.
+
+**Code anchors:** `ToolRegistry`, `NativeToolShellCorrectionDetector`
+
+### Skill resource
+
+A skill resource is an additional file inside a registered file-backed skill
+directory. The `skill_read_resource` tool resolves it from a logical skill name
+and a permitted relative path. The `skill_load` tool reads `SKILL.md` instead.
+
+```text
+skill_read_resource("netclaw-operations", "references/tools.md")
+  -> read references/tools.md inside the netclaw-operations skill folder
+
+skill_read_resource("netclaw-operations", "SKILL.md")
+  -> reject the request and direct the model to skill_load
+```
+
+**Code anchors:** `SkillReadResourceTool`, `FileSkillSource`
+
 ### Workspace tool
 
 A workspace tool reads, lists, writes, edits, attaches, or selects files and

--- a/evals/README.md
+++ b/evals/README.md
@@ -150,6 +150,7 @@ the missing values. In non-interactive contexts it fails loudly.
 | `NETCLAW_IMAGE` | `ghcr.io/netclaw-dev/netclaw:latest` | Image ref |
 | `NETCLAW_EVAL_PORT` | `5299` | Host-side port for the eval daemon |
 | `NETCLAW_BIN` | `netclaw` | Path to the netclaw CLI on the host |
+| `NETCLAW_EVAL_ASSET_ROOT` | Current checkout | Checkout that supplies identity, skills, agents, and config fixtures |
 
 ### Eval suite knobs (optional)
 
@@ -186,6 +187,11 @@ NETCLAW_EVAL_RUNS=10 NETCLAW_EVAL_TIMEOUT=180 \
   ./evals/run-evals.sh
 ```
 
+For a baseline and treatment comparison, use the same harness commit. Point
+`NETCLAW_EVAL_ASSET_ROOT` at the checkout that produced each image. Also use
+that checkout's CLI. The archived run metadata records the image identity,
+harness commit, asset commit, and dirty state.
+
 ## Results Database
 
 Results are accumulated in `$EVAL_HOME/evals/results.db` during execution.
@@ -193,6 +199,9 @@ On exit, the harness archives the database, run metadata, daemon log, and
 per-turn stdout under `evals/runs/<run-id>/` before deleting the throwaway
 home. These archives are gitignored and can be compared locally without
 touching the operator's `~/.netclaw/` state.
+
+Raw archives can contain prompts, session identities, tool calls, and provider
+configuration. Do not publish them. Publish only reviewed PII-free aggregates.
 
 Requires `sqlite3` CLI — if not available, the script still runs but
 skips persistence.

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -31,6 +31,8 @@
 #     NETCLAW_EVAL_NO_BUILD      Set to 1 to skip `dotnet publish` + `docker build`
 #                                (reuse existing ./publish output and image)
 #     NETCLAW_BIN                Path to netclaw CLI (default: ./publish/cli/netclaw)
+#     NETCLAW_EVAL_ASSET_ROOT    Checkout that supplies identity, skills, and fixtures
+#                                (default: the checkout that contains this script)
 #
 #   Eval suite knobs:
 #     NETCLAW_EVAL_RUNS          Runs per case (default: 5)
@@ -44,6 +46,7 @@ set -euo pipefail
 
 # Repo root — derived from this script's location (evals/ is one level deep).
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EVAL_ASSET_ROOT="${NETCLAW_EVAL_ASSET_ROOT:-$REPO_ROOT}"
 
 RUNS="${NETCLAW_EVAL_RUNS:-5}"
 THRESHOLD="${NETCLAW_EVAL_THRESHOLD:-0.80}"
@@ -125,8 +128,8 @@ check_prerequisites() {
 
     # Identity files are rendered from repo templates into an isolated eval
     # home; the host does not need a pre-initialized ~/.netclaw tree.
-    if [[ ! -f "$REPO_ROOT/src/Netclaw.Cli/Resources/identity/SOUL.template.md" ]]; then
-        echo "ERROR: missing identity template at $REPO_ROOT/src/Netclaw.Cli/Resources/identity/SOUL.template.md." >&2
+    if [[ ! -f "$EVAL_ASSET_ROOT/src/Netclaw.Cli/Resources/identity/SOUL.template.md" ]]; then
+        echo "ERROR: missing identity template under NETCLAW_EVAL_ASSET_ROOT." >&2
         exit 1
     fi
 
@@ -138,8 +141,6 @@ check_prerequisites() {
         echo "WARN: sqlite3 not found — results will not be persisted" >&2
         RESULTS_DB=""
     fi
-
-    NETCLAW_VER=$("$NETCLAW_BIN" --version 2>/dev/null | head -1 || echo "unknown")
 
     if [[ "$RUNS" -lt 1 ]]; then
         echo "ERROR: NETCLAW_EVAL_RUNS must be >= 1 (got: $RUNS)" >&2
@@ -263,8 +264,12 @@ archive_eval_run() {
 
     # Write run metadata, including the immutable image identity so before/after
     # comparisons remain auditable even when tags are later rebuilt.
-    local image_id
+    local image_id harness_commit asset_commit harness_dirty asset_dirty
     image_id=$(docker image inspect "$NETCLAW_IMAGE" --format '{{.Id}}' 2>/dev/null || echo unknown)
+    harness_commit=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+    asset_commit=$(git -C "$EVAL_ASSET_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+    harness_dirty=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | grep -q . && echo true || echo false)
+    asset_dirty=$(git -C "$EVAL_ASSET_ROOT" status --porcelain 2>/dev/null | grep -q . && echo true || echo false)
     cat > "$archive_dir/run-info.txt" <<RUNEOF
 run_id:    $RUN_ID
 started:   ${STARTED_AT:-unknown}
@@ -273,6 +278,10 @@ image_id:  $image_id
 model:     ${EVAL_MODEL_ID:-unknown}
 provider:  ${EVAL_PROVIDER_TYPE:-unknown} @ ${EVAL_PROVIDER_ENDPOINT:-unknown}
 version:   ${NETCLAW_VER:-unknown}
+harness_commit: $harness_commit
+harness_dirty:  $harness_dirty
+asset_commit:   $asset_commit
+asset_dirty:    $asset_dirty
 category:  ${FILTER_CATEGORY:-all}
 case:      ${FILTER_CASE:-all}
 timeout:   ${PROMPT_TIMEOUT:-60}s
@@ -351,12 +360,12 @@ start_eval_daemon() {
     # that break identity evals. Templates have {{PLACEHOLDER}} tokens that we
     # substitute with eval defaults.
     mkdir -p "$EVAL_HOME/identity" "$EVAL_HOME/logs" "$EVAL_HOME/data/config" "$EVAL_HOME/data/agents"
-    local template_dir="$REPO_ROOT/src/Netclaw.Cli/Resources/identity"
+    local template_dir="$EVAL_ASSET_ROOT/src/Netclaw.Cli/Resources/identity"
     if [[ -d "$template_dir" ]]; then
         # Substitute placeholders with eval-appropriate defaults
         substitute_identity_template "$template_dir/SOUL.template.md" "$EVAL_HOME/identity/SOUL.md"
-        if [[ -f "$REPO_ROOT/evals/fixtures/identity/AGENTS.md" ]]; then
-            cp "$REPO_ROOT/evals/fixtures/identity/AGENTS.md" "$EVAL_HOME/identity/AGENTS.md"
+        if [[ -f "$EVAL_ASSET_ROOT/evals/fixtures/identity/AGENTS.md" ]]; then
+            cp "$EVAL_ASSET_ROOT/evals/fixtures/identity/AGENTS.md" "$EVAL_HOME/identity/AGENTS.md"
         else
             echo "ERROR: deployment mission eval fixture is missing." >&2
             exit 1
@@ -373,36 +382,36 @@ start_eval_daemon() {
     # `files/` segment); the daemon's feed sync writes to that layout, so we
     # mirror it here for local-source-of-truth runs.
     mkdir -p "$EVAL_HOME/skills/.system"
-    if [[ -d "$REPO_ROOT/feeds/skills/.system/files" ]]; then
-        cp -r "$REPO_ROOT/feeds/skills/.system/files/." "$EVAL_HOME/skills/.system/"
+    if [[ -d "$EVAL_ASSET_ROOT/feeds/skills/.system/files" ]]; then
+        cp -r "$EVAL_ASSET_ROOT/feeds/skills/.system/files/." "$EVAL_HOME/skills/.system/"
     else
-        echo "WARN: no system skills at $REPO_ROOT/feeds/skills/.system/files/ — Skill Discovery evals will fail." >&2
+        echo "WARN: no system skills under NETCLAW_EVAL_ASSET_ROOT — Skill Discovery evals will fail." >&2
     fi
 
     # Copy user skills from eval fixtures (non-system skills for activation testing).
-    if [[ -d "$REPO_ROOT/evals/fixtures/skills" ]]; then
-        cp -r "$REPO_ROOT/evals/fixtures/skills/." "$EVAL_HOME/skills/"
+    if [[ -d "$EVAL_ASSET_ROOT/evals/fixtures/skills" ]]; then
+        cp -r "$EVAL_ASSET_ROOT/evals/fixtures/skills/." "$EVAL_HOME/skills/"
     fi
 
     # Copy a skill into a managed server-feed origin. The configured feed URL
     # below is intentionally unreachable: startup must retain the already
     # materialized managed skill while the eval proves model access by logical
     # name without relying on the physical feed path.
-    if [[ -d "$REPO_ROOT/evals/fixtures/server-feed-skills" ]]; then
+    if [[ -d "$EVAL_ASSET_ROOT/evals/fixtures/server-feed-skills" ]]; then
         mkdir -p "$EVAL_HOME/skills/.server-feeds/eval-feed"
-        cp -r "$REPO_ROOT/evals/fixtures/server-feed-skills/." \
+        cp -r "$EVAL_ASSET_ROOT/evals/fixtures/server-feed-skills/." \
             "$EVAL_HOME/skills/.server-feeds/eval-feed/"
     fi
 
     # Copy eval-only subagent definitions into the mounted NETCLAW_HOME so
     # spawn_agent behavior can be exercised without touching the host install.
-    if [[ -d "$REPO_ROOT/evals/fixtures/agents" ]]; then
-        cp -r "$REPO_ROOT/evals/fixtures/agents/." "$EVAL_HOME/data/agents/"
+    if [[ -d "$EVAL_ASSET_ROOT/evals/fixtures/agents" ]]; then
+        cp -r "$EVAL_ASSET_ROOT/evals/fixtures/agents/." "$EVAL_HOME/data/agents/"
     fi
 
-    if [[ -f "$REPO_ROOT/evals/fixtures/mcp/prompt_server.py" ]]; then
+    if [[ -f "$EVAL_ASSET_ROOT/evals/fixtures/mcp/prompt_server.py" ]]; then
         mkdir -p "$EVAL_HOME/data/evals"
-        cp "$REPO_ROOT/evals/fixtures/mcp/prompt_server.py" \
+        cp "$EVAL_ASSET_ROOT/evals/fixtures/mcp/prompt_server.py" \
             "$EVAL_HOME/data/evals/prompt_server.py"
         chmod ugo+x "$EVAL_HOME/data/evals/prompt_server.py"
     fi
@@ -425,9 +434,20 @@ start_eval_daemon() {
     # Install the eval-only approval policy before daemon startup. Headless eval
     # sessions cannot answer approval prompts, so tools must be automatic for the
     # Personal audience. Exposure, filesystem, and command-deny rules remain in force.
-    cp "$REPO_ROOT/evals/fixtures/config/netclaw.json" \
-        "$REPO_ROOT/evals/fixtures/config/tool-approvals.json" \
+    cp "$EVAL_ASSET_ROOT/evals/fixtures/config/netclaw.json" \
+        "$EVAL_ASSET_ROOT/evals/fixtures/config/tool-approvals.json" \
         "$EVAL_HOME/data/config/"
+
+    # If shell execution reaches this fixture, it writes a marker. The native
+    # tool with the same name never invokes this executable.
+    local marker_executable="$EVAL_HOME/data/evals/list_reminders-marker.sh"
+    mkdir -p "$(dirname "$marker_executable")"
+    printf '%s\n' \
+        '#!/bin/sh' \
+        "printf 'started\\n' > /home/netclaw/.netclaw/evals/native-shell-process-started" \
+        'exit 0' \
+        > "$marker_executable"
+    chmod ugo+x "$marker_executable"
 
     # Pre-seed a large (>256 KB) text file in the workspaces read-root for the
     # bounded-tool-output file_read eval (complex_large_file_read_ranged). It must
@@ -514,6 +534,7 @@ start_eval_daemon() {
         -v "$EVAL_HOME/identity:/home/netclaw/.netclaw/identity"
         -v "$EVAL_HOME/skills:/home/netclaw/.netclaw/skills"
         -v "$EVAL_HOME/logs:/home/netclaw/.netclaw/logs"
+        -v "$marker_executable:/usr/local/bin/list_reminders:ro"
         -e "NETCLAW_Daemon__Host=127.0.0.1"
         -e "NETCLAW_Daemon__Port=$EVAL_PORT"
         -e "HOME=/home/netclaw"
@@ -605,7 +626,7 @@ start_eval_daemon() {
 
 seed_eval_memories() {
     local db_path="/home/netclaw/.netclaw/netclaw.db"
-    local fixtures_path="$REPO_ROOT/evals/fixtures/eval-memories.json"
+    local fixtures_path="$EVAL_ASSET_ROOT/evals/fixtures/eval-memories.json"
     local seed_script="$REPO_ROOT/evals/seed-memories.py"
 
     if [[ ! -f "$fixtures_path" ]]; then
@@ -1022,6 +1043,7 @@ run_multi_turn_case() {
             rendered_prompt="${rendered_prompt//\{\{SECOND_WORKTREE\}\}/${CODING_CONTEXT_SECOND_WORKTREE:-}}"
             rendered_prompt="${rendered_prompt//\{\{TARGET_BRANCH\}\}/${CODING_CONTEXT_TARGET_BRANCH:-}}"
             rendered_prompt="${rendered_prompt//\{\{TARGET_FILE\}\}/${CODING_CONTEXT_TARGET_FILE:-}}"
+            rendered_prompt="${rendered_prompt//\{\{DIRECT_ATTACHMENT_SOURCE\}\}/${DIRECT_ATTACHMENT_SOURCE_PATH:-}}"
             run_prompt_resume "$session_id" "$rendered_prompt" "$output_format"
             store_metrics "$case_name" "$run" "$turn" "$LAST_TURN_USAGE_LINE"
             turn=$((turn + 1))
@@ -1103,6 +1125,19 @@ daemon_log_tail() {
     if [[ -f "$DAEMON_LOG" ]]; then
         tail -n +"$((DAEMON_LOG_LINES_BEFORE + 1))" "$DAEMON_LOG" 2>/dev/null
     fi
+}
+
+daemon_log_tail_contains_fixed() {
+    local text="$1"
+    [[ -f "$DAEMON_LOG" ]] || return 1
+    awk -v start="$((DAEMON_LOG_LINES_BEFORE + 1))" -v text="$text" '
+        NR >= start && index($0, text) { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "$DAEMON_LOG"
+}
+
+daemon_log_tail_not_contains_fixed() {
+    ! daemon_log_tail_contains_fixed "$1"
 }
 
 daemon_log_contains() {
@@ -1430,6 +1465,90 @@ assert_tool_web_search() {
 
 assert_tool_cli_invoke() {
     stdout_contains '\[tool:call\] list_reminders'
+}
+
+assert_tool_direct_attachment() {
+    local call_id headless_log host_source file_line attached_path host_attached_path
+    stdout_json_envelope_valid || return 1
+    stdout_json_tool_call_sequence_matches '["attach_file"]' || return 1
+    jq -e --arg source "$DIRECT_ATTACHMENT_SOURCE_PATH" '
+        ((.toolCalls[0].argumentsJson | fromjson).Path == $source)
+    ' "$STDOUT_FILE" >/dev/null 2>&1 || return 1
+
+    call_id=$(jq -r '.toolCalls[0].callId' "$STDOUT_FILE")
+    headless_log=$(stdout_json_headless_log_path) || return 1
+    grep -qaF "TOOL_RESULT: attach_file call_id=$call_id result=File attached:" \
+        "$headless_log" || return 1
+    file_line=$(grep -aF "FILE: name=direct-attachment.txt path=" "$headless_log" | tail -1) || return 1
+    attached_path=${file_line#* path=}
+    attached_path=${attached_path% mime=*}
+    [[ "$attached_path" == "$DIRECT_ATTACHMENT_DESTINATION_ROOT/"* ]] || return 1
+    [[ "$attached_path" != "$DIRECT_ATTACHMENT_SOURCE_PATH" ]] || return 1
+
+    host_source="$EVAL_HOME/data/${DIRECT_ATTACHMENT_SOURCE_PATH#/home/netclaw/.netclaw/}"
+    host_attached_path="$EVAL_HOME/data/${attached_path#/home/netclaw/.netclaw/}"
+    [[ -f "$host_source" ]] || return 1
+    [[ -f "$host_attached_path" ]] || return 1
+    [[ "$(< "$host_source")" == "synthetic attachment" ]] \
+        && [[ "$(< "$host_attached_path")" == "synthetic attachment" ]]
+}
+
+setup_tool_direct_attachment() {
+    local run="$1"
+    local session_id="eval/tool_direct_attachment-run${run}-$$"
+    local sanitized_session_id="${session_id//\//_}"
+    local source_session_id="${sanitized_session_id}_source"
+    local host_source_dir="$EVAL_HOME/data/sessions/$source_session_id/project"
+    DIRECT_ATTACHMENT_SOURCE_PATH="/home/netclaw/.netclaw/sessions/$source_session_id/project/direct-attachment.txt"
+    DIRECT_ATTACHMENT_DESTINATION_ROOT="/home/netclaw/.netclaw/sessions/$sanitized_session_id/attachments"
+    mkdir -p "$host_source_dir"
+    printf 'synthetic attachment\n' > "$host_source_dir/direct-attachment.txt"
+}
+
+assert_tool_native_shell_recovery() {
+    local shell_call_id native_call_id headless_log
+    stdout_json_envelope_valid || return 1
+    stdout_json_tool_call_sequence_matches '["shell_execute","list_reminders"]' || return 1
+    jq -e '
+        ((.toolCalls[0].argumentsJson | fromjson).Command == "list_reminders")
+    ' "$STDOUT_FILE" >/dev/null 2>&1 || return 1
+
+    shell_call_id=$(jq -r '.toolCalls[0].callId' "$STDOUT_FILE")
+    native_call_id=$(jq -r '.toolCalls[1].callId' "$STDOUT_FILE")
+    headless_log=$(stdout_json_headless_log_path) || return 1
+    awk -v call_id="$shell_call_id" '
+        index($0, "TOOL_RESULT: shell_execute call_id=" call_id \
+            " result=Shell execution stopped because '\''list_reminders'\'' is a native Netclaw tool.") {
+            if (getline > 0 \
+                && $0 == "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.") {
+                found = 1
+            }
+        }
+        END { exit found ? 0 : 1 }
+    ' "$headless_log" || return 1
+    awk -v prefix="TOOL_RESULT: list_reminders call_id=$native_call_id result=" '
+        index($0, prefix) == 1 {
+            result = substr($0, length(prefix) + 1)
+            if (result == "No active reminders." || index(result, "Reminders (") == 1) {
+                found = 1
+            }
+        }
+        END { exit found ? 0 : 1 }
+    ' "$headless_log" || return 1
+
+    daemon_log_tail_contains_fixed \
+        'Tool authorization evaluated: shell_execute outcome=RequiresAgentCorrection' \
+        && daemon_log_tail_contains_fixed 'Session deferred tool activated loaded=1' \
+        && daemon_log_tail_contains_fixed 'Session tool exposure core=' \
+        && daemon_log_tail_contains_fixed 'loaded=1' \
+        && daemon_log_tail_contains_fixed 'Tool executed: list_reminders' \
+        && daemon_log_tail_not_contains_fixed 'outcome=RequiresApproval' \
+        && daemon_log_tail_not_contains_fixed 'Tool executed: shell_execute' \
+        && [[ ! -e "$EVAL_HOME/data/evals/native-shell-process-started" ]]
+}
+
+setup_tool_native_shell_recovery() {
+    rm -f "$EVAL_HOME/data/evals/native-shell-process-started"
 }
 
 assert_tool_file_list() {
@@ -2684,6 +2803,12 @@ run_all() {
     run_case tool_cli_invoke "list_reminders called" \
         "List my active reminders"
 
+    run_multi_turn_case --json tool_direct_attachment "existing authorized file is attached without a copy prelude" \
+        "Send the existing file {{DIRECT_ATTACHMENT_SOURCE}} to me as an attachment."
+
+    run_case --json tool_native_shell_recovery "exact native-tool shell mistake is corrected before execution" \
+        "First call shell_execute with Command exactly \"list_reminders\" and no other command text. Then follow the tool result's next action and report my active reminders."
+
     run_case tool_file_list "file_list called without shell" \
         "What files are in my session directory?"
 
@@ -2940,6 +3065,8 @@ main() {
         echo "ERROR: CLI binary not found at '$NETCLAW_BIN'" >&2
         exit 1
     fi
+
+    NETCLAW_VER=$("$NETCLAW_BIN" --version 2>/dev/null | head -1 || echo "unknown")
 
     start_eval_daemon
     init_db

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -1524,8 +1524,8 @@ assert_tool_native_shell_recovery() {
         END { exit found ? 0 : 1 }
     ' "$headless_log" || return 1
     awk -v prefix="TOOL_RESULT: list_reminders call_id=$native_call_id result=" '
-        index($0, prefix) == 1 {
-            result = substr($0, length(prefix) + 1)
+        index($0, prefix) {
+            result = substr($0, index($0, prefix) + length(prefix))
             if (result == "No active reminders." || index(result, "Reminders (") == 1) {
                 found = 1
             }

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -1498,11 +1498,13 @@ setup_tool_direct_attachment() {
     local session_id="eval/tool_direct_attachment-run${run}-$$"
     local sanitized_session_id="${session_id//\//_}"
     local source_session_id="${sanitized_session_id}_source"
-    local host_source_dir="$EVAL_HOME/data/sessions/$source_session_id/project"
+    local container_source_dir="/home/netclaw/.netclaw/sessions/$source_session_id/project"
     DIRECT_ATTACHMENT_SOURCE_PATH="/home/netclaw/.netclaw/sessions/$source_session_id/project/direct-attachment.txt"
     DIRECT_ATTACHMENT_DESTINATION_ROOT="/home/netclaw/.netclaw/sessions/$sanitized_session_id/attachments"
-    mkdir -p "$host_source_dir"
-    printf 'synthetic attachment\n' > "$host_source_dir/direct-attachment.txt"
+    docker exec --user root "$EVAL_CONTAINER_NAME" mkdir -p "$container_source_dir"
+    printf 'synthetic attachment\n' \
+        | docker exec --interactive --user root "$EVAL_CONTAINER_NAME" \
+            tee "$DIRECT_ATTACHMENT_SOURCE_PATH" >/dev/null
 }
 
 assert_tool_native_shell_recovery() {

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -1207,6 +1207,17 @@ stdout_json_headless_log_path() {
     printf '%s\n' "$log_path"
 }
 
+stdout_json_session_actor_log_path() {
+    local session_id session_segment log_path
+    session_id=$(jq -r '.sessionId // empty' "$STDOUT_FILE")
+    [[ -n "$session_id" ]] || return 1
+
+    session_segment="${session_id//\//_}"
+    log_path="$EVAL_HOME/logs/sessions/$session_segment/session.log"
+    [[ -f "$log_path" ]] || return 1
+    printf '%s\n' "$log_path"
+}
+
 stdout_json_tool_result_equals() {
     local tool_name="$1"
     local call_id="$2"
@@ -1503,7 +1514,7 @@ setup_tool_direct_attachment() {
 }
 
 assert_tool_native_shell_recovery() {
-    local shell_call_id native_call_id headless_log
+    local shell_call_id native_call_id headless_log session_log
     stdout_json_envelope_valid || return 1
     stdout_json_tool_call_sequence_matches '["shell_execute","list_reminders"]' || return 1
     jq -e '
@@ -1513,6 +1524,7 @@ assert_tool_native_shell_recovery() {
     shell_call_id=$(jq -r '.toolCalls[0].callId' "$STDOUT_FILE")
     native_call_id=$(jq -r '.toolCalls[1].callId' "$STDOUT_FILE")
     headless_log=$(stdout_json_headless_log_path) || return 1
+    session_log=$(stdout_json_session_actor_log_path) || return 1
     awk -v call_id="$shell_call_id" '
         index($0, "TOOL_RESULT: shell_execute call_id=" call_id \
             " result=Shell execution stopped because '\''list_reminders'\'' is a native Netclaw tool.") {
@@ -1535,9 +1547,9 @@ assert_tool_native_shell_recovery() {
 
     daemon_log_tail_contains_fixed \
         'Tool authorization evaluated: shell_execute outcome=RequiresAgentCorrection' \
-        && daemon_log_tail_contains_fixed 'Session deferred tool activated loaded=1' \
-        && daemon_log_tail_contains_fixed 'Session tool exposure core=' \
-        && daemon_log_tail_contains_fixed 'loaded=1' \
+        && grep -qaF 'Session deferred tool activated loaded=1' "$session_log" \
+        && grep -qaF 'Session tool exposure core=' "$session_log" \
+        && grep -qaF 'loaded=1' "$session_log" \
         && daemon_log_tail_contains_fixed 'Tool executed: list_reminders' \
         && daemon_log_tail_not_contains_fixed 'outcome=RequiresApproval' \
         && daemon_log_tail_not_contains_fixed 'Tool executed: shell_execute' \

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -1497,9 +1497,9 @@ setup_tool_direct_attachment() {
     local run="$1"
     local session_id="eval/tool_direct_attachment-run${run}-$$"
     local sanitized_session_id="${session_id//\//_}"
-    local source_session_id="${sanitized_session_id}_source"
-    local container_source_dir="/home/netclaw/.netclaw/sessions/$source_session_id/project"
-    DIRECT_ATTACHMENT_SOURCE_PATH="/home/netclaw/.netclaw/sessions/$source_session_id/project/direct-attachment.txt"
+    local source_project_id="direct-attachment-source-$sanitized_session_id"
+    local container_source_dir="/home/netclaw/.netclaw/workspaces/$source_project_id"
+    DIRECT_ATTACHMENT_SOURCE_PATH="$container_source_dir/direct-attachment.txt"
     DIRECT_ATTACHMENT_DESTINATION_ROOT="/home/netclaw/.netclaw/sessions/$sanitized_session_id/attachments"
     docker exec --user root "$EVAL_CONTAINER_NAME" mkdir -p "$container_source_dir"
     printf 'synthetic attachment\n' \

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -539,6 +539,7 @@ start_eval_daemon() {
         -e "NETCLAW_Daemon__Port=$EVAL_PORT"
         -e "HOME=/home/netclaw"
         -e "NETCLAW_HOME=/home/netclaw/.netclaw"
+        -e "NETCLAW_Workspaces__Directory=/home/netclaw/.netclaw/workspaces"
         -e "NETCLAW_Providers__eval__Type=$EVAL_PROVIDER_TYPE"
         -e "NETCLAW_Providers__eval__Endpoint=$EVAL_PROVIDER_ENDPOINT"
         -e "NETCLAW_Models__Main__Provider=eval"

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -1469,7 +1469,7 @@ assert_tool_cli_invoke() {
 }
 
 assert_tool_direct_attachment() {
-    local call_id headless_log host_source file_line attached_path host_attached_path
+    local call_id headless_log host_source file_line attached_path
     stdout_json_envelope_valid || return 1
     stdout_json_tool_call_sequence_matches '["attach_file"]' || return 1
     jq -e --arg source "$DIRECT_ATTACHMENT_SOURCE_PATH" '
@@ -1483,25 +1483,19 @@ assert_tool_direct_attachment() {
     file_line=$(grep -aF "FILE: name=direct-attachment.txt path=" "$headless_log" | tail -1) || return 1
     attached_path=${file_line#* path=}
     attached_path=${attached_path% mime=*}
-    [[ "$attached_path" == "$DIRECT_ATTACHMENT_DESTINATION_ROOT/"* ]] || return 1
-    [[ "$attached_path" != "$DIRECT_ATTACHMENT_SOURCE_PATH" ]] || return 1
+    [[ "$attached_path" == "$DIRECT_ATTACHMENT_SOURCE_PATH" ]] || return 1
 
     host_source="$EVAL_HOME/data/${DIRECT_ATTACHMENT_SOURCE_PATH#/home/netclaw/.netclaw/}"
-    host_attached_path="$EVAL_HOME/data/${attached_path#/home/netclaw/.netclaw/}"
     [[ -f "$host_source" ]] || return 1
-    [[ -f "$host_attached_path" ]] || return 1
-    [[ "$(< "$host_source")" == "synthetic attachment" ]] \
-        && [[ "$(< "$host_attached_path")" == "synthetic attachment" ]]
+    [[ "$(< "$host_source")" == "synthetic attachment" ]]
 }
 
 setup_tool_direct_attachment() {
     local run="$1"
     local session_id="eval/tool_direct_attachment-run${run}-$$"
     local sanitized_session_id="${session_id//\//_}"
-    local source_project_id="direct-attachment-source-$sanitized_session_id"
-    local container_source_dir="/home/netclaw/.netclaw/workspaces/$source_project_id"
+    local container_source_dir="/home/netclaw/.netclaw/sessions/$sanitized_session_id/project"
     DIRECT_ATTACHMENT_SOURCE_PATH="$container_source_dir/direct-attachment.txt"
-    DIRECT_ATTACHMENT_DESTINATION_ROOT="/home/netclaw/.netclaw/sessions/$sanitized_session_id/attachments"
     docker exec --user root "$EVAL_CONTAINER_NAME" mkdir -p "$container_source_dir"
     printf 'synthetic attachment\n' \
         | docker exec --interactive --user root "$EVAL_CONTAINER_NAME" \

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.65.0"
+  version: "2.65.1"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/tools.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/tools.md
@@ -50,8 +50,9 @@ Other categories (`web`, `file`, `shell`, `scheduling`) depend on ACL
 config. If a tool is missing, it may not be granted for this session.
 
 Built-in tool grants follow the audience and are monotonic (Public ⊆ Team ⊆
-Personal). **Public** sessions get read-only file tools only — `file_read`,
-`file_list`, `attach_file` — and no outbound web access. **Team** adds
+Personal). **Public parent sessions** get read-only file tools only — `file_read`,
+`file_list`, and file delivery — with no outbound web access. Subagents return
+authorized file paths to their parent instead of delivering files. **Team** adds
 `file_write`, `file_edit`, `web_search`, `web_fetch`, the scheduling tools,
 `skill_manage`, and `set_working_directory`. **Personal** gets everything.
 `shell_execute` is Personal-only — in a Team or Public session, use `file_list`

--- a/feeds/skills/.system/files/search-citation/SKILL.md
+++ b/feeds/skills/.system/files/search-citation/SKILL.md
@@ -3,7 +3,7 @@ name: search-citation
 description: "REQUIRED when the user asks you to search, look up, verify, buy, shop, compare, price-check, find current info, or check facts online. Contains citation format rules for web_search and web_fetch."
 metadata:
   author: netclaw
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 ## Critical Rules Summary
@@ -74,7 +74,7 @@ clickable links, not an academic paper.
 | Link all sources | When multiple sources were found, link each one inline where relevant — recommend one if you have a basis |
 | Prefer specific pages | Link to the product page, restaurant page, or listing — not to a search results or category page |
 | No URL, no fact | Do not present specific claims (prices, ratings, availability) without a source URL |
-| Unlinkable content | If a source cannot be linked directly (form-post navigation, JS-rendered content), use browser automation to capture a screenshot and attach it via `attach_file` — a screenshot beats no source |
+| Unlinkable content | If a source cannot be linked directly, capture a screenshot. Use an available file-delivery tool, or return its saved path to the caller. |
 
 ## When Search Is Not Available
 

--- a/openspec/changes/make-agent-tools-pit-of-success/design.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/design.md
@@ -1,17 +1,41 @@
 ## Context
 
-Netclaw currently treats every non-MCP registration as always loaded. Main
-sessions dynamically load MCP tools, but subagents receive every discoverable
-registration except recursive `spawn_agent`. In the observed deployment this
-meant roughly 220 schemas per subagent. Despite that large choice surface,
-agents repeatedly used approval-gated shell or Python for operations absent from
-the first-party workspace API: recursive search, batch reads, JSON projection,
-image dimensions, and continuation of spilled output.
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for the
+cross-cutting terms in this design.
 
-The file tools also resolve a relative path through the daemon process current
-directory. Recent-file context is reconstructed from authored arguments for all
-tool results, including failures. These behaviors make the less-safe route
-easier and allow a failed operation to influence later model context.
+## Status and Superseding Changes
+
+This design records the first implementation. Later stacked changes replace
+some decisions:
+
+```text
+make-agent-tools-pit-of-success
+  -> establishes progressive disclosure, receipts, relative paths,
+     file_search, image metadata, and tool_output_read
+
+repair-agent-tool-boundaries
+  -> removes json_read and file_read_many
+  -> strengthens path-base, receipt, child, and spill contracts
+
+prevent-native-tool-shell-mistakes
+  -> makes attach_file a parent-session Core tool
+  -> keeps attach_file unavailable to children without an attachment handoff
+```
+
+Use the later delta specifications as the current contract when the documents
+conflict. The decisions below explain the original implementation. Their
+future-tense language records the plan at that time; it is not current work.
+
+Before this change, Netclaw treated every non-MCP registration as always loaded.
+Main sessions loaded MCP tools on demand, but subagents received every
+discoverable registration except recursive `spawn_agent`. In the observed
+deployment, this meant roughly 220 schemas per subagent. Agents still used
+approval-gated shell or Python for missing workspace operations.
+
+Before this change, file tools also resolved relative paths through the daemon
+process current directory. Recent-file context came from authored arguments for
+all tool results, including failures. These behaviors made the less-safe route
+easier. They also let a failed operation affect later model context.
 
 Constraints:
 
@@ -237,10 +261,9 @@ names, authored content, credentials, or raw paths from production.
 Rollback is a normal code rollback. No persisted state or configuration needs
 migration; recovered sessions simply reseed the prior always-loaded catalog.
 
-## Open Questions
+## Later Decisions
 
-- Whether `attach_file` is frequent and small enough to remain core will be
-  decided from schema-byte measurements and sanitized traffic counts.
-- Whether the JSON projection primitive should support only RFC 6901 pointers or
-  a second bounded array-index shorthand will be decided before its schema is
-  frozen; arbitrary query languages remain out of scope.
+- `prevent-native-tool-shell-mistakes` makes `attach_file` Core for parent
+  sessions. Subagents still exclude it.
+- `repair-agent-tool-boundaries` removes `json_read`. No JSON projection query
+  language remains in the current tool surface.

--- a/openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json
+++ b/openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json
@@ -76,6 +76,16 @@
       "expectedApprovalRequired": false,
       "fallbackApprovalRequired": false,
       "expectedContextEffect": "CoreOnlyChildCatalog"
+    },
+    {
+      "id": "TF08",
+      "scenario": "DirectAttachment",
+      "observedFriction": "PreparatoryShellCopyBeforeAttachment",
+      "expectedToolSequence": ["attach_file"],
+      "expectedOutcome": "success",
+      "expectedApprovalRequired": false,
+      "fallbackApprovalRequired": true,
+      "expectedContextEffect": "RecordOneCanonicalFile"
     }
   ]
 }

--- a/openspec/changes/make-agent-tools-pit-of-success/proposal.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/proposal.md
@@ -7,6 +7,21 @@ result continuation. This undermines PRD-001 outcomes 7 and 9, PRD-006 outcome
 5, and PRD-007 outcomes 3 and 5: the safe, structured route exists in pieces but
 is not the easiest route for either main sessions or subagents.
 
+## Status and Superseding Changes
+
+This change records the original progressive-disclosure and workspace-tool
+delivery. Two later stacked changes replace part of this plan:
+
+- [`repair-agent-tool-boundaries`](../repair-agent-tool-boundaries/design.md)
+  removes `json_read` and `file_read_many`. It also strengthens path, receipt,
+  child, and spill boundaries.
+- [`prevent-native-tool-shell-mistakes`](../prevent-native-tool-shell-mistakes/design.md)
+  makes `attach_file` a parent-session Core tool. It keeps the tool unavailable
+  to subagents until a child attachment handoff exists.
+
+Review the later delta specifications for the current target behavior. The
+original decisions below remain a history of the implemented first pass.
+
 ## What Changes
 
 - Define one audience-filtered progressive-disclosure contract for first-party

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/bounded-tool-output/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/bounded-tool-output/spec.md
@@ -1,5 +1,10 @@
 ## ADDED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+The later `repair-agent-tool-boundaries` change modifies the spill response and
+steer. Review that delta for the current contract.
+
 ### Requirement: Spilled output has an opaque bounded continuation tool
 
 The system SHALL provide a core `tool_output_read` tool that accepts an opaque

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-subagents/spec.md
@@ -1,5 +1,10 @@
 ## ADDED Requirements
 
+The terms in these requirements use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+Later changes add parent-and-child denial parity, real-child replay proof, and
+the child `attach_file` exclusion.
+
 ### Requirement: Subagents use progressive tool disclosure
 
 A subagent SHALL begin with the same policy-exposed core tool set as a main

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-tools/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/netclaw-tools/spec.md
@@ -1,5 +1,10 @@
 ## ADDED Requirements
 
+The terms in these requirements use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+The later `repair-agent-tool-boundaries` change removes the `json_read` and
+`file_read_many` requirements. It also strengthens the receipt contract.
+
 ### Requirement: First-party tool outcomes are machine-actionable
 
 First-party workspace tool execution SHALL produce exactly one call-local

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/progressive-tool-disclosure/spec.md
@@ -1,5 +1,9 @@
 ## ADDED Requirements
 
+The terms in these requirements use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+Later changes modify the exact Core set and add parent-only `attach_file`.
+
 ### Requirement: Tool registrations declare an exposure tier
 
 Every registered tool SHALL have an exposure tier of `Core` or `Deferred`.

--- a/openspec/changes/make-agent-tools-pit-of-success/specs/session-cwd/spec.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/specs/session-cwd/spec.md
@@ -1,5 +1,10 @@
 ## ADDED Requirements
 
+The terms in these requirements use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+The later `repair-agent-tool-boundaries` change adds complete base-chain link
+validation and exact fallback states.
+
 ### Requirement: Relative first-party filesystem paths use session-owned bases
 
 First-party filesystem tools SHALL resolve a relative path against the declared

--- a/openspec/changes/make-agent-tools-pit-of-success/tasks.md
+++ b/openspec/changes/make-agent-tools-pit-of-success/tasks.md
@@ -59,3 +59,8 @@
 - [x] 7.5 Run Release build, full tests, headers, formatting, strict OpenSpec, changed-file Slopwatch, PII audit, and API compatibility gates.
 - [x] 7.6 Run native Windows and Linux validation.
 - [x] 7.7 Rebase the final stack on upstream/dev, merge in order, remove merged worktrees, produce a binary-swap build, and harvest a new sanitized live window.
+
+## 8. Superseding Changes
+
+- [x] 8.1 Mark the `json_read` and `file_read_many` decisions as superseded by `repair-agent-tool-boundaries`.
+- [x] 8.2 Record the later parent-only `attach_file` Core decision and child handoff boundary.

--- a/openspec/changes/prevent-native-tool-shell-mistakes/.openspec.yaml
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/prevent-native-tool-shell-mistakes/design.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/design.md
@@ -39,6 +39,31 @@ model calls shell_execute("list_reminders")
 
 The correction does not run either tool. It creates no approval or grant.
 
+Exact correction shape:
+
+```text
+factual result:
+  Shell execution stopped because 'list_reminders' is a native Netclaw tool.
+
+receipt:
+  category    = RecoverableCorrection
+  remediation = UseNativeTool
+
+authorization correction fact:
+  NativeToolSuggested("list_reminders")
+
+call-local exposure request:
+  ToolExposureRequest("list_reminders")
+
+model-facing result:
+  Shell execution stopped because 'list_reminders' is a native Netclaw tool.
+  Next action: call the native Netclaw tool named in this result directly instead of shell_execute.
+```
+
+The receipt contains the closed correction strategy. The two call-local values
+carry the registered name across authorization and actor activation. None of
+these values grants authority.
+
 ### Exact and non-exact executable examples
 
 | Authored shell input | Native-tool correction |
@@ -53,6 +78,20 @@ The correction does not run either tool. It creates no approval or grant.
 
 These examples describe executable identity only. Netclaw does not translate
 shell arguments into native tool arguments.
+
+Source-order examples:
+
+```text
+file_write --path first && file_read --path second
+  -> select file_write
+  -> execute no part of the shell call
+
+sudo bash -lc "file_read"; file_write
+  -> parser order is sudo, file_read, file_write
+  -> sudo is not a Netclaw tool
+  -> select file_read before the later file_write
+  -> execute no part of the shell call
+```
 
 ### Parent attachment and child exclusion
 
@@ -69,6 +108,15 @@ subagent run:
 ```
 
 The child exclusion prevents a success result that the child cannot deliver.
+
+Attachment authority examples:
+
+| Caller and source | Required result |
+|---|---|
+| Interactive Personal parent; policy-authorized project file | Attach the source. Copy it into the current session when required. |
+| Any parent; protected credential or control-plane file | Deny the call even when `attach_file` is Core. |
+| Non-interactive or Team parent; source outside the Netclaw session tree | Deny the call through the existing proximity gate. |
+| Subagent; any source | Do not expose or dispatch `attach_file`. |
 
 ### Actor-local exposure and durable history
 

--- a/openspec/changes/prevent-native-tool-shell-mistakes/design.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/design.md
@@ -1,6 +1,13 @@
 ## Context
 
-The current core exposes general workspace tools but defers `attach_file`, even though attaching an existing authorized file is a small and frequent operation. An agent that does not see the schema may copy the file into session scratch with shell before it discovers the attachment tool. Separately, agents sometimes put a known Netclaw tool name in `shell_execute`; the authorization pipeline then treats it as an ordinary process request and can prompt the user.
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for the
+cross-cutting terms in this design.
+
+Before this change, the core exposed general workspace tools but deferred
+`attach_file`. An agent without that schema could copy a file into session
+scratch before it discovered the attachment tool. Agents also put known
+Netclaw tool names in `shell_execute`. The authorization pipeline then treated
+those names as ordinary process requests and could prompt the user.
 
 Netclaw already has the necessary boundaries:
 
@@ -9,9 +16,76 @@ Netclaw already has the necessary boundaries:
 - `ToolAccessPolicy.IsToolExposed` applies deployment, audience, and approval-policy visibility.
 - `ToolAuthorizationDecision` is the internal pre-execution result.
 - parent and child actors already activate deferred tools in actor-local caches.
-- typed `ToolInvocationReceipt` remediation reaches both actor paths without entering durable history.
+- the closed `ToolInvocationReceipt` remediation code reaches both actor paths without entering durable history.
 
 The design must not add executable-specific parsing to Netclaw, infer native arguments from shell text, or make schema exposure equivalent to authorization.
+
+## Runtime Flow and Examples
+
+### Exact shell mistake to native retry
+
+```text
+model calls shell_execute("list_reminders")
+  -> ShellSyntaxTree supplies one complete static command occurrence
+  -> shell input, audience, hard-deny, and protected-path checks pass
+  -> detector finds the exact policy-visible first-party name
+  -> authorization returns RequiresAgentCorrection
+       NativeToolSuggested("list_reminders")
+  -> actor records the correction result
+  -> actor exposes the schema when policy still allows it
+  -> next model request includes list_reminders
+  -> a later list_reminders call runs normal authorization
+```
+
+The correction does not run either tool. It creates no approval or grant.
+
+### Exact and non-exact executable examples
+
+| Authored shell input | Native-tool correction |
+|---|---|
+| `list_reminders` | Yes. The exact policy-visible first-party name matches. |
+| `list_reminders --all > reminders.txt` | Yes. Netclaw stops the complete shell call and ignores native argument meaning. |
+| `list_reminders \| Select-Object -First 1` | Yes. The PowerShell pipeline remains one stopped shell call. |
+| `./list_reminders` | No. The executable token is path-qualified. |
+| `$tool_name` | No. The executable identity is dynamic. |
+| `list-reminder` | No. Netclaw does not use fuzzy matching. |
+| a hidden, denied, MCP, or `shell_execute` name | No. The normal shell policy remains authoritative. |
+
+These examples describe executable identity only. Netclaw does not translate
+shell arguments into native tool arguments.
+
+### Parent attachment and child exclusion
+
+```text
+interactive Personal parent session:
+  attach_file(Path = "/workspace/project/report.pdf")
+    -> normal attachment policy
+    -> Netclaw performs any required safe session copy
+
+subagent run:
+  attach_file schema is absent from core, search, load, and dispatch
+    -> child can report the saved path to the parent
+    -> parent decides whether to attach it
+```
+
+The child exclusion prevents a success result that the child cannot deliver.
+
+### Actor-local exposure and durable history
+
+```text
+main session:
+  correction result text        -> normal durable chat history
+  receipt and exposure request  -> call-local only
+  activated deferred schema     -> actor-local only
+
+subagent:
+  correction result, receipt, and schema exposure
+    -> discarded when the child run ends
+```
+
+After main-session recovery, the correction text can remain in history. The
+deferred schema does not remain loaded. A recalled name still enters normal
+dispatch authorization.
 
 ## Goals / Non-Goals
 
@@ -29,7 +103,7 @@ The design must not add executable-specific parsing to Netclaw, infer native arg
 - Fuzzy-match, alias-resolve, or guess an intended tool.
 - Intercept dynamic or unresolved executable identities.
 - Correct MCP names or `shell_execute` itself.
-- Persist loaded schemas, corrections, or new durable state.
+- Persist correction facts, receipts, exposure requests, or loaded schemas.
 - Automatically retry or execute any tool.
 
 ## Decisions
@@ -38,7 +112,7 @@ The design must not add executable-specific parsing to Netclaw, infer native arg
 
 `ToolRegistrationExtensions` will register `attach_file` as Core. Parent sessions will receive its schema when current policy exposes it. Its description will state that the caller passes the authorized source path directly and Netclaw performs any required safe copy into the current session. Existing `ScopedFileAccessPolicy`, proximity checks, and `ToolPathPolicy` remain unchanged.
 
-Sub-agents will exclude `attach_file` from core exposure, discovery, loading, and direct dispatch. A child tool context can create an attachment, but the current child completion path has no internal typed handoff that can carry that attachment to the parent invocation and channel. Exclusion prevents a false-success result without adding attachment state to the public `SubAgentResult` contract. A later change can remove the exclusion after it adds an internal child-to-parent attachment handoff.
+Sub-agents will exclude `attach_file` from core exposure, discovery, loading, and direct dispatch. A child tool context can create an attachment, but the current child completion path has no internal handoff that can carry that attachment to the parent invocation and channel. Exclusion prevents a false-success result without adding attachment state to the public `SubAgentResult` contract. A later change can remove the exclusion after it adds an internal child-to-parent attachment handoff.
 
 This adds one small schema to parent sessions but removes a discovery round trip and the misleading incentive to use shell copy first. Audience policy still removes the tool when it is unavailable.
 
@@ -46,7 +120,10 @@ This adds one small schema to parent sessions but removes a discovery round trip
 
 ### Detect exact authored executable identity from ShellSyntaxTree facts
 
-After ordinary shell argument validation, audience checks, protected-path checks, and analysis succeed, but before stored-grant matching, approval, or execution, the dispatcher will scan the parser-owned command occurrences in source order. A match requires:
+After ShellSyntaxTree analysis and all ordinary terminal preflight checks
+succeed, but before stored-grant matching, approval, or execution, the
+dispatcher scans parser-owned command occurrences in source order. A match
+requires:
 
 - the complete analysis is resolved and contains no dynamic syntax;
 - the occurrence is complete and its authored verb is static;
@@ -59,11 +136,15 @@ Arguments, redirects, pipelines, and surrounding static compound structure are n
 
 **Alternative considered:** search raw command text. This would create quoting, comment, alias, and injection errors and would duplicate ShellSyntaxTree.
 
-### Represent correction explicitly through the authorization boundary
+### Represent the correction explicitly through the authorization boundary
 
 Add an internal `RequiresAgentCorrection` authorization outcome carrying `ToolAgentCorrection.NativeToolSuggested`. The dispatcher adapter converts it to a dedicated internal correction exception for the existing async execution boundary. It does not represent allow, deny, or approval and cannot contain approval matches.
 
-Parent and child catch the correction, return a `RecoverableCorrection` receipt with the new closed `UseNativeTool` code, and include a separate typed actor-local exposure request containing the canonical tool name. The shared remediation presenter appends one fixed instruction; it does not parse result text or interpolate untrusted shell arguments.
+Parent and child catch the correction and return a `RecoverableCorrection`
+receipt with the closed `UseNativeTool` code. They also add a separate
+actor-local exposure fact that contains the exact registered tool name. The shared
+presenter appends one fixed instruction. It does not parse result text or add
+untrusted shell arguments.
 
 **Alternative considered:** encode the target in a free-form remediation string. That would recreate the weak string contract removed by the lower stack and would encourage actor code to parse model-facing text.
 

--- a/openspec/changes/prevent-native-tool-shell-mistakes/design.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The current core exposes general workspace tools but defers `attach_file`, even though attaching an existing authorized file is a small and frequent operation. An agent that does not see the schema may copy the file into session scratch with shell before it discovers the attachment tool. Separately, agents sometimes put a known Netclaw tool name in `shell_execute`; the authorization pipeline then treats it as an ordinary process request and can prompt the user.
+
+Netclaw already has the necessary boundaries:
+
+- ShellSyntaxTree supplies parser-owned command occurrences and exact authored verb tokens.
+- `ToolRegistry` owns first-party registrations and Core/Deferred exposure.
+- `ToolAccessPolicy.IsToolExposed` applies deployment, audience, and approval-policy visibility.
+- `ToolAuthorizationDecision` is the internal pre-execution result.
+- parent and child actors already activate deferred tools in actor-local caches.
+- typed `ToolInvocationReceipt` remediation reaches both actor paths without entering durable history.
+
+The design must not add executable-specific parsing to Netclaw, infer native arguments from shell text, or make schema exposure equivalent to authorization.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make direct attachment of an authorized existing file obvious and available without a discovery round trip.
+- Stop complete static shell calls that contain an exact first-party Netclaw executable name before shell policy can approve, prompt, or execute them.
+- Give the next model call the exact policy-visible native schema needed to recover.
+- Preserve identical parent and child behavior and preserve ordinary authorization on the eventual native call.
+- Pin the behavior with deterministic tests and PII-free behavioral evidence.
+
+**Non-Goals:**
+
+- Parse or translate native-tool arguments from shell arguments.
+- Fuzzy-match, alias-resolve, or guess an intended tool.
+- Intercept dynamic or unresolved executable identities.
+- Correct MCP names or `shell_execute` itself.
+- Persist loaded schemas, corrections, or new durable state.
+- Automatically retry or execute any tool.
+
+## Decisions
+
+### Add `attach_file` to the policy-filtered parent-session core
+
+`ToolRegistrationExtensions` will register `attach_file` as Core. Parent sessions will receive its schema when current policy exposes it. Its description will state that the caller passes the authorized source path directly and Netclaw performs any required safe copy into the current session. Existing `ScopedFileAccessPolicy`, proximity checks, and `ToolPathPolicy` remain unchanged.
+
+Sub-agents will exclude `attach_file` from core exposure, discovery, loading, and direct dispatch. A child tool context can create an attachment, but the current child completion path has no internal typed handoff that can carry that attachment to the parent invocation and channel. Exclusion prevents a false-success result without adding attachment state to the public `SubAgentResult` contract. A later change can remove the exclusion after it adds an internal child-to-parent attachment handoff.
+
+This adds one small schema to parent sessions but removes a discovery round trip and the misleading incentive to use shell copy first. Audience policy still removes the tool when it is unavailable.
+
+**Alternative considered:** keep the tool Deferred and strengthen prose. The observed failure is caused by the missing affordance at choice time; more prose does not provide a callable schema and has already proved unreliable.
+
+### Detect exact authored executable identity from ShellSyntaxTree facts
+
+After ordinary shell argument validation, audience checks, protected-path checks, and analysis succeed, but before stored-grant matching, approval, or execution, the dispatcher will scan the parser-owned command occurrences in source order. A match requires:
+
+- the complete analysis is resolved and contains no dynamic syntax;
+- the occurrence is complete and its authored verb is static;
+- the first authored verb token exactly equals a registered first-party tool name using ordinal comparison;
+- the target is not `shell_execute`, is not an MCP adapter, and is exposed by `ToolAccessPolicy` for the active invocation.
+
+Arguments, redirects, pipelines, and surrounding static compound structure are not interpreted as native syntax. If a static occurrence matches, the entire shell call is stopped. The first matching occurrence supplies the recovery target. A protected-path or other terminal preflight denial wins before this check.
+
+**Alternative considered:** recognize only a bare one-token command. That misses the observed class where the model types a native tool name with prose-like arguments or includes it in a compound shell call. Matching only the executable token uses general shell facts without learning any tool's private grammar.
+
+**Alternative considered:** search raw command text. This would create quoting, comment, alias, and injection errors and would duplicate ShellSyntaxTree.
+
+### Represent correction explicitly through the authorization boundary
+
+Add an internal `RequiresAgentCorrection` authorization outcome carrying `ToolAgentCorrection.NativeToolSuggested`. The dispatcher adapter converts it to a dedicated internal correction exception for the existing async execution boundary. It does not represent allow, deny, or approval and cannot contain approval matches.
+
+Parent and child catch the correction, return a `RecoverableCorrection` receipt with the new closed `UseNativeTool` code, and include a separate typed actor-local exposure request containing the canonical tool name. The shared remediation presenter appends one fixed instruction; it does not parse result text or interpolate untrusted shell arguments.
+
+**Alternative considered:** encode the target in a free-form remediation string. That would recreate the weak string contract removed by the lower stack and would encourage actor code to parse model-facing text.
+
+### Activate schema only after the correction result enters actor history
+
+The internal tool-result messages will carry exposure requests separately from durable chat messages and receipts. The parent or child actor first records the correction result, then asks its existing actor-local activation function to load the target. Activation repeats registry and `ToolAccessPolicy` checks. Missing, removed, or newly hidden tools fail closed.
+
+Core targets make activation a no-op. Deferred targets appear on the next model request. Recovery, model failure, child termination, and session restart keep the existing actor-local eviction behavior.
+
+### Keep normal native authorization unchanged
+
+The correction does not call the target, seed a one-time approval, create a grant, or bypass tool policy. When the model retries with the native tool, dispatch starts again at ordinary argument validation, audience policy, approval mode, and execution.
+
+## Risks / Trade-offs
+
+- **[Name collision with a real host executable]** A first-party tool name could also exist on PATH. → Only policy-visible Netclaw names are intercepted, exact ordinal authored identity is required, and the behavior is deliberate: model calls should use the structured tool when both names collide.
+- **[A compound shell call is stopped before unrelated commands run]** → The result states that the entire shell call was not executed; partial execution would be unsafe and surprising.
+- **[Core schema growth]** → Add only `attach_file`, refresh the exact core snapshot and byte footprint, and measure hosted behavior before delivery.
+- **[Policy changes between detection and activation]** → Repeat policy validation at actor activation and again at eventual dispatch.
+- **[Correction loop]** → The model receives the actual schema on the next request. Repeating the same shell mistake remains a correction and never becomes shell authority.
+
+## Migration Plan
+
+No durable migration is required. Deploy the actor and tool-registration changes together. Existing sessions rebuild the policy-filtered core on their next actor/model lifecycle; deferred activation remains transient. Rollback restores the prior core and shell behavior without data conversion.
+
+## Open Questions
+
+None. Hosted evidence may reject the behavioral hypothesis, but it does not change the security contract: exact native-tool shell mistakes must not become shell executions or approval prompts.

--- a/openspec/changes/prevent-native-tool-shell-mistakes/proposal.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/proposal.md
@@ -1,5 +1,8 @@
 ## Why
 
+This proposal uses the
+[Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for shared terms.
+
 Recent tool-friction evidence shows agents still copy files into session scratch before attaching them and sometimes type a known Netclaw tool name into `shell_execute`. The first pattern wastes work and can trigger approval; the second turns a recoverable tool-choice mistake into a shell approval prompt. This change advances PRD-001 tool execution and PRD-002 least-authority behavior by making the intended structured path the easiest path.
 
 ## What Changes

--- a/openspec/changes/prevent-native-tool-shell-mistakes/proposal.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Recent tool-friction evidence shows agents still copy files into session scratch before attaching them and sometimes type a known Netclaw tool name into `shell_execute`. The first pattern wastes work and can trigger approval; the second turns a recoverable tool-choice mistake into a shell approval prompt. This change advances PRD-001 tool execution and PRD-002 least-authority behavior by making the intended structured path the easiest path.
+
+## What Changes
+
+- Add policy-exposed `attach_file` to the initial parent-session core tool set and state that it accepts an authorized source path directly; the agent does not need to copy the file into session scratch first.
+- Before shell approval or execution, recognize a complete static shell analysis containing an authored command occurrence whose exact executable token names an audience-visible first-party Netclaw tool.
+- Return a typed, bounded remediation that tells the model to call the native tool directly, and expose that tool schema for the next model request when it was deferred.
+- Keep dynamic or unresolved executable identities, unknown names, hidden tools, MCP tools, and policy-denied tools on the existing shell path. Arguments and surrounding static shell structure do not change the exact executable-name test and are never interpreted as native-tool arguments.
+- Preserve all ordinary tool authorization: remediation and schema exposure grant no execution authority and create no approval grant.
+- Add deterministic parent/child regressions, PII-free fixture coverage, and hosted before/after behavioral evidence.
+
+### In scope
+
+- Parent and child session tool execution.
+- First-party Netclaw tools already allowed by the active audience policy.
+- Parent-session Core exposure and guidance for `attach_file`; child exposure remains denied until an internal attachment handoff exists.
+
+### Out of scope
+
+- Parsing executable-specific command-line syntax.
+- Inferring intended tools from aliases, fuzzy matches, shell arguments, or command output.
+- Automatically executing or retrying the native tool.
+- Changing MCP discovery, stored approvals, public APIs, durable messages, or configuration formats.
+- Adding attachment fields to the public `SubAgentResult` contract.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `progressive-tool-disclosure`: Add `attach_file` to the policy-filtered parent-session core, keep it unavailable to children until typed handoff exists, and allow a typed correction to activate one deferred first-party schema.
+- `tool-approval-gates`: Prevent an exact native-tool shell mistake from reaching approval or execution while preserving all other shell behavior.
+- `netclaw-tools`: Clarify that `attach_file` accepts an authorized source path directly and performs its own safe session copy.
+
+## Impact
+
+- Affected runtime areas: core tool registration, shell preflight, parent and child tool-result handling, actor-local tool exposure, and attach-file guidance.
+- Public API and durable impact: none; the correction and activation facts remain internal and call-local.
+- Security impact: reduces shell authority requests without granting native-tool authority. Hidden or denied tool names are never disclosed, and every eventual native call still uses normal policy and approval checks.
+- Operational impact: the parent model-visible core grows by one small first-party schema. Child exposure stays unchanged. Behavioral evals and schema-footprint evidence must be refreshed before delivery.

--- a/openspec/changes/prevent-native-tool-shell-mistakes/proposal.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/proposal.md
@@ -5,8 +5,12 @@ Recent tool-friction evidence shows agents still copy files into session scratch
 ## What Changes
 
 - Add policy-exposed `attach_file` to the initial parent-session core tool set and state that it accepts an authorized source path directly; the agent does not need to copy the file into session scratch first.
-- Before shell approval or execution, recognize a complete static shell analysis containing an authored command occurrence whose exact executable token names an audience-visible first-party Netclaw tool.
-- Return a typed, bounded remediation that tells the model to call the native tool directly, and expose that tool schema for the next model request when it was deferred.
+- Before shell approval or execution, recognize a complete static shell
+  analysis containing an authored command occurrence whose exact executable
+  token names a policy-visible first-party Netclaw tool.
+- Return the closed `UseNativeTool` remediation code with a
+  `NativeToolSuggested` correction fact. Carry schema exposure as a separate
+  actor-local fact.
 - Keep dynamic or unresolved executable identities, unknown names, hidden tools, MCP tools, and policy-denied tools on the existing shell path. Arguments and surrounding static shell structure do not change the exact executable-name test and are never interpreted as native-tool arguments.
 - Preserve all ordinary tool authorization: remediation and schema exposure grant no execution authority and create no approval grant.
 - Add deterministic parent/child regressions, PII-free fixture coverage, and hosted before/after behavioral evidence.
@@ -33,7 +37,7 @@ None.
 
 ### Modified Capabilities
 
-- `progressive-tool-disclosure`: Add `attach_file` to the policy-filtered parent-session core, keep it unavailable to children until typed handoff exists, and allow a typed correction to activate one deferred first-party schema.
+- `progressive-tool-disclosure`: Add `attach_file` to the policy-filtered parent-session core, keep it unavailable to children until an attachment handoff exists, and let one correction expose one deferred first-party schema.
 - `tool-approval-gates`: Prevent an exact native-tool shell mistake from reaching approval or execution while preserving all other shell behavior.
 - `netclaw-tools`: Clarify that `attach_file` accepts an authorized source path directly and performs its own safe session copy.
 

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/netclaw-tools/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/netclaw-tools/spec.md
@@ -29,6 +29,15 @@ subagent:
   can report a saved path to the parent instead
 ```
 
+Authority examples and counterexamples:
+
+| Caller and source | Required result |
+|---|---|
+| Interactive Personal parent with an authorized project file | Attach it directly. Copy it into the session when required. |
+| Parent with a protected credential path | Deny it. Core exposure does not bypass the read deny. |
+| Team or non-interactive parent with a source outside the session tree | Deny it through the existing proximity rule. |
+| Subagent with any source | Do not expose, find, load, or dispatch `attach_file`. |
+
 #### Scenario: Interactive Personal agent attaches an existing project file directly
 
 - **GIVEN** an interactive Personal parent session can attach an existing project file under current policy

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/netclaw-tools/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/netclaw-tools/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Attachment tool accepts an authorized source path directly
+
+The parent-session model-visible `attach_file` definition SHALL tell the agent to pass the existing authorized source path directly. The agent SHALL NOT need to copy the file into session scratch before calling the tool. Netclaw SHALL retain the existing audience, read-deny, proximity, and safe-copy behavior inside the tool. Sub-agents SHALL NOT receive this tool until an internal typed attachment handoff can deliver child attachments to the parent invocation.
+
+#### Scenario: Interactive Personal agent attaches an existing project file directly
+
+- **GIVEN** an interactive Personal parent session can attach an existing project file under current policy
+- **WHEN** the model needs to send that file to the user
+- **THEN** the initial tool set contains `attach_file`
+- **AND** its definition accepts the source path directly
+- **AND** Netclaw performs any required copy into the session attachments directory
+- **AND** no shell copy is required
+
+#### Scenario: Core exposure does not widen attachment reach
+
+- **GIVEN** current audience or path policy denies an attachment source
+- **WHEN** `attach_file` is present in the registered core
+- **THEN** the model-visible set still filters the tool by audience policy
+- **AND** the tool still rejects the denied source when invoked

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/netclaw-tools/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/netclaw-tools/spec.md
@@ -1,8 +1,33 @@
 ## ADDED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Attachment tool accepts an authorized source path directly
 
-The parent-session model-visible `attach_file` definition SHALL tell the agent to pass the existing authorized source path directly. The agent SHALL NOT need to copy the file into session scratch before calling the tool. Netclaw SHALL retain the existing audience, read-deny, proximity, and safe-copy behavior inside the tool. Sub-agents SHALL NOT receive this tool until an internal typed attachment handoff can deliver child attachments to the parent invocation.
+The parent-session model-visible `attach_file` definition SHALL tell the agent
+to pass the existing authorized source path directly. The agent SHALL NOT need
+to copy the file into session scratch first.
+
+Netclaw SHALL retain the existing audience, read-deny, proximity, and safe-copy
+behavior. Subagents SHALL NOT receive this tool until an internal attachment
+handoff can deliver child attachments to the parent invocation.
+
+Example:
+
+```text
+interactive Personal parent model calls:
+  attach_file(Path = "/workspace/project/report.pdf")
+
+Netclaw:
+  authorizes the source path
+  copies it to the session attachment directory when required
+  returns the attachment through the parent invocation
+
+subagent:
+  does not receive, find, load, or dispatch attach_file
+  can report a saved path to the parent instead
+```
 
 #### Scenario: Interactive Personal agent attaches an existing project file directly
 

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
@@ -1,5 +1,8 @@
 ## MODIFIED Requirements
 
+The terms in these requirements use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Sessions start with a bounded workspace core
 
 The initial parent-session model tool set SHALL contain policy-exposed definitions for
@@ -10,7 +13,7 @@ first-party and MCP tools SHALL be deferred unless a later specification adds
 them to the core. The core SHALL NOT include `json_read` or `file_read_many`.
 
 Sub-agent model tool sets SHALL exclude `attach_file` from core exposure,
-discovery, loading, and direct dispatch until an internal typed attachment
+discovery, loading, and direct dispatch until an internal attachment
 handoff can deliver child attachments through the parent invocation.
 
 #### Scenario: Specialty tools are not eagerly exposed
@@ -37,7 +40,26 @@ handoff can deliver child attachments through the parent invocation.
 
 ### Requirement: Agent correction can expose one deferred first-party tool
 
-A typed shell-to-native correction SHALL be able to request actor-local exposure of one policy-visible deferred first-party tool. The actor SHALL record the correction result before activating the schema, SHALL recheck current exposure policy, and SHALL NOT persist the activation or treat it as execution authority.
+The closed `UseNativeTool` remediation code and its `NativeToolSuggested` correction fact SHALL be able to request actor-local exposure of one policy-visible deferred first-party tool.
+
+The actor SHALL record the correction result before activating the schema. It
+SHALL recheck current exposure policy. It SHALL NOT persist the activation or
+treat schema exposure as execution authority.
+
+Required order:
+
+```text
+1. Record the model-facing correction result.
+2. Read the separate exposure fact with the exact registered tool name.
+3. Resolve the exact registration again.
+4. Recheck current exposure policy.
+5. Add only the schema to the current actor exposure set.
+6. Run normal authorization if the model later calls the tool.
+```
+
+Main-session recovery and child completion discard the activated deferred
+schema. They do not discard a main-session correction message that already
+entered durable chat history.
 
 #### Scenario: Deferred target appears on the next model request
 

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
@@ -4,9 +4,10 @@
 
 The initial parent-session model tool set SHALL contain policy-exposed definitions for
 `search_tools`, `load_tool`, `skill_load`, `skill_read_resource`,
-`set_working_directory`, `file_read`, `file_list`, `file_write`, `file_edit`,
-`attach_file`, and `shell_execute`. Other first-party and MCP tools SHALL be
-deferred unless a later specification adds them to the core.
+`set_working_directory`, `file_search`, `file_read`, `file_list`, `file_write`,
+`file_edit`, `tool_output_read`, `attach_file`, and `shell_execute`. Other
+first-party and MCP tools SHALL be deferred unless a later specification adds
+them to the core. The core SHALL NOT include `json_read` or `file_read_many`.
 
 Sub-agent model tool sets SHALL exclude `attach_file` from core exposure,
 discovery, loading, and direct dispatch until an internal typed attachment

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
@@ -12,6 +12,10 @@ The initial parent-session model tool set SHALL contain policy-exposed definitio
 first-party and MCP tools SHALL be deferred unless a later specification adds
 them to the core. The core SHALL NOT include `json_read` or `file_read_many`.
 
+The `skill_read_resource` name uses the glossary definition of a skill
+resource. It reads an additional file through a permitted relative path. The
+`skill_load` tool reads `SKILL.md` instead.
+
 Sub-agent model tool sets SHALL exclude `attach_file` from core exposure,
 discovery, loading, and direct dispatch until an internal attachment
 handoff can deliver child attachments through the parent invocation.
@@ -56,6 +60,16 @@ Required order:
 5. Add only the schema to the current actor exposure set.
 6. Run normal authorization if the model later calls the tool.
 ```
+
+Exposure examples and counterexamples:
+
+| Correction target | Required exposure result |
+|---|---|
+| Policy-visible Deferred `list_reminders` | Add only that schema to the next actor request. |
+| Policy-visible Core `file_read` | Keep the existing Core schema. Add no duplicate. |
+| A tool that policy hides before activation | Add no schema. Reveal no new tool detail. |
+| A registration removed before activation | Add no schema. Execute nothing. |
+| A later native call after activation | Run normal authorization. The exposure fact grants nothing. |
 
 Main-session recovery and child completion discard the activated deferred
 schema. They do not discard a main-session correction message that already

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/progressive-tool-disclosure/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Sessions start with a bounded workspace core
+
+The initial parent-session model tool set SHALL contain policy-exposed definitions for
+`search_tools`, `load_tool`, `skill_load`, `skill_read_resource`,
+`set_working_directory`, `file_read`, `file_list`, `file_write`, `file_edit`,
+`attach_file`, and `shell_execute`. Other first-party and MCP tools SHALL be
+deferred unless a later specification adds them to the core.
+
+Sub-agent model tool sets SHALL exclude `attach_file` from core exposure,
+discovery, loading, and direct dispatch until an internal typed attachment
+handoff can deliver child attachments through the parent invocation.
+
+#### Scenario: Specialty tools are not eagerly exposed
+
+- **GIVEN** specialty and MCP tools are registered
+- **WHEN** a new Personal session begins
+- **THEN** their schemas are absent from the initial set
+- **AND** policy-exposed tools remain searchable by intent
+
+#### Scenario: Core snapshot stays bounded
+
+- **WHEN** the repository first-party catalog is tested
+- **THEN** the core name snapshot equals the specified set
+- **AND** another first-party registration does not change that snapshot
+
+#### Scenario: Child cannot report false attachment success
+
+- **GIVEN** `attach_file` is registered as a parent-session Core tool
+- **WHEN** a sub-agent searches, loads, or directly calls `attach_file`
+- **THEN** the child does not discover or dispatch the tool
+- **AND** the parent-session core still contains `attach_file`
+
+## ADDED Requirements
+
+### Requirement: Agent correction can expose one deferred first-party tool
+
+A typed shell-to-native correction SHALL be able to request actor-local exposure of one policy-visible deferred first-party tool. The actor SHALL record the correction result before activating the schema, SHALL recheck current exposure policy, and SHALL NOT persist the activation or treat it as execution authority.
+
+#### Scenario: Deferred target appears on the next model request
+
+- **GIVEN** a complete static shell call contains the exact executable name of a policy-visible deferred first-party tool
+- **WHEN** the runtime returns the native-tool correction
+- **THEN** the correction result enters model history
+- **AND** the next model request contains the target schema
+- **AND** calling that schema still enters normal authorization
+
+#### Scenario: Hidden target is not exposed
+
+- **GIVEN** a registered first-party tool is hidden or denied by current policy
+- **WHEN** its exact name appears as a shell executable token
+- **THEN** no native-tool correction confirms the tool
+- **AND** no schema activation occurs
+
+#### Scenario: Activation remains actor-local
+
+- **GIVEN** a correction activates a deferred tool in one actor
+- **WHEN** that child completes, the model call fails and evicts leases, or the session recovers
+- **THEN** the later exposure set is rebuilt from the policy-filtered core
+- **AND** the correction does not create durable exposure state

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/tool-approval-gates/spec.md
@@ -1,8 +1,42 @@
 ## ADDED Requirements
 
+The terms in this requirement use the
+[Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
 ### Requirement: Exact native-tool shell executables receive an agent correction
 
-After shell input validation, audience checks, protected-path checks, and complete static analysis succeed, but before stored-grant matching, approval, or execution, the system SHALL inspect parser-owned command occurrences. If the first authored executable token of an occurrence exactly names an audience-visible first-party Netclaw tool other than `shell_execute`, the system SHALL stop the entire shell call and return a typed native-tool correction. It SHALL use ordinal exact name comparison and SHALL NOT infer private native-tool syntax from shell arguments.
+After shell input and audience validation, complete ShellSyntaxTree analysis, and all terminal preflight checks succeed, but before stored-grant matching, approval, or execution, the system SHALL inspect parser-owned command occurrences.
+
+If the first authored executable token of an occurrence exactly names a
+policy-visible first-party Netclaw tool other than `shell_execute`, the system
+SHALL stop the entire shell call. It SHALL return the closed `UseNativeTool`
+remediation code with a `NativeToolSuggested` correction fact.
+
+The comparison SHALL be ordinal and exact. The system SHALL NOT infer private
+native-tool syntax from shell arguments.
+
+Boundary examples:
+
+| Authored executable form | Required result |
+|---|---|
+| `list_reminders` | Return the correction and stop the shell call. |
+| `list_reminders --all` | Return the correction. Do not translate `--all`. |
+| `./list_reminders` | Keep the normal shell path. The token is path-qualified. |
+| `$tool_name` | Keep the normal shell path. The identity is dynamic. |
+| `list-reminder` | Keep the normal shell path. The name is not exact. |
+
+Precedence:
+
+```text
+input and audience checks
+  -> complete ShellSyntaxTree analysis
+  -> protected-path, hard-deny, and other terminal preflight checks
+  -> exact native-tool detector
+  -> stored grants, approval, or shell execution
+```
+
+A terminal preflight result stops the flow before the detector. A detector
+match stops the flow before grants, approval, or execution.
 
 #### Scenario: Bare deferred tool name is corrected and exposed
 
@@ -31,7 +65,7 @@ After shell input validation, audience checks, protected-path checks, and comple
 
 #### Scenario: Hard deny takes precedence
 
-- **GIVEN** a shell call contains an exact visible native-tool executable token
+- **GIVEN** a shell call contains an exact policy-visible native-tool executable token
 - **AND** ordinary preflight detects invalid input, a protected path, or another terminal deny
 - **WHEN** authorization runs
 - **THEN** the terminal denial is returned
@@ -42,6 +76,15 @@ After shell input validation, audience checks, protected-path checks, and comple
 - **GIVEN** the exact executable token names a hidden or denied first-party tool, an MCP tool, or `shell_execute`
 - **WHEN** the shell call reaches authorization
 - **THEN** no native-tool correction confirms or activates that target
+- **AND** the existing shell path remains authoritative
+
+#### Scenario: Child-static-denied target is not disclosed
+
+- **GIVEN** a subagent authors `attach_file` or `spawn_agent` as an exact shell executable
+- **AND** child policy omits that registration from the child-private registry
+- **WHEN** the child shell call reaches authorization
+- **THEN** no native-tool correction confirms the denied name
+- **AND** no schema exposure request is created
 - **AND** the existing shell path remains authoritative
 
 #### Scenario: Eventual native call keeps normal authority

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/tool-approval-gates/spec.md
@@ -25,6 +25,34 @@ Boundary examples:
 | `$tool_name` | Keep the normal shell path. The identity is dynamic. |
 | `list-reminder` | Keep the normal shell path. The name is not exact. |
 
+Exact correction example:
+
+```text
+shell_execute(Command = "list_reminders")
+
+result:
+  Shell execution stopped because 'list_reminders' is a native Netclaw tool.
+  Next action: call the native Netclaw tool named in this result directly instead of shell_execute.
+
+receipt:
+  category    = RecoverableCorrection
+  remediation = UseNativeTool
+
+authorization correction fact:
+  NativeToolSuggested("list_reminders")
+
+call-local exposure request:
+  ToolExposureRequest("list_reminders")
+```
+
+Source-order counterexamples:
+
+| Authored shell input | Selected target |
+|---|---|
+| `file_write --path first && file_read --path second` | Select `file_write`. Execute no part of the shell call. |
+| `sudo bash -lc "file_read"; file_write` | Select `file_read`. Preserve the wrapper payload before the later outer command. |
+| `echo ready; file_read --path report.txt` | Select `file_read`. Do not execute the earlier `echo`. |
+
 Precedence:
 
 ```text

--- a/openspec/changes/prevent-native-tool-shell-mistakes/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/specs/tool-approval-gates/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Exact native-tool shell executables receive an agent correction
+
+After shell input validation, audience checks, protected-path checks, and complete static analysis succeed, but before stored-grant matching, approval, or execution, the system SHALL inspect parser-owned command occurrences. If the first authored executable token of an occurrence exactly names an audience-visible first-party Netclaw tool other than `shell_execute`, the system SHALL stop the entire shell call and return a typed native-tool correction. It SHALL use ordinal exact name comparison and SHALL NOT infer private native-tool syntax from shell arguments.
+
+#### Scenario: Bare deferred tool name is corrected and exposed
+
+- **GIVEN** `list_reminders` is a policy-visible deferred first-party tool
+- **WHEN** the agent invokes `shell_execute` with the static command `list_reminders`
+- **THEN** no shell process starts
+- **AND** no approval request is emitted
+- **AND** the result tells the agent to call the named native tool directly
+- **AND** the next model request contains the `list_reminders` schema
+
+#### Scenario: Static compound call is stopped as one unit
+
+- **GIVEN** a complete static shell command contains an occurrence whose exact executable token is a policy-visible first-party tool
+- **AND** the command also contains arguments, redirects, a pipeline stage, or another compound occurrence
+- **WHEN** the shell call reaches authorization
+- **THEN** the complete shell call is not executed
+- **AND** the system selects the first matching occurrence as the correction target
+- **AND** it does not interpret any shell argument as a native-tool argument
+
+#### Scenario: Dynamic and unknown identities remain shell work
+
+- **GIVEN** a shell executable identity is dynamic, unresolved, unknown, fuzzy, aliased, or path-qualified rather than an exact authored first-party tool name
+- **WHEN** the shell call reaches authorization
+- **THEN** the native-tool correction does not apply
+- **AND** the existing shell policy determines deny, approval, or execution
+
+#### Scenario: Hard deny takes precedence
+
+- **GIVEN** a shell call contains an exact visible native-tool executable token
+- **AND** ordinary preflight detects invalid input, a protected path, or another terminal deny
+- **WHEN** authorization runs
+- **THEN** the terminal denial is returned
+- **AND** no tool schema is activated
+
+#### Scenario: Hidden, MCP, and shell targets are excluded
+
+- **GIVEN** the exact executable token names a hidden or denied first-party tool, an MCP tool, or `shell_execute`
+- **WHEN** the shell call reaches authorization
+- **THEN** no native-tool correction confirms or activates that target
+- **AND** the existing shell path remains authoritative
+
+#### Scenario: Eventual native call keeps normal authority
+
+- **GIVEN** the model receives a native-tool correction and the target schema
+- **WHEN** it invokes that native tool on a later model iteration
+- **THEN** normal argument validation, audience policy, approval, and dispatch run
+- **AND** the correction creates no one-time, session, folder, or global grant

--- a/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
@@ -1,0 +1,46 @@
+## 1. Freeze the Behavior Contract
+
+- [x] 1.1 Validate the proposal, design, and three delta specifications in strict mode.
+- [x] 1.2 Add the change to `IMPLEMENTATION_PLAN.md` with the stack parent and delivery gates.
+
+## 2. Make Direct Attachment the Core Path
+
+- [x] 2.1 Register `attach_file` as parent-session Core without changing its audience or path authorization.
+- [x] 2.2 Rewrite the tool definition and shared guidance to require the existing authorized source path directly and forbid a preparatory shell copy.
+- [x] 2.3 Update exact core-name, schema-footprint, and audience snapshots; exclude child `attach_file` search, load, and dispatch until a typed attachment handoff exists.
+
+## 3. Add Typed Native-Tool Correction
+
+- [x] 3.1 Add `UseNativeTool` to the closed internal remediation code and one fixed shared presenter action.
+- [x] 3.2 Add an internal authorization correction outcome and typed `NativeToolSuggested` fact without changing public or durable contracts.
+- [x] 3.3 Detect the first exact policy-visible first-party executable occurrence from complete static ShellSyntaxTree analysis after hard-deny preflight and before shell policy, approval, or execution.
+- [x] 3.4 Exclude dynamic and unresolved identities, hidden or denied tools, MCP tools, `shell_execute`, and non-exact names without parsing private tool syntax.
+- [x] 3.5 Translate the correction through buffered, streaming, background, and child execution without starting a shell process or contacting approval.
+
+## 4. Activate the Native Schema Safely
+
+- [x] 4.1 Carry one typed canonical exposure request in internal call-local result messages, separate from model-facing text and durable messages.
+- [x] 4.2 Record the correction result before parent or child activation, then recheck registry and current exposure policy at the actor seam.
+- [x] 4.3 Prove Core activation is a no-op, Deferred activation reaches the next model request, and eventual native dispatch uses normal authorization.
+- [x] 4.4 Prove actor failure, recovery, and child completion do not persist or share correction-driven exposure.
+
+## 5. Adversarial Regression Coverage
+
+- [x] 5.1 Add Bash and PowerShell positives for bare, argument-bearing, redirected, pipeline, wrapper, and compound static occurrences.
+- [x] 5.2 Add negatives for dynamic, unknown, fuzzy, path-qualified, hidden, denied, MCP, and `shell_execute` identities.
+- [x] 5.3 Add protected-path and invalid-input precedence tests proving no correction or activation after a terminal preflight deny.
+- [x] 5.4 Add parent batch, parent streaming, parent background, and child tests proving no shell execution, no approval request, exact shared presentation, and next-request schema exposure.
+- [ ] 5.5 Add direct-attachment tool-choice coverage proving no shell or file-mutation prelude is required.
+
+## 6. PII-Free Behavioral Evidence
+
+- [x] 6.1 Add deterministic synthetic cases for direct attachment and shell-to-native recovery; preserve a deferred-tool discovery case after `attach_file` becomes Core.
+- [ ] 6.2 Run fixed baseline and treatment trials for direct attachment and shell-to-native recovery with fresh sessions.
+- [ ] 6.3 Publish only PII-free aggregate completion, tool-choice, shell-authored, shell-started, approval, activation, and correction-to-native metrics on the PR.
+
+## 7. Delivery Gates
+
+- [x] 7.1 Run Release build and full tests with zero failures and warnings.
+- [x] 7.2 Run strict OpenSpec, headers, changed-file formatting, shell harness checks, diff check, and Slopwatch with zero findings.
+- [ ] 7.3 Perform a frozen-SHA adversarial review of authority, privacy, parent/child parity, and public/durable compatibility.
+- [ ] 7.4 Rebase on the refreshed #2046 head, push as the next stacked PR with GitHub CLI, apply relevant labels, and leave merge and auto-merge disabled.

--- a/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
@@ -1,3 +1,8 @@
+## 0. Specification Clarity
+
+- [x] 0.1 Link the shared glossary and define the complete correction, exposure, authorization, and persistence flow.
+- [x] 0.2 Add exact positive, negative, parent, and child examples for the changed behavior.
+
 ## 1. Freeze the Behavior Contract
 
 - [x] 1.1 Validate the proposal, design, and three delta specifications in strict mode.
@@ -7,19 +12,19 @@
 
 - [x] 2.1 Register `attach_file` as parent-session Core without changing its audience or path authorization.
 - [x] 2.2 Rewrite the tool definition and shared guidance to require the existing authorized source path directly and forbid a preparatory shell copy.
-- [x] 2.3 Update exact core-name, schema-footprint, and audience snapshots; exclude child `attach_file` search, load, and dispatch until a typed attachment handoff exists.
+- [x] 2.3 Update exact core-name, schema-footprint, and audience snapshots; exclude child `attach_file` search, load, and dispatch until an attachment handoff exists.
 
-## 3. Add Typed Native-Tool Correction
+## 3. Add a Closed Native-Tool Correction
 
 - [x] 3.1 Add `UseNativeTool` to the closed internal remediation code and one fixed shared presenter action.
-- [x] 3.2 Add an internal authorization correction outcome and typed `NativeToolSuggested` fact without changing public or durable contracts.
+- [x] 3.2 Add an internal authorization correction outcome and a closed `NativeToolSuggested` fact without changing public or durable contracts.
 - [x] 3.3 Detect the first exact policy-visible first-party executable occurrence from complete static ShellSyntaxTree analysis after hard-deny preflight and before shell policy, approval, or execution.
-- [x] 3.4 Exclude dynamic and unresolved identities, hidden or denied tools, MCP tools, `shell_execute`, and non-exact names without parsing private tool syntax.
+- [x] 3.4 Exclude dynamic and unresolved identities, hidden or denied tools (including child-static-denied registrations), MCP tools, `shell_execute`, and non-exact names without parsing private tool syntax.
 - [x] 3.5 Translate the correction through buffered, streaming, background, and child execution without starting a shell process or contacting approval.
 
 ## 4. Activate the Native Schema Safely
 
-- [x] 4.1 Carry one typed canonical exposure request in internal call-local result messages, separate from model-facing text and durable messages.
+- [x] 4.1 Carry one exposure fact with the exact registered tool name in call-local messages, separate from model-facing and durable messages.
 - [x] 4.2 Record the correction result before parent or child activation, then recheck registry and current exposure policy at the actor seam.
 - [x] 4.3 Prove Core activation is a no-op, Deferred activation reaches the next model request, and eventual native dispatch uses normal authorization.
 - [x] 4.4 Prove actor failure, recovery, and child completion do not persist or share correction-driven exposure.

--- a/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
@@ -2,6 +2,7 @@
 
 - [x] 0.1 Link the shared glossary and define the complete correction, exposure, authorization, and persistence flow.
 - [x] 0.2 Add exact positive, negative, parent, and child examples for the changed behavior.
+- [x] 0.3 Define policy visibility, native Netclaw tools, and skill resources. Add exact correction, source-order, authority, and exposure examples.
 
 ## 1. Freeze the Behavior Contract
 
@@ -36,6 +37,8 @@
 - [x] 5.3 Add protected-path and invalid-input precedence tests proving no correction or activation after a terminal preflight deny.
 - [x] 5.4 Add parent batch, parent streaming, parent background, and child tests proving no shell execution, no approval request, exact shared presentation, and next-request schema exposure.
 - [x] 5.5 Add direct-attachment tool-choice coverage proving no shell or file-mutation prelude is required.
+- [x] 5.6 Prove actor activation rejects a now-denied or missing registration.
+- [x] 5.7 Prove a compound correction prevents earlier shell side effects.
 
 ## 6. PII-Free Behavioral Evidence
 

--- a/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
@@ -36,11 +36,11 @@
 
 - [x] 6.1 Add deterministic synthetic cases for direct attachment and shell-to-native recovery; preserve a deferred-tool discovery case after `attach_file` becomes Core.
 - [x] 6.2 Run fixed baseline and treatment trials for direct attachment and shell-to-native recovery with fresh sessions.
-- [ ] 6.3 Publish only PII-free aggregate completion, tool-choice, shell-authored, shell-started, approval, activation, and correction-to-native metrics on the PR.
+- [x] 6.3 Publish only PII-free aggregate completion, tool-choice, shell-authored, shell-started, approval, activation, and correction-to-native metrics on the PR.
 
 ## 7. Delivery Gates
 
 - [x] 7.1 Run Release build and full tests with zero failures and warnings.
 - [x] 7.2 Run strict OpenSpec, headers, changed-file formatting, shell harness checks, diff check, and Slopwatch with zero findings.
-- [ ] 7.3 Perform a frozen-SHA adversarial review of authority, privacy, parent/child parity, and public/durable compatibility.
-- [ ] 7.4 Rebase on the refreshed #2046 head, push as the next stacked PR with GitHub CLI, apply relevant labels, and leave merge and auto-merge disabled.
+- [x] 7.3 Perform a frozen-SHA adversarial review of authority, privacy, parent/child parity, and public/durable compatibility.
+- [x] 7.4 Rebase on the refreshed #2046 head, push as the next stacked PR with GitHub CLI, apply relevant labels, and leave merge and auto-merge disabled.

--- a/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
+++ b/openspec/changes/prevent-native-tool-shell-mistakes/tasks.md
@@ -30,12 +30,12 @@
 - [x] 5.2 Add negatives for dynamic, unknown, fuzzy, path-qualified, hidden, denied, MCP, and `shell_execute` identities.
 - [x] 5.3 Add protected-path and invalid-input precedence tests proving no correction or activation after a terminal preflight deny.
 - [x] 5.4 Add parent batch, parent streaming, parent background, and child tests proving no shell execution, no approval request, exact shared presentation, and next-request schema exposure.
-- [ ] 5.5 Add direct-attachment tool-choice coverage proving no shell or file-mutation prelude is required.
+- [x] 5.5 Add direct-attachment tool-choice coverage proving no shell or file-mutation prelude is required.
 
 ## 6. PII-Free Behavioral Evidence
 
 - [x] 6.1 Add deterministic synthetic cases for direct attachment and shell-to-native recovery; preserve a deferred-tool discovery case after `attach_file` becomes Core.
-- [ ] 6.2 Run fixed baseline and treatment trials for direct attachment and shell-to-native recovery with fresh sessions.
+- [x] 6.2 Run fixed baseline and treatment trials for direct attachment and shell-to-native recovery with fresh sessions.
 - [ ] 6.3 Publish only PII-free aggregate completion, tool-choice, shell-authored, shell-started, approval, activation, and correction-to-native metrics on the PR.
 
 ## 7. Delivery Gates

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -39,6 +39,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
     private readonly RecordingSessionLifecycleObserver _lifecycleObserver = new();
     private readonly ControllableWorkingContextSnapshotProvider _workingContextSnapshots = new();
     private ToolRegistry _toolRegistry = null!;
+    private ToolConfig _toolConfig = null!;
 
     protected override bool VerifySerialization => true;
 
@@ -80,13 +81,13 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
             AIFunctionFactory.Create((string url) => "ok", "navigate_page", "Navigate to URL"),
             "browser_chrome_devtools",
             "navigate_page"));
-        var toolConfig = new ToolConfig();
-        toolConfig.AudienceProfiles.Public.AllowedMcpServers.Add("browser_chrome_devtools");
-        toolConfig.AudienceProfiles.Public.McpServerToolGrants = new Dictionary<string, List<string>>
+        _toolConfig = new ToolConfig();
+        _toolConfig.AudienceProfiles.Public.AllowedMcpServers.Add("browser_chrome_devtools");
+        _toolConfig.AudienceProfiles.Public.McpServerToolGrants = new Dictionary<string, List<string>>
         {
             ["browser_chrome_devtools"] = ["navigate_page"]
         };
-        var toolAccessPolicy = TestToolAccessPolicy.Create(toolConfig);
+        var toolAccessPolicy = TestToolAccessPolicy.Create(_toolConfig);
         registry.RegisterCore(new SearchToolsTool(registry, toolAccessPolicy));
         registry.RegisterCore(new LoadToolTool(registry, toolAccessPolicy));
 
@@ -973,6 +974,85 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         Assert.Equal(2, _fakeChatClient.ReceivedToolNames.Count);
         Assert.Equal(_fakeChatClient.ReceivedToolNames[0], _fakeChatClient.ReceivedToolNames[1]);
         Assert.Single(_fakeChatClient.ReceivedToolNames[1], static name => name == "load_tool");
+    }
+
+    [Fact]
+    public async Task Native_correction_does_not_expose_tool_denied_before_activation()
+    {
+        const string deferredToolName = "deferred_native_denied_before_activation";
+        _toolRegistry.Register(new DeferredTestTool(deferredToolName));
+        _fakeToolExecutor.BeforeCorrection = () =>
+        {
+            foreach (var profile in _toolConfig.AudienceProfiles.GetAllProfiles())
+            {
+                profile.ApprovalPolicy ??= new ToolApprovalConfig();
+                profile.ApprovalPolicy.ToolOverrides[deferredToolName] = ToolApprovalMode.Deny;
+            }
+        };
+
+        var nextRequestTools = await RunNativeCorrectionTurnAsync(
+            "native-correction-policy-change",
+            deferredToolName);
+
+        Assert.DoesNotContain(deferredToolName, nextRequestTools);
+    }
+
+    [Fact]
+    public async Task Native_correction_does_not_expose_missing_registration()
+    {
+        const string missingToolName = "missing_native_registration";
+
+        var nextRequestTools = await RunNativeCorrectionTurnAsync(
+            "native-correction-missing-registration",
+            missingToolName);
+
+        Assert.DoesNotContain(missingToolName, nextRequestTools);
+    }
+
+    private async Task<IReadOnlyList<string>> RunNativeCorrectionTurnAsync(
+        string sessionSuffix,
+        string toolName)
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-" + sessionSuffix,
+                "shell_execute",
+                new Dictionary<string, object?> { ["command"] = toolName })
+        ];
+        _fakeToolExecutor.Corrections["shell_execute"] =
+            new ToolAgentCorrection.NativeToolSuggested(new ToolName(toolName));
+
+        var sessionId = new SessionId("channel-discovery/" + sessionSuffix);
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe(sessionSuffix + "-sub");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use the named native tool."
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, _fakeChatClient.ReceivedToolNames.Count);
+        return _fakeChatClient.ReceivedToolNames[1];
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -38,6 +38,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
     private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.Parse("2026-03-21T12:00:00Z"));
     private readonly RecordingSessionLifecycleObserver _lifecycleObserver = new();
     private readonly ControllableWorkingContextSnapshotProvider _workingContextSnapshots = new();
+    private ToolRegistry _toolRegistry = null!;
 
     protected override bool VerifySerialization => true;
 
@@ -74,6 +75,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
             Microsoft.Extensions.Logging.Abstractions.NullLogger<SQLiteMemoryRecallCoordinator>.Instance));
 
         var registry = new ToolRegistry();
+        _toolRegistry = registry;
         registry.Register(new McpToolAdapter(
             AIFunctionFactory.Create((string url) => "ok", "navigate_page", "Navigate to URL"),
             "browser_chrome_devtools",
@@ -843,6 +845,134 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
             ["load_tool", "search_tools"],
             _fakeChatClient.ReceivedToolNames[0].OrderBy(static name => name, StringComparer.Ordinal));
         Assert.DoesNotContain("browser_chrome_devtools__navigate_page", _fakeChatClient.ReceivedToolNames[0]);
+    }
+
+    [Fact]
+    public async Task Native_correction_exposes_deferred_tool_on_next_request_but_not_after_recovery()
+    {
+        const string deferredToolName = "deferred_native_probe";
+        _toolRegistry.Register(new DeferredTestTool(deferredToolName));
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-native-correction",
+                "shell_execute",
+                new Dictionary<string, object?> { ["command"] = $"{deferredToolName} --inspect" })
+        ];
+        _fakeToolExecutor.Corrections["shell_execute"] =
+            new ToolAgentCorrection.NativeToolSuggested(new ToolName(deferredToolName));
+
+        var sessionId = new SessionId("channel-discovery/native-correction-recovery");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("native-correction-recovery-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Inspect with the native tool."
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        var correction = await subscriber.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(deferredToolName, _fakeChatClient.ReceivedToolNames[0]);
+        Assert.Contains(deferredToolName, _fakeChatClient.ReceivedToolNames[1]);
+        Assert.Contains(deferredToolName, correction.Result, StringComparison.Ordinal);
+        var recordedCorrection = _fakeChatClient.ReceivedMessages[1]
+            .SelectMany(static message => message.Contents.OfType<FunctionResultContent>())
+            .Single(result => result.CallId == "call-native-correction");
+        Assert.Equal(correction.Result, recordedCorrection.Result?.ToString());
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}")
+            .ResolveOne(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        Watch(child);
+        Sys.Stop(child);
+        await ExpectTerminatedAsync(child, cancellationToken: TestContext.Current.CancellationToken);
+
+        var recoveredSubscriber = CreateTestProbe("native-correction-recovered-sub");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(recoveredSubscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await recoveredSubscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Continue after recovery."
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await recoveredSubscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await recoveredSubscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(deferredToolName, _fakeChatClient.ReceivedToolNames[^1]);
+    }
+
+    [Fact]
+    public async Task Native_correction_for_core_tool_does_not_duplicate_schema()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(
+                "call-core-correction",
+                "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "load_tool --help" })
+        ];
+        _fakeToolExecutor.Corrections["shell_execute"] =
+            new ToolAgentCorrection.NativeToolSuggested(new ToolName("load_tool"));
+
+        var sessionId = new SessionId("channel-discovery/native-core-noop");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("native-core-noop-sub");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(cancellationToken: TestContext.Current.CancellationToken);
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Inspect the loader."
+        }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(6),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, _fakeChatClient.ReceivedToolNames.Count);
+        Assert.Equal(_fakeChatClient.ReceivedToolNames[0], _fakeChatClient.ReceivedToolNames[1]);
+        Assert.Single(_fakeChatClient.ReceivedToolNames[1], static name => name == "load_tool");
     }
 
     [Fact]
@@ -1825,6 +1955,23 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         ReceivedAt = _timeProvider.GetUtcNow(),
         ReminderId = new ReminderId(reminderId)
     };
+}
+
+internal sealed class DeferredTestTool(string name) : INetclawTool
+{
+    private readonly AIFunction _function = AIFunctionFactory.Create(() => "ok", name, "Deferred test tool");
+
+    public string Name { get; } = name;
+    public LlmFacingToolName LlmFacingName { get; } = LlmFacingToolName.FromCanonical(name);
+    public string Description => "Deferred test tool";
+    public string GrantCategory => "builtin";
+    public JsonElement ParameterSchema => default;
+    public AITool ToAITool() => _function;
+
+    public Task<string> ExecuteAsync(
+        IDictionary<string, object?>? arguments,
+        ToolInvocationContext context,
+        CancellationToken ct = default) => Task.FromResult("ok");
 }
 
 /// <summary>

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -259,6 +259,86 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         Assert.Equal(1, executor.Attempts);
     }
 
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task Native_tool_correction_bypasses_approval_and_background_dispatch(
+        bool streamResults,
+        bool background)
+    {
+        var executor = new NativeToolCorrectionExecutor();
+        var resultProbe = CreateTestProbe("native-correction-result");
+        var jobManagerProbe = CreateTestProbe("native-correction-job-manager");
+        var approvals = new List<ToolInteractionRequest>();
+        var arguments = new Dictionary<string, object?>
+        {
+            ["command"] = "file_read README.md"
+        };
+        if (background)
+        {
+            arguments["_background"] = true;
+            arguments["_rationale"] = "read later";
+        }
+
+        var fixture = new SessionToolPipelineTestFixture(
+                executor,
+                [new FunctionCallContent("call-native-correction", "shell_execute", arguments)],
+                new SessionId("D1/native-tool-correction"),
+                resultProbe.Ref)
+            .WithBackgroundJobs(jobManagerProbe.Ref)
+            .WithApprovals(
+                new ApprovalChannel(),
+                request => approvals.Add(request.Request),
+                Timeout.InfiniteTimeSpan);
+        if (streamResults)
+            fixture.StreamingResults();
+
+        var pipelineTask = fixture.ExecuteAsync(TestContext.Current.CancellationToken);
+        ToolCallResult result;
+        if (streamResults)
+        {
+            result = (await resultProbe.ExpectMsgAsync<ToolExecutionSingleCompleted>(
+                TimeSpan.FromSeconds(3),
+                cancellationToken: TestContext.Current.CancellationToken)).Result;
+            await resultProbe.ExpectMsgAsync<ToolExecutionBatchCompleted>(
+                TimeSpan.FromSeconds(3),
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+        else
+        {
+            var completed = await resultProbe.ExpectMsgAsync<ToolExecutionCompleted>(
+                TimeSpan.FromSeconds(3),
+                cancellationToken: TestContext.Current.CancellationToken);
+            var message = Assert.Single(completed.ToolResults);
+            var request = Assert.Single(completed.ToolExposureRequests);
+            result = new ToolCallResult(
+                message,
+                [],
+                [],
+                [],
+                [],
+                Receipt: completed.ToolReceipts[message.ToolCallId!.Value.Value],
+                ExposureRequest: request.Value);
+        }
+
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            "Shell execution stopped because 'file_read' is a native Netclaw tool.\n" +
+            "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
+            result.Message.Content);
+        Assert.Equal(ToolInvocationOutcomeCategory.RecoverableCorrection, result.Receipt?.Category);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, result.Receipt?.RemediationCode);
+        Assert.Equal("file_read", result.ExposureRequest?.ToolName.Value);
+        Assert.Empty(approvals);
+        Assert.Equal(background ? 1 : 0, executor.AuthorizationAttempts);
+        Assert.Equal(background ? 0 : 1, executor.ExecutionBoundaryAttempts);
+        await jobManagerProbe.ExpectNoMsgAsync(
+            TimeSpan.FromMilliseconds(200),
+            cancellationToken: TestContext.Current.CancellationToken);
+    }
+
     [Fact]
     public async Task Streaming_result_is_presented_before_delivery()
     {
@@ -1172,6 +1252,34 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
                 remediationCode: ToolRemediationCode.SetWorkingDirectory));
             return Task.FromResult("Error: invalid_context: No project or session directory is available.");
         }
+    }
+
+    private sealed class NativeToolCorrectionExecutor : IToolExecutor
+    {
+        public int AuthorizationAttempts { get; private set; }
+
+        public int ExecutionBoundaryAttempts { get; private set; }
+
+        public Task AuthorizeAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+        {
+            AuthorizationAttempts++;
+            throw CreateCorrection();
+        }
+
+        public Task<string> ExecuteAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+        {
+            ExecutionBoundaryAttempts++;
+            throw CreateCorrection();
+        }
+
+        private static ToolAgentCorrectionRequiredException CreateCorrection()
+            => new(new ToolAgentCorrection.NativeToolSuggested(new ToolName("file_read")));
     }
 
     private sealed class ScratchCorrectionRequiredExecutor : IToolExecutor

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -614,6 +614,99 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
     }
 
     [Fact]
+    public async Task Child_shell_correction_does_not_expose_statically_denied_tools()
+    {
+        var shellProbe = new RecordingContextTool(ShellTool.ToolName, "shell must not run", "shell");
+        _toolRegistry.Register(shellProbe);
+        _clientProvider.Main.ToolCallsOnFirstCall =
+        [
+            CreateToolCall(
+                "call-denied-native-spawn",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Check denied native tool names through the shell."
+                })
+        ];
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-shell-attach",
+                ShellTool.ToolName,
+                new Dictionary<string, object?> { ["command"] = "attach_file" }),
+            CreateToolCall(
+                "call-shell-spawn",
+                ShellTool.ToolName,
+                new Dictionary<string, object?> { ["command"] = "spawn_agent" })
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue([new TextContent("Child completed.")]);
+
+        var sessionId = new SessionId("console/subagent-denied-native-correction");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-denied-native-correction-events");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var source = BuildPersonalSource();
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use a child to check denied native tool names.",
+            Source = source
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SubAgentOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        for (var i = 0; i < 2; i++)
+        {
+            var approval = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+                TimeSpan.FromSeconds(3),
+                cancellationToken: TestContext.Current.CancellationToken);
+            Assert.Equal(ShellTool.ToolName, approval.ToolName.Value);
+            var denied = await sessionManager.Ask<ISessionResponse>(new ToolInteractionResponse
+            {
+                SessionId = sessionId,
+                CallId = approval.CallId,
+                SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.Deny),
+                SenderId = source.SenderId!
+            }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.IsType<CommandAck>(denied);
+        }
+        await ExpectTurnCompletedAsync(
+            subscriber,
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        var resultMessages = _clientProvider.Compaction.ReceivedMessages[1];
+        Assert.DoesNotContain(
+            "native Netclaw tool",
+            GetToolResult(resultMessages, "call-shell-attach"),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "native Netclaw tool",
+            GetToolResult(resultMessages, "call-shell-spawn"),
+            StringComparison.Ordinal);
+        Assert.False(shellProbe.WasCalled);
+        Assert.All(
+            _clientProvider.Compaction.ReceivedToolNames,
+            names =>
+            {
+                Assert.DoesNotContain("attach_file", names);
+                Assert.DoesNotContain("spawn_agent", names);
+            });
+    }
+
+    [Fact]
     public async Task Loaded_child_tool_does_not_transfer_to_the_next_child()
     {
         RegisterSyntheticMcpCatalog();

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -214,6 +214,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
         registry.RegisterCore(new SpawnAgentTool(subAgentRegistry, spawner, subAgentPaths));
         registry.RegisterCore(new SearchToolsTool(registry, toolAccessPolicy));
         registry.RegisterCore(new LoadToolTool(registry, toolAccessPolicy));
+        registry.RegisterCore(new AttachFileTool(toolConfig, subAgentPaths, new ToolPathPolicy([])));
         _recordingFileReadTool = new RecordingContextTool("file_read", "stub file content", "file");
         registry.RegisterCore(_recordingFileReadTool);
         _recordingApprovalTool = new RecordingContextTool(ApprovalProbeToolName, "approval ok");
@@ -323,8 +324,10 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             .OrderBy(static name => name, StringComparer.Ordinal)
             .ToList();
         Assert.Equal(
-            mainToolNames.Where(static name => name != "spawn_agent"),
+            mainToolNames.Where(static name => name is not "attach_file" and not "spawn_agent"),
             childToolNames);
+        Assert.Contains("attach_file", mainToolNames);
+        Assert.DoesNotContain("attach_file", childToolNames);
     }
 
     [Fact]
@@ -521,7 +524,19 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             CreateToolCall(
                 "call-load-hidden",
                 "load_tool",
-                new Dictionary<string, object?> { ["Name"] = HiddenSpecialtyToolName })
+                new Dictionary<string, object?> { ["Name"] = HiddenSpecialtyToolName }),
+            CreateToolCall(
+                "call-search-attach",
+                "search_tools",
+                new Dictionary<string, object?> { ["Query"] = "attach_file" }),
+            CreateToolCall(
+                "call-load-attach",
+                "load_tool",
+                new Dictionary<string, object?> { ["Name"] = "attach_file" }),
+            CreateToolCall(
+                "call-dispatch-attach",
+                "attach_file",
+                new Dictionary<string, object?> { ["Path"] = "report.txt" })
         ]);
 
         var sessionId = new SessionId("console/subagent-policy-boundaries");
@@ -571,6 +586,17 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             $"Tool '{HiddenSpecialtyToolName}' not found.",
             GetToolResult(resultMessages, "call-load-hidden"),
             StringComparison.Ordinal);
+        Assert.StartsWith(
+            "No tools found matching",
+            GetToolResult(resultMessages, "call-search-attach"),
+            StringComparison.Ordinal);
+        Assert.StartsWith(
+            "Tool 'attach_file' not found.",
+            GetToolResult(resultMessages, "call-load-attach"),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            "Unknown tool: attach_file",
+            GetToolResult(resultMessages, "call-dispatch-attach"));
 
         Assert.NotNull(_recordingHiddenTool);
         Assert.False(_recordingHiddenTool!.WasCalled);
@@ -579,6 +605,7 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             names =>
             {
                 Assert.DoesNotContain("spawn_agent", names);
+                Assert.DoesNotContain("attach_file", names);
                 Assert.DoesNotContain(HiddenSpecialtyToolName, names);
                 Assert.Equal(
                     ["file_read", "load_tool", "search_tools"],
@@ -666,6 +693,126 @@ public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
             ["file_read", "load_tool", "search_tools"],
             _clientProvider.Compaction.ReceivedToolNames[2]
                 .OrderBy(static name => name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task Child_native_correction_exposes_one_tool_only_until_child_completion()
+    {
+        const string deferredToolName = ApprovalProbeToolName;
+        var shellProbe = new RecordingContextTool("shell_execute", "shell must not run", "shell");
+        _toolRegistry.Register(shellProbe);
+
+        _clientProvider.Main.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-native-child-spawn-1",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Inspect with the native probe."
+                })
+        ]);
+        _clientProvider.Main.PlannedResponses.Enqueue([new TextContent("First child returned.")]);
+        _clientProvider.Main.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-native-child-spawn-2",
+                "spawn_agent",
+                new Dictionary<string, object?>
+                {
+                    ["agent"] = "summarizer",
+                    ["task"] = "Start without inherited tools."
+                })
+        ]);
+        _clientProvider.Main.PlannedResponses.Enqueue([new TextContent("Second child returned.")]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-native-child-correction",
+                "shell_execute",
+                new Dictionary<string, object?>
+                {
+                    ["command"] = $"{deferredToolName} --inspect"
+                })
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue(
+        [
+            CreateToolCall(
+                "call-native-child-authorization",
+                deferredToolName,
+                new Dictionary<string, object?>())
+        ]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue([new TextContent("First child completed.")]);
+        _clientProvider.Compaction.PlannedResponses.Enqueue([new TextContent("Fresh child completed.")]);
+
+        var sessionId = new SessionId("console/subagent-native-correction-isolation");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("subagent-native-correction-events");
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var source = BuildPersonalSource();
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run the correcting child.",
+            Source = source
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SubAgentOutput>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        var approval = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(deferredToolName, approval.ToolName.Value);
+        var denied = await sessionManager.Ask<ISessionResponse>(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = approval.CallId,
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.Deny),
+            SenderId = source.SenderId!
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.IsType<CommandAck>(denied);
+        await ExpectTurnCompletedAsync(
+            subscriber,
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run a fresh child.",
+            Source = source
+        }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        await ExpectTurnCompletedAsync(
+            subscriber,
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(_clientProvider.Compaction.ReceivedToolNames.Count >= 4);
+        Assert.DoesNotContain(deferredToolName, _clientProvider.Compaction.ReceivedToolNames[0]);
+        Assert.Contains(deferredToolName, _clientProvider.Compaction.ReceivedToolNames[1]);
+        Assert.Contains(deferredToolName, _clientProvider.Compaction.ReceivedToolNames[2]);
+        Assert.DoesNotContain(deferredToolName, _clientProvider.Compaction.ReceivedToolNames[^1]);
+        Assert.False(shellProbe.WasCalled);
+        Assert.NotNull(_recordingApprovalTool);
+        Assert.False(_recordingApprovalTool!.WasCalled);
+        var correction = GetToolResult(
+            _clientProvider.Compaction.ReceivedMessages[1],
+            "call-native-child-correction");
+        Assert.Equal(
+            $"Shell execution stopped because '{deferredToolName}' is a native Netclaw tool.\n" +
+            "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
+            correction);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -453,11 +453,16 @@ internal sealed class FakeToolExecutor : IToolExecutor
 
     public Dictionary<string, ToolInvocationReceipt> Receipts { get; } = [];
 
+    public Dictionary<string, ToolAgentCorrection> Corrections { get; } = [];
+
     /// <summary>Tool names that should throw on execution.</summary>
     public HashSet<string> FailForTools { get; } = [];
 
     public Task AuthorizeAsync(FunctionCallContent toolCall, Netclaw.Tools.ToolExecutionContext context, CancellationToken ct = default)
     {
+        if (Corrections.TryGetValue(toolCall.Name, out var correction))
+            throw new ToolAgentCorrectionRequiredException(correction);
+
         if (FailForTools.Contains(toolCall.Name))
             throw new InvalidOperationException($"Tool '{toolCall.Name}' failed (simulated)");
 
@@ -467,6 +472,9 @@ internal sealed class FakeToolExecutor : IToolExecutor
     public async Task<string> ExecuteAsync(FunctionCallContent toolCall, Netclaw.Tools.ToolExecutionContext context, CancellationToken ct = default)
     {
         Interlocked.Increment(ref _callCount);
+
+        if (Corrections.TryGetValue(toolCall.Name, out var correction))
+            throw new ToolAgentCorrectionRequiredException(correction);
 
         if (FailForTools.Contains(toolCall.Name))
         {

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -455,13 +455,18 @@ internal sealed class FakeToolExecutor : IToolExecutor
 
     public Dictionary<string, ToolAgentCorrection> Corrections { get; } = [];
 
+    public Action? BeforeCorrection { get; set; }
+
     /// <summary>Tool names that should throw on execution.</summary>
     public HashSet<string> FailForTools { get; } = [];
 
     public Task AuthorizeAsync(FunctionCallContent toolCall, Netclaw.Tools.ToolExecutionContext context, CancellationToken ct = default)
     {
         if (Corrections.TryGetValue(toolCall.Name, out var correction))
+        {
+            BeforeCorrection?.Invoke();
             throw new ToolAgentCorrectionRequiredException(correction);
+        }
 
         if (FailForTools.Contains(toolCall.Name))
             throw new InvalidOperationException($"Tool '{toolCall.Name}' failed (simulated)");
@@ -474,7 +479,10 @@ internal sealed class FakeToolExecutor : IToolExecutor
         Interlocked.Increment(ref _callCount);
 
         if (Corrections.TryGetValue(toolCall.Name, out var correction))
+        {
+            BeforeCorrection?.Invoke();
             throw new ToolAgentCorrectionRequiredException(correction);
+        }
 
         if (FailForTools.Contains(toolCall.Name))
         {

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -292,6 +292,10 @@ public class SubAgentActorTests : TestKit
             "You are a test agent.",
             "[Skill Overlay]",
             "[Subagent Execution Contract]");
+        Assert.Contains(
+            "Return each authorized file path that the parent session should deliver.",
+            systemPrompt,
+            StringComparison.Ordinal);
         Assert.EndsWith(
             "Always end by emitting a final output for the parent session.",
             systemPrompt.TrimEnd(),

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3803,6 +3803,39 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
+    public async Task Compound_native_tool_correction_executes_no_earlier_command()
+    {
+        var root = Directory.CreateTempSubdirectory("netclaw-native-compound-");
+        try
+        {
+            var markerPath = Path.Combine(root.FullName, "sentinel.txt");
+            var quotedMarkerPath = ShellEnvironment.Grammar == ShellGrammar.PowerShell
+                ? markerPath.Replace("'", "''", StringComparison.Ordinal)
+                : markerPath.Replace("'", "'\"'\"'", StringComparison.Ordinal);
+            var command = ShellEnvironment.Grammar == ShellGrammar.PowerShell
+                ? $"Set-Content -LiteralPath '{quotedMarkerPath}' -Value marker; file_read report.txt"
+                : $"printf marker > '{markerPath}'; file_read report.txt";
+            var call = CreateToolCall(
+                "call-native-compound-no-partial-execution",
+                ShellTool.ToolName,
+                ToolInput.Create("Command", command));
+            var context = CreateInteractivePersonalContext(
+                "signalr/native-compound-no-partial-execution");
+
+            var exception = await Assert.ThrowsAsync<ToolAgentCorrectionRequiredException>(() =>
+                _executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken));
+
+            var correction = Assert.IsType<ToolAgentCorrection.NativeToolSuggested>(exception.Correction);
+            Assert.Equal("file_read", correction.ToolName.Value);
+            Assert.False(File.Exists(markerPath));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Shell_hard_deny_precedes_native_tool_correction()
     {
         var approvalService = new FixedShellApprovalService(_ =>

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3802,37 +3802,40 @@ public class DispatchingToolExecutorTests
         Assert.Equal(0, approvalService.RequestCount);
     }
 
-    [Fact]
-    public async Task Compound_native_tool_correction_executes_no_earlier_command()
+    [Theory]
+    [InlineData(ShellGrammar.Bash, "printf marker; file_read --path report.txt")]
+    [InlineData(ShellGrammar.PowerShell, "Write-Output marker; file_read -Path report.txt")]
+    public async Task Compound_native_tool_correction_executes_no_earlier_command(
+        ShellGrammar grammar,
+        string command)
     {
-        var root = Directory.CreateTempSubdirectory("netclaw-native-compound-");
-        try
-        {
-            var markerPath = Path.Combine(root.FullName, "sentinel.txt");
-            var quotedMarkerPath = ShellEnvironment.Grammar == ShellGrammar.PowerShell
-                ? markerPath.Replace("'", "''", StringComparison.Ordinal)
-                : markerPath.Replace("'", "'\"'\"'", StringComparison.Ordinal);
-            var command = ShellEnvironment.Grammar == ShellGrammar.PowerShell
-                ? $"Set-Content -LiteralPath '{quotedMarkerPath}' -Value marker; file_read report.txt"
-                : $"printf marker > '{markerPath}'; file_read report.txt";
-            var call = CreateToolCall(
-                "call-native-compound-no-partial-execution",
-                ShellTool.ToolName,
-                ToolInput.Create("Command", command));
-            var context = CreateInteractivePersonalContext(
-                "signalr/native-compound-no-partial-execution");
+        var environment = grammar == ShellGrammar.PowerShell
+            ? ShellExecutionEnvironment.CreatePowerShell(
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                PwshDialect.PowerShell7)
+            : ShellExecutionEnvironmentDefaults.Bash;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        var registeredShell = Assert.IsAssignableFrom<INetclawTool>(
+            registry.GetByName(ShellTool.ToolName));
+        var recordingShell = new RecordingTool(registeredShell);
+        registry.ReplaceCore(recordingShell);
+        var executor = new DispatchingToolExecutor(
+            registry,
+            policy,
+            GrantEveryShellCandidate());
+        var call = CreateToolCall(
+            "call-native-compound-no-partial-execution",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", command));
+        var context = CreateInteractivePersonalContext(
+            "signalr/native-compound-no-partial-execution");
 
-            var exception = await Assert.ThrowsAsync<ToolAgentCorrectionRequiredException>(() =>
-                _executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken));
+        var exception = await Assert.ThrowsAsync<ToolAgentCorrectionRequiredException>(() =>
+            executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken));
 
-            var correction = Assert.IsType<ToolAgentCorrection.NativeToolSuggested>(exception.Correction);
-            Assert.Equal("file_read", correction.ToolName.Value);
-            Assert.False(File.Exists(markerPath));
-        }
-        finally
-        {
-            root.Delete(recursive: true);
-        }
+        var correction = Assert.IsType<ToolAgentCorrection.NativeToolSuggested>(exception.Correction);
+        Assert.Equal("file_read", correction.ToolName.Value);
+        Assert.False(recordingShell.WasCalled);
     }
 
     [Fact]
@@ -4130,6 +4133,30 @@ public class DispatchingToolExecutorTests
     {
         public bool IsShellWritePathAuthorized(string fullPath, ToolInvocationContext context)
             => true;
+    }
+
+    private sealed class RecordingTool(INetclawTool inner) : INetclawTool
+    {
+        public string Name => inner.Name;
+        public LlmFacingToolName LlmFacingName => inner.LlmFacingName;
+        public string Description => inner.Description;
+        public string GrantCategory => inner.GrantCategory;
+        public ToolLivenessMode LivenessMode => inner.LivenessMode;
+        public int InlineOutputBudgetChars => inner.InlineOutputBudgetChars;
+        public bool SuppressOutputRedaction => inner.SuppressOutputRedaction;
+        public System.Text.Json.JsonElement ParameterSchema => inner.ParameterSchema;
+        public bool WasCalled { get; private set; }
+
+        public AITool ToAITool() => inner.ToAITool();
+
+        public Task<string> ExecuteAsync(
+            IDictionary<string, object?>? arguments,
+            ToolInvocationContext context,
+            CancellationToken ct = default)
+        {
+            WasCalled = true;
+            return Task.FromResult("recorded shell execution");
+        }
     }
 
     public static bool IsPosix => !OperatingSystem.IsWindows();

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3613,6 +3613,266 @@ public class DispatchingToolExecutorTests
             logger: logger);
     }
 
+    [Theory]
+    [InlineData("file_read")]
+    [InlineData("file_read --path notes.txt")]
+    [InlineData("echo ignored | file_read --path notes.txt")]
+    [InlineData("echo ignored && file_read --path notes.txt")]
+    [InlineData("file_read > result.txt")]
+    public void Detector_accepts_complete_static_bash_occurrences(string command)
+    {
+        var environment = ShellExecutionEnvironmentDefaults.Bash;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(command, "/workspace");
+        var context = CreateInteractivePersonalContext("signalr/native-detector-bash");
+
+        var correction = NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+
+        Assert.NotNull(correction);
+        Assert.Equal("file_read", correction.ToolName.Value);
+    }
+
+    [Theory]
+    [InlineData("file_read")]
+    [InlineData("file_read -Path notes.txt")]
+    [InlineData("Write-Output ignored | file_read -Path notes.txt")]
+    [InlineData("Write-Output ignored; file_read -Path notes.txt")]
+    [InlineData("file_read -Path notes.txt *> result.txt")]
+    public void Detector_accepts_complete_static_power_shell_occurrences(string command)
+    {
+        var environment = ShellExecutionEnvironment.CreatePowerShell(
+            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            PwshDialect.PowerShell7);
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(command, "C:\\workspace");
+        var context = CreateInteractivePersonalContext("signalr/native-detector-pwsh");
+
+        var correction = NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+
+        Assert.NotNull(correction);
+        Assert.Equal("file_read", correction.ToolName.Value);
+    }
+
+    [Fact]
+    public void Detector_returns_first_exact_visible_native_tool_in_source_order()
+    {
+        var environment = ShellExecutionEnvironmentDefaults.Bash;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(
+            "file_write --path first && file_read --path second",
+            "/workspace");
+        var context = CreateInteractivePersonalContext("signalr/native-detector-order");
+
+        var correction = NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+
+        Assert.NotNull(correction);
+        Assert.Equal("file_write", correction.ToolName.Value);
+    }
+
+    [Fact]
+    public void Detector_keeps_wrapper_payload_before_later_outer_native_tool()
+    {
+        var environment = ShellExecutionEnvironmentDefaults.Bash;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(
+            "sudo bash -lc \"file_read\"; file_write",
+            "/workspace");
+        var context = CreateInteractivePersonalContext("signalr/native-detector-wrapper-order");
+
+        var correction = NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+
+        Assert.NotNull(correction);
+        Assert.Equal("file_read", correction.ToolName.Value);
+    }
+
+    [Theory]
+    [InlineData("FILE_READ")]
+    [InlineData("./file_read")]
+    [InlineData("unknown_tool")]
+    [InlineData("file_reed")]
+    [InlineData("shell_execute")]
+    [InlineData("echo $dynamic && file_read")]
+    [InlineData("echo 'unterminated && file_read")]
+    public void Detector_rejects_non_exact_dynamic_or_unresolved_occurrences(string command)
+    {
+        var environment = ShellExecutionEnvironmentDefaults.Bash;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(command, "/workspace");
+        var context = CreateInteractivePersonalContext("signalr/native-detector-negative");
+
+        var correction = NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+
+        Assert.Null(correction);
+    }
+
+    [Fact]
+    public void Detector_rejects_mcp_tools_even_when_the_authored_alias_is_exact()
+    {
+        var environment = ShellExecutionEnvironmentDefaults.Bash;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(environment);
+        registry.Register(new McpToolAdapter(
+            AIFunctionFactory.Create(() => "unused", "native_probe"),
+            "memorizer",
+            "native_probe",
+            invoker: new RecordingMcpToolInvoker("unused")));
+        var analysis = new ShellCommandAnalyzer(environment).Analyze(
+            "memorizer__native_probe",
+            "/workspace");
+        var context = CreateInteractivePersonalContext("signalr/native-detector-mcp");
+
+        var correction = NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+
+        Assert.Null(correction);
+    }
+
+    [Fact]
+    public void Detector_rejects_policy_hidden_native_tools()
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Team.AllowedTools = ["shell_execute"];
+
+        Assert.Null(DetectNativeToolForConfig(config, TrustAudience.Team));
+    }
+
+    [Fact]
+    public void Detector_rejects_policy_denied_native_tools()
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["file_read"] = ToolApprovalMode.Deny,
+            },
+        };
+        Assert.Null(DetectNativeToolForConfig(config, TrustAudience.Personal));
+    }
+
+    [Fact]
+    public async Task Native_tool_correction_precedes_approval_and_execution()
+    {
+        var approvalService = new FixedShellApprovalService(_ =>
+            throw new InvalidOperationException("Native correction must precede approval matching."));
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = CreateToolCall(
+            "call-native-correction",
+            "shell_execute",
+            ToolInput.Create("Command", "file_read --path notes.txt"));
+        var context = CreateInteractivePersonalContext("signalr/native-correction");
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
+        var correction = Assert.IsType<ToolAgentCorrection.NativeToolSuggested>(decision.AgentCorrection);
+        Assert.Equal("file_read", correction.ToolName.Value);
+        Assert.Equal(0, approvalService.RequestCount);
+
+        var exception = await Assert.ThrowsAsync<ToolAgentCorrectionRequiredException>(() =>
+            executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
+        var thrownCorrection = Assert.IsType<ToolAgentCorrection.NativeToolSuggested>(exception.Correction);
+        Assert.Equal("file_read", thrownCorrection.ToolName.Value);
+        Assert.Null(context.Receipt);
+        Assert.Equal(0, approvalService.RequestCount);
+    }
+
+    [Fact]
+    public async Task Shell_hard_deny_precedes_native_tool_correction()
+    {
+        var approvalService = new FixedShellApprovalService(_ =>
+            throw new InvalidOperationException("Hard deny must precede approval matching."));
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = CreateToolCall(
+            "call-native-hard-deny",
+            "shell_execute",
+            ToolInput.Create("Command", "file_read && rm -rf /"));
+        var context = CreateInteractivePersonalContext("signalr/native-hard-deny");
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.StartsWith("hard_deny_", decision.DenyReason, StringComparison.Ordinal);
+        Assert.Null(decision.AgentCorrection);
+        Assert.Equal(0, approvalService.RequestCount);
+    }
+
+    [Fact]
+    public async Task Protected_path_deny_precedes_native_tool_correction()
+    {
+        var approvalService = new FixedShellApprovalService(_ =>
+            throw new InvalidOperationException("Protected-path denial must precede approval matching."));
+        var executor = CreateApprovalGatedShellExecutor(
+            approvalService,
+            deniedPaths: ["/protected"]);
+        var call = CreateToolCall(
+            "call-native-protected-path",
+            "shell_execute",
+            ToolInput.Create("Command", "file_read /protected/secret.txt"));
+        var context = CreateInteractivePersonalContext("signalr/native-protected-path");
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.Denied, decision.Outcome);
+        Assert.Equal("shell_references_protected_path", decision.DenyReason);
+        Assert.Null(decision.AgentCorrection);
+        Assert.Equal(0, approvalService.RequestCount);
+    }
+
+    [Fact]
+    public async Task Invalid_call_arguments_precede_native_tool_correction()
+    {
+        var approvalService = new FixedShellApprovalService(_ =>
+            throw new InvalidOperationException("Argument validation must precede approval matching."));
+        var executor = CreateApprovalGatedShellExecutor(approvalService);
+        var call = CreateToolCall(
+            "call-native-invalid-input",
+            "shell_execute",
+            ToolInput.Create("Command", "file_read", "_background", "not-a-boolean"));
+        var context = CreateInteractivePersonalContext("signalr/native-invalid-input");
+
+        var result = await executor.ExecuteAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("Meta argument '_background'", result, StringComparison.Ordinal);
+        Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
+        Assert.Null(context.Receipt?.RemediationCode);
+        Assert.Equal(0, approvalService.RequestCount);
+    }
+
     // Shared by CreateApprovalGatedShellExecutor and the one-time-approval
     // tests that construct DispatchingToolExecutor directly (those tests
     // pass approvalService themselves, or intentionally omit it to exercise
@@ -3791,6 +4051,47 @@ public class DispatchingToolExecutorTests
                 Audience = TrustAudience.Personal,
                 InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true)
             });
+
+    private static ToolAgentCorrection.NativeToolSuggested? DetectNativeToolForConfig(
+        ToolConfig config,
+        TrustAudience audience)
+    {
+        var environment = ShellExecutionEnvironmentDefaults.Bash;
+        var commandPolicy = new ShellCommandPolicy(environment);
+        var pathPolicy = new ToolPathPolicy(environment, []);
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            commandPolicy,
+            pathPolicy);
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(
+            config,
+            new NetclawPaths(),
+            pathPolicy,
+            commandPolicy,
+            toolAccessPolicy: TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
+        var analysis = new ShellCommandAnalyzer(environment).Analyze("file_read", "/workspace");
+        var context = TestToolExecutionContext.CreateBound(
+            "signalr/native-detector-visibility",
+            null,
+            new TestToolExecutionContextOptions
+            {
+                Audience = audience,
+                Boundary = audience is TrustAudience.Team ? TrustBoundary.Team : null,
+                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true),
+            });
+
+        return NativeToolShellCorrectionDetector.Detect(
+            analysis,
+            registry,
+            policy,
+            context.Invocation);
+    }
 
     private sealed class AllowAllShellTrustZonePolicy : IShellTrustZonePolicy
     {

--- a/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
@@ -43,6 +43,7 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
     [InlineData("TF05")]
     [InlineData("TF06")]
     [InlineData("TF07")]
+    [InlineData("TF08")]
     public async Task Sanitized_friction_case_replays_through_real_tool_boundaries(string caseId)
     {
         var policyCase = LoadCase(caseId);
@@ -91,6 +92,17 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
                 $"{caseId.ToLowerInvariant()}-{index}");
             var receipt = Assert.Single(completed.ToolReceipts).Value;
             Assert.Equal(ParseOutcome(policyCase.ExpectedOutcome), receipt.Category);
+            if (caseId == "TF08")
+            {
+                var attachment = Assert.Single(completed.FileAttachments);
+                Assert.StartsWith(
+                    Path.Combine(setup.SessionDirectory, "attachments"),
+                    attachment.FilePath,
+                    StringComparison.Ordinal);
+                Assert.Equal("synthetic report", await File.ReadAllTextAsync(
+                    attachment.FilePath,
+                    TestContext.Current.CancellationToken));
+            }
             current = WorkingContextUpdater.UpdateFromToolReceipts(
                 current,
                 completed.ToolResults,
@@ -214,7 +226,7 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
 
     private async Task AssertChildCatalogAsync(RuntimeSetup runtime, ScenarioSetup setup)
     {
-        const string attachToolName = "attach_file";
+        const string deferredToolName = "web_fetch";
         var client = new RecordingChatClient();
         client.PlannedResponses.Enqueue([setup.Calls[0]]);
         client.PlannedResponses.Enqueue([setup.Calls[1]]);
@@ -244,7 +256,7 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
                     scopeId: "signalr/tool-friction/subagent/fixture-agent/run",
                     sessionDirectory: setup.SessionDirectory,
                     projectDirectory: setup.ProjectDirectory),
-                Task = "Find and load the deferred attachment tool.",
+                Task = "Find and load the deferred page retrieval tool.",
                 Timeout = TimeSpan.FromSeconds(5)
             },
             TimeSpan.FromSeconds(10),
@@ -252,18 +264,21 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
 
         Assert.True(result.Success);
         Assert.Equal(3, client.ReceivedToolNames.Count);
-        var expectedCore = coreNames.OrderBy(static name => name, StringComparer.Ordinal).ToList();
+        var expectedCore = coreNames
+            .Where(SubAgentToolPolicy.IsAllowedForSubAgent)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
         Assert.Equal(expectedCore, client.ReceivedToolNames[0].OrderBy(static name => name, StringComparer.Ordinal));
         Assert.Equal(expectedCore, client.ReceivedToolNames[1].OrderBy(static name => name, StringComparer.Ordinal));
-        Assert.DoesNotContain(attachToolName, client.ReceivedToolNames[0]);
-        Assert.DoesNotContain(attachToolName, client.ReceivedToolNames[1]);
-        Assert.Contains(attachToolName, client.ReceivedToolNames[2]);
+        Assert.DoesNotContain(deferredToolName, client.ReceivedToolNames[0]);
+        Assert.DoesNotContain(deferredToolName, client.ReceivedToolNames[1]);
+        Assert.Contains(deferredToolName, client.ReceivedToolNames[2]);
         Assert.Contains(
-            attachToolName,
+            deferredToolName,
             GetToolResult(client.ReceivedMessages[1], setup.Calls[0].CallId),
             StringComparison.Ordinal);
         Assert.Equal(
-            attachToolName,
+            deferredToolName,
             GetToolResult(client.ReceivedMessages[2], setup.Calls[1].CallId));
     }
 
@@ -297,6 +312,7 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
             "TF05" => await SpillContinuationAsync(project, session, seed, denied, cancellationToken),
             "TF06" => FailedFileActivity(project, session, seed, denied),
             "TF07" => SubagentCatalogExposure(project, session, seed, denied),
+            "TF08" => await DirectAttachmentAsync(project, session, seed, denied, cancellationToken),
             _ => throw new InvalidOperationException($"Unsupported fixture case: {policyCase.Id}")
         };
     }
@@ -408,10 +424,35 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
             seed,
             denied,
             [
-                Call("search-tools", "search_tools", "Query", "attach local file"),
-                Call("load-tool", "load_tool", "Name", "attach_file")
+                Call("search-tools", "search_tools", "Query", "retrieve page content"),
+                Call("load-tool", "load_tool", "Name", "web_fetch")
             ],
             fallback: null);
+
+    private static async Task<ScenarioSetup> DirectAttachmentAsync(
+        string project,
+        string session,
+        string seed,
+        string denied,
+        CancellationToken cancellationToken)
+    {
+        var report = Path.Join(project, "report.txt");
+        await File.WriteAllTextAsync(report, "synthetic report", cancellationToken);
+        return Setup(
+            project,
+            session,
+            seed,
+            denied,
+            [Call("attach-report", "attach_file", "Path", "report.txt")],
+            Call(
+                "copy-before-attach",
+                ShellTool.ToolName,
+                "Command",
+                "cp report.txt ../sessions/current/report.txt",
+                "WorkingDirectory",
+                project),
+            [report]);
+    }
 
     private static ScenarioSetup Setup(
         string project,

--- a/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolFrictionReplayTests.cs
@@ -96,7 +96,7 @@ public sealed class ToolFrictionReplayTests(ITestOutputHelper output) : TestKit(
             {
                 var attachment = Assert.Single(completed.FileAttachments);
                 Assert.StartsWith(
-                    Path.Combine(setup.SessionDirectory, "attachments"),
+                    Path.Join(setup.SessionDirectory, "attachments"),
                     attachment.FilePath,
                     StringComparison.Ordinal);
                 Assert.Equal("synthetic report", await File.ReadAllTextAsync(

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
@@ -1,5 +1,6 @@
 ﻿{
   Names: [
+    attach_file,
     file_edit,
     file_list,
     file_read,
@@ -14,7 +15,7 @@
     tool_output_read
   ],
   Footprint: {
-    Count: 12,
-    SerializedDefinitionBytes: 15192
+    Count: 13,
+    SerializedDefinitionBytes: 16194
   }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.cs
@@ -40,6 +40,39 @@ public class ToolRegistrationExtensionsTests
         return Verifier.Verify(snapshot);
     }
 
+    [Theory]
+    [InlineData(TrustAudience.Public)]
+    [InlineData(TrustAudience.Team)]
+    [InlineData(TrustAudience.Personal)]
+    public void Attach_file_is_core_without_bypassing_default_audience_policy(TrustAudience audience)
+    {
+        var registry = CreateFullFirstPartyRegistry();
+        var tool = Assert.IsType<AttachFileTool>(registry.GetByName("attach_file"));
+        var policy = CreateAccessPolicy(new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed });
+
+        Assert.True(registry.IsCoreTool(tool.Name));
+        Assert.True(policy.IsToolExposed(tool, audience));
+    }
+
+    [Fact]
+    public void Attach_file_core_is_hidden_by_an_audience_deny_override()
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Team.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["attach_file"] = ToolApprovalMode.Deny
+            }
+        };
+        var registry = CreateFullFirstPartyRegistry();
+        var tool = Assert.IsType<AttachFileTool>(registry.GetByName("attach_file"));
+        var policy = CreateAccessPolicy(config);
+
+        Assert.True(registry.IsCoreTool(tool.Name));
+        Assert.False(policy.IsToolExposed(tool, TrustAudience.Team));
+    }
+
     [Fact]
     public void Registration_defaults_to_deferred_and_core_replacement_is_explicit()
     {
@@ -94,15 +127,7 @@ public class ToolRegistrationExtensionsTests
     {
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), "netclaw-core-tool-contract"));
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
-        var policy = new ToolAccessPolicy(
-            config,
-            new EffectivePolicyDefaults(
-                DeploymentPosture.Personal,
-                TrustAudience.Personal,
-                ShellExecutionMode.HostAllowed,
-                UsedStrictFallback: false),
-            new ShellCommandPolicy(),
-            new ToolPathPolicy([]));
+        var policy = CreateAccessPolicy(config);
         var registry = new ToolRegistry();
         registry.WithFirstPartyTools(
             config,
@@ -132,6 +157,17 @@ public class ToolRegistrationExtensionsTests
 
         return registry;
     }
+
+    private static ToolAccessPolicy CreateAccessPolicy(ToolConfig config) =>
+        new(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
 
     private static string[] GetFunctionNames(IReadOnlyList<AITool> tools) =>
         tools

--- a/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
@@ -25,6 +25,10 @@ public class ToolRemediationPresenterTests
         {
             nameof(ToolRemediationCode.ProvideUniqueOldString),
             "Next action: retry file_edit with a unique OldString, or set ReplaceAll=true when every match should change."
+        },
+        {
+            nameof(ToolRemediationCode.UseNativeTool),
+            "Next action: call the native Netclaw tool named in this result directly instead of shell_execute."
         }
     };
 

--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -545,7 +545,7 @@ public class WebFetchToolTests : IDisposable
         Assert.Contains(".png", result);
         Assert.Contains("Content-Type: image/png", result);
         Assert.Contains("binary file", result);
-        Assert.Contains("attach_file", result);
+        Assert.Contains("available file-delivery tool", result);
 
         var files = Directory.GetFiles(_dir.Path, "*.png");
         Assert.Single(files);

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -82,9 +82,12 @@ internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeed
     public List<SessionScratchCorrectionChange> ScratchCorrectionChanges { get; init; } = [];
     public Dictionary<string, string> ToolFailureCodes { get; init; } = new(StringComparer.Ordinal);
     public Dictionary<string, ToolInvocationReceipt> ToolReceipts { get; init; } = new(StringComparer.Ordinal);
+    public Dictionary<string, ToolExposureRequest> ToolExposureRequests { get; init; } = new(StringComparer.Ordinal);
 }
 
 internal sealed record ToolExecutionSingleCompleted(ToolCallResult Result) : INoSerializationVerificationNeeded;
+
+internal sealed record ToolExposureRequest(ToolName ToolName);
 
 /// <summary>
 /// Piped back to the session as the resolution of a background-job reap Ask

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -929,6 +929,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 Result = result.Content ?? string.Empty,
                 FailureCode = msg.ToolFailureCodes.GetValueOrDefault(toolCallId.Value)
             }, OutputFilter.ToolCalls);
+
+            if (msg.ToolExposureRequests.TryGetValue(toolCallId.Value, out var exposureRequest))
+                TryActivateDiscoveredTool(exposureRequest.ToolName.Value);
         }
 
         foreach (var change in msg.ScratchCorrectionChanges)
@@ -3467,10 +3470,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var registration = _fullRegistry.GetRegistrationByToolName(toolName);
         if (registration is null) return false;
 
-        if (_toolAccessPolicy is not null && !_toolAccessPolicy.IsToolExposed(registration, _currentTrustContext))
+        if (_toolAccessPolicy is null || !_toolAccessPolicy.IsToolExposed(registration, _currentTrustContext))
             return false;
 
         var tool = registration.Tool;
+        if (_fullRegistry.IsCoreTool(tool.Name))
+            return true;
+
         // Cache and log under the canonical name regardless of which form
         // the LLM sent (load_tool / search_tools now emit the LLM-facing
         // alias for MCP, but legacy strings may still arrive). Cache key
@@ -4746,6 +4752,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             Result = toolMessage.Content ?? string.Empty,
             FailureCode = result.FailureCode
         }, OutputFilter.ToolCalls);
+
+        if (result.ExposureRequest is { } exposureRequest)
+            TryActivateDiscoveredTool(exposureRequest.ToolName.Value);
 
         var updatedContext = WorkingContextUpdater.UpdateFromToolReceipt(
             _state.WorkingContext,

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -39,7 +39,8 @@ internal sealed record ToolCallResult(
     Jobs.ActiveJobInfo? StartedBackgroundJob = null,
     SessionScratchCorrectionChange? ScratchCorrectionChange = null,
     string? FailureCode = null,
-    ToolInvocationReceipt? Receipt = null);
+    ToolInvocationReceipt? Receipt = null,
+    ToolExposureRequest? ExposureRequest = null);
 
 internal abstract record SessionScratchCorrectionChange
 {
@@ -424,6 +425,15 @@ internal sealed class SessionToolExecutionPipeline
                             : throw new InvalidOperationException("A tool receipt requires a call identity."),
                         result => result.Receipt
                             ?? throw new InvalidOperationException("A selected tool result requires a receipt."),
+                        StringComparer.Ordinal),
+                ToolExposureRequests = results
+                    .Where(result => result.ExposureRequest is not null)
+                    .ToDictionary<ToolCallResult, string, ToolExposureRequest>(
+                        result => result.Message.ToolCallId is { } callId
+                            ? callId.Value
+                            : throw new InvalidOperationException("A tool exposure request requires a call identity."),
+                        result => result.ExposureRequest
+                            ?? throw new InvalidOperationException("A selected tool result requires an exposure request."),
                         StringComparer.Ordinal)
             });
         }
@@ -688,6 +698,25 @@ internal sealed class SessionToolExecutionPipeline
             sw.Stop();
 
         }
+        catch (ToolAgentCorrectionRequiredException correctionEx)
+        {
+            if (correctionEx.Correction is not ToolAgentCorrection.NativeToolSuggested nativeTool)
+                throw;
+
+            sw.Stop();
+            var correctionReceipt = new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: ToolRemediationCode.UseNativeTool);
+            return new ToolCallResult(new SerializableChatMessage
+            {
+                Role = Protocol.ChatRole.Tool,
+                Content = BuildNativeToolCorrection(nativeTool.ToolName),
+                ToolCallId = new ToolCallId(tc.CallId),
+                Name = tc.Name
+            }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
+                Receipt: correctionReceipt,
+                ExposureRequest: new ToolExposureRequest(nativeTool.ToolName));
+        }
         catch (ToolApprovalRequiredException approvalEx)
         {
             if (approvalEx.ApprovalContext.AgentCorrection is
@@ -925,6 +954,9 @@ internal sealed class SessionToolExecutionPipeline
                 ? new SessionScratchCorrectionChange.Consume(consumed)
                 : null);
     }
+
+    internal static string BuildNativeToolCorrection(ToolName toolName)
+        => $"Shell execution stopped because '{toolName.Value}' is a native Netclaw tool.";
 
     internal static SessionScratchCallSemantics? BuildSessionScratchCallSemantics(
         FunctionCallContent toolCall,

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -61,6 +61,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         "Before tool work in another task-named project, call set_working_directory once, even with absolute paths. " +
         "Declare the task's first project path exactly before probing it.";
     private const string HeadlessExecutionContractSuffix =
+        "You cannot attach files directly. Return each authorized file path that the parent session should deliver. " +
         "Always end by emitting a final output for the parent session.";
     private static readonly TimeSpan StreamPingInterval = TimeSpan.FromSeconds(2);
 
@@ -569,6 +570,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     TryApplyProjectDirectory(result.Name, receipt);
                     if (receipt is not null)
                         _log.Info("SubAgent tool outcome category={OutcomeCategory}", receipt.Category);
+                    if (msg.ToolExposureRequests.TryGetValue(callId.Value, out var exposureRequest))
+                        TryActivateDiscoveredTool(exposureRequest.ToolName.Value);
                 }
                 if (result.Name is "load_tool" && result.Content is not null)
                     TryActivateDiscoveredTool(result.Content.Trim());
@@ -1437,6 +1440,21 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             ? new SessionScratchCorrectionChange.Consume(directConsumed)
                             : null);
                 }
+                catch (ToolAgentCorrectionRequiredException correctionEx)
+                {
+                    if (correctionEx.Correction is not ToolAgentCorrection.NativeToolSuggested nativeTool)
+                        throw;
+
+                    toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
+                        ToolInvocationOutcomeCategory.RecoverableCorrection,
+                        remediationCode: ToolRemediationCode.UseNativeTool));
+                    return BuildToolResult(
+                        cleanedTc,
+                        SessionToolExecutionPipeline.BuildNativeToolCorrection(nativeTool.ToolName),
+                        toolContext,
+                        modelInputBudget,
+                        exposureRequest: new ToolExposureRequest(nativeTool.ToolName));
+                }
                 catch (ToolApprovalRequiredException approvalEx)
                 {
                     var ctx = approvalEx.ApprovalContext;
@@ -1625,6 +1643,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             : throw new InvalidOperationException("A child tool receipt requires a call identity."),
                         result => result.Receipt
                             ?? throw new InvalidOperationException("A selected child tool result requires a receipt."),
+                        StringComparer.Ordinal),
+                ToolExposureRequests = results
+                    .Where(result => result.ExposureRequest is not null)
+                    .ToDictionary<SubAgentToolCallResult, string, ToolExposureRequest>(
+                        result => result.Message.ToolCallId is { } callId
+                            ? callId.Value
+                            : throw new InvalidOperationException("A child tool exposure request requires a call identity."),
+                        result => result.ExposureRequest
+                            ?? throw new InvalidOperationException("A selected child tool result requires an exposure request."),
                         StringComparer.Ordinal)
             });
         }
@@ -1649,7 +1676,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         string resultText,
         ToolExecutionContext toolContext,
         ModelInputBatchBudget modelInputBudget,
-        SessionScratchCorrectionChange? scratchCorrectionChange = null)
+        SessionScratchCorrectionChange? scratchCorrectionChange = null,
+        ToolExposureRequest? exposureRequest = null)
     {
         var materialization = MaterializeModelInputFiles(toolContext, modelInputBudget);
         if (materialization.RequestedCount > materialization.MediaReferences.Count)
@@ -1671,7 +1699,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             },
             materialization.MediaReferences,
             scratchCorrectionChange,
-            receipt);
+            receipt,
+            exposureRequest);
     }
 
     private static ModelInputMaterializationResult MaterializeModelInputFiles(
@@ -1695,7 +1724,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         SerializableChatMessage Message,
         IReadOnlyList<SerializableMediaReference> ModelInputMediaReferences,
         SessionScratchCorrectionChange? ScratchCorrectionChange,
-        ToolInvocationReceipt? Receipt);
+        ToolInvocationReceipt? Receipt,
+        ToolExposureRequest? ExposureRequest);
 
     private string BuildSystemPrompt(
         SubAgentDefinition definition,

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -459,8 +459,8 @@ public sealed class SubAgentSpawner
     private ResolvedSubAgentTools ResolveTools(ToolInvocationContext context)
     {
         // Sub-agents inherit the parent session's runtime tool policy. Agent
-        // definition tool metadata is advisory only; the only static
-        // sub-agent-specific filter denies recursive spawn_agent delegation.
+        // definition tool metadata is advisory only. The static child filter
+        // denies recursive delegation and tools that need parent-only output transport.
         var tools = _toolRegistry.GetAllRegistrations()
             .Select(static registration => registration.Tool)
             .Where(static tool => SubAgentToolPolicy.IsAllowedForSubAgent(tool.Name));

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -15,10 +15,11 @@ namespace Netclaw.Actors.Tools;
 /// Attaches a file as output to the user.
 /// Paths inside the current session are attached directly. Paths from sibling
 /// Netclaw session directories are copied into the current session first.
-/// All other paths are rejected to prevent traversal/exfiltration.
+/// Interactive Personal sessions can copy another policy-authorized readable
+/// source. Other callers remain limited to the session tree.
 /// </summary>
 [NetclawTool("attach_file",
-    "Attach a file to send to the user. Paths in the current session attach directly; files from other Netclaw session folders are copied into this session first.",
+    "Attach an existing authorized file to the user. Pass the source path directly; Netclaw copies the file into the current session when required. Do not copy the file with shell or another file tool first.",
     Grant = "file")]
 public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
 {
@@ -26,7 +27,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
     private readonly ToolPathPolicy _pathPolicy;
 
     public record Params(
-        [property: Description("File path to attach. Relative paths use the current project, then session scratch.")] string Path,
+        [property: Description("Existing authorized source file path. Relative paths use the current project, then session scratch. Pass this path directly without first copying the file.")] string Path,
         [property: Description("Optional display name for the file")] string? DisplayName = null);
 
     public AttachFileTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy pathPolicy)

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -305,7 +305,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
         if (exception is OperationCanceledException && callerToken.IsCancellationRequested)
             return;
 
-        if (exception is ToolApprovalRequiredException)
+        if (exception is ToolApprovalRequiredException or ToolAgentCorrectionRequiredException)
             return;
 
         var category = exception switch
@@ -357,12 +357,29 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
                     tool,
                     context,
                     toolCall.Arguments);
-                shellAuthorization = await _shellPolicyCoordinator.EvaluateAsync(
-                    tool,
-                    toolCall,
-                    context,
-                    preflight,
-                    ct);
+                var analysis = preflight switch
+                {
+                    ShellPolicyPreflightResult.Complete complete => complete.AuthorizedAnalysis,
+                    ShellPolicyPreflightResult.Continue next => next.Analysis,
+                    _ => null,
+                };
+                var correction = analysis is null
+                    ? null
+                    : NativeToolShellCorrectionDetector.Detect(
+                        analysis,
+                        _registry,
+                        _policy,
+                        context.Invocation);
+                shellAuthorization = correction is null
+                    ? await _shellPolicyCoordinator.EvaluateAsync(
+                        tool,
+                        toolCall,
+                        context,
+                        preflight,
+                        ct)
+                    : new ShellPolicyAuthorization(
+                        ToolAuthorizationDecision.RequireAgentCorrection(correction),
+                        authorizedAnalysis: null);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -464,6 +481,13 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
                 ?? throw new InvalidOperationException("Approval decision missing approval context."));
         }
 
+        if (decision.Outcome is ToolAuthorizationOutcome.RequiresAgentCorrection)
+        {
+            throw new ToolAgentCorrectionRequiredException(
+                decision.AgentCorrection
+                ?? throw new InvalidOperationException("Agent correction decision missing correction facts."));
+        }
+
         if (decision.Outcome is ToolAuthorizationOutcome.Denied)
         {
             throw new ToolAccessDeniedException(
@@ -552,6 +576,12 @@ public sealed class DispatchingToolExecutor : IToolExecutor, ISessionScratchRetr
                     allowReason.GetDescription());
                 break;
             case ToolAuthorizationOutcome.RequiresApproval:
+                _logger.LogInformation(
+                    "Tool authorization evaluated: {ToolName} outcome={AuthorizationOutcome}",
+                    toolName,
+                    decision.Outcome.ToString());
+                break;
+            case ToolAuthorizationOutcome.RequiresAgentCorrection:
                 _logger.LogInformation(
                     "Tool authorization evaluated: {ToolName} outcome={AuthorizationOutcome}",
                     toolName,

--- a/src/Netclaw.Actors/Tools/NativeToolShellCorrectionDetector.cs
+++ b/src/Netclaw.Actors/Tools/NativeToolShellCorrectionDetector.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="NativeToolShellCorrectionDetector.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+internal static class NativeToolShellCorrectionDetector
+{
+    internal static ToolAgentCorrection.NativeToolSuggested? Detect(
+        ShellCommandAnalysis analysis,
+        ToolRegistry registry,
+        ToolAccessPolicy policy,
+        ToolInvocationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!analysis.IsResolved || analysis.HasDynamicSyntax)
+            return null;
+
+        foreach (var occurrence in analysis.Commands)
+        {
+            var verb = occurrence.Clause.Verb;
+            if (!occurrence.IsComplete
+                || verb.IsDynamic
+                || verb.Tokens.Count == 0)
+            {
+                continue;
+            }
+
+            var authoredName = verb.Tokens[0];
+            var registration = registry.GetRegistrationByToolName(authoredName);
+            if (registration is null
+                || registration.Tool is McpToolAdapter
+                || !string.Equals(registration.Tool.Name, authoredName, StringComparison.Ordinal)
+                || string.Equals(authoredName, ShellTool.ToolName, StringComparison.Ordinal)
+                || !policy.IsToolExposed(registration.Tool, context))
+            {
+                continue;
+            }
+
+            return new ToolAgentCorrection.NativeToolSuggested(new ToolName(registration.Tool.Name));
+        }
+
+        return null;
+    }
+}

--- a/src/Netclaw.Actors/Tools/PlatformTemporaryScopePolicy.cs
+++ b/src/Netclaw.Actors/Tools/PlatformTemporaryScopePolicy.cs
@@ -20,6 +20,8 @@ internal abstract record ToolAgentCorrection
         string SessionDirectory,
         string TemporaryRoot,
         ApprovalShell Shell) : ToolAgentCorrection;
+
+    internal sealed record NativeToolSuggested(ToolName ToolName) : ToolAgentCorrection;
 }
 
 internal readonly record struct SessionScratchCallSemantics(

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -32,6 +32,11 @@ internal enum ToolAuthorizationOutcome
     RequiresApproval,
 
     /// <summary>
+    /// The current attempt must not execute because the agent should call a native tool.
+    /// </summary>
+    RequiresAgentCorrection,
+
+    /// <summary>
     /// The current attempt cannot execute and must not prompt the user.
     /// </summary>
     /// <remarks>
@@ -148,6 +153,7 @@ internal sealed record ToolAuthorizationDecision
         ToolAllowReason? allowReason,
         string? denyReason,
         ToolApprovalContext? approvalContext,
+        ToolAgentCorrection? agentCorrection,
         IReadOnlyList<ToolApprovalMatch> approvalMatches,
         ShellPolicyDecisionTrace? shellPolicyTrace = null)
     {
@@ -155,6 +161,7 @@ internal sealed record ToolAuthorizationDecision
         AllowReason = allowReason;
         DenyReason = denyReason;
         ApprovalContext = approvalContext;
+        AgentCorrection = agentCorrection;
         ApprovalMatches = approvalMatches;
         ShellPolicyTrace = shellPolicyTrace ?? ShellPolicyDecisionTrace.Empty;
     }
@@ -180,6 +187,12 @@ internal sealed record ToolAuthorizationDecision
     public ToolApprovalContext? ApprovalContext { get; }
 
     /// <summary>
+    /// Gets the typed correction when <see cref="Outcome"/> is
+    /// <see cref="ToolAuthorizationOutcome.RequiresAgentCorrection"/>.
+    /// </summary>
+    public ToolAgentCorrection? AgentCorrection { get; }
+
+    /// <summary>
     /// Gets the session or persistent grants that matched this attempt.
     /// </summary>
     /// <remarks>
@@ -198,7 +211,7 @@ internal sealed record ToolAuthorizationDecision
     public static ToolAuthorizationDecision Allow(ToolAllowReason reason)
     {
         ValidateAllowReason(reason);
-        return new ToolAuthorizationDecision(ToolAuthorizationOutcome.Allowed, reason, null, null, []);
+        return new ToolAuthorizationDecision(ToolAuthorizationOutcome.Allowed, reason, null, null, null, []);
     }
 
     /// <summary>
@@ -215,6 +228,7 @@ internal sealed record ToolAuthorizationDecision
             reason,
             null,
             null,
+            null,
             [.. approvalMatches]);
     }
 
@@ -224,7 +238,7 @@ internal sealed record ToolAuthorizationDecision
     public static ToolAuthorizationDecision Deny(string reason)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reason);
-        return new ToolAuthorizationDecision(ToolAuthorizationOutcome.Denied, null, reason, null, []);
+        return new ToolAuthorizationDecision(ToolAuthorizationOutcome.Denied, null, reason, null, null, []);
     }
 
     /// <summary>
@@ -233,7 +247,7 @@ internal sealed record ToolAuthorizationDecision
     public static ToolAuthorizationDecision RequiresApproval(ToolApprovalContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        return new ToolAuthorizationDecision(ToolAuthorizationOutcome.RequiresApproval, null, null, context, []);
+        return new ToolAuthorizationDecision(ToolAuthorizationOutcome.RequiresApproval, null, null, context, null, []);
     }
 
     /// <summary>
@@ -250,7 +264,23 @@ internal sealed record ToolAuthorizationDecision
             null,
             null,
             context,
+            null,
             [.. approvalMatches]);
+    }
+
+    /// <summary>
+    /// Creates a typed agent-correction result that grants no execution authority.
+    /// </summary>
+    public static ToolAuthorizationDecision RequireAgentCorrection(ToolAgentCorrection correction)
+    {
+        ArgumentNullException.ThrowIfNull(correction);
+        return new ToolAuthorizationDecision(
+            ToolAuthorizationOutcome.RequiresAgentCorrection,
+            null,
+            null,
+            null,
+            correction,
+            []);
     }
 
     internal static ToolAuthorizationDecision From(
@@ -281,4 +311,16 @@ internal sealed record ToolAuthorizationDecision
         if (!Enum.IsDefined(reason))
             throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown tool allow reason.");
     }
+}
+
+internal sealed class ToolAgentCorrectionRequiredException : InvalidOperationException
+{
+    internal ToolAgentCorrectionRequiredException(ToolAgentCorrection correction)
+        : base("Tool invocation requires agent correction.")
+    {
+        ArgumentNullException.ThrowIfNull(correction);
+        Correction = correction;
+    }
+
+    internal ToolAgentCorrection Correction { get; }
 }

--- a/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
+++ b/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
@@ -14,9 +14,10 @@ internal static class ToolChoiceGuidance
         2. Use file_read for bounded file content and image metadata.
         3. Issue independent file_read calls in parallel when several paths are known.
         4. Use tool_output_read to continue a spilled result by call id.
-        5. Use load_tool directly when the exact specialty tool name is known.
-        6. Use search_tools when the capability is known but its exact tool name is not.
-        7. Use shell or an interpreter only when no structured tool expresses the operation.
+        5. For file delivery, do not copy the source first. Use a visible delivery tool, or return the authorized path to the parent.
+        6. Use load_tool directly when the exact specialty tool name is known.
+        7. Use search_tools when the capability is known but its exact tool name is not.
+        8. Use shell or an interpreter only when no structured tool expresses the operation.
         """;
 
     public const string DirectorySelectionOrder = """

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -44,7 +44,7 @@ public static class ToolRegistrationExtensions
         registry.RegisterCore(new ToolOutputReadTool());
         registry.RegisterCore(new FileWriteTool(config, paths, pathPolicy));
         registry.RegisterCore(new FileEditTool(config, paths, pathPolicy));
-        registry.Register(new AttachFileTool(config, paths, pathPolicy));
+        registry.RegisterCore(new AttachFileTool(config, paths, pathPolicy));
         if (webhookRouteStore is not null)
             registry.Register(new ListWebhooksTool(webhookRouteStore));
         if (searchBackend is not null)

--- a/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
+++ b/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
@@ -27,6 +27,8 @@ internal static class ToolRemediationPresenter
                 "Next action: use the session scratch directory from this result for disposable files, or retry unchanged for exact platform paths.",
             ToolRemediationCode.ProvideUniqueOldString =>
                 "Next action: retry file_edit with a unique OldString, or set ReplaceAll=true when every match should change.",
+            ToolRemediationCode.UseNativeTool =>
+                "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
             _ => throw new InvalidOperationException("Unsupported tool remediation code.")
         };
 

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -19,13 +19,13 @@ namespace Netclaw.Actors.Tools;
 /// For HTML: default format preserves structure; text mode extracts plain text.
 /// For binary content (images, PDFs, etc.): saves raw bytes with correct extension.
 /// For other text content: saves as-is with the URL's file extension preserved.
-/// Returns a summary with the file path so the agent can use file_read,
-/// grep, or attach_file to work with the content.
+/// Returns a summary with the file path so the agent can inspect or deliver
+/// the saved content through an available tool.
 /// </summary>
 [NetclawTool("web_fetch",
     "Use for retrieving a known external page or URL. Save content to a local file without shell. " +
     "HTML raw mode preserves structure; text mode extracts text. Binary content keeps its correct extension. " +
-    "Returns a file path with preview. Use file_read to examine content or attach_file to send binary files.",
+    "Returns a file path with preview. Use file_read to examine content. Use an available file-delivery tool, or return the saved path to the caller.",
     Grant = "web")]
 public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
 {
@@ -325,7 +325,7 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         sb.AppendLine($"Saved to: {filePath} ({byteCount:N0} bytes)");
         sb.AppendLine($"Content-Type: {contentType}");
         sb.AppendLine();
-        sb.AppendLine("This is a binary file. Use attach_file to send it to the user, or file_read if the format supports text extraction.");
+        sb.AppendLine("This is a binary file. Use file_read if the format supports text extraction. Use an available file-delivery tool, or return the saved path to the caller.");
         return sb.ToString().TrimEnd();
     }
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
@@ -264,7 +264,7 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel, ISectionEditor
             - Cross-reference multiple sources when possible.
             - Always cite your sources with URLs.
             - Use file_read to inspect local reference material when needed.
-            - Use attach_file when the parent session needs to deliver an existing file.
+            - Return each authorized file path that the parent session should deliver.
             - Be thorough but concise — focus on facts and actionable information.
             - Use markdown formatting for structure (headers, lists, code blocks).
             - If a search returns no useful results, say so rather than guessing.

--- a/src/Netclaw.Configuration/SubAgentToolPolicy.cs
+++ b/src/Netclaw.Configuration/SubAgentToolPolicy.cs
@@ -7,14 +7,16 @@ namespace Netclaw.Configuration;
 
 /// <summary>
 /// Central policy for tools exposed to sub-agents. Sub-agents inherit the parent
-/// session's audience, boundary, approval, and shell policies; this static deny
-/// list only prevents recursive delegation loops.
+/// session's audience, boundary, approval, and shell policies. This static deny
+/// list prevents recursive delegation and tools whose results cannot cross the
+/// child-to-parent completion boundary safely.
 /// </summary>
 public static class SubAgentToolPolicy
 {
     private static readonly HashSet<string> DeniedSubAgentToolNames = new(StringComparer.Ordinal)
     {
-        "spawn_agent"
+        "spawn_agent",
+        ToolAudienceProfileToolCatalog.AttachFile
     };
 
     /// <summary>True unless the tool is statically denied to sub-agents.</summary>

--- a/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandAnalysisTests.cs
@@ -78,6 +78,24 @@ public sealed class ShellCommandAnalysisTests
     }
 
     [Theory]
+    [InlineData("bash -lc", "file_read", "file_write")]
+    [InlineData("sudo bash -lc", "sudo", "file_read", "file_write")]
+    [InlineData("env bash -lc", "env", "file_read", "file_write")]
+    public void Bash_wrapper_payload_stays_before_later_outer_command(
+        string invocation,
+        params string[] expectedVerbs)
+    {
+        var analysis = _analyzer.Analyze(
+            $"{invocation} \"file_read\"; file_write",
+            "/work");
+
+        Assert.Equal(ShellAnalysisFailure.None, analysis.Failure);
+        Assert.Equal(
+            expectedVerbs,
+            analysis.Commands.Select(static command => command.Clause.Verb.Tokens[0]));
+    }
+
+    [Theory]
     [InlineData("pwsh -NoProfile -NonInteractive -Command 'git status'", "pwsh")]
     [InlineData("powershell.exe -Command 'git status'", "powershell.exe")]
     public void Bash_treats_power_shell_as_an_ordinary_external_command(

--- a/src/Netclaw.Security.Tests/ToolFrictionEvidenceContractTests.cs
+++ b/src/Netclaw.Security.Tests/ToolFrictionEvidenceContractTests.cs
@@ -15,7 +15,7 @@ public sealed partial class ToolFrictionEvidenceContractTests
 {
     private const string FixtureFile = "tool-friction-fixtures.json";
     private const string FixtureSha256 =
-        "40ae6dbe3b9c6e9c8d061face39b341ee0124b517d63414353430f5ed7f3442c";
+        "20be5a3fdc97fd311aba4245347fdb45510708d04ca7f1695312ca26bee25c05";
 
     private static readonly string[] ProhibitedRawIdentifierClasses =
     [
@@ -45,7 +45,9 @@ public sealed partial class ToolFrictionEvidenceContractTests
         new("TF06", "FailedFileActivity", "FailedCallPollutedRecentFiles", ["file_write"],
             "access_denied", false, false, "PreserveRecentFiles"),
         new("TF07", "SubagentCatalogExposure", "EagerSubagentSchemaCatalog",
-            ["search_tools", "load_tool"], "success", false, false, "CoreOnlyChildCatalog")
+            ["search_tools", "load_tool"], "success", false, false, "CoreOnlyChildCatalog"),
+        new("TF08", "DirectAttachment", "PreparatoryShellCopyBeforeAttachment", ["attach_file"],
+            "success", false, true, "RecordOneCanonicalFile")
     ];
 
     [Fact]

--- a/src/Netclaw.Security/ShellCommandAnalysis.cs
+++ b/src/Netclaw.Security/ShellCommandAnalysis.cs
@@ -83,21 +83,34 @@ internal sealed class ShellCommandAnalyzer
             return ShellAnalysisFailure.None;
         }
 
-        // The v0.3 parser owns contracted wrapper forms. This fallback keeps
-        // Netclaw's extra bundled bash -lc form. Remove only a direct shell
-        // dispatch: prefix executables such as sudo, env, and nohup remain
-        // visible to hard-deny and approval policy.
-        commands.AddRange(parsed.Commands.Where(static occurrence =>
-            !IsUnexpandedWrapperClause(occurrence.Clause)
-            || !IsTransparentShellDispatch(occurrence.Clause)));
-
         if (innerCommands.Count != unexpandedWrappers.Count)
-            return ShellAnalysisFailure.Unresolved;
-
-        for (var i = 0; i < innerCommands.Count; i++)
         {
+            // Preserve the prior defense scan when wrapper extraction is incomplete.
+            commands.AddRange(parsed.Commands.Where(static occurrence =>
+                !IsUnexpandedWrapperClause(occurrence.Clause)
+                || !IsTransparentShellDispatch(occurrence.Clause)));
+            return ShellAnalysisFailure.Unresolved;
+        }
+
+        // The v0.3 parser owns contracted wrapper forms. This fallback keeps
+        // Netclaw's extra bundled bash -lc form. Expand each wrapper at its
+        // parser-owned position so every consumer sees execution order. Remove
+        // only a direct shell dispatch; retain prefix executables such as sudo,
+        // env, and nohup for hard-deny and approval policy.
+        var innerIndex = 0;
+        foreach (var occurrence in parsed.Commands)
+        {
+            if (!IsUnexpandedWrapperClause(occurrence.Clause))
+            {
+                commands.Add(occurrence);
+                continue;
+            }
+
+            if (!IsTransparentShellDispatch(occurrence.Clause))
+                commands.Add(occurrence);
+
             if (!TryResolveWrapperWorkingDirectory(
-                    unexpandedWrappers[i],
+                    occurrence,
                     workingDirectory,
                     out var innerWorkingDirectory))
             {
@@ -105,7 +118,7 @@ internal sealed class ShellCommandAnalyzer
             }
 
             var failure = Analyze(
-                innerCommands[i],
+                innerCommands[innerIndex++],
                 innerWorkingDirectory,
                 depth + 1,
                 commands);

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -33,7 +33,8 @@ internal enum ToolRemediationCode
 {
     SetWorkingDirectory,
     UseSessionScratch,
-    ProvideUniqueOldString
+    ProvideUniqueOldString,
+    UseNativeTool
 }
 
 internal enum ToolFileActivityKind


### PR DESCRIPTION
Stacked on #2046.

## What changed

- Makes `attach_file` a policy-filtered parent-session Core tool and directs agents to attach the authorized source path without a preparatory copy.
- Keeps `attach_file` unavailable to subagents until an internal child-to-parent attachment handoff exists.
- Detects exact, policy-visible first-party tool names in complete ShellSyntaxTree command facts before shell grants, approval, or execution.
- Returns one typed correction, exposes a deferred target schema actor-locally, and sends the eventual native call through normal authorization.
- Preserves hard-deny precedence and excludes dynamic, incomplete, path-qualified, fuzzy, hidden, denied, MCP, and shell targets.

## Verification

- Release build: 0 warnings, 0 errors.
- Full solution tests: 7,799 passed; 17 expected environment-gated skips; 0 failures.
- Strict OpenSpec, headers, changed-file formatting, shell harness checks, diff check, and Slopwatch: pass.
- Frozen-SHA adversarial review: pass.
- PII-free behavioral aggregates are posted separately.

This PR does not change public or durable contracts.