### PR TITLE
Widen the approval store Ask budget and run the PowerShell 5.1 test alone

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -71,7 +71,16 @@ jobs:
         # 30-min job cap) and is diagnosable from the CI log + the uploaded dump instead of a silent
         # timeout. The full dump carries every thread's stack — needed to confirm the suspected
         # macOS/ARM64 weak-memory-ordering hang in the TUI view-models.
-        run: dotnet test -c Release --blame-hang-timeout 300s --blame-hang-dump-type full --results-directory ./TestResults
+        # The NativeShell category is excluded here and runs alone in the next step.
+        run: dotnet test -c Release --filter "Category!=NativeShell" --blame-hang-timeout 300s --blame-hang-dump-type full --results-directory ./TestResults
+
+      - name: "dotnet test (native shell, serial)"
+        if: runner.os == 'Windows'
+        shell: bash
+        # The live Windows PowerShell 5.1 test launches a real powershell.exe. It runs after the
+        # parallel run so it does not share CPU with other test collections; on a starved runner
+        # that contention is what pushed it past its 90 s budget.
+        run: dotnet test -c Release --no-build --filter "Category=NativeShell" --blame-hang-timeout 300s --blame-hang-dump-type full --results-directory ./TestResults
 
       # Diagnostic: surface the blame Sequence file (names the stuck test) in the CI log so a
       # platform-specific hang can be pinpointed even without downloading the dump artifact.

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -182,6 +182,9 @@ public class ShellToolTests
     }
 
     [SlopwatchSuppress("SW001", "This native fallback test requires Windows PowerShell 5.1.")]
+    // This test starts a real powershell.exe. CI runs the NativeShell category alone, after the
+    // parallel run, so a live process start does not compete for CPU with other test collections.
+    [Trait("Category", "NativeShell")]
     [Fact(SkipUnless = nameof(IsWindows), Skip = "Native Windows PowerShell 5.1 execution requires Windows.")]
     public async Task Windows_power_shell_51_executes_through_the_selected_host()
     {

--- a/src/Netclaw.Actors/Tools/AkkaToolApprovalService.cs
+++ b/src/Netclaw.Actors/Tools/AkkaToolApprovalService.cs
@@ -14,11 +14,19 @@ using static Netclaw.Actors.Tools.ToolApprovalProtocol;
 
 namespace Netclaw.Actors.Tools;
 
+// Every Ask below uses AskTimeout as its budget.
+//
+// The approval actor opens the approvals file on its own mailbox. A fixed 5 second budget was too
+// small for the first cold read on a slow host. The budget covers that file round-trip only. It
+// does not cover the wait for a person to approve the tool call. The budget stays finite because
+// some callers pass CancellationToken.None. A lost reply then suspends the caller mailbox forever.
 public sealed class AkkaToolApprovalService :
     IToolApprovalService,
     IStructuredToolApprovalService,
     IShellApprovalMatchService
 {
+    private static readonly TimeSpan AskTimeout = TimeSpan.FromSeconds(30);
+
     private readonly IRequiredActor<ToolApprovalActorKey> _actorProvider;
     private readonly ShellExecutionEnvironment? _compatibilityEnvironment;
 
@@ -78,7 +86,7 @@ public sealed class AkkaToolApprovalService :
         var protocolSessionId = sessionId.HasValue ? (SessionId)sessionId.Value.Value : (SessionId?)null;
         var response = await actor.Ask<UnapprovedPatternsResponse>(
             new GetUnapprovedPatterns(protocolSessionId, audience, toolName, candidates, cwd),
-            TimeSpan.FromSeconds(5),
+            AskTimeout,
             ct);
 
         return response.Result;
@@ -99,7 +107,7 @@ public sealed class AkkaToolApprovalService :
                 request.ToolName,
                 request.Environment,
                 request.Candidates),
-            TimeSpan.FromSeconds(5),
+            AskTimeout,
             cancellationToken);
 
         return response.Result;
@@ -151,7 +159,7 @@ public sealed class AkkaToolApprovalService :
         var actor = await _actorProvider.GetAsync(ct);
         var result = await actor.Ask<ToolApprovalRecorded>(
             new RecordToolApproval((SessionId)sessionId.Value, audience, toolName, patterns, persistent, cwd),
-            TimeSpan.FromSeconds(5),
+            AskTimeout,
             ct);
         if (result.Failure is { } failure)
         {
@@ -175,7 +183,7 @@ public sealed class AkkaToolApprovalService :
                 toolName,
                 grants,
                 persistent),
-            TimeSpan.FromSeconds(5),
+            AskTimeout,
             ct);
         if (result.Failure is { } failure)
         {


### PR DESCRIPTION
## Summary

Two Windows-only tests failed on PR #2060 and passed on a re-run of the same commit. Both lost a fixed wall-clock budget on a slow runner. This change removes the race in each.

Failed run: https://github.com/netclaw-dev/netclaw/actions/runs/32948913877/job/98115679851

## Changes

- `AkkaToolApprovalService`: each `Ask` to the approval actor uses a 30 s service constant instead of 5 s. The actor reads the approvals file on its mailbox, and the first cold read lost the 5 s budget under CI load. The bound covers that file round-trip only, not the wait for a person to approve. It stays finite because some callers pass `CancellationToken.None`.
- `ShellToolTests.Windows_power_shell_51_executes_through_the_selected_host`: tagged `Category=NativeShell`. The parallel `dotnet test` excludes that category. A Windows-only serial step runs it alone, after the parallel run, with `--no-build`. The test launches a real `powershell.exe`; CPU contention with other collections pushed it past its 90 s budget.

## Verification

- `Category=NativeShell` selects exactly one test across the solution; the parallel filter keeps the other 3613.
- Full `Netclaw.Actors.Tests`: 3611 passed, 3 skipped. Slopwatch and header checks pass.

Related: #1409, #1378
