### PR TITLE
Fix release notes parsing

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -54,6 +54,10 @@ jobs:
       - name: "Restore .NET tools"
         run: dotnet tool restore
 
+      - name: "Validate release notes parser"
+        shell: pwsh
+        run: ./scripts/smoke/release-notes-smoke.ps1
+
       - name: "Update release notes"
         shell: pwsh
         run: |

--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,12 @@
 ######################################################################
 $releaseNotes = Get-ReleaseNotes -MarkdownFile (Join-Path -Path $PSScriptRoot -ChildPath "RELEASE_NOTES.md")
 
-# inject release notes into Directory.Buil
+if ([string]::IsNullOrWhiteSpace($releaseNotes.Version) -or
+    [string]::IsNullOrWhiteSpace($releaseNotes.ReleaseNotes)) {
+    throw "Release notes must contain a version and release notes text."
+}
+
+# Inject release notes into Directory.Build.props.
 UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath (Join-Path -Path $PSScriptRoot -ChildPath "Directory.Build.props")
 
-Write-Output "Added release notes $releaseNotes"
+Write-Output "Updated release metadata for version $($releaseNotes.Version)."

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -4,36 +4,24 @@ function Get-ReleaseNotes {
         [string]$MarkdownFile
     )
 
-    # Read markdown file content
     $content = Get-Content -Path $MarkdownFile -Raw
+    $pattern = '(?ms)^##\s+(?<version>\S+)\s+\((?<date>\d{4}-\d{2}-\d{2})\)\s*\r?\n(?<notes>.*?)(?=^##\s+|\z)'
+    $match = [regex]::Match($content, $pattern)
 
-    # Split content based on headers
-    $sections = $content -split "####"
-
-    # Output object to store result
-    $outputObject = [PSCustomObject]@{
-        Version       = $null
-        Date          = $null
-        ReleaseNotes  = $null
+    if (-not $match.Success) {
+        throw "Could not find a release header in '$MarkdownFile'. Expected '## <version> (<yyyy-MM-dd>)'."
     }
 
-    # Check if we have at least 3 sections (1. Before the header, 2. Header, 3. Release notes)
-    if ($sections.Count -ge 3) {
-        $header = $sections[1].Trim()
-        $releaseNotes = $sections[2].Trim()
-
-        # Extract version and date from the header
-        $headerParts = $header -split " ", 2
-        if ($headerParts.Count -eq 2) {
-            $outputObject.Version = $headerParts[0]
-            $outputObject.Date = $headerParts[1]
-        }
-
-        $outputObject.ReleaseNotes = $releaseNotes
+    $releaseNotes = $match.Groups['notes'].Value.Trim()
+    if ([string]::IsNullOrWhiteSpace($releaseNotes)) {
+        throw "Release '$($match.Groups['version'].Value)' in '$MarkdownFile' has no release notes."
     }
 
-    # Return the output object
-    return $outputObject
+    return [PSCustomObject]@{
+        Version      = $match.Groups['version'].Value
+        Date         = $match.Groups['date'].Value
+        ReleaseNotes = $releaseNotes
+    }
 }
 
 # Call function example:

--- a/scripts/smoke/release-notes-smoke.ps1
+++ b/scripts/smoke/release-notes-smoke.ps1
@@ -1,0 +1,54 @@
+# Validates release-note parsing without modifying repository files.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "..\getReleaseNotes.ps1")
+
+$fixturePath = [System.IO.Path]::GetTempFileName()
+try {
+    @"
+# Release Notes
+
+## 1.2.3 (2026-01-02)
+
+Summary text.
+
+### Features
+- First feature.
+
+## 1.2.2 (2025-12-01)
+
+Older release.
+"@ | Set-Content -Path $fixturePath -NoNewline
+
+    $result = Get-ReleaseNotes -MarkdownFile $fixturePath
+    if ($result.Version -ne "1.2.3") { throw "The parser returned the wrong version." }
+    if ($result.Date -ne "2026-01-02") { throw "The parser returned the wrong date." }
+    if ($result.ReleaseNotes -notmatch "First feature" -or $result.ReleaseNotes -match "Older release") {
+        throw "The parser returned the wrong release section."
+    }
+} finally {
+    Remove-Item -LiteralPath $fixturePath -Force -ErrorAction SilentlyContinue
+}
+
+$repositoryRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$actual = Get-ReleaseNotes -MarkdownFile (Join-Path $repositoryRoot "RELEASE_NOTES.md")
+if ([string]::IsNullOrWhiteSpace($actual.Version) -or [string]::IsNullOrWhiteSpace($actual.ReleaseNotes)) {
+    throw "The repository release notes did not produce complete metadata."
+}
+
+$invalidPath = [System.IO.Path]::GetTempFileName()
+try {
+    "# No release header" | Set-Content -Path $invalidPath
+    try {
+        Get-ReleaseNotes -MarkdownFile $invalidPath | Out-Null
+        throw "The parser accepted release notes without a release header."
+    } catch {
+        if ($_.Exception.Message -notmatch "Could not find a release header") { throw }
+    }
+} finally {
+    Remove-Item -LiteralPath $invalidPath -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "Release-note parser smoke test passed."


### PR DESCRIPTION
Parse the established release header format, preserve the newest release section, fail on missing metadata, and add a PowerShell smoke test. Validation: release-notes smoke test, full build.ps1 flow in an isolated worktree, Slopwatch, and copyright headers.