### PR TITLE
Refactor session tool approval state

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/ToolApprovalStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolApprovalStateTests.cs
@@ -1,0 +1,203 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolApprovalStateTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using Xunit;
+using static Netclaw.Actors.Sessions.SessionProtocol;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public sealed class ToolApprovalStateTests
+{
+    [Fact]
+    public void Resolve_moves_one_call_from_pending_to_resolved()
+    {
+        var state = new ToolApprovalState();
+        var request = CreateRequest("call-1", requestedAtMs: 10);
+
+        var pending = state.Request(request, persistApprovalState: true, recovered: false);
+
+        Assert.Equal(1, state.PendingCount);
+        Assert.Equal(0, state.ResolvedCount);
+        Assert.Equal(ApprovalTurnPhase.Waiting, state.TurnPhase);
+        Assert.Equal(request, pending.Request);
+
+        Assert.True(state.Resolve(request.CallId, ApprovalDecision.ApprovedOnce, out var resolvedPending));
+        Assert.Same(pending, resolvedPending);
+        Assert.Equal(0, state.PendingCount);
+        Assert.Equal(1, state.ResolvedCount);
+        Assert.Equal(ApprovalTurnPhase.Running, state.TurnPhase);
+        Assert.False(state.Resolve(request.CallId, ApprovalDecision.Denied, out _));
+    }
+
+    [Fact]
+    public void Concurrent_requests_wait_until_the_last_call_resolves()
+    {
+        var state = new ToolApprovalState();
+        var first = CreateRequest("call-1", requestedAtMs: 10);
+        var second = CreateRequest("call-2", requestedAtMs: 20);
+
+        state.Request(first, persistApprovalState: true, recovered: true);
+        state.Request(second, persistApprovalState: true, recovered: true);
+
+        Assert.Equal(ApprovalTurnPhase.RecoveredWaiting, state.TurnPhase);
+        Assert.True(state.Resolve(first.CallId, ApprovalDecision.ApprovedOnce, out _));
+        Assert.Equal(ApprovalTurnPhase.RecoveredWaiting, state.TurnPhase);
+        Assert.Equal(1, state.PendingCount);
+
+        Assert.True(state.Resolve(second.CallId, ApprovalDecision.Denied, out _));
+        Assert.Equal(ApprovalTurnPhase.Running, state.TurnPhase);
+        Assert.Equal(0, state.PendingCount);
+        Assert.Equal(2, state.ResolvedCount);
+    }
+
+    [Fact]
+    public void A_repeated_request_replaces_the_resolved_call_state()
+    {
+        var state = new ToolApprovalState();
+        var request = CreateRequest("call-1", requestedAtMs: 10);
+
+        state.Request(request, persistApprovalState: true, recovered: false);
+        Assert.True(state.Resolve(request.CallId, ApprovalDecision.Denied, out _));
+
+        var replacement = request with { RequestedAtMs = 20 };
+        state.Request(replacement, persistApprovalState: true, recovered: false);
+
+        Assert.Equal(1, state.PendingCount);
+        Assert.Equal(0, state.ResolvedCount);
+        Assert.True(state.TryGetPending(request.CallId, out var pending));
+        Assert.Equal(20, pending.Request.RequestedAtMs);
+    }
+
+    [Fact]
+    public void An_incomplete_legacy_request_has_no_turn_authority()
+    {
+        var state = new ToolApprovalState();
+        var request = new ToolApprovalRequested
+        {
+            SessionId = new SessionId("session-1"),
+            CallId = "legacy-call",
+            ToolName = "shell_execute",
+            RequesterPrincipal = PrincipalClassification.TrustedInternal
+        };
+
+        var pending = state.Request(request, persistApprovalState: true, recovered: true);
+
+        Assert.Equal(1, state.PendingCount);
+        Assert.Equal(ApprovalTurnPhase.None, state.TurnPhase);
+        Assert.Null(pending.TurnContext);
+        Assert.Equal("legacy approval event is missing channel type", pending.TurnContextRestoreFailure);
+        Assert.False(state.MarkRedriving(pending));
+    }
+
+    [Fact]
+    public void Approval_turn_transitions_reject_invalid_source_states()
+    {
+        var state = new ToolApprovalState();
+        var request = CreateRequest("call-1", requestedAtMs: 10);
+        var pending = state.Request(request, persistApprovalState: true, recovered: true);
+
+        Assert.True(state.MarkAbandoning());
+        Assert.Equal(ApprovalTurnPhase.Abandoning, state.TurnPhase);
+        Assert.False(state.MarkAbandoning());
+        Assert.False(state.MarkRedriving(pending));
+
+        state.ClearCalls();
+        state.ClearTurn();
+        pending = state.Request(request, persistApprovalState: true, recovered: true);
+        Assert.True(state.Resolve(request.CallId, ApprovalDecision.ApprovedOnce, out _));
+        Assert.True(state.MarkRedriving(pending));
+        Assert.Equal(ApprovalTurnPhase.Redriving, state.TurnPhase);
+
+        state.MarkRunningAfterRedrive();
+        Assert.Equal(ApprovalTurnPhase.Running, state.TurnPhase);
+    }
+
+    [Fact]
+    public void Latest_pending_request_uses_the_durable_request_time()
+    {
+        var state = new ToolApprovalState();
+        state.Request(CreateRequest("newer", requestedAtMs: 20), persistApprovalState: true, recovered: true);
+        state.Request(CreateRequest("older", requestedAtMs: 10), persistApprovalState: true, recovered: true);
+
+        var latest = state.FindLatestPending(static _ => true);
+
+        Assert.NotNull(latest);
+        Assert.Equal("newer", latest.Request.CallId);
+    }
+
+    [Fact]
+    public void Redrive_plan_uses_only_resolved_calls()
+    {
+        var state = new ToolApprovalState();
+        var approved = CreateRequest("call-approved", requestedAtMs: 10);
+        var denied = CreateRequest("call-denied", requestedAtMs: 20) with
+        {
+            SessionScratchDirectory = "/session/tmp"
+        };
+        var pending = CreateRequest("call-pending", requestedAtMs: 30);
+
+        state.Request(approved, persistApprovalState: true, recovered: true);
+        state.Request(denied, persistApprovalState: true, recovered: true);
+        state.Request(pending, persistApprovalState: true, recovered: true);
+        Assert.True(state.Resolve(approved.CallId, ApprovalDecision.ApprovedOnce, out _));
+        Assert.True(state.Resolve(denied.CallId, ApprovalDecision.Denied, out _));
+
+        var plan = state.BuildRedrivePlan([approved.CallId, denied.CallId, pending.CallId]);
+
+        Assert.NotNull(plan.OneTimeApprovalPreSeed);
+        Assert.NotNull(plan.DecisionOverride);
+        Assert.NotNull(plan.SessionScratchDenialDirectories);
+        Assert.NotNull(plan.AuthorizationAttemptIds);
+        Assert.Equal(approved.Patterns, plan.OneTimeApprovalPreSeed[approved.CallId]);
+        Assert.Equal(ApprovalDecision.Denied, plan.DecisionOverride[denied.CallId]);
+        Assert.Equal("/session/tmp", plan.SessionScratchDenialDirectories[denied.CallId]);
+        var attempts = plan.AuthorizationAttemptIds;
+        Assert.Equal(approved.AuthorizationAttemptId, attempts[approved.CallId].Value);
+        Assert.Equal(denied.AuthorizationAttemptId, attempts[denied.CallId].Value);
+        Assert.False(attempts.ContainsKey(pending.CallId));
+    }
+
+    private static ToolApprovalRequested CreateRequest(string callId, long requestedAtMs)
+    {
+        var context = new TurnContext
+        {
+            SessionId = new SessionId("session-1"),
+            TurnId = new TurnId("turn-1"),
+            Audience = TrustAudience.Personal,
+            Boundary = TrustBoundary.Personal,
+            ChannelType = ChannelType.Slack,
+            RequesterSenderId = new SenderId("user-1"),
+            RequesterPrincipal = PrincipalClassification.TrustedInternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Trusted),
+            SupportsInteractiveApproval = true
+        };
+        var authorizationAttemptId = AuthorizationAttemptId.New();
+
+        return new ToolApprovalRequested
+        {
+            SessionId = context.SessionId,
+            CallId = callId,
+            AuthorizationAttemptId = authorizationAttemptId.Value,
+            ToolName = "shell_execute",
+            Patterns = ["git status"],
+            CandidateVerbs = ["git"],
+            Audience = context.Audience,
+            Boundary = context.Boundary,
+            ChannelType = context.ChannelType?.ToWireValue(),
+            SupportsInteractiveApproval = context.SupportsInteractiveApproval,
+            RequesterSenderId = context.RequesterSenderId,
+            RequesterPrincipal = context.RequesterPrincipal,
+            Cwd = "/repo",
+            OptionKeys = [ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.Deny],
+            TurnContext = context.ToRecord(),
+            RequestedAtMs = requestedAtMs
+        };
+    }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -80,8 +80,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // In-flight reminder/background-job dedup (transient; rebuilt from journal on recovery).
     private readonly InFlightTurnDedup _inFlightDedup = new();
     private readonly SessionSubscriberManager _subscribers = new();
-    private readonly Dictionary<string, PendingToolInteraction> _pendingToolInteractions = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, ResolvedToolApproval> _resolvedToolApprovals = new(StringComparer.Ordinal);
+    private readonly ToolApprovalState _toolApprovals = new();
     // Live-only coordination for the currently executing streamed tool batch.
     // Durable recovery derives unanswered calls from _state.History.
     private readonly ActiveToolBatchTracker _activeToolBatch = new();
@@ -92,7 +91,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private TurnContext? _currentTurnContext;
     private readonly SessionScratchCorrectionState _sessionScratchCorrections = new();
     private bool _processingStateActive;
-    private ApprovalTurnState _approvalTurnState = ApprovalTurnState.None;
     private readonly ToolRegistry? _fullRegistry;
     private readonly ToolAccessPolicy? _toolAccessPolicy;
     private readonly TrustContextDeriver? _trustContextDeriver;
@@ -280,8 +278,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Recover<TurnRecorded>(evt =>
         {
             ApplyTurnRecorded(evt);
-            _pendingToolInteractions.Clear();
-            _resolvedToolApprovals.Clear();
+            _toolApprovals.ClearCalls();
             ClearApprovalTurnState();
             ClearActiveToolBatchTracking();
         });
@@ -290,8 +287,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Recover<SessionCompacted>(evt =>
         {
             _state = _state.Apply(evt);
-            _pendingToolInteractions.Clear();
-            _resolvedToolApprovals.Clear();
+            _toolApprovals.ClearCalls();
             ClearApprovalTurnState();
             ClearActiveToolBatchTracking();
         });
@@ -432,18 +428,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // rehydrates the session and re-drives the parked batch, the same
             // path that already covers daemon restarts. Keeping the actor in
             // memory while a human decides buys nothing but resident memory.
-            if (_pendingToolInteractions.Count > 0)
+            if (_toolApprovals.PendingCount > 0)
             {
                 _log.Info(
                     "Session idle with {PendingApprovalCount} journaled approval(s) outstanding; passivating — an approval response will rehydrate and resume",
-                    _pendingToolInteractions.Count);
+                    _toolApprovals.PendingCount);
             }
 
-            if (_resolvedToolApprovals.Count > 0)
+            if (_toolApprovals.ResolvedCount > 0)
             {
                 _log.Info(
                     "Session idle with {ResolvedApprovalCount} resolved approval(s) but no completed tool result; abandoning parked tool batch before passivation",
-                    _resolvedToolApprovals.Count);
+                    _toolApprovals.ResolvedCount);
                 var abandoned = BuildToolBatchAbandonedEvent(
                     "Tool call was not completed — the session became idle before the approved action completed.");
                 Persist(abandoned, evt =>
@@ -1038,8 +1034,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        _pendingToolInteractions.Clear();
-        _resolvedToolApprovals.Clear();
+        _toolApprovals.ClearCalls();
         TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
             _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolIterationsPerTurn, msg.ToolResults.Count);
         MarkApprovalRunningAfterRedrive();
@@ -2266,14 +2261,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // approval gate means the user abandoned that approval. This is only
         // reachable on a cold-recovered session — a live session parked on
         // approval is in Processing, not Ready — so a non-empty
-        // _pendingToolInteractions here is the cold-recovery signal. Close the
+        // Pending approval state here is the cold-recovery signal. Close the
         // orphaned tool_use blocks before the new turn's LLM call: an assistant
         // tool_use with no matching tool_result is rejected by the provider
         // API, which would otherwise wedge every subsequent turn.
-        if (_pendingToolInteractions.Count > 0)
+        if (_toolApprovals.PendingCount > 0)
         {
-            if (_approvalTurnState is WaitingApprovalTurn waiting)
-                _approvalTurnState = new AbandoningApprovalTurn(waiting.Context, "superseded_by_new_message");
+            _toolApprovals.MarkAbandoning();
             var abandoned = BuildToolBatchAbandonedEvent();
             Persist(abandoned, evt =>
             {
@@ -2283,7 +2277,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        if (_resolvedToolApprovals.Count > 0)
+        if (_toolApprovals.ResolvedCount > 0)
         {
             var abandoned = BuildResolvedToolBatchInterruptedByRestartEvent();
             Persist(abandoned, evt =>
@@ -2318,7 +2312,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _sessionId,
             _activeTurnId ?? new Protocol.TurnId(IdGen.ShortId()),
             cmd.Source);
-        _approvalTurnState = new RunningApprovalTurn(_currentTurnContext);
+        _toolApprovals.StartTurn(_currentTurnContext);
         _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(_currentTurnContext);
         PersistAdoptedContextIfNeeded(cmd.Source);
 
@@ -3614,79 +3608,43 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void ApplyToolApprovalRequested(ToolApprovalRequested evt, bool persistApprovalState)
     {
-        var turnContext = ToolApprovalTurnContext.Restore(evt, out var restoreFailure);
-        var authorizationAttemptId = ToolApprovalTurnContext.RestoreAuthorizationAttemptId(evt);
-        _pendingToolInteractions[evt.CallId] = new PendingToolInteraction(
-            evt.CallId,
-            authorizationAttemptId,
-            evt.ToolName,
-            evt.Patterns,
-            evt.CandidateVerbs,
-            evt.Audience,
-            evt.Boundary,
-            evt.ChannelType,
-            evt.SupportsInteractiveApproval,
-            evt.RequesterSenderId?.Value,
-            evt.RequesterPrincipal,
-            evt.HasThirdPartyAdoptedContext,
-            evt.AdoptedSpeakerIds,
-            evt.Cwd,
-            evt.RequestedAtMs,
+        var pending = _toolApprovals.Request(
+            evt,
             persistApprovalState,
-            turnContext,
-            restoreFailure,
-            evt.OptionKeys,
-            evt.Candidates,
-            evt.SessionScratchDirectory);
-        _resolvedToolApprovals.Remove(evt.CallId);
+            recovered: _phase.Current == SessionPhase.Recovering);
 
         _log.Info(
             "Tool approval requested authorizationAttemptId={AuthorizationAttemptId} " +
             "sessionId={SessionId} callId={CallId} toolName={ToolName}",
-            authorizationAttemptId.Value,
+            pending.AuthorizationAttemptId.Value,
             _sessionId.Value,
             evt.CallId,
             evt.ToolName);
 
-        if (persistApprovalState && turnContext is not null)
-            RecordWaitingApprovalState(turnContext, evt.CallId, recovered: _phase.Current == SessionPhase.Recovering);
-        else if (persistApprovalState && restoreFailure is not null)
+        if (persistApprovalState && pending.TurnContext is { } turnContext)
+            _currentTurnContext = turnContext;
+        else if (persistApprovalState && pending.TurnContextRestoreFailure is { } restoreFailure)
             _log.Warning(
                 "Approval request {CallId} could not restore turn context: {Reason}",
                 evt.CallId,
                 restoreFailure);
     }
 
-    private void RecordWaitingApprovalState(TurnContext context, string callId, bool recovered)
+    private bool MarkApprovalRedrive(PendingToolInteraction pending)
     {
-        var pendingCallIds = _approvalTurnState is WaitingApprovalTurn waiting
-            ? new HashSet<string>(waiting.PendingCallIds, StringComparer.Ordinal)
-            : new HashSet<string>(StringComparer.Ordinal);
-        pendingCallIds.Add(callId);
-
-        _currentTurnContext = context;
-        _approvalTurnState = new WaitingApprovalTurn(context, pendingCallIds, recovered);
-    }
-
-    private void MarkApprovalRedrive(PendingToolInteraction pending, string callId)
-    {
-        if (pending.TurnContext is null)
-            return;
+        if (!_toolApprovals.MarkRedriving(pending))
+            return false;
 
         _currentTurnContext = pending.TurnContext;
-        _approvalTurnState = new RedrivingApprovalTurn(pending.TurnContext, callId);
+        return true;
     }
 
-    private void MarkApprovalRunningAfterRedrive()
-    {
-        if (_approvalTurnState is RedrivingApprovalTurn redriving)
-            _approvalTurnState = new RunningApprovalTurn(redriving.Context);
-    }
+    private void MarkApprovalRunningAfterRedrive() => _toolApprovals.MarkRunningAfterRedrive();
 
     private void ClearApprovalTurnState()
     {
         _sessionScratchCorrections.Clear();
-        _approvalTurnState = ApprovalTurnState.None;
+        _toolApprovals.ClearTurn();
         _currentTurnContext = null;
     }
 
@@ -3696,13 +3654,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ? parsed
             : ApprovalDecision.Denied;
 
-        if (_pendingToolInteractions.Remove(evt.CallId, out var pending))
-        {
-            _resolvedToolApprovals[evt.CallId] = new ResolvedToolApproval(pending, decision);
-
-            if (_pendingToolInteractions.Count == 0 && pending.TurnContext is not null)
-                _approvalTurnState = new RunningApprovalTurn(pending.TurnContext);
-        }
+        _toolApprovals.Resolve(evt.CallId, decision, out _);
     }
 
     private void ApplyToolBatchAbandoned(ToolBatchAbandoned evt)
@@ -3714,8 +3666,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 ToolResult = result,
                 RecordedAtMs = evt.AbandonedAtMs
             });
-        _pendingToolInteractions.Clear();
-        _resolvedToolApprovals.Clear();
+        _toolApprovals.ClearCalls();
         ClearApprovalTurnState();
         ClearActiveToolBatchTracking();
     }
@@ -3737,8 +3688,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // SessionSnapshot intentionally excludes parked approval state. Writing a
         // snapshot while an assistant tool_use is unanswered would let recovery
         // skip the journal event that rehydrates pending approval context.
-        if (_pendingToolInteractions.Count > 0
-            || _resolvedToolApprovals.Count > 0
+        if (_toolApprovals.PendingCount > 0
+            || _toolApprovals.ResolvedCount > 0
             || ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, null) is not null)
         {
             _log.Info("Skipping snapshot while approval-paused tool batch is still unresolved");
@@ -3862,7 +3813,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     };
 
     private bool HasApprovalHistory
-        => _resolvedToolApprovals.Count > 0
+        => _toolApprovals.ResolvedCount > 0
         || ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, null) is not null;
 
     /// <summary>
@@ -3887,7 +3838,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// </summary>
     private string ClassifyUnknownApprovalCall(string callId)
     {
-        if (_resolvedToolApprovals.ContainsKey(callId))
+        if (_toolApprovals.HasResolved(callId))
             return "already_resolved";
 
         if (ParkedToolBatchHistory.HasToolResult(_state.History, callId))
@@ -3938,14 +3889,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Legacy journal entries created before option persistence landed have
         // an empty OptionKeys list. Skip this check for that concrete recovery
         // path only; live prompts always persist their offered option keys.
-        if (pending.OptionKeys.Count > 0
-            && !pending.OptionKeys.Any(key => string.Equals(key, msg.SelectedKey.Value, StringComparison.Ordinal)))
+        if (pending.Request.OptionKeys.Count > 0
+            && !pending.Request.OptionKeys.Any(key => string.Equals(key, msg.SelectedKey.Value, StringComparison.Ordinal)))
         {
             _log.Warning(
                 "Ignoring unavailable approval option {SelectedKey} for call {CallId}; offered options were [{OptionKeys}]",
                 msg.SelectedKey,
                 msg.CallId,
-                string.Join(", ", pending.OptionKeys));
+                string.Join(", ", pending.Request.OptionKeys));
             EmitUnavailableApprovalOptionNotice();
             return (null, ApprovalNackReasons.OptionUnavailable);
         }
@@ -4006,7 +3957,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var pending = ResolveLatestPendingApprovalForSender(msg.SenderId);
         if (pending is null)
         {
-            if (_pendingToolInteractions.Count == 0)
+            if (_toolApprovals.PendingCount == 0)
             {
                 if (HasApprovalHistory)
                 {
@@ -4034,8 +3985,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return false;
         }
 
-        var optionKeys = pending.OptionKeys.Count > 0
-            ? pending.OptionKeys
+        var optionKeys = pending.Request.OptionKeys.Count > 0
+            ? pending.Request.OptionKeys
             :
             [
                 ApprovalOptionKeys.ApproveOnce,
@@ -4047,7 +3998,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var options = optionKeys
             .Select(key => new ToolInteractionOption(
                 new ApprovalOptionKey(key),
-                ApprovalOptionKeys.LabelFor(key, new ToolName(pending.ToolName).IsMcp)))
+                ApprovalOptionKeys.LabelFor(key, new ToolName(pending.Request.ToolName).IsMcp)))
             .ToArray();
 
         if (!ToolInteractionResponseParser.TryParseApprovalResponse(msg.Text, options, out var selectedKey)
@@ -4056,8 +4007,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _log.Warning(
                 "Ignoring unparseable text tool interaction response '{Text}' for call {CallId}; offered options were [{OptionKeys}]",
                 msg.Text,
-                pending.CallId,
-                string.Join(", ", pending.OptionKeys));
+                pending.Request.CallId,
+                string.Join(", ", pending.Request.OptionKeys));
             EmitUnavailableApprovalOptionNotice();
             nackReason = ApprovalNackReasons.OptionUnavailable;
             return false;
@@ -4066,7 +4017,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         structured = new ToolInteractionResponse
         {
             SessionId = msg.SessionId,
-            CallId = new ToolCallId(pending.CallId),
+            CallId = new ToolCallId(pending.Request.CallId),
             SelectedKey = new ApprovalOptionKey(selectedKey),
             SenderId = msg.SenderId
         };
@@ -4074,10 +4025,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     private PendingToolInteraction? ResolveLatestPendingApprovalForSender(SenderId senderId)
-        => _pendingToolInteractions.Values
-            .Where(pending => CanApprovePending(pending, senderId))
-            .OrderBy(pending => pending.RequestedAtMs)
-            .LastOrDefault();
+        => _toolApprovals.FindLatestPending(pending => CanApprovePending(pending, senderId));
 
     private static bool CanApprovePending(PendingToolInteraction pending, SenderId senderId)
         => TryGetApprovalAuthority(pending, out var principal, out var requesterSenderId, out _)
@@ -4104,8 +4052,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return true;
         }
 
-        requesterPrincipal = pending.RequesterPrincipal;
-        requesterSenderId = pending.RequesterSenderId;
+        requesterPrincipal = pending.Request.RequesterPrincipal;
+        requesterSenderId = pending.Request.RequesterSenderId?.Value;
         if (pending.TurnContextRestoreFailure is not null)
         {
             failure = pending.TurnContextRestoreFailure;
@@ -4125,7 +4073,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private async Task HandleProcessingApprovalResponseAsync(ToolInteractionResponse msg)
     {
-        if (!_pendingToolInteractions.TryGetValue(msg.CallId.Value, out var pending))
+        if (!_toolApprovals.TryGetPending(msg.CallId.Value, out var pending))
         {
             _log.Warning("Ignoring tool interaction response for unknown call {CallId}", msg.CallId);
             TryReplyNack(ApprovalNackReasons.PromptExpired);
@@ -4160,7 +4108,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             claimedWait = approvalWait;
 
             if (!pending.PersistApprovalState)
-                _pendingToolInteractions.Remove(msg.CallId.Value);
+                _toolApprovals.RemovePending(msg.CallId.Value);
 
             await PersistApprovalGrantIfNeededAsync(pending, decision, CancellationToken.None);
 
@@ -4219,7 +4167,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         var callId = msg.CallId.Value;
 
-        if (!_pendingToolInteractions.TryGetValue(callId, out var pending))
+        if (!_toolApprovals.TryGetPending(callId, out var pending))
         {
             // No persisted pending record — there is no turn context and no Patterns to
             // pre-seed an ApprovedOnce re-drive. Whether or not the history
@@ -4238,7 +4186,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var classification = ClassifyUnknownApprovalCall(callId);
             _log.Warning(
                 "Tool interaction response for unknown/expired call {CallId} ({Classification}); pending={PendingCount} resolved={ResolvedCount}",
-                msg.CallId, classification, _pendingToolInteractions.Count, _resolvedToolApprovals.Count);
+                msg.CallId, classification, _toolApprovals.PendingCount, _toolApprovals.ResolvedCount);
             EmitExpiredPromptNotice();
             TryReplyNack(ApprovalNackReasons.PromptExpired);
             return;
@@ -4309,7 +4257,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return ApprovalRedriveOutcome.Failed;
         }
 
-        if (assistantMsg.ToolCalls.Any(tc => _pendingToolInteractions.ContainsKey(tc.CallId.Value)))
+        if (assistantMsg.ToolCalls.Any(tc => _toolApprovals.HasPending(tc.CallId.Value)))
         {
             _log.Info(
                 "Deferring parked tool batch re-drive for call {CallId}: sibling approval(s) still pending",
@@ -4317,7 +4265,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return ApprovalRedriveOutcome.Deferred;
         }
 
-        if (!_resolvedToolApprovals.TryGetValue(callId, out var resolved))
+        if (!_toolApprovals.TryGetResolved(callId, out var resolved))
         {
             _log.Warning(
                 "Cannot re-drive tool batch for call {CallId}: approval decision was not recoverable",
@@ -4326,7 +4274,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return ApprovalRedriveOutcome.Failed;
         }
 
-        var redrivePlan = BuildApprovalRedrivePlan(assistantMsg);
+        var redrivePlan = _toolApprovals.BuildRedrivePlan(
+            assistantMsg.ToolCalls.Select(static call => call.CallId.Value));
         if (RedriveToolBatchForApproval(callId, resolved.Pending, redrivePlan))
             return ApprovalRedriveOutcome.Started;
 
@@ -4338,15 +4287,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private bool AbandonResolvedToolBatchAfterRecovery()
     {
-        if (_resolvedToolApprovals.Count == 0)
+        if (_toolApprovals.ResolvedCount == 0)
             return false;
 
-        if (_pendingToolInteractions.Count > 0)
+        if (_toolApprovals.PendingCount > 0)
             return false;
 
         _log.Info(
             "Abandoning recovered parked tool batch with {ResolvedApprovalCount} resolved approval(s) after restart",
-            _resolvedToolApprovals.Count);
+            _toolApprovals.ResolvedCount);
         var abandoned = BuildResolvedToolBatchInterruptedByRestartEvent();
         Persist(abandoned, ApplyToolBatchAbandoned);
 
@@ -4365,8 +4314,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     private bool HasInterruptedToolBatchAfterRecovery()
-        => _pendingToolInteractions.Count == 0
-        && _resolvedToolApprovals.Count == 0
+        => _toolApprovals.PendingCount == 0
+        && _toolApprovals.ResolvedCount == 0
         && ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, null) is not null;
 
     private ToolBatchAbandoned BuildResolvedToolBatchInterruptedByRestartEvent()
@@ -4376,60 +4325,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private ToolBatchAbandoned BuildInterruptedToolBatchAfterRecoveryEvent()
         => BuildToolBatchAbandonedEvent(
             "Tool call was not completed — the session restarted before the action completed.");
-
-    private ApprovalRedrivePlan BuildApprovalRedrivePlan(SerializableChatMessage assistantMessage)
-    {
-        // Approval redrive is only for a live actor processing a fresh click
-        // after the original tool-loop task is gone. If replay shows an approval
-        // was already resolved before restart but no tool result was recorded,
-        // we abandon the parked batch instead of replaying side effects.
-        var preSeed = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
-        var decisionOverride = new Dictionary<string, ApprovalDecision>(StringComparer.Ordinal);
-        var sessionScratchDenialDirectories = new Dictionary<string, string>(StringComparer.Ordinal);
-        var authorizationAttemptIds = new Dictionary<string, AuthorizationAttemptId>(StringComparer.Ordinal);
-        foreach (var call in assistantMessage.ToolCalls)
-        {
-            if (!_resolvedToolApprovals.TryGetValue(call.CallId.Value, out var resolved))
-                continue;
-
-            authorizationAttemptIds[call.CallId.Value] = resolved.Pending.AuthorizationAttemptId;
-
-            if (resolved.Decision.IsApprovalGrant())
-            {
-                // Pre-seed the one-time bypass for the just-approved call so the
-                // re-drive runs it once even when its durable grant (if any) does
-                // not cover every candidate verb — e.g. a piped command's standalone
-                // verbs (base64, head) are never persisted directory-scoped.
-                // ApprovedOnce has no durable grant at all; broader scopes still
-                // record their durable grant separately. This only authorizes the
-                // immediate re-drive, matching the live pipeline and the sub-agent.
-                // See https://github.com/netclaw-dev/netclaw/issues/1802.
-                preSeed[call.CallId.Value] = OneTimeApprovalKeys.Create(
-                    resolved.Pending.Patterns,
-                    resolved.Pending.Candidates,
-                    resolved.Pending.Cwd);
-            }
-
-            if (resolved.Decision is ApprovalDecision.Denied or ApprovalDecision.TimedOut)
-            {
-                // Denials and timeouts still need a tool_result so provider
-                // history stays well-formed, but the reconstructed dispatch
-                // must not execute the tool or ask for approval again.
-                decisionOverride[call.CallId.Value] = resolved.Decision;
-                if (resolved.Decision == ApprovalDecision.Denied
-                    && resolved.Pending.SessionScratchDirectory is { Length: > 0 } scratchDirectory)
-                {
-                    sessionScratchDenialDirectories[call.CallId.Value] = scratchDirectory;
-                }
-            }
-        }
-
-        return new ApprovalRedrivePlan(
-            preSeed.Count == 0 ? null : preSeed,
-            decisionOverride.Count == 0 ? null : decisionOverride,
-            sessionScratchDenialDirectories.Count == 0 ? null : sessionScratchDenialDirectories,
-            authorizationAttemptIds.Count == 0 ? null : authorizationAttemptIds);
-    }
 
     /// <summary>
     /// Re-drives the parked tool batch after an approval decision was applied
@@ -4464,7 +4359,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var toolCalls = aiMessage.Contents
             .OfType<FunctionCallContent>()
             .Where(tc => !ParkedToolBatchHistory.HasToolResult(_state.History, tc.CallId)
-                && (tc.CallId == callId || !_pendingToolInteractions.ContainsKey(tc.CallId)))
+                && (tc.CallId == callId || !_toolApprovals.HasPending(tc.CallId)))
             .ToList();
         if (toolCalls.Count == 0)
         {
@@ -4489,10 +4384,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return false;
         }
 
-        _currentTurnContext = turnContext;
+        if (!MarkApprovalRedrive(pending))
+        {
+            _log.Warning(
+                "Cannot re-drive tool batch for call {CallId}: approval turn phase is {ApprovalTurnPhase}",
+                callId,
+                _toolApprovals.TurnPhase);
+            EmitExpiredPromptNotice();
+            return false;
+        }
+
         _currentTrustContext = _trustContextDeriver?.DeriveFromTurnContext(turnContext);
         BindTurnTelemetry(turnContext);
-        MarkApprovalRedrive(pending, callId);
 
         TransitionTo(SessionPhase.Processing);
         DispatchToolBatch(
@@ -4510,7 +4413,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// <see cref="Protocol.ChatRole.Tool"/> result for every unanswered tool
     /// call in the tail assistant message so history stays well-formed — an
     /// assistant tool_use with no matching tool_result is rejected by the
-    /// provider API — then clears <see cref="_pendingToolInteractions"/>.
+    /// provider API — then clears the actor-local approval state.
     /// </summary>
     private ToolBatchAbandoned BuildToolBatchAbandonedEvent()
         => BuildToolBatchAbandonedEvent(
@@ -4545,8 +4448,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         CancelAndDisposeLlmCts();
         CancelAndDisposeToolExecutionCts();
         _deliveryRetry.Clear();
-        _pendingToolInteractions.Clear();
-        _resolvedToolApprovals.Clear();
+        _toolApprovals.ClearCalls();
         ClearApprovalTurnState();
         _state = _state.AddErrorReply(errorMessage);
 
@@ -4595,20 +4497,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var persistent = decision is ApprovalDecision.ApprovedAlways
             or ApprovalDecision.ApprovedEverywhere;
         var globalWildcard = decision == ApprovalDecision.ApprovedEverywhere;
-        var audience = pending.TurnContext?.Audience ?? pending.Audience;
+        var request = pending.Request;
+        var audience = pending.TurnContext?.Audience ?? request.Audience;
 
         // Prefer per-clause Candidates so we can use each clause's extracted
         // path argument as the directory half. Fall back to the verb-only
         // CandidateVerbs list for older callers (or non-shell tools whose
         // matcher doesn't populate Candidates).
-        if (pending.Candidates.Count == 0)
+        if (request.Candidates.Count == 0)
         {
-            var fallbackCwd = globalWildcard ? null : pending.Cwd;
+            var fallbackCwd = globalWildcard ? null : request.Cwd;
             await _approvalService.RecordApprovalAsync(
                 (ToolApprovalSessionId)_sessionId.Value,
                 audience,
-                new ToolName(pending.ToolName),
-                pending.CandidateVerbs,
+                new ToolName(request.ToolName),
+                request.CandidateVerbs,
                 persistent,
                 fallbackCwd,
                 ct);
@@ -4631,20 +4534,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var sessionDirectory = GetSessionDirectory();
         var grantContext = ApprovalGrantContext.FromDecision(
             decision,
-            pending.Cwd,
+            request.Cwd,
             sessionDirectory);
 
         if (_approvalService is IStructuredToolApprovalService structuredApprovalService)
         {
             var grants = ApprovalBucketBuilder.BuildGrants(
-                pending.Candidates,
+                request.Candidates,
                 grantContext);
             if (grants.Count > 0)
             {
                 await structuredApprovalService.RecordApprovalCandidatesAsync(
                     (ToolApprovalSessionId)_sessionId.Value,
                     audience,
-                    new ToolName(pending.ToolName),
+                    new ToolName(request.ToolName),
                     grants,
                     persistent,
                     ct);
@@ -4654,7 +4557,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
 
         var grouping = ApprovalBucketBuilder.Build(
-            pending.Candidates,
+            request.Candidates,
             grantContext);
 
         foreach (var (key, verbs) in grouping)
@@ -4669,7 +4572,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             await _approvalService.RecordApprovalAsync(
                 (ToolApprovalSessionId)_sessionId.Value,
                 audience,
-                new ToolName(pending.ToolName),
+                new ToolName(request.ToolName),
                 verbs,
                 persistent,
                 directory,
@@ -4899,8 +4802,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        _pendingToolInteractions.Clear();
-        _resolvedToolApprovals.Clear();
+        _toolApprovals.ClearCalls();
         ClearActiveToolBatchTracking();
         TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
             _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolIterationsPerTurn, resultCount);

--- a/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
+++ b/src/Netclaw.Actors/Sessions/ToolApprovalState.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -14,35 +15,26 @@ using static Netclaw.Actors.Sessions.SessionProtocol;
 namespace Netclaw.Actors.Sessions;
 
 internal sealed record PendingToolInteraction(
-    // Tool call id of the parked invocation. Carried explicitly (not just as
-    // the _pendingToolInteractions dictionary key) so the record can be
-    // persisted in a flat repeated list in the session snapshot.
-    string CallId,
+    ToolApprovalRequested Request,
     AuthorizationAttemptId AuthorizationAttemptId,
-    string ToolName,
-    IReadOnlyList<string> Patterns,
-    IReadOnlyList<string> CandidateVerbs,
-    TrustAudience Audience,
-    TrustBoundary? Boundary,
-    string? ChannelType,
-    bool? SupportsInteractiveApproval,
-    string? RequesterSenderId,
-    PrincipalClassification? RequesterPrincipal,
-    bool HasThirdPartyAdoptedContext,
-    IReadOnlyList<string> AdoptedSpeakerIds,
-    string? Cwd,
-    long RequestedAtMs,
     bool PersistApprovalState,
     TurnContext? TurnContext,
-    string? TurnContextRestoreFailure,
-    // Option keys that were actually offered to the user when the prompt was
-    // rendered. Persisted so a later response cannot select a pruned scope.
-    IReadOnlyList<string> OptionKeys,
-    // Per-clause (verb, directory) pairs preserved across the pause-for-approval
-    // round trip so persistent approvals can write folder-scoped grants from the
-    // path arguments the agent originally passed, rather than collapsing to cwd.
-    IReadOnlyList<ApprovalCandidate> Candidates,
-    string? SessionScratchDirectory) : INoSerializationVerificationNeeded;
+    string? TurnContextRestoreFailure) : INoSerializationVerificationNeeded
+{
+    public static PendingToolInteraction From(
+        ToolApprovalRequested evt,
+        bool persistApprovalState)
+    {
+        var turnContext = ToolApprovalTurnContext.Restore(evt, out var restoreFailure);
+        var authorizationAttemptId = ToolApprovalTurnContext.RestoreAuthorizationAttemptId(evt);
+        return new PendingToolInteraction(
+            evt,
+            authorizationAttemptId,
+            persistApprovalState,
+            turnContext,
+            restoreFailure);
+    }
+}
 
 // Internal actor message for approval prompts. The request is the public output
 // shape; PersistApprovalState is session routing policy that decides whether the
@@ -54,23 +46,15 @@ internal sealed record ToolInteractionRequestDispatch(
     internal string? SessionScratchDirectory { get; init; }
 }
 
-internal abstract record ApprovalTurnState : INoSerializationVerificationNeeded
+internal enum ApprovalTurnPhase
 {
-    public static ApprovalTurnState None { get; } = new NoActiveApprovalTurn();
+    None,
+    Running,
+    Waiting,
+    RecoveredWaiting,
+    Redriving,
+    Abandoning
 }
-
-internal sealed record NoActiveApprovalTurn : ApprovalTurnState;
-
-internal sealed record RunningApprovalTurn(TurnContext Context) : ApprovalTurnState;
-
-internal sealed record WaitingApprovalTurn(
-    TurnContext Context,
-    ISet<string> PendingCallIds,
-    bool Recovered) : ApprovalTurnState;
-
-internal sealed record RedrivingApprovalTurn(TurnContext Context, string CallId) : ApprovalTurnState;
-
-internal sealed record AbandoningApprovalTurn(TurnContext Context, string Reason) : ApprovalTurnState;
 
 internal sealed record ApprovalRedrivePlan(
     IReadOnlyDictionary<string, IReadOnlyList<string>>? OneTimeApprovalPreSeed,
@@ -78,9 +62,213 @@ internal sealed record ApprovalRedrivePlan(
     IReadOnlyDictionary<string, string>? SessionScratchDenialDirectories,
     IReadOnlyDictionary<string, AuthorizationAttemptId>? AuthorizationAttemptIds);
 
+internal abstract record ToolApprovalCallState(PendingToolInteraction Pending);
+
+internal sealed record PendingToolApproval(PendingToolInteraction Pending)
+    : ToolApprovalCallState(Pending);
+
 internal sealed record ResolvedToolApproval(
     PendingToolInteraction Pending,
-    ApprovalDecision Decision);
+    ApprovalDecision Decision) : ToolApprovalCallState(Pending);
+
+/// <summary>
+/// Owns all actor-local approval state for one session.
+/// Durable events remain the source of truth after recovery.
+/// </summary>
+internal sealed class ToolApprovalState
+{
+    private readonly Dictionary<string, ToolApprovalCallState> _calls = new(StringComparer.Ordinal);
+
+    public int PendingCount => _calls.Values.Count(static call => call is PendingToolApproval);
+
+    public int ResolvedCount => _calls.Values.Count(static call => call is ResolvedToolApproval);
+
+    public ApprovalTurnPhase TurnPhase { get; private set; }
+
+    public TurnContext? TurnContext { get; private set; }
+
+    public PendingToolInteraction Request(
+        ToolApprovalRequested evt,
+        bool persistApprovalState,
+        bool recovered)
+    {
+        var pending = PendingToolInteraction.From(evt, persistApprovalState);
+        _calls[evt.CallId] = new PendingToolApproval(pending);
+
+        if (persistApprovalState && pending.TurnContext is { } context)
+        {
+            TurnContext = context;
+            TurnPhase = recovered
+                ? ApprovalTurnPhase.RecoveredWaiting
+                : ApprovalTurnPhase.Waiting;
+        }
+
+        return pending;
+    }
+
+    public bool TryGetPending(string callId, out PendingToolInteraction pending)
+    {
+        if (_calls.TryGetValue(callId, out var call)
+            && call is PendingToolApproval pendingCall)
+        {
+            pending = pendingCall.Pending;
+            return true;
+        }
+
+        pending = null!;
+        return false;
+    }
+
+    public bool TryGetResolved(string callId, out ResolvedToolApproval resolved)
+    {
+        if (_calls.TryGetValue(callId, out var call)
+            && call is ResolvedToolApproval resolvedCall)
+        {
+            resolved = resolvedCall;
+            return true;
+        }
+
+        resolved = null!;
+        return false;
+    }
+
+    public bool HasPending(string callId)
+        => _calls.TryGetValue(callId, out var call) && call is PendingToolApproval;
+
+    public bool HasResolved(string callId)
+        => _calls.TryGetValue(callId, out var call) && call is ResolvedToolApproval;
+
+    public bool RemovePending(string callId)
+        => _calls.TryGetValue(callId, out var call)
+           && call is PendingToolApproval
+           && _calls.Remove(callId);
+
+    public bool Resolve(
+        string callId,
+        ApprovalDecision decision,
+        out PendingToolInteraction pending)
+    {
+        if (!TryGetPending(callId, out pending))
+            return false;
+
+        _calls[callId] = new ResolvedToolApproval(pending, decision);
+        if (PendingCount == 0 && pending.TurnContext is { } context)
+        {
+            TurnContext = context;
+            TurnPhase = ApprovalTurnPhase.Running;
+        }
+
+        return true;
+    }
+
+    public PendingToolInteraction? FindLatestPending(
+        Func<PendingToolInteraction, bool> predicate)
+        => _calls.Values
+            .OfType<PendingToolApproval>()
+            .Select(static call => call.Pending)
+            .Where(predicate)
+            .OrderBy(static pending => pending.Request.RequestedAtMs)
+            .LastOrDefault();
+
+    public void StartTurn(TurnContext context)
+    {
+        TurnContext = context;
+        TurnPhase = ApprovalTurnPhase.Running;
+    }
+
+    public bool MarkAbandoning()
+    {
+        if (TurnPhase is not ApprovalTurnPhase.Waiting
+            and not ApprovalTurnPhase.RecoveredWaiting)
+        {
+            return false;
+        }
+
+        TurnPhase = ApprovalTurnPhase.Abandoning;
+        return true;
+    }
+
+    public bool MarkRedriving(PendingToolInteraction pending)
+    {
+        if (TurnPhase is not ApprovalTurnPhase.Running
+            || pending.TurnContext is not { } context)
+        {
+            return false;
+        }
+
+        TurnContext = context;
+        TurnPhase = ApprovalTurnPhase.Redriving;
+        return true;
+    }
+
+    public void MarkRunningAfterRedrive()
+    {
+        if (TurnPhase is not ApprovalTurnPhase.Redriving)
+            return;
+
+        TurnPhase = ApprovalTurnPhase.Running;
+    }
+
+    public ApprovalRedrivePlan BuildRedrivePlan(IEnumerable<string> callIds)
+    {
+        var builder = new ApprovalRedrivePlanBuilder();
+
+        foreach (var callId in callIds)
+        {
+            if (TryGetResolved(callId, out var resolved))
+                builder.Add(callId, resolved);
+        }
+
+        return builder.Build();
+    }
+
+    public void ClearCalls() => _calls.Clear();
+
+    public void ClearTurn()
+    {
+        TurnContext = null;
+        TurnPhase = ApprovalTurnPhase.None;
+    }
+
+    private sealed class ApprovalRedrivePlanBuilder
+    {
+        private readonly Dictionary<string, IReadOnlyList<string>> _preSeed = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, ApprovalDecision> _decisionOverride = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, string> _sessionScratchDenialDirectories = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, AuthorizationAttemptId> _authorizationAttemptIds = new(StringComparer.Ordinal);
+
+        public void Add(string callId, ResolvedToolApproval resolved)
+        {
+            var request = resolved.Pending.Request;
+            _authorizationAttemptIds[callId] = resolved.Pending.AuthorizationAttemptId;
+
+            if (resolved.Decision.IsApprovalGrant())
+            {
+                _preSeed[callId] = OneTimeApprovalKeys.Create(
+                    request.Patterns,
+                    request.Candidates,
+                    request.Cwd);
+            }
+
+            if (resolved.Decision is not (ApprovalDecision.Denied or ApprovalDecision.TimedOut))
+                return;
+
+            _decisionOverride[callId] = resolved.Decision;
+            if (resolved.Decision == ApprovalDecision.Denied
+                && request.SessionScratchDirectory is { Length: > 0 } scratchDirectory)
+            {
+                _sessionScratchDenialDirectories[callId] = scratchDirectory;
+            }
+        }
+
+        public ApprovalRedrivePlan Build()
+            => new(
+                _preSeed.Count == 0 ? null : _preSeed,
+                _decisionOverride.Count == 0 ? null : _decisionOverride,
+                _sessionScratchDenialDirectories.Count == 0 ? null : _sessionScratchDenialDirectories,
+                _authorizationAttemptIds.Count == 0 ? null : _authorizationAttemptIds);
+    }
+}
 
 internal static class ToolApprovalTurnContext
 {


### PR DESCRIPTION
## Summary

- Put the session tool approval state under one actor-local owner.
- Replace two parallel dictionaries with one per-call state map.
- Preserve the canonical durable request in each pending interaction.
- Reject an invalid approval redrive phase before tool dispatch.
- Add focused state transition and recovery tests.

This PR addresses https://github.com/netclaw-dev/netclaw/pull/2078#discussion_r3886731608.

## Validation

- `dotnet test Netclaw.slnx -c Release --no-restore`: 8,135 passed, 17 skipped, and 0 failed.
- The focused approval suite passed 728 tests.
- The new aggregate has 90.6% line coverage and 70.9% branch coverage.
- The new aggregate has a maximum cyclomatic complexity of 12.
- `dotnet slopwatch analyze` found 0 issues.
- The file header check passed.
- `git diff --check` passed.

## Compatibility

- No persisted event changed.
- No protobuf contract changed.
- No public API changed.
- No authorization behavior changed.
