### PR TITLE
Fix VersionPrefix split for 0.27.0-beta.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.27.0-beta.2</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
     <VersionSuffix>beta.2</VersionSuffix>
     <PackageReleaseNotes>Follow-up beta to 0.27.0-beta.1. Slack replies now render with Slack's own Markdown blocks and tables, Socket Mode connections are supervised and self-heal, MCP auth failures stop firing false alarms, and a full reset no longer deletes the binaries it resets from.
 


### PR DESCRIPTION
The 0.27.0-beta.2 tag failed the release version gate. Directory.Build.props had the full tag in VersionPrefix (0.27.0-beta.2) plus a duplicate in VersionSuffix (beta.2). The gate expects VersionPrefix=0.27.0 + VersionSuffix=beta.2.

This corrects VersionPrefix to 0.27.0 so the release gate passes and the tag can be re-created.