### PR TITLE
Add OpenSpec change for MCP tool outcome receipts (#2058)

### DIFF
--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -292,6 +292,80 @@ final message:
 If the named tool is hidden, the presenter leaves the factual result unchanged.
 This prevents an instruction that the current model cannot follow.
 
+## MCP Invocation Terms
+
+These terms classify what an MCP server's answer means for the client. The
+`netclaw-mcp` and `netclaw-tools` capabilities share them. The examples come
+from a link-shortener MCP server observed on 2026-08-26.
+
+### Transport or session failure
+
+A transport or session failure means the request got no usable answer. The
+connection broke, the request timed out, or the server reported that the
+session is gone (HTTP 404 under Streamable HTTP). A new session can repair it.
+Netclaw reconnects once for later calls and never replays the failed call.
+
+Example:
+
+```text
+HttpRequestException with no status code      -> transport failure
+HttpRequestException with HTTP 404            -> session failure
+IOException, ClientTransportClosedException   -> transport failure
+```
+
+**Code anchor:** `McpClientManager.IsTransportOrSessionFailure`
+
+### Application error
+
+An application error is an answer from a server that received the request: an
+HTTP status other than 404, a JSON-RPC error, or a tool-declared error. A new
+session cannot change the answer, so Netclaw returns it without a reconnect.
+
+Example:
+
+```text
+HTTP 429  {"statusCode":429,"error":"Too Many Requests","message":"Rate limit exceeded, retry in 52 seconds"}
+HTTP 401  {"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: No API key provided"},"id":null}
+```
+
+Both are application errors. Neither triggers a reconnect.
+
+### Tool-declared error
+
+A tool-declared error is a successful JSON-RPC response whose result carries
+`isError: true`. The tool ran and reported a failure in its own words. Netclaw
+formats it as a tool result and logs it at Warning. It is not an exception and
+does not produce an exception outcome.
+
+Example (`search-links` called with only its one required argument):
+
+```text
+HTTP 200
+{"result":{"content":[{"type":"text","text":"Internal Server Error"}],"isError":true},"jsonrpc":"2.0","id":70}
+
+tool result: "Error: MCP tool 'shortio/search-links' reported a failure: Internal Server Error"
+daemon log:  [WRN] McpClientManager: MCP tool 'shortio/search-links' reported a failure: Internal Server Error
+```
+
+**Code anchors:** `McpClientManager.ReportToolFailure`, `McpToolResultFormatter`
+
+### OAuth-capable server
+
+An OAuth-capable server is an HTTP or SSE MCP server with no operator-configured
+`Authorization` header. Only such a server can hold OAuth tokens, so only such a
+server can enter `AuthFailed` because of a tool-declared auth error. A stdio
+server or a static-header server cannot use `netclaw mcp auth`.
+
+Example:
+
+```text
+stdio, no headers                        -> not OAuth-capable
+http, Headers.Authorization configured   -> not OAuth-capable (static header)
+http, no Authorization header            -> OAuth-capable
+```
+
+**Code anchor:** `McpClientManager.HasOAuthRuntimeHints`
+
 ## Filesystem and Output Terms
 
 ### Project scope

--- a/openspec/changes/mcp-tool-outcome-receipts/.openspec.yaml
+++ b/openspec/changes/mcp-tool-outcome-receipts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/mcp-tool-outcome-receipts/design.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/design.md
@@ -1,0 +1,251 @@
+## Context
+
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for tool call, dispatcher, tool result, tool receipt, outcome category, and authority. See proposal.md for motivation.
+
+Current flow at `dev` (`94d2bfce`) for an MCP tool call that ends in an exception. This pseudocode is schematic. It omits authorization, redaction, and the output bound.
+
+```text
+MCP server or transport throws
+  -> McpClientManager.InvokeSharedAsync
+       McpException       -> return "Error: MCP tool '<server>/<tool>' failed: <message>"  (no log)
+       transport failure  -> log at Debug, reconnect, rethrow
+  -> McpToolAdapter.ExecuteAsync
+       catch-all          -> return "Error: MCP tool '<name>' failed: <message>"           (no log, no receipt)
+  -> DispatchingToolExecutor
+       string result      -> receipt category = success
+                          -> log "Tool executed: ..." at Information
+  -> SessionToolExecutionPipeline
+       receipt            -> log "Tool outcome category=Success" at Information
+```
+
+Constraints that shape the approach:
+
+- `INetclawTool.ExecuteAsync` returns a string. The public contract stays.
+- The tool receipt is first-writer-wins (`ToolExecutionOutputs.TryComplete` uses `CompareExchange`). A tool that completes the receipt before it returns wins over the dispatcher's `success` completion.
+- `ToolOutcomeResults` (#2033) already attaches a category to a result string. The workspace tools use it. Its one-argument helpers need no file activity and no remediation code.
+- `McpClientManager.IsTransportOrSessionFailure` is the single predicate that decides a reconnect. It has two consumers: the tool path (`InvokeSharedAsync`) and the prompt-skill path (`LoadAsync`).
+- `McpClientManager.ReportToolFailure` owns the tool-declared `isError` path and its Warning log.
+- `McpClientManager.HasOAuthRuntimeHints(serverName, entry)` already answers "can this server use OAuth": the transport is not stdio and no operator-configured `Authorization` header exists.
+- In the SDK (`ModelContextProtocol.Core` 2.2.0), `McpException` carries no error code. Only the derived `McpProtocolException.ErrorCode` does, and the SDK reserves `-32602` for a malformed request or an unknown primitive name. Tool input validation arrives as an `isError` result, not as this exception.
+- The existing test `ToolLevelAuthFailure_MovesServerOutOfConnected` documents the expired-token case: the token failure reaches the agent as `isError` text, not as an HTTP 401. Its harness uses a stdio entry today.
+- Production always passes the manager as the adapter's invoker (`PrepareMcpTools`). The adapter's bound-tool path is unreachable in the daemon.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One converter from exception to tool result. The adapter owns it.
+- One receipt per failed call with a category the actor can trust.
+- One Warning line per failed call in the daemon log.
+- Reconnect only when a new session can help.
+- No false `AuthFailed` for a server that cannot use OAuth.
+- The fewest moving parts. Reuse existing helpers. Add no new type, interface, or configuration.
+
+**Non-Goals:**
+
+- Change the model-facing text shape of an MCP failure.
+- Retry, replay, or add a per-server request budget.
+- Propagate `Retry-After` from the SDK exception. The SDK exception carries no headers.
+- Map JSON-RPC error codes to categories.
+- Change the receipt category of a tool-declared `isError` result.
+- Change the connect-path auth classification (#1908 covers it).
+- Change the adapter's bound-tool path.
+
+## Proposed flow
+
+This pseudocode is schematic. It omits authorization, redaction, and the output bound.
+
+```text
+MCP server or transport throws
+  -> McpClientManager.InvokeSharedAsync
+       caller cancellation            -> rethrow, no log
+       any other exception            -> log one Warning (server, tool, HTTP status when present, redacted exception)
+         transport or session failure -> reconnect for later calls, rethrow
+         application error            -> rethrow, no reconnect
+  -> McpToolAdapter.ExecuteAsync
+       caller cancellation            -> rethrow
+       any other exception            -> receipt category per D1, return "Error: MCP tool '<name>' failed: <message>"
+  -> DispatchingToolExecutor
+       string result                  -> receipt already complete; "Tool executed: ..." unchanged
+  -> SessionToolExecutionPipeline
+       receipt                        -> log "Tool outcome category=<category>"
+```
+
+## Decisions
+
+### D1. The adapter completes the receipt from the caught exception
+
+`McpToolAdapter.ExecuteAsync` keeps its catch-all. Instead of a bare `return`, it returns the same error string through `ToolOutcomeResults`:
+
+```text
+HttpRequestException 401 or 403  -> context.AccessDenied(text)
+HttpRequestException 404         -> context.NotFound(text)
+anything else                    -> context.TransientFailure(text)
+```
+
+The receipt is call-local. Nothing durable changes. Every receipt consumer today gates on `success`, so a non-success receipt has no state effect. The category becomes visible in the pipeline's `Tool outcome category=` Information line, which today prints `Success` for a failed MCP call.
+
+The bound-tool path (`ExecuteViaBoundToolAsync`) stays as it is. The daemon never uses it.
+
+Positive example:
+
+```text
+tools/call -> HTTP 500
+  result:  "Error: MCP tool 'shortener/search-links' failed: ... 500 ..."
+  receipt: category = transient_failure
+```
+
+Negative example:
+
+```text
+tools/call -> HTTP 200, {"isError": true, "content": [{"type": "text", "text": "Internal Server Error"}]}
+  result:  "Error: MCP tool 'shortener/search-links' reported a failure: Internal Server Error"
+  receipt: unchanged by this change
+```
+
+Alternatives:
+
+- Let the exception reach the dispatcher's classification branch. Rejected. It changes the model-facing text, drops the tool name prefix, and reopens the `HttpClient` timeout versus caller cancellation distinction that the adapter's filter exists for.
+- Return a typed result object from `IMcpToolInvoker`. Rejected. It adds a type and an interface change for one consumer.
+- Map `McpProtocolException.ErrorCode == InvalidParams` to `invalid_input`. Rejected. The SDK uses that code for a malformed request or an unknown tool name, not for tool input. One more branch for an ambiguous meaning.
+
+### D2. The manager rethrows non-transport exceptions and logs once
+
+`McpClientManager.InvokeSharedAsync` no longer converts `McpException` to a string. The adapter is then the only converter. The tool lookup that throws `CreateUnavailableException` moves out of the `try` block, so the manager's own exception does not log as an invocation failure.
+
+```text
+try
+  return InvokeFunctionAsync(...)
+catch OperationCanceledException when ct.IsCancellationRequested
+  rethrow                                   (no log, no reconnect)
+catch Exception ex
+  log Warning: server, tool, HTTP status when ex is HttpRequestException with a status, RedactForLogging(ex)
+  if not IsTransportOrSessionFailure(ex): rethrow
+  transportFailure = ex
+reconnect for later calls; rethrow transportFailure
+```
+
+Both branches log Warning. This matters for delivery order: the #2055 pull request lands before D3, and an HTTP 500 is still a transport failure at that point. The Debug line in `ReconnectAfterTransportFailureAsync` stays.
+
+An `HttpClient` timeout surfaces as `TaskCanceledException` with the caller token not cancelled. It logs Warning, is not a transport failure, and reaches the adapter as `transient_failure`.
+
+The dispatcher's `Tool executed:` line stays unchanged. It reports duration and size. The Warning line is the failure signal.
+
+Alternative: log in the adapter. Rejected. The adapter has no logger and no server context.
+
+### D3. The classifier reads the HTTP status, on both consumers
+
+`IsTransportOrSessionFailure` returns true for `HttpRequestException` only when `StatusCode` is null or `404`. Every other status is an application error. The other branches of the predicate stay as they are.
+
+Tool path: the manager rethrows an application error without a reconnect, the generation does not change, and the adapter maps it per D1.
+
+Prompt-skill path (`LoadAsync`): today its first catch clause accepts only `McpException`. After D3 an `HttpRequestException` with an application status would match neither clause and escape to the dispatcher. The first clause widens to `McpException` or `HttpRequestException` when not a transport failure, and returns the existing `McpPromptSkillLoadResult.Failed(...)` text. No new clause, no new type.
+
+Positive example (application error, no reconnect):
+
+```text
+tools/call -> HTTP 429, body {"statusCode":429,...}
+  manager:    Warning logged; rethrow; generation stays N
+  adapter:    transient_failure; "Error: MCP tool '...' failed: ... 429 ..."
+```
+
+Negative example (session expiry, reconnect):
+
+```text
+tools/call -> HTTP 404
+  manager:    Warning logged; one coalesced reconnect for later calls; rethrow
+  adapter:    not_found; "Error: MCP tool '...' failed: ... 404 ..."
+```
+
+Alternative: a second predicate for application statuses. Rejected. One predicate is enough.
+
+### D4. Result-text auth detection applies only to servers that can use OAuth
+
+`ReportToolFailure` calls `MarkToolAuthFailure` only when `HasOAuthRuntimeHints(serverName, entry)` is true. A stdio server or a server with an operator-configured `Authorization` header keeps `Connected`. The Warning line from `ReportToolFailure` still records the failure. The manager reads the entry from `_serverEntries`, as `ReconnectAfterTransportFailureAsync` does.
+
+Positive example (OAuth-capable server, reclassified):
+
+```text
+HTTP server, no Authorization header
+  isError text: "Unauthorized: token expired"
+  status: AuthFailed; remedy names "netclaw mcp auth <name>"
+```
+
+Negative example (static-header server, not reclassified):
+
+```text
+HTTP server, Authorization header configured
+  isError text: "Forbidden: you do not own this domain"
+  status: Connected; Warning logged; no remedy names "netclaw mcp auth"
+```
+
+Alternative: delete the result-text heuristic. Rejected. The expired-token case is real and has a test. A false positive on an OAuth server is a separate issue.
+
+Alternative: gate on `HasConfiguredAuthorizationHeader` only. Rejected. A stdio server has no header and would stay demotable, with the same wrong remedy.
+
+### D5. Owners and data lifetime
+
+| Decision | Owner | Data |
+|---|---|---|
+| Outcome category for an MCP exception | `McpToolAdapter` | call-local |
+| Tool receipt storage | `DispatchingToolExecutor` via `ToolExecutionOutputs` | call-local |
+| Reconnect or not | `McpClientManager.IsTransportOrSessionFailure` | call-local |
+| Warning log line | `McpClientManager.InvokeSharedAsync` | call-local |
+| Prompt load failure result | `McpClientManager.LoadAsync` | call-local |
+| Server status change | `McpClientManager.ReportToolFailure` | actor-local snapshot |
+
+No durable record, event, snapshot, protobuf, configuration, or public API changes.
+
+## Failure modes and recovery
+
+This pseudocode is schematic. It omits the ACL gate and redaction.
+
+```text
+transport failure (no status, 404, socket fault)
+  -> Warning log -> at most one coalesced reconnect for later calls -> rethrow
+  -> adapter: transient_failure (404: not_found) -> result string
+
+reconnect also fails
+  -> Warning log -> existing Error log -> AggregateException rethrown
+  -> adapter: transient_failure -> result string
+
+application status (5xx, 429, 401, 403, other 4xx)
+  -> Warning log -> rethrow, no reconnect, generation unchanged
+  -> adapter: category per D1 -> result string
+
+JSON-RPC error (McpException, not session-related)
+  -> Warning log -> rethrow, no reconnect
+  -> adapter: transient_failure -> result string
+
+prompt load, application status
+  -> failed load result that names the status; no reconnect
+
+caller cancellation
+  -> propagates; no log, no receipt, no reconnect (unchanged)
+
+HttpClient timeout (TaskCanceledException, caller token not cancelled)
+  -> Warning log -> rethrow, no reconnect -> adapter: transient_failure
+```
+
+## Risks / Trade-offs
+
+- [OAuth-capable servers keep substring auth detection on result text] → Documented in D4. A false positive on such a server gets its own issue.
+- [Tests that assert the manager returns an error string for `McpException`] → `McpClientManagerLifecycleTests` (the `application MCP failure` assertion) changes to expect the exception. The adapter test asserts the string.
+- [The existing expired-token test uses a stdio entry] → It changes to an HTTP entry without an `Authorization` header, so it keeps its meaning under D4.
+- [One Warning per failed call on a flapping server] → Same volume as the `isError` path today. Acceptable.
+- [401 or 403 on an OAuth server maps to `access_denied`] → The SDK refreshes inside the call. A surfaced 401 means refresh failed. `access_denied` is accurate.
+- [A static-header server whose key is revoked stays `Connected`] → The Warning line and the `access_denied` result name the status. `netclaw mcp list` cannot show it. Acceptable for MVP.
+- [Sub-issue text narrows] → #2056 drops `Retry-After`; #2057 keeps the heuristic for OAuth-capable servers and adds no 401/403 remedy text. The issues get edited to match, and the pull requests say so.
+
+## Migration Plan
+
+None. No durable data changes. Rollback is a revert.
+
+## Delivery order
+
+Stacked pull requests, one per issue, each on the previous branch:
+
+1. This change's artifacts.
+2. #2055: D1 and D2.
+3. #2056: D3, both consumers.
+4. #2057: D4.

--- a/openspec/changes/mcp-tool-outcome-receipts/design.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/design.md
@@ -1,6 +1,8 @@
 ## Context
 
-Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for tool call, dispatcher, tool result, tool receipt, outcome category, and authority. See proposal.md for motivation.
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for tool call, dispatcher, tool result, tool receipt, outcome category, authority, transport or session failure, application error, tool-declared error, and OAuth-capable server. This change adds the last four terms to the glossary. See proposal.md for motivation.
+
+The real examples below come from a link-shortener MCP server (`shortio`) observed on 2026-08-26. The server never returned HTTP 5xx. It returned tool-declared errors with the text `Internal Server Error`, HTTP 429 under a 30-requests-per-minute budget, and HTTP 401 for a bad key.
 
 Current flow at `dev` (`94d2bfce`) for an MCP tool call that ends in an exception. This pseudocode is schematic. It omits authorization, redaction, and the output bound.
 
@@ -24,10 +26,10 @@ Constraints that shape the approach:
 - The tool receipt is first-writer-wins (`ToolExecutionOutputs.TryComplete` uses `CompareExchange`). A tool that completes the receipt before it returns wins over the dispatcher's `success` completion.
 - `ToolOutcomeResults` (#2033) already attaches a category to a result string. The workspace tools use it. Its one-argument helpers need no file activity and no remediation code.
 - `McpClientManager.IsTransportOrSessionFailure` is the single predicate that decides a reconnect. It has two consumers: the tool path (`InvokeSharedAsync`) and the prompt-skill path (`LoadAsync`).
-- `McpClientManager.ReportToolFailure` owns the tool-declared `isError` path and its Warning log.
-- `McpClientManager.HasOAuthRuntimeHints(serverName, entry)` already answers "can this server use OAuth": the transport is not stdio and no operator-configured `Authorization` header exists.
-- In the SDK (`ModelContextProtocol.Core` 2.2.0), `McpException` carries no error code. Only the derived `McpProtocolException.ErrorCode` does, and the SDK reserves `-32602` for a malformed request or an unknown primitive name. Tool input validation arrives as an `isError` result, not as this exception.
-- The existing test `ToolLevelAuthFailure_MovesServerOutOfConnected` documents the expired-token case: the token failure reaches the agent as `isError` text, not as an HTTP 401. Its harness uses a stdio entry today.
+- `McpClientManager.ReportToolFailure` owns the tool-declared error path and its Warning log.
+- `McpClientManager.HasOAuthRuntimeHints(serverName, entry)` already decides whether a server is OAuth-capable.
+- In the SDK (`ModelContextProtocol.Core` 2.2.0), `McpException` carries no error code. Only the derived `McpProtocolException.ErrorCode` does, and the SDK reserves `-32602` for a malformed request or an unknown primitive name. Tool input validation arrives as a tool-declared error, not as this exception.
+- The existing test `ToolLevelAuthFailure_MovesServerOutOfConnected` documents the expired-token case: the token failure reaches the agent as a tool-declared error, not as an HTTP 401. Its harness uses a stdio entry today.
 - Production always passes the manager as the adapter's invoker (`PrepareMcpTools`). The adapter's bound-tool path is unreachable in the daemon.
 
 ## Goals / Non-Goals
@@ -37,8 +39,8 @@ Constraints that shape the approach:
 - One converter from exception to tool result. The adapter owns it.
 - One receipt per failed call with a category the actor can trust.
 - One Warning line per failed call in the daemon log.
-- Reconnect only when a new session can help.
-- No false `AuthFailed` for a server that cannot use OAuth.
+- Reconnect only for a transport or session failure.
+- No false `AuthFailed` for a server that is not OAuth-capable.
 - The fewest moving parts. Reuse existing helpers. Add no new type, interface, or configuration.
 
 **Non-Goals:**
@@ -47,7 +49,7 @@ Constraints that shape the approach:
 - Retry, replay, or add a per-server request budget.
 - Propagate `Retry-After` from the SDK exception. The SDK exception carries no headers.
 - Map JSON-RPC error codes to categories.
-- Change the receipt category of a tool-declared `isError` result.
+- Change the receipt category of a tool-declared error.
 - Change the connect-path auth classification (#1908 covers it).
 - Change the adapter's bound-tool path.
 
@@ -87,19 +89,30 @@ The receipt is call-local. Nothing durable changes. Every receipt consumer today
 
 The bound-tool path (`ExecuteViaBoundToolAsync`) stays as it is. The daemon never uses it.
 
-Positive example:
+Positive example (observed HTTP 429 after the 30-per-minute budget):
 
 ```text
-tools/call -> HTTP 500
-  result:  "Error: MCP tool 'shortener/search-links' failed: ... 500 ..."
+tools/call -> HTTP 429
+              {"statusCode":429,"error":"Too Many Requests","message":"Rate limit exceeded, retry in 52 seconds"}
+  result:  "Error: MCP tool 'shortio/get-domains' failed: Response status code does not indicate success: 429 (Too Many Requests). Response body: {"statusCode":429,...}"
   receipt: category = transient_failure
 ```
 
-Negative example:
+Positive example (observed HTTP 401 for a key with a `Bearer ` prefix the server rejects):
 
 ```text
-tools/call -> HTTP 200, {"isError": true, "content": [{"type": "text", "text": "Internal Server Error"}]}
-  result:  "Error: MCP tool 'shortener/search-links' reported a failure: Internal Server Error"
+tools/call -> HTTP 401
+              {"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: No API key provided"},"id":null}
+  result:  "Error: MCP tool 'shortio/get-domains' failed: ... 401 (Unauthorized) ..."
+  receipt: category = access_denied
+```
+
+Negative example (observed tool-declared error; `search-links` with only its required `domainId`):
+
+```text
+tools/call -> HTTP 200
+              {"result":{"content":[{"type":"text","text":"Internal Server Error"}],"isError":true},"jsonrpc":"2.0","id":70}
+  result:  "Error: MCP tool 'shortio/search-links' reported a failure: Internal Server Error"
   receipt: unchanged by this change
 ```
 
@@ -127,6 +140,12 @@ reconnect for later calls; rethrow transportFailure
 
 Both branches log Warning. This matters for delivery order: the #2055 pull request lands before D3, and an HTTP 500 is still a transport failure at that point. The Debug line in `ReconnectAfterTransportFailureAsync` stays.
 
+Real log line for the 429 example above:
+
+```text
+[WRN] Netclaw.Daemon.Mcp.McpClientManager: MCP tool 'shortio/get-domains' invocation failed (HTTP 429)
+```
+
 An `HttpClient` timeout surfaces as `TaskCanceledException` with the caller token not cancelled. It logs Warning, is not a transport failure, and reaches the adapter as `transient_failure`.
 
 The dispatcher's `Tool executed:` line stays unchanged. It reports duration and size. The Warning line is the failure signal.
@@ -135,51 +154,53 @@ Alternative: log in the adapter. Rejected. The adapter has no logger and no serv
 
 ### D3. The classifier reads the HTTP status, on both consumers
 
-`IsTransportOrSessionFailure` returns true for `HttpRequestException` only when `StatusCode` is null or `404`. Every other status is an application error. The other branches of the predicate stay as they are.
+`IsTransportOrSessionFailure` returns true for `HttpRequestException` only when `StatusCode` is null or `404`. Every other status is an application error, as the glossary defines it. The other branches of the predicate stay as they are.
 
 Tool path: the manager rethrows an application error without a reconnect, the generation does not change, and the adapter maps it per D1.
 
 Prompt-skill path (`LoadAsync`): today its first catch clause accepts only `McpException`. After D3 an `HttpRequestException` with an application status would match neither clause and escape to the dispatcher. The first clause widens to `McpException` or `HttpRequestException` when not a transport failure, and returns the existing `McpPromptSkillLoadResult.Failed(...)` text. No new clause, no new type.
 
-Positive example (application error, no reconnect):
+Positive example (application error, no reconnect; observed):
 
 ```text
-tools/call -> HTTP 429, body {"statusCode":429,...}
-  manager:    Warning logged; rethrow; generation stays N
-  adapter:    transient_failure; "Error: MCP tool '...' failed: ... 429 ..."
+tools/call -> HTTP 429, body {"statusCode":429,"error":"Too Many Requests",...}
+  manager:    Warning "... invocation failed (HTTP 429)"; rethrow; generation stays 1
+  adapter:    transient_failure; "Error: MCP tool 'shortio/get-domains' failed: ... 429 ..."
 ```
 
-Negative example (session expiry, reconnect):
+Negative example (session failure, reconnect; the Streamable HTTP contract):
 
 ```text
-tools/call -> HTTP 404
-  manager:    Warning logged; one coalesced reconnect for later calls; rethrow
-  adapter:    not_found; "Error: MCP tool '...' failed: ... 404 ..."
+tools/call -> HTTP 404 (session expired)
+  manager:    Warning "... invocation failed (HTTP 404)"; one coalesced reconnect for later calls; rethrow
+  adapter:    not_found; "Error: MCP tool 'shortio/get-domains' failed: ... 404 ..."
 ```
 
 Alternative: a second predicate for application statuses. Rejected. One predicate is enough.
 
-### D4. Result-text auth detection applies only to servers that can use OAuth
+### D4. Result-text auth detection applies only to OAuth-capable servers
 
-`ReportToolFailure` calls `MarkToolAuthFailure` only when `HasOAuthRuntimeHints(serverName, entry)` is true. A stdio server or a server with an operator-configured `Authorization` header keeps `Connected`. The Warning line from `ReportToolFailure` still records the failure. The manager reads the entry from `_serverEntries`, as `ReconnectAfterTransportFailureAsync` does.
+`ReportToolFailure` calls `MarkToolAuthFailure` only when `HasOAuthRuntimeHints(serverName, entry)` is true, so only an OAuth-capable server (glossary) can be demoted from a tool-declared error. A stdio server or a static-header server keeps `Connected`. The Warning line from `ReportToolFailure` still records the failure. The manager reads the entry from `_serverEntries`, as `ReconnectAfterTransportFailureAsync` does.
 
-Positive example (OAuth-capable server, reclassified):
+Positive example (OAuth-capable server, reclassified; the fixture in `ToolLevelAuthFailure_MovesServerOutOfConnected`):
 
 ```text
-HTTP server, no Authorization header
-  isError text: "Unauthorized: token expired"
+http server, no Authorization header
+  tool-declared error text: "Unauthorized: token expired"
   status: AuthFailed; remedy names "netclaw mcp auth <name>"
 ```
 
-Negative example (static-header server, not reclassified):
+Negative example (static-header server, not reclassified). The observed server relays its REST layer's failures as tool-declared errors with the shape `{"error":"Request failed: 404 Not Found"}` and `{"error":"Request failed: 400 Bad Request"}`. A REST 403 follows the same shape:
 
 ```text
-HTTP server, Authorization header configured
-  isError text: "Forbidden: you do not own this domain"
-  status: Connected; Warning logged; no remedy names "netclaw mcp auth"
+http server, Authorization header configured (the observed shortio profile)
+  tool-declared error text: {"error":"Request failed: 403 Forbidden"}
+  before: IsAuthFailureMessage matches "forbidden" -> AuthFailed; false authentication_failed alert;
+          "netclaw mcp auth shortio" named as the remedy, which a static-header server cannot use
+  after:  status Connected; Warning logged; no remedy names "netclaw mcp auth"
 ```
 
-Alternative: delete the result-text heuristic. Rejected. The expired-token case is real and has a test. A false positive on an OAuth server is a separate issue.
+Alternative: delete the result-text heuristic. Rejected. The expired-token case is real and has a test. A false positive on an OAuth-capable server is a separate issue.
 
 Alternative: gate on `HasConfiguredAuthorizationHeader` only. Rejected. A stdio server has no header and would stay demotable, with the same wrong remedy.
 
@@ -201,7 +222,7 @@ No durable record, event, snapshot, protobuf, configuration, or public API chang
 This pseudocode is schematic. It omits the ACL gate and redaction.
 
 ```text
-transport failure (no status, 404, socket fault)
+transport or session failure (no status, 404, socket fault)
   -> Warning log -> at most one coalesced reconnect for later calls -> rethrow
   -> adapter: transient_failure (404: not_found) -> result string
 
@@ -209,16 +230,19 @@ reconnect also fails
   -> Warning log -> existing Error log -> AggregateException rethrown
   -> adapter: transient_failure -> result string
 
-application status (5xx, 429, 401, 403, other 4xx)
+application error, HTTP status (5xx, 429, 401, 403, other 4xx)
   -> Warning log -> rethrow, no reconnect, generation unchanged
   -> adapter: category per D1 -> result string
 
-JSON-RPC error (McpException, not session-related)
+application error, JSON-RPC (McpException, not session-related)
   -> Warning log -> rethrow, no reconnect
   -> adapter: transient_failure -> result string
 
-prompt load, application status
-  -> failed load result that names the status; no reconnect
+tool-declared error (isError: true)
+  -> ReportToolFailure Warning -> result string; D4 gate decides AuthFailed (unchanged otherwise)
+
+prompt load, application error
+  -> failed load result that names the prompt; no reconnect
 
 caller cancellation
   -> propagates; no log, no receipt, no reconnect (unchanged)
@@ -232,10 +256,11 @@ HttpClient timeout (TaskCanceledException, caller token not cancelled)
 - [OAuth-capable servers keep substring auth detection on result text] → Documented in D4. A false positive on such a server gets its own issue.
 - [Tests that assert the manager returns an error string for `McpException`] → `McpClientManagerLifecycleTests` (the `application MCP failure` assertion) changes to expect the exception. The adapter test asserts the string.
 - [The existing expired-token test uses a stdio entry] → It changes to an HTTP entry without an `Authorization` header, so it keeps its meaning under D4.
-- [One Warning per failed call on a flapping server] → Same volume as the `isError` path today. Acceptable.
-- [401 or 403 on an OAuth server maps to `access_denied`] → The SDK refreshes inside the call. A surfaced 401 means refresh failed. `access_denied` is accurate.
+- [One Warning per failed call on a flapping server] → Same volume as the tool-declared error path today. Acceptable.
+- [401 or 403 on an OAuth-capable server maps to `access_denied`] → The SDK refreshes inside the call. A surfaced 401 means refresh failed. `access_denied` is accurate.
 - [A static-header server whose key is revoked stays `Connected`] → The Warning line and the `access_denied` result name the status. `netclaw mcp list` cannot show it. Acceptable for MVP.
-- [Sub-issue text narrows] → #2056 drops `Retry-After`; #2057 keeps the heuristic for OAuth-capable servers and adds no 401/403 remedy text. The issues get edited to match, and the pull requests say so.
+- [A non-compliant server reports a dead session with HTTP 400, not 404] → The observed server answers a stale or deleted session with `HTTP 400 {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: No valid session ID provided"},"id":null}`. The SDK turns a 400 with a JSON-RPC body into `McpProtocolException`, and the predicate's message check does not read that text as a session failure. Such a server keeps a dead session until the daemon restarts. This is pre-existing: before this change the same answer was a string result with no reconnect. Out of scope here; a follow-up can add a session-scoped check for that message shape.
+- [Sub-issue text narrows] → #2056 drops `Retry-After`; #2057 keeps the heuristic for OAuth-capable servers and adds no 401/403 remedy text. The issues were edited to match, and the pull requests say so.
 
 ## Migration Plan
 
@@ -245,7 +270,7 @@ None. No durable data changes. Rollback is a revert.
 
 Stacked pull requests, one per issue, each on the previous branch:
 
-1. This change's artifacts.
+1. This change's artifacts and the glossary terms.
 2. #2055: D1 and D2.
 3. #2056: D3, both consumers.
 4. #2057: D4.

--- a/openspec/changes/mcp-tool-outcome-receipts/proposal.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/proposal.md
@@ -1,5 +1,7 @@
 ## Why
 
+Use the [Netclaw engineering glossary](../../../docs/spec/GLOSSARY.md) for shared terms: tool receipt, outcome category, transport or session failure, application error, tool-declared error, and OAuth-capable server.
+
 PRD-006 (MCP-005, MCP-008) requires that runtime diagnostics show recent MCP invocation failures and that failures degrade gracefully. Today an MCP tool call that ends in an exception becomes a tool result with no tool receipt. The dispatcher records it as a success, and the daemon log holds no failure line at the default level. The same path treats every HTTP error as a transport fault and reconnects. A server-side business error can also move a static-header server into `AuthFailed`. Epic #2058 tracks the three defects (#2055, #2056, #2057).
 
 ## What Changes
@@ -10,6 +12,7 @@ PRD-006 (MCP-005, MCP-008) requires that runtime diagnostics show recent MCP inv
 - Keep tool-result-text auth detection for HTTP servers without an operator-configured `Authorization` header. A stdio server or a server with such a header never enters `AuthFailed` because of tool-result text.
 - Apply the same application-error classification to MCP prompt loads, so an HTTP error returns a failed load result instead of an exception.
 - Remove the duplicate exception-to-string conversion in the client manager. The adapter owns that conversion.
+- Add four MCP invocation terms to the engineering glossary: transport or session failure, application error, tool-declared error, and OAuth-capable server. Both modified capabilities use them.
 
 In scope for MVP: the three defects above and their regression tests.
 

--- a/openspec/changes/mcp-tool-outcome-receipts/proposal.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+PRD-006 (MCP-005, MCP-008) requires that runtime diagnostics show recent MCP invocation failures and that failures degrade gracefully. Today an MCP tool call that ends in an exception becomes a tool result with no tool receipt. The dispatcher records it as a success, and the daemon log holds no failure line at the default level. The same path treats every HTTP error as a transport fault and reconnects. A server-side business error can also move a static-header server into `AuthFailed`. Epic #2058 tracks the three defects (#2055, #2056, #2057).
+
+## What Changes
+
+- Give an MCP tool-call exception a non-success outcome category in its tool receipt. The tool result text keeps its current shape.
+- Log each MCP tool-call exception once at Warning. The line names the server, the tool, and the HTTP status when present.
+- Classify an HTTP response that carries an application-level status code as an application error. Netclaw returns it without a reconnect. Only a missing status or a 404 session expiry counts as a transport or session failure.
+- Keep tool-result-text auth detection for HTTP servers without an operator-configured `Authorization` header. A stdio server or a server with such a header never enters `AuthFailed` because of tool-result text.
+- Apply the same application-error classification to MCP prompt loads, so an HTTP error returns a failed load result instead of an exception.
+- Remove the duplicate exception-to-string conversion in the client manager. The adapter owns that conversion.
+
+In scope for MVP: the three defects above and their regression tests.
+
+Out of scope: per-server rate-limit budgets, `Retry-After` propagation, approval gates for MCP tools that mutate state, changes to the MCP SDK discover probe, and the receipt category of a tool-declared `isError` result.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Add machine-actionable outcomes for MCP tool calls that end in an exception.
+- `netclaw-mcp`: Narrow reconnect to transport and session failures, require a Warning log for each failed invocation, and protect static-header servers from result-text auth demotion.
+
+## Impact
+
+Code: `McpToolAdapter` (receipt completion), `McpClientManager` (failure classification, one Warning log, static-header guard), and their tests. No public API, configuration property, durable record, or approval authority changes. The receipt stays call-local.
+
+Security: a tool receipt grants no authority. The static-header guard removes a false `AuthFailed` state that pointed operators at `netclaw mcp auth` for a server with no OAuth.
+
+Operations: operators gain one Warning line per failed MCP call. Servers with request budgets receive fewer reconnect requests after an application error.

--- a/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-mcp/spec.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-mcp/spec.md
@@ -1,0 +1,173 @@
+Use the [Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md) for tool call, tool result, and tool receipt.
+
+## MODIFIED Requirements
+
+### Requirement: Graceful degradation
+
+Tool calls to unavailable MCP servers SHALL return a clear error message to
+the agent. The agent SHALL continue operating with remaining available tools.
+The system SHALL attempt reconnection on the next tool call to a previously
+unavailable server. Reconnection SHALL be triggered only by
+classified transport or session failures: caller cancellation SHALL propagate
+immediately without teardown or retry, and tool-declared or application
+errors SHALL be returned without reconnecting. An HTTP response that carries a
+status code SHALL count as an application error unless the status is 404,
+which signals session expiry. An HTTP failure with no status code, a socket or
+stream fault, or a session-closed protocol error SHALL count as a transport or
+session failure. The same classification SHALL apply to an MCP prompt load: an
+application error SHALL return a failed load result without a reconnect. A
+classified transport failure
+SHALL trigger at most one coalesced reconnection for later calls. The failed
+tool invocation SHALL NOT be replayed automatically because the remote side
+effect may have completed before the failure became visible.
+
+#### Scenario: Unavailable server returns clear error
+
+- **GIVEN** a configured MCP server is unreachable
+- **WHEN** the agent invokes a tool from that server
+- **THEN** a clear error is returned indicating the server is unavailable
+- **AND** the agent continues the conversation with remaining tools
+
+#### Scenario: Reconnection on next call
+
+- **GIVEN** an MCP server was previously unreachable
+- **WHEN** the agent invokes a tool from that server again
+- **THEN** the system attempts reconnection before returning an error
+
+#### Scenario: Partial server availability
+
+- **GIVEN** two MCP servers are configured and one is unreachable
+- **WHEN** a session initializes
+- **THEN** tools from the reachable server are available
+- **AND** tools from the unreachable server are marked as unavailable
+
+#### Scenario: Caller cancellation does not tear down a healthy client
+
+- **GIVEN** a tool invocation in flight on a healthy shared connection
+- **WHEN** the caller's cancellation token fires
+- **THEN** the cancellation propagates to the caller immediately
+- **AND** the shared connection is not disposed, reconnected, or retried
+
+#### Scenario: Tool-declared errors are results, not failures
+
+- **GIVEN** an MCP tool returns a tool-declared error
+- **WHEN** the invocation completes
+- **THEN** the error is formatted as a tool result
+- **AND** no reconnection or retry occurs
+
+#### Scenario: Transport failure reconnects without replay
+
+- **GIVEN** a tool invocation fails with a classified transport failure
+- **WHEN** the system handles the failure
+- **THEN** the failed invocation is returned as an error without automatic replay
+- **AND** the system performs at most one coalesced reconnection for later calls
+
+#### Scenario: Application-level HTTP status does not reconnect
+
+- **GIVEN** a tool invocation fails with an HTTP 500 or HTTP 429 response from a connected server
+- **WHEN** the system handles the failure
+- **THEN** the failure is returned as an error that names the HTTP status
+- **AND** the published connection generation does not change
+- **AND** no reconnection or retry occurs
+
+#### Scenario: Session expiry still reconnects
+
+- **GIVEN** a tool invocation fails with an HTTP 404 response
+- **WHEN** the system handles the failure
+- **THEN** the failed invocation is returned as an error without automatic replay
+- **AND** the system performs at most one coalesced reconnection for later calls
+
+#### Scenario: Prompt load with an application-level HTTP status returns a failed result
+
+- **GIVEN** an MCP prompt load fails with an HTTP 500 response from a connected server
+- **WHEN** the system handles the failure
+- **THEN** the skill load returns a failed result that names the prompt and the failure
+- **AND** the published connection generation does not change
+- **AND** no exception reaches the tool dispatcher
+
+### Requirement: MCP diagnostics visibility
+
+The system SHALL expose MCP server health in diagnostics. Connection status
+SHALL distinguish `AwaitingAuth` (no usable authorization and interaction is
+required), `AuthFailed` (credentials or refresh were rejected), `Unreachable`
+(transport or network failure), and `Connected` (published usable
+generation). Connection state, tool count, and error information SHALL be
+updated together from the same lifecycle operation. Failure status SHALL carry
+the last error timestamp from `TimeProvider`; successful recovery SHALL update
+state and tool count without fabricating a new failure timestamp. The daemon
+log SHALL record each MCP tool invocation that ends in an exception at Warning
+level or higher. The line SHALL name the server, the tool, and the HTTP status
+when one is present, and SHALL redact secrets. Caller cancellation SHALL NOT
+produce that line. A server that uses a stdio transport or an
+operator-configured `Authorization` header SHALL NOT enter `AuthFailed`
+because of tool-result text. Only an HTTP server without an operator-configured
+`Authorization` header MAY be reclassified from a tool-declared auth error.
+
+#### Scenario: Server becomes unavailable
+
+- **WHEN** a configured MCP server is unreachable
+- **THEN** diagnostics mark it degraded or unavailable with last error timestamp
+
+#### Scenario: Recovery preserves truthful failure timing
+
+- **GIVEN** a server status contains a last error timestamp
+- **WHEN** a later generation connects successfully
+- **THEN** diagnostics report `Connected` with the new tool count
+- **AND** any retained last-failure timestamp still identifies the actual failure time rather than the recovery time
+
+#### Scenario: Daemon reports MCP auth failure
+
+- **GIVEN** the daemon can reach the MCP server but authentication is rejected on the live runtime path
+- **WHEN** the operator runs `netclaw mcp list` or `netclaw doctor`
+- **THEN** the CLI reports `auth failed`
+- **AND** remediation points to `netclaw mcp auth <name>` when OAuth is in use
+
+#### Scenario: Doctor cannot verify OAuth auth offline
+
+- **GIVEN** an HTTP/SSE MCP server uses OAuth
+- **AND** the daemon is unavailable
+- **WHEN** the operator runs `netclaw doctor`
+- **THEN** doctor may report offline connectivity evidence
+- **BUT** it SHALL not claim the server is unauthorized unless the daemon runtime path has verified that auth failure
+
+#### Scenario: Expired token without refresh token names the remedy
+
+- **GIVEN** a server whose stored access token is expired and whose record holds no refresh token
+- **WHEN** the daemon attempts to connect
+- **THEN** the status is `AwaitingAuth` rather than a generic connection error
+- **AND** diagnostics state that reauthorization is required via `netclaw mcp auth <name>`
+
+#### Scenario: Failed invocation is visible at the default log level
+
+- **GIVEN** an MCP tool invocation ends in an HTTP 500 exception
+- **WHEN** the daemon handles the failure
+- **THEN** the daemon log holds one Warning line that names the server, the tool, and status 500
+- **AND** the line contains no secret values
+
+#### Scenario: Cancelled invocation is not logged as a failure
+
+- **GIVEN** an MCP tool invocation in flight
+- **WHEN** the caller's cancellation token fires
+- **THEN** the daemon log holds no Warning line for that invocation
+
+#### Scenario: Static-header server ignores auth words in a tool result
+
+- **GIVEN** an HTTP server authenticated by an operator-configured `Authorization` header
+- **WHEN** a tool returns `isError: true` with text that contains "Forbidden"
+- **THEN** the server status stays `Connected`
+- **AND** the daemon log records the tool failure at Warning
+- **AND** no remedy names `netclaw mcp auth`
+
+#### Scenario: Stdio server ignores auth words in a tool result
+
+- **GIVEN** a stdio server
+- **WHEN** a tool returns `isError: true` with text that reports an expired token
+- **THEN** the server status stays `Connected`
+- **AND** no remedy names `netclaw mcp auth`
+
+#### Scenario: OAuth-capable server still reclassifies an expired-token result
+
+- **GIVEN** an HTTP server without an operator-configured `Authorization` header
+- **WHEN** a tool returns `isError: true` with text that reports an expired token
+- **THEN** the server status becomes `AuthFailed`
+- **AND** remediation points to `netclaw mcp auth <name>`

--- a/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-mcp/spec.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-mcp/spec.md
@@ -1,4 +1,4 @@
-Use the [Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md) for tool call, tool result, and tool receipt.
+Use the [Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md) for tool call, tool result, tool receipt, transport or session failure, application error, tool-declared error, and OAuth-capable server.
 
 ## MODIFIED Requirements
 
@@ -10,13 +10,11 @@ The system SHALL attempt reconnection on the next tool call to a previously
 unavailable server. Reconnection SHALL be triggered only by
 classified transport or session failures: caller cancellation SHALL propagate
 immediately without teardown or retry, and tool-declared or application
-errors SHALL be returned without reconnecting. An HTTP response that carries a
-status code SHALL count as an application error unless the status is 404,
-which signals session expiry. An HTTP failure with no status code, a socket or
-stream fault, or a session-closed protocol error SHALL count as a transport or
-session failure. The same classification SHALL apply to an MCP prompt load: an
-application error SHALL return a failed load result without a reconnect. A
-classified transport failure
+errors SHALL be returned without reconnecting. The engineering glossary
+defines transport or session failure and application error. An HTTP answer
+with a status code other than 404 SHALL count as an application error. The
+same rule SHALL apply to an MCP prompt load: an application error SHALL return
+a failed load result without a reconnect. A classified transport failure
 SHALL trigger at most one coalesced reconnection for later calls. The failed
 tool invocation SHALL NOT be replayed automatically because the remote side
 effect may have completed before the failure became visible.
@@ -64,7 +62,7 @@ effect may have completed before the failure became visible.
 
 #### Scenario: Application-level HTTP status does not reconnect
 
-- **GIVEN** a tool invocation fails with an HTTP 500 or HTTP 429 response from a connected server
+- **GIVEN** a tool invocation fails with an HTTP 500 or HTTP 429 response from a connected server, for example a rate-limit answer `{"statusCode":429,"error":"Too Many Requests","message":"Rate limit exceeded, retry in 52 seconds"}`
 - **WHEN** the system handles the failure
 - **THEN** the failure is returned as an error that names the HTTP status
 - **AND** the published connection generation does not change
@@ -98,10 +96,9 @@ state and tool count without fabricating a new failure timestamp. The daemon
 log SHALL record each MCP tool invocation that ends in an exception at Warning
 level or higher. The line SHALL name the server, the tool, and the HTTP status
 when one is present, and SHALL redact secrets. Caller cancellation SHALL NOT
-produce that line. A server that uses a stdio transport or an
-operator-configured `Authorization` header SHALL NOT enter `AuthFailed`
-because of tool-result text. Only an HTTP server without an operator-configured
-`Authorization` header MAY be reclassified from a tool-declared auth error.
+produce that line. Only an OAuth-capable server, as the engineering glossary
+defines it, MAY enter `AuthFailed` because of a tool-declared auth error. Any
+other server SHALL stay `Connected` after such a result.
 
 #### Scenario: Server becomes unavailable
 
@@ -141,7 +138,7 @@ because of tool-result text. Only an HTTP server without an operator-configured
 
 - **GIVEN** an MCP tool invocation ends in an HTTP 500 exception
 - **WHEN** the daemon handles the failure
-- **THEN** the daemon log holds one Warning line that names the server, the tool, and status 500
+- **THEN** the daemon log holds one Warning line that names the server, the tool, and status 500, for example `MCP tool 'shortio/get-domains' invocation failed (HTTP 500)`
 - **AND** the line contains no secret values
 
 #### Scenario: Cancelled invocation is not logged as a failure
@@ -153,7 +150,7 @@ because of tool-result text. Only an HTTP server without an operator-configured
 #### Scenario: Static-header server ignores auth words in a tool result
 
 - **GIVEN** an HTTP server authenticated by an operator-configured `Authorization` header
-- **WHEN** a tool returns `isError: true` with text that contains "Forbidden"
+- **WHEN** a tool returns a tool-declared error whose text contains "Forbidden", for example `{"error":"Request failed: 403 Forbidden"}`
 - **THEN** the server status stays `Connected`
 - **AND** the daemon log records the tool failure at Warning
 - **AND** no remedy names `netclaw mcp auth`
@@ -161,13 +158,13 @@ because of tool-result text. Only an HTTP server without an operator-configured
 #### Scenario: Stdio server ignores auth words in a tool result
 
 - **GIVEN** a stdio server
-- **WHEN** a tool returns `isError: true` with text that reports an expired token
+- **WHEN** a tool returns a tool-declared error whose text reports an expired token
 - **THEN** the server status stays `Connected`
 - **AND** no remedy names `netclaw mcp auth`
 
 #### Scenario: OAuth-capable server still reclassifies an expired-token result
 
 - **GIVEN** an HTTP server without an operator-configured `Authorization` header
-- **WHEN** a tool returns `isError: true` with text that reports an expired token
+- **WHEN** a tool returns a tool-declared error whose text reports an expired token
 - **THEN** the server status becomes `AuthFailed`
 - **AND** remediation points to `netclaw mcp auth <name>`

--- a/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-tools/spec.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-tools/spec.md
@@ -1,0 +1,30 @@
+Use the [Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md) for tool call, dispatcher, tool result, tool receipt, and outcome category.
+
+## ADDED Requirements
+
+### Requirement: MCP tool outcomes are machine-actionable
+
+An MCP tool call that ends in an exception SHALL produce a tool receipt under the same rules as the requirement "First-party tool outcomes are machine-actionable". The category SHALL follow the failure kind: an HTTP 401 or 403 is `access_denied`, an HTTP 404 is `not_found`, and every other exception is `transient_failure`. The tool result SHALL stay a factual error string that names the tool. The receipt SHALL NOT grant authority, retry the call, or replay it.
+
+#### Scenario: HTTP 500 becomes a transient failure receipt
+
+- **GIVEN** an MCP tool call that the server answers with HTTP 500
+- **WHEN** the adapter returns the tool result
+- **THEN** the outcome category is `transient_failure`
+- **AND** the tool result names the tool and the HTTP status
+- **AND** the receipt records no file activity
+
+#### Scenario: HTTP 403 becomes an access-denied receipt
+
+- **GIVEN** an MCP tool call that the server answers with HTTP 403
+- **WHEN** the adapter returns the tool result
+- **THEN** the outcome category is `access_denied`
+- **AND** no authority changes
+
+#### Scenario: Tool-declared error keeps the result path
+
+- **GIVEN** an MCP tool call that the server answers with HTTP 200 and `isError: true`
+- **WHEN** the adapter returns the tool result
+- **THEN** the tool result carries the error text the tool declared
+- **AND** no exception outcome is produced
+- **AND** no reconnect occurs

--- a/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-tools/spec.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/specs/netclaw-tools/spec.md
@@ -1,10 +1,10 @@
-Use the [Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md) for tool call, dispatcher, tool result, tool receipt, and outcome category.
+Use the [Netclaw engineering glossary](../../../../../docs/spec/GLOSSARY.md) for tool call, dispatcher, tool result, tool receipt, outcome category, application error, and tool-declared error.
 
 ## ADDED Requirements
 
 ### Requirement: MCP tool outcomes are machine-actionable
 
-An MCP tool call that ends in an exception SHALL produce a tool receipt under the same rules as the requirement "First-party tool outcomes are machine-actionable". The category SHALL follow the failure kind: an HTTP 401 or 403 is `access_denied`, an HTTP 404 is `not_found`, and every other exception is `transient_failure`. The tool result SHALL stay a factual error string that names the tool. The receipt SHALL NOT grant authority, retry the call, or replay it.
+An MCP tool call that ends in an exception SHALL produce a tool receipt under the same rules as the requirement "First-party tool outcomes are machine-actionable". The category SHALL follow the failure kind: an HTTP 401 or 403 is `access_denied`, an HTTP 404 is `not_found`, and every other exception is `transient_failure`. The tool result SHALL stay a factual error string that names the tool. A tool-declared error is not an exception and SHALL keep its current result path. The receipt SHALL NOT grant authority, retry the call, or replay it.
 
 #### Scenario: HTTP 500 becomes a transient failure receipt
 
@@ -23,7 +23,7 @@ An MCP tool call that ends in an exception SHALL produce a tool receipt under th
 
 #### Scenario: Tool-declared error keeps the result path
 
-- **GIVEN** an MCP tool call that the server answers with HTTP 200 and `isError: true`
+- **GIVEN** an MCP tool call that the server answers with HTTP 200 and a tool-declared error, for example `{"content":[{"type":"text","text":"Internal Server Error"}],"isError":true}`
 - **WHEN** the adapter returns the tool result
 - **THEN** the tool result carries the error text the tool declared
 - **AND** no exception outcome is produced

--- a/openspec/changes/mcp-tool-outcome-receipts/tasks.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/tasks.md
@@ -1,0 +1,27 @@
+## 1. Specification
+
+- [x] 1.1 Land this change's artifacts on `spec/mcp-tool-outcome-receipts`; verify `openspec validate mcp-tool-outcome-receipts --strict` passes.
+
+## 2. Receipts and one Warning log (#2055)
+
+- [ ] 2.1 Make `McpToolAdapter.ExecuteAsync` return its error string through `ToolOutcomeResults` with the category from design D1 (401/403 → `AccessDenied`, 404 → `NotFound`, else `TransientFailure`); leave `ExecuteViaBoundToolAsync` unchanged; verify adapter tests that use the `RecordingMcpToolInvoker` fake for HTTP 500, HTTP 403, and a plain `McpException`; each test also asserts that the result text names the tool.
+- [ ] 2.2 Make `McpClientManager.InvokeSharedAsync` follow design D2: tool lookup outside the `try`, one catch that logs a redacted Warning with server, tool, and HTTP status, rethrow of non-transport exceptions, and no log on caller cancellation; verify lifecycle tests that a thrown `McpException` reaches the caller with no reconnect, that `harness.Logger.Entries` holds one Warning that names the server and the tool, and that a cancelled call adds no Warning.
+- [ ] 2.3 Update the `application MCP failure` assertion in `McpClientManagerLifecycleTests` to expect the exception; run `McpToolResultFormatterTests` and `McpClientManagerLifecycleTests`; verify the tool-declared `isError` path does not change.
+
+## 3. Reconnect classification (#2056)
+
+- [ ] 3.1 Make `IsTransportOrSessionFailure` return true for `HttpRequestException` only when `StatusCode` is null or 404; verify lifecycle tests: HTTP 500 and 429 produce no reconnect and an unchanged generation; HTTP 404 and a status-less failure each produce one reconnect.
+- [ ] 3.2 Widen the first catch clause in `McpClientManager.LoadAsync` to `McpException` or `HttpRequestException` when not a transport failure; verify a `McpPromptSkillTests` test that an HTTP 500 on `GetPromptAsync` returns a failed load result that names the prompt, with no reconnect.
+
+## 4. Auth guard for servers that cannot use OAuth (#2057)
+
+- [ ] 4.1 Make `ReportToolFailure` call `MarkToolAuthFailure` only when `HasOAuthRuntimeHints(serverName, entry)` is true; add a lifecycle harness overload that accepts an `McpServerEntry`; convert `ToolLevelAuthFailure_MovesServerOutOfConnected` to an HTTP entry without an `Authorization` header; verify new lifecycle tests that a static-header HTTP server and a stdio server each stay `Connected` after an `isError` result with auth words, with the Warning present in `harness.Logger.Entries`.
+
+## 5. Validation and documentation
+
+- [ ] 5.1 Run `dotnet test` for `Netclaw.Actors.Tests` (Tools) and `Netclaw.Daemon.Tests` (Mcp), `dotnet slopwatch analyze`, and `./scripts/Add-FileHeaders.ps1 -Verify`; verify no new violations.
+- [ ] 5.2 Add the new Warning line to the diagnostics table in `feeds/skills/.system/files/netclaw-operations/references/diagnostics.md` and bump the `netclaw-operations` skill version; verify the row and the version change.
+- [ ] 5.3 Run an adversarial review on each stacked pull request before it opens; verify every finding has a NOW, PARK, or FIX INLINE disposition recorded in the pull request.
+- [x] 5.4 Edit issue #2055 so its Expected section matches design D2 (the `Tool executed:` line stays); verify the issue body no longer requires that line to be absent.
+- [x] 5.5 Edit issue #2056 to remove the `Retry-After` expectation and to add the prompt-load path; verify the body matches design D3.
+- [x] 5.6 Edit issue #2057 to state the `HasOAuthRuntimeHints` gate, the retained heuristic for OAuth-capable servers, and the absence of 401/403 remedy text; verify the body matches design D4.


### PR DESCRIPTION
## Summary

This pull request adds the OpenSpec change `mcp-tool-outcome-receipts` for epic #2058. It contains no code. It is the base of a stack of four pull requests.

The change covers three defects on the MCP tool-call path:

- #2055: an MCP tool-call exception becomes a tool result with no tool receipt, and the dispatcher records a success.
- #2056: every `HttpRequestException` forces a full reconnect, even for an application-level HTTP status.
- #2057: substring matches on tool-result text can move a static-header or stdio server into `AuthFailed`.

## Artifacts

- `docs/spec/GLOSSARY.md`: adds an "MCP Invocation Terms" section with four terms both capabilities share: transport or session failure, application error, tool-declared error, and OAuth-capable server. Each term has a code anchor and an example observed on the wire.
- `proposal.md`: why, scope, the glossary link, and the two modified capabilities.
- `specs/netclaw-tools/spec.md`: adds "MCP tool outcomes are machine-actionable" with positive and negative scenarios.
- `specs/netclaw-mcp/spec.md`: modifies "Graceful degradation" (application status does not reconnect; prompt loads follow the same rule) and "MCP diagnostics visibility" (one Warning per failed invocation; no `AuthFailed` from result text for servers that cannot use OAuth).
- `design.md`: proposed flow, decisions D1 to D5 with alternatives, owners and data lifetime, failure modes.
- `tasks.md`: one task group per stacked pull request.

## Design in one paragraph

The adapter already converts an exception to a result string. It now completes the tool receipt through the existing `ToolOutcomeResults` helpers at the same point. The client manager stops its duplicate string conversion, logs one Warning per failed call, and reads the HTTP status inside the existing reconnect predicate. Result-text auth demotion gates on the existing `HasOAuthRuntimeHints` predicate. No new type, interface, or configuration.

## Adversarial review

An independent review ran against the source at `94d2bfce` before this pull request opened. It found three FAIL items, each now fixed in the artifacts:

- The SDK's `McpException` carries no error code; the design dropped the `-32602` mapping.
- The reconnect predicate has a second consumer (the prompt-skill path); D3 now covers it.
- The cited expired-token test uses a stdio entry; D4 now gates on `HasOAuthRuntimeHints`, and the test converts to an HTTP entry.

Sub-issues #2055, #2056, and #2057 were edited to match the design. Each edit is visible in the issue history.

## Validation

- `openspec validate mcp-tool-outcome-receipts --strict`: valid.
- No source files change in this pull request.

## Stack

1. This pull request (spec).
2. #2055 on top of this branch.
3. #2056 on top of 2.
4. #2057 on top of 3.
