### PR TITLE
Record MCP tool-call exceptions as failed outcomes (#2055)

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.65.1"
+  version: "2.65.2"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
@@ -74,6 +74,7 @@ debugging a daemon-wide problem → read `daemon.log`.
 |---------|-------|
 | No LLM responses | `netclaw doctor`; verify provider credentials |
 | Missing tools | `netclaw mcp list`; check MCP connection state |
+| An MCP tool call fails | Grep `<NETCLAW_HOME>/logs/daemon-*.log` for `MCP tool '` and `invocation failed`. Each failed call writes one Warning that names the server, the tool, and the HTTP status when the server sent one. The tool-result text gives the kind: `reported a failure:` is an error the tool declared, and `failed:` is an exception from the server or the transport. |
 | Memory recall degraded | `netclaw status` memory section |
 | Daemon won't start | crash logs at `<NETCLAW_HOME>/logs/crash-*.log` (`NETCLAW_HOME` defaults to `~/.netclaw`) |
 | Docker daemon cannot create `/home/netclaw/.netclaw/*` | Official image entrypoint repairs writable bind mounts to UID/GID `1654:1654`; if bypassed or read-only, run `sudo chown -R 1654:1654 <host-data-dir>` or use a Docker named volume |

--- a/openspec/changes/mcp-tool-outcome-receipts/tasks.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/tasks.md
@@ -4,9 +4,9 @@
 
 ## 2. Receipts and one Warning log (#2055)
 
-- [ ] 2.1 Make `McpToolAdapter.ExecuteAsync` return its error string through `ToolOutcomeResults` with the category from design D1 (401/403 → `AccessDenied`, 404 → `NotFound`, else `TransientFailure`); leave `ExecuteViaBoundToolAsync` unchanged; verify adapter tests that use the `RecordingMcpToolInvoker` fake for HTTP 500, HTTP 403, and a plain `McpException`; each test also asserts that the result text names the tool.
-- [ ] 2.2 Make `McpClientManager.InvokeSharedAsync` follow design D2: tool lookup outside the `try`, one catch that logs a redacted Warning with server, tool, and HTTP status, rethrow of non-transport exceptions, and no log on caller cancellation; verify lifecycle tests that a thrown `McpException` reaches the caller with no reconnect, that `harness.Logger.Entries` holds one Warning that names the server and the tool, and that a cancelled call adds no Warning.
-- [ ] 2.3 Update the `application MCP failure` assertion in `McpClientManagerLifecycleTests` to expect the exception; run `McpToolResultFormatterTests` and `McpClientManagerLifecycleTests`; verify the tool-declared `isError` path does not change.
+- [x] 2.1 Make `McpToolAdapter.ExecuteAsync` return its error string through `ToolOutcomeResults` with the category from design D1 (401/403 → `AccessDenied`, 404 → `NotFound`, else `TransientFailure`); leave `ExecuteViaBoundToolAsync` unchanged; verify adapter tests that use the `RecordingMcpToolInvoker` fake for HTTP 500, HTTP 403, and a plain `McpException`; each test also asserts that the result text names the tool.
+- [x] 2.2 Make `McpClientManager.InvokeSharedAsync` follow design D2: tool lookup outside the `try`, one catch that logs a redacted Warning with server, tool, and HTTP status, rethrow of non-transport exceptions, and no log on caller cancellation; verify lifecycle tests that a thrown `McpException` reaches the caller with no reconnect, that `harness.Logger.Entries` holds one Warning that names the server and the tool, and that a cancelled call adds no Warning.
+- [x] 2.3 Update the `application MCP failure` assertion in `McpClientManagerLifecycleTests` to expect the exception; run `McpToolResultFormatterTests` and `McpClientManagerLifecycleTests`; verify the tool-declared `isError` path does not change.
 
 ## 3. Reconnect classification (#2056)
 
@@ -20,7 +20,7 @@
 ## 5. Validation and documentation
 
 - [ ] 5.1 Run `dotnet test` for `Netclaw.Actors.Tests` (Tools) and `Netclaw.Daemon.Tests` (Mcp), `dotnet slopwatch analyze`, and `./scripts/Add-FileHeaders.ps1 -Verify`; verify no new violations.
-- [ ] 5.2 Add the new Warning line to the diagnostics table in `feeds/skills/.system/files/netclaw-operations/references/diagnostics.md` and bump the `netclaw-operations` skill version; verify the row and the version change.
+- [x] 5.2 Add the new Warning line to the diagnostics table in `feeds/skills/.system/files/netclaw-operations/references/diagnostics.md` and bump the `netclaw-operations` skill version; verify the row and the version change.
 - [ ] 5.3 Run an adversarial review on each stacked pull request before it opens; verify every finding has a NOW, PARK, or FIX INLINE disposition recorded in the pull request.
 - [x] 5.4 Edit issue #2055 so its Expected section matches design D2 (the `Tool executed:` line stays); verify the issue body no longer requires that line to be absent.
 - [x] 5.5 Edit issue #2056 to remove the `Retry-After` expectation and to add the prompt-load path; verify the body matches design D3.

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -201,6 +201,15 @@ public class McpToolAdapterTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithContext_HttpNotFound_RecordsNotFound()
+    {
+        var context = await ExecuteWithFailureAsync(
+            new HttpRequestException("Not Found", null, HttpStatusCode.NotFound));
+
+        Assert.Equal(ToolInvocationOutcomeCategory.NotFound, context.Receipt?.Category);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithContext_McpProtocolError_RecordsTransientFailure()
     {
         var context = await ExecuteWithFailureAsync(new McpException("application MCP failure"));

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -4,8 +4,10 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Tests.Utilities;
+using System.Net;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
+using ModelContextProtocol;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Tools;
@@ -178,6 +180,51 @@ public class McpToolAdapterTests
 
         Assert.StartsWith("Error:", result);
         Assert.Contains("session transport failed", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContext_HttpServerError_RecordsTransientFailure()
+    {
+        var context = await ExecuteWithFailureAsync(
+            new HttpRequestException("upstream error", null, HttpStatusCode.InternalServerError));
+
+        Assert.Equal(ToolInvocationOutcomeCategory.TransientFailure, context.Receipt?.Category);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContext_HttpForbidden_RecordsAccessDenied()
+    {
+        var context = await ExecuteWithFailureAsync(
+            new HttpRequestException("Forbidden", null, HttpStatusCode.Forbidden));
+
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContext_McpProtocolError_RecordsTransientFailure()
+    {
+        var context = await ExecuteWithFailureAsync(new McpException("application MCP failure"));
+
+        Assert.Equal(ToolInvocationOutcomeCategory.TransientFailure, context.Receipt?.Category);
+    }
+
+    /// <summary>
+    /// Runs one failed MCP tool call and asserts the shared result contract: the text names
+    /// the tool, so the model can tell which call failed. The caller asserts the category.
+    /// </summary>
+    private static async Task<ToolExecutionContext> ExecuteWithFailureAsync(Exception failure)
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "unused", "navigate_page");
+        var invoker = new RecordingMcpToolInvoker("ignored") { Failure = failure };
+        var adapter = new McpToolAdapter(fakeTool, "browser_playwright", "navigate_page", invoker: invoker);
+        var context = TestToolExecutionContext.CreateBound("chan/thread", null, TrustAudience.Personal);
+
+        var result = await adapter.ExecuteAsync(ToolInput.Empty(), context, CancellationToken.None);
+
+        Assert.StartsWith("Error: MCP tool '", result, StringComparison.Ordinal);
+        Assert.Contains("browser_playwright/navigate_page", result, StringComparison.Ordinal);
+        Assert.Contains(failure.Message, result, StringComparison.Ordinal);
+        return context;
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -150,9 +151,21 @@ public sealed class McpToolAdapter : INetclawTool
         {
             throw;
         }
+        // The adapter completes the receipt here because the exception stops here: the
+        // dispatcher never sees it and completes the receipt as Success. The receipt is
+        // first-writer-wins, so this category is the one the actor reads.
         catch (Exception ex)
         {
-            return $"Error: MCP tool '{Name}' failed: {ex.Message}";
+            var text = $"Error: MCP tool '{Name}' failed: {ex.Message}";
+            return ex switch
+            {
+                HttpRequestException
+                    {
+                        StatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
+                    } => context.AccessDenied(text),
+                HttpRequestException { StatusCode: HttpStatusCode.NotFound } => context.NotFound(text),
+                _ => context.TransientFailure(text)
+            };
         }
     }
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
@@ -251,8 +251,11 @@ public sealed class McpClientManagerLifecycleTests
 
         var toolError = await InvokeAsync(harness.Manager, TestContext.Current.CancellationToken);
         Assert.Equal("Error: MCP tool 'test/run' reported a failure: declared failure", toolError);
-        var applicationMcpError = await InvokeAsync(harness.Manager, TestContext.Current.CancellationToken);
-        Assert.Equal("Error: MCP tool 'test/run' failed: application MCP failure", applicationMcpError);
+        // A JSON-RPC error reaches the caller. The adapter, not the manager, turns it into
+        // the tool result, so the tool call also gets a failure receipt.
+        var applicationMcpError = await Assert.ThrowsAsync<McpException>(
+            () => InvokeAsync(harness.Manager, TestContext.Current.CancellationToken));
+        Assert.Equal("application MCP failure", applicationMcpError.Message);
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => InvokeAsync(harness.Manager, TestContext.Current.CancellationToken));
 
@@ -260,6 +263,62 @@ public sealed class McpClientManagerLifecycleTests
         Assert.Equal(4, plan.InvocationCount);
         Assert.Equal(0, plan.DisposeCount);
         Assert.Equal(1, harness.Manager.GetSnapshot(ServerName)?.Generation);
+    }
+
+    [Fact]
+    public async Task ThrownToolCall_LogsOneWarningThatNamesTheServerAndTheTool()
+    {
+        var runtime = new ControlledMcpClientRuntime();
+        runtime.Enqueue(new ClientPlan("run")
+        {
+            Invoke = (_, _) => Task.FromException<object?>(new McpException("application MCP failure")),
+        });
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<McpException>(
+            () => InvokeAsync(harness.Manager, TestContext.Current.CancellationToken));
+
+        // The adapter turns the exception into a tool result, so this line is the only
+        // record of the failed call an operator can read in the daemon log.
+        var warning = Assert.Single(
+            harness.Logger.Entries,
+            entry => entry.Contains("invocation failed", StringComparison.Ordinal));
+        Assert.Contains($"'{ServerName.Value}/run'", warning, StringComparison.Ordinal);
+        Assert.Equal(
+            "application MCP failure",
+            Assert.Single(harness.Logger.Exceptions).Message);
+    }
+
+    [Fact]
+    public async Task CallerCancelledToolCall_LogsNoInvocationWarning()
+    {
+        var invocationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var neverCompletes = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runtime = new ControlledMcpClientRuntime();
+        runtime.Enqueue(new ClientPlan("run")
+        {
+            Invoke = async (_, ct) =>
+            {
+                invocationEntered.TrySetResult();
+                await neverCompletes.Task.WaitAsync(ct);
+                return "unreachable";
+            },
+        });
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        using var callerCancellation = new CancellationTokenSource();
+        var cancelledCall = InvokeAsync(harness.Manager, callerCancellation.Token);
+        await invocationEntered.Task;
+        await callerCancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancelledCall);
+
+        // A caller that aborts a call did not see a server failure. A Warning here sends
+        // the operator after a healthy server.
+        Assert.DoesNotContain(
+            harness.Logger.Entries,
+            entry => entry.Contains("invocation failed", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -584,25 +584,42 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                        ?? throw CreateUnavailableException(serverName, toolName);
         }
 
+        var qualifiedToolName = $"{serverName.Value}/{toolName.Value}";
+
+        // The lookup stays outside the try: an unavailable tool is the manager's own
+        // report, not a failed invocation, so it must not log as one.
+        if (!snapshot.ToolFunctions.TryGetValue(toolName.Value, out var function))
+            throw CreateUnavailableException(serverName, toolName);
+
         Exception? transportFailure = null;
         try
         {
-            if (!snapshot.ToolFunctions.TryGetValue(toolName.Value, out var function))
-                throw CreateUnavailableException(serverName, toolName);
-
             return await InvokeFunctionAsync(
                 serverName,
                 function,
-                $"{serverName.Value}/{toolName.Value}",
+                qualifiedToolName,
                 arguments,
                 ct);
         }
-        catch (McpException ex) when (!IsTransportOrSessionFailure(ex))
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            return $"Error: MCP tool '{serverName.Value}/{toolName.Value}' failed: {ex.Message}";
+            throw;
         }
-        catch (Exception ex) when (IsTransportOrSessionFailure(ex))
+        catch (Exception ex)
         {
+            // This is the only failure signal an operator gets for a thrown tool call: the
+            // dispatcher logs duration and size, and the adapter turns the exception into a
+            // tool result. Redact first, because an MCP error body can echo the arguments
+            // it rejected and daemon logs leave the box when OTLP export is enabled.
+            _logger.LogWarning(
+                SecretOutputRedactor.RedactForLogging(ex),
+                "MCP tool '{Tool}' invocation failed{HttpStatus}",
+                qualifiedToolName,
+                ex is HttpRequestException { StatusCode: { } statusCode } ? $" (HTTP {(int)statusCode})" : "");
+
+            if (!IsTransportOrSessionFailure(ex))
+                throw;
+
             transportFailure = ex;
         }
 


### PR DESCRIPTION
## Summary

An MCP tool call that ends in an exception now produces a failure receipt and one Warning log line.
Before this change the dispatcher recorded such a call as a success, and the daemon log showed no failure.
The model-facing result text does not change.

Closes #2055

Stacked on #2059. Review and merge that pull request first.

## Design refs

- D1: `McpToolAdapter` completes the receipt from the caught exception.
- D2: `McpClientManager.InvokeSharedAsync` rethrows a non-transport exception and logs once.

D3 and D4 stay for the next pull requests in the stack. An `HttpRequestException` with status 500 is still a
transport failure here, so it still triggers one reconnect. #2056 changes that.

## What changed

- `src/Netclaw.Actors/Tools/McpToolAdapter.cs`: the catch-all returns the same error string through
  `ToolOutcomeResults`. An HTTP 401 or 403 gives `AccessDenied`. An HTTP 404 gives `NotFound`. Every other
  exception gives `TransientFailure`. The bound-tool path does not change.
- `src/Netclaw.Daemon/Mcp/McpClientManager.cs`: the tool lookup moved out of the `try` block. One catch logs a
  redacted Warning and rethrows a non-transport exception. The `McpException`-to-string branch is gone, so the
  adapter is the only converter. A caller cancellation writes no log and starts no reconnect.
- `feeds/skills/.system/files/netclaw-operations/references/diagnostics.md`: one new row for the Warning line.
- `feeds/skills/.system/files/netclaw-operations/SKILL.md`: version 2.65.1 to 2.65.2.
- `openspec/changes/mcp-tool-outcome-receipts/tasks.md`: tasks 2.1, 2.2, 2.3, and 5.2 are complete.

Log template: `MCP tool '{Tool}' invocation failed{HttpStatus}`, for example
`MCP tool 'shortener/search-links' invocation failed (HTTP 500)`.

## Tests added

`src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs`:

- HTTP 500 gives a `TransientFailure` receipt.
- HTTP 403 gives an `AccessDenied` receipt.
- HTTP 404 gives a `NotFound` receipt.
- A plain `McpException` gives a `TransientFailure` receipt.
- Each case asserts that the result text names the tool.

`src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs`:

- The `application MCP failure` case now expects the `McpException` to reach the caller.
- A thrown tool call writes exactly one Warning that names the server and the tool.
- A caller-cancelled call writes no Warning.

## Gate outputs

- `dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj -nologo -v q`: 0 warnings, 0 errors.
- `dotnet test src/Netclaw.Actors.Tests`: 3615 passed, 0 failed, 3 skipped.
- `dotnet test src/Netclaw.Daemon.Tests`: 1041 passed, 0 failed.
- `dotnet slopwatch analyze`: 0 issues.
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`: all files have headers.

## Adversarial review

- NOW, fixed in this pull request: 404 to `not_found` had no test. The pull request adds one adapter test.
- NOW, moved to #2056: the `(HTTP 500)` suffix in the Warning line is asserted in the pull request for #2056,
  where an HTTP 500 no longer reconnects.
- PARK, decided: the Warning reads the HTTP status from the outer exception only. That matches
  `IsTransportOrSessionFailure`, which does not unwrap. A wrapped status maps to `transient_failure`.
- PARK, decided: the `HttpStatus` log field carries display text (`" (HTTP 500)"`). A numeric field needs a
  second template. The display text keeps the fewest moving parts.
- PARK, decided: no new test for redaction of the Warning. `SecretOutputRedactor` has its own tests.
- PARK, for the operator: the eval suite did not run for the one-row change to
  `netclaw-operations/references/diagnostics.md`. `evals/README.md` requires no new case for a reference-table
  row.
