### PR TITLE
chore: ignore the out/ publish directory from CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,3 +456,6 @@ phase*-mattermost-*.png
 # (~/recall-research-local/), never in the repo — it operates on real
 # (PII) corpus data and embeds instance-specific labels/endpoints.
 tools/recall-research/
+
+# Publish output. The CONTRIBUTING.md build steps use `dotnet publish -o ./out`.
+out/


### PR DESCRIPTION
`CONTRIBUTING.md` tells each contributor to publish both binaries to `./out` (lines 164-165). That command writes about 100 MB of files to the repository root. Git then shows all of them as untracked.

`.gitignore` covers `artifacts/`, `[Bb]in/`, and `[Oo]bj/`, but it does not cover `out/`. This rule closes that gap and keeps `git status` clean.