### PR TITLE
fix: keep installed binaries on full reset (#2085)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallPageTests.cs
@@ -42,7 +42,7 @@ public sealed class InitExistingInstallPageTests : IDisposable
             (_, _) => Task.FromResult(new DaemonResult(true, "Daemon stopped.")),
             path =>
             {
-                if (path == _paths.BasePath)
+                if (path == _paths.ConfigDirectory)
                 {
                     deleteStarted.TrySetResult();
                     releaseDelete.Task.GetAwaiter().GetResult();

--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
@@ -297,7 +297,7 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         var releaseDelete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var vm = Create(DaemonStopped, path =>
         {
-            if (path == _paths.BasePath)
+            if (path == _paths.ConfigDirectory)
             {
                 deleteStarted.TrySetResult();
                 releaseDelete.Task.GetAwaiter().GetResult();
@@ -355,7 +355,7 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         var releaseDelete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var vm = Create(DaemonStopped, path =>
         {
-            if (path == _paths.BasePath)
+            if (path == _paths.ConfigDirectory)
             {
                 deleteStarted.TrySetResult();
                 releaseDelete.Task.GetAwaiter().GetResult();

--- a/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitExistingInstallViewModelTests.cs
@@ -103,6 +103,9 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
     {
         File.WriteAllText(_paths.NetclawConfigPath, "{}");
         File.WriteAllText(_paths.SqliteDbPath, "db");
+        // bin/ holds the installed binaries; a full reset must purge data but keep it.
+        var binaryPath = Path.Combine(_paths.BinDirectory, "netclaw");
+        File.WriteAllText(binaryPath, "binary");
 
         var vm = Create();
         string? route = null;
@@ -113,7 +116,9 @@ public sealed class InitExistingInstallViewModelTests : IDisposable
         Select(vm, 1); // Yes → perform
         await WaitForProgressAsync(vm, 3);
 
-        Assert.False(Directory.Exists(_paths.BasePath));
+        Assert.False(Directory.Exists(_paths.ConfigDirectory), "Config should be purged.");
+        Assert.False(File.Exists(_paths.SqliteDbPath), "Memory db should be purged.");
+        Assert.True(File.Exists(binaryPath), "Installed binaries in bin/ must survive a full reset.");
         await CompleteResetAsync(vm);
         Assert.Equal(InitExistingInstallViewModel.WizardRoute, route);
     }

--- a/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
@@ -236,7 +236,19 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
 
             if (_scope == ResetScopeKind.Full)
             {
-                _deleteDirectory(_paths.BasePath);
+                // Purge everything under BasePath except bin/ — the installed binaries
+                // live there and deleting them would brick the CLI mid-reset.
+                foreach (var entry in Directory.GetDirectories(_paths.BasePath))
+                {
+                    var name = Path.GetFileName(entry);
+                    if (string.Equals(name, "bin", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    _deleteDirectory(entry);
+                }
+
+                foreach (var file in Directory.GetFiles(_paths.BasePath))
+                    File.Delete(file);
             }
             else
             {

--- a/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitExistingInstallViewModel.cs
@@ -240,8 +240,7 @@ public sealed class InitExistingInstallViewModel : ReactiveViewModel
                 // live there and deleting them would brick the CLI mid-reset.
                 foreach (var entry in Directory.GetDirectories(_paths.BasePath))
                 {
-                    var name = Path.GetFileName(entry);
-                    if (string.Equals(name, "bin", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(entry, _paths.BinDirectory, StringComparison.OrdinalIgnoreCase))
                         continue;
 
                     _deleteDirectory(entry);


### PR DESCRIPTION
Full reset in `netclaw init` deletes the installed binaries, so it bricked the CLI and every later `netclaw` call failed with "No such file or directory".

## Changes
- `InitExistingInstallViewModel.RunResetAsync` Full scope now enumerates `BasePath` and deletes every entry except `bin/`, plus root-level files (`netclaw.db`, `netclaw.pid`, `netclaw.lock`), instead of deleting the whole base directory.
- The SetupOnly scope and the daemon-stop-first flow are unchanged.
- Updated `FullReset_AfterBothConfirmations_DeletesEverything` to seed a `bin/` dir and assert it survives while config and the memory DB are purged. It previously asserted the whole base directory was gone, so the binary wipe was invisible to the suite.

Fixes #2085.
