### PR TITLE
Add Slack table block support

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -282,6 +282,31 @@ public class SlackBlockConverterTests
     }
 
     [Fact]
+    public void MarkdownTable_WithInlineMarkdown_ProducesRichTextCells()
+    {
+        var input = """
+            | Item | Guide |
+            | --- | --- |
+            | **Deploy** | [Read the guide](https://example.com/guide) |
+            """;
+
+        var blocks = SlackBlockConverter.Convert(input);
+
+        var table = Assert.Single(blocks.OfType<TableBlock>());
+        var itemCell = Assert.IsType<RichTextCell>(table.Rows[1][0]);
+        var itemSection = Assert.Single(itemCell.Elements.OfType<RichTextSection>());
+        var itemText = Assert.Single(itemSection.Elements.OfType<RichTextText>());
+        Assert.Equal("Deploy", itemText.Text);
+        Assert.True(itemText.Style?.Bold);
+
+        var guideCell = Assert.IsType<RichTextCell>(table.Rows[1][1]);
+        var guideSection = Assert.Single(guideCell.Elements.OfType<RichTextSection>());
+        var guideLink = Assert.Single(guideSection.Elements.OfType<RichTextLink>());
+        Assert.Equal("Read the guide", guideLink.Text);
+        Assert.Equal("https://example.com/guide", guideLink.Url);
+    }
+
+    [Fact]
     public void MarkdownTable_WithMoreThanTwentyColumns_RemainsRichText()
     {
         var header = string.Join(" | ", Enumerable.Range(1, 21).Select(column => $"H{column}"));

--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -247,6 +247,88 @@ public class SlackBlockConverterTests
     }
 
     [Fact]
+    public void MarkdownTable_ProducesTableBlockWithRawTextCells()
+    {
+        var input = """
+            | Name | Status |
+            | --- | --- |
+            | API | Healthy |
+            | Worker | Degraded |
+            """;
+
+        var blocks = SlackBlockConverter.Convert(input);
+
+        var table = Assert.Single(blocks.OfType<TableBlock>());
+        Assert.Equal(3, table.Rows.Count);
+        Assert.Equal(2, table.Rows[0].Count);
+        Assert.Equal("Name", Assert.IsType<RawTextCell>(table.Rows[0][0]).Text);
+        Assert.Equal("Healthy", Assert.IsType<RawTextCell>(table.Rows[1][1]).Text);
+        Assert.Equal("Degraded", Assert.IsType<RawTextCell>(table.Rows[2][1]).Text);
+    }
+
+    [Fact]
+    public void MarkdownTable_WithEscapedPipe_PreservesCellText()
+    {
+        var input = """
+            | Expression | Value |
+            | --- | --- |
+            | a \| b | true |
+            """;
+
+        var blocks = SlackBlockConverter.Convert(input);
+
+        var table = Assert.Single(blocks.OfType<TableBlock>());
+        Assert.Equal("a | b", Assert.IsType<RawTextCell>(table.Rows[1][0]).Text);
+    }
+
+    [Fact]
+    public void MarkdownTable_WithMoreThanTwentyColumns_RemainsRichText()
+    {
+        var header = string.Join(" | ", Enumerable.Range(1, 21).Select(column => $"H{column}"));
+        var divider = string.Join(" | ", Enumerable.Repeat("---", 21));
+        var row = string.Join(" | ", Enumerable.Range(1, 21).Select(column => $"V{column}"));
+
+        var blocks = SlackBlockConverter.Convert($"{header}\n{divider}\n{row}");
+
+        Assert.Empty(blocks.OfType<TableBlock>());
+        var richText = Assert.Single(blocks.OfType<RichTextBlock>());
+        Assert.Equal(3, richText.Elements.OfType<RichTextSection>().Count());
+    }
+
+    [Fact]
+    public void MarkdownTable_WithMoreThanOneHundredRows_RemainsRichText()
+    {
+        var rows = string.Join("\n", Enumerable.Range(1, 100).Select(row => $"| {row} |"));
+        var input = $"| Value |\n| --- |\n{rows}";
+
+        var blocks = SlackBlockConverter.Convert(input);
+
+        Assert.Empty(blocks.OfType<TableBlock>());
+    }
+
+    [Fact]
+    public void MarkdownTable_AfterFirstTable_RemainsRichText()
+    {
+        var input = """
+            | Name |
+            | --- |
+            | API |
+
+            | Name |
+            | --- |
+            | Worker |
+            """;
+
+        var blocks = SlackBlockConverter.Convert(input);
+
+        Assert.Single(blocks.OfType<TableBlock>());
+        var richText = Assert.Single(blocks.OfType<RichTextBlock>());
+        Assert.Contains(
+            richText.Elements.OfType<RichTextSection>(),
+            section => section.Elements.OfType<RichTextText>().Any(text => text.Text == "| Worker |"));
+    }
+
+    [Fact]
     public void Blockquote_ProducesRichTextQuote()
     {
         var blocks = SlackBlockConverter.Convert("> This is a quoted passage");

--- a/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
@@ -125,6 +125,23 @@ public sealed class SlackReplyClientTests
     }
 
     [Fact]
+    public async Task PostThreadReplyAsync_converts_markdown_table_to_table_block()
+    {
+        var fakeChat = new FakeChatApi(response: new PostMessageResponse { Ts = "1234.5678", Channel = "C123" });
+        var client = new SlackReplyClient(new FakeSlackApiClient(fakeChat));
+
+        await client.PostThreadReplyAsync(new SlackPostMessage(
+            ChannelId: new SlackChannelId("C123"),
+            ThreadTs: new SlackThreadTs("1234.5678"),
+            Text: "| Name | Status |\n| --- | --- |\n| API | Healthy |"),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(fakeChat.LastPostedMessage);
+        var table = Assert.Single(fakeChat.LastPostedMessage!.Blocks.OfType<TableBlock>());
+        Assert.Equal("Healthy", Assert.IsType<RawTextCell>(table.Rows[1][1]).Text);
+    }
+
+    [Fact]
     public async Task SetThreadStatusAsync_calls_assistant_thread_status_api()
     {
         var fakeAssistantThreads = new FakeAssistantThreadsApi();

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -26,6 +26,7 @@ public static partial class SlackBlockConverter
         var lines = markdown.Split('\n');
         var currentRichTextElements = new List<RichTextElement>();
         var i = 0;
+        var tableRendered = false;
 
         while (i < lines.Length)
         {
@@ -36,6 +37,15 @@ public static partial class SlackBlockConverter
             if (string.IsNullOrWhiteSpace(trimmed))
             {
                 i++;
+                continue;
+            }
+
+            if (!tableRendered && TryParseMarkdownTable(lines, i, out var table, out var tableLineCount))
+            {
+                FlushRichText(blocks, currentRichTextElements);
+                blocks.Add(table);
+                tableRendered = true;
+                i += tableLineCount;
                 continue;
             }
 
@@ -146,6 +156,99 @@ public static partial class SlackBlockConverter
 
         FlushRichText(blocks, currentRichTextElements);
         return blocks;
+    }
+
+    private static bool TryParseMarkdownTable(
+        IReadOnlyList<string> lines,
+        int startIndex,
+        out TableBlock table,
+        out int lineCount)
+    {
+        table = null!;
+        lineCount = 0;
+
+        if (startIndex + 1 >= lines.Count
+            || !TryParseTableRow(lines[startIndex], out var headerCells)
+            || headerCells.Count is 0 or > MaxTableColumns
+            || !IsTableDivider(lines[startIndex + 1], headerCells.Count))
+        {
+            return false;
+        }
+
+        var rows = new List<IList<TableCell>>
+        {
+            ToTableCells(headerCells)
+        };
+        var characterCount = headerCells.Sum(cell => cell.Length);
+        var nextIndex = startIndex + 2;
+
+        while (nextIndex < lines.Count && TryParseTableRow(lines[nextIndex], out var cells))
+        {
+            if (cells.Count != headerCells.Count
+                || rows.Count == MaxTableRows
+                || characterCount + cells.Sum(cell => cell.Length) > MaxTableCharacters)
+            {
+                return false;
+            }
+
+            rows.Add(ToTableCells(cells));
+            characterCount += cells.Sum(cell => cell.Length);
+            nextIndex++;
+        }
+
+        table = new TableBlock { Rows = rows };
+        lineCount = nextIndex - startIndex;
+        return true;
+    }
+
+    private static bool IsTableDivider(string line, int columnCount)
+    {
+        return TryParseTableRow(line, out var cells)
+            && cells.Count == columnCount
+            && cells.All(cell => TableDividerCellRegex().IsMatch(cell));
+    }
+
+    private static bool TryParseTableRow(string line, out List<string> cells)
+    {
+        var trimmed = line.Trim();
+        cells = [];
+
+        if (!trimmed.Contains('|', StringComparison.Ordinal))
+            return false;
+
+        var startIndex = trimmed.StartsWith('|') ? 1 : 0;
+        var endIndex = trimmed.EndsWith('|') ? trimmed.Length - 1 : trimmed.Length;
+        var currentCell = new System.Text.StringBuilder();
+
+        for (var index = startIndex; index < endIndex; index++)
+        {
+            var character = trimmed[index];
+            if (character == '\\' && index + 1 < endIndex && trimmed[index + 1] == '|')
+            {
+                currentCell.Append('|');
+                index++;
+                continue;
+            }
+
+            if (character == '|')
+            {
+                cells.Add(currentCell.ToString().Trim());
+                currentCell.Clear();
+                continue;
+            }
+
+            currentCell.Append(character);
+        }
+
+        cells.Add(currentCell.ToString().Trim());
+        return cells.Count > 0;
+    }
+
+    private static IList<TableCell> ToTableCells(IEnumerable<string> cells)
+    {
+        return cells
+            .Select(cell => (TableCell)new RawTextCell { Text = cell })
+            .ToList();
     }
 
     private static void FlushRichText(List<Block> blocks, List<RichTextElement> elements)
@@ -372,6 +475,9 @@ public static partial class SlackBlockConverter
     [GeneratedRegex(@"^\d+\.\s")]
     private static partial Regex OrderedListPrefix();
 
+    [GeneratedRegex(@"^:?-{3,}:?$")]
+    private static partial Regex TableDividerCellRegex();
+
     // Slack user mention: <@U0123ABC> or <@W0123ABC>, optionally with a
     // fallback label (<@U0123ABC|david>).
     [GeneratedRegex(@"<@([UW][0-9A-Z]+)(?:\|[^>]+)?>")]
@@ -389,4 +495,8 @@ public static partial class SlackBlockConverter
     // and group DMs), optionally with a label.
     [GeneratedRegex(@"<#([CGD][0-9A-Z]+)(?:\|[^>]+)?>")]
     private static partial Regex ChannelMentionRegex();
+
+    private const int MaxTableRows = 100;
+    private const int MaxTableColumns = 20;
+    private const int MaxTableCharacters = 10_000;
 }

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -247,8 +247,41 @@ public static partial class SlackBlockConverter
     private static IList<TableCell> ToTableCells(IEnumerable<string> cells)
     {
         return cells
-            .Select(cell => (TableCell)new RawTextCell { Text = cell })
+            .Select(ToTableCell)
             .ToList();
+    }
+
+    private static TableCell ToTableCell(string cell)
+    {
+        var elements = ParseInlineElements(cell);
+        if (!elements.Any(RequiresRichTextCell))
+            return new RawTextCell { Text = cell };
+
+        return new RichTextCell
+        {
+            Elements =
+            [
+                new RichTextSection { Elements = elements }
+            ]
+        };
+    }
+
+    private static bool RequiresRichTextCell(RichTextSectionElement element)
+    {
+        return element is not RichTextText
+        {
+            Style:
+            {
+                Bold: false,
+                Italic: false,
+                Strike: false,
+                Code: false,
+                Highlight: false,
+                ClientHighlight: false,
+                Underline: false,
+                Unlink: false
+            }
+        };
     }
 
     private static void FlushRichText(List<Block> blocks, List<RichTextElement> elements)


### PR DESCRIPTION
## Summary

- Add Slack table blocks for valid Markdown tables.
- Preserve inline Markdown with Slack rich-text cells.
- Keep unsupported tables as rich text.

Closes #55

## Tests

- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --no-restore`
- `dotnet slopwatch analyze`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`