### PR TITLE
feat: add inactive shell correction collection

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -361,6 +361,39 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     }
 
     [Fact]
+    public async Task Native_and_temporary_collection_returns_one_model_response()
+    {
+        var executor = new NativeAndTemporaryCorrectionExecutor();
+        var probe = CreateTestProbe("native-temporary-collection");
+        var call = new FunctionCallContent(
+            "call-native-temporary-collection",
+            "shell_execute",
+            new Dictionary<string, object?> { ["command"] = "file_write --path output.txt" });
+
+        var pipelineTask = new SessionToolPipelineTestFixture(
+                executor,
+                [call],
+                new SessionId("D1/native-temporary-collection"),
+                probe.Ref)
+            .WithApprovals(new ApprovalChannel(), _ => throw new InvalidOperationException("The collection must not prompt."), Timeout.InfiniteTimeSpan)
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(completed.ToolResults);
+        Assert.Equal(
+            "Shell execution stopped because 'file_write' is a native Netclaw tool.\n" +
+            $"Managed temporary directory: '{TestManagedTemporaryDirectory}'.\n" +
+            "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
+            result.Content);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-temporary-collection"].RemediationCode);
+        Assert.Equal("file_write", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
+    }
+
+    [Fact]
     public async Task Streaming_result_is_presented_before_delivery()
     {
         var executor = new CorrectiveReceiptExecutor();
@@ -1307,6 +1340,28 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
         private static ToolCorrectionRequiredException CreateCorrection()
             => new(new ToolCorrection.NativeToolSuggested(new ToolName("file_read")));
+    }
+
+    private sealed class NativeAndTemporaryCorrectionExecutor : IToolExecutor
+    {
+        public Task AuthorizeAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+            => ExecuteAsync(toolCall, context, ct);
+
+        public Task<string> ExecuteAsync(
+            FunctionCallContent toolCall,
+            ToolExecutionContext? context = null,
+            CancellationToken ct = default)
+        {
+            var collection = ShellPolicyCoordinator.TryCreateNativeAndTemporaryCandidate(
+                new ToolCorrection.NativeToolSuggested(new ToolName(FileWriteTool.ToolName)),
+                new ToolCorrection.ManagedTemporaryDirectorySuggested(
+                    new ManagedTemporaryCorrectionTarget(TestManagedTemporaryDirectory, "/tmp")))
+                ?? throw new InvalidOperationException("The correction pair must remain compatible.");
+            throw new ToolCorrectionRequiredException(collection);
+        }
     }
 
     private sealed class ManagedTemporaryCorrectionRequiredExecutor : IToolExecutor

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -18,9 +18,12 @@ using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Actors.Tests.Sessions.Pipelines;
 using Netclaw.Actors.Tools;
+using Netclaw.Actors.Tests.Tools;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
+using ShellSyntaxTree;
 using Xunit;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 
@@ -363,12 +366,17 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     [Fact]
     public async Task Native_and_temporary_collection_returns_one_model_response()
     {
-        var executor = new NativeAndTemporaryCorrectionExecutor();
+        var candidate = CreatePolicyProducedNativeAndTemporaryCollection();
+        var executor = new NativeAndTemporaryCorrectionExecutor(candidate.Corrections);
         var probe = CreateTestProbe("native-temporary-collection");
         var call = new FunctionCallContent(
             "call-native-temporary-collection",
             "shell_execute",
-            new Dictionary<string, object?> { ["command"] = "file_write --path output.txt" });
+            new Dictionary<string, object?>
+            {
+                ["command"] = candidate.Command,
+                ["WorkingDirectory"] = Path.GetTempPath()
+            });
 
         var pipelineTask = new SessionToolPipelineTestFixture(
                 executor,
@@ -391,6 +399,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             result.Content);
         Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-temporary-collection"].RemediationCode);
         Assert.Equal("file_write", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
+        Assert.Equal(1, executor.Attempts);
     }
 
     [Fact]
@@ -1342,8 +1351,75 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             => new(new ToolCorrection.NativeToolSuggested(new ToolName("file_read")));
     }
 
-    private sealed class NativeAndTemporaryCorrectionExecutor : IToolExecutor
+    private static PolicyProducedCorrectionCollection CreatePolicyProducedNativeAndTemporaryCollection()
     {
+        var environment = TestShellEnvironment.Current;
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                [ShellTool.ToolName] = ToolApprovalMode.Approval,
+                [FileWriteTool.ToolName] = ToolApprovalMode.Approval
+            }
+        };
+        var commandPolicy = new ShellCommandPolicy(environment);
+        var pathPolicy = new ToolPathPolicy(environment, []);
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
+        var policy = new ToolAccessPolicy(
+            new NetclawPaths(),
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            commandPolicy,
+            pathPolicy);
+        var storage = SessionStoragePaths.CreateVersion2(
+            new SessionStorageEnvelopeRoot(ManagedTemporarySessionDirectory));
+        var context = TestToolExecutionContext.CreateBoundWithStorage(
+            "signalr/native-temporary-collection",
+            storage,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true)
+            });
+        var nativePath = Path.Combine(Path.GetTempPath(), "netclaw-p2-output.txt");
+        var command = $"file_write --path {nativePath}";
+        var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
+        var fileWriteTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(FileWriteTool.ToolName));
+        var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
+            policy.AuthorizeShellPreflight(
+                shellTool,
+                context,
+                ToolInput.Create("Command", command, "WorkingDirectory", Path.GetTempPath())));
+        var shellTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(preflight.Correction);
+        var native = Assert.IsType<ToolCorrection.NativeToolSuggested>(
+            NativeToolShellCorrectionDetector.Detect(preflight.Analysis, registry, policy, context.Invocation));
+        var structured = policy.AuthorizeInvocation(
+            fileWriteTool,
+            context,
+            ToolInput.Create("Path", nativePath, "Content", "P2 output"));
+        Assert.True(structured.NeedsApproval);
+        var nativeTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(structured.AgentCorrection);
+        Assert.Equal(shellTemporary.Target, nativeTemporary.Target);
+
+        var corrections = ShellPolicyCoordinator.CollectApplicableCorrections(native, nativeTemporary)
+            ?? throw new InvalidOperationException("The policy-produced corrections must form a collection.");
+        return new PolicyProducedCorrectionCollection(command, corrections);
+    }
+
+    private sealed record PolicyProducedCorrectionCollection(
+        string Command,
+        ToolCorrectionCollection Corrections);
+
+    private sealed class NativeAndTemporaryCorrectionExecutor(ToolCorrectionCollection corrections) : IToolExecutor
+    {
+        public int Attempts { get; private set; }
+
         public Task AuthorizeAsync(
             FunctionCallContent toolCall,
             ToolExecutionContext? context = null,
@@ -1355,12 +1431,8 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             ToolExecutionContext? context = null,
             CancellationToken ct = default)
         {
-            var collection = ShellPolicyCoordinator.TryCreateNativeAndTemporaryCandidate(
-                new ToolCorrection.NativeToolSuggested(new ToolName(FileWriteTool.ToolName)),
-                new ToolCorrection.ManagedTemporaryDirectorySuggested(
-                    new ManagedTemporaryCorrectionTarget(TestManagedTemporaryDirectory, "/tmp")))
-                ?? throw new InvalidOperationException("The correction pair must remain compatible.");
-            throw new ToolCorrectionRequiredException(collection);
+            Attempts++;
+            throw new ToolCorrectionRequiredException(corrections);
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3955,17 +3955,21 @@ public class DispatchingToolExecutorTests
     [Fact]
     public void Native_file_write_and_temporary_directory_corrections_are_both_applicable()
     {
-        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var config = CreateApprovalGatedShellConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy!.ToolOverrides[FileWriteTool.ToolName] = ToolApprovalMode.Approval;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment, config);
         var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
+        var fileWriteTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(FileWriteTool.ToolName));
         var context = CreateInteractivePersonalContext("signalr/native-temporary-pair");
+        var nativePath = Path.Combine(Path.GetTempPath(), "netclaw-p2-output.txt");
         var arguments = ToolInput.Create(
-            "Command", "file_write --path output.txt",
+            "Command", $"file_write --path {nativePath}",
             "WorkingDirectory", Path.GetTempPath());
 
         var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
             policy.AuthorizeShellPreflight(shellTool, context, arguments));
 
-        Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(preflight.Correction);
+        var shellTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(preflight.Correction);
         var nativeCorrection = NativeToolShellCorrectionDetector.Detect(
             preflight.Analysis,
             registry,
@@ -3974,9 +3978,18 @@ public class DispatchingToolExecutorTests
         var nativeTool = Assert.IsType<ToolCorrection.NativeToolSuggested>(nativeCorrection);
         Assert.Equal(FileWriteTool.ToolName, nativeTool.ToolName.Value);
 
-        var collection = ShellPolicyCoordinator.TryCreateNativeAndTemporaryCandidate(
+        var correctedNativeDecision = policy.AuthorizeInvocation(
+            fileWriteTool,
+            context,
+            ToolInput.Create("Path", nativePath, "Content", "P2 output"));
+        Assert.True(correctedNativeDecision.NeedsApproval);
+        var nativeTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(
+            correctedNativeDecision.AgentCorrection);
+        Assert.Equal(shellTemporary.Target, nativeTemporary.Target);
+
+        var collection = ShellPolicyCoordinator.CollectApplicableCorrections(
             nativeTool,
-            preflight.Correction);
+            nativeTemporary);
         Assert.NotNull(collection);
         Assert.Collection(
             collection.Items,
@@ -3993,7 +4006,7 @@ public class DispatchingToolExecutorTests
         var executor = new DispatchingToolExecutor(registry, policy, approvalService);
         var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
         var arguments = ToolInput.Create(
-            "Command", "file_write --path output.txt",
+            "Command", $"file_write --path {Path.Combine(Path.GetTempPath(), "netclaw-p2-output.txt")}",
             "WorkingDirectory", Path.GetTempPath());
         var candidateContext = CreateInteractivePersonalContext("signalr/native-temporary-candidate");
         var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
@@ -4004,7 +4017,7 @@ public class DispatchingToolExecutorTests
                 registry,
                 policy,
                 candidateContext.Invocation));
-        var candidate = ShellPolicyCoordinator.TryCreateNativeAndTemporaryCandidate(
+        var candidate = ShellPolicyCoordinator.CollectApplicableCorrections(
             nativeCorrection,
             preflight.Correction);
         Assert.NotNull(candidate);
@@ -4019,6 +4032,20 @@ public class DispatchingToolExecutorTests
         Assert.IsType<ToolCorrection.NativeToolSuggested>(decision.AgentCorrection);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
+    }
+
+    [Fact]
+    public void Scalar_correction_accessor_rejects_multiple_corrections()
+    {
+        var exception = new ToolCorrectionRequiredException(
+            new ToolCorrectionCollection(
+                [
+                    new ToolCorrection.NativeToolSuggested(new ToolName(FileWriteTool.ToolName)),
+                    new ToolCorrection.ManagedTemporaryDirectorySuggested(
+                        new ManagedTemporaryCorrectionTarget("/session/tmp", "/tmp"))
+                ]));
+
+        Assert.Throws<InvalidOperationException>(() => _ = exception.Correction);
     }
 
     [Theory]

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3952,6 +3952,75 @@ public class DispatchingToolExecutorTests
         Assert.IsType<ToolCorrection.NativeToolSuggested>(exception.Correction);
     }
 
+    [Fact]
+    public void Native_file_write_and_temporary_directory_corrections_are_both_applicable()
+    {
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
+        var context = CreateInteractivePersonalContext("signalr/native-temporary-pair");
+        var arguments = ToolInput.Create(
+            "Command", "file_write --path output.txt",
+            "WorkingDirectory", Path.GetTempPath());
+
+        var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
+            policy.AuthorizeShellPreflight(shellTool, context, arguments));
+
+        Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(preflight.Correction);
+        var nativeCorrection = NativeToolShellCorrectionDetector.Detect(
+            preflight.Analysis,
+            registry,
+            policy,
+            context.Invocation);
+        var nativeTool = Assert.IsType<ToolCorrection.NativeToolSuggested>(nativeCorrection);
+        Assert.Equal(FileWriteTool.ToolName, nativeTool.ToolName.Value);
+
+        var collection = ShellPolicyCoordinator.TryCreateNativeAndTemporaryCandidate(
+            nativeTool,
+            preflight.Correction);
+        Assert.NotNull(collection);
+        Assert.Collection(
+            collection.Items,
+            correction => Assert.IsType<ToolCorrection.NativeToolSuggested>(correction),
+            correction => Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(correction));
+    }
+
+    [Fact]
+    public async Task Candidate_collection_leaves_the_authoritative_native_result_unchanged()
+    {
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var approvalService = new FixedShellApprovalService(_ =>
+            throw new InvalidOperationException("Candidate collection must not request approval."));
+        var executor = new DispatchingToolExecutor(registry, policy, approvalService);
+        var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
+        var arguments = ToolInput.Create(
+            "Command", "file_write --path output.txt",
+            "WorkingDirectory", Path.GetTempPath());
+        var candidateContext = CreateInteractivePersonalContext("signalr/native-temporary-candidate");
+        var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
+            policy.AuthorizeShellPreflight(shellTool, candidateContext, arguments));
+        var nativeCorrection = Assert.IsType<ToolCorrection.NativeToolSuggested>(
+            NativeToolShellCorrectionDetector.Detect(
+                preflight.Analysis,
+                registry,
+                policy,
+                candidateContext.Invocation));
+        var candidate = ShellPolicyCoordinator.TryCreateNativeAndTemporaryCandidate(
+            nativeCorrection,
+            preflight.Correction);
+        Assert.NotNull(candidate);
+
+        var authoritativeContext = CreateInteractivePersonalContext("signalr/native-temporary-authoritative");
+        var decision = await executor.EvaluateAuthorizationAsync(
+            CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments),
+            authoritativeContext,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, candidate.Items.Count);
+        Assert.IsType<ToolCorrection.NativeToolSuggested>(decision.AgentCorrection);
+        Assert.Equal(0, approvalService.RequestCount);
+        Assert.Null(authoritativeContext.Receipt);
+    }
+
     [Theory]
     [InlineData(ShellGrammar.Bash, "printf marker; file_read --path report.txt")]
     [InlineData(ShellGrammar.PowerShell, "Write-Output marker; file_read -Path report.txt")]

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -661,24 +661,20 @@ internal sealed class SessionToolExecutionPipeline
         catch (ToolCorrectionRequiredException correctionEx)
         {
             sw.Stop();
-            if (correctionEx.Correction is ToolCorrection.NativeToolSuggested nativeTool)
+            var presentation = ToolCorrectionPresentation.Build(correctionEx.Corrections);
+            var correctionReceipt = new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: ToolRemediationCode.UseNativeTool);
+            return new ToolCallResult(new SerializableChatMessage
             {
-                var correctionReceipt = new ToolInvocationReceipt(
-                    ToolInvocationOutcomeCategory.RecoverableCorrection,
-                    remediationCode: ToolRemediationCode.UseNativeTool);
-                return new ToolCallResult(new SerializableChatMessage
-                {
-                    Role = Protocol.ChatRole.Tool,
-                    Content = BuildNativeToolCorrection(nativeTool.ToolName),
-                    ToolCallId = new ToolCallId(tc.CallId),
-                    Name = tc.Name
-                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
-                    authorizationAttemptId,
-                    Receipt: correctionReceipt,
-                    ExposureRequest: new ToolExposureRequest(nativeTool.ToolName));
-            }
-
-            throw new InvalidOperationException("The correction does not name a native tool.");
+                Role = Protocol.ChatRole.Tool,
+                Content = presentation.Content,
+                ToolCallId = new ToolCallId(tc.CallId),
+                Name = tc.Name
+            }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
+                authorizationAttemptId,
+                Receipt: correctionReceipt,
+                ExposureRequest: new ToolExposureRequest(presentation.NativeTool));
         }
         catch (ToolApprovalRequiredException approvalEx)
         {

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -26,6 +26,75 @@ internal abstract record ToolCorrection
     internal sealed record ProjectDirectorySuggested(string Directory) : ToolCorrection;
 }
 
+/// <summary>Groups compatible correction facts for one tool attempt.</summary>
+/// <remarks>
+/// The collection has no authority or side effects. Current production paths
+/// still emit one correction. A later cutover can use this type after it
+/// defines the required retry and receipt behavior for every collection.
+/// </remarks>
+internal sealed class ToolCorrectionCollection
+{
+    private readonly IReadOnlyList<ToolCorrection> _items;
+
+    internal ToolCorrectionCollection(IEnumerable<ToolCorrection> corrections)
+    {
+        ArgumentNullException.ThrowIfNull(corrections);
+
+        var items = new List<ToolCorrection>();
+        foreach (var correction in corrections)
+        {
+            ArgumentNullException.ThrowIfNull(correction);
+            if (items.Contains(correction))
+                throw new ArgumentException("Correction collections cannot contain duplicates.", nameof(corrections));
+
+            items.Add(correction);
+        }
+
+        if (items.Count == 0)
+            throw new ArgumentException("Correction collections cannot be empty.", nameof(corrections));
+
+        _items = Array.AsReadOnly(items.ToArray());
+    }
+
+    internal IReadOnlyList<ToolCorrection> Items => _items;
+}
+
+/// <summary>Formats native-tool and managed-temporary correction pairs.</summary>
+internal static class ToolCorrectionPresentation
+{
+    internal static (string Content, ToolName NativeTool) Build(ToolCorrectionCollection corrections)
+    {
+        ArgumentNullException.ThrowIfNull(corrections);
+
+        ToolName? nativeTool = null;
+        ManagedTemporaryCorrectionTarget? managedTemporaryTarget = null;
+        foreach (var correction in corrections.Items)
+        {
+            switch (correction)
+            {
+                case ToolCorrection.NativeToolSuggested native when nativeTool is null:
+                    nativeTool = native.ToolName;
+                    break;
+                case ToolCorrection.ManagedTemporaryDirectorySuggested managed
+                    when managedTemporaryTarget is null:
+                    managedTemporaryTarget = managed.Target;
+                    break;
+                default:
+                    throw new InvalidOperationException("The correction collection has an unsupported or duplicate correction.");
+            }
+        }
+
+        if (nativeTool is null)
+            throw new InvalidOperationException("A shell correction collection must name a native tool.");
+
+        var content = $"Shell execution stopped because '{nativeTool.Value}' is a native Netclaw tool.";
+        if (managedTemporaryTarget is { } temporaryTarget)
+            content += $"\nManaged temporary directory: '{temporaryTarget.ManagedTemporaryDirectory}'.";
+
+        return (content, nativeTool.Value);
+    }
+}
+
 /// <summary>Captures the execution-relevant arguments of one corrected tool call.</summary>
 internal abstract record ManagedTemporaryCallSemantics(string ToolName, TimeSpan Timeout)
 {

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -59,7 +59,11 @@ internal sealed class ToolCorrectionCollection
     internal IReadOnlyList<ToolCorrection> Items => _items;
 }
 
-/// <summary>Formats native-tool and managed-temporary correction pairs.</summary>
+/// <summary>Formats correction facts for the current native-tool response path.</summary>
+/// <remarks>
+/// The response requires one native-tool fact. It can include one managed-temporary fact.
+/// A new fact requires an explicit response contract here.
+/// </remarks>
 internal static class ToolCorrectionPresentation
 {
     internal static (string Content, ToolName NativeTool) Build(ToolCorrectionCollection corrections)
@@ -80,7 +84,7 @@ internal static class ToolCorrectionPresentation
                     managedTemporaryTarget = managed.Target;
                     break;
                 default:
-                    throw new InvalidOperationException("The correction collection has an unsupported or duplicate correction.");
+                    throw new InvalidOperationException("The correction collection has an unsupported correction or duplicate fact.");
             }
         }
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -142,23 +142,28 @@ internal sealed class ShellPolicyCoordinator(
                 null);
     }
 
-    /// <summary>Creates an inactive candidate for the verified compatible correction pair.</summary>
+    /// <summary>Collects correction facts that already apply to one shell attempt.</summary>
     /// <remarks>
-    /// The current dispatcher still selects the native correction. This method
-    /// has no authority or side effects. P3 can activate the collection after
-    /// it defines the complete retry, receipt, and caller contract.
+    /// Callers determine correction applicability before this method runs.
+    /// This method preserves order and enforces collection invariants.
+    /// The current dispatcher still emits one native correction.
     /// </remarks>
-    internal static ToolCorrectionCollection? TryCreateNativeAndTemporaryCandidate(
-        ToolCorrection? nativeCorrection,
-        ToolCorrection? policyCorrection)
+    internal static ToolCorrectionCollection? CollectApplicableCorrections(
+        params ToolCorrection?[] corrections)
     {
-        if (nativeCorrection is not ToolCorrection.NativeToolSuggested native
-            || policyCorrection is not ToolCorrection.ManagedTemporaryDirectorySuggested temporary)
+        ArgumentNullException.ThrowIfNull(corrections);
+
+        var applicable = new List<ToolCorrection>();
+        foreach (var correction in corrections)
         {
-            return null;
+            if (correction is not null)
+                applicable.Add(correction);
         }
 
-        return new ToolCorrectionCollection([native, temporary]);
+        if (applicable.Count < 2)
+            return null;
+
+        return new ToolCorrectionCollection(applicable);
     }
 
     private async Task<ToolAuthorizationDecision> CompleteAsync(

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -139,7 +139,26 @@ internal sealed class ShellPolicyCoordinator(
             CompleteWithTrace(
                 ToolAuthorizationDecision.Deny("internal_policy_failure"),
                 trace),
-            null);
+                null);
+    }
+
+    /// <summary>Creates an inactive candidate for the verified compatible correction pair.</summary>
+    /// <remarks>
+    /// The current dispatcher still selects the native correction. This method
+    /// has no authority or side effects. P3 can activate the collection after
+    /// it defines the complete retry, receipt, and caller contract.
+    /// </remarks>
+    internal static ToolCorrectionCollection? TryCreateNativeAndTemporaryCandidate(
+        ToolCorrection? nativeCorrection,
+        ToolCorrection? policyCorrection)
+    {
+        if (nativeCorrection is not ToolCorrection.NativeToolSuggested native
+            || policyCorrection is not ToolCorrection.ManagedTemporaryDirectorySuggested temporary)
+        {
+            return null;
+        }
+
+        return new ToolCorrectionCollection([native, temporary]);
     }
 
     private async Task<ToolAuthorizationDecision> CompleteAsync(

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -363,5 +363,8 @@ internal sealed class ToolCorrectionRequiredException : InvalidOperationExceptio
 
     internal ToolCorrectionCollection Corrections { get; }
 
-    internal ToolCorrection Correction => Corrections.Items[0];
+    internal ToolCorrection Correction
+        => Corrections.Items.Count == 1
+            ? Corrections.Items[0]
+            : throw new InvalidOperationException("A scalar correction consumer received multiple corrections.");
 }

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -350,11 +350,18 @@ public sealed record ToolAuthorizationDecision
 internal sealed class ToolCorrectionRequiredException : InvalidOperationException
 {
     internal ToolCorrectionRequiredException(ToolCorrection correction)
-        : base("Tool invocation requires agent correction.")
+        : this(new ToolCorrectionCollection([correction]))
     {
-        ArgumentNullException.ThrowIfNull(correction);
-        Correction = correction;
     }
 
-    internal ToolCorrection Correction { get; }
+    internal ToolCorrectionRequiredException(ToolCorrectionCollection corrections)
+        : base("Tool invocation requires agent correction.")
+    {
+        ArgumentNullException.ThrowIfNull(corrections);
+        Corrections = corrections;
+    }
+
+    internal ToolCorrectionCollection Corrections { get; }
+
+    internal ToolCorrection Correction => Corrections.Items[0];
 }


### PR DESCRIPTION
## Purpose

A shell request can call `file_write` with an absolute path below the host temporary root. Netclaw detects two corrections for that request: call `file_write` directly and use the session-managed temporary directory.

This PR proves that one inactive response can carry both corrections. It does not change live authorization.

## What changes

- The shell coordinator collects two or more correction facts that already apply. It preserves source order.
- The current parent response path requires one native-tool fact. It can include one managed-temporary fact.
- A new correction fact needs an explicit response contract in the formatter.
- Scalar consumers now fail loud if they receive more than one correction.

## Evidence

The test uses this original shell request:

`shell_execute(Command: file_write --path <absolute temporary path>, WorkingDirectory: <temporary root>)`

The intended native call uses the same path:

`file_write(Path: <absolute temporary path>, Content: P2 output)`

The temporary-path policy returns the same session-managed directory for both requests. The native call still requires approval. No tool call runs.

A controlled parent-response test carries those policy results through the real response path. It asserts the complete response, one native-tool exposure request, no approval request, and one controlled execution attempt.

## Out of scope

- Live authorization still emits its existing native-tool correction.
- This PR does not start a shell process or write a grant, store, or retry state.
- This PR does not add child delivery, retry behavior, process startup, or rollout behavior.

## Verification

- Focused actor tests: 189 passed.
- Full actor suite: passed with six host-specific skips.
- `dotnet slopwatch analyze` passed.
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` passed.
- `git diff --check` passed.

## Merge order

This PR stacks on #2110. Merge #2110 first. Rebase this branch on the merged predecessor before merge.

The screenshot job failed before the test harness started. Its `ttyd` download returned HTTP 504.