### PR TITLE
test: characterize shell authorization corrections

### DIFF
--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -7,20 +7,27 @@ channel.
 
 ## Overview
 
-Tool invocations pass through four layers:
+The current source checks shell requests in this order:
 
-1. **Operation hard deny** — shell commands that are always blocked
-   (e.g., `netclaw daemon stop`, `rm -rf /`). Never approvable. Checked first.
-2. **Resource hard deny** — protected files and directories (secrets, keys,
-   lifecycle/control-plane files) that are blocked for file tools and shell
-   path references. Never approvable.
-3. **Tool access** — per-audience allowlists (`AllowedTools`,
-   `AllowedMcpServers`). Binary: the tool is available or it isn't.
-4. **Approval gate** — for tools that pass layers 1-3, does this specific
-   invocation need user sign-off?
+1. **Tool access and shell capability** — the audience must expose the tool.
+   The shell must be enabled and the caller must use the Personal audience.
+2. **Shell operation controls** — `check_background_job` can control only a
+   job that has the same session, audience, and trust boundary.
+3. **Operation and resource hard deny** — blocked shell operations and
+   protected shell paths never receive approval authority.
+4. **Mode and channel controls** — `Deny` stops the call. Non-interactive
+   calls must pass the trust-zone policy before `Auto` can allow the call.
+5. **Correction or approval** — an `Approval` call can request prior-grant
+   evidence, reviewed-safe coverage, or an interactive approval.
 
-The approval gate is transparent to the LLM — it never knows approval is
-happening. It calls `shell_execute`, gets either a result or a denial.
+The approval gate does not execute a call or grant authority by itself. A shell
+call can return a result, a denial, or a recoverable correction to the model.
+
+The dispatcher detects an exposed native tool after shell preflight and before
+it calls `ShellPolicyCoordinator`. That correction stops the shell call and
+does not contact the approval store. The temporary-path policy adds managed
+temporary-directory advice to an `Approval` result. `Auto` returns before that
+policy runs, so it does not return managed temporary-directory advice.
 
 ## Approval Modes
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3929,6 +3929,29 @@ public class DispatchingToolExecutorTests
         Assert.Equal(0, approvalService.RequestCount);
     }
 
+    [Fact]
+    public async Task Native_tool_correction_precedes_auto_execution()
+    {
+        var call = CreateToolCall(
+            "call-native-auto-correction",
+            ShellTool.ToolName,
+            ToolInput.Create("Command", "file_read --path notes.txt"));
+        var context = CreateInteractivePersonalContext("signalr/native-auto-correction");
+
+        var decision = await _executor.EvaluateAuthorizationAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
+        var correction = Assert.IsType<ToolCorrection.NativeToolSuggested>(decision.AgentCorrection);
+        Assert.Equal("file_read", correction.ToolName.Value);
+
+        var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
+            _executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
+        Assert.IsType<ToolCorrection.NativeToolSuggested>(exception.Correction);
+    }
+
     [Theory]
     [InlineData(ShellGrammar.Bash, "printf marker; file_read --path report.txt")]
     [InlineData(ShellGrammar.PowerShell, "Write-Output marker; file_read -Path report.txt")]

--- a/src/Netclaw.Actors.Tests/Tools/TemporaryPathCorrectionPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/TemporaryPathCorrectionPolicyTests.cs
@@ -233,6 +233,22 @@ public sealed class TemporaryPathCorrectionPolicyTests
         Assert.Null(decision.AgentCorrection);
     }
 
+    [Fact]
+    public void Auto_mode_skips_the_managed_temporary_path_correction()
+    {
+        var decision = Evaluate(
+            BashEnvironment(),
+            PosixTemp,
+            "gh api repos/example/project",
+            PosixSession,
+            explicitWorkingDirectory: PosixTemp,
+            approvalMode: ToolApprovalMode.Auto);
+
+        Assert.True(decision.Allowed);
+        Assert.Equal(ToolAllowReason.PolicyAuto, decision.AllowReason);
+        Assert.Null(decision.ApprovalContext);
+    }
+
     [Theory]
     [InlineData(TrustAudience.Team)]
     [InlineData(TrustAudience.Public)]
@@ -414,7 +430,8 @@ public sealed class TemporaryPathCorrectionPolicyTests
         TrustAudience audience = TrustAudience.Personal,
         IPlatformTemporaryPathInspector? inspector = null,
         IReadOnlyList<string>? deniedPaths = null,
-        IReadOnlyList<string>? additionalTemporaryRoots = null)
+        IReadOnlyList<string>? additionalTemporaryRoots = null,
+        ToolApprovalMode approvalMode = ToolApprovalMode.Approval)
     {
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
         var profile = audience switch
@@ -428,7 +445,7 @@ public sealed class TemporaryPathCorrectionPolicyTests
         {
             ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
             {
-                [ShellTool.ToolName] = ToolApprovalMode.Approval
+                [ShellTool.ToolName] = approvalMode
             }
         };
         var commandPolicy = new ShellCommandPolicy(environment);

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -102,6 +102,24 @@ public sealed class ToolApprovalGateTests
         Assert.Equal("git push", complete.AuthorizedAnalysis.Source);
     }
 
+    [Fact]
+    public void Shell_in_auto_mode_allows_a_dynamic_executable_without_approval()
+    {
+        var policy = CreatePolicy(ToolApprovalMode.Auto);
+        var args = ToolInput.Create("Command", "\"$tool\" --status");
+
+        var preflight = policy.AuthorizeShellPreflight(
+            ShellTool(),
+            PersonalContext(),
+            args);
+
+        var complete = Assert.IsType<ShellPolicyPreflightResult.Complete>(preflight);
+        Assert.True(complete.Decision.Allowed);
+        Assert.False(complete.Decision.NeedsApproval);
+        Assert.Equal(ToolAllowReason.PolicyAuto, complete.Decision.AllowReason);
+        Assert.NotNull(complete.AuthorizedAnalysis);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
## Why this change

Before changing how shell authorization returns corrective suggestions, document the behavior that callers rely on today. This PR adds three focused tests and corrects the existing approval runbook. It changes no production code or correction eligibility.

## What changes

- Add a policy test showing that Auto mode permits a shell request containing a dynamic executable expression without asking for approval.
- Add a policy test showing that Auto mode currently returns before managed-temporary-directory advice is attached.
- Add a dispatcher test showing that an exposed native-tool suggestion, such as using the structured file_read tool instead of invoking it through the shell, produces a correction even in Auto mode. The test checks the authorization result and correction exception; it does not launch a process.
- Update docs/runbooks/tool-approval-gates.md to describe capability checks, hard denials, approval-mode handling, and the separate native-tool and temporary-path correction routes in their current source order.

These tests record existing behavior, not a proposed rule that Auto should always skip corrective advice.

## Verification

Local results reported by the implementing agent after rebasing onto the merged session-storage changes in #2090:

- Policy suite: 617 passed, 3 host-specific skips.
- Shell, job, recovery, and subagent suite: 173 passed, 1 Windows-only skip.
- Slopwatch, file-header verification, and git diff --check passed.

These focused checks do not establish full-suite, native-smoke, real upgrade, or cross-platform verification. GitHub Actions results are tracked separately on this PR.

## What remains unresolved

The investigation has not demonstrated two compatible existing corrections for one shell invocation. A future change that collects multiple suggestions needs a concrete example and a reviewed design without changing policy eligibility merely to make the example pass. This PR neither implements collection nor changes process startup or approval behavior.