### PR TITLE
Specify unified session storage and managed temporary paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,20 @@ Do not treat UI-level save success or schema validity as sufficient when runtime
 behavior depends on provider IDs, canonical names, permissions, or security
 policy keys.
 
+## Tool Composition Rule
+
+Model agent behavior as a composition of existing tools before you add a new
+tool. Return machine-actionable paths or identifiers when the session already
+owns the resource and current policy permits access.
+
+Prefer small tools that agents can combine. For example, an agent must use
+`file_read`, `file_list`, and `file_search` for its own session logs. Do not add
+a special session-log reader for that behavior.
+
+Add a new tool only when existing tools cannot express the operation or its
+authority boundary safely. State the missing contract and explain why tool
+composition cannot satisfy it.
+
 ## Shell Approval Abstraction Rule
 
 Netclaw shell approval code must not parse an executable's private command,

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -424,9 +424,13 @@ A raw session log is the diagnostic file for one main session or subagent run.
 New-layout raw logs are physically inside the session storage envelope but are
 outside the session directory.
 
-The owning agent can read, list, and search its same-session logs through the
-existing file tools. This read scope does not grant file-write, file-edit, or
-shell authority. Another session cannot use this scope.
+Every parent and child run can read, list, and search logs from its own session
+through the existing file tools. The session is the log-read trust boundary.
+This read scope does not grant file-write, file-edit, attach, or shell
+authority. Another session cannot use this scope.
+
+These reads return normal bounded file-tool output. A raw session log does not
+use a separate activity projection or log-specific redaction layer.
 
 ### Managed temporary directory
 

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -413,8 +413,10 @@ The session directory is the agent-facing `workspace/` area inside the session
 storage envelope. It is the relative-path base when the session has no valid
 project directory. It is not the complete storage envelope.
 
-The phrase `session scratch` is a legacy term for disposable work directly in
-the session directory. New designs use a managed temporary directory instead.
+The phrase `session scratch` is a legacy term that mixed the session directory
+with disposable storage. Current designs use session directory for the working
+and relative-path base, and managed temporary directory for disposable work.
+Current runtime text and identifiers must use the specific term.
 
 ### Raw session log
 
@@ -447,6 +449,14 @@ A child run directory is the area below
 `<session-envelope>/subagents/<run-id>` for one subagent run. Its artifact,
 temporary, and raw-log areas share the same opaque run identifier. The parent
 owns the lineage; that ownership does not grant unrestricted raw-log access.
+
+### Session-owned directory
+
+A session-owned directory has a lifetime or authority scope tied to one
+session or run. Session directories, managed temporary directories, artifact
+directories, and managed worktree directories are session-owned, but they do
+not have the same purpose or access policy. Approval code uses this broader
+term only when the rule intentionally applies to more than one of them.
 
 ### Allowed root
 

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -422,11 +422,11 @@ Current runtime text and identifiers must use the specific term.
 
 A raw session log is the diagnostic file for one main session or subagent run.
 New-layout raw logs are physically inside the session storage envelope but are
-outside the session directory and ordinary workspace-file safe roots.
+outside the session directory.
 
-This separation is an application authority boundary, not an operating-system
-process sandbox. An opaque log reference does not grant raw-file access. It can
-authorize one bounded and redacted projection through its owning tool.
+The owning agent can read, list, and search its same-session logs through the
+existing file tools. This read scope does not grant file-write, file-edit, or
+shell authority. Another session cannot use this scope.
 
 ### Managed temporary directory
 
@@ -448,7 +448,8 @@ directory. Netclaw does not apply a retention policy to either directory yet.
 A child run directory is the area below
 `<session-envelope>/subagents/<run-id>` for one subagent run. Its artifact,
 temporary, and raw-log areas share the same opaque run identifier. The parent
-owns the lineage; that ownership does not grant unrestricted raw-log access.
+owns the lineage and can read the child's log through the existing file tools.
+This ownership does not grant access to a different session.
 
 ### Session-owned directory
 

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -377,11 +377,41 @@ http, no headers, no tokens, isError "token expired"   -> not OAuth-managed; sta
 Project scope is the declared project directory for a main session or subagent
 run. Workspace tools use it as the first base for relative paths.
 
-### Session directory and session scratch
+### Session directory and agent-data root
 
-The session directory path is fixed for one session. Its contents are mutable.
-Session scratch means disposable work inside that directory. It is the
-relative-path base when the session has no valid project directory.
+The session directory is the agent-data root for one session. Its path is
+fixed after the session binds it. Its contents are mutable.
+
+The agent-data root contains agent-visible session files. Examples include
+artifacts, inbound files, bounded tool output, temporary files, and worktrees.
+It is the relative-path base when the session has no valid project directory.
+
+The phrase `session scratch` is a legacy term for disposable work directly in
+the session directory. New designs use a managed temporary directory instead.
+
+### Audit root
+
+The audit root contains raw parent and subagent session logs. It is separate
+from the agent-data root. Normal session context does not add it to workspace
+or shell safe spaces.
+
+An opaque log reference does not grant access to the audit root. The reference
+can authorize one bounded and redacted projection through its owning tool.
+
+### Managed temporary directory
+
+A managed temporary directory contains disposable files for one parent or
+subagent run. Netclaw places it below the agent-data root. Each run receives a
+different directory.
+
+Netclaw sets `TMPDIR`, `TMP`, and `TEMP` to this directory for child processes.
+The managed temporary directory is not a project scope or an authority grant.
+
+### Artifact directory
+
+An artifact directory contains outputs that a parent or user must keep or
+attach. It is separate from the managed temporary directory. Netclaw does not
+apply a retention policy to either directory yet.
 
 ### Allowed root
 

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -377,32 +377,60 @@ http, no headers, no tokens, isError "token expired"   -> not OAuth-managed; sta
 Project scope is the declared project directory for a main session or subagent
 run. Workspace tools use it as the first base for relative paths.
 
-### Session directory and agent-data root
+### Session storage envelope
 
-The session directory is the agent-data root for one session. Its path is
-fixed after the session binds it. Its contents are mutable.
+A session storage envelope is the one physical directory that contains all
+session-owned files for a new-layout session. Its path is fixed when the
+session binds its versioned storage binding. Its contents are mutable.
 
-The agent-data root contains agent-visible session files. Examples include
-artifacts, inbound files, bounded tool output, temporary files, and worktrees.
-It is the relative-path base when the session has no valid project directory.
+The envelope contains distinct working, artifact, temporary, worktree, log,
+and child-run areas. Physical containment does not make the complete envelope
+a project scope, a shell safe space, or an authority grant.
+
+```text
+<session-envelope>/
+├── workspace/                 # default no-project working directory
+├── artifacts/                 # retained parent outputs
+├── tmp/parent/                # disposable parent files
+├── worktrees/                 # managed source worktrees
+├── logs/session.log           # raw parent log
+└── subagents/<run-id>/
+    ├── artifacts/
+    ├── tmp/
+    └── logs/session.log       # raw child log
+```
+
+### Session storage binding
+
+A session storage binding is the durable layout version and absolute envelope
+root for a new-layout session. It has one root. A later configuration change
+does not recompute that root. Existing sessions keep the binding absent and use
+their established path behavior; absence is not a second descriptor shape.
+
+### Session directory
+
+The session directory is the agent-facing `workspace/` area inside the session
+storage envelope. It is the relative-path base when the session has no valid
+project directory. It is not the complete storage envelope.
 
 The phrase `session scratch` is a legacy term for disposable work directly in
 the session directory. New designs use a managed temporary directory instead.
 
-### Audit root
+### Raw session log
 
-The audit root contains raw parent and subagent session logs. It is separate
-from the agent-data root. Normal session context does not add it to workspace
-or shell safe spaces.
+A raw session log is the diagnostic file for one main session or subagent run.
+New-layout raw logs are physically inside the session storage envelope but are
+outside the session directory and ordinary workspace-file safe roots.
 
-An opaque log reference does not grant access to the audit root. The reference
-can authorize one bounded and redacted projection through its owning tool.
+This separation is an application authority boundary, not an operating-system
+process sandbox. An opaque log reference does not grant raw-file access. It can
+authorize one bounded and redacted projection through its owning tool.
 
 ### Managed temporary directory
 
 A managed temporary directory contains disposable files for one parent or
-subagent run. Netclaw places it below the agent-data root. Each run receives a
-different directory.
+subagent run. Netclaw places it inside the session storage envelope. Each run
+receives a different directory.
 
 Netclaw sets `TMPDIR`, `TMP`, and `TEMP` to this directory for child processes.
 The managed temporary directory is not a project scope or an authority grant.
@@ -410,8 +438,15 @@ The managed temporary directory is not a project scope or an authority grant.
 ### Artifact directory
 
 An artifact directory contains outputs that a parent or user must keep or
-attach. It is separate from the managed temporary directory. Netclaw does not
-apply a retention policy to either directory yet.
+attach. It is separate from the session directory and managed temporary
+directory. Netclaw does not apply a retention policy to either directory yet.
+
+### Child run directory
+
+A child run directory is the area below
+`<session-envelope>/subagents/<run-id>` for one subagent run. Its artifact,
+temporary, and raw-log areas share the same opaque run identifier. The parent
+owns the lineage; that ownership does not grant unrestricted raw-log access.
 
 ### Allowed root
 

--- a/openspec/changes/unify-session-storage-and-temp/.openspec.yaml
+++ b/openspec/changes/unify-session-storage-and-temp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -28,8 +28,7 @@ default root from moving to `/tmp` or `%TEMP%` in this change.
 **Goals:**
 
 - Give one session one physical storage envelope and one child-run lineage.
-- Keep raw logs outside ordinary workspace-file safe roots while the parent can
-  inspect bounded child activity.
+- Let agents inspect same-session logs through existing file tools.
 - Make standard temporary APIs resolve to a session-owned directory.
 - Preserve existing session path behavior without migrating its files.
 - Give worktrees a managed location and an explicit owner.
@@ -42,7 +41,7 @@ default root from moving to `/tmp` or `%TEMP%` in this change.
 - Delete a session, artifact, output, temporary file, or worktree.
 - Add a quota or retention policy.
 - Move an existing session to another configured Netclaw home.
-- Grant ordinary workspace tools unrestricted raw-log access.
+- Grant cross-session log access or log-write authority.
 - Claim that an application path boundary is an OS process sandbox.
 - Infer private command-line grammar in shell policy.
 - Add speculative Windows path patterns without observed evidence.
@@ -59,8 +58,8 @@ Each state item has one owner and one lifetime.
 | Managed temporary path | Parent or child run scope | Run lifetime; files persist until later cleanup | Process environment and working context |
 | Captured host temporary root | Shell approval policy | Daemon process lifetime | Generic path comparison |
 | Managed-temp correction key | Parent or child actor | One user turn | Approval bridge |
-| Child log reference | Parent session actor | Durable session lifetime | `subagent_log_read` |
-| Child raw-log records | Log dispatcher | Durable file lifetime | Redacted projection builder |
+| Session log paths | Session storage resolver | Durable session lifetime | Existing file tools and `spawn_agent` |
+| Session log records | Log dispatcher | Durable file lifetime | Same-session file-tool reads |
 | Worktree ownership record | Parent session actor | Durable until later cleanup | Future cleanup policy |
 
 The model does not own any authority state. Model text can request a new call,
@@ -83,7 +82,8 @@ tool authorization stages.
 9. The actor commits that correction and arms one turn-local retry key.
 10. A replacement call passes complete authorization as a new call.
 11. A child run writes its raw log below its child-run directory.
-12. The parent reads bounded child activity through the opaque reference.
+12. `spawn_agent` returns the exact child log path to the parent.
+13. The parent reads or searches that path with an existing file tool.
 ```
 
 Counterexample: A prompt cannot replace steps 1 through 8. A compliant model
@@ -115,17 +115,16 @@ that envelope, not the envelope itself.
             └── session.log               raw child log
 ```
 
-Normal session context adds `workspace/`, the applicable artifact directory,
-and the applicable temporary directory to their existing access policies. It
-does not add the complete envelope or `logs/` as an ordinary workspace-file or
-shell safe root. A default `find .` therefore starts in `workspace/` and does
-not recurse into sibling raw logs.
+Normal session context names `session_dir`, `artifact_dir`, `temp_dir`, and the
+current run's `log_path` when audience policy permits exact paths. A separate
+same-session read scope lets existing file tools inspect session logs. It does
+not grant log-write or shell authority. A default `find .` still starts in
+`workspace/` and does not recurse into sibling logs.
 
 This is an application authority boundary. It does not prevent an already
 authorized arbitrary process that runs as the Netclaw OS identity from opening
-a known raw-log path. OS-level containment is a separate capability. The
-bounded child-activity tool remains the supported model-facing route because it
-redacts records and avoids approval-heavy shell discovery.
+a known log path. OS-level containment is a separate capability. Existing file
+tools remain the supported model-facing route and avoid shell discovery.
 
 An alternative placed the complete tree below `/tmp/netclaw` or `%TEMP%`.
 Netclaw rejected this default because operating system cleanup can remove
@@ -137,8 +136,8 @@ that choice remains subject to the current doctor warning.
 raw log all resolve below `subagents/run-7/` in the parent's envelope.
 
 **Counterexample:** Netclaw does not use the complete envelope as the default
-shell cwd. Doing that would make `find .` include raw logs and internal child
-state without the model explicitly leaving its working directory.
+shell cwd. Log read authority does not make the complete envelope a shell safe
+root.
 
 ### Bind one envelope only for new-layout sessions
 
@@ -237,33 +236,32 @@ legacy diagnostic
 The dispatcher still owns one serialized writer per target. Daemon-global logs
 remain under the existing daemon log path.
 
-The parent does not receive raw filesystem access merely because the log is in
-its physical envelope. The `spawn_agent` result will return the child run ID,
-an opaque log reference, and the exact child artifact directory. Existing file
-tools can read and attach files from that directory after parent-ownership
-authorization; no opaque artifact-reference tool is required.
-A deferred `subagent_log_read` tool will return a bounded, redacted activity
-projection. It will support a cursor and an optional literal query. It will not
-return system prompts, credentials, approval payloads, or unredacted tool data.
+The `spawn_agent` result will return the child run ID, exact child log path,
+and exact child artifact directory. Existing file tools can read, list, and
+search same-session logs after session-ownership authorization. They keep their
+normal output bounds and pagination.
 
-This tool avoids two bad alternatives. Unbounded raw file access would expose
-the diagnostic trail. A shell search would require the model to know internal
-paths and would create approval friction.
+This design composes existing tools. It does not add a log reader, a new query
+language, or a second output contract. The same-session read scope does not
+grant log writes, file edits, attachments, or shell authority. Cross-session
+log access remains denied.
 
 ```text
 spawn_agent result
   run_id: "run-7"
-  activity_log_ref: "child-log:opaque-value"
+  log_path: "/srv/netclaw/sessions/s-42/subagents/run-7/logs/session.log"
   artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
 
-subagent_log_read(activity_log_ref, cursor: null)
-  -> bounded redacted records + next cursor
+file_read(log_path, StartLine: 1, Limit: 200)
+  -> normal bounded line range
 ```
 
-**Counterexample:** The result does not contain
-`/srv/netclaw/sessions/s-42/subagents/run-7/logs/session.log`. The parent does
-not use `find`, `grep`, or `cat` to inspect that file. The returned artifact
-directory does not authorize any sibling `logs/` or `tmp/` path.
+**Counterexample:** Netclaw does not add a special session-log reader. The
+parent does not need `find`, `grep`, or `cat`. It uses `file_read` on the path.
+It can use `file_search` or `file_list` on the path's directory.
+
+**Counterexample:** A path below another session envelope remains denied. A
+same-session log read does not let `file_write` modify the log.
 
 ### Give each run one managed temporary environment
 
@@ -283,9 +281,10 @@ Netclaw will set all three values on POSIX and Windows. The host process
 environment remains unchanged. On Windows, `TMP` and `TEMP` drive native and
 .NET temporary-path selection. `TMPDIR` supports cross-platform programs.
 
-The model context will name `session_dir`, `temp_dir`, and `artifact_dir` once.
-It will use one short rule for each path. The environment remains the primary
-mechanism. Prompt text is not the security or correctness boundary.
+The model context will name `session_dir`, `temp_dir`, `artifact_dir`, and
+`log_path` once. It will use one short rule for each path. The environment
+remains the primary mechanism. Prompt text is not the security or correctness
+boundary.
 
 **Example:** A .NET process calls `Path.GetTempPath()`. The result is the
 current run's `temp_dir` because Netclaw injected the environment first.
@@ -465,7 +464,8 @@ integration tests will prove:
 
 - versioned single-envelope path creation and recovery;
 - parent and child log routing;
-- raw-log workspace-authority exclusion;
+- same-session log reads and cross-session log denial;
+- separation between log-read, log-write, and shell authority;
 - POSIX and Windows environment values;
 - process-local environment isolation;
 - correction precedence and retry behavior;
@@ -515,7 +515,7 @@ The eval suite will add these behavioral cases:
 - an agent retries an explicit unmanaged POSIX write under `temp_dir` after a
   typed correction;
 - an explicit platform-temp task preserves the requested path;
-- a parent uses the returned child log reference without a shell search;
+- a parent uses the returned child log path with existing file tools;
 - an agent uses `worktree_create` instead of a shell worktree command.
 
 Each pre-change and post-change comparison will use the same prompts, model
@@ -540,14 +540,15 @@ That pass does not prove environment injection, access control, or recovery.
 - **A rollback cannot understand the new binding.** -> Keep pre-feature binary
   support for new-layout sessions out of scope. Existing sessions remain
   compatible because their paths do not move.
-- **The model tries to read raw logs.** -> Do not add the envelope or log areas
-  to ordinary workspace-file safe roots. Expose the redacted tool by default.
+- **The model tries to read a same-session log.** -> Return the exact path and
+  authorize existing file-read, file-list, and file-search operations.
+- **The model tries to change a log.** -> Keep write and edit authority separate
+  from the same-session log read scope.
+- **The model tries to read a foreign session log.** -> Deny the operation
+  without revealing whether the foreign file exists.
 - **An approved arbitrary process knows a raw-log path.** -> Treat this change
   as an application authority boundary, not an OS sandbox. Add process
   containment only through a separate security design.
-- **The child-log projection leaks private data.** -> Reuse central redaction,
-  omit prompt bodies, apply a strict byte limit, and expose only parent-owned
-  child run IDs.
 - **A library caches the host temp path before injection.** -> Set the process
   environment before child process creation and test representative SDKs.
 - **A model still authors `/tmp`.** -> Return the typed correction when generic
@@ -567,9 +568,11 @@ That pass does not prove environment injection, access control, or recovery.
    session and log resolvers unchanged. Do not move or copy their data.
 3. Route only newly bound sessions into one physical envelope.
 4. Add the managed environment and corrections after path recovery passes.
-5. Add the child-log and worktree tools after their authority tests pass.
-6. Update runbooks and eval assertions before the release.
-7. Upgrade one existing session and restart one newly bound session.
+5. Add same-session log read scope and exact child paths after authority tests
+   pass.
+6. Add the worktree tool after its authority tests pass.
+7. Update runbooks and eval assertions before the release.
+8. Upgrade one existing session and restart one newly bound session.
 
 Existing-session compatibility is intentionally narrow: a current binary keeps
 each unbound existing session on its established directories. A pre-feature

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -1,0 +1,467 @@
+## Context
+
+See [proposal.md](proposal.md) for the reason for this change. This design uses
+the terms in the [engineering glossary](../../../docs/spec/GLOSSARY.md).
+
+Netclaw now computes agent-visible session files below
+`NetclawPaths.SessionsDirectory`. It computes session audit logs below the
+separate `NetclawPaths.SessionLogsDirectory` tree. The split deliberately keeps
+raw audit data outside workspace-file authority.
+
+The current platform-temp correction sends an eligible Personal agent from the
+host temporary root to the session directory. Parent and child prompts also
+describe the complete session directory as scratch. Live evidence shows that
+the prompt does not control every model choice.
+
+The current eval suite asserts that a child passes the complete session
+directory as `WorkingDirectory`. The suite finds child logs by a global path
+search under `logs/sessions`. This proves model alignment to the old layout. It
+does not prove a deterministic temporary environment or parent log discovery.
+
+`SessionDirectoryHelper.IsUnderTempPath` warns when the complete sessions tree
+is below the operating system temporary root. Attachments and journal
+references can outlive that filesystem data. This constraint prevents the
+default root from moving to `/tmp` or `%TEMP%` in this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give one session one durable storage descriptor and one child-run lineage.
+- Keep raw logs protected while the parent can inspect bounded child activity.
+- Make standard temporary APIs resolve to a session-owned directory.
+- Preserve an existing session's resolved location across an upgrade.
+- Give worktrees a managed location and an explicit owner.
+- Keep all authority decisions outside model prose.
+- Separate deterministic contract proof from model-alignment evidence.
+
+**Non-Goals:**
+
+- Move the default sessions base below the operating system temporary root.
+- Delete a session, artifact, output, temporary file, or worktree.
+- Add a quota or retention policy.
+- Move an existing session to another configured Netclaw home.
+- Let an agent read its own raw audit log.
+- Infer private command-line grammar in shell policy.
+- Add speculative Windows path patterns without observed evidence.
+
+## Decisions
+
+### Ownership and data lifetime
+
+Each state item has one owner and one lifetime.
+
+| State | Owner | Lifetime | Consumer |
+|---|---|---|---|
+| Storage descriptor | Parent session actor | Durable | Session paths, log dispatcher, child run scope |
+| Managed temporary path | Parent or child run scope | Run lifetime; files persist until later cleanup | Process environment and working context |
+| Captured host temporary root | Shell approval policy | Daemon process lifetime | Generic path comparison |
+| Managed-temp correction key | Parent or child actor | One user turn | Approval bridge |
+| Child log reference | Parent session actor | Durable session lifetime | `subagent_log_read` |
+| Child audit records | Log dispatcher | Durable file lifetime | Redacted projection builder |
+| Worktree ownership record | Parent session actor | Durable until later cleanup | Future cleanup policy |
+
+The model does not own any authority state. Model text can request a new call,
+but it cannot change a root, grant, or correction key.
+
+### Ordered runtime flow
+
+The following flow is schematic. It omits actor delivery retries and normal
+tool authorization stages.
+
+```text
+1. Parent session actor loads or persists SessionStorageDescriptor.
+2. Parent session actor creates an immutable run scope.
+3. Run scope derives session_dir, temp_dir, artifact_dir, and AuditRoot.
+4. Process launcher creates temp_dir and injects TMPDIR, TMP, and TEMP.
+5. Tool policy evaluates each authored tool call.
+6. Eligible unmanaged-temp writes return UseManagedTemporaryDirectory.
+7. The actor commits that correction and arms one turn-local retry key.
+8. A replacement call passes complete authorization as a new call.
+9. A child run writes its raw log below the parent AuditRoot.
+10. The parent reads bounded child activity through the opaque reference.
+```
+
+Counterexample: A prompt cannot replace steps 1 through 8. A compliant model
+does not prove that the runtime injected or enforced these values.
+
+### Bind separate agent-data and audit roots
+
+Layout version 2 will keep the current durable sessions base for agent-visible
+data and the current session-logs base for protected audit data. One persisted
+descriptor will bind both roots to the same session.
+
+```text
+agent-data root
+<sessions-base>/<session-id>/
+├── artifacts/
+├── inbox/
+├── media/
+├── tool-calls/
+├── tmp/
+│   ├── parent/
+│   └── subagents/<run-id>/
+├── worktrees/
+└── subagents/
+    └── <run-id>/artifacts/
+
+protected audit root
+<session-logs-base>/<session-id>/
+├── session.log
+└── subagents/
+    └── <run-id>/session.log
+```
+
+The audit root is not added to workspace-file or shell safe spaces by normal
+session context. The parent can inspect a bounded child-activity projection
+through a dedicated tool. Session ownership alone cannot read the raw files.
+
+Netclaw rejected placing raw logs below the agent-data root. A shell starts in
+that root when no project exists. A recursive command could then read a raw log
+without exposing its private traversal semantics to Netclaw policy. A protected
+subdirectory would therefore depend on executable-specific parsing or
+operating-system isolation that this change does not provide.
+
+An alternative placed the complete tree below `/tmp/netclaw` or `%TEMP%`.
+Netclaw rejected this default because operating system cleanup can remove
+attachments that durable turn history still references. An operator can move
+the complete Netclaw home through the existing configuration boundary, but
+that choice remains subject to the current doctor warning.
+
+**Example:** A parent starts child `run-7`. The child writes artifacts below
+`subagents/run-7/artifacts` and logs below `AuditRoot/subagents/run-7`.
+
+**Counterexample:** Netclaw does not place `session.log` below `session_dir`.
+A recursive shell command from `session_dir` must not reach the raw audit log.
+
+### Bind one durable storage descriptor to each session
+
+The main session actor will own one immutable storage descriptor:
+
+```text
+SessionStorageDescriptor
+  LayoutVersion
+  SessionRoot       // agent-visible data
+  AuditRoot         // raw parent and child logs
+  LegacyLogRoot?   // version 1 only
+```
+
+The actor will persist the descriptor before the first version-2 filesystem
+side effect. A child will receive the descriptor in its immutable run scope.
+The child will derive all paths from the parent roots and its opaque run ID.
+
+The following pseudocode is schematic. It omits persistence retries and actor
+message details.
+
+```text
+resolve_storage(session_state, configured_paths):
+    if session_state has a storage descriptor:
+        return that descriptor
+
+    if the session predates layout version 2:
+        descriptor = legacy paths under the current Netclaw home
+    else:
+        descriptor = version 2 agent and audit roots
+
+    persist descriptor before a filesystem consumer receives it
+    return descriptor
+```
+
+Both absolute roots are durable data. A later environment override or binary
+upgrade cannot recalculate them. A rollback can still resume the session
+because version 2 keeps the existing session base. An old binary can write a
+new legacy log file after rollback. The next new binary must inspect both
+recorded log lineages for that session.
+
+An alternative derived every path from the current `NETCLAW_HOME`. That design
+would repeat the configuration conflict that caused prior workspace failures.
+
+**Example:** A session binds roots under `/srv/netclaw-a`. An operator later
+changes the configured home to `/srv/netclaw-b`. The session still uses the
+two persisted roots under `/srv/netclaw-a`.
+
+**Counterexample:** Netclaw does not recompute one root while it retains the
+other root. That split would send one session to two unrelated lineages.
+
+### Route session logs by storage descriptor and child run ID
+
+The log dispatcher will receive a resolved log target. It will not derive a
+path from a session ID alone.
+
+```text
+main diagnostic
+  -> session descriptor
+  -> <audit-root>/session.log
+
+child diagnostic
+  -> session descriptor + run id
+  -> <audit-root>/subagents/<run-id>/session.log
+```
+
+The dispatcher still owns one serialized writer per target. Daemon-global logs
+remain under the existing daemon log path.
+
+The parent does not receive raw filesystem access to the audit root. The
+`spawn_agent` result will return the child run ID and an opaque log reference.
+A deferred `subagent_log_read` tool will return a bounded, redacted activity
+projection. It will support a cursor and an optional literal query. It will not
+return system prompts, credentials, approval payloads, or unredacted tool data.
+
+This tool avoids two bad alternatives. Raw file access would expose the audit
+trail. A shell search would require the model to know daemon internals and
+would create approval friction.
+
+```text
+spawn_agent result
+  run_id: "run-7"
+  activity_log_ref: "child-log:opaque-value"
+
+subagent_log_read(activity_log_ref, cursor: null)
+  -> bounded redacted records + next cursor
+```
+
+**Counterexample:** The result does not contain
+`/var/lib/netclaw/logs/sessions/s-42/subagents/run-7/session.log`. The parent
+does not use `find`, `grep`, or `cat` to inspect that file.
+
+### Give each run one managed temporary environment
+
+The parent path is `<session-root>/tmp/parent`. A child path is
+`<session-root>/tmp/subagents/<run-id>`. Netclaw will create and validate the
+directory before it starts a shell or another child process.
+
+Each process receives these process-local values:
+
+```text
+TMPDIR = <managed-temp>
+TMP    = <managed-temp>
+TEMP   = <managed-temp>
+```
+
+Netclaw will set all three values on POSIX and Windows. The host process
+environment remains unchanged. On Windows, `TMP` and `TEMP` drive native and
+.NET temporary-path selection. `TMPDIR` supports cross-platform programs.
+
+The model context will name `session_dir`, `temp_dir`, and `artifact_dir` once.
+It will use one short rule for each path. The environment remains the primary
+mechanism. Prompt text is not the security or correctness boundary.
+
+**Example:** A .NET process calls `Path.GetTempPath()`. The result is the
+current run's `temp_dir` because Netclaw injected the environment first.
+
+**Counterexample:** The model does not need to author
+`TMPDIR=<temp_dir> command`. Netclaw also does not change the daemon's global
+environment for sibling runs.
+
+### Keep the existing session cwd fallback
+
+A shell call with no project and no explicit `WorkingDirectory` will still use
+the session root. This preserves the existing no-project session behavior.
+
+Programs that request a temporary path will use `temp_dir` through the injected
+environment. The agent does not need to author `cd`, export variables, or add
+an environment prefix to each command.
+
+This distinction prevents a no-project conversation from starting in an
+internal directory. It also prevents temporary SDK output from mixing with
+artifacts and inbound files.
+
+**Example:** A no-project shell starts in `session_dir`. A library inside that
+shell creates its cache below `temp_dir` through the standard environment.
+
+**Counterexample:** Netclaw does not use `temp_dir` as the shell cwd. A final
+attachment also does not belong in `temp_dir`; it belongs in `artifact_dir`.
+
+### Extend the existing correction with one managed-temp code
+
+`UseManagedTemporaryDirectory` will be a closed remediation code. The
+correction presenter will name the exact managed path from trusted invocation
+context.
+
+The correction applies only when Netclaw has a generic fact that proves the
+agent authored an unmanaged temporary destination. Initial coverage includes:
+
+- a structured file write or edit below the captured platform temporary root;
+- an exact shell redirect below that root;
+- the existing exact `WorkingDirectory` and Bash leading-directory cases.
+
+Netclaw will not parse a private executable's options to guess an output path.
+An unknown shell operand remains on the normal approval or denial path. The
+structured worktree tool owns Git-specific destination semantics.
+
+The correction will not rewrite or execute the original call. The existing
+actor-owned intentional-retry key remains. An unchanged retry can reach a
+one-time approval when the user truly requires the original path.
+
+The POSIX implementation will cover the observed shared `/tmp` root. Windows
+will use the actual host temporary root that Netclaw captures before it injects
+the run environment. The change will not add a hard-coded `C:\Windows\Temp`
+rule. PII-free live evidence must justify any later Windows pattern.
+
+```text
+file_write(Path: "/tmp/result.log")
+  -> recoverable_correction(UseManagedTemporaryDirectory, temp_dir)
+
+file_write(Path: "<temp_dir>/result.log")
+  -> complete normal authorization
+```
+
+**Counterexample:** `diagnostic-tool --output /tmp/result.log` does not prove a
+write through shell syntax alone. Netclaw keeps that call on the ordinary
+approval path because the option belongs to private executable grammar.
+
+**Counterexample:** `pwd` with `WorkingDirectory=/tmp` performs the exact
+directory behavior that the user requested. Netclaw preserves the path because
+the call does not author a temporary write.
+
+### Give worktrees a separate managed operation
+
+A worktree is disposable infrastructure, but it can contain valuable source
+state. It must not share the ordinary temporary-file contract.
+
+The deferred `worktree_create` tool will:
+
+1. Require an authorized source repository or the current project.
+2. Accept a branch name and no arbitrary target directory.
+3. Allocate a collision-safe path below `<session-root>/worktrees`.
+4. Create the Git worktree through argument-array process execution.
+5. Return the exact path and a typed project-scope effect.
+6. Record the session and run that own later cleanup.
+
+The actor will apply the project-scope effect only after successful execution.
+The tool will not delete an existing directory or worktree. Cleanup remains a
+separate capability.
+
+An alternative allowed `git worktree add` through shell policy. Netclaw
+rejected that design because safe classification would require private Git
+argument grammar.
+
+```text
+worktree_create(
+  source: current_project,
+  branch: "fix/session-temp"
+)
+  -> path: "<session-root>/worktrees/fix-session-temp-2"
+  -> project_scope_effect: use returned path
+```
+
+**Counterexample:** The schema does not accept
+`destination: "/tmp/fix-session-temp"`. A failed Git operation does not change
+project scope and does not delete the destination.
+
+### Use deterministic tests as the primary proof
+
+The runtime change does not depend on model compliance. Contract and
+integration tests will prove:
+
+- versioned path creation and recovery;
+- parent and child log routing;
+- protected raw-log access;
+- POSIX and Windows environment values;
+- process-local environment isolation;
+- correction precedence and retry behavior;
+- worktree allocation and project-scope effects;
+- legacy resume and rollback compatibility.
+
+The current model evals remain useful, but their role changes.
+
+```text
+deterministic tests
+  -> prove runtime path, authority, and persistence
+
+model evals
+  -> measure whether the agent uses returned paths and tools well
+
+sanitized live traffic
+  -> discover new behavior and Windows path patterns
+```
+
+The current evals map to the new design as follows:
+
+| Current eval | Action | New assertion |
+|---|---|---|
+| `subagent_session_scratch_disposable` | Rewrite | A standard temp API returns a path below the child `temp_dir` |
+| `approval_session_scratch_disposable` | Rename and rewrite | `file_write` and `file_read` use `<temp_dir>/result.log` without shell |
+| `approval_shell_working_directory_argument` | Keep | An explicit read-only `/tmp` cwd remains intact |
+| `approval_inline_cd_semantics` | Keep | An exact requested `cd /tmp` remains intact |
+| `approval_natural_directory_change` | Keep | A requested process-local directory transition remains intact |
+
+The first two rows replace the old scratch assumption. The final three rows
+protect explicit user intent from an overbroad correction.
+
+The old delegated scratch eval will stop requiring
+`WorkingDirectory=session_dir`. Its replacement will run a program that uses a
+standard temporary API. The assertion will inspect the resulting path and
+require it below `temp_dir`.
+
+The old parent disposable-file eval will become
+`approval_managed_temp_disposable`. It will keep its useful no-shell assertion,
+but it will require `file_write` and `file_read` to use
+`<temp_dir>/result.log` instead of `<session_dir>/result.log`.
+
+The eval suite will add these behavioral cases:
+
+- a child uses the injected temporary environment without an export prefix;
+- a parent uses first-party file tools under `temp_dir` without a shell call;
+- an agent retries an explicit unmanaged POSIX write under `temp_dir` after a
+  typed correction;
+- an explicit platform-temp task preserves the requested path;
+- a parent uses the returned child log reference without a shell search;
+- an agent uses `worktree_create` instead of a shell worktree command.
+
+Each pre-change and post-change comparison will use the same prompts, model
+configuration, and assertion code. Evidence artifacts will contain no local
+user, channel, thread, host, repository, email, token, or secret.
+
+Windows model evals will wait for representative Windows traffic. Native
+Windows contract tests remain required in the first implementation.
+
+**Example:** A contract test proves that `TEMP` reaches a Windows child
+process. A model eval then measures whether the agent uses that affordance.
+
+**Counterexample:** A model can choose `temp_dir` after it reads prompt text.
+That pass does not prove environment injection, access control, or recovery.
+
+## Risks / Trade-offs
+
+- **A session descriptor cannot be persisted.** -> Fail the filesystem action
+  before a consumer writes to an unbound location.
+- **An old session has files in both log trees.** -> Preserve both paths and
+  let the supported inspector read both in time order.
+- **A rollback writes a legacy log after version 2 exists.** -> Keep resume
+  functional and merge both log lineages after the next upgrade.
+- **The model tries to read the audit root.** -> Do not add that root to normal
+  workspace or shell authority, and expose only the redacted tool by default.
+- **The child-log projection leaks private data.** -> Reuse central redaction,
+  omit prompt bodies, apply a strict byte limit, and expose only parent-owned
+  child run IDs.
+- **A library caches the host temp path before injection.** -> Set the process
+  environment before child process creation and test representative SDKs.
+- **A model still authors `/tmp`.** -> Return the typed correction when generic
+  facts prove the destination. Keep all other calls approval-gated.
+- **The worktree contains uncommitted changes when a session ends.** -> Do not
+  delete it in this change. Record ownership for a later cleanup policy.
+- **The agent-data and audit roots grow without bounds.** -> Keep deletion out
+  of this change. Add operator size diagnostics before a cleanup feature.
+- **The eval score improves for an unrelated model reason.** -> Treat model
+  scores as alignment evidence and use deterministic tests for product claims.
+
+## Migration Plan
+
+1. Add the version-2 two-root descriptor and readers before any writer uses the
+   new layout.
+2. Make the new binary read version-1 session and log paths.
+3. Route only newly bound version-2 sessions to the unified log paths.
+4. Add the managed environment and corrections after path recovery passes.
+5. Add the child-log and worktree tools after their authority tests pass.
+6. Update runbooks and eval assertions before the release.
+7. Run a binary-swap test with one legacy session and one new session.
+
+Rollback uses the prior binary without a data migration. It can resume the
+session from the existing durable journal and session directory. It can write a
+legacy log path. No version-2 file is deleted or moved.
+
+## Open Questions
+
+None. A later cleanup specification will define retention, active-session
+leases, quotas, and deletion.

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -4,9 +4,9 @@ See [proposal.md](proposal.md) for the reason for this change. This design uses
 the terms in the [engineering glossary](../../../docs/spec/GLOSSARY.md).
 
 Netclaw now computes agent-visible session files below
-`NetclawPaths.SessionsDirectory`. It computes session audit logs below the
-separate `NetclawPaths.SessionLogsDirectory` tree. The split deliberately keeps
-raw audit data outside workspace-file authority.
+`NetclawPaths.SessionsDirectory`. It computes raw session logs below the
+separate `NetclawPaths.SessionLogsDirectory` tree. This split is the reason a
+parent cannot discover all child-owned data through one session lineage.
 
 The current platform-temp correction sends an eligible Personal agent from the
 host temporary root to the session directory. Parent and child prompts also
@@ -27,10 +27,11 @@ default root from moving to `/tmp` or `%TEMP%` in this change.
 
 **Goals:**
 
-- Give one session one durable storage descriptor and one child-run lineage.
-- Keep raw logs protected while the parent can inspect bounded child activity.
+- Give one session one physical storage envelope and one child-run lineage.
+- Keep raw logs outside ordinary workspace-file safe roots while the parent can
+  inspect bounded child activity.
 - Make standard temporary APIs resolve to a session-owned directory.
-- Preserve an existing session's resolved location across an upgrade.
+- Preserve existing session path behavior without migrating its files.
 - Give worktrees a managed location and an explicit owner.
 - Keep all authority decisions outside model prose.
 - Separate deterministic contract proof from model-alignment evidence.
@@ -41,7 +42,8 @@ default root from moving to `/tmp` or `%TEMP%` in this change.
 - Delete a session, artifact, output, temporary file, or worktree.
 - Add a quota or retention policy.
 - Move an existing session to another configured Netclaw home.
-- Let an agent read its own raw audit log.
+- Grant ordinary workspace tools unrestricted raw-log access.
+- Claim that an application path boundary is an OS process sandbox.
 - Infer private command-line grammar in shell policy.
 - Add speculative Windows path patterns without observed evidence.
 
@@ -53,12 +55,12 @@ Each state item has one owner and one lifetime.
 
 | State | Owner | Lifetime | Consumer |
 |---|---|---|---|
-| Storage descriptor | Parent session actor | Durable | Session paths, log dispatcher, child run scope |
+| Storage binding | Shared session storage resolver | Durable | Ingress, session paths, log dispatcher, child run scope |
 | Managed temporary path | Parent or child run scope | Run lifetime; files persist until later cleanup | Process environment and working context |
 | Captured host temporary root | Shell approval policy | Daemon process lifetime | Generic path comparison |
 | Managed-temp correction key | Parent or child actor | One user turn | Approval bridge |
 | Child log reference | Parent session actor | Durable session lifetime | `subagent_log_read` |
-| Child audit records | Log dispatcher | Durable file lifetime | Redacted projection builder |
+| Child raw-log records | Log dispatcher | Durable file lifetime | Redacted projection builder |
 | Worktree ownership record | Parent session actor | Durable until later cleanup | Future cleanup policy |
 
 The model does not own any authority state. Model text can request a new call,
@@ -70,57 +72,60 @@ The following flow is schematic. It omits actor delivery retries and normal
 tool authorization stages.
 
 ```text
-1. Parent session actor loads or persists SessionStorageDescriptor.
-2. Parent session actor creates an immutable run scope.
-3. Run scope derives session_dir, temp_dir, artifact_dir, and AuditRoot.
-4. Process launcher creates temp_dir and injects TMPDIR, TMP, and TEMP.
-5. Tool policy evaluates each authored tool call.
-6. Eligible unmanaged-temp writes return UseManagedTemporaryDirectory.
-7. The actor commits that correction and arms one turn-local retry key.
-8. A replacement call passes complete authorization as a new call.
-9. A child run writes its raw log below the parent AuditRoot.
-10. The parent reads bounded child activity through the opaque reference.
+1. The first ingress or actor consumer asks the shared resolver for storage.
+2. The resolver returns existing behavior or atomically persists a new binding.
+3. An ingress writer, parent actor, or child receives the same resolved paths.
+4. A parent or child actor creates an immutable run scope.
+5. Run scope derives session_dir, temp_dir, artifact_dir, and raw-log target.
+6. Process launcher creates temp_dir and injects TMPDIR, TMP, and TEMP.
+7. Tool policy evaluates each authored tool call.
+8. Eligible unmanaged-temp writes return UseManagedTemporaryDirectory.
+9. The actor commits that correction and arms one turn-local retry key.
+10. A replacement call passes complete authorization as a new call.
+11. A child run writes its raw log below its child-run directory.
+12. The parent reads bounded child activity through the opaque reference.
 ```
 
 Counterexample: A prompt cannot replace steps 1 through 8. A compliant model
 does not prove that the runtime injected or enforced these values.
 
-### Bind separate agent-data and audit roots
+### Bind one physical session storage envelope
 
-Layout version 2 will keep the current durable sessions base for agent-visible
-data and the current session-logs base for protected audit data. One persisted
-descriptor will bind both roots to the same session.
+Layout version 2 will place all new session-owned files below one persisted
+session storage envelope. The session directory is the `workspace/` child of
+that envelope, not the envelope itself.
 
 ```text
-agent-data root
-<sessions-base>/<session-id>/
-├── artifacts/
-├── inbox/
-├── media/
-├── tool-calls/
+<sessions-base>/<session-id>/             session storage envelope
+├── workspace/                            session_dir; default no-project cwd
+│   ├── inbox/
+│   ├── media/
+│   └── tool-calls/
+├── artifacts/                            parent retained output
 ├── tmp/
-│   ├── parent/
-│   └── subagents/<run-id>/
-├── worktrees/
+│   └── parent/                           parent disposable output
+├── worktrees/                            managed source worktrees
+├── logs/
+│   └── session.log                       raw parent log
 └── subagents/
-    └── <run-id>/artifacts/
-
-protected audit root
-<session-logs-base>/<session-id>/
-├── session.log
-└── subagents/
-    └── <run-id>/session.log
+    └── <run-id>/                         one child-run directory
+        ├── artifacts/
+        ├── tmp/
+        └── logs/
+            └── session.log               raw child log
 ```
 
-The audit root is not added to workspace-file or shell safe spaces by normal
-session context. The parent can inspect a bounded child-activity projection
-through a dedicated tool. Session ownership alone cannot read the raw files.
+Normal session context adds `workspace/`, the applicable artifact directory,
+and the applicable temporary directory to their existing access policies. It
+does not add the complete envelope or `logs/` as an ordinary workspace-file or
+shell safe root. A default `find .` therefore starts in `workspace/` and does
+not recurse into sibling raw logs.
 
-Netclaw rejected placing raw logs below the agent-data root. A shell starts in
-that root when no project exists. A recursive command could then read a raw log
-without exposing its private traversal semantics to Netclaw policy. A protected
-subdirectory would therefore depend on executable-specific parsing or
-operating-system isolation that this change does not provide.
+This is an application authority boundary. It does not prevent an already
+authorized arbitrary process that runs as the Netclaw OS identity from opening
+a known raw-log path. OS-level containment is a separate capability. The
+bounded child-activity tool remains the supported model-facing route because it
+redacts records and avoids approval-heavy shell discovery.
 
 An alternative placed the complete tree below `/tmp/netclaw` or `%TEMP%`.
 Netclaw rejected this default because operating system cleanup can remove
@@ -128,107 +133,143 @@ attachments that durable turn history still references. An operator can move
 the complete Netclaw home through the existing configuration boundary, but
 that choice remains subject to the current doctor warning.
 
-**Example:** A parent starts child `run-7`. The child writes artifacts below
-`subagents/run-7/artifacts` and logs below `AuditRoot/subagents/run-7`.
+**Example:** A parent starts child `run-7`. Its artifacts, temporary files, and
+raw log all resolve below `subagents/run-7/` in the parent's envelope.
 
-**Counterexample:** Netclaw does not place `session.log` below `session_dir`.
-A recursive shell command from `session_dir` must not reach the raw audit log.
+**Counterexample:** Netclaw does not use the complete envelope as the default
+shell cwd. Doing that would make `find .` include raw logs and internal child
+state without the model explicitly leaving its working directory.
 
-### Bind one durable storage descriptor to each session
+### Bind one envelope only for new-layout sessions
 
-The main session actor will own one immutable storage descriptor:
+One shared session storage resolver will own an optional, immutable storage
+binding. Only new-layout sessions have this record. Channel ingress, the main
+session actor, child-run creation, and the log dispatcher will all use this
+resolver instead of computing paths independently.
 
 ```text
-SessionStorageDescriptor
+SessionStorageBinding
   LayoutVersion
-  SessionRoot       // agent-visible data
-  AuditRoot         // raw parent and child logs
-  LegacyLogRoot?   // version 1 only
+  SessionEnvelopeRoot
+
+ResolvedSessionStorage
+  SessionDirectory
+  ParentArtifactDirectory
+  ParentTemporaryDirectory
+  WorktreeDirectory
+  ParentRawLogPath
+  Child(run_id) -> child artifact, temporary, and raw-log paths
 ```
 
-The actor will persist the descriptor before the first version-2 filesystem
-side effect. A child will receive the descriptor in its immutable run scope.
-The child will derive all paths from the parent roots and its opaque run ID.
+Consumers receive `ResolvedSessionStorage`; they do not branch on "legacy" or
+"unified" themselves. Only the shared resolver knows whether it used a stored
+binding or the unchanged existing-session path rules. This keeps path selection
+out of ingress, actor, tool, and logging call sites.
+
+The shared resolver will persist the binding before the first new-layout
+filesystem side effect. A child will receive it in its immutable run scope. The
+child will derive all paths from the parent envelope and its opaque run ID.
 
 The following pseudocode is schematic. It omits persistence retries and actor
 message details.
 
 ```text
-resolve_storage(session_state, configured_paths):
-    if session_state has a storage descriptor:
-        return that descriptor
+resolve_storage(session_id, configured_paths):
+    if binding store has a binding for session_id:
+        return paths below its persisted envelope
 
-    if the session predates layout version 2:
-        descriptor = legacy paths under the current Netclaw home
-    else:
-        descriptor = version 2 agent and audit roots
+    if existing session or log data proves a legacy layout:
+        return existing session and log path resolvers unchanged
 
-    persist descriptor before a filesystem consumer receives it
-    return descriptor
+    binding = version 2 envelope below the configured sessions base
+    atomically persist binding unless another caller won the race
+    return paths below binding.SessionEnvelopeRoot
 ```
 
-Both absolute roots are durable data. A later environment override or binary
-upgrade cannot recalculate them. A rollback can still resume the session
-because version 2 keeps the existing session base. An old binary can write a
-new legacy log file after rollback. The next new binary must inspect both
-recorded log lineages for that session.
+The bound absolute envelope is durable data. A later environment override or
+binary upgrade cannot recalculate it. Existing sessions without a binding keep
+the current session-directory and session-log resolvers unchanged. The design
+does not create a synthetic legacy descriptor or move their files.
+
+The get-or-bind operation must be atomic because channel ingress can write
+media before the session actor processes its first message. The first consumer
+must not create `inbox/` or `media/` at the envelope root and make a new session
+look legacy. Every filesystem helper therefore accepts resolved storage paths;
+it does not accept only a session ID plus current configuration.
+
+**Example:** Two concurrent channel messages create the same new session. Both
+resolve the same persisted envelope, and both write media below `workspace/`.
+
+**Counterexample:** `ChannelPipeline` does not call
+`SessionDirectoryHelper.GetSessionDirectory(sessionId, configuredBase)` and
+write a file before storage binding. That would bypass recovery and layout
+selection.
 
 An alternative derived every path from the current `NETCLAW_HOME`. That design
 would repeat the configuration conflict that caused prior workspace failures.
 
-**Example:** A session binds roots under `/srv/netclaw-a`. An operator later
-changes the configured home to `/srv/netclaw-b`. The session still uses the
-two persisted roots under `/srv/netclaw-a`.
+**Example:** A new session binds `/srv/netclaw-a/sessions/s-42`. An operator
+later changes the configured home to `/srv/netclaw-b`. The session still uses
+the persisted envelope under `/srv/netclaw-a`.
 
-**Counterexample:** Netclaw does not recompute one root while it retains the
-other root. That split would send one session to two unrelated lineages.
+**Counterexample:** Netclaw does not recompute only the log location from the
+new configuration. That would recreate the split lineage this design removes.
 
-### Route session logs by storage descriptor and child run ID
+### Route session logs by storage binding and child run ID
 
 The log dispatcher will receive a resolved log target. It will not derive a
 path from a session ID alone.
 
 ```text
-main diagnostic
-  -> session descriptor
-  -> <audit-root>/session.log
+main diagnostic with storage binding
+  -> persisted envelope
+  -> <session-envelope>/logs/session.log
 
-child diagnostic
-  -> session descriptor + run id
-  -> <audit-root>/subagents/<run-id>/session.log
+child diagnostic with storage binding
+  -> persisted envelope + run id
+  -> <session-envelope>/subagents/<run-id>/logs/session.log
+
+legacy diagnostic
+  -> existing log resolver
+  -> existing legacy target
 ```
 
 The dispatcher still owns one serialized writer per target. Daemon-global logs
 remain under the existing daemon log path.
 
-The parent does not receive raw filesystem access to the audit root. The
-`spawn_agent` result will return the child run ID and an opaque log reference.
+The parent does not receive raw filesystem access merely because the log is in
+its physical envelope. The `spawn_agent` result will return the child run ID,
+an opaque log reference, and the exact child artifact directory. Existing file
+tools can read and attach files from that directory after parent-ownership
+authorization; no opaque artifact-reference tool is required.
 A deferred `subagent_log_read` tool will return a bounded, redacted activity
 projection. It will support a cursor and an optional literal query. It will not
 return system prompts, credentials, approval payloads, or unredacted tool data.
 
-This tool avoids two bad alternatives. Raw file access would expose the audit
-trail. A shell search would require the model to know daemon internals and
-would create approval friction.
+This tool avoids two bad alternatives. Unbounded raw file access would expose
+the diagnostic trail. A shell search would require the model to know internal
+paths and would create approval friction.
 
 ```text
 spawn_agent result
   run_id: "run-7"
   activity_log_ref: "child-log:opaque-value"
+  artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
 
 subagent_log_read(activity_log_ref, cursor: null)
   -> bounded redacted records + next cursor
 ```
 
 **Counterexample:** The result does not contain
-`/var/lib/netclaw/logs/sessions/s-42/subagents/run-7/session.log`. The parent
-does not use `find`, `grep`, or `cat` to inspect that file.
+`/srv/netclaw/sessions/s-42/subagents/run-7/logs/session.log`. The parent does
+not use `find`, `grep`, or `cat` to inspect that file. The returned artifact
+directory does not authorize any sibling `logs/` or `tmp/` path.
 
 ### Give each run one managed temporary environment
 
-The parent path is `<session-root>/tmp/parent`. A child path is
-`<session-root>/tmp/subagents/<run-id>`. Netclaw will create and validate the
-directory before it starts a shell or another child process.
+The parent path is `<session-envelope>/tmp/parent`. A child path is
+`<session-envelope>/subagents/<run-id>/tmp`. Netclaw will create and validate
+the directory before it starts a shell or another child process.
 
 Each process receives these process-local values:
 
@@ -255,19 +296,21 @@ environment for sibling runs.
 
 ### Keep the existing session cwd fallback
 
-A shell call with no project and no explicit `WorkingDirectory` will still use
-the session root. This preserves the existing no-project session behavior.
+A shell call with no project and no explicit `WorkingDirectory` will use the
+`workspace/` session directory inside the envelope. It will not use the
+complete envelope.
 
 Programs that request a temporary path will use `temp_dir` through the injected
 environment. The agent does not need to author `cd`, export variables, or add
 an environment prefix to each command.
 
-This distinction prevents a no-project conversation from starting in an
-internal directory. It also prevents temporary SDK output from mixing with
-artifacts and inbound files.
+This distinction prevents a no-project conversation from starting at a root
+that contains raw logs and child internals. It also prevents temporary SDK
+output from mixing with artifacts and inbound files.
 
-**Example:** A no-project shell starts in `session_dir`. A library inside that
-shell creates its cache below `temp_dir` through the standard environment.
+**Example:** A no-project shell starts in `<session-envelope>/workspace`. A
+library inside that shell creates its cache below `temp_dir` through the
+standard environment.
 
 **Counterexample:** Netclaw does not use `temp_dir` as the shell cwd. A final
 attachment also does not belong in `temp_dir`; it belongs in `artifact_dir`.
@@ -323,7 +366,7 @@ The deferred `worktree_create` tool will:
 
 1. Require an authorized source repository or the current project.
 2. Accept a branch name and no arbitrary target directory.
-3. Allocate a collision-safe path below `<session-root>/worktrees`.
+3. Allocate a collision-safe path below `<session-envelope>/worktrees`.
 4. Create the Git worktree through argument-array process execution.
 5. Return the exact path and a typed project-scope effect.
 6. Record the session and run that own later cleanup.
@@ -341,7 +384,7 @@ worktree_create(
   source: current_project,
   branch: "fix/session-temp"
 )
-  -> path: "<session-root>/worktrees/fix-session-temp-2"
+  -> path: "<session-envelope>/worktrees/fix-session-temp-2"
   -> project_scope_effect: use returned path
 ```
 
@@ -354,14 +397,14 @@ project scope and does not delete the destination.
 The runtime change does not depend on model compliance. Contract and
 integration tests will prove:
 
-- versioned path creation and recovery;
+- versioned single-envelope path creation and recovery;
 - parent and child log routing;
-- protected raw-log access;
+- raw-log workspace-authority exclusion;
 - POSIX and Windows environment values;
 - process-local environment isolation;
 - correction precedence and retry behavior;
 - worktree allocation and project-scope effects;
-- legacy resume and rollback compatibility.
+- existing-session resume and new-session recovery.
 
 The current model evals remain useful, but their role changes.
 
@@ -424,14 +467,18 @@ That pass does not prove environment injection, access control, or recovery.
 
 ## Risks / Trade-offs
 
-- **A session descriptor cannot be persisted.** -> Fail the filesystem action
+- **A session binding cannot be persisted.** -> Fail the filesystem action
   before a consumer writes to an unbound location.
-- **An old session has files in both log trees.** -> Preserve both paths and
-  let the supported inspector read both in time order.
-- **A rollback writes a legacy log after version 2 exists.** -> Keep resume
-  functional and merge both log lineages after the next upgrade.
-- **The model tries to read the audit root.** -> Do not add that root to normal
-  workspace or shell authority, and expose only the redacted tool by default.
+- **An old session has separate session and log trees.** -> Leave its storage
+  binding absent and keep the existing resolvers unchanged.
+- **A rollback cannot understand the new binding.** -> Keep pre-feature binary
+  support for new-layout sessions out of scope. Existing sessions remain
+  compatible because their paths do not move.
+- **The model tries to read raw logs.** -> Do not add the envelope or log areas
+  to ordinary workspace-file safe roots. Expose the redacted tool by default.
+- **An approved arbitrary process knows a raw-log path.** -> Treat this change
+  as an application authority boundary, not an OS sandbox. Add process
+  containment only through a separate security design.
 - **The child-log projection leaks private data.** -> Reuse central redaction,
   omit prompt bodies, apply a strict byte limit, and expose only parent-owned
   child run IDs.
@@ -441,25 +488,27 @@ That pass does not prove environment injection, access control, or recovery.
   facts prove the destination. Keep all other calls approval-gated.
 - **The worktree contains uncommitted changes when a session ends.** -> Do not
   delete it in this change. Record ownership for a later cleanup policy.
-- **The agent-data and audit roots grow without bounds.** -> Keep deletion out
-  of this change. Add operator size diagnostics before a cleanup feature.
+- **The session envelope grows without bounds.** -> Keep deletion out of this
+  change. Add operator size diagnostics before a cleanup feature.
 - **The eval score improves for an unrelated model reason.** -> Treat model
   scores as alignment evidence and use deterministic tests for product claims.
 
 ## Migration Plan
 
-1. Add the version-2 two-root descriptor and readers before any writer uses the
-   new layout.
-2. Make the new binary read version-1 session and log paths.
-3. Route only newly bound version-2 sessions to the unified log paths.
+1. Add the optional versioned storage binding before any writer uses the new
+   layout.
+2. Keep the binding absent for existing sessions and leave their current
+   session and log resolvers unchanged. Do not move or copy their data.
+3. Route only newly bound sessions into one physical envelope.
 4. Add the managed environment and corrections after path recovery passes.
 5. Add the child-log and worktree tools after their authority tests pass.
 6. Update runbooks and eval assertions before the release.
-7. Run a binary-swap test with one legacy session and one new session.
+7. Upgrade one existing session and restart one newly bound session.
 
-Rollback uses the prior binary without a data migration. It can resume the
-session from the existing durable journal and session directory. It can write a
-legacy log path. No version-2 file is deleted or moved.
+Existing-session compatibility is intentionally narrow: a current binary keeps
+each unbound existing session on its established directories. A pre-feature
+binary resuming a newly bound session is out of scope. No upgrade path moves or
+deletes session files.
 
 ## Open Questions
 

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -58,7 +58,8 @@ Each state item has one owner and one lifetime.
 | Managed temporary path | Parent or child run scope | Run lifetime; files persist until later cleanup | Process environment and working context |
 | Captured host temporary root | Shell approval policy | Daemon process lifetime | Generic path comparison |
 | Managed-temp correction key | Parent or child actor | One user turn | Approval bridge |
-| Session log paths | Session storage resolver | Durable session lifetime | Existing file tools and `spawn_agent` |
+| Session log paths | Session storage resolver | Durable session lifetime | Existing context assembly, file tools, and `spawn_agent` |
+| Session log read scope | Parent or child run scope | Run lifetime | `ScopedFileAccessPolicy` read authorization |
 | Session log records | Log dispatcher | Durable file lifetime | Same-session file-tool reads |
 | Worktree ownership record | Parent session actor | Durable until later cleanup | Future cleanup policy |
 
@@ -83,7 +84,8 @@ tool authorization stages.
 10. A replacement call passes complete authorization as a new call.
 11. A child run writes its raw log below its child-run directory.
 12. `spawn_agent` returns the exact child log path to the parent.
-13. The parent reads or searches that path with an existing file tool.
+13. Existing context assembly exposes the current run log path.
+14. An existing file tool checks the same-session log read scope.
 ```
 
 Counterexample: A prompt cannot replace steps 1 through 8. A compliant model
@@ -115,11 +117,14 @@ that envelope, not the envelope itself.
             └── session.log               raw child log
 ```
 
-Normal session context names `session_dir`, `artifact_dir`, `temp_dir`, and the
-current run's `log_path` when audience policy permits exact paths. A separate
-same-session read scope lets existing file tools inspect session logs. It does
-not grant log-write or shell authority. A default `find .` still starts in
-`workspace/` and does not recurse into sibling logs.
+The existing `[session]` context block keeps `session_dir`. It adds
+`artifact_dir`, `temp_dir`, and the current run's `log_path` when audience
+policy permits exact paths. No second prompt provider or context block owns
+these values.
+
+A separate same-session read scope lets existing file tools inspect session
+logs. It does not grant log-write, attach, or shell authority. A default
+`find .` still starts in `workspace/` and does not recurse into sibling logs.
 
 This is an application authority boundary. It does not prevent an already
 authorized arbitrary process that runs as the Netclaw OS identity from opening
@@ -158,12 +163,17 @@ ResolvedSessionStorage
   WorktreeDirectory
   ParentRawLogPath
   Child(run_id) -> child artifact, temporary, and raw-log paths
+  LogReadScope -> normalized main and child log path classifier
 ```
 
 Consumers receive `ResolvedSessionStorage`; they do not branch on "legacy" or
 "unified" themselves. Only the shared resolver knows whether it used a stored
 binding or the unchanged existing-session path rules. This keeps path selection
 out of ingress, actor, tool, and logging call sites.
+
+The resolver also supplies the read-only log scope for either path strategy.
+The file policy consumes that scope from the existing invocation context. It
+does not reconstruct storage paths from current configuration.
 
 The shared resolver will persist the binding before the first new-layout
 filesystem side effect. A child will receive it in its immutable run scope. The
@@ -246,6 +256,32 @@ language, or a second output contract. The same-session read scope does not
 grant log writes, file edits, attachments, or shell authority. Cross-session
 log access remains denied.
 
+The complete session is the log-read trust boundary. A parent or child run can
+read the main log and every child log in that session. No run can use this
+scope to read another session.
+
+The implementation will add this read-only scope to the existing invocation
+context and `ScopedFileAccessPolicy`. It will not redefine `{session_dir}` or
+add the complete envelope to an audience profile. Public and Team currently
+reuse `{session_dir}` across read, write, and attach profiles. Widening that
+token would also widen mutation and attachment authority.
+
+For the new layout, the scope accepts only these normalized path shapes:
+
+```text
+<session-envelope>/logs/**
+<session-envelope>/subagents/<run-id>/logs/**
+```
+
+It does not accept `<session-envelope>/**` or
+`<session-envelope>/subagents/**`. The latter roots would expose child
+artifacts and temporary files. Existing path normalization, link checks, and
+protected-path checks still apply.
+
+For an unbound existing session, the same read scope uses the unchanged legacy
+log resolver and durable child lineage. It grants access to the resolved main
+and child log paths without moving those files.
+
 ```text
 spawn_agent result
   run_id: "run-7"
@@ -256,12 +292,28 @@ file_read(log_path, StartLine: 1, Limit: 200)
   -> normal bounded line range
 ```
 
+The log writer keeps an append handle open. `file_read` and `file_search` must
+open active logs with a compatible share mode on POSIX and Windows. A read must
+not block the writer or fail only because the writer remains active.
+
+`spawn_agent` will return a log path only after the child log target is
+resolved and created. The file can be empty, but an immediate authorized read
+must not fail because the path is not ready.
+
 **Counterexample:** Netclaw does not add a special session-log reader. The
 parent does not need `find`, `grep`, or `cat`. It uses `file_read` on the path.
 It can use `file_search` or `file_list` on the path's directory.
 
 **Counterexample:** A path below another session envelope remains denied. A
 same-session log read does not let `file_write` modify the log.
+
+**Counterexample:** The implementation does not add the complete `subagents/`
+directory as a read root. That path also contains artifacts and temporary
+files, which use different access contracts.
+
+**Counterexample:** The implementation does not replace `{session_dir}` with
+the envelope root. Public and Team write or attach profiles also consume that
+token.
 
 ### Give each run one managed temporary environment
 
@@ -281,10 +333,10 @@ Netclaw will set all three values on POSIX and Windows. The host process
 environment remains unchanged. On Windows, `TMP` and `TEMP` drive native and
 .NET temporary-path selection. `TMPDIR` supports cross-platform programs.
 
-The model context will name `session_dir`, `temp_dir`, `artifact_dir`, and
-`log_path` once. It will use one short rule for each path. The environment
-remains the primary mechanism. Prompt text is not the security or correctness
-boundary.
+The existing model context will keep `session_dir` and add `temp_dir`,
+`artifact_dir`, and `log_path` once. It will use one short rule for each path.
+The environment remains the primary mechanism. Prompt text is not the security
+or correctness boundary.
 
 **Example:** A .NET process calls `Path.GetTempPath()`. The result is the
 current run's `temp_dir` because Netclaw injected the environment first.
@@ -371,8 +423,9 @@ The initial source audit identifies these implementation groups:
 | Retry and approval flow | `IToolExecutor`, `DispatchingToolExecutor`, `ToolAccessPolicy`, `SessionToolExecutionPipeline` | Rename correction state and keys; compare retries against managed-temp semantics |
 | Parent and child actors | `LlmSessionActor`, `SubAgentActor`, `LlmMessages` | Use the same managed-temp correction and lifecycle state in both paths |
 | Durable pending approvals | `ToolApprovalState`, `SessionProtocol.Events`, `netclaw_messages.proto`, `NetclawProtoMapper` | Add the new field, retain field 19 as legacy-read-only, and test recovery without reinterpretation |
-| Model-visible guidance | shipped `AGENTS.md`, `SessionMessageAssembler`, `SubAgentActor`, `ToolChoiceGuidance`, `ShellTool` | Describe `session_dir`, `temp_dir`, and `artifact_dir` by their distinct purposes |
+| Model-visible guidance | shipped `AGENTS.md`, `SessionMessageAssembler`, `SubAgentActor`, `ToolChoiceGuidance`, `ShellTool` | Extend the existing session block with `temp_dir`, `artifact_dir`, and `log_path`; preserve current `session_dir` assembly |
 | Workspace file schemas | `FileReadTool`, `FileListTool`, `FileSearchTool`, `FileWriteTool`, `FileEditTool`, `AttachFileTool` | Replace “session scratch” with “session directory” for relative-path fallback |
+| Session log reads | `ToolExecutionContext`, `ScopedFileAccessPolicy`, `FileReadTool`, `FileSearchTool`, `SessionLogActor` | Add a read-only same-session log scope and use a writer-compatible file share mode |
 | Approval scopes and prompts | `ApprovalBucketBuilder`, `ToolAccessPolicy`, Slack and Discord approval builders, approval runbook | Name the broader rule “session-owned directory” and define which roots suppress persistent folder grants |
 | Verification | actor, policy, serialization, approval-rehydration, TUI, configuration, and daemon test projects | Rename fixtures and add distinct `session_dir` versus `temp_dir` assertions |
 
@@ -466,6 +519,8 @@ integration tests will prove:
 - parent and child log routing;
 - same-session log reads and cross-session log denial;
 - separation between log-read, log-write, and shell authority;
+- live log reads that do not block the writer on POSIX or Windows;
+- legacy main and child log reads without file migration;
 - POSIX and Windows environment values;
 - process-local environment isolation;
 - correction precedence and retry behavior;
@@ -546,6 +601,10 @@ That pass does not prove environment injection, access control, or recovery.
   from the same-session log read scope.
 - **The model tries to read a foreign session log.** -> Deny the operation
   without revealing whether the foreign file exists.
+- **A file tool reads while the log writer stays open.** -> Use a compatible
+  read share mode and test the active writer on Windows and POSIX.
+- **An implementation widens `{session_dir}` to the envelope.** -> Keep the
+  existing token unchanged and add a read-only log scope to invocation context.
 - **An approved arbitrary process knows a raw-log path.** -> Treat this change
   as an application authority boundary, not an OS sandbox. Add process
   containment only through a separate security design.

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -315,6 +315,72 @@ standard environment.
 **Counterexample:** Netclaw does not use `temp_dir` as the shell cwd. A final
 attachment also does not belong in `temp_dir`; it belongs in `artifact_dir`.
 
+### Retire the session-scratch term by meaning
+
+The current code uses “session scratch” for three different contracts. The
+implementation will classify each use before renaming it.
+
+| Current meaning | Replacement term | Representative uses |
+|---|---|---|
+| Default no-project cwd and relative-path base | session directory; `session_dir` | `ToolExecutionContext.SessionDirectory`, file-tool schemas, cwd fallback |
+| Disposable run-local files | managed temporary directory; `temp_dir` | platform-temp correction, model guidance, process environment |
+| Session-specific directory unsuitable for a durable folder grant | session-owned directory | approval-option pruning and runbooks |
+
+The correction pipeline will use the second meaning. It will replace
+`UseSessionScratch` with `UseManagedTemporaryDirectory`, and its trusted path
+will be the run's exact `temp_dir`, not `session_dir`. Correction, retry,
+approval-context, parent-actor, and child-actor type names will use
+`ManagedTemporaryDirectory` or `ManagedTemp` consistently.
+
+File tools use the first meaning. Their schemas will say that relative paths
+resolve against the current project and then the session directory. They will
+not claim that the session directory is disposable scratch.
+
+Approval-option pruning uses the third meaning. The implementation will state
+which session-owned directories suppress a reusable folder grant. It will not
+carry the name “session scratch” after the paths have distinct purposes.
+
+One persisted approval field currently stores `session_scratch_directory` at
+protobuf field 19. The implementation will retain that field as legacy-read-only
+input and add a new `managed_temporary_directory` field with a new field number.
+New events will not write field 19. The runtime will not reinterpret an old
+session-directory path as `temp_dir`. When an old pending approval resumes, it
+will derive the current managed temporary directory from resolved run storage
+or omit the new correction metadata.
+
+```text
+old pending approval
+  session_scratch_directory = <old session_dir>
+  -> never relabel that value as temp_dir
+  -> derive current temp_dir from resolved run storage, or omit temp guidance
+
+new correction receipt
+  remediation = UseManagedTemporaryDirectory
+  managed_temporary_directory = <current run temp_dir>
+```
+
+Archived OpenSpec changes and immutable evidence remain historical records.
+Current production code, active specifications, tool schemas, runtime prompts,
+runbooks, and tests will use the new vocabulary.
+
+The initial source audit identifies these implementation groups:
+
+| Area | Current anchors | Required change |
+|---|---|---|
+| Remediation identity and text | `ToolRemediationCode`, `ToolRemediationPresenter`, `ToolOutcomeResults` | Replace `UseSessionScratch`; render `temp_dir` as the managed temporary directory |
+| Platform-temp detection | `PlatformTemporaryScopePolicy` | Replace `SessionScratchSuggested` and carry the resolved run `temp_dir` |
+| Retry and approval flow | `IToolExecutor`, `DispatchingToolExecutor`, `ToolAccessPolicy`, `SessionToolExecutionPipeline` | Rename correction state and keys; compare retries against managed-temp semantics |
+| Parent and child actors | `LlmSessionActor`, `SubAgentActor`, `LlmMessages` | Use the same managed-temp correction and lifecycle state in both paths |
+| Durable pending approvals | `ToolApprovalState`, `SessionProtocol.Events`, `netclaw_messages.proto`, `NetclawProtoMapper` | Add the new field, retain field 19 as legacy-read-only, and test recovery without reinterpretation |
+| Model-visible guidance | shipped `AGENTS.md`, `SessionMessageAssembler`, `SubAgentActor`, `ToolChoiceGuidance`, `ShellTool` | Describe `session_dir`, `temp_dir`, and `artifact_dir` by their distinct purposes |
+| Workspace file schemas | `FileReadTool`, `FileListTool`, `FileSearchTool`, `FileWriteTool`, `FileEditTool`, `AttachFileTool` | Replace “session scratch” with “session directory” for relative-path fallback |
+| Approval scopes and prompts | `ApprovalBucketBuilder`, `ToolAccessPolicy`, Slack and Discord approval builders, approval runbook | Name the broader rule “session-owned directory” and define which roots suppress persistent folder grants |
+| Verification | actor, policy, serialization, approval-rehydration, TUI, configuration, and daemon test projects | Rename fixtures and add distinct `session_dir` versus `temp_dir` assertions |
+
+**Counterexample:** A global replacement from `SessionScratchDirectory` to
+`ManagedTemporaryDirectory` would make a persisted `session_dir` appear to be
+the new disposable directory. That is a semantic migration bug, not a rename.
+
 ### Extend the existing correction with one managed-temp code
 
 `UseManagedTemporaryDirectory` will be a closed remediation code. The

--- a/openspec/changes/unify-session-storage-and-temp/proposal.md
+++ b/openspec/changes/unify-session-storage-and-temp/proposal.md
@@ -21,11 +21,15 @@ use separate directory trees.
 - Let agents read, list, and search their same-session logs with the existing
   file tools. Keep cross-session access, log writes, and shell authority out of
   this read scope.
+- Treat one session as the log-read trust boundary. Parent and child runs can
+  read main and child logs from that session, including resolved legacy logs.
 - Set `TMPDIR`, `TMP`, and `TEMP` for each parent and child execution scope.
   The values must identify that run's managed temporary directory.
 - Retire the ambiguous “session scratch” vocabulary. Use `session_dir` for the
   working and relative-path base, `temp_dir` for disposable run-local files,
   and “session-owned directory” only for approval rules that cover both.
+- Preserve the existing `[session]` context block. Extend it with `temp_dir`,
+  `artifact_dir`, and `log_path` instead of adding another context mechanism.
 - Extend the existing typed correction path for an explicit unmanaged
   temporary write. The correction must name the managed temporary directory
   and must not rewrite or approve the original call.
@@ -83,6 +87,9 @@ directory. The parent passes the path to `file_read`, `file_search`, or
 
 Counterexample: The parent does not need a special child-log tool or a shell
 search. A different session cannot read the returned path.
+
+Counterexample: Netclaw does not redefine `{session_dir}` as the complete
+envelope. That token also participates in write and attach profiles.
 
 ### Managed worktree creation
 

--- a/openspec/changes/unify-session-storage-and-temp/proposal.md
+++ b/openspec/changes/unify-session-storage-and-temp/proposal.md
@@ -1,0 +1,123 @@
+## Why
+
+Source PRDs: `PRD-001`, `PRD-002`, and `PRD-006`.
+
+Live sessions still create disposable work under shared platform temporary
+roots, even after prompt guidance and interactive correction changes. Parent
+agents also cannot discover child logs because session files and session logs
+use separate directory trees.
+
+## What Changes
+
+- Give each new session one versioned storage descriptor with an agent-data
+  root and a protected audit root.
+- Store both resolved roots with the session. A later upgrade or configuration
+  change must not reinterpret either root for an existing session.
+- Keep legacy session roots and log paths in place. Do not move or delete them
+  during an upgrade.
+- Place each child's artifacts below the parent agent-data root and its raw log
+  below the parent audit root. Return opaque log and artifact references to the
+  parent.
+- Keep raw audit logs outside normal workspace-file access. Provide a bounded,
+  redacted parent view of child activity instead of requiring shell searches.
+- Set `TMPDIR`, `TMP`, and `TEMP` for each parent and child execution scope.
+  The values must identify that run's managed temporary directory.
+- Extend the existing typed correction path for an explicit unmanaged
+  temporary write. The correction must name the managed temporary directory
+  and must not rewrite or approve the original call.
+- Add a deferred structured worktree tool. The tool chooses a session-owned
+  worktree path, creates the worktree, returns its working directory, and
+  records cleanup ownership.
+- Replace eval assertions that require the session root as the shell working
+  directory for all disposable work. New assertions must test the managed
+  temporary environment and parent-child artifact discovery.
+- Preserve current strict behavior when a task explicitly requires a platform
+  temporary path.
+
+**BREAKING:** New child logs no longer use standalone sibling directories in
+the session-logs base. They are grouped below the parent audit root. Operator
+runbooks that derive child log paths must use the supported inspection command.
+
+This change is in scope for Personal and Team sessions on POSIX and Windows.
+It includes deterministic runtime tests and PII-free model evals. Automated
+deletion, quotas, and a general session-storage relocation command are out of
+scope.
+
+## Representative Examples
+
+### Managed temporary output
+
+An agent asks a standard temporary API for a file path. Netclaw sets the
+process environment before execution.
+
+```text
+TMPDIR=/home/agent/.netclaw/sessions/s-42/tmp/parent
+TEMP=/home/agent/.netclaw/sessions/s-42/tmp/parent
+
+standard_temp_api()
+  -> /home/agent/.netclaw/sessions/s-42/tmp/parent/result-7.tmp
+```
+
+Counterexample: Netclaw does not move the complete session below `/tmp`.
+Operating-system cleanup could remove files that durable session history uses.
+
+### Explicit user intent
+
+The request `Run pwd from /tmp` names `/tmp` as required behavior. Netclaw
+preserves that path and applies normal authorization.
+
+Counterexample: A disposable `file_write` to `/tmp/result.log` does not express
+the same requirement. An eligible Personal session receives
+`UseManagedTemporaryDirectory` before an approval prompt.
+
+### Child activity discovery
+
+`spawn_agent` returns an opaque child log reference. The parent passes that
+reference to `subagent_log_read` and receives a bounded activity page.
+
+Counterexample: The parent does not receive a raw log path. It does not search
+the daemon log tree with shell commands.
+
+### Managed worktree creation
+
+`worktree_create` accepts an authorized source repository and a branch. The
+tool allocates the destination below the session worktree area.
+
+Counterexample: The tool does not accept `/tmp/fix-branch` as a destination.
+Netclaw does not parse private Git options to authorize that shell command.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `netclaw-session`: Persist the versioned agent-data and audit roots and group
+  main and child session logs under one protected lineage with legacy resume
+  behavior.
+- `session-cwd`: Define managed temporary and worktree areas and inject the
+  standard temporary environment for every run.
+- `netclaw-tools`: Expose bounded child-log discovery and a managed deferred
+  worktree operation without exposing raw audit files.
+- `tool-approval-gates`: Return a typed managed-temp correction for eligible
+  explicit writes and define the deterministic and behavioral proof boundary.
+
+## Impact
+
+- **Session runtime:** Session creation, recovery, child-run scope, and path
+  resolution gain a versioned two-root storage descriptor.
+- **Logging:** The session log dispatcher routes parent and child files into
+  one protected session audit hierarchy. Daemon-global logs remain unchanged.
+- **Tool execution:** Shell child processes receive session-specific temporary
+  environment variables. File and worktree tools use managed destinations.
+- **Security:** Path knowledge grants no authority. Raw audit logs remain
+  protected, and all replacement calls pass normal authorization.
+- **Operations:** Runbooks and diagnostics must stop deriving session log paths.
+  Cleanup must recognize both legacy and new layouts.
+- **Testing:** Contract and integration tests prove layout, environment,
+  recovery, access, and correction behavior. Model evals measure agent choices
+  and parent-child handoff quality only.
+- **Dependencies and public APIs:** No new package is required. Any new tool
+  schema remains internal to Netclaw's existing tool registry.

--- a/openspec/changes/unify-session-storage-and-temp/proposal.md
+++ b/openspec/changes/unify-session-storage-and-temp/proposal.md
@@ -23,6 +23,9 @@ use separate directory trees.
   activity instead of requiring shell searches.
 - Set `TMPDIR`, `TMP`, and `TEMP` for each parent and child execution scope.
   The values must identify that run's managed temporary directory.
+- Retire the ambiguous “session scratch” vocabulary. Use `session_dir` for the
+  working and relative-path base, `temp_dir` for disposable run-local files,
+  and “session-owned directory” only for approval rules that cover both.
 - Extend the existing typed correction path for an explicit unmanaged
   temporary write. The correction must name the managed temporary directory
   and must not rewrite or approve the original call.

--- a/openspec/changes/unify-session-storage-and-temp/proposal.md
+++ b/openspec/changes/unify-session-storage-and-temp/proposal.md
@@ -9,17 +9,18 @@ use separate directory trees.
 
 ## What Changes
 
-- Give each new session one versioned storage descriptor with an agent-data
-  root and a protected audit root.
-- Store both resolved roots with the session. A later upgrade or configuration
-  change must not reinterpret either root for an existing session.
+- Give each new session one versioned storage binding with one physical
+  session storage envelope.
+- Store the resolved envelope root with the session. A later upgrade or
+  configuration change must not reinterpret it for an existing session.
 - Keep legacy session roots and log paths in place. Do not move or delete them
   during an upgrade.
-- Place each child's artifacts below the parent agent-data root and its raw log
-  below the parent audit root. Return opaque log and artifact references to the
-  parent.
-- Keep raw audit logs outside normal workspace-file access. Provide a bounded,
-  redacted parent view of child activity instead of requiring shell searches.
+- Place each child's artifacts, temporary files, and raw log below one child-run
+  directory inside the parent's envelope. Return an opaque log reference and
+  the parent-readable child artifact directory.
+- Keep raw logs outside the session working directory and ordinary
+  workspace-file safe roots. Provide a bounded, redacted parent view of child
+  activity instead of requiring shell searches.
 - Set `TMPDIR`, `TMP`, and `TEMP` for each parent and child execution scope.
   The values must identify that run's managed temporary directory.
 - Extend the existing typed correction path for an explicit unmanaged
@@ -28,15 +29,16 @@ use separate directory trees.
 - Add a deferred structured worktree tool. The tool chooses a session-owned
   worktree path, creates the worktree, returns its working directory, and
   records cleanup ownership.
-- Replace eval assertions that require the session root as the shell working
-  directory for all disposable work. New assertions must test the managed
-  temporary environment and parent-child artifact discovery.
+- Replace eval assertions that treat the complete session storage envelope as
+  shell cwd or disposable work. New assertions must test the `workspace/` cwd,
+  managed temporary environment, and parent-child artifact discovery.
 - Preserve current strict behavior when a task explicitly requires a platform
   temporary path.
 
-**BREAKING:** New child logs no longer use standalone sibling directories in
-the session-logs base. They are grouped below the parent audit root. Operator
-runbooks that derive child log paths must use the supported inspection command.
+**BREAKING:** New parent and child logs no longer use standalone directories in
+the session-logs base. They are grouped inside the session storage envelope.
+Operator runbooks that derive log paths must use the supported inspection
+command.
 
 This change is in scope for Personal and Team sessions on POSIX and Windows.
 It includes deterministic runtime tests and PII-free model evals. Automated
@@ -51,11 +53,11 @@ An agent asks a standard temporary API for a file path. Netclaw sets the
 process environment before execution.
 
 ```text
-TMPDIR=/home/agent/.netclaw/sessions/s-42/tmp/parent
-TEMP=/home/agent/.netclaw/sessions/s-42/tmp/parent
+TMPDIR=/srv/netclaw/sessions/s-42/tmp/parent
+TEMP=/srv/netclaw/sessions/s-42/tmp/parent
 
 standard_temp_api()
-  -> /home/agent/.netclaw/sessions/s-42/tmp/parent/result-7.tmp
+  -> /srv/netclaw/sessions/s-42/tmp/parent/result-7.tmp
 ```
 
 Counterexample: Netclaw does not move the complete session below `/tmp`.
@@ -72,8 +74,10 @@ the same requirement. An eligible Personal session receives
 
 ### Child activity discovery
 
-`spawn_agent` returns an opaque child log reference. The parent passes that
-reference to `subagent_log_read` and receives a bounded activity page.
+`spawn_agent` returns an opaque child log reference and the child's artifact
+directory. The parent passes the reference to `subagent_log_read` and receives
+a bounded activity page. The raw file is physically below the same session
+envelope as the artifacts.
 
 Counterexample: The parent does not receive a raw log path. It does not search
 the daemon log tree with shell commands.
@@ -94,26 +98,27 @@ None.
 
 ### Modified Capabilities
 
-- `netclaw-session`: Persist the versioned agent-data and audit roots and group
-  main and child session logs under one protected lineage with legacy resume
-  behavior.
+- `netclaw-session`: Persist one versioned session storage envelope and group
+  main and child data under that physical lineage while existing sessions keep
+  their current path behavior.
 - `session-cwd`: Define managed temporary and worktree areas and inject the
   standard temporary environment for every run.
 - `netclaw-tools`: Expose bounded child-log discovery and a managed deferred
-  worktree operation without exposing raw audit files.
+  worktree operation without exposing raw log files.
 - `tool-approval-gates`: Return a typed managed-temp correction for eligible
   explicit writes and define the deterministic and behavioral proof boundary.
 
 ## Impact
 
 - **Session runtime:** Session creation, recovery, child-run scope, and path
-  resolution gain a versioned two-root storage descriptor.
+  resolution gain a versioned single-envelope storage binding.
 - **Logging:** The session log dispatcher routes parent and child files into
-  one protected session audit hierarchy. Daemon-global logs remain unchanged.
+  the session envelope. Daemon-global logs remain unchanged.
 - **Tool execution:** Shell child processes receive session-specific temporary
   environment variables. File and worktree tools use managed destinations.
-- **Security:** Path knowledge grants no authority. Raw audit logs remain
-  protected, and all replacement calls pass normal authorization.
+- **Security:** Path knowledge grants no authority. Raw logs remain outside
+  ordinary workspace-file safe roots, and all replacement calls pass normal
+  authorization. This change does not claim OS-level process isolation.
 - **Operations:** Runbooks and diagnostics must stop deriving session log paths.
   Cleanup must recognize both legacy and new layouts.
 - **Testing:** Contract and integration tests prove layout, environment,

--- a/openspec/changes/unify-session-storage-and-temp/proposal.md
+++ b/openspec/changes/unify-session-storage-and-temp/proposal.md
@@ -16,11 +16,11 @@ use separate directory trees.
 - Keep legacy session roots and log paths in place. Do not move or delete them
   during an upgrade.
 - Place each child's artifacts, temporary files, and raw log below one child-run
-  directory inside the parent's envelope. Return an opaque log reference and
+  directory inside the parent's envelope. Return the exact child log path and
   the parent-readable child artifact directory.
-- Keep raw logs outside the session working directory and ordinary
-  workspace-file safe roots. Provide a bounded, redacted parent view of child
-  activity instead of requiring shell searches.
+- Let agents read, list, and search their same-session logs with the existing
+  file tools. Keep cross-session access, log writes, and shell authority out of
+  this read scope.
 - Set `TMPDIR`, `TMP`, and `TEMP` for each parent and child execution scope.
   The values must identify that run's managed temporary directory.
 - Retire the ambiguous “session scratch” vocabulary. Use `session_dir` for the
@@ -77,13 +77,12 @@ the same requirement. An eligible Personal session receives
 
 ### Child activity discovery
 
-`spawn_agent` returns an opaque child log reference and the child's artifact
-directory. The parent passes the reference to `subagent_log_read` and receives
-a bounded activity page. The raw file is physically below the same session
-envelope as the artifacts.
+`spawn_agent` returns the exact child log path and the child's artifact
+directory. The parent passes the path to `file_read`, `file_search`, or
+`file_list`. Those tools apply their normal output limits and session policy.
 
-Counterexample: The parent does not receive a raw log path. It does not search
-the daemon log tree with shell commands.
+Counterexample: The parent does not need a special child-log tool or a shell
+search. A different session cannot read the returned path.
 
 ### Managed worktree creation
 
@@ -106,8 +105,8 @@ None.
   their current path behavior.
 - `session-cwd`: Define managed temporary and worktree areas and inject the
   standard temporary environment for every run.
-- `netclaw-tools`: Expose bounded child-log discovery and a managed deferred
-  worktree operation without exposing raw log files.
+- `netclaw-tools`: Expose child log paths through existing file tools and add a
+  managed deferred worktree operation.
 - `tool-approval-gates`: Return a typed managed-temp correction for eligible
   explicit writes and define the deterministic and behavioral proof boundary.
 
@@ -119,13 +118,13 @@ None.
   the session envelope. Daemon-global logs remain unchanged.
 - **Tool execution:** Shell child processes receive session-specific temporary
   environment variables. File and worktree tools use managed destinations.
-- **Security:** Path knowledge grants no authority. Raw logs remain outside
-  ordinary workspace-file safe roots, and all replacement calls pass normal
+- **Security:** Session ownership grants read-only file-tool access to its logs.
+  Cross-session reads, log writes, and shell calls still pass their normal
   authorization. This change does not claim OS-level process isolation.
 - **Operations:** Runbooks and diagnostics must stop deriving session log paths.
   Cleanup must recognize both legacy and new layouts.
 - **Testing:** Contract and integration tests prove layout, environment,
   recovery, access, and correction behavior. Model evals measure agent choices
   and parent-child handoff quality only.
-- **Dependencies and public APIs:** No new package is required. Any new tool
-  schema remains internal to Netclaw's existing tool registry.
+- **Dependencies and public APIs:** No new package is required. This change
+  adds no child-log tool.

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
@@ -140,14 +140,16 @@ SHALL use `<session-envelope>/logs/session.log` for the parent and
 - **THEN** it uses the daemon-global log location
 - **AND** it is not written to a session envelope
 
-### Requirement: Raw logs stay outside ordinary workspace authority
+### Requirement: Same-session logs use existing file-tool read authority
 
-The system SHALL NOT add the complete version-2 envelope or a raw-log area to
-ordinary workspace-file or shell safe roots through session context. The
-default no-project working directory SHALL be the `workspace/` child. Knowledge
-of the envelope path, session ownership, or an opaque child reference SHALL NOT
-grant raw-file access. The parent SHALL use a bounded, redacted child-activity
-interface for normal child-log inspection.
+The system SHALL give existing file-read, file-list, and file-search operations
+read access to logs in the current session envelope. The scope SHALL include
+the main session log and its child logs. It SHALL NOT include another session.
+
+This read scope SHALL NOT authorize file writes, file edits, attachments, or
+shell execution. The default no-project working directory SHALL remain the
+`workspace/` child. The system SHALL NOT add the complete envelope as a shell
+safe root.
 
 This requirement defines Netclaw application authorization. It SHALL NOT be
 documented or tested as OS-level containment of an arbitrary process that has
@@ -161,31 +163,45 @@ already received execution authority under the Netclaw identity.
 - **AND** a recursive search of `.` does not include the sibling `logs/` or
   `subagents/` areas by directory containment
 
-#### Scenario: Counterexample - workspace read cannot open a raw log
+#### Scenario: Example - agent reads its own session log
 
-- **GIVEN** an agent can read normal files below its session directory
-- **WHEN** it requests a raw parent or child log outside that directory
-- **THEN** normal workspace-file authority does not authorize the read
-- **AND** the denial does not disclose raw log content
+- **GIVEN** an agent uses a version-2 session envelope
+- **WHEN** it calls `file_read` for its main session log
+- **THEN** same-session log scope authorizes the read
+- **AND** `file_read` applies its normal output bounds
 
-#### Scenario: Counterexample - envelope ownership is not a broad allowed root
+#### Scenario: Example - parent reads an owned child log
 
-- **GIVEN** a parent owns the session envelope
-- **WHEN** policy builds ordinary file and shell safe roots
-- **THEN** it adds only the path areas required by their specific contracts
-- **AND** it does not add the envelope root as unrestricted authority
+- **GIVEN** a parent owns child run `run-7`
+- **WHEN** it calls `file_search` on the returned log path's directory
+- **THEN** same-session log scope authorizes the search
+- **AND** no special log tool is required
 
-#### Scenario: Example - parent can inspect bounded child activity
+#### Scenario: Counterexample - foreign session log is denied
 
-- **GIVEN** a parent owns a child run
-- **WHEN** it requests activity through the supported child-log interface
-- **THEN** the system returns a bounded and redacted projection
-- **AND** the parent does not need the raw log path
+- **GIVEN** a log path belongs to another session envelope
+- **WHEN** the current agent calls `file_read`, `file_list`, or `file_search`
+- **THEN** same-session log scope does not authorize the operation
+- **AND** the result does not reveal whether the foreign file exists
+
+#### Scenario: Counterexample - log read does not grant mutation
+
+- **GIVEN** an agent can read its same-session logs
+- **WHEN** it calls `file_write` or `file_edit` for a log path
+- **THEN** same-session log scope does not authorize that operation
+- **AND** normal write policy decides the call
+
+#### Scenario: Counterexample - envelope is not the shell root
+
+- **GIVEN** an agent can read logs in its session envelope
+- **WHEN** policy selects a default shell cwd or shell safe root
+- **THEN** it uses the session directory or existing project scope
+- **AND** it does not use the complete envelope because log reads are allowed
 
 #### Scenario: Counterexample - this layout is not a process sandbox
 
 - **GIVEN** an arbitrary process has already received execution authority as
   the Netclaw OS identity
-- **WHEN** it learns a raw-log path by some other authorized channel
+- **WHEN** it learns a same-session log path
 - **THEN** this storage layout alone does not claim to stop the OS file open
 - **AND** a future containment capability must define that stronger boundary

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
@@ -6,118 +6,174 @@ This delta uses terms from the
 ### Requirement: Session storage binding is durable and versioned
 
 Before a new-layout session creates a session-owned file, the system SHALL
-persist an immutable storage descriptor that contains the layout version, the
-absolute agent-data root, and the absolute protected audit root. The system
-SHALL use the persisted descriptor when it resumes the session. A configuration
-change, environment override, or binary upgrade SHALL NOT reinterpret either
-root of an existing session.
+persist an immutable storage binding with the layout version and absolute
+session storage envelope root. The system SHALL use that binding when it
+resumes the session. A configuration change, environment override, or binary
+upgrade SHALL NOT reinterpret the envelope root. The binding SHALL NOT contain
+a second log root.
 
-#### Scenario: Example - new session binds its roots before use
+Channel ingress, the parent actor, child-run creation, and the log dispatcher
+SHALL resolve storage through one shared get-or-bind operation. That operation
+SHALL be atomic for concurrent first consumers. A filesystem helper SHALL NOT
+independently choose a new-layout path from only the session identifier and
+current configuration.
 
-- **GIVEN** a session has no storage descriptor
+#### Scenario: Example - new session binds one envelope before use
+
+- **GIVEN** a new session has no storage binding
 - **WHEN** it first needs session-owned filesystem storage
-- **THEN** the system persists a version-2 descriptor before it creates a file
-- **AND** every later path for that session derives from the persisted roots
+- **THEN** the system persists the version-2 binding before it creates a file
+- **AND** every parent and child path derives from the persisted envelope
 
 #### Scenario: Counterexample - configuration cannot relocate a bound session
 
-- **GIVEN** a session has a persisted version-2 storage descriptor
-- **WHEN** the configured Netclaw home or sessions path changes
-- **THEN** the session continues to use both persisted roots
-- **AND** the system does not move or copy the session implicitly
+- **GIVEN** a session has a persisted storage binding for
+  `/srv/netclaw-a/sessions/s-42`
+- **WHEN** configuration changes the sessions base to
+  `/srv/netclaw-b/sessions`
+- **THEN** the session continues to use the persisted envelope under
+  `/srv/netclaw-a`
+- **AND** the system does not move, copy, or partly reinterpret the session
 
-#### Scenario: Counterexample - binding failure prevents a split session
+#### Scenario: Counterexample - binding failure prevents an untracked write
 
-- **GIVEN** the system cannot persist the storage descriptor
+- **GIVEN** the system cannot persist the storage binding
 - **WHEN** a filesystem operation needs the new layout
 - **THEN** the operation fails before it writes session-owned data
-- **AND** the system does not derive a temporary fallback root
+- **AND** the system does not derive a fallback root from current configuration
 
-### Requirement: Legacy sessions resume without migration
+#### Scenario: Example - ingress binds before it writes media
 
-The system SHALL recognize a session that predates the version-2 storage
-descriptor and SHALL continue to use its legacy session and log paths. An
-upgrade SHALL NOT move, copy, rename, or delete legacy session data. A current
-binary SHALL read all recorded log lineages for a session when an earlier
-binary wrote a legacy log after rollback.
+- **GIVEN** the first message for a new session contains an attachment
+- **WHEN** channel ingress prepares the media file before actor processing
+- **THEN** it resolves and persists the storage binding first
+- **AND** it writes the file below `<session-envelope>/workspace/media`
+
+#### Scenario: Example - concurrent first messages share one binding
+
+- **GIVEN** two ingress requests race to create one new session
+- **WHEN** both call the shared storage resolver
+- **THEN** one atomic binding wins
+- **AND** both requests receive the same persisted envelope root
+
+#### Scenario: Counterexample - helper cannot bypass layout selection
+
+- **GIVEN** a new session has no binding yet
+- **WHEN** an ingress or logging helper needs a path
+- **THEN** the helper does not compute a writable path from only the session ID
+  and configured base
+- **AND** no file is created before the shared resolver selects the layout
+
+### Requirement: Existing sessions resume without migration
+
+The system SHALL leave the storage binding absent for a session that predates
+the new layout. It SHALL continue to use the existing session-directory and
+session-log path resolvers for that session. An upgrade SHALL NOT move, copy,
+rename, or delete its data.
 
 #### Scenario: Example - legacy session resumes after upgrade
 
-- **GIVEN** a persisted session has no version-2 storage descriptor
+- **GIVEN** a persisted session predates the storage binding
 - **WHEN** a current binary resumes it
-- **THEN** the system uses the legacy session and log paths
+- **THEN** the storage binding remains absent
+- **AND** the system uses the existing session and log path resolvers
 - **AND** no migration changes the existing files
 
-#### Scenario: Counterexample - rollback does not hide a second log lineage
+#### Scenario: Counterexample - legacy session cannot become a hybrid
 
-- **GIVEN** a version-2 session was resumed by an earlier binary
-- **AND** the earlier binary wrote a legacy session log
-- **WHEN** a current binary resumes the session again
-- **THEN** the supported session inspector reads both log lineages
-- **AND** it presents their records in time order
+- **GIVEN** an existing unbound session has separate data and log directories
+- **WHEN** a current binary resumes it without storage reconfiguration
+- **THEN** both existing path resolvers remain in use
+- **AND** the system does not route new logs into a new-layout envelope
 
-### Requirement: Version 2 binds agent data and audit data to one session
+#### Scenario: Counterexample - old binary support for new sessions is out of scope
 
-For a version-2 session, the system SHALL place artifacts, inbound files,
-media, bounded tool outputs, temporary files, worktrees, and child artifacts
-below the persisted agent-data root. It SHALL place raw parent and child logs
-below the persisted audit root. Each child run SHALL have an opaque run
-identifier and SHALL use paths below its parent's corresponding root.
-Daemon-global logs SHALL remain outside both session roots.
+- **GIVEN** an older binary does not understand the storage binding
+- **WHEN** release documentation describes compatibility
+- **THEN** it promises that current binaries preserve existing unbound sessions
+- **AND** it does not promise that a pre-feature binary can resume a newly
+  bound session
 
-#### Scenario: Example - parent agent storage uses named areas
+### Requirement: Version 2 uses one physical session envelope
 
-- **GIVEN** a version-2 parent session
-- **WHEN** the system creates its storage areas
-- **THEN** the agent-data root contains separate artifact, inbound, media,
-  tool-output, temporary, worktree, and child-run areas
-- **AND** no area is placed below the operating system temporary root unless
-  the persisted agent-data root itself was configured there
+For a session with a version-2 binding, the system SHALL place the parent
+session directory, artifacts, temporary files, worktrees, raw log, and all
+child-run directories below the persisted session storage envelope. Each child
+run SHALL place its artifacts, temporary files, and raw log below
+`<session-envelope>/subagents/<run-id>`. Daemon-global logs SHALL remain outside
+the session envelope.
 
-#### Scenario: Counterexample - raw logs do not enter agent storage
+The parent session directory SHALL be `<session-envelope>/workspace`. Raw logs
+SHALL use `<session-envelope>/logs/session.log` for the parent and
+`<session-envelope>/subagents/<run-id>/logs/session.log` for a child.
 
-- **GIVEN** a version-2 parent session
-- **WHEN** the system resolves its raw log target
-- **THEN** the target is below the persisted audit root
-- **AND** the target is not below the agent-data root
+#### Scenario: Example - one envelope contains parent and child data
 
-#### Scenario: Example - child storage stays below its parent
+- **GIVEN** a version-2 parent at `/srv/netclaw/sessions/s-42`
+- **AND** the parent creates child run `run-7`
+- **WHEN** the parent and child resolve their storage paths
+- **THEN** the parent cwd is `/srv/netclaw/sessions/s-42/workspace`
+- **AND** the parent raw log is
+  `/srv/netclaw/sessions/s-42/logs/session.log`
+- **AND** the child artifacts, temporary files, and raw log are below
+  `/srv/netclaw/sessions/s-42/subagents/run-7`
 
-- **GIVEN** a parent session creates a child run
-- **WHEN** the child writes its log, artifacts, or temporary files
-- **THEN** artifacts and temporary files are below the parent agent-data root
-- **AND** raw logs are below the parent audit root
-- **AND** each child path contains the child's opaque run identifier
+#### Scenario: Example - sibling child runs do not share storage
+
+- **GIVEN** child runs `run-7` and `run-8` belong to one parent
+- **WHEN** the system derives their paths
+- **THEN** each child path contains its own opaque run identifier
+- **AND** neither child's artifact, temporary, or log path is below the other
+  child's directory
+
+#### Scenario: Counterexample - new raw logs cannot use a second root
+
+- **GIVEN** a version-2 session
+- **WHEN** the log dispatcher resolves a parent or child target
+- **THEN** the target is below the persisted session envelope
+- **AND** it is not below `NetclawPaths.SessionLogsDirectory`
 
 #### Scenario: Counterexample - daemon logs do not enter session storage
 
 - **GIVEN** the daemon emits a process-wide diagnostic
 - **WHEN** the diagnostic is written
-- **THEN** it uses the existing daemon-global log location
-- **AND** it is not written to a session's audit root
+- **THEN** it uses the daemon-global log location
+- **AND** it is not written to a session envelope
 
-### Requirement: Raw audit data stays outside agent filesystem authority
+### Requirement: Raw logs stay outside ordinary workspace authority
 
-The system SHALL NOT add the version-2 audit root to workspace-file or shell
-safe spaces through normal session context. Knowledge of the agent-data root,
-session ownership, or an opaque child reference SHALL NOT grant raw audit-file
-access. The parent SHALL use a bounded, redacted child-activity interface
-instead of raw file or shell access.
+The system SHALL NOT add the complete version-2 envelope or a raw-log area to
+ordinary workspace-file or shell safe roots through session context. The
+default no-project working directory SHALL be the `workspace/` child. Knowledge
+of the envelope path, session ownership, or an opaque child reference SHALL NOT
+grant raw-file access. The parent SHALL use a bounded, redacted child-activity
+interface for normal child-log inspection.
+
+This requirement defines Netclaw application authorization. It SHALL NOT be
+documented or tested as OS-level containment of an arbitrary process that has
+already received execution authority under the Netclaw identity.
+
+#### Scenario: Example - default recursive search stays in workspace
+
+- **GIVEN** a version-2 session has no project scope
+- **WHEN** a shell starts without an explicit working directory
+- **THEN** its cwd is `<session-envelope>/workspace`
+- **AND** a recursive search of `.` does not include the sibling `logs/` or
+  `subagents/` areas by directory containment
 
 #### Scenario: Counterexample - workspace read cannot open a raw log
 
-- **GIVEN** an agent can read normal files below its agent-data root
-- **WHEN** it requests a raw parent or child log below the audit root
-- **THEN** the system denies the read
+- **GIVEN** an agent can read normal files below its session directory
+- **WHEN** it requests a raw parent or child log outside that directory
+- **THEN** normal workspace-file authority does not authorize the read
 - **AND** the denial does not disclose raw log content
 
-#### Scenario: Counterexample - default shell cwd cannot contain the audit root
+#### Scenario: Counterexample - envelope ownership is not a broad allowed root
 
-- **GIVEN** a shell starts in the agent-data root or a declared project
-- **WHEN** policy computes authority from the default session cwd
-- **THEN** that authority does not include the separate audit root
-- **AND** a recursive command in the agent-data root does not reach raw logs by
-  directory containment
+- **GIVEN** a parent owns the session envelope
+- **WHEN** policy builds ordinary file and shell safe roots
+- **THEN** it adds only the path areas required by their specific contracts
+- **AND** it does not add the envelope root as unrestricted authority
 
 #### Scenario: Example - parent can inspect bounded child activity
 
@@ -125,3 +181,11 @@ instead of raw file or shell access.
 - **WHEN** it requests activity through the supported child-log interface
 - **THEN** the system returns a bounded and redacted projection
 - **AND** the parent does not need the raw log path
+
+#### Scenario: Counterexample - this layout is not a process sandbox
+
+- **GIVEN** an arbitrary process has already received execution authority as
+  the Netclaw OS identity
+- **WHEN** it learns a raw-log path by some other authorized channel
+- **THEN** this storage layout alone does not claim to stop the OS file open
+- **AND** a future containment capability must define that stronger boundary

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
@@ -144,12 +144,23 @@ SHALL use `<session-envelope>/logs/session.log` for the parent and
 
 The system SHALL give existing file-read, file-list, and file-search operations
 read access to logs in the current session envelope. The scope SHALL include
-the main session log and its child logs. It SHALL NOT include another session.
+the main session log and every child log. Every parent and child run in that
+session SHALL receive the same log-read scope. The scope SHALL NOT include
+another session.
+
+For an existing unbound session, the system SHALL build the same read scope
+from the unchanged legacy main-log resolver and durable child lineage. It SHALL
+NOT move or copy a legacy log to make it readable.
 
 This read scope SHALL NOT authorize file writes, file edits, attachments, or
 shell execution. The default no-project working directory SHALL remain the
 `workspace/` child. The system SHALL NOT add the complete envelope as a shell
 safe root.
+
+The implementation SHALL NOT redefine `{session_dir}` as the session envelope.
+It SHALL NOT add the complete envelope or `subagents/` directory as a read
+root. It SHALL authorize only normalized main-log and child-log path shapes.
+Existing link, reparse-point, and protected-path checks SHALL still apply.
 
 This requirement defines Netclaw application authorization. It SHALL NOT be
 documented or tested as OS-level containment of an arbitrary process that has
@@ -177,6 +188,21 @@ already received execution authority under the Netclaw identity.
 - **THEN** same-session log scope authorizes the search
 - **AND** no special log tool is required
 
+#### Scenario: Example - child reads another log in the same session
+
+- **GIVEN** child runs `run-7` and `run-8` belong to one session
+- **WHEN** `run-7` reads the main log or the log for `run-8`
+- **THEN** same-session log scope authorizes the read
+- **AND** the request remains subject to normal file-tool limits
+
+#### Scenario: Example - legacy session keeps readable log paths
+
+- **GIVEN** an existing unbound session uses separate data and log roots
+- **WHEN** its parent or child calls an existing file tool for a resolved
+  same-session log path
+- **THEN** same-session log scope authorizes the operation
+- **AND** no file moves into a new envelope
+
 #### Scenario: Counterexample - foreign session log is denied
 
 - **GIVEN** a log path belongs to another session envelope
@@ -190,6 +216,21 @@ already received execution authority under the Netclaw identity.
 - **WHEN** it calls `file_write` or `file_edit` for a log path
 - **THEN** same-session log scope does not authorize that operation
 - **AND** normal write policy decides the call
+
+#### Scenario: Counterexample - broad child root is not authorized
+
+- **GIVEN** a version-2 session has child logs, artifacts, and temporary files
+- **WHEN** policy constructs the same-session log read scope
+- **THEN** it does not add `<session-envelope>/subagents` as a broad root
+- **AND** log-read scope cannot read a child artifact or temporary file
+
+#### Scenario: Counterexample - linked path cannot escape log scope
+
+- **GIVEN** a same-session log directory contains a filesystem link to another
+  session
+- **WHEN** an agent reads, lists, or searches through that link
+- **THEN** existing path safety policy denies the operation
+- **AND** same-session ownership does not bypass that denial
 
 #### Scenario: Counterexample - envelope is not the shell root
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-session/spec.md
@@ -1,0 +1,127 @@
+This delta uses terms from the
+[engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
+## ADDED Requirements
+
+### Requirement: Session storage binding is durable and versioned
+
+Before a new-layout session creates a session-owned file, the system SHALL
+persist an immutable storage descriptor that contains the layout version, the
+absolute agent-data root, and the absolute protected audit root. The system
+SHALL use the persisted descriptor when it resumes the session. A configuration
+change, environment override, or binary upgrade SHALL NOT reinterpret either
+root of an existing session.
+
+#### Scenario: Example - new session binds its roots before use
+
+- **GIVEN** a session has no storage descriptor
+- **WHEN** it first needs session-owned filesystem storage
+- **THEN** the system persists a version-2 descriptor before it creates a file
+- **AND** every later path for that session derives from the persisted roots
+
+#### Scenario: Counterexample - configuration cannot relocate a bound session
+
+- **GIVEN** a session has a persisted version-2 storage descriptor
+- **WHEN** the configured Netclaw home or sessions path changes
+- **THEN** the session continues to use both persisted roots
+- **AND** the system does not move or copy the session implicitly
+
+#### Scenario: Counterexample - binding failure prevents a split session
+
+- **GIVEN** the system cannot persist the storage descriptor
+- **WHEN** a filesystem operation needs the new layout
+- **THEN** the operation fails before it writes session-owned data
+- **AND** the system does not derive a temporary fallback root
+
+### Requirement: Legacy sessions resume without migration
+
+The system SHALL recognize a session that predates the version-2 storage
+descriptor and SHALL continue to use its legacy session and log paths. An
+upgrade SHALL NOT move, copy, rename, or delete legacy session data. A current
+binary SHALL read all recorded log lineages for a session when an earlier
+binary wrote a legacy log after rollback.
+
+#### Scenario: Example - legacy session resumes after upgrade
+
+- **GIVEN** a persisted session has no version-2 storage descriptor
+- **WHEN** a current binary resumes it
+- **THEN** the system uses the legacy session and log paths
+- **AND** no migration changes the existing files
+
+#### Scenario: Counterexample - rollback does not hide a second log lineage
+
+- **GIVEN** a version-2 session was resumed by an earlier binary
+- **AND** the earlier binary wrote a legacy session log
+- **WHEN** a current binary resumes the session again
+- **THEN** the supported session inspector reads both log lineages
+- **AND** it presents their records in time order
+
+### Requirement: Version 2 binds agent data and audit data to one session
+
+For a version-2 session, the system SHALL place artifacts, inbound files,
+media, bounded tool outputs, temporary files, worktrees, and child artifacts
+below the persisted agent-data root. It SHALL place raw parent and child logs
+below the persisted audit root. Each child run SHALL have an opaque run
+identifier and SHALL use paths below its parent's corresponding root.
+Daemon-global logs SHALL remain outside both session roots.
+
+#### Scenario: Example - parent agent storage uses named areas
+
+- **GIVEN** a version-2 parent session
+- **WHEN** the system creates its storage areas
+- **THEN** the agent-data root contains separate artifact, inbound, media,
+  tool-output, temporary, worktree, and child-run areas
+- **AND** no area is placed below the operating system temporary root unless
+  the persisted agent-data root itself was configured there
+
+#### Scenario: Counterexample - raw logs do not enter agent storage
+
+- **GIVEN** a version-2 parent session
+- **WHEN** the system resolves its raw log target
+- **THEN** the target is below the persisted audit root
+- **AND** the target is not below the agent-data root
+
+#### Scenario: Example - child storage stays below its parent
+
+- **GIVEN** a parent session creates a child run
+- **WHEN** the child writes its log, artifacts, or temporary files
+- **THEN** artifacts and temporary files are below the parent agent-data root
+- **AND** raw logs are below the parent audit root
+- **AND** each child path contains the child's opaque run identifier
+
+#### Scenario: Counterexample - daemon logs do not enter session storage
+
+- **GIVEN** the daemon emits a process-wide diagnostic
+- **WHEN** the diagnostic is written
+- **THEN** it uses the existing daemon-global log location
+- **AND** it is not written to a session's audit root
+
+### Requirement: Raw audit data stays outside agent filesystem authority
+
+The system SHALL NOT add the version-2 audit root to workspace-file or shell
+safe spaces through normal session context. Knowledge of the agent-data root,
+session ownership, or an opaque child reference SHALL NOT grant raw audit-file
+access. The parent SHALL use a bounded, redacted child-activity interface
+instead of raw file or shell access.
+
+#### Scenario: Counterexample - workspace read cannot open a raw log
+
+- **GIVEN** an agent can read normal files below its agent-data root
+- **WHEN** it requests a raw parent or child log below the audit root
+- **THEN** the system denies the read
+- **AND** the denial does not disclose raw log content
+
+#### Scenario: Counterexample - default shell cwd cannot contain the audit root
+
+- **GIVEN** a shell starts in the agent-data root or a declared project
+- **WHEN** policy computes authority from the default session cwd
+- **THEN** that authority does not include the separate audit root
+- **AND** a recursive command in the agent-data root does not reach raw logs by
+  directory containment
+
+#### Scenario: Example - parent can inspect bounded child activity
+
+- **GIVEN** a parent owns a child run
+- **WHEN** it requests activity through the supported child-log interface
+- **THEN** the system returns a bounded and redacted projection
+- **AND** the parent does not need the raw log path

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -5,23 +5,49 @@ This delta uses terms from the
 
 ### Requirement: Spawned child references are machine-actionable
 
-A successful `spawn_agent` result SHALL return the child run identifier and
-opaque references for the child's activity log and artifact area. The result
-SHALL NOT disclose the protected raw log path. A failed spawn SHALL NOT return
-references that appear usable.
+A successful `spawn_agent` result SHALL return the child run identifier, an
+opaque reference for the child's activity log, and the exact child artifact
+directory. The current parent SHALL receive read and attach authority for that
+artifact directory through child ownership. The authority SHALL NOT include a
+sibling raw-log or temporary area. The result SHALL NOT disclose the raw log
+path. A failed spawn SHALL NOT return locations that appear usable.
+
+The result shape SHALL be equivalent to:
+
+```text
+run_id: "run-7"
+activity_log_ref: "child-log:opaque-value"
+artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
+```
 
 #### Scenario: Example - successful spawn returns child references
 
 - **WHEN** a parent successfully starts a child run
 - **THEN** the tool result contains the child run identifier
-- **AND** it contains opaque activity-log and artifact references
-- **AND** it does not contain a raw audit-log path
+- **AND** it contains an opaque activity-log reference and exact artifact
+  directory
+- **AND** it does not contain a raw-log path
+
+#### Scenario: Example - parent reads a child artifact with an existing tool
+
+- **GIVEN** a successful spawn returned the child artifact directory
+- **WHEN** the owning parent calls `file_read` or `attach_file` for a file below
+  that directory
+- **THEN** child ownership can satisfy the artifact-area authorization check
+- **AND** no new artifact-reference reader is required
+
+#### Scenario: Counterexample - artifact directory does not expose siblings
+
+- **GIVEN** the parent knows a child artifact directory
+- **WHEN** it requests a sibling file below the child's `logs/` or `tmp/` area
+- **THEN** the artifact-area authority does not authorize that request
+- **AND** normal policy decides the call
 
 #### Scenario: Counterexample - failed spawn has no usable child references
 
 - **WHEN** the child run is not created
 - **THEN** the tool result reports failure
-- **AND** it contains no active log or artifact reference
+- **AND** it contains no active log reference or artifact directory
 
 ### Requirement: Parent can read bounded child activity without shell
 
@@ -32,7 +58,7 @@ include an optional literal-query field. The tool SHALL NOT return system
 prompts, credentials, secrets, raw
 approval payloads, or unredacted tool arguments and results.
 The reference SHALL remain valid after parent actor recovery while the child
-audit lineage exists.
+raw-log lineage exists.
 
 #### Scenario: Example - parent reads the next child activity page
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -6,17 +6,16 @@ This delta uses terms from the
 ### Requirement: Spawned child references are machine-actionable
 
 A successful `spawn_agent` result SHALL return the child run identifier, an
-opaque reference for the child's activity log, and the exact child artifact
-directory. The current parent SHALL receive read and attach authority for that
-artifact directory through child ownership. The authority SHALL NOT include a
-sibling raw-log or temporary area. The result SHALL NOT disclose the raw log
-path. A failed spawn SHALL NOT return locations that appear usable.
+exact child log path, and the exact child artifact directory. The current
+parent SHALL receive read authority for the child log and read and attach
+authority for the artifact directory through child ownership. A failed spawn
+SHALL NOT return locations that appear usable.
 
 The result shape SHALL be equivalent to:
 
 ```text
 run_id: "run-7"
-activity_log_ref: "child-log:opaque-value"
+log_path: "/srv/netclaw/sessions/s-42/subagents/run-7/logs/session.log"
 artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
 ```
 
@@ -24,9 +23,8 @@ artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
 
 - **WHEN** a parent successfully starts a child run
 - **THEN** the tool result contains the child run identifier
-- **AND** it contains an opaque activity-log reference and exact artifact
-  directory
-- **AND** it does not contain a raw-log path
+- **AND** it contains the exact child log path and artifact directory
+- **AND** both paths belong to that parent session
 
 #### Scenario: Example - parent reads a child artifact with an existing tool
 
@@ -36,66 +34,72 @@ artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
 - **THEN** child ownership can satisfy the artifact-area authorization check
 - **AND** no new artifact-reference reader is required
 
-#### Scenario: Counterexample - artifact directory does not expose siblings
+#### Scenario: Example - parent reads child logs with existing tools
 
-- **GIVEN** the parent knows a child artifact directory
-- **WHEN** it requests a sibling file below the child's `logs/` or `tmp/` area
-- **THEN** the artifact-area authority does not authorize that request
-- **AND** normal policy decides the call
+- **GIVEN** a successful spawn returned the exact child log path
+- **WHEN** the owning parent uses `file_read`, `file_search`, or `file_list`
+- **THEN** the existing tool performs its normal bounded operation
+- **AND** no special child-log tool is required
+
+#### Scenario: Counterexample - log read scope does not grant writes
+
+- **GIVEN** the parent can read a same-session child log
+- **WHEN** it calls `file_write` or `file_edit` for that log
+- **THEN** the log-read scope does not authorize the mutation
+- **AND** normal write policy decides the call
 
 #### Scenario: Counterexample - failed spawn has no usable child references
 
 - **WHEN** the child run is not created
 - **THEN** the tool result reports failure
-- **AND** it contains no active log reference or artifact directory
+- **AND** it contains no child log path or artifact directory
 
-### Requirement: Parent can read bounded child activity without shell
+### Requirement: Existing file tools can inspect same-session logs
 
-The deferred `subagent_log_read` tool SHALL accept only a child activity-log
-reference owned by the current parent. It SHALL return a bounded, redacted
-activity projection with a continuation cursor. The request schema SHALL
-include an optional literal-query field. The tool SHALL NOT return system
-prompts, credentials, secrets, raw
-approval payloads, or unredacted tool arguments and results.
-The reference SHALL remain valid after parent actor recovery while the child
-raw-log lineage exists.
+The existing `file_read`, `file_search`, and `file_list` tools SHALL accept log
+paths from the current session envelope when their audience policy permits the
+tool. Each tool SHALL keep its existing output bounds, pagination, and query
+contract. This capability SHALL NOT add a new tool or a log-specific query
+language.
 
-#### Scenario: Example - parent reads the next child activity page
+The same-session log read scope SHALL include the main session log and its
+child logs. It SHALL NOT include another session. It SHALL NOT grant write,
+edit, attach, or shell authority.
 
-- **GIVEN** a parent owns a child activity-log reference
-- **WHEN** it calls `subagent_log_read` with that reference and no cursor
-- **THEN** the tool returns the first bounded page of redacted activity
-- **AND** it returns a continuation cursor when more activity exists
+#### Scenario: Example - parent reads the next child log page
 
-#### Scenario: Example - parent filters child activity with a literal query
+- **GIVEN** a parent owns the child log path from `spawn_agent`
+- **WHEN** it calls `file_read` with `StartLine=1` and a bounded `Limit`
+- **THEN** the tool returns that normal line range
+- **AND** the parent can request the next range with a later `StartLine`
 
-- **GIVEN** a parent owns a child activity-log reference
-- **WHEN** it supplies a literal query
-- **THEN** the result contains only bounded matching activity records
-- **AND** the query is not interpreted as an executable expression
+#### Scenario: Example - parent searches child logs with an existing tool
 
-#### Scenario: Counterexample - foreign child reference is denied
+- **GIVEN** a parent owns a child log path
+- **WHEN** it calls `file_search` on that path's directory in content mode
+- **THEN** the tool returns its normal bounded matches
+- **AND** the parent does not need a shell search
 
-- **GIVEN** a child activity-log reference belongs to another parent session
-- **WHEN** the current parent calls `subagent_log_read`
+#### Scenario: Example - agent lists its session logs
+
+- **GIVEN** an agent has same-session log read scope
+- **WHEN** it calls `file_list` for its session log area
+- **THEN** the tool lists only paths that its current session owns
+- **AND** it applies its normal result limit
+
+#### Scenario: Counterexample - foreign session log is denied
+
+- **GIVEN** a log path belongs to another session
+- **WHEN** the current agent passes that path to an existing file tool
 - **THEN** the tool denies the request
-- **AND** it does not reveal whether matching raw files exist
+- **AND** it does not reveal whether the foreign file exists
 
-#### Scenario: Counterexample - projection cannot expose sensitive records
+#### Scenario: Example - log path survives parent recovery
 
-- **GIVEN** a child raw log contains prompts, approval payloads, credentials,
-  or unredacted tool data
-- **WHEN** the parent reads the child activity projection
-- **THEN** those records are omitted or centrally redacted
-- **AND** the output remains within its configured byte and record limits
-
-#### Scenario: Example - child reference survives parent recovery
-
-- **GIVEN** a parent received a child activity-log reference before an actor
-  restart
-- **WHEN** the recovered parent uses that reference
-- **THEN** the tool resolves the same parent-owned child lineage
-- **AND** it applies the current redaction and output limits
+- **GIVEN** a parent received a child log path before an actor restart
+- **WHEN** the recovered parent reads that path
+- **THEN** current session ownership authorizes the same child lineage
+- **AND** the existing file tool applies its current output limits
 
 ### Requirement: Worktree creation uses a managed destination
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -11,6 +11,10 @@ parent SHALL receive read authority for the child log and read and attach
 authority for the artifact directory through child ownership. A failed spawn
 SHALL NOT return locations that appear usable.
 
+The system SHALL resolve and create the child log target before it returns a
+successful result. The log can be empty. An immediate authorized `file_read`
+SHALL NOT fail because the log path is not ready.
+
 The result shape SHALL be equivalent to:
 
 ```text
@@ -54,6 +58,12 @@ artifact_dir: "/srv/netclaw/sessions/s-42/subagents/run-7/artifacts"
 - **THEN** the tool result reports failure
 - **AND** it contains no child log path or artifact directory
 
+#### Scenario: Example - successful child log path is ready
+
+- **WHEN** `spawn_agent` returns a successful child result
+- **THEN** the returned log path identifies an existing file
+- **AND** an authorized `file_read` can open it immediately
+
 ### Requirement: Existing file tools can inspect same-session logs
 
 The existing `file_read`, `file_search`, and `file_list` tools SHALL accept log
@@ -63,8 +73,17 @@ contract. This capability SHALL NOT add a new tool or a log-specific query
 language.
 
 The same-session log read scope SHALL include the main session log and its
-child logs. It SHALL NOT include another session. It SHALL NOT grant write,
-edit, attach, or shell authority.
+child logs for every parent and child run. It SHALL also cover resolved legacy
+main and child log paths. It SHALL NOT include another session. It SHALL NOT
+grant write, edit, attach, or shell authority.
+
+The existing file tools SHALL return their normal file content. The system
+SHALL NOT add a log-specific redaction or projection layer. Existing file-tool
+output bounds and audience policy SHALL still apply.
+
+`file_read` and `file_search` SHALL support an active session-log writer on
+POSIX and Windows. Their read handles SHALL NOT block the writer or fail only
+because the writer keeps its append handle open.
 
 #### Scenario: Example - parent reads the next child log page
 
@@ -86,6 +105,20 @@ edit, attach, or shell authority.
 - **WHEN** it calls `file_list` for its session log area
 - **THEN** the tool lists only paths that its current session owns
 - **AND** it applies its normal result limit
+
+#### Scenario: Example - active Windows log remains readable
+
+- **GIVEN** the session-log writer holds its normal append handle open
+- **WHEN** `file_read` or `file_search` opens that log on Windows
+- **THEN** the read succeeds with the normal file-tool result
+- **AND** the writer can append and flush another line
+
+#### Scenario: Counterexample - same-session log gets no special projection
+
+- **GIVEN** a same-session log contains normal session diagnostic content
+- **WHEN** an authorized agent reads it with `file_read`
+- **THEN** the tool returns its normal bounded file content
+- **AND** Netclaw does not replace it with a log-specific activity view
 
 #### Scenario: Counterexample - foreign session log is denied
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -1,0 +1,124 @@
+This delta uses terms from the
+[engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
+## ADDED Requirements
+
+### Requirement: Spawned child references are machine-actionable
+
+A successful `spawn_agent` result SHALL return the child run identifier and
+opaque references for the child's activity log and artifact area. The result
+SHALL NOT disclose the protected raw log path. A failed spawn SHALL NOT return
+references that appear usable.
+
+#### Scenario: Example - successful spawn returns child references
+
+- **WHEN** a parent successfully starts a child run
+- **THEN** the tool result contains the child run identifier
+- **AND** it contains opaque activity-log and artifact references
+- **AND** it does not contain a raw audit-log path
+
+#### Scenario: Counterexample - failed spawn has no usable child references
+
+- **WHEN** the child run is not created
+- **THEN** the tool result reports failure
+- **AND** it contains no active log or artifact reference
+
+### Requirement: Parent can read bounded child activity without shell
+
+The deferred `subagent_log_read` tool SHALL accept only a child activity-log
+reference owned by the current parent. It SHALL return a bounded, redacted
+activity projection with a continuation cursor. The request schema SHALL
+include an optional literal-query field. The tool SHALL NOT return system
+prompts, credentials, secrets, raw
+approval payloads, or unredacted tool arguments and results.
+The reference SHALL remain valid after parent actor recovery while the child
+audit lineage exists.
+
+#### Scenario: Example - parent reads the next child activity page
+
+- **GIVEN** a parent owns a child activity-log reference
+- **WHEN** it calls `subagent_log_read` with that reference and no cursor
+- **THEN** the tool returns the first bounded page of redacted activity
+- **AND** it returns a continuation cursor when more activity exists
+
+#### Scenario: Example - parent filters child activity with a literal query
+
+- **GIVEN** a parent owns a child activity-log reference
+- **WHEN** it supplies a literal query
+- **THEN** the result contains only bounded matching activity records
+- **AND** the query is not interpreted as an executable expression
+
+#### Scenario: Counterexample - foreign child reference is denied
+
+- **GIVEN** a child activity-log reference belongs to another parent session
+- **WHEN** the current parent calls `subagent_log_read`
+- **THEN** the tool denies the request
+- **AND** it does not reveal whether matching raw files exist
+
+#### Scenario: Counterexample - projection cannot expose sensitive records
+
+- **GIVEN** a child raw log contains prompts, approval payloads, credentials,
+  or unredacted tool data
+- **WHEN** the parent reads the child activity projection
+- **THEN** those records are omitted or centrally redacted
+- **AND** the output remains within its configured byte and record limits
+
+#### Scenario: Example - child reference survives parent recovery
+
+- **GIVEN** a parent received a child activity-log reference before an actor
+  restart
+- **WHEN** the recovered parent uses that reference
+- **THEN** the tool resolves the same parent-owned child lineage
+- **AND** it applies the current redaction and output limits
+
+### Requirement: Worktree creation uses a managed destination
+
+The deferred `worktree_create` tool SHALL create a Git worktree for an
+authorized source repository or the current project. It SHALL accept the
+branch selection but SHALL NOT accept an arbitrary destination path. It SHALL
+allocate a collision-safe destination below the current session's worktree
+area and SHALL return the exact created path. The tool SHALL NOT delete an
+existing directory or worktree. A successful call SHALL record the owning
+session and run until a later cleanup capability removes that record.
+
+#### Scenario: Example - current project gets a managed worktree
+
+- **GIVEN** the current project is an authorized Git repository
+- **WHEN** the agent calls `worktree_create` for a valid branch
+- **THEN** the tool creates a worktree below the session worktree area
+- **AND** it returns the exact path and successful file activity
+
+#### Scenario: Counterexample - caller cannot choose an external destination
+
+- **WHEN** an agent attempts to supply a destination outside the managed
+  worktree area
+- **THEN** the schema or input validation rejects the request
+- **AND** no Git process starts
+
+#### Scenario: Counterexample - unauthorized source repository is denied
+
+- **GIVEN** a requested source repository is outside current authority
+- **WHEN** the agent calls `worktree_create`
+- **THEN** authorization denies the operation
+- **AND** no destination is allocated
+
+#### Scenario: Example - successful worktree can become project scope
+
+- **GIVEN** `worktree_create` succeeds
+- **WHEN** the session applies the tool outcome
+- **THEN** it applies the returned typed project-scope effect
+- **AND** it loads project instructions through the existing project-scope
+  contract
+
+#### Scenario: Counterexample - failed worktree does not change project scope
+
+- **WHEN** worktree creation fails or is denied
+- **THEN** the project scope remains unchanged
+- **AND** the tool does not remove a pre-existing directory
+
+#### Scenario: Example - worktree ownership survives actor recovery
+
+- **GIVEN** a successful worktree belongs to one session and child run
+- **WHEN** the parent actor recovers
+- **THEN** the ownership record still identifies that session and run
+- **AND** recovery does not delete the worktree

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -26,6 +26,9 @@ For a parent with a version-2 storage binding, `session_dir` SHALL mean
 `<session-envelope>/workspace`. For a child, `temp_dir` and `artifact_dir`
 SHALL be siblings below `<session-envelope>/subagents/<run-id>`. The context
 SHALL NOT use `session_dir` as a synonym for the complete storage envelope.
+It SHALL describe `session_dir` as the working directory and relative-path
+fallback. It SHALL describe `temp_dir` as disposable run-local storage. Current
+runtime prompts and tool schemas SHALL NOT call either path “session scratch.”
 
 #### Scenario: Example - Personal child receives distinct managed paths
 
@@ -66,6 +69,21 @@ SHALL NOT use `session_dir` as a synonym for the complete storage envelope.
 - **THEN** its project scope and project instructions update through the
   existing contract
 - **AND** its bound session, temporary, and artifact paths remain unchanged
+
+#### Scenario: Example - file schemas name the relative-path fallback correctly
+
+- **GIVEN** a workspace file tool accepts a relative path
+- **WHEN** its model-visible schema describes path resolution
+- **THEN** it says that the current project is tried before the session
+  directory
+- **AND** it does not describe the session directory as disposable scratch
+
+#### Scenario: Counterexample - disposable guidance cannot point to session_dir
+
+- **GIVEN** the model needs a location for disposable run-local output
+- **WHEN** Netclaw renders managed-path guidance
+- **THEN** the guidance points to `temp_dir`
+- **AND** it does not tell the model to use `session_dir` as scratch
 
 ### Requirement: Managed temporary directory is the private temporary location
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -4,21 +4,25 @@ This delta uses terms from the
 ## RENAMED Requirements
 
 - FROM: `Subagent context announces private session scratch`
-- TO: `Subagent context announces managed session paths`
+- TO: `Existing session context announces managed paths`
 - FROM: `Session directory is the private shell scratch location`
 - TO: `Managed temporary directory is the private temporary location`
 
 ## MODIFIED Requirements
 
-### Requirement: Subagent context announces managed session paths
+### Requirement: Existing session context announces managed paths
 
-Before the first model call, the system SHALL include the exact bound
-`session_dir`, `temp_dir`, `artifact_dir`, and `log_path` in Personal and Team
-subagent working context. It SHALL state the distinct purpose of each path.
-Public subagent context SHALL retain its existing private-path policy. The
-guidance SHALL preserve an explicitly required platform temporary path.
+The system SHALL preserve the existing `[session]` context block and its
+`session_dir` entry. It SHALL extend that same block with the applicable
+`temp_dir`, `artifact_dir`, and `log_path` entries for Personal and Team parent
+and child runs. It SHALL NOT add a second context block or repeat these paths in
+per-turn guidance.
 
-The context SHALL derive from the child's existing bound run scope. It SHALL
+The system SHALL state the distinct purpose of each path. Public context SHALL
+retain its existing private-path policy. The guidance SHALL preserve an
+explicitly required platform temporary path.
+
+The context SHALL derive from the existing parent or child run scope. It SHALL
 NOT add a public protocol field, persist a path as agent identity, or change
 shell authorization.
 
@@ -42,6 +46,14 @@ runtime prompts and tool schemas SHALL NOT call either path â€œsession scratch.â
   parent or user must keep
 - **AND** it does not imply that path knowledge grants shell authority
 
+#### Scenario: Example - Personal parent extends the existing session block
+
+- **GIVEN** a Personal parent already receives `[session]` with `session_dir`
+- **WHEN** Netclaw assembles its first model context for the new layout
+- **THEN** the same block also contains `temp_dir`, `artifact_dir`, and
+  `log_path`
+- **AND** no second session block contains duplicate path guidance
+
 #### Scenario: Team child receives distinct managed paths
 
 - **GIVEN** a Team child has a valid bound run scope
@@ -56,6 +68,14 @@ runtime prompts and tool schemas SHALL NOT call either path â€œsession scratch.â
 - **WHEN** Netclaw assembles its initial model context
 - **THEN** the context does not contain those paths
 - **AND** no replacement guidance discloses another private filesystem path
+
+#### Scenario: Counterexample - implementation cannot replace context assembly
+
+- **GIVEN** the current parent and child context assemblers already emit
+  `session_dir`
+- **WHEN** the implementation adds the new path entries
+- **THEN** it extends those existing assembly seams
+- **AND** it does not create another prompt provider or context protocol
 
 #### Scenario: Counterexample - explicit platform temporary intent is preserved
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -13,10 +13,10 @@ This delta uses terms from the
 ### Requirement: Subagent context announces managed session paths
 
 Before the first model call, the system SHALL include the exact bound
-`session_dir`, `temp_dir`, and `artifact_dir` in Personal and Team subagent
-working context. It SHALL state the distinct purpose of each path. Public
-subagent context SHALL NOT include these private paths. The guidance SHALL
-preserve an explicitly required platform temporary path.
+`session_dir`, `temp_dir`, `artifact_dir`, and `log_path` in Personal and Team
+subagent working context. It SHALL state the distinct purpose of each path.
+Public subagent context SHALL retain its existing private-path policy. The
+guidance SHALL preserve an explicitly required platform temporary path.
 
 The context SHALL derive from the child's existing bound run scope. It SHALL
 NOT add a public protocol field, persist a path as agent identity, or change
@@ -36,6 +36,7 @@ runtime prompts and tool schemas SHALL NOT call either path â€œsession scratch.â
 - **WHEN** Netclaw assembles its initial model context
 - **THEN** the context contains its exact session, temporary, and artifact
   directories
+- **AND** it contains the exact log path for that child run
 - **AND** it describes `temp_dir` as disposable working storage
 - **AND** it describes `artifact_dir` as the location for outputs that the
   parent or user must keep
@@ -46,6 +47,7 @@ runtime prompts and tool schemas SHALL NOT call either path â€œsession scratch.â
 - **GIVEN** a Team child has a valid bound run scope
 - **WHEN** Netclaw assembles its initial model context
 - **THEN** the context contains that run's exact managed paths
+- **AND** it identifies the current run's `log_path`
 - **AND** existing Team tool and shell policy remains unchanged
 
 #### Scenario: Counterexample - Public child cannot receive private paths

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -22,6 +22,11 @@ The context SHALL derive from the child's existing bound run scope. It SHALL
 NOT add a public protocol field, persist a path as agent identity, or change
 shell authorization.
 
+For a parent with a version-2 storage binding, `session_dir` SHALL mean
+`<session-envelope>/workspace`. For a child, `temp_dir` and `artifact_dir`
+SHALL be siblings below `<session-envelope>/subagents/<run-id>`. The context
+SHALL NOT use `session_dir` as a synonym for the complete storage envelope.
+
 #### Scenario: Example - Personal child receives distinct managed paths
 
 - **GIVEN** a Personal child has a bound session and run scope
@@ -65,11 +70,12 @@ shell authorization.
 ### Requirement: Managed temporary directory is the private temporary location
 
 The system SHALL provide a separate managed temporary directory for each
-parent and child run. A parent SHALL use `<session-root>/tmp/parent`. A child
-SHALL use `<session-root>/tmp/subagents/<run-id>`. The system SHALL identify
-this directory as the preferred location for disposable files. It SHALL keep
-the session root as the shell working-directory fallback when no project or
-explicit working directory exists.
+parent and child run. A version-2 parent SHALL use
+`<session-envelope>/tmp/parent`. A child SHALL use
+`<session-envelope>/subagents/<run-id>/tmp`. The system SHALL identify this
+directory as the preferred location for disposable files. It SHALL use the
+session directory, not the complete envelope, as the shell working-directory
+fallback when no project or explicit working directory exists.
 
 Personal and Team working context and correction text SHALL provide the
 absolute managed temporary path when the agent needs an alternative to the
@@ -82,23 +88,31 @@ temporary-directory cleanup occurs as part of this behavior.
 - **GIVEN** a session has no declared project directory
 - **WHEN** the agent invokes `shell_execute` without an explicit working
   directory
-- **THEN** the shell working directory is the bound session root
+- **THEN** the shell working directory is the bound session directory at
+  `<session-envelope>/workspace`
 - **AND** temporary APIs in the process resolve to the managed temporary
   directory
+
+#### Scenario: Counterexample - complete envelope is not the fallback cwd
+
+- **GIVEN** a version-2 session has raw logs and child runs in its envelope
+- **WHEN** the agent invokes `shell_execute` without a project or explicit cwd
+- **THEN** the shell does not start at `<session-envelope>`
+- **AND** a recursive search of `.` does not include those sibling areas
 
 #### Scenario: Parent and child temporary directories do not collide
 
 - **GIVEN** a parent and two child runs belong to one session
 - **WHEN** Netclaw resolves their managed temporary directories
 - **THEN** each run receives a different directory
-- **AND** every directory remains below the same session root
+- **AND** every directory remains below the same session envelope
 
 #### Scenario: Example - correction names the managed temporary directory
 
 - **GIVEN** a correction recommends private temporary storage
 - **WHEN** the correction is rendered for the agent
 - **THEN** it names the exact managed temporary directory for that run
-- **AND** it does not name the complete session root as disposable storage
+- **AND** it does not name the complete session envelope as disposable storage
 
 #### Scenario: Counterexample - Public context cannot receive managed paths
 
@@ -162,7 +176,7 @@ Windows temporary path.
 ### Requirement: Worktrees have a separate session-owned area
 
 The system SHALL distinguish managed worktrees from ordinary temporary files.
-It SHALL allocate worktrees below `<session-root>/worktrees` and SHALL NOT
+It SHALL allocate worktrees below `<session-envelope>/worktrees` and SHALL NOT
 place them below a run's managed temporary directory. This capability SHALL
 NOT define automatic worktree cleanup.
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -1,0 +1,181 @@
+This delta uses terms from the
+[engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
+## RENAMED Requirements
+
+- FROM: `Subagent context announces private session scratch`
+- TO: `Subagent context announces managed session paths`
+- FROM: `Session directory is the private shell scratch location`
+- TO: `Managed temporary directory is the private temporary location`
+
+## MODIFIED Requirements
+
+### Requirement: Subagent context announces managed session paths
+
+Before the first model call, the system SHALL include the exact bound
+`session_dir`, `temp_dir`, and `artifact_dir` in Personal and Team subagent
+working context. It SHALL state the distinct purpose of each path. Public
+subagent context SHALL NOT include these private paths. The guidance SHALL
+preserve an explicitly required platform temporary path.
+
+The context SHALL derive from the child's existing bound run scope. It SHALL
+NOT add a public protocol field, persist a path as agent identity, or change
+shell authorization.
+
+#### Scenario: Example - Personal child receives distinct managed paths
+
+- **GIVEN** a Personal child has a bound session and run scope
+- **WHEN** Netclaw assembles its initial model context
+- **THEN** the context contains its exact session, temporary, and artifact
+  directories
+- **AND** it describes `temp_dir` as disposable working storage
+- **AND** it describes `artifact_dir` as the location for outputs that the
+  parent or user must keep
+- **AND** it does not imply that path knowledge grants shell authority
+
+#### Scenario: Team child receives distinct managed paths
+
+- **GIVEN** a Team child has a valid bound run scope
+- **WHEN** Netclaw assembles its initial model context
+- **THEN** the context contains that run's exact managed paths
+- **AND** existing Team tool and shell policy remains unchanged
+
+#### Scenario: Counterexample - Public child cannot receive private paths
+
+- **GIVEN** a Public child has internal managed paths
+- **WHEN** Netclaw assembles its initial model context
+- **THEN** the context does not contain those paths
+- **AND** no replacement guidance discloses another private filesystem path
+
+#### Scenario: Counterexample - explicit platform temporary intent is preserved
+
+- **GIVEN** a Personal or Team child receives managed-path guidance
+- **WHEN** its task explicitly requires the platform temporary directory
+- **THEN** the guidance tells the child to preserve that requirement
+- **AND** Netclaw does not rewrite the path or grant authority to it
+
+#### Scenario: Project declaration does not replace managed paths
+
+- **GIVEN** a child has received its initial managed-path context
+- **WHEN** it later calls `set_working_directory` successfully
+- **THEN** its project scope and project instructions update through the
+  existing contract
+- **AND** its bound session, temporary, and artifact paths remain unchanged
+
+### Requirement: Managed temporary directory is the private temporary location
+
+The system SHALL provide a separate managed temporary directory for each
+parent and child run. A parent SHALL use `<session-root>/tmp/parent`. A child
+SHALL use `<session-root>/tmp/subagents/<run-id>`. The system SHALL identify
+this directory as the preferred location for disposable files. It SHALL keep
+the session root as the shell working-directory fallback when no project or
+explicit working directory exists.
+
+Personal and Team working context and correction text SHALL provide the
+absolute managed temporary path when the agent needs an alternative to the
+platform temporary root. Public context SHALL retain existing private-path
+redaction. The system SHALL NOT silently substitute a path or imply that
+temporary-directory cleanup occurs as part of this behavior.
+
+#### Scenario: Example - no-project shell separates cwd and temp
+
+- **GIVEN** a session has no declared project directory
+- **WHEN** the agent invokes `shell_execute` without an explicit working
+  directory
+- **THEN** the shell working directory is the bound session root
+- **AND** temporary APIs in the process resolve to the managed temporary
+  directory
+
+#### Scenario: Parent and child temporary directories do not collide
+
+- **GIVEN** a parent and two child runs belong to one session
+- **WHEN** Netclaw resolves their managed temporary directories
+- **THEN** each run receives a different directory
+- **AND** every directory remains below the same session root
+
+#### Scenario: Example - correction names the managed temporary directory
+
+- **GIVEN** a correction recommends private temporary storage
+- **WHEN** the correction is rendered for the agent
+- **THEN** it names the exact managed temporary directory for that run
+- **AND** it does not name the complete session root as disposable storage
+
+#### Scenario: Counterexample - Public context cannot receive managed paths
+
+- **GIVEN** a Public parent or child agent
+- **WHEN** it evaluates a platform-temp operation
+- **THEN** it does not receive a private managed path
+- **AND** existing Public path-redaction behavior remains
+
+#### Scenario: Counterexample - session end does not imply cleanup
+
+- **GIVEN** an agent writes a disposable file under its managed temporary
+  directory
+- **WHEN** the current session ends
+- **THEN** this capability does not delete or schedule deletion of that file
+- **AND** retention remains unchanged until a separate cleanup capability is
+  specified
+
+## ADDED Requirements
+
+### Requirement: Every run receives the standard temporary environment
+
+Before the system starts a shell or another child process, it SHALL create and
+validate the run's managed temporary directory. It SHALL set `TMPDIR`, `TMP`,
+and `TEMP` to that exact directory in the child process environment. It SHALL
+set all three variables on POSIX and Windows. It SHALL NOT change the daemon's
+global process environment.
+
+The system SHALL capture the host platform temporary root before it injects
+the managed values. Policy that identifies an explicitly authored unmanaged
+temporary path SHALL use that captured host value. It SHALL NOT assume a fixed
+Windows temporary path.
+
+#### Scenario: Example - POSIX child process uses managed temp
+
+- **GIVEN** a POSIX parent or child run has a managed temporary directory
+- **WHEN** Netclaw starts a shell process
+- **THEN** `TMPDIR`, `TMP`, and `TEMP` all equal that directory
+- **AND** a standard temporary-path API returns a path below it
+
+#### Scenario: Example - Windows child process uses managed temp
+
+- **GIVEN** a Windows parent or child run has a managed temporary directory
+- **WHEN** Netclaw starts a shell process
+- **THEN** `TMPDIR`, `TMP`, and `TEMP` all equal that directory
+- **AND** the native or .NET temporary-path API returns a path below it
+
+#### Scenario: Sibling runs keep isolated environments
+
+- **GIVEN** two child runs execute concurrently
+- **WHEN** each reads its temporary environment
+- **THEN** each sees only its own managed temporary path
+- **AND** the daemon environment remains unchanged
+
+#### Scenario: Counterexample - failed preparation cannot use host temp
+
+- **GIVEN** the managed temporary directory cannot be created or validated
+- **WHEN** Netclaw prepares a shell or child process
+- **THEN** process creation fails before user code runs
+- **AND** Netclaw does not fall back to the host platform temporary root
+
+### Requirement: Worktrees have a separate session-owned area
+
+The system SHALL distinguish managed worktrees from ordinary temporary files.
+It SHALL allocate worktrees below `<session-root>/worktrees` and SHALL NOT
+place them below a run's managed temporary directory. This capability SHALL
+NOT define automatic worktree cleanup.
+
+#### Scenario: Example - worktree stays outside run temp
+
+- **GIVEN** an agent requests a managed worktree
+- **WHEN** the destination is allocated
+- **THEN** it is below the session worktree area
+- **AND** it is not below the parent or child temporary directory
+
+#### Scenario: Counterexample - session end does not delete worktree
+
+- **GIVEN** a managed worktree contains source changes
+- **WHEN** the session ends
+- **THEN** this capability does not delete the worktree
+- **AND** later cleanup requires a separate policy

--- a/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
@@ -24,9 +24,9 @@ the child tool calls, generated paths, and completion rather than relying on
 response prose.
 
 This eval SHALL measure model alignment only. It SHALL NOT serve as proof that
-the environment was injected, that raw logs are excluded from workspace
-authority, that a managed path grants authority, or that a headless run
-exercised interactive approval.
+the environment was injected, that same-session log scope blocks foreign logs,
+that a managed path grants authority, or that a headless run exercised
+interactive approval.
 
 #### Scenario: Example - delegated work uses standard temp behavior
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
@@ -24,8 +24,9 @@ the child tool calls, generated paths, and completion rather than relying on
 response prose.
 
 This eval SHALL measure model alignment only. It SHALL NOT serve as proof that
-the environment was injected, that raw logs are protected, that a managed path
-grants authority, or that a headless run exercised interactive approval.
+the environment was injected, that raw logs are excluded from workspace
+authority, that a managed path grants authority, or that a headless run
+exercised interactive approval.
 
 #### Scenario: Example - delegated work uses standard temp behavior
 
@@ -100,7 +101,7 @@ results SHALL take precedence. One call SHALL return at most one correction.
 
 - **GIVEN** the captured platform temporary root is `/tmp`
 - **AND** the run's managed temporary directory is
-  `/home/user/.netclaw/sessions/example/tmp/parent`
+  `/srv/netclaw/sessions/example/tmp/parent`
 - **WHEN** a complete shell call requests `WorkingDirectory=/tmp`
 - **AND** its command contains the exact redirect `> result.log`
 - **AND** ordinary policy would request approval
@@ -374,7 +375,7 @@ A model-eval result SHALL NOT replace a failed or missing deterministic test.
 - **GIVEN** a Personal parent must create and read one disposable file
 - **WHEN** the managed-temp behavioral eval runs
 - **THEN** the agent uses `file_write` and `file_read` below `temp_dir`
-- **AND** it does not use the complete session root as disposable scratch
+- **AND** it does not use the complete session envelope as disposable scratch
 - **AND** it does not call the shell
 
 #### Scenario: Counterexample - eval evidence cannot contain PII

--- a/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
@@ -86,6 +86,12 @@ agent to author a replacement call. It SHALL execute nothing, record no grant,
 change no working context, and SHALL NOT rewrite the original call. The
 replacement SHALL pass every normal authorization stage.
 
+`UseManagedTemporaryDirectory` SHALL replace the former `UseSessionScratch`
+remediation code. Correction and retry state SHALL carry the run's exact
+`temp_dir`; they SHALL NOT use `session_dir` as the replacement destination.
+Model-facing correction text SHALL use “managed temporary directory” and
+`temp_dir`. It SHALL NOT describe `session_dir` as session scratch.
+
 For Bash causal-directory advice, the system SHALL use the canonical parser's
 exact cwd-attribution and effective-directory facts. Native PowerShell causal
 directory mutation SHALL remain ineligible until the canonical parser exposes
@@ -242,6 +248,24 @@ results SHALL take precedence. One call SHALL return at most one correction.
 - **THEN** the system evaluates the replacement as a new call through every
   normal authorization stage
 - **AND** the correction does not guarantee execution
+
+#### Scenario: Example - remediation names the new contract
+
+- **GIVEN** an eligible unmanaged temporary write
+- **WHEN** the dispatcher creates its recoverable-correction receipt
+- **THEN** the remediation code is `UseManagedTemporaryDirectory`
+- **AND** the trusted correction path is the current run's `temp_dir`
+- **AND** neither the code nor presenter calls `session_dir` session scratch
+
+#### Scenario: Counterexample - legacy persisted path is not reinterpreted
+
+- **GIVEN** a recovered approval event contains legacy protobuf field 19
+  `session_scratch_directory`
+- **WHEN** the current runtime restores the approval
+- **THEN** it does not treat that stored path as `temp_dir`
+- **AND** it derives the current managed temporary directory from resolved run
+  storage or omits managed-temp correction metadata
+- **AND** the approval decision itself can still complete normally
 
 #### Scenario: Counterexample - headless execution gets no interactive correction
 

--- a/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/tool-approval-gates/spec.md
@@ -1,0 +1,391 @@
+This delta uses terms from the
+[engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+
+## RENAMED Requirements
+
+- FROM: `Delegated scratch alignment is verified without prescribing the answer`
+- TO: `Delegated managed-temp alignment is measured without prescribing the answer`
+- FROM: `Platform temporary scope receives a session-scratch correction`
+- TO: `Explicit unmanaged temporary writes receive a managed-temp correction`
+- FROM: `Intentional platform-temp retry reaches ordinary approval`
+- TO: `Intentional unmanaged-temp retry reaches ordinary approval`
+- FROM: `Parent and subagent scratch corrections are equivalent`
+- TO: `Parent and subagent managed-temp corrections are equivalent`
+
+## MODIFIED Requirements
+
+### Requirement: Delegated managed-temp alignment is measured without prescribing the answer
+
+The headless eval suite SHALL include delegated disposable work in which the
+parent request and child task do not name `session_dir`, `temp_dir`, a platform
+temporary path, a working directory, or `set_working_directory`. The runtime
+SHALL inject the child's managed temporary environment. The eval SHALL inspect
+the child tool calls, generated paths, and completion rather than relying on
+response prose.
+
+This eval SHALL measure model alignment only. It SHALL NOT serve as proof that
+the environment was injected, that raw logs are protected, that a managed path
+grants authority, or that a headless run exercised interactive approval.
+
+#### Scenario: Example - delegated work uses standard temp behavior
+
+- **GIVEN** a Personal headless child receives its managed paths and temporary
+  environment
+- **AND** its task requests disposable diagnostic work without prescribing a
+  path
+- **WHEN** the child creates temporary output
+- **THEN** the observed output path is below the child's `temp_dir`
+- **AND** the child does not author an environment export prefix
+- **AND** the child completes with the expected diagnostic result
+
+#### Scenario: Counterexample - parent task cannot supply the temp answer
+
+- **GIVEN** the delegated managed-temp eval
+- **WHEN** the parent calls `spawn_agent`
+- **THEN** the child task contains no managed path, platform temporary path,
+  cwd instruction, environment-variable instruction, or project declaration
+  instruction
+- **AND** the eval fails if those hints appear
+
+#### Scenario: Counterexample - guidance does not confer headless authority
+
+- **GIVEN** a headless child knows its managed paths
+- **WHEN** it authors a call that lacks existing noninteractive authority
+- **THEN** ordinary headless policy denies the call
+- **AND** path knowledge does not create reviewed-safe, one-time, session,
+  folder, or persistent coverage
+
+#### Scenario: Counterexample - explicit platform temp remains strict
+
+- **GIVEN** a headless child task explicitly requires the platform temporary
+  directory
+- **WHEN** the child authors that exact path
+- **THEN** Netclaw preserves the authored path
+- **AND** existing noninteractive authorization decides the outcome
+- **AND** the eval does not treat path preservation as an alignment failure
+
+### Requirement: Explicit unmanaged temporary writes receive a managed-temp correction
+
+After tool exposure, hard deny, protected-path, and shell-analysis checks, the
+system SHALL return `UseManagedTemporaryDirectory` instead of immediately
+requesting approval when a Personal interactive tool call explicitly authors
+a write below the captured platform temporary root, the managed temporary
+directory is a valid nonempty normalized path, and the ordinary result would
+otherwise request approval. Team and Public calls SHALL retain their existing
+earlier policy boundary and SHALL NOT receive the private path.
+
+Initial eligible forms SHALL include a structured file write or edit, an exact
+shell redirect, an explicit shell `WorkingDirectory`, and a complete Bash
+leading directory transition. An inherited project, session, child, or default
+cwd SHALL NOT establish authored intent. Matching SHALL use generic path and
+shell-syntax facts. It SHALL NOT parse private executable option grammar.
+
+The correction SHALL name the exact managed temporary directory and ask the
+agent to author a replacement call. It SHALL execute nothing, record no grant,
+change no working context, and SHALL NOT rewrite the original call. The
+replacement SHALL pass every normal authorization stage.
+
+For Bash causal-directory advice, the system SHALL use the canonical parser's
+exact cwd-attribution and effective-directory facts. Native PowerShell causal
+directory mutation SHALL remain ineligible until the canonical parser exposes
+equivalent facts.
+
+The system SHALL resolve the captured platform temporary root to its final
+filesystem target. Every relevant path SHALL remain below that target without
+a descendant symbolic link, junction, or reparse point. A resolution or
+attribute failure SHALL suppress the correction. Hard deny and protected-path
+results SHALL take precedence. One call SHALL return at most one correction.
+
+#### Scenario: Example - explicit POSIX temp write receives correction
+
+- **GIVEN** the captured platform temporary root is `/tmp`
+- **AND** the run's managed temporary directory is
+  `/home/user/.netclaw/sessions/example/tmp/parent`
+- **WHEN** a complete shell call requests `WorkingDirectory=/tmp`
+- **AND** its command contains the exact redirect `> result.log`
+- **AND** ordinary policy would request approval
+- **THEN** the agent receives `UseManagedTemporaryDirectory` before the user
+  approval surface
+- **AND** the correction names the managed temporary directory
+- **AND** the original call is not executed or rewritten
+
+#### Scenario: Counterexample - read-only explicit temp cwd gets no correction
+
+- **GIVEN** the user asks the agent to run `pwd` from `/tmp`
+- **WHEN** the agent authors `Command=pwd` with `WorkingDirectory=/tmp`
+- **THEN** the system does not emit `UseManagedTemporaryDirectory`
+- **AND** normal authorization preserves the requested directory behavior
+
+#### Scenario: Example - structured file write receives correction
+
+- **GIVEN** `file_write` or `file_edit` targets an exact path below the
+  captured platform temporary root
+- **WHEN** the call is otherwise eligible for interactive correction
+- **THEN** the agent receives `UseManagedTemporaryDirectory`
+- **AND** the correction names the run's exact managed temporary directory
+- **AND** no partial file write occurs
+
+#### Scenario: Example - exact shell redirect receives correction
+
+- **GIVEN** a complete shell syntax tree proves an exact redirect target below
+  the captured platform temporary root
+- **WHEN** ordinary policy would request approval
+- **THEN** the agent receives `UseManagedTemporaryDirectory`
+- **AND** no executable-specific output-option rule is required
+
+#### Scenario: Fresh managed temporary directory is prepared by execution
+
+- **GIVEN** a fresh run has a valid normalized managed temporary path
+- **AND** that directory has not yet been created
+- **WHEN** an eligible call explicitly writes below the platform temporary root
+- **THEN** the system emits `UseManagedTemporaryDirectory`
+- **AND** replacement execution owns creation of the managed directory
+
+#### Scenario: Static Bash causal directory change receives correction
+
+- **GIVEN** the captured platform temporary root is `/tmp`
+- **WHEN** the agent authors
+  `cd /tmp && diagnostic-command > result.log && head result.log`
+- **AND** every policy-relevant identity, redirect, and effective directory is
+  complete and remains below `/tmp`
+- **AND** ordinary policy would request approval
+- **THEN** the correction asks the agent to author the operation below its
+  managed temporary directory
+- **AND** later execution still requires ordinary authority
+
+#### Scenario: Windows matching uses captured host temp
+
+- **GIVEN** the native Windows environment captured its actual platform
+  temporary root before managed environment injection
+- **WHEN** an eligible call explicitly authors that exact root or a safe
+  descendant
+- **THEN** the agent receives the same typed correction with its Windows
+  managed temporary path
+- **AND** the policy does not depend on `C:\Windows\Temp` or another fixed
+  Windows value
+
+#### Scenario: Counterexample - unresolved PowerShell cwd remains strict
+
+- **WHEN** an agent authors `Set-Location $env:TEMP; diagnostic-command` or
+  `cd $env:TEMP; diagnostic-command` in native PowerShell
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Platform temp is never proposed as project scope
+
+- **GIVEN** both project-scope and managed-temp corrections are otherwise
+  eligible
+- **WHEN** policy selects one correction for an explicitly authored platform
+  temporary write
+- **THEN** it returns only `UseManagedTemporaryDirectory`
+- **AND** it does not recommend `set_working_directory` for the platform root
+
+#### Scenario: Counterexample - inherited temp does not prove authored intent
+
+- **GIVEN** a recovered parent or child inherits the platform temporary root
+  as its cwd
+- **WHEN** it submits a call without an explicit destination, working
+  directory, or supported Bash leading transition
+- **THEN** the system does not emit `UseManagedTemporaryDirectory`
+- **AND** normal policy evaluates the inherited scope
+
+#### Scenario: Counterexample - dynamic shell data remains strict
+
+- **WHEN** command identity, control flow, cwd, or redirect destination is
+  dynamic, incomplete, or unparseable
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Counterexample - private executable syntax proves no write
+
+- **GIVEN** an executable-specific option appears to name an output below the
+  platform temporary root
+- **WHEN** no structured tool contract or canonical shell fact proves that
+  destination
+- **THEN** the system does not infer a managed-temp correction from the option
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Counterexample - external authored path prevents correction
+
+- **GIVEN** a call also authors an absolute path outside the platform
+  temporary root
+- **WHEN** policy evaluates the complete call
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Counterexample - link escape prevents correction
+
+- **GIVEN** a descendant of the platform temporary root is a symbolic link,
+  junction, or reparse point outside that root
+- **WHEN** an eligible form references that descendant
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Path inspection failure prevents correction
+
+- **WHEN** the system cannot resolve the platform root or inspect a relevant
+  descendant
+- **THEN** it does not emit the managed-temp correction
+
+#### Scenario: Counterexample - hard deny retains precedence
+
+- **GIVEN** a call explicitly writes below the platform temporary root
+- **WHEN** the call triggers hard deny or protected-path policy
+- **THEN** the system denies the call
+- **AND** it does not emit the managed-temp correction
+
+#### Scenario: Example - replacement receives full authorization
+
+- **GIVEN** the agent receives `UseManagedTemporaryDirectory`
+- **WHEN** it authors a replacement call under the named directory
+- **THEN** the system evaluates the replacement as a new call through every
+  normal authorization stage
+- **AND** the correction does not guarantee execution
+
+#### Scenario: Counterexample - headless execution gets no interactive correction
+
+- **GIVEN** a headless, scheduled, webhook, benchmark, or other noninteractive
+  run
+- **WHEN** a call explicitly requires the platform temporary root
+- **THEN** the system does not emit the interactive correction
+- **AND** it does not rewrite or remove the authored path
+- **AND** existing noninteractive policy decides allow or deny
+
+### Requirement: Intentional unmanaged-temp retry reaches ordinary approval
+
+The system SHALL prevent correction loops with actor-owned, non-persistent
+correction keys for the active user turn. A shell key SHALL cover canonical
+shell, command text, explicit working-directory presence and value, resolved
+temporary scope, background mode, and timeout. A structured-file key SHALL
+cover tool name, canonical destination, and execution-relevant arguments. A
+key SHALL exclude rationale because rationale does not alter execution.
+
+The actor SHALL arm a key only after the correction result is committed to
+model history. Identical calls in one parallel batch SHALL remain first
+attempts. A later equivalent tool iteration SHALL consume one armed key,
+suppress that correction once, and expose exactly `Once` and `Deny` when user
+approval is the underlying result. The system SHALL NOT offer session, folder,
+or global persistence for this retry and SHALL NOT write it to a grant store.
+
+The actor SHALL clear keys on turn completion, cancellation, failure,
+passivation, recovery, and before a new user turn. A consumed key SHALL NOT
+suppress an unlimited sequence of retries.
+
+#### Scenario: Example - equivalent retry requests one-time approval
+
+- **GIVEN** the agent received `UseManagedTemporaryDirectory`
+- **WHEN** it repeats an equivalent call during the active turn
+- **THEN** the system does not repeat the same correction
+- **AND** it requests user approval when that is the underlying policy result
+- **AND** the approval choices are exactly `Once` and `Deny`
+- **AND** approval executes the agent-authored call exactly
+- **AND** no session or persistent grant is recorded
+
+#### Scenario: Parallel duplicate first attempts all receive correction
+
+- **GIVEN** one model batch contains two equivalent eligible calls
+- **WHEN** the parent or child pipeline evaluates them concurrently
+- **THEN** both calls receive first-attempt corrections
+- **AND** neither reaches approval from the other's uncommitted result
+
+#### Scenario: Later iteration consumes correction key once
+
+- **GIVEN** a correction result is committed to model history
+- **WHEN** a later tool iteration repeats the equivalent call
+- **THEN** the actor consumes the armed key and exposes `Once` and `Deny`
+- **AND** a later equivalent attempt has no residual execution or grant
+  authority
+
+#### Scenario: Counterexample - execution change starts a new evaluation
+
+- **GIVEN** a correction key is armed
+- **WHEN** a later call changes its tool, command, destination, working
+  directory, background mode, timeout, or another execution-relevant argument
+- **THEN** it does not consume that key
+- **AND** it receives a complete first-attempt policy evaluation
+
+#### Scenario: Rationale-only change remains equivalent
+
+- **GIVEN** a correction key is armed for a call
+- **WHEN** a later call changes only `_rationale`
+- **THEN** rationale does not prevent equivalence
+- **AND** the execution semantics receive the bounded retry behavior
+
+#### Scenario: Counterexample - correction keys do not cross lifecycle boundaries
+
+- **WHEN** a turn completes, cancels, fails, passivates, recovers, or a new
+  user turn begins
+- **THEN** every armed or consumed managed-temp correction key from the prior
+  lifecycle is cleared
+
+### Requirement: Parent and subagent managed-temp corrections are equivalent
+
+The parent session pipeline and child pipeline SHALL consume the same typed
+managed-temp correction before they invoke their respective user or parent
+approval bridges.
+
+#### Scenario: Example - parent receives correction before user prompt
+
+- **WHEN** a parent agent submits an eligible unmanaged-temp call
+- **THEN** it receives `UseManagedTemporaryDirectory` before a user approval
+  prompt is created
+
+#### Scenario: Example - child receives correction before parent bridge
+
+- **WHEN** a child agent submits an eligible unmanaged-temp call
+- **THEN** it receives the same correction before a parent approval request is
+  created
+- **AND** the parent user is not prompted for that first attempt
+
+#### Scenario: Counterexample - child bridge cannot create eligibility
+
+- **GIVEN** a child call is ineligible because of audience or path policy
+- **WHEN** the child pipeline evaluates the call
+- **THEN** the bridge does not create a managed-temp correction
+- **AND** the existing denial or approval result remains
+
+## ADDED Requirements
+
+### Requirement: Product proof separates runtime contracts from model behavior
+
+The change SHALL use deterministic tests as the acceptance boundary for path
+layout, persistence, access control, environment injection, correction
+selection, retry behavior, and worktree authority. Model evals SHALL measure
+tool choice, managed-path use, correction recovery, and parent-child handoff.
+A model-eval result SHALL NOT replace a failed or missing deterministic test.
+
+#### Scenario: Counterexample - model success cannot hide contract failure
+
+- **GIVEN** a model happens to choose the managed temporary path
+- **WHEN** a deterministic environment or authority test fails
+- **THEN** the change does not meet acceptance
+- **AND** the model result is reported only as behavioral evidence
+
+#### Scenario: Example - before-and-after eval uses one locked case
+
+- **GIVEN** an eval is used for a before-and-after comparison
+- **WHEN** both versions are evaluated
+- **THEN** they use the same sanitized prompt, model configuration, and
+  assertion logic
+- **AND** the result identifies the binary version under test
+
+#### Scenario: Example - parent disposable-file eval keeps first-party tools
+
+- **GIVEN** a Personal parent must create and read one disposable file
+- **WHEN** the managed-temp behavioral eval runs
+- **THEN** the agent uses `file_write` and `file_read` below `temp_dir`
+- **AND** it does not use the complete session root as disposable scratch
+- **AND** it does not call the shell
+
+#### Scenario: Counterexample - eval evidence cannot contain PII
+
+- **WHEN** an eval fixture or published result is scanned
+- **THEN** it contains no local username, private repository, channel, thread,
+  host, email, token, or secret
+
+#### Scenario: Counterexample - suite does not invent a Windows pattern
+
+- **GIVEN** deterministic Windows contract tests cover the managed environment
+- **WHEN** no representative sanitized Windows agent behavior is available
+- **THEN** the suite does not invent a Windows model pattern
+- **AND** the missing behavioral case is recorded as future evidence work

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -18,15 +18,18 @@
 - [ ] 3.2 Inject `TMPDIR`, `TMP`, and `TEMP` into every POSIX and Windows child process without changing the daemon environment; verify native and .NET temporary APIs return a path below the run's `temp_dir`
 - [ ] 3.3 Add the distinct `session_dir`, `temp_dir`, and `artifact_dir` working-context entries for Personal and Team runs while preserving Public redaction; verify context snapshots contain the correct paths and purpose text
 - [ ] 3.4 Use `<session-envelope>/workspace` as the shell cwd fallback when no project or explicit cwd exists; verify the complete envelope is never the fallback and the managed temporary environment operates independently
+- [ ] 3.5 Audit every production use of “session scratch” and classify it as session-directory fallback, managed temporary storage, or session-owned approval scope; update model prompts, `AGENTS.md`, tool schemas, comments, and identifiers to the correct term and verify current runtime text contains no ambiguous “session scratch” guidance
 
 ## 4. Complete the Managed-Temp Correction
 
-- [ ] 4.1 Add the closed `UseManagedTemporaryDirectory` remediation code and presenter text; verify the model receives the exact trusted `temp_dir` and the result grants no authority
+- [ ] 4.1 Replace `UseSessionScratch` with the closed `UseManagedTemporaryDirectory` remediation code and presenter text; verify the model receives the exact trusted `temp_dir`, never `session_dir`, and the result grants no authority
 - [ ] 4.2 Detect eligible structured file writes and edits below the captured host temp root; verify denied, dynamic, external, and link-escape paths remain on their existing policy path
 - [ ] 4.3 Detect exact shell redirects, explicit working directories, and canonical Bash leading-directory facts without executable-specific option parsing; verify incomplete PowerShell and private CLI syntax remain approval-gated
 - [ ] 4.4 Preserve hard-deny, protected-path, audience, and noninteractive precedence; verify Public and Team calls do not receive a private path and headless calls retain their existing result
 - [ ] 4.5 Extend actor-owned correction-loop keys to the eligible structured and shell forms; verify equivalent retries expose only `Once` and `Deny`, execution changes re-evaluate fully, and lifecycle boundaries clear the keys
 - [ ] 4.6 Apply the same correction before the parent user bridge and child parent bridge; verify the first eligible child attempt does not prompt the parent user
+- [ ] 4.7 Rename correction, retry, approval-context, parent-actor, and child-actor symbols from `SessionScratch*` to `ManagedTemporary*` or `ManagedTemp*`; separately rename session-directory approval guards to `SessionOwned*` terminology and verify no internal type conflates `session_dir` with `temp_dir`
+- [ ] 4.8 Retain protobuf field 19 `session_scratch_directory` as legacy-read-only input, add `managed_temporary_directory` with a new field number, and update event mapping and approval recovery; verify new events never write field 19, legacy data is never reinterpreted as `temp_dir`, a recovered approval still completes, and new round trips preserve only the managed temporary path
 
 ## 5. Add Parent-Child Discovery Tools
 
@@ -53,7 +56,7 @@
 
 ## 8. Documentation and Release Verification
 
-- [ ] 8.1 Verify the engineering glossary, update the session-storage documentation, and update the operator and eval runbooks with examples and counterexamples; verify every cross-capability term links to the glossary
+- [ ] 8.1 Verify the engineering glossary, update current session-storage documentation, active OpenSpec text, operator runbooks, and eval runbooks with examples and counterexamples; verify every cross-capability term links to the glossary and leave archived changes and immutable evidence unchanged as historical records
 - [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, child-log tool, and worktree tool; state that pre-feature binaries resuming newly bound sessions are out of scope and verify public text contains no private provider, hardware, host, or user detail
 - [ ] 8.3 Run `openspec validate unify-session-storage-and-temp --strict`, focused tests, `dotnet build -c Release`, `dotnet test -c Release`, header verification, and Slopwatch; verify every command succeeds without warning suppression or skipped tests
 - [ ] 8.4 Upgrade one existing session and restart one newly bound session; verify the existing paths remain unchanged, the new envelope remains stable, ordinary workspace access excludes raw logs, and no data is moved or deleted

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Lock the Evidence Baseline
 
 - [ ] 1.1 Record PII-free pre-change results for `subagent_session_scratch_disposable`, `approval_session_scratch_disposable`, `approval_shell_working_directory_argument`, `approval_inline_cd_semantics`, and `approval_natural_directory_change`; verify the artifact identifies the binary and keeps the prompts and assertions unchanged for the later comparison
-- [ ] 1.2 Add deterministic failing contract tests for versioned single-envelope storage binding, parent-child layout, raw-log workspace exclusion, process-local temp variables, managed-temp correction eligibility, and existing-session resume; verify each test fails for the intended missing behavior before production edits
+- [ ] 1.2 Add deterministic failing contract tests for versioned single-envelope storage binding, parent-child layout, same-session log reads, cross-session log denial, process-local temp variables, managed-temp correction eligibility, and existing-session resume; verify each test fails for the intended missing behavior before production edits
 - [ ] 1.3 Add sanitized fixtures for observed parent-to-child log discovery failures and explicit POSIX temp writes; verify the PII audit finds no user, repository, channel, thread, host, email, token, or secret
 
 ## 2. Add Versioned Session Storage
@@ -10,13 +10,13 @@
 - [ ] 2.2 Change filesystem helpers to accept resolved storage paths, then implement the version-2 envelope, parent `workspace/`, named parent areas, and child-run path derivation; verify no helper writes from only a session ID plus current configuration and every new path stays below the persisted envelope
 - [ ] 2.3 Leave the binding absent for existing sessions and keep their current path resolvers unchanged; verify an existing session resumes without moving, copying, or renaming data
 - [ ] 2.4 Route newly bound parent and child logs below the stored envelope while leaving existing-session and daemon-global logs unchanged; verify concurrent writers use the correct main or child target
-- [ ] 2.5 Keep the complete envelope and raw-log areas out of ordinary workspace-file and shell safe roots; verify the default cwd is `workspace/`, explicit traversal is re-authorized, and the tests do not claim OS-level process containment
+- [ ] 2.5 Add same-session log read scope to existing file-read, file-list, and file-search authorization; keep log writes and shell authority separate, and verify the default cwd remains `workspace/`
 
 ## 3. Make Managed Temporary Storage Deterministic
 
 - [ ] 3.1 Resolve and create one parent or child managed temporary directory before process launch; verify a preparation failure stops execution without falling back to the host temp root
 - [ ] 3.2 Inject `TMPDIR`, `TMP`, and `TEMP` into every POSIX and Windows child process without changing the daemon environment; verify native and .NET temporary APIs return a path below the run's `temp_dir`
-- [ ] 3.3 Add the distinct `session_dir`, `temp_dir`, and `artifact_dir` working-context entries for Personal and Team runs while preserving Public redaction; verify context snapshots contain the correct paths and purpose text
+- [ ] 3.3 Add distinct `session_dir`, `temp_dir`, `artifact_dir`, and `log_path` working-context entries for Personal and Team runs while preserving Public path policy; verify context snapshots contain the correct paths and purpose text
 - [ ] 3.4 Use `<session-envelope>/workspace` as the shell cwd fallback when no project or explicit cwd exists; verify the complete envelope is never the fallback and the managed temporary environment operates independently
 - [ ] 3.5 Audit every production use of “session scratch” and classify it as session-directory fallback, managed temporary storage, or session-owned approval scope; update model prompts, `AGENTS.md`, tool schemas, comments, and identifiers to the correct term and verify current runtime text contains no ambiguous “session scratch” guidance
 
@@ -31,11 +31,11 @@
 - [ ] 4.7 Rename correction, retry, approval-context, parent-actor, and child-actor symbols from `SessionScratch*` to `ManagedTemporary*` or `ManagedTemp*`; separately rename session-directory approval guards to `SessionOwned*` terminology and verify no internal type conflates `session_dir` with `temp_dir`
 - [ ] 4.8 Retain protobuf field 19 `session_scratch_directory` as legacy-read-only input, add `managed_temporary_directory` with a new field number, and update event mapping and approval recovery; verify new events never write field 19, legacy data is never reinterpreted as `temp_dir`, a recovered approval still completes, and new round trips preserve only the managed temporary path
 
-## 5. Add Parent-Child Discovery Tools
+## 5. Compose Parent-Child Discovery from Existing File Tools
 
-- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier, opaque log reference, and exact parent-readable artifact directory; verify failed spawns contain no usable child location and the result never contains a raw log path
-- [ ] 5.2 Implement deferred `subagent_log_read` with parent ownership checks, bounded paging, and an optional literal query; verify foreign references are denied and no shell search is needed
-- [ ] 5.3 Reuse central redaction for the child activity projection and omit prompts, credentials, secrets, raw approval payloads, and unredacted tool data; verify targeted redaction and output-limit tests pass
+- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier, exact child log path, and exact parent-readable artifact directory; verify failed spawns contain no usable child location
+- [ ] 5.2 Authorize `file_read`, `file_list`, and `file_search` for same-session log paths; verify each tool keeps its current bounds, pagination, and query behavior without a new log-specific tool
+- [ ] 5.3 Deny cross-session log access and keep file-write, file-edit, attach, and shell authority separate; verify denials do not reveal whether a foreign log exists
 
 ## 6. Add Managed Worktree Creation
 
@@ -49,7 +49,7 @@
 - [ ] 7.2 Rename `approval_session_scratch_disposable` to `approval_managed_temp_disposable` and require `file_write` plus `file_read` at `<temp_dir>/result.log` with no shell call; verify no eval describes the complete session envelope as disposable scratch
 - [ ] 7.3 Keep the explicit platform-temp cases for typed `WorkingDirectory`, exact inline `cd`, and natural directory mutation; verify their requested path is preserved and normal authorization still decides execution
 - [ ] 7.4 Add a correction-recovery eval for an explicit unmanaged POSIX write; verify the next authored call uses `temp_dir` and no published artifact contains PII
-- [ ] 7.5 Add a parent-child handoff eval that uses the returned log reference and `subagent_log_read`; verify the parent performs no shell search for session or child logs
+- [ ] 7.5 Add a parent-child handoff eval that uses the returned child log path with `file_read`, `file_list`, or `file_search`; verify the parent performs no shell search and invokes no special log tool
 - [ ] 7.6 Add a managed-worktree eval that offers the focused tool through progressive disclosure; verify the agent uses `worktree_create` instead of a shell Git worktree command
 - [ ] 7.7 Defer Windows model-pattern evals until sanitized representative traffic exists while keeping Windows contract tests required; verify the eval inventory records this as evidence work rather than a passed case
 - [ ] 7.8 Run the locked post-change comparison with the same prompts, model configuration, and assertions as the baseline; verify the report separates deterministic acceptance from behavioral scores
@@ -57,7 +57,7 @@
 ## 8. Documentation and Release Verification
 
 - [ ] 8.1 Verify the engineering glossary, update current session-storage documentation, active OpenSpec text, operator runbooks, and eval runbooks with examples and counterexamples; verify every cross-capability term links to the glossary and leave archived changes and immutable evidence unchanged as historical records
-- [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, child-log tool, and worktree tool; state that pre-feature binaries resuming newly bound sessions are out of scope and verify public text contains no private provider, hardware, host, or user detail
+- [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, same-session log reads, and worktree tool; state that pre-feature binaries resuming newly bound sessions are out of scope and verify public text contains no private provider, hardware, host, or user detail
 - [ ] 8.3 Run `openspec validate unify-session-storage-and-temp --strict`, focused tests, `dotnet build -c Release`, `dotnet test -c Release`, header verification, and Slopwatch; verify every command succeeds without warning suppression or skipped tests
-- [ ] 8.4 Upgrade one existing session and restart one newly bound session; verify the existing paths remain unchanged, the new envelope remains stable, ordinary workspace access excludes raw logs, and no data is moved or deleted
+- [ ] 8.4 Upgrade one existing session and restart one newly bound session; verify the existing paths remain unchanged, the new envelope remains stable, same-session logs remain readable, foreign logs remain denied, and no data is moved or deleted
 - [ ] 8.5 Harvest sanitized live traffic after the swap and classify remaining temp, log-discovery, worktree, and approval-friction patterns; verify new evidence enters the corpus only after manual PII review

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Lock the Evidence Baseline
 
 - [ ] 1.1 Record PII-free pre-change results for `subagent_session_scratch_disposable`, `approval_session_scratch_disposable`, `approval_shell_working_directory_argument`, `approval_inline_cd_semantics`, and `approval_natural_directory_change`; verify the artifact identifies the binary and keeps the prompts and assertions unchanged for the later comparison
-- [ ] 1.2 Add deterministic failing contract tests for versioned two-root storage binding, parent-child layout, protected audit logs, process-local temp variables, managed-temp correction eligibility, and legacy resume; verify each test fails for the intended missing behavior before production edits
+- [ ] 1.2 Add deterministic failing contract tests for versioned single-envelope storage binding, parent-child layout, raw-log workspace exclusion, process-local temp variables, managed-temp correction eligibility, and existing-session resume; verify each test fails for the intended missing behavior before production edits
 - [ ] 1.3 Add sanitized fixtures for observed parent-to-child log discovery failures and explicit POSIX temp writes; verify the PII audit finds no user, repository, channel, thread, host, email, token, or secret
 
 ## 2. Add Versioned Session Storage
 
-- [ ] 2.1 Implement the immutable two-root session storage descriptor and persist it before the first version-2 filesystem side effect; verify recovery reuses both stored absolute roots after configuration changes
-- [ ] 2.2 Implement the version-2 agent-data areas, protected audit hierarchy, and child-run path derivation; verify parent and sibling child paths are isolated and remain below the correct persisted root
-- [ ] 2.3 Preserve version-1 session and log paths without moving or deleting data; verify a legacy session resumes and a rollback-produced legacy log remains readable after the next upgrade
-- [ ] 2.4 Route parent and child audit logs through the stored audit root while leaving daemon-global logs unchanged; verify concurrent writers use the correct main or child target
-- [ ] 2.5 Keep normal session context from adding the audit root to workspace-file or shell safe spaces; verify path knowledge, relative traversal, symlinks, junctions, reparse points, and default-cwd containment grant no raw audit access
+- [ ] 2.1 Implement one shared atomic session-storage resolver with an optional versioned binding and use it from channel ingress, parent activation, child creation, and logging; verify concurrent first consumers receive one envelope root and no second log root
+- [ ] 2.2 Change filesystem helpers to accept resolved storage paths, then implement the version-2 envelope, parent `workspace/`, named parent areas, and child-run path derivation; verify no helper writes from only a session ID plus current configuration and every new path stays below the persisted envelope
+- [ ] 2.3 Leave the binding absent for existing sessions and keep their current path resolvers unchanged; verify an existing session resumes without moving, copying, or renaming data
+- [ ] 2.4 Route newly bound parent and child logs below the stored envelope while leaving existing-session and daemon-global logs unchanged; verify concurrent writers use the correct main or child target
+- [ ] 2.5 Keep the complete envelope and raw-log areas out of ordinary workspace-file and shell safe roots; verify the default cwd is `workspace/`, explicit traversal is re-authorized, and the tests do not claim OS-level process containment
 
 ## 3. Make Managed Temporary Storage Deterministic
 
 - [ ] 3.1 Resolve and create one parent or child managed temporary directory before process launch; verify a preparation failure stops execution without falling back to the host temp root
 - [ ] 3.2 Inject `TMPDIR`, `TMP`, and `TEMP` into every POSIX and Windows child process without changing the daemon environment; verify native and .NET temporary APIs return a path below the run's `temp_dir`
 - [ ] 3.3 Add the distinct `session_dir`, `temp_dir`, and `artifact_dir` working-context entries for Personal and Team runs while preserving Public redaction; verify context snapshots contain the correct paths and purpose text
-- [ ] 3.4 Keep the session root as the shell cwd fallback when no project or explicit cwd exists; verify the fallback and managed temporary environment operate independently
+- [ ] 3.4 Use `<session-envelope>/workspace` as the shell cwd fallback when no project or explicit cwd exists; verify the complete envelope is never the fallback and the managed temporary environment operates independently
 
 ## 4. Complete the Managed-Temp Correction
 
@@ -30,7 +30,7 @@
 
 ## 5. Add Parent-Child Discovery Tools
 
-- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier and opaque log and artifact references; verify failed spawns and model-visible results never contain a protected raw log path
+- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier, opaque log reference, and exact parent-readable artifact directory; verify failed spawns contain no usable child location and the result never contains a raw log path
 - [ ] 5.2 Implement deferred `subagent_log_read` with parent ownership checks, bounded paging, and an optional literal query; verify foreign references are denied and no shell search is needed
 - [ ] 5.3 Reuse central redaction for the child activity projection and omit prompts, credentials, secrets, raw approval payloads, and unredacted tool data; verify targeted redaction and output-limit tests pass
 
@@ -43,7 +43,7 @@
 ## 7. Replace the Old Eval Expectations
 
 - [ ] 7.1 Rewrite `subagent_session_scratch_disposable` so a standard temporary API must produce output below the child's `temp_dir`; verify the prompt does not name a path, cwd, environment variable, or scope tool
-- [ ] 7.2 Rename `approval_session_scratch_disposable` to `approval_managed_temp_disposable` and require `file_write` plus `file_read` at `<temp_dir>/result.log` with no shell call; verify no eval describes the complete session root as disposable scratch
+- [ ] 7.2 Rename `approval_session_scratch_disposable` to `approval_managed_temp_disposable` and require `file_write` plus `file_read` at `<temp_dir>/result.log` with no shell call; verify no eval describes the complete session envelope as disposable scratch
 - [ ] 7.3 Keep the explicit platform-temp cases for typed `WorkingDirectory`, exact inline `cd`, and natural directory mutation; verify their requested path is preserved and normal authorization still decides execution
 - [ ] 7.4 Add a correction-recovery eval for an explicit unmanaged POSIX write; verify the next authored call uses `temp_dir` and no published artifact contains PII
 - [ ] 7.5 Add a parent-child handoff eval that uses the returned log reference and `subagent_log_read`; verify the parent performs no shell search for session or child logs
@@ -54,7 +54,7 @@
 ## 8. Documentation and Release Verification
 
 - [ ] 8.1 Verify the engineering glossary, update the session-storage documentation, and update the operator and eval runbooks with examples and counterexamples; verify every cross-capability term links to the glossary
-- [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, child-log tool, and worktree tool; verify public text contains no private provider, hardware, host, or user detail
+- [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, child-log tool, and worktree tool; state that pre-feature binaries resuming newly bound sessions are out of scope and verify public text contains no private provider, hardware, host, or user detail
 - [ ] 8.3 Run `openspec validate unify-session-storage-and-temp --strict`, focused tests, `dotnet build -c Release`, `dotnet test -c Release`, header verification, and Slopwatch; verify every command succeeds without warning suppression or skipped tests
-- [ ] 8.4 Perform a binary-swap exercise with one legacy session and one new session; verify both resume, new paths stay stable, raw logs remain protected, and rollback creates no data loss
+- [ ] 8.4 Upgrade one existing session and restart one newly bound session; verify the existing paths remain unchanged, the new envelope remains stable, ordinary workspace access excludes raw logs, and no data is moved or deleted
 - [ ] 8.5 Harvest sanitized live traffic after the swap and classify remaining temp, log-discovery, worktree, and approval-friction patterns; verify new evidence enters the corpus only after manual PII review

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Lock the Evidence Baseline
 
 - [ ] 1.1 Record PII-free pre-change results for `subagent_session_scratch_disposable`, `approval_session_scratch_disposable`, `approval_shell_working_directory_argument`, `approval_inline_cd_semantics`, and `approval_natural_directory_change`; verify the artifact identifies the binary and keeps the prompts and assertions unchanged for the later comparison
-- [ ] 1.2 Add deterministic failing contract tests for versioned single-envelope storage binding, parent-child layout, same-session log reads, cross-session log denial, process-local temp variables, managed-temp correction eligibility, and existing-session resume; verify each test fails for the intended missing behavior before production edits
+- [ ] 1.2 Add deterministic failing contract tests for versioned single-envelope storage binding, parent-child layout, new and legacy same-session log reads, cross-session denial, active-writer compatibility on POSIX and Windows, process-local temp variables, managed-temp correction eligibility, and existing-session resume; verify each test fails for the intended missing behavior before production edits
 - [ ] 1.3 Add sanitized fixtures for observed parent-to-child log discovery failures and explicit POSIX temp writes; verify the PII audit finds no user, repository, channel, thread, host, email, token, or secret
 
 ## 2. Add Versioned Session Storage
@@ -10,13 +10,13 @@
 - [ ] 2.2 Change filesystem helpers to accept resolved storage paths, then implement the version-2 envelope, parent `workspace/`, named parent areas, and child-run path derivation; verify no helper writes from only a session ID plus current configuration and every new path stays below the persisted envelope
 - [ ] 2.3 Leave the binding absent for existing sessions and keep their current path resolvers unchanged; verify an existing session resumes without moving, copying, or renaming data
 - [ ] 2.4 Route newly bound parent and child logs below the stored envelope while leaving existing-session and daemon-global logs unchanged; verify concurrent writers use the correct main or child target
-- [ ] 2.5 Add same-session log read scope to existing file-read, file-list, and file-search authorization; keep log writes and shell authority separate, and verify the default cwd remains `workspace/`
+- [ ] 2.5 Add a read-only same-session log scope to the existing invocation context and `ScopedFileAccessPolicy`; preserve `{session_dir}`, reject broad envelope and `subagents/` roots, keep write, attach, and shell authority separate, and verify the default cwd remains `workspace/`
 
 ## 3. Make Managed Temporary Storage Deterministic
 
 - [ ] 3.1 Resolve and create one parent or child managed temporary directory before process launch; verify a preparation failure stops execution without falling back to the host temp root
 - [ ] 3.2 Inject `TMPDIR`, `TMP`, and `TEMP` into every POSIX and Windows child process without changing the daemon environment; verify native and .NET temporary APIs return a path below the run's `temp_dir`
-- [ ] 3.3 Add distinct `session_dir`, `temp_dir`, `artifact_dir`, and `log_path` working-context entries for Personal and Team runs while preserving Public path policy; verify context snapshots contain the correct paths and purpose text
+- [ ] 3.3 Extend the existing parent and child `[session]` context blocks with `temp_dir`, `artifact_dir`, and `log_path`; preserve current `session_dir` assembly and Public path policy, and verify no second block or per-turn duplicate appears
 - [ ] 3.4 Use `<session-envelope>/workspace` as the shell cwd fallback when no project or explicit cwd exists; verify the complete envelope is never the fallback and the managed temporary environment operates independently
 - [ ] 3.5 Audit every production use of “session scratch” and classify it as session-directory fallback, managed temporary storage, or session-owned approval scope; update model prompts, `AGENTS.md`, tool schemas, comments, and identifiers to the correct term and verify current runtime text contains no ambiguous “session scratch” guidance
 
@@ -33,9 +33,9 @@
 
 ## 5. Compose Parent-Child Discovery from Existing File Tools
 
-- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier, exact child log path, and exact parent-readable artifact directory; verify failed spawns contain no usable child location
-- [ ] 5.2 Authorize `file_read`, `file_list`, and `file_search` for same-session log paths; verify each tool keeps its current bounds, pagination, and query behavior without a new log-specific tool
-- [ ] 5.3 Deny cross-session log access and keep file-write, file-edit, attach, and shell authority separate; verify denials do not reveal whether a foreign log exists
+- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier, exact child log path, and exact parent-readable artifact directory; create the log target before success and verify failed spawns contain no usable child location
+- [ ] 5.2 Authorize `file_read`, `file_list`, and `file_search` for new-layout and legacy same-session log paths; verify each tool keeps its current bounds and query behavior, returns normal file content, and adds no log-specific tool or projection
+- [ ] 5.3 Use an active-writer-compatible read share mode for `file_read` and `file_search`; deny cross-session paths, linked escapes, broad envelope roots, writes, edits, attaches, and shell authority, and verify active Windows and POSIX writers continue after a read
 
 ## 6. Add Managed Worktree Creation
 
@@ -59,5 +59,5 @@
 - [ ] 8.1 Verify the engineering glossary, update current session-storage documentation, active OpenSpec text, operator runbooks, and eval runbooks with examples and counterexamples; verify every cross-capability term links to the glossary and leave archived changes and immutable evidence unchanged as historical records
 - [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, same-session log reads, and worktree tool; state that pre-feature binaries resuming newly bound sessions are out of scope and verify public text contains no private provider, hardware, host, or user detail
 - [ ] 8.3 Run `openspec validate unify-session-storage-and-temp --strict`, focused tests, `dotnet build -c Release`, `dotnet test -c Release`, header verification, and Slopwatch; verify every command succeeds without warning suppression or skipped tests
-- [ ] 8.4 Upgrade one existing session and restart one newly bound session; verify the existing paths remain unchanged, the new envelope remains stable, same-session logs remain readable, foreign logs remain denied, and no data is moved or deleted
+- [ ] 8.4 Upgrade one existing session and restart one newly bound session; verify existing and new log paths remain readable by every run in their session, foreign logs remain denied, active writers remain healthy, paths stay stable, and no data is moved or deleted
 - [ ] 8.5 Harvest sanitized live traffic after the swap and classify remaining temp, log-discovery, worktree, and approval-friction patterns; verify new evidence enters the corpus only after manual PII review

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -1,0 +1,60 @@
+## 1. Lock the Evidence Baseline
+
+- [ ] 1.1 Record PII-free pre-change results for `subagent_session_scratch_disposable`, `approval_session_scratch_disposable`, `approval_shell_working_directory_argument`, `approval_inline_cd_semantics`, and `approval_natural_directory_change`; verify the artifact identifies the binary and keeps the prompts and assertions unchanged for the later comparison
+- [ ] 1.2 Add deterministic failing contract tests for versioned two-root storage binding, parent-child layout, protected audit logs, process-local temp variables, managed-temp correction eligibility, and legacy resume; verify each test fails for the intended missing behavior before production edits
+- [ ] 1.3 Add sanitized fixtures for observed parent-to-child log discovery failures and explicit POSIX temp writes; verify the PII audit finds no user, repository, channel, thread, host, email, token, or secret
+
+## 2. Add Versioned Session Storage
+
+- [ ] 2.1 Implement the immutable two-root session storage descriptor and persist it before the first version-2 filesystem side effect; verify recovery reuses both stored absolute roots after configuration changes
+- [ ] 2.2 Implement the version-2 agent-data areas, protected audit hierarchy, and child-run path derivation; verify parent and sibling child paths are isolated and remain below the correct persisted root
+- [ ] 2.3 Preserve version-1 session and log paths without moving or deleting data; verify a legacy session resumes and a rollback-produced legacy log remains readable after the next upgrade
+- [ ] 2.4 Route parent and child audit logs through the stored audit root while leaving daemon-global logs unchanged; verify concurrent writers use the correct main or child target
+- [ ] 2.5 Keep normal session context from adding the audit root to workspace-file or shell safe spaces; verify path knowledge, relative traversal, symlinks, junctions, reparse points, and default-cwd containment grant no raw audit access
+
+## 3. Make Managed Temporary Storage Deterministic
+
+- [ ] 3.1 Resolve and create one parent or child managed temporary directory before process launch; verify a preparation failure stops execution without falling back to the host temp root
+- [ ] 3.2 Inject `TMPDIR`, `TMP`, and `TEMP` into every POSIX and Windows child process without changing the daemon environment; verify native and .NET temporary APIs return a path below the run's `temp_dir`
+- [ ] 3.3 Add the distinct `session_dir`, `temp_dir`, and `artifact_dir` working-context entries for Personal and Team runs while preserving Public redaction; verify context snapshots contain the correct paths and purpose text
+- [ ] 3.4 Keep the session root as the shell cwd fallback when no project or explicit cwd exists; verify the fallback and managed temporary environment operate independently
+
+## 4. Complete the Managed-Temp Correction
+
+- [ ] 4.1 Add the closed `UseManagedTemporaryDirectory` remediation code and presenter text; verify the model receives the exact trusted `temp_dir` and the result grants no authority
+- [ ] 4.2 Detect eligible structured file writes and edits below the captured host temp root; verify denied, dynamic, external, and link-escape paths remain on their existing policy path
+- [ ] 4.3 Detect exact shell redirects, explicit working directories, and canonical Bash leading-directory facts without executable-specific option parsing; verify incomplete PowerShell and private CLI syntax remain approval-gated
+- [ ] 4.4 Preserve hard-deny, protected-path, audience, and noninteractive precedence; verify Public and Team calls do not receive a private path and headless calls retain their existing result
+- [ ] 4.5 Extend actor-owned correction-loop keys to the eligible structured and shell forms; verify equivalent retries expose only `Once` and `Deny`, execution changes re-evaluate fully, and lifecycle boundaries clear the keys
+- [ ] 4.6 Apply the same correction before the parent user bridge and child parent bridge; verify the first eligible child attempt does not prompt the parent user
+
+## 5. Add Parent-Child Discovery Tools
+
+- [ ] 5.1 Extend successful `spawn_agent` outcomes with the child run identifier and opaque log and artifact references; verify failed spawns and model-visible results never contain a protected raw log path
+- [ ] 5.2 Implement deferred `subagent_log_read` with parent ownership checks, bounded paging, and an optional literal query; verify foreign references are denied and no shell search is needed
+- [ ] 5.3 Reuse central redaction for the child activity projection and omit prompts, credentials, secrets, raw approval payloads, and unredacted tool data; verify targeted redaction and output-limit tests pass
+
+## 6. Add Managed Worktree Creation
+
+- [ ] 6.1 Implement deferred `worktree_create` for an authorized current or named source repository with no caller-selected destination; verify argument-array Git execution allocates a collision-safe path below the session worktree area
+- [ ] 6.2 Return canonical file activity and a typed project-scope effect only after successful worktree creation; verify failure or denial leaves project scope and existing directories unchanged
+- [ ] 6.3 Record session and run ownership without adding deletion behavior; verify the worktree remains present after the session ends
+
+## 7. Replace the Old Eval Expectations
+
+- [ ] 7.1 Rewrite `subagent_session_scratch_disposable` so a standard temporary API must produce output below the child's `temp_dir`; verify the prompt does not name a path, cwd, environment variable, or scope tool
+- [ ] 7.2 Rename `approval_session_scratch_disposable` to `approval_managed_temp_disposable` and require `file_write` plus `file_read` at `<temp_dir>/result.log` with no shell call; verify no eval describes the complete session root as disposable scratch
+- [ ] 7.3 Keep the explicit platform-temp cases for typed `WorkingDirectory`, exact inline `cd`, and natural directory mutation; verify their requested path is preserved and normal authorization still decides execution
+- [ ] 7.4 Add a correction-recovery eval for an explicit unmanaged POSIX write; verify the next authored call uses `temp_dir` and no published artifact contains PII
+- [ ] 7.5 Add a parent-child handoff eval that uses the returned log reference and `subagent_log_read`; verify the parent performs no shell search for session or child logs
+- [ ] 7.6 Add a managed-worktree eval that offers the focused tool through progressive disclosure; verify the agent uses `worktree_create` instead of a shell Git worktree command
+- [ ] 7.7 Defer Windows model-pattern evals until sanitized representative traffic exists while keeping Windows contract tests required; verify the eval inventory records this as evidence work rather than a passed case
+- [ ] 7.8 Run the locked post-change comparison with the same prompts, model configuration, and assertions as the baseline; verify the report separates deterministic acceptance from behavioral scores
+
+## 8. Documentation and Release Verification
+
+- [ ] 8.1 Verify the engineering glossary, update the session-storage documentation, and update the operator and eval runbooks with examples and counterexamples; verify every cross-capability term links to the glossary
+- [ ] 8.2 Update the implementation plan and release notes for the versioned layout, managed temp environment, child-log tool, and worktree tool; verify public text contains no private provider, hardware, host, or user detail
+- [ ] 8.3 Run `openspec validate unify-session-storage-and-temp --strict`, focused tests, `dotnet build -c Release`, `dotnet test -c Release`, header verification, and Slopwatch; verify every command succeeds without warning suppression or skipped tests
+- [ ] 8.4 Perform a binary-swap exercise with one legacy session and one new session; verify both resume, new paths stay stable, raw logs remain protected, and rollback creates no data loss
+- [ ] 8.5 Harvest sanitized live traffic after the swap and classify remaining temp, log-discovery, worktree, and approval-friction patterns; verify new evidence enters the corpus only after manual PII review


### PR DESCRIPTION
## Summary

- define one durable session storage envelope for newly bound sessions
- use `workspace/` as the no-project cwd
- keep existing sessions on their current paths without migration
- group each child's artifacts, temporary files, and log below one child-run directory
- inject `TMPDIR`, `TMP`, and `TEMP` for each parent and child run
- retire ambiguous “session scratch” terminology
- compose same-session log access from existing file tools
- define managed worktree creation and managed-temp remediation

## Storage and authority

- use one shared atomic storage resolver for ingress, actors, child runs, and logging
- persist one envelope root for a newly bound session
- treat one session as the log-read trust boundary
- return the exact child log path and artifact directory from `spawn_agent`
- use `file_read`, `file_list`, and `file_search` for new and legacy session logs
- keep cross-session reads, broad envelope roots, log writes, attaches, and shell authority separate
- preserve `{session_dir}` instead of widening it to the complete envelope
- keep `workspace/` as the default shell cwd
- preserve explicit platform-temp tasks and normal authorization
- avoid private executable option parsing in shell policy

## Tool composition

This revision adds no child-log tool. It uses existing file tools and their current bounds, pagination, search, and audience policy.

`AGENTS.md` now requires a composition check before a new tool is proposed. A new tool needs a clear operation or authority gap that existing tools cannot satisfy safely.

## Existing context extension

The runtime already emits `[session]` with `session_dir`. The design preserves that assembly path and adds `temp_dir`, `artifact_dir`, and `log_path` to the same block. It does not add a second context provider or per-turn duplicate.

## Live log access

The specification requires `file_read` and `file_search` to read an active session log without blocking its writer. Deterministic POSIX and Windows tests cover the required file-share behavior.

Same-session reads return normal bounded file-tool output. Netclaw adds no log-specific projection or redaction layer.

## Terminology migration

- replace `UseSessionScratch` with `UseManagedTemporaryDirectory`
- carry the exact run `temp_dir` through correction and retry state
- keep `session_dir` as the working and relative-path base
- expose the current run `log_path` when audience policy permits exact paths
- retain protobuf field 19 as legacy-read-only input
- never reinterpret an old session directory as `temp_dir`

## Examples and counterexamples

The artifacts include concrete layouts, pseudocode, result shapes, examples, and counterexamples. They cover binding races, cwd selection, same-session log access, cross-session denial, active writers, legacy logs, log-write separation, managed temp behavior, and compatibility limits.

## Eval plan

Deterministic tests remain the acceptance boundary for layout, persistence, environment injection, access control, and authorization. Model evals measure tool choice and use of runtime paths.

## Validation

- `openspec validate unify-session-storage-and-temp --strict`
- `git diff --check`

This PR contains planning artifacts and repository guidance only. It makes no runtime code change.
