### PR TITLE
feat: deliver collected shell corrections

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -75,7 +75,13 @@ jobs:
         # 30-min job cap) and is diagnosable from the CI log + the uploaded dump instead of a silent
         # timeout. The full dump carries every thread's stack — needed to confirm the suspected
         # macOS/ARM64 weak-memory-ordering hang in the TUI view-models.
-        run: dotnet test -c Release --blame-hang-timeout 300s --blame-hang-dump-type full --results-directory ./TestResults
+        run: dotnet test -c Release --filter "Category!=NativeShell" --blame-hang-timeout 300s --blame-hang-dump-type full --results-directory ./TestResults
+
+      - name: "dotnet test (native shell, serial)"
+        if: runner.os == 'Windows'
+        shell: bash
+        # The native PowerShell test needs an isolated Windows host.
+        run: dotnet test -c Release --no-build --filter "Category=NativeShell" --blame-hang-timeout 300s --blame-hang-dump-type full --results-directory ./TestResults
 
       # Diagnostic: surface the blame Sequence file (names the stuck test) in the CI log so a
       # platform-specific hang can be pinpointed even without downloading the dump artifact.

--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -23,11 +23,12 @@ The current source checks shell requests in this order:
 The approval gate does not execute a call or grant authority by itself. A shell
 call can return a result, a denial, or a recoverable correction to the model.
 
-`ShellPolicyCoordinator` detects an exposed native tool after shell preflight
-and before it checks the approval store. That correction stops the shell call.
-The temporary-path policy adds managed temporary-directory advice to an
-`Approval` result. `Auto` returns before that policy runs, so it does not return
-managed temporary-directory advice.
+`ShellPolicyCoordinator` asks `ToolAccessPolicy` to analyze the request and
+apply synchronous access checks. It then detects an exposed native tool before
+it checks the approval store. That correction stops the shell call. The
+temporary-path policy adds managed temporary-directory advice to an `Approval`
+result. `Auto` returns before that policy runs, so it does not return managed
+temporary-directory advice.
 
 ## Approval Modes
 

--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -23,11 +23,11 @@ The current source checks shell requests in this order:
 The approval gate does not execute a call or grant authority by itself. A shell
 call can return a result, a denial, or a recoverable correction to the model.
 
-The dispatcher detects an exposed native tool after shell preflight and before
-it calls `ShellPolicyCoordinator`. That correction stops the shell call and
-does not contact the approval store. The temporary-path policy adds managed
-temporary-directory advice to an `Approval` result. `Auto` returns before that
-policy runs, so it does not return managed temporary-directory advice.
+`ShellPolicyCoordinator` detects an exposed native tool after shell preflight
+and before it checks the approval store. That correction stops the shell call.
+The temporary-path policy adds managed temporary-directory advice to an
+`Approval` result. `Auto` returns before that policy runs, so it does not return
+managed temporary-directory advice.
 
 ## Approval Modes
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -404,8 +404,10 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     }
 
     [Fact]
-    public async Task Native_file_read_response_excludes_temporary_directory_advice()
+    public async Task Native_file_read_response_keeps_the_existing_path_without_temporary_advice()
     {
+        // The native reader must keep the requested source path.
+        // Managed temporary advice would redirect the read to a different file.
         var executor = CreateApprovalGatedShellExecutor();
         var probe = CreateTestProbe("native-read-without-temporary");
         var call = new FunctionCallContent(

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -404,6 +404,45 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     }
 
     [Fact]
+    public async Task Native_file_read_response_excludes_temporary_directory_advice()
+    {
+        var executor = CreateApprovalGatedShellExecutor();
+        var probe = CreateTestProbe("native-read-without-temporary");
+        var call = new FunctionCallContent(
+            "call-native-read-without-temporary",
+            ShellTool.ToolName,
+            new Dictionary<string, object?>
+            {
+                ["Command"] = $"file_read --path {Path.Combine(Path.GetTempPath(), "existing-report.txt")}",
+                ["WorkingDirectory"] = Path.GetTempPath(),
+                ["_rationale"] = "Read the requested diagnostic report with the native tool."
+            });
+
+        var pipelineTask = new SessionToolPipelineTestFixture(
+                executor,
+                [call],
+                new SessionId("D1/native-read-without-temporary"),
+                probe.Ref)
+            .WithTurnContext(InteractiveTurnContext(new SessionId("D1/native-read-without-temporary")))
+            .WithApprovals(new ApprovalChannel(), _ => throw new InvalidOperationException("The correction must not prompt."), Timeout.InfiniteTimeSpan)
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(completed.ToolResults);
+        Assert.Equal(
+            "Shell execution stopped because 'file_read' is a native Netclaw tool.\n" +
+            "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
+            result.Content);
+        Assert.DoesNotContain("Managed temporary directory", result.Content, StringComparison.Ordinal);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-read-without-temporary"].RemediationCode);
+        Assert.Equal("file_read", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
+    }
+
+    [Fact]
     public async Task Streaming_result_is_presented_before_delivery()
     {
         var executor = new CorrectiveReceiptExecutor();

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -366,16 +366,17 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     [Fact]
     public async Task Native_and_temporary_collection_returns_one_model_response()
     {
-        var candidate = CreatePolicyProducedNativeAndTemporaryCollection();
-        var executor = new NativeAndTemporaryCorrectionExecutor(candidate.Corrections);
+        var executor = CreateApprovalGatedShellExecutor();
         var probe = CreateTestProbe("native-temporary-collection");
+        var nativePath = Path.Combine(Path.GetTempPath(), "netclaw-p3-output.txt");
         var call = new FunctionCallContent(
             "call-native-temporary-collection",
             "shell_execute",
             new Dictionary<string, object?>
             {
-                ["command"] = candidate.Command,
-                ["WorkingDirectory"] = Path.GetTempPath()
+                ["Command"] = $"file_write --path {nativePath}",
+                ["WorkingDirectory"] = Path.GetTempPath(),
+                ["_rationale"] = "Write disposable output with the native tool."
             });
 
         var pipelineTask = new SessionToolPipelineTestFixture(
@@ -383,6 +384,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
                 [call],
                 new SessionId("D1/native-temporary-collection"),
                 probe.Ref)
+            .WithTurnContext(InteractiveTurnContext(new SessionId("D1/native-temporary-collection")))
             .WithApprovals(new ApprovalChannel(), _ => throw new InvalidOperationException("The collection must not prompt."), Timeout.InfiniteTimeSpan)
             .ExecuteAsync(TestContext.Current.CancellationToken);
 
@@ -394,12 +396,11 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var result = Assert.Single(completed.ToolResults);
         Assert.Equal(
             "Shell execution stopped because 'file_write' is a native Netclaw tool.\n" +
-            $"Managed temporary directory: '{TestManagedTemporaryDirectory}'.\n" +
+            $"Managed temporary directory: '{Path.Combine(Path.GetTempPath(), "tmp", "parent")}'.\n" +
             "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
             result.Content);
         Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-temporary-collection"].RemediationCode);
         Assert.Equal("file_write", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
-        Assert.Equal(1, executor.Attempts);
     }
 
     [Fact]
@@ -1351,7 +1352,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             => new(new ToolCorrection.NativeToolSuggested(new ToolName("file_read")));
     }
 
-    private static PolicyProducedCorrectionCollection CreatePolicyProducedNativeAndTemporaryCollection()
+    private static DispatchingToolExecutor CreateApprovalGatedShellExecutor()
     {
         var environment = TestShellEnvironment.Current;
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
@@ -1377,63 +1378,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
                 UsedStrictFallback: false),
             commandPolicy,
             pathPolicy);
-        var storage = SessionStoragePaths.CreateVersion2(
-            new SessionStorageEnvelopeRoot(ManagedTemporarySessionDirectory));
-        var context = TestToolExecutionContext.CreateBoundWithStorage(
-            "signalr/native-temporary-collection",
-            storage,
-            new TestToolExecutionContextOptions
-            {
-                Audience = TrustAudience.Personal,
-                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true)
-            });
-        var nativePath = Path.Combine(Path.GetTempPath(), "netclaw-p2-output.txt");
-        var command = $"file_write --path {nativePath}";
-        var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
-        var fileWriteTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(FileWriteTool.ToolName));
-        var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
-            policy.AuthorizeShellPreflight(
-                shellTool,
-                context,
-                ToolInput.Create("Command", command, "WorkingDirectory", Path.GetTempPath())));
-        var shellTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(preflight.Correction);
-        var native = Assert.IsType<ToolCorrection.NativeToolSuggested>(
-            NativeToolShellCorrectionDetector.Detect(preflight.Analysis, registry, policy, context.Invocation));
-        var structured = policy.AuthorizeInvocation(
-            fileWriteTool,
-            context,
-            ToolInput.Create("Path", nativePath, "Content", "P2 output"));
-        Assert.True(structured.NeedsApproval);
-        var nativeTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(structured.AgentCorrection);
-        Assert.Equal(shellTemporary.Target, nativeTemporary.Target);
-
-        var corrections = ShellPolicyCoordinator.CollectApplicableCorrections(native, nativeTemporary)
-            ?? throw new InvalidOperationException("The policy-produced corrections must form a collection.");
-        return new PolicyProducedCorrectionCollection(command, corrections);
-    }
-
-    private sealed record PolicyProducedCorrectionCollection(
-        string Command,
-        ToolCorrectionCollection Corrections);
-
-    private sealed class NativeAndTemporaryCorrectionExecutor(ToolCorrectionCollection corrections) : IToolExecutor
-    {
-        public int Attempts { get; private set; }
-
-        public Task AuthorizeAsync(
-            FunctionCallContent toolCall,
-            ToolExecutionContext? context = null,
-            CancellationToken ct = default)
-            => ExecuteAsync(toolCall, context, ct);
-
-        public Task<string> ExecuteAsync(
-            FunctionCallContent toolCall,
-            ToolExecutionContext? context = null,
-            CancellationToken ct = default)
-        {
-            Attempts++;
-            throw new ToolCorrectionRequiredException(corrections);
-        }
+        return new DispatchingToolExecutor(registry, policy, approvalService: null);
     }
 
     private sealed class ManagedTemporaryCorrectionRequiredExecutor : IToolExecutor

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -710,6 +710,51 @@ public class SubAgentActorTests : TestKit
             GetLastToolResult(fakeClient, "call-managed-temporary-correction"));
     }
 
+    [Fact]
+    public async Task Subagent_delivers_native_and_temporary_corrections_without_execution_or_approval()
+    {
+        var sessionDirectory = TestPath("sessions", "native-temporary-correction");
+        var environment = TestShellEnvironment.Current;
+        var shell = new FakeNetclawTool(ShellTool.ToolName, "should not run");
+        var fileWrite = new FileWriteTool(
+            new ToolConfig(),
+            new NetclawPaths(),
+            new ToolPathPolicy(environment, []));
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                NativeTemporaryFileWriteCall("call-native-temporary-correction")
+            ]
+        };
+        var approvalBridge = new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(
+            CreateDefinition([shell, fileWrite]),
+            fakeClient,
+            CreateManagedTemporaryCorrectionPolicy()));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Scope = SubAgentTestScope.Create(
+                    sessionDirectory: sessionDirectory,
+                    approvalBridge: approvalBridge),
+                Task = "Write a disposable diagnostic artifact.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            ApprovalAskTimeout,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success, result.Output);
+        Assert.False(shell.WasCalled);
+        Assert.Equal(0, approvalBridge.RequestCount);
+        Assert.Equal(
+            "Shell execution stopped because 'file_write' is a native Netclaw tool.\n" +
+            $"Managed temporary directory: '{Path.Combine(sessionDirectory, "subagents", "run", "tmp")}'.\n" +
+            "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
+            GetLastToolResult(fakeClient, "call-native-temporary-correction"));
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -1497,6 +1542,16 @@ public class SubAgentActorTests : TestKit
                 : "Get-Content result.log",
             ["WorkingDirectory"] = Path.GetFullPath(Path.GetTempPath()),
             ["_rationale"] = "Inspect a disposable diagnostic artifact."
+        });
+
+    private static FunctionCallContent NativeTemporaryFileWriteCall(string callId)
+        => new(callId, ShellTool.ToolName, new Dictionary<string, object?>
+        {
+            ["Command"] = TestShellEnvironment.Current.Grammar == ShellGrammar.Bash
+                ? $"file_write --path {Path.Combine(Path.GetTempPath(), "subagent-output.txt")}"
+                : $"file_write -Path {Path.Combine(Path.GetTempPath(), "subagent-output.txt")}",
+            ["WorkingDirectory"] = Path.GetFullPath(Path.GetTempPath()),
+            ["_rationale"] = "Write a disposable diagnostic artifact."
         });
 
     private static FunctionCallContent ProjectScopeCall(string callId, string workingDirectory)

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3761,7 +3761,8 @@ public class DispatchingToolExecutorTests
             context.Invocation);
 
         Assert.NotNull(correction);
-        Assert.Equal("file_read", correction.ToolName.Value);
+        Assert.Equal("file_read", correction.Correction.ToolName.Value);
+        Assert.False(correction.SupportsManagedTemporaryDirectory);
     }
 
     [Theory]
@@ -3786,7 +3787,8 @@ public class DispatchingToolExecutorTests
             context.Invocation);
 
         Assert.NotNull(correction);
-        Assert.Equal("file_read", correction.ToolName.Value);
+        Assert.Equal("file_read", correction.Correction.ToolName.Value);
+        Assert.False(correction.SupportsManagedTemporaryDirectory);
     }
 
     [Fact]
@@ -3806,7 +3808,8 @@ public class DispatchingToolExecutorTests
             context.Invocation);
 
         Assert.NotNull(correction);
-        Assert.Equal("file_write", correction.ToolName.Value);
+        Assert.Equal("file_write", correction.Correction.ToolName.Value);
+        Assert.True(correction.SupportsManagedTemporaryDirectory);
     }
 
     [Fact]
@@ -3826,7 +3829,8 @@ public class DispatchingToolExecutorTests
             context.Invocation);
 
         Assert.NotNull(correction);
-        Assert.Equal("file_read", correction.ToolName.Value);
+        Assert.Equal("file_read", correction.Correction.ToolName.Value);
+        Assert.False(correction.SupportsManagedTemporaryDirectory);
     }
 
     [Theory]
@@ -3976,8 +3980,9 @@ public class DispatchingToolExecutorTests
             registry,
             policy,
             context.Invocation);
-        var nativeTool = Assert.IsType<ToolCorrection.NativeToolSuggested>(nativeCorrection);
-        Assert.Equal(FileWriteTool.ToolName, nativeTool.ToolName.Value);
+        var nativeTool = Assert.IsType<NativeToolShellCorrection>(nativeCorrection);
+        Assert.True(nativeTool.SupportsManagedTemporaryDirectory);
+        Assert.Equal(FileWriteTool.ToolName, nativeTool.Correction.ToolName.Value);
 
         var correctedNativeDecision = policy.AuthorizeInvocation(
             fileWriteTool,
@@ -3989,7 +3994,7 @@ public class DispatchingToolExecutorTests
         Assert.Equal(shellTemporary.Target, nativeTemporary.Target);
 
         var collection = ShellPolicyCoordinator.CollectApplicableCorrections(
-            nativeTool,
+            nativeTool.Correction,
             nativeTemporary);
         Assert.NotNull(collection);
         Assert.Collection(
@@ -4028,6 +4033,30 @@ public class DispatchingToolExecutorTests
         Assert.Equal(2, exception.Corrections.Items.Count);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
+    }
+
+    [Fact]
+    public async Task Coordinator_excludes_temporary_correction_for_native_file_read()
+    {
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var approvalService = new FixedShellApprovalService(_ =>
+            throw new InvalidOperationException("Native correction must not request approval."));
+        var executor = new DispatchingToolExecutor(registry, policy, approvalService);
+        var arguments = ToolInput.Create(
+            "Command", $"file_read --path {Path.Combine(Path.GetTempPath(), "existing-report.txt")}",
+            "WorkingDirectory", Path.GetTempPath());
+        var context = CreateInteractivePersonalContext("signalr/native-read-without-temporary");
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            CreateToolCall("call-native-read-without-temporary", ShellTool.ToolName, arguments),
+            context,
+            TestContext.Current.CancellationToken);
+
+        var corrections = Assert.IsType<ToolCorrectionCollection>(decision.AgentCorrections);
+        var correction = Assert.Single(corrections.Items);
+        Assert.Equal("file_read", Assert.IsType<ToolCorrection.NativeToolSuggested>(correction).ToolName.Value);
+        Assert.Equal(0, approvalService.RequestCount);
+        Assert.Null(context.Receipt);
     }
 
     [Fact]
@@ -4357,7 +4386,7 @@ public class DispatchingToolExecutorTests
                 InteractiveApproval = TestToolExecutionContext.InteractiveApproval(true)
             });
 
-    private static ToolCorrection.NativeToolSuggested? DetectNativeToolForConfig(
+    private static NativeToolShellCorrection? DetectNativeToolForConfig(
         ToolConfig config,
         TrustAudience audience)
     {

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3505,6 +3505,7 @@ public class DispatchingToolExecutorTests
                 call,
                 context,
                 preflight,
+                nativeCorrection: null,
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(ToolAuthorizationOutcome.Allowed, authorization.Decision.Outcome);
@@ -3998,38 +3999,33 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
-    public async Task Candidate_collection_leaves_the_authoritative_native_result_unchanged()
+    public async Task Coordinator_selects_native_and_temporary_corrections_before_approval()
     {
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var approvalService = new FixedShellApprovalService(_ =>
             throw new InvalidOperationException("Candidate collection must not request approval."));
         var executor = new DispatchingToolExecutor(registry, policy, approvalService);
-        var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
         var arguments = ToolInput.Create(
             "Command", $"file_write --path {Path.Combine(Path.GetTempPath(), "netclaw-p2-output.txt")}",
             "WorkingDirectory", Path.GetTempPath());
-        var candidateContext = CreateInteractivePersonalContext("signalr/native-temporary-candidate");
-        var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
-            policy.AuthorizeShellPreflight(shellTool, candidateContext, arguments));
-        var nativeCorrection = Assert.IsType<ToolCorrection.NativeToolSuggested>(
-            NativeToolShellCorrectionDetector.Detect(
-                preflight.Analysis,
-                registry,
-                policy,
-                candidateContext.Invocation));
-        var candidate = ShellPolicyCoordinator.CollectApplicableCorrections(
-            nativeCorrection,
-            preflight.Correction);
-        Assert.NotNull(candidate);
-
         var authoritativeContext = CreateInteractivePersonalContext("signalr/native-temporary-authoritative");
         var decision = await executor.EvaluateAuthorizationAsync(
             CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments),
             authoritativeContext,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, candidate.Items.Count);
-        Assert.IsType<ToolCorrection.NativeToolSuggested>(decision.AgentCorrection);
+        Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
+        var corrections = Assert.IsType<ToolCorrectionCollection>(decision.AgentCorrections);
+        Assert.Collection(
+            corrections.Items,
+            correction => Assert.IsType<ToolCorrection.NativeToolSuggested>(correction),
+            correction => Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(correction));
+        var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
+            executor.AuthorizeAsync(
+                CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments),
+                authoritativeContext,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(2, exception.Corrections.Items.Count);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
     }

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3498,14 +3498,14 @@ public class DispatchingToolExecutorTests
                 ToolInput.Create("Command", phrase, "WorkingDirectory", root));
             var preflight = policy.AuthorizeShellPreflight(tool, context, call.Arguments);
             var continuation = Assert.IsType<ShellPolicyPreflightResult.Continue>(preflight);
-            var coordinator = new ShellPolicyCoordinator(policy, approvalService: null);
+            var registry = new ToolRegistry();
+            var coordinator = new ShellPolicyCoordinator(registry, policy, approvalService: null);
 
             var authorization = await coordinator.EvaluateAsync(
                 tool,
                 call,
                 context,
                 preflight,
-                nativeCorrection: null,
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(ToolAuthorizationOutcome.Allowed, authorization.Decision.Outcome);
@@ -4009,28 +4009,30 @@ public class DispatchingToolExecutorTests
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var approvalService = new FixedShellApprovalService(_ =>
             throw new InvalidOperationException("Candidate collection must not request approval."));
-        var executor = new DispatchingToolExecutor(registry, policy, approvalService);
+        var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
         var arguments = ToolInput.Create(
             "Command", $"file_write --path {Path.Combine(Path.GetTempPath(), "netclaw-p2-output.txt")}",
             "WorkingDirectory", Path.GetTempPath());
         var authoritativeContext = CreateInteractivePersonalContext("signalr/native-temporary-authoritative");
-        var decision = await executor.EvaluateAuthorizationAsync(
-            CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments),
+        var call = CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments);
+        var preflight = policy.AuthorizeShellPreflight(shellTool, authoritativeContext, arguments);
+        var coordinator = new ShellPolicyCoordinator(registry, policy, approvalService);
+
+        var authorization = await coordinator.EvaluateAsync(
+            shellTool,
+            call,
             authoritativeContext,
+            preflight,
             TestContext.Current.CancellationToken);
 
+        var decision = authorization.Decision;
         Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
         var corrections = Assert.IsType<ToolCorrectionCollection>(decision.AgentCorrections);
         Assert.Collection(
             corrections.Items,
             correction => Assert.IsType<ToolCorrection.NativeToolSuggested>(correction),
             correction => Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(correction));
-        var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
-            executor.AuthorizeAsync(
-                CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments),
-                authoritativeContext,
-                TestContext.Current.CancellationToken));
-        Assert.Equal(2, exception.Corrections.Items.Count);
+        Assert.Null(authorization.AuthorizedAnalysis);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
     }

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3449,7 +3449,7 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
-    public async Task Shell_completion_returns_the_exact_preflight_analysis()
+    public async Task Shell_completion_returns_the_authorized_analysis()
     {
         var root = Path.Combine(Path.GetTempPath(), $"shell-preflight-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
@@ -3496,8 +3496,6 @@ public class DispatchingToolExecutorTests
                 "call-exact-preflight-analysis",
                 ShellTool.ToolName,
                 ToolInput.Create("Command", phrase, "WorkingDirectory", root));
-            var preflight = policy.AuthorizeShellPreflight(tool, context, call.Arguments);
-            var continuation = Assert.IsType<ShellPolicyPreflightResult.Continue>(preflight);
             var registry = new ToolRegistry();
             var coordinator = new ShellPolicyCoordinator(registry, policy, approvalService: null);
 
@@ -3505,11 +3503,12 @@ public class DispatchingToolExecutorTests
                 tool,
                 call,
                 context,
-                preflight,
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(ToolAuthorizationOutcome.Allowed, authorization.Decision.Outcome);
-            Assert.Same(continuation.Analysis, authorization.AuthorizedAnalysis);
+            var analysis = Assert.IsType<ShellCommandAnalysis>(authorization.AuthorizedAnalysis);
+            Assert.Equal(phrase, analysis.Source);
+            Assert.Equal(root, analysis.WorkingDirectory);
         }
         finally
         {
@@ -4015,14 +4014,12 @@ public class DispatchingToolExecutorTests
             "WorkingDirectory", Path.GetTempPath());
         var authoritativeContext = CreateInteractivePersonalContext("signalr/native-temporary-authoritative");
         var call = CreateToolCall("call-native-temporary-authoritative", ShellTool.ToolName, arguments);
-        var preflight = policy.AuthorizeShellPreflight(shellTool, authoritativeContext, arguments);
         var coordinator = new ShellPolicyCoordinator(registry, policy, approvalService);
 
         var authorization = await coordinator.EvaluateAsync(
             shellTool,
             call,
             authoritativeContext,
-            preflight,
             TestContext.Current.CancellationToken);
 
         var decision = authorization.Decision;

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -196,6 +196,7 @@ public class ShellToolTests
     }
 
     [SlopwatchSuppress("SW001", "This native fallback test requires Windows PowerShell 5.1.")]
+    [Trait("Category", "NativeShell")]
     [Fact(SkipUnless = nameof(IsWindows), Skip = "Native Windows PowerShell 5.1 execution requires Windows.")]
     public async Task Windows_power_shell_51_executes_through_the_selected_host()
     {

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -924,9 +924,6 @@ internal sealed class SessionToolExecutionPipeline
                 : null);
     }
 
-    internal static string BuildNativeToolCorrection(ToolName toolName)
-        => $"Shell execution stopped because '{toolName.Value}' is a native Netclaw tool.";
-
     private static async Task<string> ExecuteToolAttemptAsync(
         IToolExecutor executor,
         FunctionCallContent toolCall,

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -1466,6 +1466,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (ToolCorrectionRequiredException correctionEx)
                 {
+                    // The coordinator selects all compatible correction facts.
+                    // The child presents them and requests the named native tool for the next model turn.
                     var presentation = ToolCorrectionPresentation.Build(correctionEx.Corrections);
                     toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
                         ToolInvocationOutcomeCategory.RecoverableCorrection,

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -1466,20 +1466,16 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (ToolCorrectionRequiredException correctionEx)
                 {
-                    if (correctionEx.Correction is ToolCorrection.NativeToolSuggested nativeTool)
-                    {
-                        toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
-                            ToolInvocationOutcomeCategory.RecoverableCorrection,
-                            remediationCode: ToolRemediationCode.UseNativeTool));
-                        return BuildToolResult(
-                            cleanedTc,
-                            SessionToolExecutionPipeline.BuildNativeToolCorrection(nativeTool.ToolName),
-                            toolContext,
-                            modelInputBudget,
-                            exposureRequest: new ToolExposureRequest(nativeTool.ToolName));
-                    }
-
-                    throw new InvalidOperationException("The correction does not name a native tool.");
+                    var presentation = ToolCorrectionPresentation.Build(correctionEx.Corrections);
+                    toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
+                        ToolInvocationOutcomeCategory.RecoverableCorrection,
+                        remediationCode: ToolRemediationCode.UseNativeTool));
+                    return BuildToolResult(
+                        cleanedTc,
+                        presentation.Content,
+                        toolContext,
+                        modelInputBudget,
+                        exposureRequest: new ToolExposureRequest(presentation.NativeTool));
                 }
                 catch (ToolApprovalRequiredException approvalEx)
                 {

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -42,7 +42,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         _registry = registry;
         _policy = policy;
         _approvalService = approvalService;
-        _shellPolicyCoordinator = new ShellPolicyCoordinator(policy, approvalService);
+        _shellPolicyCoordinator = new ShellPolicyCoordinator(registry, policy, approvalService);
         _logger = logger;
     }
 
@@ -421,25 +421,11 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                     tool,
                     context,
                     toolCall.Arguments);
-                var analysis = preflight switch
-                {
-                    ShellPolicyPreflightResult.Complete complete => complete.AuthorizedAnalysis,
-                    ShellPolicyPreflightResult.Continue next => next.Analysis,
-                    _ => null,
-                };
-                var correction = analysis is null
-                    ? null
-                    : NativeToolShellCorrectionDetector.Detect(
-                        analysis,
-                        _registry,
-                        _policy,
-                        context.Invocation);
                 shellAuthorization = await _shellPolicyCoordinator.EvaluateAsync(
                     tool,
                     toolCall,
                     context,
                     preflight,
-                    correction,
                     ct);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -434,16 +434,13 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                         _registry,
                         _policy,
                         context.Invocation);
-                shellAuthorization = correction is null
-                    ? await _shellPolicyCoordinator.EvaluateAsync(
-                        tool,
-                        toolCall,
-                        context,
-                        preflight,
-                        ct)
-                    : (
-                        ToolAuthorizationDecision.RequireAgentCorrection(correction),
-                        null);
+                shellAuthorization = await _shellPolicyCoordinator.EvaluateAsync(
+                    tool,
+                    toolCall,
+                    context,
+                    preflight,
+                    correction,
+                    ct);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -546,7 +543,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         if (decision.Outcome is ToolAuthorizationOutcome.RequiresAgentCorrection)
         {
             throw new ToolCorrectionRequiredException(
-                decision.AgentCorrection
+                decision.AgentCorrections
                 ?? throw new InvalidOperationException("Agent correction decision missing correction facts."));
         }
 

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -414,28 +414,11 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
 
         if (string.Equals(tool.Name, ShellTool.ToolName, StringComparison.Ordinal))
         {
-            (ToolAuthorizationDecision Decision, ShellCommandAnalysis? AuthorizedAnalysis) shellAuthorization;
-            try
-            {
-                var preflight = _policy.AuthorizeShellPreflight(
-                    tool,
-                    context,
-                    toolCall.Arguments);
-                shellAuthorization = await _shellPolicyCoordinator.EvaluateAsync(
-                    tool,
-                    toolCall,
-                    context,
-                    preflight,
-                    ct);
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception)
-            {
-                shellAuthorization = ShellPolicyCoordinator.CompleteInternalFailure();
-            }
+            var shellAuthorization = await _shellPolicyCoordinator.EvaluateAsync(
+                tool,
+                toolCall,
+                context,
+                ct);
 
             LogAuthorizationDecision(toolCall, context, shellAuthorization.Decision);
             return (shellAuthorization.Decision, shellAuthorization.AuthorizedAnalysis);

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -23,7 +23,7 @@ namespace Netclaw.Actors.Tools;
     "For full writes, creates the file and parent directories if needed. " +
     "A successful result confirms the change; do not verify it with shell unless requested.",
     Grant = "file")]
-public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
+public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>, IManagedTemporaryDirectoryCorrectionTool
 {
     public const string ToolName = "file_edit";
 

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -22,7 +22,7 @@ namespace Netclaw.Actors.Tools;
     "Write content and create parent directories when needed. " +
     "A successful result confirms the write; do not verify it with shell unless requested.",
     Grant = "file")]
-public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
+public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>, IManagedTemporaryDirectoryCorrectionTool
 {
     public const string ToolName = "file_write";
 

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -28,9 +28,8 @@ internal abstract record ToolCorrection
 
 /// <summary>Groups compatible correction facts for one tool attempt.</summary>
 /// <remarks>
-/// The collection has no authority or side effects. Current production paths
-/// still emit one correction. A later cutover can use this type after it
-/// defines the required retry and receipt behavior for every collection.
+/// The collection has no authority or side effects. The caller defines the
+/// required retry and receipt behavior for all correction facts.
 /// </remarks>
 internal sealed class ToolCorrectionCollection
 {

--- a/src/Netclaw.Actors/Tools/NativeToolShellCorrectionDetector.cs
+++ b/src/Netclaw.Actors/Tools/NativeToolShellCorrectionDetector.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Actors.Tools;
 
 internal static class NativeToolShellCorrectionDetector
 {
-    internal static ToolCorrection.NativeToolSuggested? Detect(
+    internal static NativeToolShellCorrection? Detect(
         ShellCommandAnalysis analysis,
         ToolRegistry registry,
         ToolAccessPolicy policy,
@@ -45,9 +45,16 @@ internal static class NativeToolShellCorrectionDetector
                 continue;
             }
 
-            return new ToolCorrection.NativeToolSuggested(new ToolName(registration.Tool.Name));
+            return new NativeToolShellCorrection(
+                new ToolCorrection.NativeToolSuggested(new ToolName(registration.Tool.Name)),
+                registration.Tool is IManagedTemporaryDirectoryCorrectionTool);
         }
 
         return null;
     }
 }
+
+/// <summary>Describes a native-tool correction and its compatible advice categories.</summary>
+internal sealed record NativeToolShellCorrection(
+    ToolCorrection.NativeToolSuggested Correction,
+    bool SupportsManagedTemporaryDirectory);

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -20,18 +20,25 @@ internal sealed class ShellPolicyCoordinator(
 {
     private readonly ShellApprovalEvidenceAdapter _approvalEvidence = new(approvalService);
 
+    /// <summary>Evaluates one shell request from access checks through its final authorization result.</summary>
+    /// <remarks>
+    /// The access policy creates one canonical command analysis and applies hard denials first.
+    /// The coordinator then collects corrections before it accepts automatic policy approval or checks stored approval evidence.
+    /// It returns the analysis only when the caller can start the authorized command.
+    /// </remarks>
     internal async Task<(ToolAuthorizationDecision Decision, ShellCommandAnalysis? AuthorizedAnalysis)> EvaluateAsync(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
-        ShellPolicyPreflightResult preflight,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(preflight);
-
         var trace = new ShellPolicyDecisionTraceBuilder();
         try
         {
+            var preflight = policy.AuthorizeShellPreflight(
+                tool,
+                context,
+                toolCall.Arguments);
             return await EvaluateCoreAsync(
                 tool,
                 toolCall,
@@ -62,7 +69,6 @@ internal sealed class ShellPolicyCoordinator(
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
-        // Preflight owns hard denials. The coordinator checks corrections before it accepts an Auto allow or requests approval.
         var analysis = preflight switch
         {
             ShellPolicyPreflightResult.Complete preflightComplete => preflightComplete.AuthorizedAnalysis,
@@ -79,7 +85,7 @@ internal sealed class ShellPolicyCoordinator(
 
         if (nativeCorrection is not null)
         {
-            // Managed temporary advice applies only when the suggested native operation can use the same target.
+            // Temporary relocation is valid only when the suggested native operation can use the same target.
             var corrections = nativeCorrection.SupportsManagedTemporaryDirectory
                 && preflight is ShellPolicyPreflightResult.Continue
                 {
@@ -93,7 +99,6 @@ internal sealed class ShellPolicyCoordinator(
                 null);
         }
 
-        // A terminal preflight result needs no policy projection or approval-store request.
         if (preflight is ShellPolicyPreflightResult.Complete complete)
         {
             var preflightDecision = complete.Decision;
@@ -113,7 +118,6 @@ internal sealed class ShellPolicyCoordinator(
                 complete.AuthorizedAnalysis);
         }
 
-        // The remaining request needs projected path checks and one approval-evidence evaluation.
         if (preflight is not ShellPolicyPreflightResult.Continue continuation
             || !ShellPolicyProjection.TryCreate(
                 continuation.Environment,
@@ -163,17 +167,6 @@ internal sealed class ShellPolicyCoordinator(
             decision.Outcome == ToolAuthorizationOutcome.Allowed
                 ? continuation.Analysis
                 : null);
-    }
-
-    internal static (ToolAuthorizationDecision Decision, ShellCommandAnalysis? AuthorizedAnalysis)
-        CompleteInternalFailure()
-    {
-        var trace = new ShellPolicyDecisionTraceBuilder();
-        return (
-            CompleteWithTrace(
-                ToolAuthorizationDecision.Deny("internal_policy_failure"),
-                trace),
-                null);
     }
 
     /// <summary>Collects correction facts that already apply to one shell attempt.</summary>

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -11,9 +11,10 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Coordinates shell preflight, one approval-store check, and final policy.
+/// Coordinates shell preflight, correction selection, one approval-store check, and final policy.
 /// </summary>
 internal sealed class ShellPolicyCoordinator(
+    ToolRegistry registry,
     ToolAccessPolicy policy,
     IToolApprovalService? approvalService)
 {
@@ -24,7 +25,6 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight,
-        NativeToolShellCorrection? nativeCorrection,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(preflight);
@@ -37,7 +37,6 @@ internal sealed class ShellPolicyCoordinator(
                 toolCall,
                 context,
                 preflight,
-                nativeCorrection,
                 trace,
                 cancellationToken);
         }
@@ -60,10 +59,23 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight,
-        NativeToolShellCorrection? nativeCorrection,
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
+        var analysis = preflight switch
+        {
+            ShellPolicyPreflightResult.Complete preflightComplete => preflightComplete.AuthorizedAnalysis,
+            ShellPolicyPreflightResult.Continue preflightContinuation => preflightContinuation.Analysis,
+            _ => throw new InvalidOperationException("Unsupported shell policy preflight result."),
+        };
+        var nativeCorrection = analysis is null
+            ? null
+            : NativeToolShellCorrectionDetector.Detect(
+                analysis,
+                registry,
+                policy,
+                context.Invocation);
+
         if (nativeCorrection is not null)
         {
             var corrections = nativeCorrection.SupportsManagedTemporaryDirectory
@@ -162,7 +174,7 @@ internal sealed class ShellPolicyCoordinator(
 
     /// <summary>Collects correction facts that already apply to one shell attempt.</summary>
     /// <remarks>
-    /// Callers determine correction applicability before this method runs.
+    /// Each correction policy determines applicability before this method runs.
     /// This method preserves order and enforces collection invariants.
     /// The coordinator selects correction collections for shell requests.
     /// </remarks>

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -24,6 +24,7 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight,
+        ToolCorrection.NativeToolSuggested? nativeCorrection,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(preflight);
@@ -36,6 +37,7 @@ internal sealed class ShellPolicyCoordinator(
                 toolCall,
                 context,
                 preflight,
+                nativeCorrection,
                 trace,
                 cancellationToken);
         }
@@ -58,9 +60,24 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight,
+        ToolCorrection.NativeToolSuggested? nativeCorrection,
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
+        if (nativeCorrection is not null)
+        {
+            var corrections = preflight is ShellPolicyPreflightResult.Continue
+                {
+                    Correction: ToolCorrection.ManagedTemporaryDirectorySuggested temporaryCorrection
+                }
+                ? CollectApplicableCorrections(nativeCorrection, temporaryCorrection)
+                    ?? throw new InvalidOperationException("Compatible corrections must form a collection.")
+                : new ToolCorrectionCollection([nativeCorrection]);
+            return (
+                Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
+                null);
+        }
+
         if (preflight is ShellPolicyPreflightResult.Complete complete)
         {
             var preflightDecision = complete.Decision;
@@ -146,7 +163,7 @@ internal sealed class ShellPolicyCoordinator(
     /// <remarks>
     /// Callers determine correction applicability before this method runs.
     /// This method preserves order and enforces collection invariants.
-    /// The current dispatcher still emits one native correction.
+    /// The coordinator selects correction collections for shell requests.
     /// </remarks>
     internal static ToolCorrectionCollection? CollectApplicableCorrections(
         params ToolCorrection?[] corrections)

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -62,6 +62,7 @@ internal sealed class ShellPolicyCoordinator(
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
+        // Preflight owns hard denials. The coordinator checks corrections before it accepts an Auto allow or requests approval.
         var analysis = preflight switch
         {
             ShellPolicyPreflightResult.Complete preflightComplete => preflightComplete.AuthorizedAnalysis,
@@ -78,6 +79,7 @@ internal sealed class ShellPolicyCoordinator(
 
         if (nativeCorrection is not null)
         {
+            // Managed temporary advice applies only when the suggested native operation can use the same target.
             var corrections = nativeCorrection.SupportsManagedTemporaryDirectory
                 && preflight is ShellPolicyPreflightResult.Continue
                 {
@@ -91,6 +93,7 @@ internal sealed class ShellPolicyCoordinator(
                 null);
         }
 
+        // A terminal preflight result needs no policy projection or approval-store request.
         if (preflight is ShellPolicyPreflightResult.Complete complete)
         {
             var preflightDecision = complete.Decision;
@@ -110,6 +113,7 @@ internal sealed class ShellPolicyCoordinator(
                 complete.AuthorizedAnalysis);
         }
 
+        // The remaining request needs projected path checks and one approval-evidence evaluation.
         if (preflight is not ShellPolicyPreflightResult.Continue continuation
             || !ShellPolicyProjection.TryCreate(
                 continuation.Environment,

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -24,7 +24,7 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight,
-        ToolCorrection.NativeToolSuggested? nativeCorrection,
+        NativeToolShellCorrection? nativeCorrection,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(preflight);
@@ -60,19 +60,20 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight,
-        ToolCorrection.NativeToolSuggested? nativeCorrection,
+        NativeToolShellCorrection? nativeCorrection,
         ShellPolicyDecisionTraceBuilder trace,
         CancellationToken cancellationToken)
     {
         if (nativeCorrection is not null)
         {
-            var corrections = preflight is ShellPolicyPreflightResult.Continue
+            var corrections = nativeCorrection.SupportsManagedTemporaryDirectory
+                && preflight is ShellPolicyPreflightResult.Continue
                 {
                     Correction: ToolCorrection.ManagedTemporaryDirectorySuggested temporaryCorrection
                 }
-                ? CollectApplicableCorrections(nativeCorrection, temporaryCorrection)
+                ? CollectApplicableCorrections(nativeCorrection.Correction, temporaryCorrection)
                     ?? throw new InvalidOperationException("Compatible corrections must form a collection.")
-                : new ToolCorrectionCollection([nativeCorrection]);
+                : new ToolCorrectionCollection([nativeCorrection.Correction]);
             return (
                 Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
                 null);

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -7,6 +7,12 @@ using Netclaw.Security;
 
 namespace Netclaw.Actors.Tools;
 
+/// <summary>
+/// Represents the synchronous shell access phase before the coordinator checks approval evidence.
+/// </summary>
+/// <remarks>
+/// A complete result ends evaluation. A continuation carries canonical facts into correction and approval selection.
+/// </remarks>
 internal abstract record ShellPolicyPreflightResult
 {
     private ShellPolicyPreflightResult()

--- a/src/Netclaw.Actors/Tools/TemporaryPathCorrectionPolicy.cs
+++ b/src/Netclaw.Actors/Tools/TemporaryPathCorrectionPolicy.cs
@@ -11,6 +11,15 @@ using ShellSyntaxTree;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
+/// Marks a native tool for which managed temporary-directory advice is valid.
+/// </summary>
+/// <remarks>
+/// The marker describes the native operation. It does not interpret shell
+/// command syntax or rewrite a tool call.
+/// </remarks>
+internal interface IManagedTemporaryDirectoryCorrectionTool;
+
+/// <summary>
 /// Identifies advice-only calls that explicitly use the shared platform temp root.
 /// This policy grants no authority and does not change the submitted call.
 /// </summary>

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -201,6 +201,7 @@ public sealed class ToolAccessPolicy
             deferReviewedSafeCoverage: false,
             out _);
 
+    /// <summary>Builds canonical shell analysis and applies synchronous access rules before approval evidence.</summary>
     internal ShellPolicyPreflightResult AuthorizeShellPreflight(
         INetclawTool tool,
         ToolExecutionContext context,

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -154,7 +154,7 @@ public sealed record ToolAuthorizationDecision
         string? denyReason,
         string? denyMessage,
         ToolApprovalContext? approvalContext,
-        ToolCorrection? agentCorrection,
+        ToolCorrectionCollection? agentCorrections,
         IReadOnlyList<ToolApprovalMatch> approvalMatches,
         ShellPolicyDecisionTrace? shellPolicyTrace = null)
     {
@@ -163,7 +163,7 @@ public sealed record ToolAuthorizationDecision
         DenyReason = denyReason;
         DenyMessage = denyMessage;
         ApprovalContext = approvalContext;
-        AgentCorrection = agentCorrection;
+        AgentCorrections = agentCorrections;
         ApprovalMatches = approvalMatches;
         ShellPolicyTrace = shellPolicyTrace ?? ShellPolicyDecisionTrace.Empty;
     }
@@ -205,10 +205,17 @@ public sealed record ToolAuthorizationDecision
     public ToolApprovalContext? ApprovalContext { get; }
 
     /// <summary>
-    /// Gets the typed correction when <see cref="Outcome"/> is
-    /// <see cref="ToolAuthorizationOutcome.RequiresAgentCorrection"/>.
+    /// Gets the correction facts when <see cref="Outcome"/> requires correction.
     /// </summary>
-    internal ToolCorrection? AgentCorrection { get; }
+    internal ToolCorrectionCollection? AgentCorrections { get; }
+
+    /// <summary>Gets one correction for callers that support only scalar advice.</summary>
+    internal ToolCorrection? AgentCorrection => AgentCorrections switch
+    {
+        null => null,
+        { Items.Count: 1 } corrections => corrections.Items[0],
+        _ => throw new InvalidOperationException("A scalar correction consumer received multiple corrections.")
+    };
 
     /// <summary>
     /// Gets the session or persistent grants that matched this attempt.
@@ -280,7 +287,7 @@ public sealed record ToolAuthorizationDecision
             null,
             null,
             context,
-            correction,
+            ToCollection(correction),
             []);
     }
 
@@ -300,7 +307,7 @@ public sealed record ToolAuthorizationDecision
             null,
             null,
             context,
-            correction,
+            ToCollection(correction),
             [.. approvalMatches]);
     }
 
@@ -308,15 +315,21 @@ public sealed record ToolAuthorizationDecision
     /// Creates a typed agent-correction result that grants no execution authority.
     /// </summary>
     internal static ToolAuthorizationDecision RequireAgentCorrection(ToolCorrection correction)
+        => RequireAgentCorrection(new ToolCorrectionCollection([correction]));
+
+    /// <summary>
+    /// Creates a typed agent-correction result that grants no execution authority.
+    /// </summary>
+    internal static ToolAuthorizationDecision RequireAgentCorrection(ToolCorrectionCollection corrections)
     {
-        ArgumentNullException.ThrowIfNull(correction);
+        ArgumentNullException.ThrowIfNull(corrections);
         return new ToolAuthorizationDecision(
             ToolAuthorizationOutcome.RequiresAgentCorrection,
             null,
             null,
             null,
             null,
-            correction,
+            corrections,
             []);
     }
 
@@ -345,6 +358,9 @@ public sealed record ToolAuthorizationDecision
         if (!Enum.IsDefined(reason))
             throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown tool allow reason.");
     }
+
+    private static ToolCorrectionCollection? ToCollection(ToolCorrection? correction)
+        => correction is null ? null : new ToolCorrectionCollection([correction]);
 }
 
 internal sealed class ToolCorrectionRequiredException : InvalidOperationException

--- a/tests/smoke/tapes/init-wizard.tape
+++ b/tests/smoke/tapes/init-wizard.tape
@@ -70,8 +70,8 @@ Enter
 # They contact the smoke provider, write config, validate, and start the daemon.
 # On a clean bootstrap, once validation passes the wizard launches chat
 # automatically — there is no Enter gate / post-flight summary to confirm.
-# Anchor on a health item that renders during the run (it stays on screen
-# through the daemon-start poll), then wait for the chat screen to take over.
+# Anchor on a health item that remains through the daemon-start poll.
+# The session message proves that the chat screen took control.
 Wait+Screen@60s /Configuration written/
-Wait+Screen@60s /Ready  \|  netclaw-smoke-tool-model/
+Wait+Screen@60s /System: Session started\./
 Ctrl+Q

--- a/tests/smoke/tapes/mcp-permissions-save.tape
+++ b/tests/smoke/tapes/mcp-permissions-save.tape
@@ -29,7 +29,7 @@ Wait+Screen@30s /record-tasks/
 Wait+Screen@10s /Server default:/
 Down
 Space
-Wait+Screen@5s /unsaved/
+Wait+Screen@5s /\[✓\] Server enabled for personal/
 Enter
 Wait+Screen@5s /Enter\/Y.*Save/
 Enter


### PR DESCRIPTION
## Purpose

A shell request can have a safer native Netclaw tool. Some native file-change tools can also use the session temporary directory. This draft returns both facts only when they apply to the same operation.

## What changes

- Netclaw selects correction facts in one shell policy path.
- A native tool declares whether temporary-directory advice applies to its operation.
- The main session and a delegated agent return the same correction response.
- A native file-read correction does not include temporary-directory advice.
- Netclaw does not parse shell command options or operands for this decision.
- CI runs the native Windows PowerShell test without parallel test load.
- The init wizard smoke tape waits for stable chat-session text.

## What stays the same

- Netclaw checks denials, protected paths, shell mode, and audience before it returns advice.
- A correction does not start a process, ask for approval, or change stored approval data.
- The corrected native tool call starts a new authorization check.
- This draft does not change process startup or deployment behavior.

## Evidence

Focused tests cover policy selection, the main-session response, and the delegated-agent response. The tests prove that no process starts and no approval request occurs. The file-read test proves that irrelevant temporary-directory advice is absent.

The full local test suite passes. The init wizard native tape passed three consecutive local runs. Slopwatch, file-header verification, and diff checks pass.

All GitHub CI checks pass on commit 67f6e44a. The isolated Windows PowerShell 5.1 test and both native smoke suites pass.

## Draft status

This draft addresses the current review items and CI races. It remains a draft for reviewer approval. Shared process-start checks remain separate work.