### PR TITLE
refactor: unify temporary correction delivery

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -401,6 +401,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             result.Content);
         Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-temporary-collection"].RemediationCode);
         Assert.Equal("file_write", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
+        Assert.Empty(completed.ManagedTemporaryCorrectionChanges);
     }
 
     [Fact]
@@ -442,6 +443,61 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         Assert.DoesNotContain("Managed temporary directory", result.Content, StringComparison.Ordinal);
         Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-read-without-temporary"].RemediationCode);
         Assert.Equal("file_read", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
+    }
+
+    [Theory]
+    [InlineData(ShellTool.ToolName)]
+    [InlineData(FileWriteTool.ToolName)]
+    public async Task Temporary_only_policy_result_uses_the_common_correction_delivery(
+        string toolName)
+    {
+        var executor = CreateApprovalGatedShellExecutor();
+        var probe = CreateTestProbe("temporary-only-policy-result");
+        var sessionId = new SessionId("D1/temporary-only-policy-result");
+        var arguments = toolName == ShellTool.ToolName
+            ? new Dictionary<string, object?>
+            {
+                ["Command"] = "gh api repos/example/project",
+                ["WorkingDirectory"] = Path.GetTempPath(),
+                ["_rationale"] = "Inspect a disposable diagnostic artifact."
+            }
+            : new Dictionary<string, object?>
+            {
+                ["Path"] = Path.Combine(Path.GetTempPath(), "netclaw-structured-output.txt"),
+                ["Content"] = "unused",
+                ["_rationale"] = "Write a disposable diagnostic artifact."
+            };
+        var call = new FunctionCallContent(
+            $"call-temporary-only-{toolName}",
+            toolName,
+            arguments);
+
+        var pipelineTask = new SessionToolPipelineTestFixture(executor, [call], sessionId, probe.Ref)
+            .WithTurnContext(InteractiveTurnContext(sessionId))
+            .InSessionDirectory(ManagedTemporarySessionDirectory)
+            .WithApprovals(
+                new ApprovalChannel(),
+                _ => throw new InvalidOperationException("The correction must not prompt."),
+                Timeout.InfiniteTimeSpan)
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        var completed = await probe.ExpectMsgAsync<ToolExecutionCompleted>(
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await pipelineTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(completed.ToolResults);
+        Assert.Equal(
+            "Tool execution deferred: use_managed_temporary_directory\n" +
+            $"Managed temporary directory: '{TestManagedTemporaryDirectory}'.\n" +
+            "Next action: use the managed temporary directory from this result for disposable files, or retry unchanged for exact platform paths.",
+            result.Content);
+        Assert.Equal(
+            ToolRemediationCode.UseManagedTemporaryDirectory,
+            completed.ToolReceipts[call.CallId].RemediationCode);
+        Assert.IsType<ManagedTemporaryCorrectionChange.Arm>(
+            Assert.Single(completed.ManagedTemporaryCorrectionChanges));
+        Assert.Empty(completed.ToolExposureRequests);
     }
 
     [Fact]
@@ -1447,13 +1503,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             FunctionCallContent toolCall,
             ToolExecutionContext? context = null,
             CancellationToken ct = default)
-            => throw new ToolApprovalRequiredException(
-                new ToolApprovalContext(
-                    ToolName: toolCall.Name,
-                    DisplayText: Command,
-                    Patterns: ["gh api"],
-                    CandidateVerbs: ["gh api"],
-                    Options: []),
+            => throw new ToolCorrectionRequiredException(
                 new ToolCorrection.ManagedTemporaryDirectorySuggested(Key.Target));
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -2916,7 +2916,9 @@ public class DispatchingToolExecutorTests
     [Fact]
     public async Task One_time_approval_bypasses_policy_for_path_aware_file_patterns()
     {
-        var controlPlaneRoot = Path.Combine(Path.GetTempPath(), $"netclaw-control-plane-{Guid.NewGuid():N}");
+        var controlPlaneRoot = Path.Combine(
+            AppContext.BaseDirectory,
+            $"netclaw-control-plane-{Guid.NewGuid():N}");
         var targetPath = Path.Combine(controlPlaneRoot, "netclaw.json");
         var secondPath = Path.Combine(controlPlaneRoot, "devices.json");
         Directory.CreateDirectory(controlPlaneRoot);
@@ -4032,6 +4034,71 @@ public class DispatchingToolExecutorTests
         Assert.Null(authorization.AuthorizedAnalysis);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
+    }
+
+    [Fact]
+    public async Task Coordinator_returns_temporary_only_correction_after_approval_miss()
+    {
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var approvalService = new FixedShellApprovalService(request =>
+            new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                Array.AsReadOnly(request.Candidates
+                    .Select(candidate => new ShellGrantCandidateMatch(
+                        candidate.CandidateId,
+                        Match: null,
+                        GrantCoverage: null,
+                        NearMisses: []))
+                    .ToArray())));
+        var executor = new DispatchingToolExecutor(registry, policy, approvalService);
+        var call = CreateToolCall(
+            "call-temporary-only-correction",
+            ShellTool.ToolName,
+            ToolInput.Create(
+                "Command", "gh api repos/example/project",
+                "WorkingDirectory", Path.GetTempPath()));
+        var context = CreateInteractivePersonalContext("signalr/temporary-only-correction");
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
+        Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(decision.AgentCorrection);
+        Assert.Equal(1, approvalService.RequestCount);
+        await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
+            executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Structured_file_temporary_correction_becomes_common_result_after_approval_miss()
+    {
+        var config = CreateApprovalGatedShellConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy!.ToolOverrides[FileWriteTool.ToolName] =
+            ToolApprovalMode.Approval;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment, config);
+        var executor = new DispatchingToolExecutor(
+            registry,
+            policy,
+            new FixedApprovalService(new ToolApprovalCheckResult([FileWriteTool.ToolName], [])));
+        var call = CreateToolCall(
+            "call-structured-temporary-correction",
+            FileWriteTool.ToolName,
+            ToolInput.Create(
+                "Path", Path.Combine(Path.GetTempPath(), "netclaw-structured-output.txt"),
+                "Content", "unused"));
+        var context = CreateInteractivePersonalContext("signalr/structured-temporary-correction");
+
+        var decision = await executor.EvaluateAuthorizationAsync(
+            call,
+            context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
+        Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(decision.AgentCorrection);
+        await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
+            executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3952,6 +3952,11 @@ public class DispatchingToolExecutorTests
         Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
         var correction = Assert.IsType<ToolCorrection.NativeToolSuggested>(decision.AgentCorrection);
         Assert.Equal("file_read", correction.ToolName.Value);
+        var completion = Assert.Single(
+            decision.ShellPolicyTrace.Rows,
+            row => row.Stage == ShellPolicyTraceStage.Completion);
+        Assert.Equal(ShellPolicyTraceOutcome.RequiresAgentCorrection, completion.Outcome);
+        Assert.Equal(ShellPolicyTraceReason.AgentCorrection, completion.Reason);
 
         var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
             _executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
@@ -4040,22 +4045,41 @@ public class DispatchingToolExecutorTests
     public async Task Coordinator_returns_temporary_only_correction_after_approval_miss()
     {
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        ToolApprovalMatch? approvedMatch = null;
         var approvalService = new FixedShellApprovalService(request =>
-            new ShellApprovalMatchResult(
-                new PersistentGrantStoreStatus.Ready(),
-                Array.AsReadOnly(request.Candidates
-                    .Select(candidate => new ShellGrantCandidateMatch(
+        {
+            Assert.Equal(2, request.Candidates.Count);
+            var matches = request.Candidates.Select((candidate, index) =>
+            {
+                if (index != 0)
+                {
+                    return new ShellGrantCandidateMatch(
                         candidate.CandidateId,
                         Match: null,
                         GrantCoverage: null,
-                        NearMisses: []))
-                    .ToArray())));
+                        NearMisses: []);
+                }
+
+                approvedMatch = new ToolApprovalMatch(
+                    candidate.Candidate.Verb,
+                    "session",
+                    "this chat");
+                return new ShellGrantCandidateMatch(
+                    candidate.CandidateId,
+                    approvedMatch,
+                    ShellCoverageKind.Session,
+                    NearMisses: []);
+            }).ToArray();
+            return new ShellApprovalMatchResult(
+                new PersistentGrantStoreStatus.Ready(),
+                Array.AsReadOnly(matches));
+        });
         var executor = new DispatchingToolExecutor(registry, policy, approvalService);
         var call = CreateToolCall(
             "call-temporary-only-correction",
             ShellTool.ToolName,
             ToolInput.Create(
-                "Command", "gh api repos/example/project",
+                "Command", "gh api repos/example/project && git push",
                 "WorkingDirectory", Path.GetTempPath()));
         var context = CreateInteractivePersonalContext("signalr/temporary-only-correction");
 
@@ -4066,6 +4090,13 @@ public class DispatchingToolExecutorTests
 
         Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, decision.Outcome);
         Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(decision.AgentCorrection);
+        Assert.NotNull(approvedMatch);
+        Assert.Equal(approvedMatch, Assert.Single(decision.ApprovalMatches));
+        var completion = Assert.Single(
+            decision.ShellPolicyTrace.Rows,
+            row => row.Stage == ShellPolicyTraceStage.Completion);
+        Assert.Equal(ShellPolicyTraceOutcome.RequiresAgentCorrection, completion.Outcome);
+        Assert.Equal(ShellPolicyTraceReason.AgentCorrection, completion.Reason);
         Assert.Equal(1, approvalService.RequestCount);
         await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
             executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -661,46 +661,25 @@ internal sealed class SessionToolExecutionPipeline
         catch (ToolCorrectionRequiredException correctionEx)
         {
             sw.Stop();
-            var presentation = ToolCorrectionPresentation.Build(correctionEx.Corrections);
-            var correctionReceipt = new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.RecoverableCorrection,
-                remediationCode: ToolRemediationCode.UseNativeTool);
+            var delivery = ToolCorrectionDelivery.Create(
+                correctionEx.Corrections,
+                managedTemporaryCall);
             return new ToolCallResult(new SerializableChatMessage
             {
                 Role = Protocol.ChatRole.Tool,
-                Content = presentation.Content,
+                Content = delivery.Content,
                 ToolCallId = new ToolCallId(tc.CallId),
                 Name = tc.Name
             }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
                 authorizationAttemptId,
-                Receipt: correctionReceipt,
-                ExposureRequest: new ToolExposureRequest(presentation.NativeTool));
+                Receipt: delivery.Receipt,
+                ExposureRequest: delivery.NativeTool is { } nativeTool
+                    ? new ToolExposureRequest(nativeTool)
+                    : null,
+                ManagedTemporaryCorrectionUpdate: delivery.ManagedTemporaryStateChange);
         }
         catch (ToolApprovalRequiredException approvalEx)
         {
-            if (approvalEx.Correction is ToolCorrection.ManagedTemporaryDirectorySuggested managedTemporaryCorrection
-                && managedTemporaryCall is { } correctedCall)
-            {
-                sw.Stop();
-                var correctionReceipt = new ToolInvocationReceipt(
-                    ToolInvocationOutcomeCategory.RecoverableCorrection,
-                    remediationCode: ToolRemediationCode.UseManagedTemporaryDirectory);
-                var newCorrectionKey = new ManagedTemporaryCorrectionKey(
-                    correctedCall,
-                    managedTemporaryCorrection.Target);
-                return new ToolCallResult(new SerializableChatMessage
-                {
-                    Role = Protocol.ChatRole.Tool,
-                    Content = ManagedTemporaryCorrection.BuildSuggestion(
-                        managedTemporaryCorrection.Target.ManagedTemporaryDirectory),
-                    ToolCallId = new ToolCallId(tc.CallId),
-                    Name = tc.Name
-                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
-                    authorizationAttemptId,
-                    Receipt: correctionReceipt,
-                    ManagedTemporaryCorrectionUpdate: new ManagedTemporaryCorrectionChange.Arm(newCorrectionKey));
-            }
-
             var projectScopeCorrection = BuildProjectScopeDeclarationCorrection(
                 approvalEx.Correction,
                 batch.SetWorkingDirectoryAvailable,

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -1466,40 +1466,23 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 }
                 catch (ToolCorrectionRequiredException correctionEx)
                 {
-                    // The coordinator selects all compatible correction facts.
-                    // The child presents them and requests the named native tool for the next model turn.
-                    var presentation = ToolCorrectionPresentation.Build(correctionEx.Corrections);
-                    toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
-                        ToolInvocationOutcomeCategory.RecoverableCorrection,
-                        remediationCode: ToolRemediationCode.UseNativeTool));
+                    var delivery = ToolCorrectionDelivery.Create(
+                        correctionEx.Corrections,
+                        managedTemporaryCall);
+                    toolContext.Outputs.TryComplete(delivery.Receipt);
                     return BuildToolResult(
                         cleanedTc,
-                        presentation.Content,
+                        delivery.Content,
                         toolContext,
                         modelInputBudget,
-                        exposureRequest: new ToolExposureRequest(presentation.NativeTool));
+                        delivery.ManagedTemporaryStateChange,
+                        delivery.NativeTool is { } nativeTool
+                            ? new ToolExposureRequest(nativeTool)
+                            : null);
                 }
                 catch (ToolApprovalRequiredException approvalEx)
                 {
                     var ctx = approvalEx.ApprovalContext;
-                    if (approvalEx.Correction is ToolCorrection.ManagedTemporaryDirectorySuggested managedTemporaryCorrection
-                        && managedTemporaryCall is { } correctedCall)
-                    {
-                        toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
-                            ToolInvocationOutcomeCategory.RecoverableCorrection,
-                            remediationCode: ToolRemediationCode.UseManagedTemporaryDirectory));
-                        var newCorrectionKey = new ManagedTemporaryCorrectionKey(
-                            correctedCall,
-                            managedTemporaryCorrection.Target);
-                        return BuildToolResult(
-                            cleanedTc,
-                            ManagedTemporaryCorrection.BuildSuggestion(
-                                managedTemporaryCorrection.Target.ManagedTemporaryDirectory),
-                            toolContext,
-                            modelInputBudget,
-                            new ManagedTemporaryCorrectionChange.Arm(newCorrectionKey));
-                    }
-
                     var projectScopeCorrection =
                         SessionToolExecutionPipeline.BuildProjectScopeDeclarationCorrection(
                             approvalEx.Correction,

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -491,7 +491,9 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 AgentCorrection: ToolCorrection.ManagedTemporaryDirectorySuggested temporaryCorrection
             })
         {
-            accessDecision = ToolAuthorizationDecision.RequireAgentCorrection(temporaryCorrection);
+            accessDecision = ToolAuthorizationDecision.RequireAgentCorrection(
+                temporaryCorrection,
+                approvalMatches);
         }
 
         var authorizationDecision = CompleteAuthorizationDecision(accessDecision, approvalMatches);

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -485,6 +485,15 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
             accessDecision = ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval);
         }
 
+        if (accessDecision is
+            {
+                Outcome: ToolAuthorizationOutcome.RequiresApproval,
+                AgentCorrection: ToolCorrection.ManagedTemporaryDirectorySuggested temporaryCorrection
+            })
+        {
+            accessDecision = ToolAuthorizationDecision.RequireAgentCorrection(temporaryCorrection);
+        }
+
         var authorizationDecision = CompleteAuthorizationDecision(accessDecision, approvalMatches);
         LogAuthorizationDecision(toolCall, context, authorizationDecision);
         return (authorizationDecision, null);

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -29,7 +29,7 @@ internal abstract record ToolCorrection
 /// <summary>Groups compatible correction facts for one tool attempt.</summary>
 /// <remarks>
 /// The collection has no authority or side effects. The caller defines the
-/// required retry and receipt behavior for all correction facts.
+/// applicable facts, and the delivery factory defines response and state behavior.
 /// </remarks>
 internal sealed class ToolCorrectionCollection
 {

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -58,14 +58,21 @@ internal sealed class ToolCorrectionCollection
     internal IReadOnlyList<ToolCorrection> Items => _items;
 }
 
-/// <summary>Formats correction facts for the current native-tool response path.</summary>
-/// <remarks>
-/// The response requires one native-tool fact. It can include one managed-temporary fact.
-/// A new fact requires an explicit response contract here.
-/// </remarks>
-internal static class ToolCorrectionPresentation
+/// <summary>Defines the shared correction content, receipt, and actor state change.</summary>
+internal sealed record ToolCorrectionDelivery(
+    string Content,
+    ToolInvocationReceipt Receipt,
+    ToolName? NativeTool,
+    ManagedTemporaryCorrectionChange? ManagedTemporaryStateChange)
 {
-    internal static (string Content, ToolName NativeTool) Build(ToolCorrectionCollection corrections)
+    /// <summary>Creates one delivery result from the corrections that policy selected.</summary>
+    /// <remarks>
+    /// Native-tool advice requires a new call and a fresh authorization attempt.
+    /// Temporary-only advice records one exact retry key after the result reaches the model.
+    /// </remarks>
+    internal static ToolCorrectionDelivery Create(
+        ToolCorrectionCollection corrections,
+        ManagedTemporaryCallSemantics? managedTemporaryCall)
     {
         ArgumentNullException.ThrowIfNull(corrections);
 
@@ -87,14 +94,35 @@ internal static class ToolCorrectionPresentation
             }
         }
 
-        if (nativeTool is null)
-            throw new InvalidOperationException("A shell correction collection must name a native tool.");
+        if (nativeTool is { } replacementTool)
+        {
+            var content = $"Shell execution stopped because '{replacementTool}' is a native Netclaw tool.";
+            if (managedTemporaryTarget is { } temporaryTarget)
+                content += $"\nManaged temporary directory: '{temporaryTarget.ManagedTemporaryDirectory}'.";
 
-        var content = $"Shell execution stopped because '{nativeTool.Value}' is a native Netclaw tool.";
-        if (managedTemporaryTarget is { } temporaryTarget)
-            content += $"\nManaged temporary directory: '{temporaryTarget.ManagedTemporaryDirectory}'.";
+            return new ToolCorrectionDelivery(
+                content,
+                new ToolInvocationReceipt(
+                    ToolInvocationOutcomeCategory.RecoverableCorrection,
+                    remediationCode: ToolRemediationCode.UseNativeTool),
+                replacementTool,
+                ManagedTemporaryStateChange: null);
+        }
 
-        return (content, nativeTool.Value);
+        if (managedTemporaryTarget is not { } retryTarget)
+            throw new InvalidOperationException("The correction collection has no supported delivery result.");
+
+        if (managedTemporaryCall is null)
+            throw new InvalidOperationException("A temporary correction requires exact call semantics.");
+
+        var correctionKey = new ManagedTemporaryCorrectionKey(managedTemporaryCall, retryTarget);
+        return new ToolCorrectionDelivery(
+            ManagedTemporaryCorrection.BuildSuggestion(retryTarget.ManagedTemporaryDirectory),
+            new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: ToolRemediationCode.UseManagedTemporaryDirectory),
+            NativeTool: null,
+            new ManagedTemporaryCorrectionChange.Arm(correctionKey));
     }
 }
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -156,10 +156,13 @@ internal sealed class ShellPolicyCoordinator(
             && continuation.Correction is { } correction
             && decision.ApprovalContext is { } finalApprovalContext)
         {
-            decision = ToolAuthorizationDecision.RequiresApproval(
-                finalApprovalContext,
-                decision.ApprovalMatches,
-                correction);
+            decision = (correction is ToolCorrection.ManagedTemporaryDirectorySuggested
+                ? ToolAuthorizationDecision.RequireAgentCorrection(correction)
+                : ToolAuthorizationDecision.RequiresApproval(
+                    finalApprovalContext,
+                    decision.ApprovalMatches,
+                    correction))
+                .WithShellPolicyTrace(decision.ShellPolicyTrace);
         }
 
         return (

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -151,19 +151,8 @@ internal sealed class ShellPolicyCoordinator(
             toolCall,
             context,
             projection,
+            continuation.Correction,
             cancellationToken);
-        if (decision.Outcome == ToolAuthorizationOutcome.RequiresApproval
-            && continuation.Correction is { } correction
-            && decision.ApprovalContext is { } finalApprovalContext)
-        {
-            decision = (correction is ToolCorrection.ManagedTemporaryDirectorySuggested
-                ? ToolAuthorizationDecision.RequireAgentCorrection(correction)
-                : ToolAuthorizationDecision.RequiresApproval(
-                    finalApprovalContext,
-                    decision.ApprovalMatches,
-                    correction))
-                .WithShellPolicyTrace(decision.ShellPolicyTrace);
-        }
 
         return (
             decision,
@@ -201,6 +190,7 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyProjection projection,
+        ToolCorrection? correction,
         CancellationToken cancellationToken)
     {
         var evaluation = new ShellPolicyEvaluation(projection);
@@ -211,6 +201,7 @@ internal sealed class ShellPolicyCoordinator(
                 toolCall,
                 context,
                 evaluation,
+                correction,
                 cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -229,6 +220,7 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyEvaluation evaluation,
+        ToolCorrection? correction,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -239,7 +231,7 @@ internal sealed class ShellPolicyCoordinator(
                 candidate.Candidate.Shell is null
                 || candidate.Candidate.VerbTokens is null))
         {
-            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name);
+            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, correction);
         }
 
         var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
@@ -272,7 +264,7 @@ internal sealed class ShellPolicyCoordinator(
                     intentDirectory,
                     candidate.IntentFallbackDirectories)))
         {
-            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name);
+            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, correction);
         }
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -347,7 +339,7 @@ internal sealed class ShellPolicyCoordinator(
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        return CompleteFinal(evaluation, context);
+        return CompleteFinal(evaluation, context, correction);
     }
 
     private static void ApplyReviewedSafeCoverage(
@@ -396,18 +388,20 @@ internal sealed class ShellPolicyCoordinator(
 
     private static ToolAuthorizationDecision CompleteFinal(
         ShellPolicyEvaluation evaluation,
-        ToolExecutionContext context)
+        ToolExecutionContext context,
+        ToolCorrection? correction)
     {
         var projection = evaluation.Projection;
         var approvalMatches = evaluation.ApprovalMatches;
         var uncovered = evaluation.UncoveredCandidates;
         if (uncovered.Count > 0)
         {
-            return evaluation.Complete(
-                ToolAuthorizationDecision.RequiresApproval(
-                    evaluation.GetUncoveredApprovalContext(
-                        ToolAccessPolicy.GetSessionOwnedApprovalDirectories(context)),
-                    approvalMatches));
+            return CompleteApprovalOrCorrection(
+                evaluation,
+                evaluation.GetUncoveredApprovalContext(
+                    ToolAccessPolicy.GetSessionOwnedApprovalDirectories(context)),
+                approvalMatches,
+                correction);
         }
 
         if (!evaluation.AllCovered)
@@ -453,15 +447,34 @@ internal sealed class ShellPolicyCoordinator(
 
     private static ToolAuthorizationDecision CompleteOneTimeOrPrompt(
         ShellPolicyEvaluation evaluation,
-        string toolName)
+        string toolName,
+        ToolCorrection? correction)
     {
         var projection = evaluation.Projection;
         return projection.HasExactOneTimeApproval(toolName, projection.ApprovalContext)
             ? evaluation.Complete(
                 ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval),
                 allowsUncoveredOneTime: true)
-            : evaluation.Complete(
-                ToolAuthorizationDecision.RequiresApproval(projection.ApprovalContext));
+            : CompleteApprovalOrCorrection(
+                evaluation,
+                projection.ApprovalContext,
+                [],
+                correction);
+    }
+
+    private static ToolAuthorizationDecision CompleteApprovalOrCorrection(
+        ShellPolicyEvaluation evaluation,
+        ToolApprovalContext approvalContext,
+        IReadOnlyList<ToolApprovalMatch> approvalMatches,
+        ToolCorrection? correction)
+    {
+        var decision = correction is ToolCorrection.ManagedTemporaryDirectorySuggested
+            ? ToolAuthorizationDecision.RequireAgentCorrection(correction, approvalMatches)
+            : ToolAuthorizationDecision.RequiresApproval(
+                approvalContext,
+                approvalMatches,
+                correction);
+        return evaluation.Complete(decision);
     }
 
     private static ToolAuthorizationDecision Complete(

--- a/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyDecisionTrace.cs
@@ -26,6 +26,7 @@ internal enum ShellPolicyTraceOutcome
     RequiresApproval = 3,
     Deny = 4,
     TraceTruncated = 5,
+    RequiresAgentCorrection = 6,
 }
 
 internal enum ShellPolicyTraceReason
@@ -53,6 +54,7 @@ internal enum ShellPolicyTraceReason
     ApprovalExemptShellCandidates = 20,
     TraceLimitReached = 21,
     PolicyDenied = 22,
+    AgentCorrection = 23,
 }
 
 internal enum ShellScopeRelation
@@ -287,6 +289,9 @@ internal sealed class ShellPolicyDecisionTraceBuilder
             ToolAuthorizationOutcome.RequiresApproval => (
                 ShellPolicyTraceOutcome.RequiresApproval,
                 ShellPolicyTraceReason.UncoveredCandidates),
+            ToolAuthorizationOutcome.RequiresAgentCorrection => (
+                ShellPolicyTraceOutcome.RequiresAgentCorrection,
+                ShellPolicyTraceReason.AgentCorrection),
             ToolAuthorizationOutcome.Denied => (
                 ShellPolicyTraceOutcome.Deny,
                 ToTraceReason(decision.DenyReason)),

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -204,6 +204,7 @@ internal sealed class ShellPolicyEvaluation
                                                 || allowsUncoveredOneTime
                                                 && decision.AllowReason == ToolAllowReason.OneTimeApproval,
             ToolAuthorizationOutcome.RequiresApproval => Candidates.Count == 0 || !AllCovered,
+            ToolAuthorizationOutcome.RequiresAgentCorrection => Candidates.Count == 0 || !AllCovered,
             ToolAuthorizationOutcome.Denied => true,
             _ => false,
         };

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -32,7 +32,7 @@ internal enum ToolAuthorizationOutcome
     RequiresApproval,
 
     /// <summary>
-    /// The current attempt must not execute because the agent should call a native tool.
+    /// The current attempt must not execute because the agent must author a replacement call.
     /// </summary>
     RequiresAgentCorrection,
 
@@ -224,6 +224,7 @@ public sealed record ToolAuthorizationDecision
     /// A prompt decision can contain partial matches for a compound command.
     /// An allowed stored-approval decision contains a match for each required candidate.
     /// A one-time decision can contain stored matches for part of a compound command.
+    /// A correction decision can retain matches found before the correction became final.
     /// Policy, safe-rule, approval-exempt, and deny decisions contain an empty list.
     /// </remarks>
     internal IReadOnlyList<ToolApprovalMatch> ApprovalMatches { get; }
@@ -318,11 +319,28 @@ public sealed record ToolAuthorizationDecision
         => RequireAgentCorrection(new ToolCorrectionCollection([correction]));
 
     /// <summary>
+    /// Creates a typed agent-correction result with prior stored approval matches.
+    /// </summary>
+    internal static ToolAuthorizationDecision RequireAgentCorrection(
+        ToolCorrection correction,
+        IReadOnlyList<ToolApprovalMatch> approvalMatches)
+        => RequireAgentCorrection(new ToolCorrectionCollection([correction]), approvalMatches);
+
+    /// <summary>
     /// Creates a typed agent-correction result that grants no execution authority.
     /// </summary>
     internal static ToolAuthorizationDecision RequireAgentCorrection(ToolCorrectionCollection corrections)
+        => RequireAgentCorrection(corrections, []);
+
+    /// <summary>
+    /// Creates a typed agent-correction result with prior stored approval matches.
+    /// </summary>
+    internal static ToolAuthorizationDecision RequireAgentCorrection(
+        ToolCorrectionCollection corrections,
+        IReadOnlyList<ToolApprovalMatch> approvalMatches)
     {
         ArgumentNullException.ThrowIfNull(corrections);
+        ArgumentNullException.ThrowIfNull(approvalMatches);
         return new ToolAuthorizationDecision(
             ToolAuthorizationOutcome.RequiresAgentCorrection,
             null,
@@ -330,7 +348,7 @@ public sealed record ToolAuthorizationDecision
             null,
             null,
             corrections,
-            []);
+            [.. approvalMatches]);
     }
 
     internal ToolAuthorizationDecision WithShellPolicyTrace(ShellPolicyDecisionTrace trace)


### PR DESCRIPTION
## Summary

- Route temporary-directory corrections through one shared delivery result.
- Use the same result in parent and child execution paths.
- Preserve stored approvals and one-time approvals before a temporary correction becomes final.

## Key review points

- `ToolCorrectionDelivery` owns content, receipts, native-tool exposure, and actor state changes.
- Native advice requires a new call and fresh authorization. It does not arm a stale retry key.
- Temporary-only advice arms one exact retry key after existing authority misses.
- Correction decisions retain prior partial grant matches.
- Shell traces now report `RequiresAgentCorrection` as the final outcome.
- Project-scope advice stays in approval handling because caller capabilities affect that result.

## Verification

- `Netclaw.Actors.Tests`: 3,817 passed and 6 platform tests skipped.
- `dotnet slopwatch analyze`: passed.
- Copyright header check: passed.
- Changed-file format check: passed.
- `git diff --check`: passed.