### PR TITLE
Fix Slack health and reconnect supervision

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.65.2"
+  version: "2.65.3"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/diagnostics.md
@@ -84,6 +84,10 @@ debugging a daemon-wide problem → read `daemon.log`.
 | Discord/Slack channel offline | `netclaw status` shows the channel `disconnected` with a reason. Discord may also report `degraded` when Discord.Net says the socket is connected but the gateway is not ready, such as after a resumed session that Netclaw is replacing with a clean reconnect. A misconfigured channel (bad token, missing Discord Message Content intent) degrades only that channel — the daemon keeps running and other channels are unaffected. A transient network failure retries automatically; a config/permission failure stays offline until the operator fixes the config and restarts the daemon. |
 | `command not found` for `netclaw`/`dotnet`/a user tool from the shell tool when the daemon runs as a systemd service | The systemd `--user` service does not inherit your login-shell `PATH`; `netclaw daemon install` captures it into `~/.netclaw/config/daemon.env`. Run `netclaw doctor` (the **Systemd Unit PATH** check flags a missing/stale/legacy env file), then `netclaw doctor --fix` to rehydrate `PATH` from your current shell (or re-run `netclaw daemon install`), and finally `systemctl --user restart netclaw`. Installed a new tool after install? Its dir won't be seen until you re-run one of those and restart. Per-directory managers (`mise`/`asdf`/`direnv`) are not captured. |
 
+Slack health reads the live Socket Mode state. The connection supervisor checks this state every five seconds.
+A disconnect emits `channel.disconnected`. The supervisor retries with exponential backoff up to five minutes.
+A successful recovery emits `channel.reconnected`.
+
 If webhook notifications are configured, daemon crash paths emit
 `daemon.crashing` operational alerts with context (PID, reason, and latest known
 session/turn snapshot when available).

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackChannelHealthContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackChannelHealthContractTests.cs
@@ -3,7 +3,9 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Tests.Channels.TestHelpers;
 using Netclaw.Channels;
@@ -18,32 +20,35 @@ using Xunit;
 namespace Netclaw.Actors.Tests.Channels.Contracts;
 
 /// <summary>
-/// Slack implements only the base health contract: its socket-mode transport
-/// is binary (connected after the channel's own connect path succeeds,
-/// disconnected otherwise), so the snapshot-based connected-but-not-ready and
-/// detail-propagation behaviors in <see cref="SnapshotChannelHealthContractTests"/>
-/// do not apply.
+/// Slack implements the base health contract with the live Socket Mode state.
+/// The transport has no separate ready state or health detail.
 /// </summary>
 public sealed class SlackChannelHealthContractTests(ITestOutputHelper output)
     : ChannelHealthContractTests(output)
 {
     private SlackChannel? _channel;
+    private FakeSlackSocketModeClient? _socketModeClient;
+    private FakeTimeProvider? _timeProvider;
+    private RecordingNotificationSink? _notificationSink;
 
     protected override IChannel CreateChannel(bool enabled)
     {
+        _socketModeClient = new FakeSlackSocketModeClient();
+        _timeProvider = new FakeTimeProvider();
+        _notificationSink = new RecordingNotificationSink();
         _channel = new SlackChannel(
             new FailingSessionPipeline(new InvalidOperationException("not used")),
             Sys,
             new FakeSlackApiClient(auth: new StubAuthApi()),
-            new FakeSlackSocketModeClient(),
+            _socketModeClient,
             new RecordingSlackReplyClient(),
             TestSlackGatewayDeps.DefaultChannelRegistry,
             new SessionIngressGate(),
             new NullContentScanner(),
             SafePromptInjectionDetector.Instance,
             new FakeHttpClientFactory(),
-            NullNotificationSink.Instance,
-            TimeProvider.System,
+            _notificationSink,
+            _timeProvider,
             new SlackChannelOptions
             {
                 Enabled = enabled,
@@ -64,6 +69,88 @@ public sealed class SlackChannelHealthContractTests(ITestOutputHelper output)
         return _channel;
     }
 
+    [Fact]
+    public async Task Disconnected_when_live_transport_drops_after_start()
+    {
+        var channel = CreateChannel(enabled: true);
+        await channel.StartAsync(TestContext.Current.CancellationToken);
+
+        _socketModeClient!.DropConnection();
+
+        var health = await channel.GetHealthAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(ChannelHealthStatus.Disconnected, health.Status);
+        Assert.Equal("Slack socket mode disconnected.", health.Detail);
+    }
+
+    [Fact]
+    public async Task Supervisor_reconnects_after_live_transport_drops()
+    {
+        var channel = CreateChannel(enabled: true);
+        await channel.StartAsync(TestContext.Current.CancellationToken);
+        _socketModeClient!.DropConnection();
+
+        _timeProvider!.Advance(SlackChannel.ConnectionCheckInterval);
+        await _socketModeClient.WaitForConnectCountAsync(
+            expectedCount: 2,
+            TestContext.Current.CancellationToken);
+
+        var health = await channel.GetHealthAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(ChannelHealthStatus.Healthy, health.Status);
+        Assert.Contains(
+            _notificationSink!.Alerts,
+            alert => alert.Category == AlertType.ChannelDisconnected);
+        Assert.Contains(
+            _notificationSink.Alerts,
+            alert => alert.Category == AlertType.ChannelReconnected
+                     && alert.Type == "channel.reconnected");
+    }
+
+    [Fact]
+    public async Task Supervisor_backs_off_then_recovers_after_reconnect_failure()
+    {
+        var channel = CreateChannel(enabled: true);
+        await channel.StartAsync(TestContext.Current.CancellationToken);
+        _socketModeClient!.FailNextConnections(1);
+        _socketModeClient.DropConnection();
+
+        _timeProvider!.Advance(SlackChannel.ConnectionCheckInterval);
+        await _socketModeClient.WaitForConnectCountAsync(
+            expectedCount: 2,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(2, _socketModeClient.ConnectCount);
+        Assert.Equal(
+            ChannelHealthStatus.Disconnected,
+            (await channel.GetHealthAsync(TestContext.Current.CancellationToken)).Status);
+
+        _timeProvider.Advance(SlackChannel.ComputeReconnectDelay(1) - TimeSpan.FromSeconds(1));
+        Assert.Equal(2, _socketModeClient.ConnectCount);
+
+        _timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await _socketModeClient.WaitForConnectCountAsync(
+            expectedCount: 3,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, _socketModeClient.ConnectCount);
+        Assert.Equal(
+            ChannelHealthStatus.Healthy,
+            (await channel.GetHealthAsync(TestContext.Current.CancellationToken)).Status);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 5)]
+    [InlineData(2, 10)]
+    [InlineData(6, 160)]
+    [InlineData(7, 300)]
+    [InlineData(20, 300)]
+    public void Reconnect_delay_is_bounded(int failureCount, int expectedSeconds)
+    {
+        Assert.Equal(
+            TimeSpan.FromSeconds(expectedSeconds),
+            SlackChannel.ComputeReconnectDelay(failureCount));
+    }
+
     protected override async Task SetTransportStateAsync(bool connected, bool ready, string? healthDetail)
     {
         // Guard against future base-contract tests assuming a partial-ready
@@ -77,6 +164,14 @@ public sealed class SlackChannelHealthContractTests(ITestOutputHelper output)
         // connect path; a freshly constructed channel is already disconnected.
         if (connected)
             await _channel!.StartAsync(CancellationToken.None);
+    }
+
+    protected override async Task AfterAllAsync()
+    {
+        if (_channel is not null)
+            await _channel.StopAsync(CancellationToken.None);
+
+        await base.AfterAllAsync();
     }
 
     private sealed class StubAuthApi : IAuthApi
@@ -97,20 +192,83 @@ public sealed class SlackChannelHealthContractTests(ITestOutputHelper output)
 
     private sealed class FakeSlackSocketModeClient : ISlackSocketModeClient
     {
-        public bool Connected { get; private set; }
+        private readonly Lock _sync = new();
+        private TaskCompletionSource _connectChanged = NewSignal();
+        private int _connectCount;
+        private int _failNextConnections;
+        private volatile bool _connected;
+
+        public bool Connected => _connected;
+
+        public int ConnectCount => Volatile.Read(ref _connectCount);
 
         public Task Connect(
             SocketModeConnectionOptions? connectionOptions = null,
             CancellationToken cancellationToken = default)
         {
-            Connected = true;
+            TaskCompletionSource signal;
+            bool mustFail;
+            lock (_sync)
+            {
+                Interlocked.Increment(ref _connectCount);
+                mustFail = _failNextConnections > 0;
+                if (mustFail)
+                    _failNextConnections--;
+                else
+                    _connected = true;
+
+                signal = _connectChanged;
+                _connectChanged = NewSignal();
+            }
+
+            signal.TrySetResult();
+            if (mustFail)
+                throw new HttpRequestException("Test Socket Mode connection failed.");
+
             return Task.CompletedTask;
         }
 
-        public void Disconnect() => Connected = false;
+        public void Disconnect() => _connected = false;
+
+        public void DropConnection() => _connected = false;
+
+        public void FailNextConnections(int count)
+        {
+            lock (_sync)
+                _failNextConnections = count;
+        }
+
+        public async Task WaitForConnectCountAsync(int expectedCount, CancellationToken cancellationToken)
+        {
+            while (ConnectCount < expectedCount)
+            {
+                Task signal;
+                lock (_sync)
+                {
+                    if (ConnectCount >= expectedCount)
+                        return;
+
+                    signal = _connectChanged.Task;
+                }
+
+                await signal.WaitAsync(cancellationToken);
+            }
+        }
+
+        private static TaskCompletionSource NewSignal() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void Dispose()
         {
         }
+    }
+
+    private sealed class RecordingNotificationSink : IOperationalNotificationSink
+    {
+        private readonly ConcurrentQueue<OperationalAlert> _alerts = new();
+
+        public IReadOnlyCollection<OperationalAlert> Alerts => _alerts.ToArray();
+
+        public void Emit(OperationalAlert alert) => _alerts.Enqueue(alert);
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannel.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using SlackNet;
@@ -49,10 +50,15 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private SlackChannelId? _defaultChannelId;
     private volatile bool _connected;
 
-    // Cancels the background reconnect loop when the channel stops.
+    internal static readonly TimeSpan ConnectionCheckInterval = TimeSpan.FromSeconds(5);
+    internal static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromMinutes(5);
+
+    // This token stops the connection supervisor before transport disposal.
     private readonly CancellationTokenSource _lifetimeCts = new();
-    private Task? _reconnectTask;
+    private Task? _connectionSupervisorTask;
     private volatile string? _connectFailureDetail;
+    private int _reconnectFailureCount;
+    private DateTimeOffset _nextReconnectAttemptAt = DateTimeOffset.MinValue;
 
     public SlackChannel(
         ISessionPipeline pipeline,
@@ -138,7 +144,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         if (!_options.Enabled)
             return ValueTask.FromResult(new ChannelHealth(ChannelHealthStatus.Degraded, "Slack channel disabled."));
 
-        if (_connected)
+        if (_connected && _socketModeClient.Connected)
             return ValueTask.FromResult(new ChannelHealth(ChannelHealthStatus.Healthy));
 
         return ValueTask.FromResult(new ChannelHealth(
@@ -193,6 +199,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         {
             await ConnectCoreAsync(cancellationToken);
             _logger.LogInformation("Channel connected as user {BotUserId}.", _botUserId);
+            StartConnectionSupervisor();
         }
         catch (Exception ex)
         {
@@ -261,18 +268,9 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     {
         _connectFailureDetail = failure.Message;
 
-        _notificationSink.Emit(OperationalAlert.Create(
-            _timeProvider,
-            "channel.disconnected",
-            AlertType.ChannelDisconnected,
+        EmitDisconnectedAlert(
             $"Slack channel failed to connect: {failure.Message}",
-            AlertSeverity.Warning,
-            source: "slack",
-            context: new Dictionary<string, string>
-            {
-                ["channel"] = "slack",
-                ["failure_kind"] = failure.Kind.ToString(),
-            }));
+            failure.Kind);
 
         if (failure.IsFatal)
         {
@@ -292,90 +290,167 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             "Slack channel could not connect (transient). The daemon will keep running "
             + "and retry the connection in the background. {Reason}",
             failure.Message);
-        StartReconnectLoop();
+        StartConnectionSupervisor();
     }
 
-    private void StartReconnectLoop()
+    private void StartConnectionSupervisor()
     {
-        if (_reconnectTask is { IsCompleted: false })
+        if (_connectionSupervisorTask is { IsCompleted: false })
             return;
 
-        _reconnectTask = Task.Run(() => ReconnectLoopAsync(_lifetimeCts.Token));
+        _connectionSupervisorTask = RunConnectionSupervisorAsync(_lifetimeCts.Token);
     }
 
-    private async Task ReconnectLoopAsync(CancellationToken cancellationToken)
+    private async Task RunConnectionSupervisorAsync(CancellationToken cancellationToken)
     {
-        var delay = TimeSpan.FromSeconds(5);
-        var maxDelay = TimeSpan.FromMinutes(5);
-
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            try
+            using var timer = new PeriodicTimer(ConnectionCheckInterval, _timeProvider);
+            while (await timer.WaitForNextTickAsync(cancellationToken))
             {
-                await Task.Delay(delay, _timeProvider, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-
-            // Reset transport state so the retry performs a clean connect.
-            try
-            {
-                _socketModeClient.Disconnect();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Transport reset before reconnect failed; continuing.");
-            }
-
-            try
-            {
-                await ConnectCoreAsync(cancellationToken);
-                _logger.LogInformation("Channel reconnected after a transient failure.");
-                return;
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                var classified = SlackConnectFailureClassifier.Classify(ex);
-                _connectFailureDetail = classified.Message;
-
-                if (classified.IsFatal)
-                {
-                    _logger.LogError(
-                        classified,
-                        "Slack reconnect hit a fatal failure; giving up until the daemon "
-                        + "is restarted. {Reason}",
-                        classified.Message);
+                if (!await CheckConnectionAsync(cancellationToken))
                     return;
-                }
-
-                _logger.LogWarning(
-                    classified,
-                    "Slack reconnect attempt failed; will retry. {Reason}",
-                    classified.Message);
-                delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, maxDelay.Ticks));
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogDebug("Connection supervisor stopped with the channel.");
+        }
+    }
+
+    private async Task<bool> CheckConnectionAsync(CancellationToken cancellationToken)
+    {
+        if (_socketModeClient.Connected)
+            return true;
+
+        if (_connected)
+        {
+            _connected = false;
+            _connectFailureDetail = "Slack socket mode disconnected.";
+            EmitDisconnectedAlert(_connectFailureDetail, ChannelConnectFailureKind.Transient);
+            ChannelTelemetry.For(ChannelType).RecordExtra("connection_disconnected");
+            _logger.LogWarning("Channel socket disconnected. The channel will reconnect automatically.");
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        if (now < _nextReconnectAttemptAt)
+            return true;
+
+        var attempt = _reconnectFailureCount + 1;
+        ChannelTelemetry.For(ChannelType).RecordExtra("reconnect_attempt");
+        _logger.LogInformation("Channel reconnect attempt {Attempt} started.", attempt);
+
+        // A clean reset prevents a failed SlackNet reconnect task from retaining the transport.
+        try
+        {
+            _socketModeClient.Disconnect();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Transport reset before reconnect failed. The reconnect attempt will continue.");
+        }
+
+        try
+        {
+            await ConnectCoreAsync(cancellationToken);
+            ResetReconnectBackoff();
+            EmitReconnectedAlert();
+            ChannelTelemetry.For(ChannelType).RecordExtra("connection_recovered");
+            _logger.LogInformation("Channel reconnected after attempt {Attempt}.", attempt);
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var classified = SlackConnectFailureClassifier.Classify(ex);
+            _connected = false;
+            _connectFailureDetail = classified.Message;
+
+            if (classified.IsFatal)
+            {
+                _logger.LogError(
+                    classified,
+                    "Slack reconnect found a fatal failure. The channel will stay offline until the daemon restarts. {Reason}",
+                    classified.Message);
+                return false;
+            }
+
+            _reconnectFailureCount++;
+            var retryDelay = ComputeReconnectDelay(_reconnectFailureCount);
+            _nextReconnectAttemptAt = now + retryDelay;
+            _logger.LogWarning(
+                classified,
+                "Channel reconnect attempt {Attempt} failed. The next attempt starts in {RetryDelay}. {Reason}",
+                attempt,
+                retryDelay,
+                classified.Message);
+            return true;
+        }
+    }
+
+    internal static TimeSpan ComputeReconnectDelay(int failureCount)
+    {
+        if (failureCount <= 0)
+            return TimeSpan.Zero;
+
+        var exponent = Math.Min(failureCount - 1, 16);
+        var ticks = ConnectionCheckInterval.Ticks * (1L << exponent);
+        return TimeSpan.FromTicks(Math.Min(ticks, MaxReconnectDelay.Ticks));
+    }
+
+    private void ResetReconnectBackoff()
+    {
+        _reconnectFailureCount = 0;
+        _nextReconnectAttemptAt = DateTimeOffset.MinValue;
+    }
+
+    private void EmitDisconnectedAlert(string summary, ChannelConnectFailureKind failureKind)
+    {
+        _notificationSink.Emit(OperationalAlert.Create(
+            _timeProvider,
+            "channel.disconnected",
+            AlertType.ChannelDisconnected,
+            summary,
+            AlertSeverity.Warning,
+            source: "slack",
+            context: new Dictionary<string, string>
+            {
+                ["channel"] = "slack",
+                ["failure_kind"] = failureKind.ToString(),
+            }));
+    }
+
+    private void EmitReconnectedAlert()
+    {
+        _notificationSink.Emit(OperationalAlert.Create(
+            _timeProvider,
+            "channel.reconnected",
+            AlertType.ChannelReconnected,
+            "Slack channel reconnected.",
+            AlertSeverity.Info,
+            source: "slack",
+            context: new Dictionary<string, string>
+            {
+                ["channel"] = "slack",
+            }));
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        // Stop the background reconnect loop before tearing down the transport.
+        // Stop the connection supervisor before transport disposal.
         await _lifetimeCts.CancelAsync();
-        if (_reconnectTask is { } reconnectTask)
+        if (_connectionSupervisorTask is { } connectionSupervisorTask)
         {
             try
             {
-                await reconnectTask;
+                await connectionSupervisorTask;
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Reconnect loop ended with an error during shutdown.");
+                _logger.LogDebug(ex, "Connection supervisor ended with an error during shutdown.");
             }
         }
 

--- a/src/Netclaw.Configuration/OperationalAlert.cs
+++ b/src/Netclaw.Configuration/OperationalAlert.cs
@@ -39,8 +39,9 @@ public enum AlertType
     UpdateAvailable,
     MemoryEmbeddingModelUnavailable,
     MemoryRelevanceModelUnavailable,
-    // Appended at the end so prior ordinal values remain stable.
+    // New values stay at the end so prior ordinal values remain stable.
     ReminderScheduleFailed,
+    ChannelReconnected,
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Read the live Socket Mode state for Slack health.
- Check the connection every five seconds.
- Retry failed connections with a five-minute backoff cap.
- Emit disconnect and recovery alerts.
- Record reconnect attempts in logs and channel metrics.
- Update the operations skill and diagnostics guide.

## Validation

- `dotnet test Netclaw.slnx`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter FullyQualifiedName~SlackChannelHealthContractTests --no-restore`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- The changed Slack files pass `dotnet format --verify-no-changes`.

## Eval note

The local diagnostics eval scored 3/5 on `qwen3:8b`. Two responses asked for details and made no tool call. The runtime and assertion paths completed without errors.

Closes #2087.
Closes #2088.