### PR TITLE
Reconnect MCP clients only for transport and session failures (#2056)

### DIFF
--- a/openspec/changes/mcp-tool-outcome-receipts/tasks.md
+++ b/openspec/changes/mcp-tool-outcome-receipts/tasks.md
@@ -10,8 +10,8 @@
 
 ## 3. Reconnect classification (#2056)
 
-- [ ] 3.1 Make `IsTransportOrSessionFailure` return true for `HttpRequestException` only when `StatusCode` is null or 404; verify lifecycle tests: HTTP 500 and 429 produce no reconnect and an unchanged generation; HTTP 404 and a status-less failure each produce one reconnect.
-- [ ] 3.2 Widen the first catch clause in `McpClientManager.LoadAsync` to `McpException` or `HttpRequestException` when not a transport failure; verify a `McpPromptSkillTests` test that an HTTP 500 on `GetPromptAsync` returns a failed load result that names the prompt, with no reconnect.
+- [x] 3.1 Make `IsTransportOrSessionFailure` return true for `HttpRequestException` only when `StatusCode` is null or 404; verify lifecycle tests: HTTP 500 and 429 produce no reconnect and an unchanged generation; HTTP 404 and a status-less failure each produce one reconnect.
+- [x] 3.2 Widen the first catch clause in `McpClientManager.LoadAsync` to `McpException` or `HttpRequestException` when not a transport failure; verify a `McpPromptSkillTests` test that an HTTP 500 on `GetPromptAsync` returns a failed load result that names the prompt, with no reconnect.
 
 ## 4. Auth guard for servers that cannot use OAuth (#2057)
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs
@@ -372,6 +372,68 @@ public sealed class McpClientManagerLifecycleTests
         Assert.Equal(2, harness.Manager.GetSnapshot(ServerName)?.Generation);
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    public async Task ApplicationHttpStatus_ReachesTheCallerWithoutAReconnect(HttpStatusCode status)
+    {
+        var runtime = new ControlledMcpClientRuntime();
+        var plan = runtime.Enqueue(new ClientPlan("run")
+        {
+            Invoke = (_, _) => Task.FromException<object?>(
+                new HttpRequestException("boom", null, status)),
+        });
+        // A replacement is queued but must stay unused. Without it a reconnect would fail
+        // inside the runtime before it counts the client, and CreateCount would still
+        // read 1. With it, one reconnect drives CreateCount to 2 and this test fails.
+        var replacement = runtime.Enqueue(new ClientPlan("run"));
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        var error = await Assert.ThrowsAsync<HttpRequestException>(
+            () => InvokeAsync(harness.Manager, TestContext.Current.CancellationToken));
+
+        // A server that answers with a status is reachable. A new session cannot change the
+        // answer, and each reconnect costs about five more requests against a server that
+        // may already enforce a request budget.
+        Assert.Equal(status, error.StatusCode);
+        // The Warning line is the only operator-visible record of a thrown tool call, so it
+        // must name the tool and the status the server sent.
+        var warning = Assert.Single(
+            harness.Logger.Entries,
+            entry => entry.Contains($"{ServerName.Value}/run", StringComparison.Ordinal));
+        Assert.Contains($"(HTTP {(int)status})", warning, StringComparison.Ordinal);
+        Assert.Equal(1, runtime.CreateCount);
+        Assert.Equal(0, plan.DisposeCount);
+        Assert.Null(replacement.Client);
+        Assert.Equal(1, harness.Manager.GetSnapshot(ServerName)?.Generation);
+    }
+
+    [Fact]
+    public async Task SessionExpiryStatus_ReconnectsForLaterCalls()
+    {
+        var runtime = new ControlledMcpClientRuntime();
+        var initial = runtime.Enqueue(new ClientPlan("run")
+        {
+            Invoke = (_, _) => Task.FromException<object?>(
+                new HttpRequestException("session expired", null, HttpStatusCode.NotFound)),
+        });
+        var replacement = runtime.Enqueue(new ClientPlan("run"));
+        await using var harness = CreateHarness(runtime);
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+
+        var error = await Assert.ThrowsAsync<HttpRequestException>(
+            () => InvokeAsync(harness.Manager, TestContext.Current.CancellationToken));
+
+        // Streamable HTTP reports an expired session as 404, so a new session repairs it.
+        Assert.Equal(HttpStatusCode.NotFound, error.StatusCode);
+        // The token makes a missed reconnect fail the run instead of hanging it.
+        await initial.Disposed.Task.WaitAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, runtime.CreateCount);
+        Assert.Equal(0, replacement.InvocationCount);
+        Assert.Equal(2, harness.Manager.GetSnapshot(ServerName)?.Generation);
+    }
+
     [Fact]
     public async Task CandidateInitializationAndDisposalFailures_AreLoudAndPriorToolsRemainPublished()
     {
@@ -738,6 +800,8 @@ public sealed class McpClientManagerLifecycleTests
             Interlocked.Increment(ref plan.PromptInvocationCountStorage);
             plan.LastPromptName = promptName;
             plan.LastPromptArguments = new Dictionary<string, string>(arguments, StringComparer.Ordinal);
+            if (plan.GetPromptFailure is not null)
+                return ValueTask.FromException<GetPromptResult>(plan.GetPromptFailure);
             return plan.GetPromptResult is null
                 ? ValueTask.FromException<GetPromptResult>(
                     new InvalidOperationException("The controlled prompt result is not configured."))
@@ -804,6 +868,8 @@ public sealed class McpClientManagerLifecycleTests
         public Exception? ListFailure { get; set; }
 
         public Exception? PromptListFailure { get; set; }
+
+        public Exception? GetPromptFailure { get; set; }
 
         public string? LastPromptName { get; set; }
 

--- a/src/Netclaw.Daemon.Tests/Mcp/McpPromptSkillTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpPromptSkillTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
 using Microsoft.Extensions.Time.Testing;
 using ModelContextProtocol.Protocol;
 using Netclaw.Actors.Skills;
@@ -237,6 +238,46 @@ public sealed class McpPromptSkillTests
 
         Assert.False(result.Success);
         Assert.Contains("unsupported content type 'image'", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LoadReturnsFailedResultForAnApplicationHttpStatus()
+    {
+        var runtime = new McpClientManagerLifecycleTests.ControlledMcpClientRuntime();
+        var plan = CreatePromptPlan();
+        plan.GetPromptFailure = new HttpRequestException(
+            "boom",
+            null,
+            HttpStatusCode.InternalServerError);
+        runtime.Enqueue(plan);
+        // A replacement is queued but must stay unused. Without it a reconnect would fail
+        // inside the runtime before it counts the client, and CreateCount would still
+        // read 1. With it, one reconnect drives CreateCount to 2 and this test fails.
+        var replacement = runtime.Enqueue(CreatePromptPlan());
+        await using var harness = new McpClientManagerLifecycleTests.ManagerHarness(
+            runtime,
+            new FakeTimeProvider(InitialTime));
+        await harness.Manager.StartAsync(TestContext.Current.CancellationToken);
+        var source = Assert.IsType<McpPromptSkillSource>(
+            harness.SkillRegistry.GetByName("mcp__test__analyze-property")?.Source);
+
+        var result = await harness.Manager.LoadAsync(
+            source,
+            new Dictionary<string, string> { ["property"] = "petabridge-com" },
+            TestToolExecutionContext.CreateUnbound(TrustAudience.Personal).Invocation,
+            TestContext.Current.CancellationToken);
+
+        // The load owns this failure. An escaped exception would reach the tool dispatcher,
+        // and a reconnect cannot change a status the server chose to send.
+        Assert.False(result.Success);
+        Assert.Contains("analyze-property", result.Error, StringComparison.Ordinal);
+        // The first catch clause owns this text. The transport clause says "connection
+        // closed" instead, so this pins which clause ran.
+        Assert.Contains("failed:", result.Error, StringComparison.Ordinal);
+        Assert.DoesNotContain("connection closed", result.Error, StringComparison.Ordinal);
+        Assert.Equal(1, runtime.CreateCount);
+        Assert.Null(replacement.Client);
+        Assert.Equal(1, harness.Manager.GetSnapshot(ServerName)?.Generation);
     }
 
     private static McpClientManagerLifecycleTests.ClientPlan CreatePromptPlan()

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -538,7 +538,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 suppliedArguments,
                 cancellationToken);
         }
-        catch (McpException ex) when (!IsTransportOrSessionFailure(ex))
+        catch (Exception ex) when (ex is McpException or HttpRequestException && !IsTransportOrSessionFailure(ex))
         {
             return McpPromptSkillLoadResult.Failed(
                 $"MCP prompt '{source.PromptName}' failed: {ex.Message}");
@@ -1798,8 +1798,14 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
     internal static bool IsTransportOrSessionFailure(Exception ex)
     {
-        if (ex is HttpRequestException
-            or IOException
+        // A missing status means the request never got an answer, and the Streamable HTTP
+        // spec reports an expired session as 404. A new session repairs both. Every other
+        // status is an application error from a server that answered, so a new session
+        // cannot change the answer and the reconnect is wasted work.
+        if (ex is HttpRequestException http)
+            return http.StatusCode is null or HttpStatusCode.NotFound;
+
+        if (ex is IOException
             or EndOfStreamException
             or TimeoutException
             or ObjectDisposedException)


### PR DESCRIPTION
## Summary

`McpClientManager.IsTransportOrSessionFailure` treated every `HttpRequestException` as a transport failure. An HTTP 500, 429, or 403 on `tools/call` therefore built a new session. That costs about five extra requests, and it raises the published generation with no config change. A new session cannot repair a server-side application error. A rate-limited server gets hit harder, so the loop feeds itself.

The predicate now reads the typed status. It returns true only when the status is absent or 404.

Closes #2056
Stacked on #2060

## Design refs

`openspec/changes/mcp-tool-outcome-receipts/design.md`, decision D3. Tasks 3.1 and 3.2.

## What changed

- `IsTransportOrSessionFailure` returns true for an `HttpRequestException` only when `StatusCode` is null or 404. An absent status means the request got no answer. The Streamable HTTP spec reports an expired session as 404. Every other status is an application error from a server that answered. The `IOException`, `EndOfStreamException`, `TimeoutException`, `ObjectDisposedException`, and `McpException` branches do not change.
- `LoadAsync` owns the MCP prompt-skill path. Its first catch clause accepted only `McpException`, so an `HttpRequestException` with an application status would match neither clause and escape to the tool dispatcher. The clause now also accepts `HttpRequestException` and returns the same failed load result. No new clause and no new type.

The tool path is unchanged apart from the predicate. `InvokeSharedAsync` still logs one Warning and rethrows. The adapter still turns the exception into the tool result (#2060).

## Tests added

`src/Netclaw.Daemon.Tests/Mcp/McpClientManagerLifecycleTests.cs`:

- `ApplicationHttpStatus_ReachesTheCallerWithoutAReconnect` (Theory: HTTP 500 and HTTP 429). The exception reaches the caller. A spare client plan is queued and stays unused, so a reconnect would raise `CreateCount` to 2 and fail the test. The generation stays 1. The test also pins the Warning line that #2060 added: exactly one entry names `test/run`, and it carries the `(HTTP 500)` suffix (`(HTTP 429)` for the second case). Nothing in the stack asserted that suffix before.
- `SessionExpiryStatus_ReconnectsForLaterCalls` (HTTP 404). The exception reaches the caller. The manager builds one replacement client and does not replay the call. The wait on the disposal of the first client runs under the test token, so an over-narrowed predicate fails the run instead of hanging it.
- `TransportFailure_ReconnectsForLaterCallsAndDoesNotReplay` pins the status-less case. It still passes without a change.

`src/Netclaw.Daemon.Tests/Mcp/McpPromptSkillTests.cs`:

- `LoadReturnsFailedResultForAnApplicationHttpStatus`. An HTTP 500 on `GetPromptAsync` returns a failed load result that names the prompt. A spare client plan is queued and stays unused. The result text must match the first catch clause: it contains `failed:` and it does not contain `connection closed`, which is the transport clause's text.

Mutation check: with the predicate reverted to "every `HttpRequestException` is a transport failure", all three tests fail.

The `ClientPlan` test double gets a `GetPromptFailure` hook. It mirrors the `PromptListFailure` hook that is already there.

## Gate outputs

| Gate | Result |
|---|---|
| `dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj` | Build succeeded. 0 Warning(s). 0 Error(s). |
| `dotnet test ... --filter "FullyQualifiedName~Mcp"` | Passed. Failed 0, Passed 189, Skipped 0. |
| `dotnet test src/Netclaw.Daemon.Tests` | Passed. Failed 0, Passed 1045, Skipped 0. |
| `dotnet slopwatch analyze` | Scan complete: 0 issue(s) found. |
| `./scripts/Add-FileHeaders.ps1 -Verify` | All files have headers. |

## Adversarial review

The review returned PARTIAL. Four NOW findings are fixed in this pull request:

1. The 500 and 429 tests did not discriminate. With one client plan queued, a reconnect throws inside `ControlledMcpClientRuntime.CreateAsync` before it counts the client, so `CreateCount` read 1 either way. Each test now queues a spare plan.
2. The prompt-load test had the same hole. It now queues a spare plan and asserts the text of the first catch clause.
3. Task 3.1 and this body claimed proof that the tests did not give. The spare plans make the claim true, and this body now states how each test discriminates.
4. The 404 test waited on a disposal task with no token. An over-narrowed predicate hung the run instead of failing it. The wait now uses the test token.

DISMISSED: the 404 test near-duplicates the status-less transport test. Both are kept because each maps to one scenario in the spec delta.
