### PR TITLE
Limit tool denial guidance to the current user turn

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.65.3"
+  version: "2.65.4"
 ---
 
 # Netclaw Operations
@@ -61,9 +61,11 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. After an approval-required result, do not retry or substitute shell variants.
-6. A `Tool access denied:` result is terminal; do not change scope, retry, or substitute another tool.
-7. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 ## Project Directory
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -61,10 +61,11 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. After an access denial, do not retry that call during the same user turn.
-6. Do not change its scope or substitute another tool to evade the denial.
-7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. If approval is required but no interactive requester is available, do not retry or substitute the call during that turn.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 ## Project Directory
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -61,11 +61,10 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
-6. After an access denial, do not retry that call during the same user turn.
-7. Do not change its scope or substitute another tool to evade the denial.
-8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. After an access denial, do not retry that call during the same user turn.
+6. Do not change its scope or substitute another tool to evade the denial.
+7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 ## Project Directory
 

--- a/feeds/skills/.system/files/netclaw-operations/references/projects.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/projects.md
@@ -51,11 +51,10 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
-6. After an access denial, do not retry that call during the same user turn.
-7. Do not change its scope or substitute another tool to evade the denial.
-8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. After an access denial, do not retry that call during the same user turn.
+6. Do not change its scope or substitute another tool to evade the denial.
+7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 The project directory is distinct from the session directory
 (`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for

--- a/feeds/skills/.system/files/netclaw-operations/references/projects.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/projects.md
@@ -51,10 +51,11 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. After an access denial, do not retry that call during the same user turn.
-6. Do not change its scope or substitute another tool to evade the denial.
-7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. If approval is required but no interactive requester is available, do not retry or substitute the call during that turn.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 The project directory is distinct from the session directory
 (`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for

--- a/feeds/skills/.system/files/netclaw-operations/references/projects.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/projects.md
@@ -51,9 +51,11 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. After an approval-required result, do not retry or substitute shell variants.
-6. A `Tool access denied:` result is terminal; do not change scope, retry, or substitute another tool.
-7. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 The project directory is distinct from the session directory
 (`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for

--- a/openspec/changes/reduce-fresh-session-approval-spam/design.md
+++ b/openspec/changes/reduce-fresh-session-approval-spam/design.md
@@ -135,10 +135,11 @@ The same surfaces will state one shell-composition order:
    them with shell separators or presentation labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. Do not retry or substitute shell variants after an approval-required result.
-6. Treat a `Tool access denied:` result as terminal. Do not change scope, retry,
-   or substitute another tool.
-7. Apply one `Tool execution deferred:` correction unchanged. Otherwise use an
+5. If approval is unavailable, do not retry or substitute the call during that turn.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call under normal approval policy.
+9. Apply one `Tool execution deferred:` correction unchanged. Otherwise use an
    available structured tool or report the blocked operation once.
 
 A successful `file_write` or `file_edit` result is the confirmation for that
@@ -250,6 +251,8 @@ context. A failed declaration leaves the prior project unchanged.
   remains active, and the follow-up eval records the redundant attempt.
 - **The model retries after a policy denial.** → Normal approval remains active,
   and the no-retry assertion records the additional call.
+- **The model retries when no interactive requester exists.** → Guidance ends
+  the current attempt, and normal policy remains active.
 - **A tool is unavailable.** → Guidance does not invent it. The model uses an
   available tool under normal policy.
 - **A parser fact is incomplete.** → The command remains promptable. No fallback

--- a/openspec/changes/reduce-fresh-session-approval-spam/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/reduce-fresh-session-approval-spam/specs/tool-approval-gates/spec.md
@@ -116,10 +116,12 @@ Guidance SHALL NOT claim that a preferred tool bypasses its own authority.
 Guidance SHALL start with the smallest necessary shell operation. It SHALL use
 one operation per call unless the requested result requires a pipeline. After
 independent searches or diagnostics, it SHALL keep later operations in separate
-calls instead of joining them with separators or presentation labels. After
-an approval-required result, it SHALL avoid retried or substitute shell variants.
-A `Tool access denied:` result SHALL be terminal: guidance SHALL NOT change
-scope, retry, or substitute another tool. It MAY apply one
+calls instead of joining them with separators or presentation labels. If a
+tool requires approval but no interactive requester is available, guidance
+SHALL NOT retry or substitute that call during the current turn. After a
+`Tool access denied:` result, guidance SHALL NOT change scope, retry, or
+substitute another tool during the same user turn. A later explicit user
+request MAY start a new call under normal approval policy. Guidance MAY apply one
 `Tool execution deferred:` correction unchanged. Otherwise it SHALL use an
 available structured tool or report the blocked operation once.
 A successful structured file mutation SHALL serve as confirmation of that
@@ -213,7 +215,15 @@ tool can complete.
 - **THEN** each independent operation uses a separate call
 - **AND** separators or presentation labels do not join their outputs
 
-#### Scenario: Policy-blocked shell work does not fan out
+#### Scenario: Approval without an interactive requester does not fan out
+
+- **GIVEN** a shell result reports that approval is required
+- **AND** no interactive approval requester is available
+- **WHEN** the agent continues the current turn
+- **THEN** guidance does not retry or substitute that call
+- **AND** it reports the block once
+
+#### Scenario: Access-denied shell work does not fan out during the same turn
 
 - **GIVEN** a shell result reports `Tool access denied:`
 - **WHEN** the agent continues the task
@@ -221,12 +231,19 @@ tool can complete.
 - **AND** it does not call `set_working_directory`
 - **AND** it reports the block once
 
+#### Scenario: A later user request starts a new approval decision
+
+- **GIVEN** the user denied an earlier shell call
+- **WHEN** a later explicit user request requires a new shell call
+- **THEN** guidance permits the new call
+- **AND** normal approval policy evaluates it
+
 #### Scenario: Deferred shell work applies one correction
 
 - **GIVEN** a shell result reports `Tool execution deferred:` with one explicit correction
 - **WHEN** the agent continues the task
 - **THEN** it may apply that correction once and retry the original shell call unchanged
-- **AND** any later approval-required or denied result terminates the attempt
+- **AND** any later approval-required or denied result terminates that turn's attempt
 
 #### Scenario: Preferred tool is unavailable
 

--- a/openspec/changes/reduce-fresh-session-approval-spam/tasks.md
+++ b/openspec/changes/reduce-fresh-session-approval-spam/tasks.md
@@ -98,6 +98,7 @@
 - [x] 10.18 Freeze sanitized post-#1990 batching evidence and a strict five-run 3/5 behavior baseline.
 - [x] 10.19 Strengthen generic independent-operation guidance and rerun the unchanged five-session eval.
 - [ ] 10.20 Deliver, swap the exact merged binary, and validate multiple new live sessions.
+- [x] 10.21 Preserve the no-requester loop guard and limit user-denial guidance to the current user turn.
 
 ## 11. Completion Audit
 

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalRehydrationTests.cs
@@ -1291,6 +1291,107 @@ public sealed class ApprovalRehydrationTests : LlmSessionTestBase
     }
 
     [Fact]
+    public async Task Denied_approval_does_not_block_a_later_user_directed_call()
+    {
+        const string firstCallId = "call-shell-denied-first";
+        const string secondCallId = "call-shell-user-directed-second";
+        _toolExecutor.GatedTools.Add("shell_execute");
+
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent(firstCallId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git status" })
+        ];
+        _fakeChatClient.PlannedResponses.Enqueue(
+            [new TextContent("The user denied the first call.")]);
+        _fakeChatClient.PlannedResponses.Enqueue(
+        [
+            new FunctionCallContent(secondCallId, "shell_execute",
+                new Dictionary<string, object?> { ["command"] = "git status" })
+        ]);
+        _fakeChatClient.PlannedResponses.Enqueue(
+            [new TextContent("The user denied the second call.")]);
+
+        var sessionId = new SessionId("test-channel/user-directed-call-after-denial");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("user-directed-call-after-denial-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession(subscriber)
+        {
+            SessionId = sessionId,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<SessionJoined>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Run git status",
+            Source = RequesterSource("local-user")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var firstCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var firstRequest = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(firstCallId, firstCall.CallId.Value);
+        Assert.Equal(firstCallId, firstRequest.CallId.Value);
+
+        var firstDenial = await sessionManager.Ask<ISessionResponse>(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(firstCallId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.Deny),
+            SenderId = new SenderId("local-user")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.IsType<CommandAck>(firstDenial);
+
+        var firstResult = await subscriber.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains("approval_denied_by_user", firstResult.Result, StringComparison.Ordinal);
+        await subscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, _toolExecutor.SuccessfulExecutions);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Try the command again",
+            Source = RequesterSource("local-user")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var secondCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var secondRequest = await subscriber.ExpectMsgAsync<ToolInteractionRequest>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(secondCallId, secondCall.CallId.Value);
+        Assert.Equal(secondCallId, secondRequest.CallId.Value);
+        Assert.NotEqual(firstRequest.AuthorizationAttemptId, secondRequest.AuthorizationAttemptId);
+        Assert.Equal(2, _toolExecutor.AuthorizationAttempts.Count);
+        Assert.Equal(0, _toolExecutor.SuccessfulExecutions);
+
+        var secondDenial = await sessionManager.Ask<ISessionResponse>(new ToolInteractionResponse
+        {
+            SessionId = sessionId,
+            CallId = new Netclaw.Tools.ToolCallId(secondCallId),
+            SelectedKey = new ApprovalOptionKey(ApprovalOptionKeys.Deny),
+            SenderId = new SenderId("local-user")
+        }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.IsType<CommandAck>(secondDenial);
+
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TextOutput>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, _toolExecutor.SuccessfulExecutions);
+    }
+
+    [Fact]
     public async Task Cold_recovered_denied_scratch_retry_preserves_session_directory_hint()
     {
         const string callId = "call-shell-scratch-denied";

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -66,8 +66,9 @@ public class ShellToolTests
         Assert.Contains("do not join them with separators or labels", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Add a pipeline only when the requested result requires it", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Do not use shell only to verify successful structured results", _tool.Description, StringComparison.Ordinal);
-        Assert.Contains("After approval-required results, do not retry or substitute variants", _tool.Description, StringComparison.Ordinal);
-        Assert.Contains("Treat 'Tool access denied:' as terminal; do not change scope", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("Do not submit variants while the decision is pending", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("do not retry that call during the same user turn", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("A later explicit user request can start a new call", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Apply one 'Tool execution deferred:' correction unchanged", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Do not use shell for known file reads", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("or disposable text unless shell behavior is requested", _tool.Description, StringComparison.Ordinal);
@@ -89,8 +90,9 @@ public class ShellToolTests
         Assert.Contains("do not join them with separators or labels", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Add a pipeline only when the requested result requires it", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Do not verify successful structured results with shell", commandDescription, StringComparison.Ordinal);
-        Assert.Contains("Do not retry approval-required variants", commandDescription, StringComparison.Ordinal);
-        Assert.Contains("Treat 'Tool access denied:' as terminal; do not change scope", commandDescription, StringComparison.Ordinal);
+        Assert.Contains("Wait for the user's decision when a call requires approval", commandDescription, StringComparison.Ordinal);
+        Assert.Contains("do not retry that call during the same user turn", commandDescription, StringComparison.Ordinal);
+        Assert.Contains("A later explicit user request can start a new call", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Apply one 'Tool execution deferred:' correction unchanged", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Do not use shell for disposable text unless shell behavior is requested", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Set only for one call", description, StringComparison.Ordinal);

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -66,7 +66,6 @@ public class ShellToolTests
         Assert.Contains("do not join them with separators or labels", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Add a pipeline only when the requested result requires it", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Do not use shell only to verify successful structured results", _tool.Description, StringComparison.Ordinal);
-        Assert.Contains("Do not submit variants while the decision is pending", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("do not retry that call during the same user turn", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("A later explicit user request can start a new call", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Apply one 'Tool execution deferred:' correction unchanged", _tool.Description, StringComparison.Ordinal);
@@ -90,7 +89,6 @@ public class ShellToolTests
         Assert.Contains("do not join them with separators or labels", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Add a pipeline only when the requested result requires it", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Do not verify successful structured results with shell", commandDescription, StringComparison.Ordinal);
-        Assert.Contains("Wait for the user's decision when a call requires approval", commandDescription, StringComparison.Ordinal);
         Assert.Contains("do not retry that call during the same user turn", commandDescription, StringComparison.Ordinal);
         Assert.Contains("A later explicit user request can start a new call", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Apply one 'Tool execution deferred:' correction unchanged", commandDescription, StringComparison.Ordinal);

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -66,7 +66,8 @@ public class ShellToolTests
         Assert.Contains("do not join them with separators or labels", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Add a pipeline only when the requested result requires it", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Do not use shell only to verify successful structured results", _tool.Description, StringComparison.Ordinal);
-        Assert.Contains("do not retry that call during the same user turn", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("no interactive requester is available", _tool.Description, StringComparison.Ordinal);
+        Assert.Contains("After an access denial", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("A later explicit user request can start a new call", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Apply one 'Tool execution deferred:' correction unchanged", _tool.Description, StringComparison.Ordinal);
         Assert.Contains("Do not use shell for known file reads", _tool.Description, StringComparison.Ordinal);
@@ -89,7 +90,8 @@ public class ShellToolTests
         Assert.Contains("do not join them with separators or labels", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Add a pipeline only when the requested result requires it", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Do not verify successful structured results with shell", commandDescription, StringComparison.Ordinal);
-        Assert.Contains("do not retry that call during the same user turn", commandDescription, StringComparison.Ordinal);
+        Assert.Contains("no interactive requester is available", commandDescription, StringComparison.Ordinal);
+        Assert.Contains("After an access denial", commandDescription, StringComparison.Ordinal);
         Assert.Contains("A later explicit user request can start a new call", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Apply one 'Tool execution deferred:' correction unchanged", commandDescription, StringComparison.Ordinal);
         Assert.Contains("Do not use shell for disposable text unless shell behavior is requested", commandDescription, StringComparison.Ordinal);

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.Core_tool_names_and_schema_footprint_match_snapshot.verified.txt
@@ -16,6 +16,6 @@
   ],
   Footprint: {
     Count: 13,
-    SerializedDefinitionBytes: 16194
+    SerializedDefinitionBytes: 16635
   }
 }

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -27,7 +27,6 @@ namespace Netclaw.Actors.Tools;
     "Start with the smallest operation that answers the request. Use one operation per call. " +
     "Keep independent searches and diagnostics separate; do not join them with separators or labels. " +
     "Add a pipeline only when the requested result requires it. Do not use shell only to verify successful structured results. " +
-    "When a call requires approval, wait for the user's decision. Do not submit variants while the decision is pending. " +
     "After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. " +
     "A later explicit user request can start a new call under normal approval policy. " +
     "Apply one 'Tool execution deferred:' correction unchanged. " +
@@ -53,7 +52,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 
     public record Params(
         [param: Description(
-            "The smallest shell operation that answers the request. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels. Add a pipeline only when the requested result requires it. Omit WorkingDirectory for declared-project work. Do not use shell for disposable text unless shell behavior is requested. Do not verify successful structured results with shell. Wait for the user's decision when a call requires approval. After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. A later explicit user request can start a new call under normal approval policy. Apply one 'Tool execution deferred:' correction unchanged.")]
+            "The smallest shell operation that answers the request. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels. Add a pipeline only when the requested result requires it. Omit WorkingDirectory for declared-project work. Do not use shell for disposable text unless shell behavior is requested. Do not verify successful structured results with shell. After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. A later explicit user request can start a new call under normal approval policy. Apply one 'Tool execution deferred:' correction unchanged.")]
         string Command,
         [param: Description(
             "Set only for one call in a named child directory or worktree. Omit for declared-project work. Use session_dir for disposable writable work outside a project; do not substitute platform temporary storage.")]

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -27,6 +27,7 @@ namespace Netclaw.Actors.Tools;
     "Start with the smallest operation that answers the request. Use one operation per call. " +
     "Keep independent searches and diagnostics separate; do not join them with separators or labels. " +
     "Add a pipeline only when the requested result requires it. Do not use shell only to verify successful structured results. " +
+    "If approval is required but no interactive requester is available, do not retry or substitute the call during that turn. " +
     "After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. " +
     "A later explicit user request can start a new call under normal approval policy. " +
     "Apply one 'Tool execution deferred:' correction unchanged. " +
@@ -52,7 +53,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 
     public record Params(
         [param: Description(
-            "The smallest shell operation that answers the request. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels. Add a pipeline only when the requested result requires it. Omit WorkingDirectory for declared-project work. Do not use shell for disposable text unless shell behavior is requested. Do not verify successful structured results with shell. After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. A later explicit user request can start a new call under normal approval policy. Apply one 'Tool execution deferred:' correction unchanged.")]
+            "The smallest shell operation that answers the request. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels. Add a pipeline only when the requested result requires it. Omit WorkingDirectory for declared-project work. Do not use shell for disposable text unless shell behavior is requested. Do not verify successful structured results with shell. If approval is required but no interactive requester is available, do not retry or substitute the call during that turn. After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. A later explicit user request can start a new call under normal approval policy. Apply one 'Tool execution deferred:' correction unchanged.")]
         string Command,
         [param: Description(
             "Set only for one call in a named child directory or worktree. Omit for declared-project work. Use session_dir for disposable writable work outside a project; do not substitute platform temporary storage.")]

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -27,7 +27,9 @@ namespace Netclaw.Actors.Tools;
     "Start with the smallest operation that answers the request. Use one operation per call. " +
     "Keep independent searches and diagnostics separate; do not join them with separators or labels. " +
     "Add a pipeline only when the requested result requires it. Do not use shell only to verify successful structured results. " +
-    "After approval-required results, do not retry or substitute variants. Treat 'Tool access denied:' as terminal; do not change scope. " +
+    "When a call requires approval, wait for the user's decision. Do not submit variants while the decision is pending. " +
+    "After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. " +
+    "A later explicit user request can start a new call under normal approval policy. " +
     "Apply one 'Tool execution deferred:' correction unchanged. " +
     "Do not use shell for known file reads, listings, edits, or disposable text unless shell behavior is requested.",
     Grant = "shell")]
@@ -51,7 +53,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 
     public record Params(
         [param: Description(
-            "The smallest shell operation that answers the request. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels. Add a pipeline only when the requested result requires it. Omit WorkingDirectory for declared-project work. Do not use shell for disposable text unless shell behavior is requested. Do not verify successful structured results with shell. Do not retry approval-required variants. Treat 'Tool access denied:' as terminal; do not change scope. Apply one 'Tool execution deferred:' correction unchanged.")]
+            "The smallest shell operation that answers the request. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels. Add a pipeline only when the requested result requires it. Omit WorkingDirectory for declared-project work. Do not use shell for disposable text unless shell behavior is requested. Do not verify successful structured results with shell. Wait for the user's decision when a call requires approval. After an access denial, do not retry that call during the same user turn. Do not change its scope or substitute another tool to evade the denial. A later explicit user request can start a new call under normal approval policy. Apply one 'Tool execution deferred:' correction unchanged.")]
         string Command,
         [param: Description(
             "Set only for one call in a named child directory or worktree. Omit for declared-project work. Use session_dir for disposable writable work outside a project; do not substitute platform temporary storage.")]

--- a/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
+++ b/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
@@ -33,9 +33,10 @@ internal static class ToolChoiceGuidance
         1. Start with the smallest single shell operation that directly answers the request.
         2. Use one operation per call. Add a pipeline only when the requested result requires it.
         3. Do not use shell only to verify a successful structured tool result.
-        4. After an access denial, do not retry that call during the same user turn.
-        5. Do not change its scope or substitute another tool to evade the denial.
-        6. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-        7. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+        4. If approval is required but no interactive requester is available, do not retry or substitute the call during that turn.
+        5. After an access denial, do not retry that call during the same user turn.
+        6. Do not change its scope or substitute another tool to evade the denial.
+        7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+        8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
         """;
 }

--- a/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
+++ b/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
@@ -33,8 +33,10 @@ internal static class ToolChoiceGuidance
         1. Start with the smallest single shell operation that directly answers the request.
         2. Use one operation per call. Add a pipeline only when the requested result requires it.
         3. Do not use shell only to verify a successful structured tool result.
-        4. After an approval-required result, do not retry or substitute shell variants.
-        5. A `Tool access denied:` result is terminal; do not change scope, retry, or substitute another tool.
-        6. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+        4. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
+        5. After an access denial, do not retry that call during the same user turn.
+        6. Do not change its scope or substitute another tool to evade the denial.
+        7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+        8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
         """;
 }

--- a/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
+++ b/src/Netclaw.Actors/Tools/ToolChoiceGuidance.cs
@@ -33,10 +33,9 @@ internal static class ToolChoiceGuidance
         1. Start with the smallest single shell operation that directly answers the request.
         2. Use one operation per call. Add a pipeline only when the requested result requires it.
         3. Do not use shell only to verify a successful structured tool result.
-        4. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
-        5. After an access denial, do not retry that call during the same user turn.
-        6. Do not change its scope or substitute another tool to evade the denial.
-        7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-        8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+        4. After an access denial, do not retry that call during the same user turn.
+        5. Do not change its scope or substitute another tool to evade the denial.
+        6. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+        7. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
         """;
 }

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -117,16 +117,6 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.DoesNotContain("correct the path and retry the tool", prompt);
     }
 
-    [Fact]
-    public void Personal_prompt_does_not_extend_call_denial_to_later_user_turns()
-    {
-        var prompt = _provider.GetSystemPrompt(TrustAudience.Personal);
-
-        Assert.DoesNotContain("A `Tool access denied:` result is terminal", prompt);
-        Assert.Contains("A user denial applies only to the current tool call", prompt);
-        Assert.Contains("A later explicit user request can create a new tool call", prompt);
-    }
-
     [Theory]
     [InlineData(TrustAudience.Team)]
     [InlineData(TrustAudience.Personal)]

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -110,7 +110,7 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.Contains("Do not repeat", prompt);
         Assert.Contains("`project_dir` already names the correct project", prompt);
         Assert.Contains("Only `Tool execution deferred:` permits one scope correction", prompt);
-        Assert.Contains("Never call `set_working_directory` after `Tool access denied:`", prompt);
+        Assert.Contains("Do not call `set_working_directory` to evade an access denial during the same user turn", prompt);
         Assert.Contains("correct an evident path error once", prompt);
         Assert.Contains("preserve the current scope and report the block", prompt);
         Assert.DoesNotContain("Recovery from a denied shell call", prompt);
@@ -140,8 +140,8 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.Contains("Add a pipeline only when the requested result requires it", prompt);
         Assert.Contains("disposable writable work outside a project", prompt);
         Assert.Contains("do not substitute platform temporary storage", prompt);
-        Assert.Contains("After an approval-required result", prompt);
-        Assert.Contains("A `Tool access denied:` result is terminal", prompt);
+        Assert.Contains("After an access denial, do not retry that call during the same user turn", prompt);
+        Assert.Contains("A later explicit user request can start a new call", prompt);
         Assert.Contains("Apply one `Tool execution deferred:` correction unchanged", prompt);
         Assert.Contains("Use `load_tool` directly for a known exact tool name", prompt);
         Assert.Contains("Use `search_tools` when the capability is known", prompt);

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -140,6 +140,7 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.Contains("Add a pipeline only when the requested result requires it", prompt);
         Assert.Contains("disposable writable work outside a project", prompt);
         Assert.Contains("do not substitute platform temporary storage", prompt);
+        Assert.Contains("If approval is required but no interactive requester is available", prompt);
         Assert.Contains("After an access denial, do not retry that call during the same user turn", prompt);
         Assert.Contains("A later explicit user request can start a new call", prompt);
         Assert.Contains("Apply one `Tool execution deferred:` correction unchanged", prompt);

--- a/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSystemPromptProviderAudienceTests.cs
@@ -117,6 +117,16 @@ public sealed class FileSystemPromptProviderAudienceTests : IDisposable
         Assert.DoesNotContain("correct the path and retry the tool", prompt);
     }
 
+    [Fact]
+    public void Personal_prompt_does_not_extend_call_denial_to_later_user_turns()
+    {
+        var prompt = _provider.GetSystemPrompt(TrustAudience.Personal);
+
+        Assert.DoesNotContain("A `Tool access denied:` result is terminal", prompt);
+        Assert.Contains("A user denial applies only to the current tool call", prompt);
+        Assert.Contains("A later explicit user request can create a new tool call", prompt);
+    }
+
     [Theory]
     [InlineData(TrustAudience.Team)]
     [InlineData(TrustAudience.Personal)]

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -41,11 +41,10 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
-6. After an access denial, do not retry that call during the same user turn.
-7. Do not change its scope or substitute another tool to evade the denial.
-8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. After an access denial, do not retry that call during the same user turn.
+6. Do not change its scope or substitute another tool to evade the denial.
+7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 ## Tool Call Contract
 

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -41,9 +41,11 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. After an approval-required result, do not retry or substitute shell variants.
-6. A `Tool access denied:` result is terminal; do not change scope, retry, or substitute another tool.
-7. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. When a call requires approval, wait for the user's decision; do not submit variants while the decision is pending.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 ## Tool Call Contract
 
@@ -101,7 +103,7 @@ Inline directory changes alter control flow and remain subject to ordinary appro
 **Recovery from deferred shell execution.**
 
 - Only `Tool execution deferred:` permits one scope correction and unchanged shell retry.
-- Never call `set_working_directory` after `Tool access denied:`.
+- Do not call `set_working_directory` to evade an access denial during the same user turn.
 - If a proactive project declaration fails, correct an evident path error once.
 - Otherwise, preserve the current scope and report the block.
 - Never use inline `cd` as a workaround.

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -41,10 +41,11 @@ Keep shell approval friction bounded:
 2. Use one operation per call. Keep independent searches and diagnostics separate; do not join them with separators or labels.
 3. Add a pipeline only when the requested result requires it.
 4. Do not use shell only to verify a successful structured tool result.
-5. After an access denial, do not retry that call during the same user turn.
-6. Do not change its scope or substitute another tool to evade the denial.
-7. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-8. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+5. If approval is required but no interactive requester is available, do not retry or substitute the call during that turn.
+6. After an access denial, do not retry that call during the same user turn.
+7. Do not change its scope or substitute another tool to evade the denial.
+8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
+9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
 
 ## Tool Call Contract
 

--- a/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
+++ b/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
@@ -72,6 +72,7 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
         Assert.Contains("Add a pipeline only when the requested result requires it", skill, StringComparison.Ordinal);
         Assert.Contains("disposable writable work outside a project", skill, StringComparison.Ordinal);
         Assert.Contains("do not substitute platform temporary storage", skill, StringComparison.Ordinal);
+        Assert.Contains("If approval is required but no interactive requester is available", skill, StringComparison.Ordinal);
         Assert.Contains("After an access denial, do not retry that call during the same user turn", skill, StringComparison.Ordinal);
         Assert.Contains("A later explicit user request can start a new call", skill, StringComparison.Ordinal);
         Assert.Contains("Do not probe a named project path before declaring it", skill, StringComparison.Ordinal);
@@ -91,6 +92,7 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
             "Keep independent searches and diagnostics separate",
             "do not join them with separators or labels",
             "Add a pipeline only when the requested result requires it",
+            "If approval is required but no interactive requester is available",
             "After an access denial, do not retry that call during the same user turn",
             "A later explicit user request can start a new call",
             "Apply one `Tool execution deferred:` correction unchanged"

--- a/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
+++ b/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
@@ -72,8 +72,8 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
         Assert.Contains("Add a pipeline only when the requested result requires it", skill, StringComparison.Ordinal);
         Assert.Contains("disposable writable work outside a project", skill, StringComparison.Ordinal);
         Assert.Contains("do not substitute platform temporary storage", skill, StringComparison.Ordinal);
-        Assert.Contains("After an approval-required result", skill, StringComparison.Ordinal);
-        Assert.Contains("A `Tool access denied:` result is terminal", skill, StringComparison.Ordinal);
+        Assert.Contains("After an access denial, do not retry that call during the same user turn", skill, StringComparison.Ordinal);
+        Assert.Contains("A later explicit user request can start a new call", skill, StringComparison.Ordinal);
         Assert.Contains("Do not probe a named project path before declaring it", skill, StringComparison.Ordinal);
         Assert.Contains("user-provided fallback before other tools", skill, StringComparison.Ordinal);
         Assert.Contains("Use the task's first project path exactly", skill, StringComparison.Ordinal);
@@ -91,8 +91,8 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
             "Keep independent searches and diagnostics separate",
             "do not join them with separators or labels",
             "Add a pipeline only when the requested result requires it",
-            "After an approval-required result",
-            "A `Tool access denied:` result is terminal",
+            "After an access denial, do not retry that call during the same user turn",
+            "A later explicit user request can start a new call",
             "Apply one `Tool execution deferred:` correction unchanged"
         };
         foreach (var statement in statements)


### PR DESCRIPTION
## Purpose

A denied tool call remains terminal for the current user turn. A later explicit user request can start a new call.

This rule prevents same-turn retry loops. It does not create a session-wide tool ban.

## Changes

- Keep a separate loop guard when approval is required and no interactive requester exists.
- Limit access-denial guidance to the current user turn.
- Permit a later explicit user request to start a new call under normal approval policy.
- Apply the same rules to AGENTS.md, tool guidance, and the shell tool schema.
- Update the netclaw-operations skill and its project reference.
- Bump the netclaw-operations skill version to 2.65.4.
- Update the active OpenSpec contract.
- Add a session actor plumbing test for a denial and a later user-directed call.
- Remove redundant guidance about the approval wait because the runtime already pauses the call.

## Plumbing proof

The test uses the session manager and the tool approval protocol.

1. The first shell call emits a `ToolInteractionRequest`.
2. The test sends a `ToolInteractionResponse` with `Deny`.
3. The denied tool does not execute.
4. A later user message causes a second shell call.
5. The second call emits a distinct approval request.

This test proves the runtime plumbing. It does not prove model behavior after an interactive denial.

## Verification

- Session approval plumbing test: passed.
- Shell and schema tests: 43 passed, 1 platform skip.
- Prompt assembly tests: 24 passed.
- System-skill seed tests: 10 passed.
- OpenSpec strict validation: passed.
- `dotnet slopwatch analyze`: passed with zero issues.
- Header verification: passed.
- `git diff --check`: passed.
- Focused Spark2 policy-denial traces: all 3 made one denied call and made no substitute call.

The focused eval reported 2/3. Its completion-claim regex matched the word `result` and a later `/tmp` from separate sentences.

No denial-specific model eval was added. The current headless eval path cannot produce an interactive user denial and then continue that session.