### PR TITLE
Complete coordinator ownership of shell corrections

### DIFF
--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -24,11 +24,14 @@ The approval gate does not execute a call or grant authority by itself. A shell
 call can return a result, a denial, or a recoverable correction to the model.
 
 `ShellPolicyCoordinator` asks `ToolAccessPolicy` to analyze the request and
-apply synchronous access checks. It then detects an exposed native tool before
-it checks the approval store. That correction stops the shell call. The
-temporary-path policy adds managed temporary-directory advice to an `Approval`
-result. `Auto` returns before that policy runs, so it does not return managed
-temporary-directory advice.
+apply synchronous access checks. The coordinator collects compatible native,
+temporary, and project advice from existing invocation facts and policy.
+Native advice precedes stored grants. Temporary-only and project-only advice
+retain existing stored-grant and exact one-time approval precedence.
+Corrections precede an `Auto` allow. Hard denials precede all advice.
+Parent and child deliver the common result and retain their state and transport duties.
+Project advice requires a visible declaration tool that accepts the exact directory.
+That advice can apply without an approval bridge; temporary advice retains its interactive capability requirement.
 
 ## Approval Modes
 
@@ -36,7 +39,7 @@ Each tool can be in one of three modes per audience:
 
 | Mode | Behavior |
 |------|----------|
-| `Auto` | No approval needed. Tool executes immediately. This is the default. |
+| `Auto` | No approval prompt. Shell corrections and hard denials still apply before execution. |
 | `Approval` | User must approve before execution. Unapproved commands pause and prompt. |
 | `Deny` | Always blocked. No approval prompt offered. |
 

--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -29,6 +29,8 @@ temporary, and project advice from existing invocation facts and policy.
 Native advice precedes stored grants. Temporary-only and project-only advice
 retain existing stored-grant and exact one-time approval precedence.
 Corrections precede an `Auto` allow. Hard denials precede all advice.
+Reviewed diagnostics without file output retain their requested temporary directory. Normal authorization still applies.
+A redirect that writes a file or an additional unclassified command can still require relocation advice.
 Parent and child deliver the common result and retain their state and transport duties.
 Project advice requires a visible declaration tool that accepts the exact directory.
 That advice can apply without an approval bridge; temporary advice retains its interactive capability requirement.

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -70,6 +70,7 @@ Keep shell approval friction bounded:
 10. A shell call can return correction advice under Auto. Auto removes approval prompts; it does not remove corrections.
 11. Advice grants no authority. Every replacement call passes current policy.
 12. If you require the exact platform path, retry unchanged once through normal policy.
+13. Reviewed diagnostics without file output do not receive temporary relocation advice. Normal approval and denial rules still apply.
 
 ## Project Directory
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.67.0"
+  version: "2.68.0"
 ---
 
 # Netclaw Operations
@@ -66,7 +66,10 @@ Keep shell approval friction bounded:
 6. After an access denial, do not retry that call during the same user turn.
 7. Do not change its scope or substitute another tool to evade the denial.
 8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+9. Apply all compatible advice in a correction response before the next call.
+10. A shell call can return correction advice under Auto. Auto removes approval prompts; it does not remove corrections.
+11. Advice grants no authority. Every replacement call passes current policy.
+12. If you require the exact platform path, retry unchanged once through normal policy.
 
 ## Project Directory
 

--- a/feeds/skills/.system/files/netclaw-operations/references/projects.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/projects.md
@@ -55,7 +55,10 @@ Keep shell approval friction bounded:
 6. After an access denial, do not retry that call during the same user turn.
 7. Do not change its scope or substitute another tool to evade the denial.
 8. A later explicit user request can start a new call. Apply the normal approval policy to that call.
-9. Apply one `Tool execution deferred:` correction unchanged; otherwise use a structured tool or report the block once.
+9. Apply all compatible advice in a correction response before the next call.
+10. A shell call can return correction advice under Auto. Auto removes approval prompts; it does not remove corrections.
+11. Advice grants no authority. Every replacement call passes current policy.
+12. If you require the exact platform path, retry unchanged once through normal policy.
 
 The project directory is distinct from the session directory
 (`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for

--- a/feeds/skills/.system/files/netclaw-operations/references/projects.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/projects.md
@@ -59,6 +59,7 @@ Keep shell approval friction bounded:
 10. A shell call can return correction advice under Auto. Auto removes approval prompts; it does not remove corrections.
 11. Advice grants no authority. Every replacement call passes current policy.
 12. If you require the exact platform path, retry unchanged once through normal policy.
+13. Reviewed diagnostics without file output do not receive temporary relocation advice. Normal approval and denial rules still apply.
 
 The project directory is distinct from the session directory
 (`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for

--- a/openspec/changes/complete-shell-correction-cutover/.openspec.yaml
+++ b/openspec/changes/complete-shell-correction-cutover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/complete-shell-correction-cutover/design.md
+++ b/openspec/changes/complete-shell-correction-cutover/design.md
@@ -1,0 +1,42 @@
+## Context
+
+At 77f825a3, parent and child select project advice from an approval exception.
+Auto completes before temporary and project detection. See proposal.md for scope.
+
+## Decisions
+
+ShellPolicyCoordinator collects facts through the existing detectors and registry.
+It reuses canonical shell analysis, invocation scope, and the current declaration tool.
+ToolCorrectionDelivery handles project advice alongside native and temporary advice.
+No caller supplies a correction list. No new authority store or optional security dependency is required.
+
+Schematic flow; each stage retains its existing validation and cancellation checks:
+
+```text
+preflight hard checks -> collect compatible facts
+  native replacement -> correction collection
+  Auto -> correction collection or allow
+  Approval -> existing grant, reviewed-safe, and exact one-time checks
+    uncovered -> correction collection or approval
+    covered -> allow
+```
+
+The coordinator owns call-local decisions. Parent persistence commits results and approval state.
+The child retains live approval transport and its lifecycle state.
+An exact temporary retry suppresses that advice once; it grants no authority.
+Native advice starts a new authorization attempt and arms no shell retry key.
+
+## Risks / Trade-offs
+
+Project-only migration is smaller but leaves Auto inconsistent and requires another change to the same policy path.
+Capability eligibility differs: project declaration can work without a bridge; temporary advice requires its existing interactive capability.
+Preserve full and partial grant evidence. Do not expand correction eligibility through executable-specific syntax.
+Pure collection tests cannot prove process containment. Shared checked startup remains a separate PR.
+
+## Delivery
+
+One cohesive PR changes the coordinator, delivery consumer, tests, runbook, and operational skill.
+Required evidence includes parent/child parity, hard denial, Auto, exact retry, grants, and recovery.
+Run focused tests, the actor suite, Slopwatch, headers, and applicable evals.
+Open a draft PR for review. Merge and rollout require later authorization.
+No persistence migration applies. A source revert cannot undo earlier external actions or grants.

--- a/openspec/changes/complete-shell-correction-cutover/proposal.md
+++ b/openspec/changes/complete-shell-correction-cutover/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Callers still select project corrections, and shell Auto skips temporary and project advice.
+The common coordinator must own these decisions before callers deliver the result.
+
+## What Changes
+
+- Collect compatible shell corrections from existing policy and invocation facts in the coordinator.
+- Deliver project advice through the same result as native and temporary advice.
+- Apply corrections before shell Auto approval. Preserve existing grant and exact retry checks.
+- Remove replaced caller policy branches. Keep actor lifecycle and persistence duties.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tool-approval-gates`: coordinator-owned correction collection and precedence before Auto.
+
+## Impact
+
+Source PRDs: PRD-002 and PRD-006. Implementation plan: tasks 4.2 and 4.3.
+Affected code includes the coordinator, access policy, correction delivery, parent pipeline, and child actor.
+Shared process startup, storage migration, public API changes, and rollout are outside this PR.
+
+## Security and operational impact
+
+Hard denials remain authoritative. Advice grants no authority and performs no tool action.
+Parent and child retain their distinct recovery and approval lifetimes.
+The runbook and operational skill will describe correction collections under Auto.

--- a/openspec/changes/complete-shell-correction-cutover/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/complete-shell-correction-cutover/specs/tool-approval-gates/spec.md
@@ -1,0 +1,263 @@
+Terms: [engineering glossary](../../../../../docs/spec/GLOSSARY.md).
+Source PRDs: PRD-002 and PRD-006.
+
+## MODIFIED Requirements
+
+### Requirement: Explicit unmanaged temporary writes receive a managed-temp correction
+
+After tool exposure, hard deny, protected-path, and shell-analysis checks, the
+system SHALL return `UseManagedTemporaryDirectory` instead of immediately
+requesting approval when a Personal interactive tool call explicitly authors
+a write below the captured platform temporary root, the managed temporary
+directory is a valid nonempty normalized path, and the ordinary result would
+otherwise request approval or allow shell execution through Auto.
+Structured non-shell Auto behavior SHALL remain unchanged. Team and Public calls SHALL retain their existing
+earlier policy boundary and SHALL NOT receive the private path.
+
+Initial eligible forms SHALL include a structured file write or edit, an exact
+shell redirect, an explicit shell `WorkingDirectory`, and a complete Bash
+leading directory transition. An inherited project, session, child, or default
+cwd SHALL NOT establish authored intent. Matching SHALL use generic path and
+shell-syntax facts. It SHALL NOT parse private executable option grammar.
+
+The correction SHALL name the exact managed temporary directory and ask the
+agent to author a replacement call. It SHALL execute nothing, record no grant,
+change no working context, and SHALL NOT rewrite the original call. The
+replacement SHALL pass every normal authorization stage.
+
+`UseManagedTemporaryDirectory` SHALL replace the former `UseSessionScratch`
+remediation code. Correction and retry state SHALL carry the run's exact
+`temp_dir`; they SHALL NOT use `session_dir` as the replacement destination.
+Model-facing correction text SHALL use “managed temporary directory” and
+`temp_dir`. It SHALL NOT describe `session_dir` as session scratch.
+
+For Bash causal-directory advice, the system SHALL use the canonical parser's
+exact cwd-attribution and effective-directory facts. Native PowerShell causal
+directory mutation SHALL remain ineligible until the canonical parser exposes
+equivalent facts.
+
+The system SHALL resolve the captured platform temporary root to its final
+filesystem target. Every relevant path SHALL remain below that target without
+a descendant symbolic link, junction, or reparse point. A resolution or
+attribute failure SHALL suppress the correction. Hard deny and protected-path
+results SHALL take precedence. One call SHALL return one collection of compatible corrections.
+Native file-write advice can accompany managed temporary advice.
+Native file-read advice SHALL NOT relocate its existing input.
+
+#### Scenario: Example - explicit POSIX temp write receives correction
+
+- **GIVEN** the captured platform temporary root is `/tmp`
+- **AND** the run's managed temporary directory is
+  `/srv/netclaw/sessions/example/tmp/parent`
+- **WHEN** a complete shell call requests `WorkingDirectory=/tmp`
+- **AND** its command contains the exact redirect `> result.log`
+- **AND** ordinary policy would request approval
+- **THEN** the agent receives `UseManagedTemporaryDirectory` before the user
+  approval surface
+- **AND** the correction names the managed temporary directory
+- **AND** the original call is not executed or rewritten
+
+#### Scenario: Counterexample - read-only explicit temp cwd gets no correction
+
+- **GIVEN** the user asks the agent to run `pwd` from `/tmp`
+- **WHEN** the agent authors `Command=pwd` with `WorkingDirectory=/tmp`
+- **THEN** the system does not emit `UseManagedTemporaryDirectory`
+- **AND** normal authorization preserves the requested directory behavior
+
+#### Scenario: Example - structured file write receives correction
+
+- **GIVEN** `file_write` or `file_edit` targets an exact path below the
+  captured platform temporary root
+- **WHEN** the call is otherwise eligible for interactive correction
+- **THEN** the agent receives `UseManagedTemporaryDirectory`
+- **AND** the correction names the run's exact managed temporary directory
+- **AND** no partial file write occurs
+
+#### Scenario: Example - exact shell redirect receives correction
+
+- **GIVEN** a complete shell syntax tree proves an exact redirect target below
+  the captured platform temporary root
+- **WHEN** ordinary policy would request approval
+- **THEN** the agent receives `UseManagedTemporaryDirectory`
+- **AND** no executable-specific output-option rule is required
+
+#### Scenario: Fresh managed temporary directory is prepared by execution
+
+- **GIVEN** a fresh run has a valid normalized managed temporary path
+- **AND** that directory has not yet been created
+- **WHEN** an eligible call explicitly writes below the platform temporary root
+- **THEN** the system emits `UseManagedTemporaryDirectory`
+- **AND** replacement execution owns creation of the managed directory
+
+#### Scenario: Static Bash causal directory change receives correction
+
+- **GIVEN** the captured platform temporary root is `/tmp`
+- **WHEN** the agent authors
+  `cd /tmp && diagnostic-command > result.log && head result.log`
+- **AND** every policy-relevant identity, redirect, and effective directory is
+  complete and remains below `/tmp`
+- **AND** ordinary policy would request approval
+- **THEN** the correction asks the agent to author the operation below its
+  managed temporary directory
+- **AND** later execution still requires ordinary authority
+
+#### Scenario: Windows matching uses captured host temp
+
+- **GIVEN** the native Windows environment captured its actual platform
+  temporary root before managed environment injection
+- **WHEN** an eligible call explicitly authors that exact root or a canonical
+  descendant that crosses no filesystem link
+- **THEN** the agent receives the same typed correction with its Windows
+  managed temporary path
+- **AND** the policy does not depend on `C:\Windows\Temp` or another fixed
+  Windows value
+
+#### Scenario: Counterexample - unresolved PowerShell cwd remains strict
+
+- **WHEN** an agent authors `Set-Location $env:TEMP; diagnostic-command` or
+  `cd $env:TEMP; diagnostic-command` in native PowerShell
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Platform temp is never proposed as project scope
+
+- **GIVEN** both project-scope and managed-temp corrections are otherwise
+  eligible
+- **WHEN** policy selects one correction for an explicitly authored platform
+  temporary write
+- **THEN** it returns only `UseManagedTemporaryDirectory`
+- **AND** it does not recommend `set_working_directory` for the platform root
+
+#### Scenario: Counterexample - inherited temp does not prove authored intent
+
+- **GIVEN** a recovered parent or child inherits the platform temporary root
+  as its cwd
+- **WHEN** it submits a call without an explicit destination, working
+  directory, or supported Bash leading transition
+- **THEN** the system does not emit `UseManagedTemporaryDirectory`
+- **AND** normal policy evaluates the inherited scope
+
+#### Scenario: Counterexample - dynamic shell data remains strict
+
+- **WHEN** command identity, control flow, cwd, or redirect destination is
+  dynamic, incomplete, or unparseable
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Counterexample - private executable syntax proves no write
+
+- **GIVEN** an executable-specific option appears to name an output below the
+  platform temporary root
+- **WHEN** no structured tool contract or canonical shell fact proves that
+  destination
+- **THEN** the system does not infer a managed-temp correction from the option
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Counterexample - external authored path prevents correction
+
+- **GIVEN** a call also authors an absolute path outside the platform
+  temporary root
+- **WHEN** policy evaluates the complete call
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Counterexample - link escape prevents correction
+
+- **GIVEN** a descendant of the platform temporary root is a symbolic link,
+  junction, or reparse point outside that root
+- **WHEN** an eligible form references that descendant
+- **THEN** the system does not emit the managed-temp correction
+- **AND** normal approval or deny behavior remains
+
+#### Scenario: Path inspection failure prevents correction
+
+- **WHEN** the system cannot resolve the platform root or inspect a relevant
+  descendant
+- **THEN** it does not emit the managed-temp correction
+
+#### Scenario: Counterexample - hard deny retains precedence
+
+- **GIVEN** a call explicitly writes below the platform temporary root
+- **WHEN** the call triggers hard deny or protected-path policy
+- **THEN** the system denies the call
+- **AND** it does not emit the managed-temp correction
+
+#### Scenario: Example - replacement receives full authorization
+
+- **GIVEN** the agent receives `UseManagedTemporaryDirectory`
+- **WHEN** it authors a replacement call under the named directory
+- **THEN** the system evaluates the replacement as a new call through every
+  normal authorization stage
+- **AND** the correction does not guarantee execution
+
+#### Scenario: Example - remediation names the new contract
+
+- **GIVEN** an eligible unmanaged temporary write
+- **WHEN** the dispatcher creates its recoverable-correction receipt
+- **THEN** the remediation code is `UseManagedTemporaryDirectory`
+- **AND** the correction destination is the current run's `temp_dir`
+- **AND** neither the code nor presenter calls `session_dir` session scratch
+
+#### Scenario: Counterexample - legacy persisted path is not reinterpreted
+
+- **GIVEN** a recovered approval event contains legacy protobuf field 19
+  `session_scratch_directory`
+- **WHEN** the current runtime restores the approval
+- **THEN** it does not treat that stored path as `temp_dir`
+- **AND** it derives the current managed temporary directory from resolved run
+  storage or omits managed-temp correction metadata
+- **AND** the approval decision itself can still complete normally
+
+#### Scenario: Counterexample - headless execution gets no interactive correction
+
+- **GIVEN** a headless, scheduled, webhook, benchmark, or other noninteractive
+  run
+- **WHEN** a call explicitly requires the platform temporary root
+- **THEN** the system does not emit the interactive correction
+- **AND** it does not rewrite or remove the authored path
+- **AND** existing noninteractive policy decides allow or deny
+
+
+## ADDED Requirements
+
+### Requirement: Shell corrections use one common decision
+
+The shell coordinator SHALL collect applicable corrections from existing policy, registry, and invocation facts.
+Callers SHALL deliver that decision without independent correction selection.
+The coordinator SHALL apply hard denials before corrections and corrections before Auto allows execution.
+Existing stored-grant and exact one-time approval precedence SHALL remain unchanged for temporary-only and project-only advice.
+Project advice SHALL require a policy-visible declaration tool that accepts the exact directory.
+Project advice SHALL NOT require an approval bridge when declaration remains available.
+Collection SHALL cause no prompt, process, grant, store, journal, or retry-state effect.
+Actors SHALL retain their existing state commit, recovery, and transport duties.
+
+#### Scenario: Project correction uses the common result
+- **GIVEN** a reviewed-safe command requires a permitted project declaration
+- **WHEN** a parent or child submits the command
+- **THEN** the common result contains project advice and no prompt or process starts
+
+#### Scenario: Unavailable declaration preserves approval
+- **GIVEN** the declaration tool is absent, hidden, or rejects the directory
+- **WHEN** a shell call needs approval
+- **THEN** no project correction applies and the existing approval boundary remains
+
+#### Scenario: Auto still receives corrections
+- **GIVEN** shell Auto and an applicable correction
+- **WHEN** the coordinator evaluates the call
+- **THEN** it returns the compatible collection without a prompt or process
+
+#### Scenario: Auto without advice retains its meaning
+- **GIVEN** shell Auto with an unresolved executable and no applicable correction
+- **WHEN** all hard checks pass
+- **THEN** the call remains automatically approved
+
+#### Scenario: Hard deny prevents correction
+- **GIVEN** a denied call with an otherwise applicable correction
+- **WHEN** the coordinator evaluates the call
+- **THEN** it returns denial without advice, exposure, or execution
+
+#### Scenario: Retry requires current authority
+- **GIVEN** an actor committed one exact temporary retry key
+- **WHEN** the same call retries
+- **THEN** it consumes the key once and passes current authorization
+- **AND** a changed invocation cannot consume that key

--- a/openspec/changes/complete-shell-correction-cutover/tasks.md
+++ b/openspec/changes/complete-shell-correction-cutover/tasks.md
@@ -6,5 +6,36 @@
 
 ## 2. Integrated proof and review
 
-- [ ] 2.1 Run focused tests, the actor suite, Slopwatch, and headers. Record exact results and limits.
-- [ ] 2.2 Open a draft PR with the change and evidence. Request review before merge.
+- [x] 2.1 Run focused tests, the actor suite, Slopwatch, and headers. Record exact results and limits.
+- [x] 2.2 Open a draft PR with the change and evidence. Request review before merge.
+
+## Evidence
+
+- Draft PR: https://github.com/netclaw-dev/netclaw/pull/2117. Review precedes merge.
+- Base: `77f825a38f7bf260d54f3579bd9758223d39ca0d`.
+- Tested code: `075898c5d711b68800856c87a8861a3bb44f9bbb`, Linux, .NET SDK 10.0.400.
+- Focused tests: 560 passed before the final whitespace and comment pass.
+- Full actor suite after that pass: 3,823 passed, six platform cases skipped, zero failures.
+- Skips cover native Windows shell/path cases and the macOS temporary-root alias.
+- Slopwatch, copyright headers, strict OpenSpec validation, and diff checks passed.
+- OpenCover: collection method line coverage 97.29%; branch coverage 97.36%.
+- Delivery factory line coverage 92.85%; branch coverage 73.52%.
+- ReportGenerator flags complexity hotspots. It emits no CRAP score column for this report.
+- These coverage figures do not prove process containment or project-wide simplification.
+
+Full actor command:
+
+```sh
+dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --no-restore \
+  --test-adapter-path "$NUGET_PACKAGES/coverlet.collector/10.0.1/build/net10.0" \
+  --collect 'XPlat Code Coverage' --settings coverlet.runsettings \
+  --results-directory /tmp/netclaw-cutover-coverage --verbosity quiet \
+  --logger 'trx;LogFileName=actors.trx'
+```
+
+The adapter path names the local cached collector; another host must use its corresponding package path.
+
+Task 1.3 remains open: `./evals/run-evals.sh` exits before execution because no provider target is configured.
+Required variables are `NETCLAW_EVAL_PROVIDER_TYPE`, `NETCLAW_EVAL_PROVIDER_ENDPOINT`, and `NETCLAW_EVAL_MODEL_ID`.
+The operator must supply the target. No endpoint or credential is stored in this change.
+Cross-platform CI and native smoke remain pending at this checkpoint. No merge or rollout occurred.

--- a/openspec/changes/complete-shell-correction-cutover/tasks.md
+++ b/openspec/changes/complete-shell-correction-cutover/tasks.md
@@ -1,0 +1,10 @@
+## 1. Correction cutover
+
+- [x] 1.1 Move shell correction collection into the coordinator. Verify project, native, temporary, Auto, and denial cases.
+- [x] 1.2 Extend common delivery and delete caller selection branches. Verify parent/child parity, capabilities, retries, and recovery.
+- [ ] 1.3 Update the runbook and operational skill. Validate the spec and run applicable evals.
+
+## 2. Integrated proof and review
+
+- [ ] 2.1 Run focused tests, the actor suite, Slopwatch, and headers. Record exact results and limits.
+- [ ] 2.2 Open a draft PR with the change and evidence. Request review before merge.

--- a/src/Netclaw.Actors.Tests/Sessions/SQLiteMemoryRecallGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SQLiteMemoryRecallGateTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
@@ -35,6 +36,7 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
     private static readonly float[] QueryVector = [1f, 0f];
 
     private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-recall-gate-tests", Guid.NewGuid().ToString("N"));
+    private readonly FakeTimeProvider _timeProvider = new();
     private readonly string _dbPath;
     private readonly SQLiteMemoryStore _store;
 
@@ -42,7 +44,7 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
     {
         Directory.CreateDirectory(_baseDir);
         _dbPath = Path.Combine(_baseDir, "netclaw.db");
-        _store = new SQLiteMemoryStore(_dbPath, TimeProvider.System);
+        _store = new SQLiteMemoryStore(_dbPath, _timeProvider);
     }
 
     public async ValueTask DisposeAsync() => await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
@@ -160,11 +162,8 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         await _store.InitializeAsync(ct);
         await SeedFloorSurvivingDocumentAsync("doc-timeout", ct);
 
-        // Never completes on its own; only the coordinator's envelope-clamped sub-budget CTS
-        // (ceiling 120ms, default 300ms RecallTimeoutMs here so the ceiling itself governs) can
-        // cancel it. Task.Delay inside a fake is the sanctioned way to simulate latency
-        // deterministically — no Thread.Sleep/Task.Delay appears in this test's own orchestration.
-        var scorer = new HangingRelevanceScorer(RelevanceModelId);
+        // The scorer exceeds the 120 ms gate ceiling while the outer envelope retains time.
+        var scorer = new VirtualTimeRelevanceScorer(_timeProvider, TimeSpan.FromMilliseconds(150), score: 0.0);
         var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer));
 
         var result = await coordinator.RecallAsync(BuildRequest("gate/sub-budget-timeout"), ct);
@@ -175,25 +174,29 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
 
     // ── Envelope-derived sub-budget (2026-07 production-canary fix, task 3) ────
 
-    [Fact]
-    public async Task Gate_sub_budget_is_capped_by_the_remaining_outer_envelope_not_just_the_ceiling()
+    [Theory]
+    [InlineData(250)]
+    [InlineData(300)]
+    [InlineData(350)]
+    public async Task Gate_sub_budget_is_capped_by_the_remaining_outer_envelope_not_just_the_ceiling(int queryDurationMs)
     {
         var ct = TestContext.Current.CancellationToken;
         await _store.InitializeAsync(ct);
         await SeedFloorSurvivingDocumentAsync("doc-envelope-exhausted", ct);
 
-        // A real 50ms delay comfortably UNDER the 120ms gate-sub-budget ceiling -- if the fixed
-        // ceiling alone governed the gate's CTS, this scorer would complete in time and its
-        // (rejecting) score would apply. An almost-zero outer RecallTimeoutMs forces the
-        // envelope-derived clamp to hand the gate far less than 120ms instead, so the scorer gets
-        // cancelled and the turn degrades to the floor's unfiltered result.
-        var scorer = new DelayedRelevanceScorer(RelevanceModelId, TimeSpan.FromMilliseconds(50), score: 0.0);
-        var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer), recallTimeoutMs: 1);
+        // The query leaves at most 50 ms. An 80 ms score exceeds the remainder, but not the gate ceiling.
+        var logger = new RecordingLogger<SQLiteMemoryRecallCoordinator>();
+        var scorer = new VirtualTimeRelevanceScorer(_timeProvider, TimeSpan.FromMilliseconds(80), score: 0.0);
+        var coordinator = BuildCoordinator(
+            relevanceScorerHolder: BuildHolder(scorer),
+            logger: logger,
+            queryDuration: TimeSpan.FromMilliseconds(queryDurationMs));
 
         var result = await coordinator.RecallAsync(BuildRequest("gate/envelope-exhausted"), ct);
 
         Assert.False(result.Degraded);
         Assert.Contains(result.Items, i => i.Id.Value == "doc-envelope-exhausted");
+        Assert.Contains(logger.Entries, e => e.Message.Contains("reason=sub_budget_exceeded", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -203,12 +206,9 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         await _store.InitializeAsync(ct);
         await SeedFloorSurvivingDocumentAsync("doc-envelope-headroom", ct);
 
-        // Same 50ms real delay and same rejecting score as the test above -- the only difference
-        // is a generous outer envelope. Proves the previous test's degradation was caused by the
-        // exhausted envelope specifically, not merely by the fake being slow: with headroom, the
-        // gate runs to completion and its score is honored (candidate dropped, not degraded).
-        var scorer = new DelayedRelevanceScorer(RelevanceModelId, TimeSpan.FromMilliseconds(50), score: 0.0);
-        var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer), recallTimeoutMs: 5000);
+        // The same score completes when the query leaves the full envelope available.
+        var scorer = new VirtualTimeRelevanceScorer(_timeProvider, TimeSpan.FromMilliseconds(80), score: 0.0);
+        var coordinator = BuildCoordinator(relevanceScorerHolder: BuildHolder(scorer));
 
         var result = await coordinator.RecallAsync(BuildRequest("gate/envelope-headroom"), ct);
 
@@ -387,7 +387,8 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         bool? relevanceGateEnabled = null,
         double? thresholdOverride = null,
         ILogger<SQLiteMemoryRecallCoordinator>? logger = null,
-        int recallTimeoutMs = 300)
+        int recallTimeoutMs = 300,
+        TimeSpan queryDuration = default)
         => new(
             _store,
             logger ?? NullLogger<SQLiteMemoryRecallCoordinator>.Instance,
@@ -400,14 +401,14 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
                     RelevanceGate = new MemoryRelevanceGateConfig { Enabled = relevanceGateEnabled, Threshold = thresholdOverride },
                 },
             },
-            TimeProvider.System,
+            _timeProvider,
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true },
             // memory-query-prefix design D3: Memory.Recall.MinCosineSimilarity now defaults to
             // null (manifest-follows). Every candidate here embeds at cosine 1.0 against itself
             // (SeedFloorSurvivingDocumentAsync), so any floor below 1.0 clears it identically to
             // this file's pre-existing fixture geometry.
             embedderHolder: new MemoryEmbedderHolder(
-                new ScriptedEmbedder(EmbedderModelId, Dimensions, QueryVector), initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: 0.5),
+                new ScriptedEmbedder(EmbedderModelId, Dimensions, QueryVector, _timeProvider, queryDuration), initialQueryPrefix: "", initialCalibratedMinCosineSimilarity: 0.5),
             vectorIndexHolder: new MemoryVectorIndexHolder(_store),
             relevanceScorerHolder: relevanceScorerHolder);
 
@@ -421,7 +422,7 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
     private async Task SeedFloorSurvivingDocumentAsync(string documentId, CancellationToken ct)
     {
         var anchor = _store.CreateDefaultAnchor(documentId);
-        var now = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds();
+        var now = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
         await _store.UpsertDocumentAsync(new SQLiteMemoryDocument(
             DocumentId: documentId,
             Anchor: anchor,
@@ -460,7 +461,8 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
     /// <c>SQLiteMemoryRecallHybridTests</c> and <c>MemoryCurationNominatorTests</c> — kept
     /// separate per those files' own stated convention.
     /// </summary>
-    private sealed class ScriptedEmbedder(string modelId, int dimensions, float[] queryVector) : IMemoryEmbedder
+    private sealed class ScriptedEmbedder(
+        string modelId, int dimensions, float[] queryVector, FakeTimeProvider timeProvider, TimeSpan queryDuration) : IMemoryEmbedder
     {
         public string ModelId => modelId;
 
@@ -469,7 +471,10 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
         public bool IsAvailable => true;
 
         public ValueTask<ReadOnlyMemory<float>> EmbedAsync(string text, EmbeddingPurpose purpose, CancellationToken ct)
-            => ValueTask.FromResult<ReadOnlyMemory<float>>(queryVector);
+        {
+            timeProvider.Advance(queryDuration);
+            return ValueTask.FromResult<ReadOnlyMemory<float>>(queryVector);
+        }
 
         public ValueTask<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(IReadOnlyList<string> texts, EmbeddingPurpose purpose, CancellationToken ct)
             => ValueTask.FromResult<IReadOnlyList<ReadOnlyMemory<float>>>(
@@ -497,45 +502,18 @@ public sealed class SQLiteMemoryRecallGateTests : IAsyncDisposable
             => ValueTask.FromResult(scoreFn(query, candidates));
     }
 
-    /// <summary>
-    /// Fake relevance scorer that never completes on its own — only the coordinator's own
-    /// sub-budget-linked <see cref="CancellationTokenSource"/> can end the call, so the sub-
-    /// budget-timeout test is deterministic rather than racing a wall-clock delay against the
-    /// coordinator's timer.
-    /// </summary>
-    private sealed class HangingRelevanceScorer(string modelId) : IRelevanceScorer
+    /// <summary>Advances the gate's clock before it returns a score or observes cancellation.</summary>
+    private sealed class VirtualTimeRelevanceScorer(FakeTimeProvider timeProvider, TimeSpan duration, double score) : IRelevanceScorer
     {
-        public string ModelId => modelId;
+        public string ModelId => RelevanceModelId;
 
         public bool IsAvailable => true;
 
-        public async ValueTask<IReadOnlyList<double>> ScoreAsync(string query, IReadOnlyList<string> candidates, CancellationToken ct)
+        public ValueTask<IReadOnlyList<double>> ScoreAsync(string query, IReadOnlyList<string> candidates, CancellationToken ct)
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
-            return [];
-        }
-    }
-
-    /// <summary>
-    /// Fake relevance scorer that completes after a fixed, finite real-wall-clock delay (2026-07
-    /// production-canary envelope-derived-budget tests) rather than hanging forever like
-    /// <see cref="HangingRelevanceScorer"/> — this file's own copy of a "slow but not infinite"
-    /// fake, needed to prove the gate's sub-budget is actually smaller than the fixed
-    /// <c>RelevanceGateSubBudgetMs</c> ceiling when the outer envelope is nearly exhausted. The
-    /// delay itself is real (Task.Delay inside the fake, not this test's own orchestration) — the
-    /// sanctioned way to simulate latency deterministically per this repo's testing guidelines.
-    /// </summary>
-    private sealed class DelayedRelevanceScorer(string modelId, TimeSpan delay, double score) : IRelevanceScorer
-    {
-        public string ModelId => modelId;
-
-        public bool IsAvailable => true;
-
-        [SlopwatchSuppress("SW004", "Intentional latency simulation inside a fake (never in test orchestration) -- proves the envelope-derived sub-budget clamp actually cancels a scorer that would otherwise complete within the fixed 120ms ceiling.")]
-        public async ValueTask<IReadOnlyList<double>> ScoreAsync(string query, IReadOnlyList<string> candidates, CancellationToken ct)
-        {
-            await Task.Delay(delay, ct);
-            return candidates.Select(_ => score).ToArray();
+            timeProvider.Advance(duration);
+            ct.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IReadOnlyList<double>>(candidates.Select(_ => score).ToArray());
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineHintTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineHintTests.cs
@@ -171,30 +171,4 @@ public sealed class SessionToolExecutionPipelineHintTests
         Assert.Empty(hint);
     }
 
-    [Fact]
-    public void Project_scope_correction_reports_only_the_failure_reason()
-    {
-        var context = new ToolCorrection.ProjectDirectorySuggested("/home/user/repos/project");
-
-        var correction = SessionToolExecutionPipeline.BuildProjectScopeDeclarationCorrection(
-            context,
-            setWorkingDirectoryAvailable: true);
-
-        Assert.Contains("working_directory_not_declared", correction);
-        Assert.DoesNotContain("set_working_directory", correction);
-        Assert.Contains("Project directory: '/home/user/repos/project'", correction);
-        Assert.DoesNotContain("Next action", correction);
-    }
-
-    [Fact]
-    public void Project_scope_correction_is_suppressed_when_tool_is_unavailable()
-    {
-        var context = new ToolCorrection.ProjectDirectorySuggested("/home/user/repos/project");
-
-        var correction = SessionToolExecutionPipeline.BuildProjectScopeDeclarationCorrection(
-            context,
-            setWorkingDirectoryAvailable: false);
-
-        Assert.Empty(correction);
-    }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -19,6 +19,7 @@ using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Actors.Tests.Sessions.Pipelines;
 using Netclaw.Actors.Tools;
 using Netclaw.Actors.Tests.Tools;
+using Netclaw.Actors.Tests.Memory;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tests.Utilities;
@@ -239,7 +240,29 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
     [Fact]
     public async Task Undeclared_project_scope_returns_agent_correction_without_user_prompt()
     {
-        var executor = new ProjectScopeDeclarationRequiredExecutor("/home/user/repos/project");
+        var directory = Path.GetFullPath(AppContext.BaseDirectory);
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                [ShellTool.ToolName] = ToolApprovalMode.Approval
+            }
+        };
+        var environment = TestShellEnvironment.Current;
+        var command = environment.Grammar == ShellGrammar.Bash ? "pwd" : "Get-Location";
+        var shell = environment.Grammar == ShellGrammar.Bash ? ApprovalShell.Bash : ApprovalShell.PowerShell;
+        var paths = new NetclawPaths(directory, directory);
+        var registry = new ToolRegistry();
+        var shellTool = new FakeNetclawTool(ShellTool.ToolName, "unexpected execution");
+        registry.Register(shellTool);
+        registry.Register(new SetWorkingDirectoryTool(config, paths, new ToolPathPolicy(environment, [])));
+        var policy = new ToolAccessPolicy(paths, config,
+            new EffectivePolicyDefaults(DeploymentPosture.Personal, TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed, UsedStrictFallback: false),
+            new ShellCommandPolicy(environment), new ToolPathPolicy(environment, []),
+            safeVerbs: SafeVerbList.FromVerbs(shell, [command]));
+        var executor = new DispatchingToolExecutor(registry, policy);
         var probe = CreateTestProbe("project-scope-correction-probe");
         var approvals = new List<ToolInteractionRequest>();
         var sessionId = new SessionId("D1/project-scope-correction");
@@ -247,7 +270,9 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         {
             new("call-1", "shell_execute", new Dictionary<string, object?>
             {
-                ["command"] = "head -40 src/file.cs"
+                ["Command"] = command,
+                ["WorkingDirectory"] = directory,
+                ["_rationale"] = "Inspect the project directory."
             })
         };
 
@@ -268,14 +293,15 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         var result = Assert.Single(completed.ToolResults);
         Assert.Equal(
             "Tool execution deferred: working_directory_not_declared\n" +
-            "Project directory: '/home/user/repos/project'.\n" +
+            $"Project directory: '{directory}'.\n" +
             "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call.",
             result.Content);
         Assert.Equal(
             ToolRemediationCode.SetWorkingDirectory,
             completed.ToolReceipts["call-1"].RemediationCode);
         Assert.Empty(approvals);
-        Assert.Equal(1, executor.Attempts);
+        Assert.False(shellTool.WasCalled);
+        Assert.Empty(completed.ManagedTemporaryCorrectionChanges);
         Assert.True(AuthorizationAttemptId.TryParse(
             completed.AuthorizationAttemptIds["call-1"].Value,
             out _));
@@ -1369,33 +1395,6 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
             ct.ThrowIfCancellationRequested();
             return Task.FromResult("approved-and-ran");
-        }
-    }
-
-    private sealed class ProjectScopeDeclarationRequiredExecutor(string directory) : IToolExecutor
-    {
-        public int Attempts { get; private set; }
-
-        public Task AuthorizeAsync(
-            FunctionCallContent toolCall,
-            ToolExecutionContext? context = null,
-            CancellationToken ct = default)
-            => ExecuteAsync(toolCall, context, ct);
-
-        public Task<string> ExecuteAsync(
-            FunctionCallContent toolCall,
-            ToolExecutionContext? context = null,
-            CancellationToken ct = default)
-        {
-            Attempts++;
-            throw new ToolApprovalRequiredException(
-                new ToolApprovalContext(
-                    ToolName: toolCall.Name,
-                    DisplayText: "head -40 src/file.cs",
-                    Patterns: ["head"],
-                    CandidateVerbs: ["head"],
-                    Options: []),
-                new ToolCorrection.ProjectDirectorySuggested(directory));
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3980,7 +3980,8 @@ public class DispatchingToolExecutorTests
         var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
             policy.AuthorizeShellPreflight(shellTool, context, arguments));
 
-        var shellTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(preflight.Correction);
+        var shellTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(
+            policy.AuthorizeInvocation(shellTool, context, arguments).AgentCorrection);
         var nativeCorrection = NativeToolShellCorrectionDetector.Detect(
             preflight.Analysis,
             registry,
@@ -3999,9 +4000,11 @@ public class DispatchingToolExecutorTests
             correctedNativeDecision.AgentCorrection);
         Assert.Equal(shellTemporary.Target, nativeTemporary.Target);
 
-        var collection = ShellPolicyCoordinator.CollectApplicableCorrections(
-            nativeTool.Correction,
-            nativeTemporary);
+        var collection = new ShellPolicyCoordinator(registry, policy, approvalService: null).CollectApplicableCorrections(
+            preflight.Analysis,
+            CreateToolCall("pair", ShellTool.ToolName, arguments),
+            context,
+            preflight);
         Assert.NotNull(collection);
         Assert.Collection(
             collection.Items,
@@ -4009,10 +4012,14 @@ public class DispatchingToolExecutorTests
             correction => Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(correction));
     }
 
-    [Fact]
-    public async Task Coordinator_selects_native_and_temporary_corrections_before_approval()
+    [Theory]
+    [InlineData(ToolApprovalMode.Approval)]
+    [InlineData(ToolApprovalMode.Auto)]
+    public async Task Coordinator_selects_native_and_temporary_corrections_before_approval(ToolApprovalMode mode)
     {
-        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var config = CreateApprovalGatedShellConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy!.ToolOverrides[ShellTool.ToolName] = mode;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment, config);
         var approvalService = new FixedShellApprovalService(_ =>
             throw new InvalidOperationException("Candidate collection must not request approval."));
         var shellTool = Assert.IsAssignableFrom<INetclawTool>(registry.GetByName(ShellTool.ToolName));
@@ -4039,6 +4046,107 @@ public class DispatchingToolExecutorTests
         Assert.Null(authorization.AuthorizedAnalysis);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
+    }
+
+    [Fact]
+    public void Correction_collection_does_not_mutate_authority_or_delivery_state()
+    {
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var context = CreateInteractivePersonalContext("signalr/pure-correction");
+        var call = CreateToolCall("pure", ShellTool.ToolName, ToolInput.Create(
+            "Command", $"file_write --path {Path.Combine(Path.GetTempPath(), "netclaw-pure-output.txt")}",
+            "WorkingDirectory", Path.GetTempPath()));
+        var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
+            policy.AuthorizeShellPreflight(registry.GetByName(ShellTool.ToolName)!, context, call.Arguments));
+        context.Approval.SeedOneTimeApproval(ShellTool.ToolName, ["unrelated invocation"]);
+        context.Approval.ApplyDecision("existing decision", "existing pattern");
+        var patterns = context.Approval.OneTimeApprovedPatterns;
+        var cwd = context.Approval.Cwd;
+        var attempt = context.Approval.AuthorizationAttemptId;
+        var service = new FixedShellApprovalService(_ => throw new InvalidOperationException("Collection cannot contact the store."));
+        var coordinator = new ShellPolicyCoordinator(registry, policy, service);
+
+        var first = coordinator.CollectApplicableCorrections(preflight.Analysis, call, context, preflight);
+        var second = coordinator.CollectApplicableCorrections(preflight.Analysis, call, context, preflight);
+
+        Assert.Equal(2, first!.Items.Count);
+        Assert.Equal(first.Items, second!.Items);
+        Assert.Equal(0, service.RequestCount);
+        Assert.Same(patterns, context.Approval.OneTimeApprovedPatterns);
+        Assert.Equal(ShellTool.ToolName, context.Approval.OneTimeApprovedToolName);
+        Assert.Equal(cwd, context.Approval.Cwd);
+        Assert.Equal(attempt, context.Approval.AuthorizationAttemptId);
+        Assert.Equal("existing decision", context.Approval.AppliedDecision);
+        Assert.Equal("existing pattern", context.Approval.AppliedPattern);
+        Assert.Null(context.Approval.ManagedTemporaryRetry);
+        Assert.Null(context.Receipt);
+        Assert.Empty(context.Outputs.FileAttachments);
+    }
+
+    [Theory]
+    [InlineData(ToolApprovalMode.Auto, true)]
+    [InlineData(ToolApprovalMode.Auto, false)]
+    [InlineData(ToolApprovalMode.Approval, true)]
+    [InlineData(ToolApprovalMode.Approval, false)]
+    public async Task Coordinator_selects_project_correction_from_registry_without_caller_advice(
+        ToolApprovalMode mode, bool interactive)
+    {
+        var directory = Path.GetFullPath(AppContext.BaseDirectory);
+        var config = CreateApprovalGatedShellConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy!.ToolOverrides[ShellTool.ToolName] = mode;
+        var paths = new NetclawPaths(directory, directory);
+        var command = ShellEnvironment.Grammar == ShellGrammar.Bash ? "pwd" : "Get-Location";
+        var shell = ShellEnvironment.Grammar == ShellGrammar.Bash ? ApprovalShell.Bash : ApprovalShell.PowerShell;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(
+            ShellEnvironment, config, SafeVerbList.FromVerbs(shell, [command]), paths: paths);
+        registry.Replace(new SetWorkingDirectoryTool(config, paths, new ToolPathPolicy(ShellEnvironment, [])));
+        var context = TestToolExecutionContext.CreateBound("signalr/project-correction", null,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                InteractiveApproval = TestToolExecutionContext.InteractiveApproval(interactive)
+            });
+        var coordinator = new ShellPolicyCoordinator(registry, policy, approvalService: null);
+        var call = CreateToolCall("project", ShellTool.ToolName,
+            ToolInput.Create("Command", command, "WorkingDirectory", directory));
+
+        var result = await coordinator.EvaluateAsync(registry.GetByName(ShellTool.ToolName)!, call, context,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, result.Decision.Outcome);
+        Assert.Equal(directory, Assert.IsType<ToolCorrection.ProjectDirectorySuggested>(result.Decision.AgentCorrection).Directory);
+        Assert.Null(result.AuthorizedAnalysis);
+        Assert.Null(result.Decision.ApprovalContext);
+        Assert.Null(context.Receipt);
+    }
+
+    [Theory]
+    [InlineData(ToolApprovalMode.Auto)]
+    [InlineData(ToolApprovalMode.Deny)]
+    public async Task Coordinator_temporary_advice_precedes_auto_but_not_deny(ToolApprovalMode mode)
+    {
+        var config = CreateApprovalGatedShellConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy!.ToolOverrides[ShellTool.ToolName] = mode;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment, config);
+        var service = new FixedShellApprovalService(_ => throw new InvalidOperationException("No grant request is permitted."));
+        var context = CreateInteractivePersonalContext("signalr/auto-temporary");
+        var call = CreateToolCall("auto-temporary", ShellTool.ToolName,
+            ToolInput.Create("Command", "git push", "WorkingDirectory", Path.GetTempPath()));
+        var result = await new ShellPolicyCoordinator(registry, policy, service).EvaluateAsync(
+            registry.GetByName(ShellTool.ToolName)!, call, context, TestContext.Current.CancellationToken);
+
+        Assert.Null(result.AuthorizedAnalysis);
+        Assert.Equal(0, service.RequestCount);
+        if (mode == ToolApprovalMode.Auto)
+        {
+            Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, result.Decision.Outcome);
+            Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(result.Decision.AgentCorrection);
+        }
+        else
+        {
+            Assert.Equal(ToolAuthorizationOutcome.Denied, result.Decision.Outcome);
+            Assert.Null(result.Decision.AgentCorrections);
+        }
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -4149,6 +4149,44 @@ public class DispatchingToolExecutorTests
         }
     }
 
+    [Theory]
+    [InlineData(ToolApprovalMode.Auto, "", nameof(ToolAuthorizationOutcome.Allowed))]
+    [InlineData(ToolApprovalMode.Approval, "", nameof(ToolAuthorizationOutcome.RequiresApproval))]
+    [InlineData(ToolApprovalMode.Deny, "", nameof(ToolAuthorizationOutcome.Denied))]
+    [InlineData(ToolApprovalMode.Auto, " > result.log", nameof(ToolAuthorizationOutcome.RequiresAgentCorrection))]
+    [InlineData(ToolApprovalMode.Approval, " > result.log", nameof(ToolAuthorizationOutcome.RequiresAgentCorrection))]
+    [InlineData(ToolApprovalMode.Deny, " > result.log", nameof(ToolAuthorizationOutcome.Denied))]
+    [InlineData(ToolApprovalMode.Auto, "; git push", nameof(ToolAuthorizationOutcome.RequiresAgentCorrection))]
+    [InlineData(ToolApprovalMode.Approval, "; git push", nameof(ToolAuthorizationOutcome.RequiresAgentCorrection))]
+    public async Task Temporary_relocation_preserves_reviewed_diagnostics_and_normal_authority(
+        ToolApprovalMode mode, string suffix, string expected)
+    {
+        var config = CreateApprovalGatedShellConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy!.ToolOverrides[ShellTool.ToolName] = mode;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(
+            ShellEnvironment, config, SafeVerbLoader.Load());
+        var context = CreateInteractivePersonalContext("signalr/temp-diagnostic");
+        var directory = Path.GetTempPath();
+        var diagnostic = ShellEnvironment.Grammar == ShellGrammar.Bash ? "pwd" : "Get-Location";
+        var call = CreateToolCall("temp-diagnostic", ShellTool.ToolName,
+            ToolInput.Create("Command", diagnostic + suffix, "WorkingDirectory", directory));
+
+        var result = await new ShellPolicyCoordinator(registry, policy, approvalService: null).EvaluateAsync(
+            registry.GetByName(ShellTool.ToolName)!, call, context, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, result.Decision.Outcome.ToString());
+        Assert.Equal(directory, call.Arguments!["WorkingDirectory"]);
+        Assert.Null(context.Receipt);
+        if (expected == nameof(ToolAuthorizationOutcome.RequiresAgentCorrection))
+            Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(result.Decision.AgentCorrection);
+        else
+            Assert.Null(result.Decision.AgentCorrections);
+        if (expected == nameof(ToolAuthorizationOutcome.Allowed))
+            Assert.Equal(Path.GetFullPath(directory), result.AuthorizedAnalysis!.WorkingDirectory);
+        else
+            Assert.Null(result.AuthorizedAnalysis);
+    }
+
     [Fact]
     public async Task Coordinator_returns_temporary_only_correction_after_approval_miss()
     {

--- a/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellApprovalDispositionMatrixTests.cs
@@ -151,7 +151,7 @@ public sealed class ShellApprovalDispositionMatrixTests(ShellApprovalMatrixFixtu
 
     [SlopwatchSuppress("SW001", "This regression requires a POSIX shell cwd and Bash authorization behavior.")]
     [Fact(SkipUnless = nameof(IsPosix), Skip = "The project-scope correction defines Bash path behavior.")]
-    public async Task Reviewed_safe_external_cwd_exposes_project_scope_correction()
+    public async Task Unavailable_registry_scope_preserves_ordinary_approval()
     {
         var testCase = new ShellApprovalCase(
             "reviewed-safe-external-cwd-suggests-project-scope",
@@ -168,8 +168,9 @@ public sealed class ShellApprovalDispositionMatrixTests(ShellApprovalMatrixFixtu
         var decision = await harness.EvaluateDecisionAsync(TestContext.Current.CancellationToken);
         var context = Assert.IsType<ToolApprovalContext>(decision.ApprovalContext);
 
-        var correction = Assert.IsType<ToolCorrection.ProjectDirectorySuggested>(decision.AgentCorrection);
-        Assert.Equal(context.Cwd, correction.Directory);
+        Assert.True(decision.NeedsApproval);
+        Assert.Null(decision.AgentCorrection);
+        Assert.NotNull(context.Cwd);
     }
 
     [SlopwatchSuppress("SW001", "This regression requires a POSIX shell cwd and Bash authorization behavior.")]

--- a/src/Netclaw.Actors.Tests/Tools/TemporaryPathCorrectionPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/TemporaryPathCorrectionPolicyTests.cs
@@ -48,7 +48,7 @@ public sealed class TemporaryPathCorrectionPolicyTests
         var decision = Evaluate(
             BashEnvironment(),
             PosixTemp,
-            "cat /tmp/result.log",
+            "cat /tmp/input.log > /tmp/result.log",
             PosixSession,
             explicitWorkingDirectory: PosixTemp,
             inspector: new TestPathInspector(resolvedRoot: "/private/tmp"));
@@ -83,7 +83,7 @@ public sealed class TemporaryPathCorrectionPolicyTests
         var decision = Evaluate(
             BashEnvironment(),
             runtimeTemp,
-            "cat /tmp/result.log",
+            "cat /tmp/input.log > /tmp/result.log",
             PosixSession,
             explicitWorkingDirectory: PosixTemp,
             inspector: new MappedPathInspector(

--- a/src/Netclaw.Actors.Tests/Tools/ToolCorrectionDeliveryTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolCorrectionDeliveryTests.cs
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolCorrectionDeliveryTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class ToolCorrectionDeliveryTests
+{
+    private static readonly ToolCorrection.NativeToolSuggested Native = new(new ToolName("file_write"));
+    private static readonly ToolCorrection.ManagedTemporaryDirectorySuggested Temporary = new(
+        new ManagedTemporaryCorrectionTarget("/session/tmp", "/tmp"));
+    private static readonly ToolCorrection.ProjectDirectorySuggested Project = new("/project");
+    private static readonly ManagedTemporaryCallSemantics.ShellCall Call = new(
+        ApprovalShell.Bash, "printf result > /tmp/result.txt", "/tmp", false, TimeSpan.FromSeconds(30));
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Native_and_temporary_advice_preserve_both_targets_without_a_shell_retry(bool reverseOrder, bool includeCall)
+    {
+        var corrections = new ToolCorrectionCollection(reverseOrder ? [Temporary, Native] : [Native, Temporary]);
+
+        var delivery = ToolCorrectionDelivery.Create(corrections, includeCall ? Call : null);
+
+        Assert.Equal(Native.ToolName, delivery.NativeTool);
+        Assert.Contains(Native.ToolName.Value, delivery.Content, StringComparison.Ordinal);
+        Assert.Contains(Temporary.Target.ManagedTemporaryDirectory, delivery.Content, StringComparison.Ordinal);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, delivery.Receipt.RemediationCode);
+        Assert.Null(delivery.ManagedTemporaryStateChange);
+    }
+
+    [Fact]
+    public void Native_only_advice_does_not_arm_a_shell_retry()
+    {
+        var delivery = ToolCorrectionDelivery.Create(new ToolCorrectionCollection([Native]), Call);
+
+        Assert.Equal(Native.ToolName, delivery.NativeTool);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, delivery.Receipt.RemediationCode);
+        Assert.Null(delivery.ManagedTemporaryStateChange);
+    }
+
+    [Fact]
+    public void Project_advice_does_not_arm_a_shell_retry()
+    {
+        var delivery = ToolCorrectionDelivery.Create(new ToolCorrectionCollection([Project]), Call);
+
+        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, delivery.Receipt.RemediationCode);
+        Assert.Null(delivery.NativeTool);
+        Assert.Null(delivery.ManagedTemporaryStateChange);
+    }
+
+    [Fact]
+    public void Temporary_only_advice_arms_the_exact_call_and_target()
+    {
+        var delivery = ToolCorrectionDelivery.Create(new ToolCorrectionCollection([Temporary]), Call);
+
+        var arm = Assert.IsType<ManagedTemporaryCorrectionChange.Arm>(delivery.ManagedTemporaryStateChange);
+        Assert.Equal(Call, arm.Key.Call);
+        Assert.Equal(Temporary.Target, arm.Key.Target);
+        Assert.Equal(ToolRemediationCode.UseManagedTemporaryDirectory, delivery.Receipt.RemediationCode);
+        Assert.Null(delivery.NativeTool);
+    }
+
+    [Fact]
+    public void Temporary_only_advice_rejects_missing_call_semantics()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            ToolCorrectionDelivery.Create(new ToolCorrectionCollection([Temporary]), managedTemporaryCall: null));
+    }
+
+    [Fact]
+    public void Delivery_rejects_conflicting_targets_and_duplicate_categories()
+    {
+        IReadOnlyList<ToolCorrection>[] invalidCombinations =
+        [
+            [Project, Native],
+            [Native, Project],
+            [Project, Temporary],
+            [Temporary, Project],
+            [Native, Temporary, Project],
+            [Native, new ToolCorrection.NativeToolSuggested(new ToolName("file_read"))],
+            [Temporary, new ToolCorrection.ManagedTemporaryDirectorySuggested(new ManagedTemporaryCorrectionTarget("/other/tmp", "/tmp"))],
+            [Project, new ToolCorrection.ProjectDirectorySuggested("/other/project")]
+        ];
+
+        foreach (var corrections in invalidCombinations)
+        {
+            var collection = new ToolCorrectionCollection(corrections);
+            Assert.Throws<InvalidOperationException>(() => ToolCorrectionDelivery.Create(collection, Call));
+        }
+    }
+}

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -680,30 +680,6 @@ internal sealed class SessionToolExecutionPipeline
         }
         catch (ToolApprovalRequiredException approvalEx)
         {
-            var projectScopeCorrection = BuildProjectScopeDeclarationCorrection(
-                approvalEx.Correction,
-                batch.SetWorkingDirectoryAvailable,
-                context.Invocation,
-                batch.CanDeclareWorkingDirectory);
-            if (!string.IsNullOrEmpty(projectScopeCorrection))
-            {
-                sw.Stop();
-                resultText = projectScopeCorrection;
-
-                var correctionReceipt = new ToolInvocationReceipt(
-                    ToolInvocationOutcomeCategory.RecoverableCorrection,
-                    remediationCode: ToolRemediationCode.SetWorkingDirectory);
-                return new ToolCallResult(new SerializableChatMessage
-                {
-                    Role = Protocol.ChatRole.Tool,
-                    Content = resultText,
-                    ToolCallId = new ToolCallId(tc.CallId),
-                    Name = tc.Name
-                }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
-                    authorizationAttemptId,
-                    Receipt: correctionReceipt);
-            }
-
             if (!CanRequestInteractiveApproval(batch.TurnContext))
             {
                 sw.Stop();
@@ -1294,30 +1270,6 @@ internal sealed class SessionToolExecutionPipeline
 
     private static bool CanRequestInteractiveApproval(TurnContext turnContext)
         => turnContext.SupportsInteractiveApproval && turnContext.HasApprovalRequester;
-
-    /// <summary>
-    /// Builds the agent-facing correction for reviewed-safe shell work whose
-    /// requested directory has not yet been declared as project scope.
-    /// </summary>
-    internal static string BuildProjectScopeDeclarationCorrection(
-        ToolCorrection? correction,
-        bool setWorkingDirectoryAvailable,
-        ToolInvocationContext? invocation = null,
-        Func<string, ToolInvocationContext, bool>? canDeclare = null)
-    {
-        if (!setWorkingDirectoryAvailable
-            || correction is not ToolCorrection.ProjectDirectorySuggested projectDirectory
-            || string.IsNullOrWhiteSpace(projectDirectory.Directory)
-            || invocation is not null
-                && (canDeclare is null
-                    || !canDeclare(projectDirectory.Directory, invocation)))
-        {
-            return string.Empty;
-        }
-
-        return "Tool execution deferred: working_directory_not_declared\n" +
-               $"Project directory: '{projectDirectory.Directory}'.";
-    }
 
     /// <summary>
     /// Returns a one-line agent-facing hint pointing at <c>set_working_directory</c>

--- a/src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs
+++ b/src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs
@@ -618,8 +618,8 @@ public sealed class SQLiteMemoryRecallCoordinator(
         IReadOnlyList<double> scores;
         try
         {
-            using var gateCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            gateCts.CancelAfter(subBudgetMs);
+            using var budgetCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(subBudgetMs), timeProvider);
+            using var gateCts = CancellationTokenSource.CreateLinkedTokenSource(ct, budgetCts.Token);
             scores = await scorer.ScoreAsync(request.Query, texts, gateCts.Token);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -841,13 +841,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 _toolExecutorLogger);
         var setWorkingDirectoryTool =
             _toolRegistry.GetByName(SetWorkingDirectoryTool.ToolName) as SetWorkingDirectoryTool;
-        Func<string, ToolInvocationContext, bool>? canDeclareWorkingDirectory =
-            setWorkingDirectoryTool is null
-            || !_toolAccessPolicy.IsToolExposed(
-                setWorkingDirectoryTool,
-                ToolExecutionContext.Invocation)
-                ? null
-                : setWorkingDirectoryTool.CanDeclare;
+        var setWorkingDirectoryAvailable = setWorkingDirectoryTool is not null
+            && _toolAccessPolicy.IsToolExposed(setWorkingDirectoryTool, ToolExecutionContext.Invocation);
         _toolExecutionWatchdogState = _approvalBridge is null
             ? ToolExecutionWatchdogState.None
             : ToolExecutionWatchdogState.RunningApprovalCapableTools;
@@ -861,7 +856,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             self,
             _approvalBridge,
             _managedTemporaryCorrections.Snapshot(),
-            canDeclareWorkingDirectory,
+            setWorkingDirectoryAvailable,
             _log,
             _definition.Name,
             _parentSessionId,
@@ -1400,7 +1395,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         IActorRef self,
         IParentApprovalBridge? approvalBridge,
         ManagedTemporaryCorrectionDispatch managedTemporaryCorrections,
-        Func<string, ToolInvocationContext, bool>? canDeclareWorkingDirectory,
+        bool setWorkingDirectoryAvailable,
         ILoggingAdapter logger,
         AgentName agentName,
         string? parentSessionId,
@@ -1483,24 +1478,6 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 catch (ToolApprovalRequiredException approvalEx)
                 {
                     var ctx = approvalEx.ApprovalContext;
-                    var projectScopeCorrection =
-                        SessionToolExecutionPipeline.BuildProjectScopeDeclarationCorrection(
-                            approvalEx.Correction,
-                            canDeclareWorkingDirectory is not null,
-                            toolContext.Invocation,
-                            canDeclareWorkingDirectory);
-                    if (!string.IsNullOrEmpty(projectScopeCorrection))
-                    {
-                        toolContext.Outputs.TryComplete(new ToolInvocationReceipt(
-                            ToolInvocationOutcomeCategory.RecoverableCorrection,
-                            remediationCode: ToolRemediationCode.SetWorkingDirectory));
-                        return BuildToolResult(
-                            cleanedTc,
-                            projectScopeCorrection,
-                            toolContext,
-                            modelInputBudget);
-                    }
-
                     if (approvalBridge is null)
                     {
                         throw new ParentApprovalUnavailableException(
@@ -1649,7 +1626,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     Message = ToolRemediationPresenter.Present(
                         result.Message,
                         result.Receipt,
-                        canDeclareWorkingDirectory is not null)
+                        setWorkingDirectoryAvailable)
                 };
             }
             self.Tell(new ToolExecutionCompleted

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -516,8 +516,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         {
             throw new ToolApprovalRequiredException(
                 decision.ApprovalContext
-                ?? throw new InvalidOperationException("Approval decision missing approval context."),
-                decision.AgentCorrection);
+                ?? throw new InvalidOperationException("Approval decision missing approval context."));
         }
 
         if (decision.Outcome is ToolAuthorizationOutcome.RequiresAgentCorrection)

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -76,61 +76,48 @@ internal sealed record ToolCorrectionDelivery(
     {
         ArgumentNullException.ThrowIfNull(corrections);
 
-        ToolName? nativeTool = null;
-        string? projectDirectory = null;
-        ManagedTemporaryCorrectionTarget? managedTemporaryTarget = null;
-        foreach (var correction in corrections.Items)
+        return corrections.Items switch
         {
-            switch (correction)
-            {
-                case ToolCorrection.NativeToolSuggested native when nativeTool is null:
-                    nativeTool = native.ToolName;
-                    break;
-                case ToolCorrection.ManagedTemporaryDirectorySuggested managed
-                    when managedTemporaryTarget is null:
-                    managedTemporaryTarget = managed.Target;
-                    break;
-                case ToolCorrection.ProjectDirectorySuggested project when projectDirectory is null:
-                    projectDirectory = project.Directory;
-                    break;
-                default:
-                    throw new InvalidOperationException("The correction collection has an unsupported correction or duplicate fact.");
-            }
-        }
+            [ToolCorrection.ProjectDirectorySuggested project] => CreateProject(project.Directory),
+            [ToolCorrection.NativeToolSuggested native] => CreateNative(native.ToolName, temporaryTarget: null),
+            [ToolCorrection.ManagedTemporaryDirectorySuggested temporary] => CreateTemporary(temporary.Target, managedTemporaryCall),
+            [ToolCorrection.NativeToolSuggested native, ToolCorrection.ManagedTemporaryDirectorySuggested temporary]
+                => CreateNative(native.ToolName, temporary.Target),
+            [ToolCorrection.ManagedTemporaryDirectorySuggested temporary, ToolCorrection.NativeToolSuggested native]
+                => CreateNative(native.ToolName, temporary.Target),
+            _ => throw new InvalidOperationException("The correction collection has an unsupported combination or duplicate fact.")
+        };
+    }
 
-        if (projectDirectory is not null)
-        {
-            if (nativeTool is not null || managedTemporaryTarget is not null)
-                throw new InvalidOperationException("Project advice cannot accompany advice that replaces its target.");
+    private static ToolCorrectionDelivery CreateProject(string directory)
+        => new(
+            "Tool execution deferred: working_directory_not_declared\n" +
+            $"Project directory: '{directory}'.",
+            new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: ToolRemediationCode.SetWorkingDirectory),
+            NativeTool: null,
+            ManagedTemporaryStateChange: null);
 
-            return new ToolCorrectionDelivery(
-                "Tool execution deferred: working_directory_not_declared\n" +
-                $"Project directory: '{projectDirectory}'.",
-                new ToolInvocationReceipt(
-                    ToolInvocationOutcomeCategory.RecoverableCorrection,
-                    remediationCode: ToolRemediationCode.SetWorkingDirectory),
-                NativeTool: null,
-                ManagedTemporaryStateChange: null);
-        }
+    private static ToolCorrectionDelivery CreateNative(ToolName tool, ManagedTemporaryCorrectionTarget? temporaryTarget)
+    {
+        var content = $"Shell execution stopped because '{tool}' is a native Netclaw tool.";
+        if (temporaryTarget is { } target)
+            content += $"\nManaged temporary directory: '{target.ManagedTemporaryDirectory}'.";
 
-        if (nativeTool is { } replacementTool)
-        {
-            var content = $"Shell execution stopped because '{replacementTool}' is a native Netclaw tool.";
-            if (managedTemporaryTarget is { } temporaryTarget)
-                content += $"\nManaged temporary directory: '{temporaryTarget.ManagedTemporaryDirectory}'.";
+        return new ToolCorrectionDelivery(
+            content,
+            new ToolInvocationReceipt(
+                ToolInvocationOutcomeCategory.RecoverableCorrection,
+                remediationCode: ToolRemediationCode.UseNativeTool),
+            tool,
+            ManagedTemporaryStateChange: null);
+    }
 
-            return new ToolCorrectionDelivery(
-                content,
-                new ToolInvocationReceipt(
-                    ToolInvocationOutcomeCategory.RecoverableCorrection,
-                    remediationCode: ToolRemediationCode.UseNativeTool),
-                replacementTool,
-                ManagedTemporaryStateChange: null);
-        }
-
-        if (managedTemporaryTarget is not { } retryTarget)
-            throw new InvalidOperationException("The correction collection has no supported delivery result.");
-
+    private static ToolCorrectionDelivery CreateTemporary(
+        ManagedTemporaryCorrectionTarget retryTarget,
+        ManagedTemporaryCallSemantics? managedTemporaryCall)
+    {
         if (managedTemporaryCall is null)
             throw new InvalidOperationException("A temporary correction requires exact call semantics.");
 

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -28,7 +28,7 @@ internal abstract record ToolCorrection
 
 /// <summary>Groups compatible correction facts for one tool attempt.</summary>
 /// <remarks>
-/// The collection has no authority or side effects. The caller defines the
+/// The collection has no authority or side effects. The coordinator selects the
 /// applicable facts, and the delivery factory defines response and state behavior.
 /// </remarks>
 internal sealed class ToolCorrectionCollection
@@ -77,6 +77,7 @@ internal sealed record ToolCorrectionDelivery(
         ArgumentNullException.ThrowIfNull(corrections);
 
         ToolName? nativeTool = null;
+        string? projectDirectory = null;
         ManagedTemporaryCorrectionTarget? managedTemporaryTarget = null;
         foreach (var correction in corrections.Items)
         {
@@ -89,9 +90,27 @@ internal sealed record ToolCorrectionDelivery(
                     when managedTemporaryTarget is null:
                     managedTemporaryTarget = managed.Target;
                     break;
+                case ToolCorrection.ProjectDirectorySuggested project when projectDirectory is null:
+                    projectDirectory = project.Directory;
+                    break;
                 default:
                     throw new InvalidOperationException("The correction collection has an unsupported correction or duplicate fact.");
             }
+        }
+
+        if (projectDirectory is not null)
+        {
+            if (nativeTool is not null || managedTemporaryTarget is not null)
+                throw new InvalidOperationException("Project advice cannot accompany advice that replaces its target.");
+
+            return new ToolCorrectionDelivery(
+                "Tool execution deferred: working_directory_not_declared\n" +
+                $"Project directory: '{projectDirectory}'.",
+                new ToolInvocationReceipt(
+                    ToolInvocationOutcomeCategory.RecoverableCorrection,
+                    remediationCode: ToolRemediationCode.SetWorkingDirectory),
+                NativeTool: null,
+                ManagedTemporaryStateChange: null);
         }
 
         if (nativeTool is { } replacementTool)

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -80,7 +80,10 @@ internal sealed record ToolCorrectionDelivery(
         {
             [ToolCorrection.ProjectDirectorySuggested project] => CreateProject(project.Directory),
             [ToolCorrection.NativeToolSuggested native] => CreateNative(native.ToolName, temporaryTarget: null),
-            [ToolCorrection.ManagedTemporaryDirectorySuggested temporary] => CreateTemporary(temporary.Target, managedTemporaryCall),
+            [ToolCorrection.ManagedTemporaryDirectorySuggested temporary] when managedTemporaryCall is not null
+                => CreateTemporary(temporary.Target, managedTemporaryCall),
+            [ToolCorrection.ManagedTemporaryDirectorySuggested]
+                => throw new InvalidOperationException("A temporary correction requires exact call semantics."),
             [ToolCorrection.NativeToolSuggested native, ToolCorrection.ManagedTemporaryDirectorySuggested temporary]
                 => CreateNative(native.ToolName, temporary.Target),
             [ToolCorrection.ManagedTemporaryDirectorySuggested temporary, ToolCorrection.NativeToolSuggested native]
@@ -116,11 +119,8 @@ internal sealed record ToolCorrectionDelivery(
 
     private static ToolCorrectionDelivery CreateTemporary(
         ManagedTemporaryCorrectionTarget retryTarget,
-        ManagedTemporaryCallSemantics? managedTemporaryCall)
+        ManagedTemporaryCallSemantics managedTemporaryCall)
     {
-        if (managedTemporaryCall is null)
-            throw new InvalidOperationException("A temporary correction requires exact call semantics.");
-
         var correctionKey = new ManagedTemporaryCorrectionKey(managedTemporaryCall, retryTarget);
         return new ToolCorrectionDelivery(
             ManagedTemporaryCorrection.BuildSuggestion(retryTarget.ManagedTemporaryDirectory),

--- a/src/Netclaw.Actors/Tools/ReviewedSafeShellPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ReviewedSafeShellPolicy.cs
@@ -256,23 +256,30 @@ internal sealed class ReviewedSafeShellPolicy
         out ApprovalShell shell)
     {
         shell = default;
-        if (candidate is not
-            {
-                Shell: { } candidateShell,
-                VerbTokens: { }
-            }
-            || sourceOccurrence is null
-            || HasFileWritingRedirect(resolvedPaths)
-            || HasUnprovedNonFileSystemSemantics(resolvedPaths)
-            || !_safeVerbs.TryMatchReviewedDiagnostic(
-                candidateShell,
-                candidate.VerbTokens,
-                out var matchedTokenCount)
-            || sourceOccurrence.Arguments.Any(argument =>
-                argument.Element.PrecedingVerbElementCount < matchedTokenCount))
-        {
+        if (candidate is not { Shell: { } candidateShell })
             return false;
-        }
+
+        if (candidate.VerbTokens is not { } verbTokens)
+            return false;
+
+        if (sourceOccurrence is null)
+            return false;
+
+        if (HasFileWritingRedirect(resolvedPaths))
+            return false;
+
+        if (HasUnprovedNonFileSystemSemantics(resolvedPaths))
+            return false;
+
+        if (!_safeVerbs.TryMatchReviewedDiagnostic(
+                candidateShell,
+                verbTokens,
+                out var matchedTokenCount))
+            return false;
+
+        // Arguments before the matched verb phrase can change its meaning. The reviewed catalog does not authorize those forms.
+        if (sourceOccurrence.Arguments.Any(argument => argument.Element.PrecedingVerbElementCount < matchedTokenCount))
+            return false;
 
         shell = candidateShell;
         return true;

--- a/src/Netclaw.Actors/Tools/ReviewedSafeShellPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ReviewedSafeShellPolicy.cs
@@ -233,6 +233,22 @@ internal sealed class ReviewedSafeShellPolicy
         ShellPolicyResolvedPathView? resolvedPaths)
         => resolvedPaths?.HasUnprovedNonFileSystemSemantics == true;
 
+    /// <summary>Classifies diagnostic syntax without granting path or execution authority.</summary>
+    internal bool IsReviewedDiagnosticInvocation(
+        IReadOnlyList<ApprovalCandidate> candidates,
+        ShellPathStyle pathStyle)
+    {
+        if (candidates.Count == 0)
+            return false;
+
+        var facts = ShellPolicyPathFacts.Create(candidates, pathStyle);
+        return candidates.Select((candidate, index) => IsReviewedDiagnosticSyntax(
+            candidate,
+            candidate.SourceOccurrence,
+            facts[index].Real,
+            out _)).All(static diagnostic => diagnostic);
+    }
+
     private bool IsReviewedDiagnosticSyntax(
         ApprovalCandidate candidate,
         CommandOccurrence? sourceOccurrence,

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -75,25 +75,19 @@ internal sealed class ShellPolicyCoordinator(
             ShellPolicyPreflightResult.Continue preflightContinuation => preflightContinuation.Analysis,
             _ => throw new InvalidOperationException("Unsupported shell policy preflight result."),
         };
-        var nativeCorrection = analysis is null
+        cancellationToken.ThrowIfCancellationRequested();
+        var corrections = analysis is null
             ? null
-            : NativeToolShellCorrectionDetector.Detect(
-                analysis,
-                registry,
-                policy,
-                context.Invocation);
+            : CollectApplicableCorrections(analysis, toolCall, context, preflight);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        if (nativeCorrection is not null)
-        {
-            // Temporary relocation is valid only when the suggested native operation can use the same target.
-            var corrections = nativeCorrection.SupportsManagedTemporaryDirectory
-                && preflight is ShellPolicyPreflightResult.Continue
+        if (corrections is not null
+            && (corrections.Items.Any(static correction => correction is ToolCorrection.NativeToolSuggested)
+                || preflight is ShellPolicyPreflightResult.Complete
                 {
-                    Correction: ToolCorrection.ManagedTemporaryDirectorySuggested temporaryCorrection
-                }
-                ? CollectApplicableCorrections(nativeCorrection.Correction, temporaryCorrection)
-                    ?? throw new InvalidOperationException("Compatible corrections must form a collection.")
-                : new ToolCorrectionCollection([nativeCorrection.Correction]);
+                    Decision.AllowReason: ToolAllowReason.PolicyAuto
+                }))
+        {
             return (
                 Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
                 null);
@@ -151,7 +145,7 @@ internal sealed class ShellPolicyCoordinator(
             toolCall,
             context,
             projection,
-            continuation.Correction,
+            corrections,
             cancellationToken);
 
         return (
@@ -161,28 +155,61 @@ internal sealed class ShellPolicyCoordinator(
                 : null);
     }
 
-    /// <summary>Collects correction facts that already apply to one shell attempt.</summary>
-    /// <remarks>
-    /// Each correction policy determines applicability before this method runs.
-    /// This method preserves order and enforces collection invariants.
-    /// The coordinator selects correction collections for shell requests.
-    /// </remarks>
-    internal static ToolCorrectionCollection? CollectApplicableCorrections(
-        params ToolCorrection?[] corrections)
+    /// <summary>Collects compatible advice from the same invocation and its existing policies.</summary>
+    internal ToolCorrectionCollection? CollectApplicableCorrections(
+        ShellCommandAnalysis analysis,
+        FunctionCallContent toolCall,
+        ToolExecutionContext context,
+        ShellPolicyPreflightResult preflight)
     {
-        ArgumentNullException.ThrowIfNull(corrections);
-
-        var applicable = new List<ToolCorrection>();
-        foreach (var correction in corrections)
-        {
-            if (correction is not null)
-                applicable.Add(correction);
-        }
-
-        if (applicable.Count < 2)
+        if (preflight is ShellPolicyPreflightResult.Complete { Decision.Allowed: false })
             return null;
 
-        return new ToolCorrectionCollection(applicable);
+        var native = NativeToolShellCorrectionDetector.Detect(analysis, registry, policy, context.Invocation);
+        var applicable = new List<ToolCorrection>();
+        if (native is not null)
+            applicable.Add(native.Correction);
+
+        // A native operation without relocation support must keep its target. Retry keys never authorize replacement native calls.
+        if (native is { SupportsManagedTemporaryDirectory: false }
+            || native is null && context.Approval.ManagedTemporaryRetry is not null)
+        {
+            return applicable.Count == 0 ? null : new ToolCorrectionCollection(applicable);
+        }
+
+        IReadOnlyList<ApprovalCandidate> candidates;
+        bool isMessy;
+        if (preflight is ShellPolicyPreflightResult.Continue continuation)
+        {
+            candidates = continuation.ApprovalContext.Candidates!;
+            isMessy = continuation.ApprovalContext.IsMessy;
+        }
+        else
+        {
+            // Auto omits the approval context. Reuse its canonical parse without asking the approval store.
+            var approval = policy.ShellApprovalMatcher.AnalyzeInvocation(
+                new ToolName(toolCall.Name),
+                ToolAccessPolicy.WithResolvedShellWorkingDirectory(toolCall.Arguments, analysis.WorkingDirectory),
+                analysis);
+            candidates = approval.Candidates;
+            isMessy = approval.IsMessy;
+        }
+
+        var temporary = policy.EvaluateShellTemporaryCorrection(analysis, candidates, toolCall.Arguments, context.Invocation);
+        if (temporary is not null)
+            applicable.Add(temporary);
+
+        // Relocation invalidates project advice for the original directory. A native replacement also requires fresh policy.
+        if (native is null && temporary is null && !isMessy
+            && policy.EvaluateShellProjectCorrection(candidates, analysis.WorkingDirectory, context.Invocation) is { } project
+            && registry.GetByName(SetWorkingDirectoryTool.ToolName) is SetWorkingDirectoryTool declaration
+            && policy.IsToolExposed(declaration, context.Invocation)
+            && declaration.CanDeclare(project.Directory, context.Invocation))
+        {
+            applicable.Add(project);
+        }
+
+        return applicable.Count == 0 ? null : new ToolCorrectionCollection(applicable);
     }
 
     private async Task<ToolAuthorizationDecision> CompleteAsync(
@@ -190,7 +217,7 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyProjection projection,
-        ToolCorrection? correction,
+        ToolCorrectionCollection? corrections,
         CancellationToken cancellationToken)
     {
         var evaluation = new ShellPolicyEvaluation(projection);
@@ -201,7 +228,7 @@ internal sealed class ShellPolicyCoordinator(
                 toolCall,
                 context,
                 evaluation,
-                correction,
+                corrections,
                 cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -220,7 +247,7 @@ internal sealed class ShellPolicyCoordinator(
         FunctionCallContent toolCall,
         ToolExecutionContext context,
         ShellPolicyEvaluation evaluation,
-        ToolCorrection? correction,
+        ToolCorrectionCollection? corrections,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -231,7 +258,7 @@ internal sealed class ShellPolicyCoordinator(
                 candidate.Candidate.Shell is null
                 || candidate.Candidate.VerbTokens is null))
         {
-            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, correction);
+            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, corrections);
         }
 
         var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
@@ -264,7 +291,7 @@ internal sealed class ShellPolicyCoordinator(
                     intentDirectory,
                     candidate.IntentFallbackDirectories)))
         {
-            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, correction);
+            return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, corrections);
         }
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -339,7 +366,7 @@ internal sealed class ShellPolicyCoordinator(
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        return CompleteFinal(evaluation, context, correction);
+        return CompleteFinal(evaluation, context, corrections);
     }
 
     private static void ApplyReviewedSafeCoverage(
@@ -389,7 +416,7 @@ internal sealed class ShellPolicyCoordinator(
     private static ToolAuthorizationDecision CompleteFinal(
         ShellPolicyEvaluation evaluation,
         ToolExecutionContext context,
-        ToolCorrection? correction)
+        ToolCorrectionCollection? corrections)
     {
         var projection = evaluation.Projection;
         var approvalMatches = evaluation.ApprovalMatches;
@@ -401,7 +428,7 @@ internal sealed class ShellPolicyCoordinator(
                 evaluation.GetUncoveredApprovalContext(
                     ToolAccessPolicy.GetSessionOwnedApprovalDirectories(context)),
                 approvalMatches,
-                correction);
+                corrections);
         }
 
         if (!evaluation.AllCovered)
@@ -448,7 +475,7 @@ internal sealed class ShellPolicyCoordinator(
     private static ToolAuthorizationDecision CompleteOneTimeOrPrompt(
         ShellPolicyEvaluation evaluation,
         string toolName,
-        ToolCorrection? correction)
+        ToolCorrectionCollection? corrections)
     {
         var projection = evaluation.Projection;
         return projection.HasExactOneTimeApproval(toolName, projection.ApprovalContext)
@@ -459,21 +486,18 @@ internal sealed class ShellPolicyCoordinator(
                 evaluation,
                 projection.ApprovalContext,
                 [],
-                correction);
+                corrections);
     }
 
     private static ToolAuthorizationDecision CompleteApprovalOrCorrection(
         ShellPolicyEvaluation evaluation,
         ToolApprovalContext approvalContext,
         IReadOnlyList<ToolApprovalMatch> approvalMatches,
-        ToolCorrection? correction)
+        ToolCorrectionCollection? corrections)
     {
-        var decision = correction is ToolCorrection.ManagedTemporaryDirectorySuggested
-            ? ToolAuthorizationDecision.RequireAgentCorrection(correction, approvalMatches)
-            : ToolAuthorizationDecision.RequiresApproval(
-                approvalContext,
-                approvalMatches,
-                correction);
+        var decision = corrections is not null
+            ? ToolAuthorizationDecision.RequireAgentCorrection(corrections, approvalMatches)
+            : ToolAuthorizationDecision.RequiresApproval(approvalContext, approvalMatches);
         return evaluation.Complete(decision);
     }
 

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -291,44 +291,22 @@ internal sealed class ShellPolicyCoordinator(
     {
         cancellationToken.ThrowIfCancellationRequested();
         var projection = evaluation.Projection;
-        if (projection.ApprovalContext.IsMessy && !projection.HasCausalIntent
-            || projection.Candidates.Count == 0
-            || projection.Candidates.Any(static candidate =>
-                candidate.Candidate.Shell is null
-                || candidate.Candidate.VerbTokens is null))
+        if (RequiresExactApproval(projection))
         {
             return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, corrections);
         }
 
-        var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
-            ? ApprovalShell.Bash
-            : ApprovalShell.PowerShell;
-        if (projection.Candidates.Any(candidate =>
-                candidate.Candidate.Shell != expectedShell
-                || candidate.Candidate.VerbTokens!.Count == 0
-                || candidate.Candidate.VerbTokens.Any(static token =>
-                    token.Length == 0 || token.Any(char.IsWhiteSpace))))
-        {
-            throw new InvalidOperationException("Invalid shell policy projection.");
-        }
+        ValidateCandidateSyntax(projection);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (projection.Candidates.Any(candidate =>
-                candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
-                && policy.CausalIntentReferencesProtectedPath(
-                    projection.PathFacts[candidate.Id.Value])))
+        if (HasProtectedIntentPath(projection))
         {
             return evaluation.Complete(
                 ToolAuthorizationDecision.Deny("shell_references_protected_path"));
         }
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (projection.Candidates.Any(candidate =>
-                candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
-                && candidate.IntentDirectory is { } intentDirectory
-                && !policy.AreCausalIntentDirectoriesEligible(
-                    intentDirectory,
-                    candidate.IntentFallbackDirectories)))
+        if (HasIneligibleIntentDirectory(projection))
         {
             return CompleteOneTimeOrPrompt(evaluation, toolCall.Name, corrections);
         }
@@ -408,15 +386,94 @@ internal sealed class ShellPolicyCoordinator(
         return CompleteFinal(evaluation, context, corrections);
     }
 
+    private static bool RequiresExactApproval(ShellPolicyProjection projection)
+    {
+        // Unresolved syntax needs an exact approval unless the causal projection supplies the missing intent.
+        if (projection.ApprovalContext.IsMessy && !projection.HasCausalIntent)
+            return true;
+
+        if (projection.Candidates.Count == 0)
+            return true;
+
+        foreach (var candidate in projection.Candidates)
+        {
+            if (candidate.Candidate.Shell is null)
+                return true;
+
+            if (candidate.Candidate.VerbTokens is null)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static void ValidateCandidateSyntax(ShellPolicyProjection projection)
+    {
+        var expectedShell = projection.Environment.Grammar == ShellGrammar.Bash
+            ? ApprovalShell.Bash
+            : ApprovalShell.PowerShell;
+        foreach (var candidate in projection.Candidates)
+        {
+            if (candidate.Candidate.Shell != expectedShell)
+                throw new InvalidOperationException("Invalid shell policy projection.");
+
+            // RequiresExactApproval handles missing facts before this validation of supplied facts.
+            var tokens = candidate.Candidate.VerbTokens!;
+            if (tokens.Count == 0)
+                throw new InvalidOperationException("Invalid shell policy projection.");
+
+            foreach (var token in tokens)
+            {
+                if (token.Length == 0 || token.Any(char.IsWhiteSpace))
+                    throw new InvalidOperationException("Invalid shell policy projection.");
+            }
+        }
+    }
+
+    private bool HasProtectedIntentPath(ShellPolicyProjection projection)
+    {
+        foreach (var candidate in projection.Candidates)
+        {
+            if (candidate.Role != ShellPolicyCandidateRole.CausalIntentConsumer)
+                continue;
+
+            if (policy.CausalIntentReferencesProtectedPath(projection.PathFacts[candidate.Id.Value]))
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool HasIneligibleIntentDirectory(ShellPolicyProjection projection)
+    {
+        foreach (var candidate in projection.Candidates)
+        {
+            if (candidate.Role != ShellPolicyCandidateRole.CausalIntentConsumer)
+                continue;
+
+            if (candidate.IntentDirectory is not { } directory)
+                continue;
+
+            if (!policy.AreCausalIntentDirectoriesEligible(directory, candidate.IntentFallbackDirectories))
+                return true;
+        }
+
+        return false;
+    }
+
     private static void ApplyReviewedSafeCoverage(
         ShellPolicyEvaluation evaluation,
         ToolAccessPolicy policy,
         ToolInvocationContext invocation)
     {
-        foreach (var candidate in evaluation.Projection.GrantCandidates.Where(candidate =>
-                     candidate.CanUseRealReviewedSafePolicy
-                     && !evaluation.IsCovered(candidate.Id)))
+        foreach (var candidate in evaluation.Projection.GrantCandidates)
         {
+            if (!candidate.CanUseRealReviewedSafePolicy)
+                continue;
+
+            if (evaluation.IsCovered(candidate.Id))
+                continue;
+
             if (!policy.IsReviewedSafeCandidate(
                     candidate,
                     evaluation.Projection.PathFacts[candidate.Id.Value],
@@ -430,15 +487,18 @@ internal sealed class ShellPolicyCoordinator(
                 ShellPolicyCoverageSource.ReviewedSafeReal);
         }
 
-        foreach (var candidate in evaluation.Candidates.Where(candidate =>
-                     candidate.Role == ShellPolicyCandidateRole.CausalIntentConsumer
-                     && !evaluation.IsCovered(candidate.Id)))
+        foreach (var candidate in evaluation.Candidates)
         {
-            if (candidate.IntentDirectory is null
-                || candidate.IntentPrerequisites.Count == 0
-                || candidate.IntentPrerequisites.Any(prerequisite =>
-                    !evaluation.IsCovered(prerequisite))
-                || !policy.IsReviewedSafeIntentCandidate(
+            if (candidate.Role != ShellPolicyCandidateRole.CausalIntentConsumer)
+                continue;
+
+            if (evaluation.IsCovered(candidate.Id))
+                continue;
+
+            if (!HasCoveredIntentPrerequisites(candidate, evaluation))
+                continue;
+
+            if (!policy.IsReviewedSafeIntentCandidate(
                     candidate,
                     evaluation.Projection.PathFacts[candidate.Id.Value],
                     invocation))
@@ -450,6 +510,24 @@ internal sealed class ShellPolicyCoordinator(
                 candidate,
                 ShellPolicyCoverageSource.ReviewedSafeIntent);
         }
+    }
+
+    private static bool HasCoveredIntentPrerequisites(ShellPolicyCandidate candidate, ShellPolicyEvaluation evaluation)
+    {
+        if (candidate.IntentDirectory is null)
+            return false;
+
+        // An intent consumer needs explicit prerequisite evidence; an empty list cannot establish coverage.
+        if (candidate.IntentPrerequisites.Count == 0)
+            return false;
+
+        foreach (var prerequisite in candidate.IntentPrerequisites)
+        {
+            if (!evaluation.IsCovered(prerequisite))
+                return false;
+        }
+
+        return true;
     }
 
     private static ToolAuthorizationDecision CompleteFinal(

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -81,12 +81,8 @@ internal sealed class ShellPolicyCoordinator(
             : CollectApplicableCorrections(analysis, toolCall, context, preflight);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (corrections is not null
-            && (corrections.Items.Any(static correction => correction is ToolCorrection.NativeToolSuggested)
-                || preflight is ShellPolicyPreflightResult.Complete
-                {
-                    Decision.AllowReason: ToolAllowReason.PolicyAuto
-                }))
+        // A native tool needs a separate call. Shell approval cannot authorize that replacement.
+        if (corrections?.Items.Any(static correction => correction is ToolCorrection.NativeToolSuggested) == true)
         {
             return (
                 Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
@@ -96,6 +92,14 @@ internal sealed class ShellPolicyCoordinator(
         if (preflight is ShellPolicyPreflightResult.Complete complete)
         {
             var preflightDecision = complete.Decision;
+            // Auto permits execution, but the agent must first receive any applicable directory advice.
+            if (preflightDecision.AllowReason == ToolAllowReason.PolicyAuto && corrections is not null)
+            {
+                return (
+                    Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
+                    null);
+            }
+
             if (preflightDecision.NeedsApproval
                 && preflightDecision.ApprovalContext is { } approvalContext
                 && OneTimeApprovalKeys.Matches(
@@ -162,6 +166,7 @@ internal sealed class ShellPolicyCoordinator(
         ToolExecutionContext context,
         ShellPolicyPreflightResult preflight)
     {
+        // Denial and approval without command analysis cannot become advice to submit a different call.
         if (preflight is ShellPolicyPreflightResult.Complete { Decision.Allowed: false })
             return null;
 
@@ -170,12 +175,27 @@ internal sealed class ShellPolicyCoordinator(
         if (native is not null)
             applicable.Add(native.Correction);
 
-        // A native operation without relocation support must keep its target. Retry keys never authorize replacement native calls.
-        if (native is { SupportsManagedTemporaryDirectory: false }
-            || native is null && context.Approval.ManagedTemporaryRetry is not null)
-        {
-            return applicable.Count == 0 ? null : new ToolCorrectionCollection(applicable);
-        }
+        var directory = SelectDirectoryCorrection(native, analysis, toolCall, context, preflight);
+        if (directory is not null)
+            applicable.Add(directory);
+
+        return applicable.Count == 0 ? null : new ToolCorrectionCollection(applicable);
+    }
+
+    private ToolCorrection? SelectDirectoryCorrection(
+        NativeToolShellCorrection? native,
+        ShellCommandAnalysis analysis,
+        FunctionCallContent toolCall,
+        ToolExecutionContext context,
+        ShellPolicyPreflightResult preflight)
+    {
+        // For example, file_read must keep its source path; file_write can create output in the managed temporary directory.
+        if (native is { SupportsManagedTemporaryDirectory: false })
+            return null;
+
+        // An exact shell retry already received directory advice. A native replacement is a new call and cannot use that retry.
+        if (native is null && context.Approval.ManagedTemporaryRetry is not null)
+            return null;
 
         IReadOnlyList<ApprovalCandidate> candidates;
         bool isMessy;
@@ -195,21 +215,40 @@ internal sealed class ShellPolicyCoordinator(
             isMessy = approval.IsMessy;
         }
 
+        // Relocation changes the directory, so project advice for the original directory no longer applies.
         var temporary = policy.EvaluateShellTemporaryCorrection(analysis, candidates, toolCall.Arguments, context.Invocation);
         if (temporary is not null)
-            applicable.Add(temporary);
+            return temporary;
 
-        // Relocation invalidates project advice for the original directory. A native replacement also requires fresh policy.
-        if (native is null && temporary is null && !isMessy
-            && policy.EvaluateShellProjectCorrection(candidates, analysis.WorkingDirectory, context.Invocation) is { } project
-            && registry.GetByName(SetWorkingDirectoryTool.ToolName) is SetWorkingDirectoryTool declaration
-            && policy.IsToolExposed(declaration, context.Invocation)
-            && declaration.CanDeclare(project.Directory, context.Invocation))
-        {
-            applicable.Add(project);
-        }
+        // Project advice applies to shell calls. The replacement native tool must pass its own policy checks.
+        if (native is not null)
+            return null;
 
-        return applicable.Count == 0 ? null : new ToolCorrectionCollection(applicable);
+        if (isMessy)
+            return null;
+
+        return GetAvailableProjectCorrection(candidates, analysis.WorkingDirectory, context.Invocation);
+    }
+
+    private ToolCorrection.ProjectDirectorySuggested? GetAvailableProjectCorrection(
+        IReadOnlyList<ApprovalCandidate> candidates,
+        string? workingDirectory,
+        ToolInvocationContext invocation)
+    {
+        var project = policy.EvaluateShellProjectCorrection(candidates, workingDirectory, invocation);
+        if (project is null)
+            return null;
+
+        if (registry.GetByName(SetWorkingDirectoryTool.ToolName) is not SetWorkingDirectoryTool declaration)
+            return null;
+
+        if (!policy.IsToolExposed(declaration, invocation))
+            return null;
+
+        if (!declaration.CanDeclare(project.Directory, invocation))
+            return null;
+
+        return project;
     }
 
     private async Task<ToolAuthorizationDecision> CompleteAsync(

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -48,8 +48,7 @@ internal abstract record ShellPolicyPreflightResult
         internal Continue(
             ShellCommandAnalysis analysis,
             ToolApprovalContext approvalContext,
-            ShellExecutionEnvironment environment,
-            ToolCorrection? correction)
+            ShellExecutionEnvironment environment)
         {
             ArgumentNullException.ThrowIfNull(analysis);
             ArgumentNullException.ThrowIfNull(approvalContext);
@@ -58,7 +57,6 @@ internal abstract record ShellPolicyPreflightResult
             Analysis = analysis;
             ApprovalContext = approvalContext;
             Environment = environment;
-            Correction = correction;
         }
 
         internal ShellCommandAnalysis Analysis { get; }
@@ -66,8 +64,6 @@ internal abstract record ShellPolicyPreflightResult
         internal ToolApprovalContext ApprovalContext { get; }
 
         internal ShellExecutionEnvironment Environment { get; }
-
-        internal ToolCorrection? Correction { get; }
     }
 }
 

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -760,14 +760,19 @@ public sealed class ToolAccessPolicy
         IReadOnlyList<ApprovalCandidate> approvalCandidates = candidates;
         ToolCorrection? agentCorrection = null;
 
-        // The public synchronous API retains preflight hints. Live shell dispatch collects corrections only in the coordinator.
-        if (isShell && shellAnalysis is not null && !deferShellCompletion)
+        // The public synchronous API completes shell policy here. Live dispatch leaves those decisions to the coordinator.
+        if (isShell && !deferShellCompletion)
         {
-            agentCorrection = EvaluateShellTemporaryCorrection(
+            (approvalCandidates, agentCorrection) = EvaluateSynchronousShellPolicy(
                 shellAnalysis,
-                approvalCandidates,
+                candidates,
+                isMessy,
                 arguments,
-                context.Invocation);
+                context);
+
+            // An empty original candidate set proves nothing. Only removal of covered candidates permits this early allow.
+            if (candidates.Count > 0 && approvalCandidates.Count == 0)
+                return ToolAuthorizationDecision.Allow(ToolAllowReason.ReviewedSafePolicy);
         }
         else if (!isShell)
         {
@@ -776,32 +781,6 @@ public sealed class ToolAccessPolicy
                 arguments,
                 context.Invocation,
                 _toolPathPolicy);
-        }
-
-        // A clean shell command can combine reviewed-safe candidates with candidates
-        // that need a stored grant. Remove only candidates that independently
-        // satisfy both the safe-verb and reviewed diagnostic path rules. The approval store
-        // must still cover every remaining candidate.
-        if (_safeVerbPolicy is not null
-            && isShell
-            && !isMessy
-            && approvalCandidates.Count > 0)
-        {
-            if (!deferShellCompletion && agentCorrection is null)
-                agentCorrection = EvaluateShellProjectCorrection(approvalCandidates, context.Approval.Cwd, context.Invocation);
-
-            if (!deferShellCompletion)
-            {
-                approvalCandidates = approvalCandidates
-                    .Where(candidate => !_safeVerbPolicy.ShortCircuits(
-                        candidate,
-                        context.Approval.Cwd,
-                        context.Invocation))
-                    .ToList();
-
-                if (approvalCandidates.Count == 0)
-                    return ToolAuthorizationDecision.Allow(ToolAllowReason.ReviewedSafePolicy);
-            }
         }
 
         var candidateVerbs = approvalCandidates
@@ -818,16 +797,22 @@ public sealed class ToolAccessPolicy
         }
         else
         {
-            options = BuildApprovalOptions(GetApprovalOptionProfile(
-                toolName,
-                isMessy,
-                !isShell || approvalCandidates.All(HasReusableShellPhrase),
-                matcher is ShellApprovalMatcher
-                && IsShellDirectoryApprovalAvailable(
+            var hasReusablePhrase = !isShell || approvalCandidates.All(HasReusableShellPhrase);
+            var directoryApprovalAvailable = false;
+            if (matcher is ShellApprovalMatcher)
+            {
+                directoryApprovalAvailable = IsShellDirectoryApprovalAvailable(
                     approvalCandidates,
                     context.Approval.Cwd,
                     GetSessionOwnedApprovalDirectories(context),
-                    ShellEnvironment.PathStyle)));
+                    ShellEnvironment.PathStyle);
+            }
+
+            options = BuildApprovalOptions(GetApprovalOptionProfile(
+                toolName,
+                isMessy,
+                hasReusablePhrase,
+                directoryApprovalAvailable));
         }
 
         var approvalContext = new ToolApprovalContext(
@@ -848,6 +833,36 @@ public sealed class ToolAccessPolicy
         return ToolAuthorizationDecision.RequiresApproval(
             approvalContext,
             isManagedTemporaryRetry ? null : agentCorrection);
+    }
+
+    private (IReadOnlyList<ApprovalCandidate> UncoveredCandidates, ToolCorrection? Correction) EvaluateSynchronousShellPolicy(
+        ShellCommandAnalysis? analysis,
+        IReadOnlyList<ApprovalCandidate> candidates,
+        bool isMessy,
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext context)
+    {
+        ToolCorrection? correction = null;
+        if (analysis is not null)
+            correction = EvaluateShellTemporaryCorrection(analysis, candidates, arguments, context.Invocation);
+
+        if (_safeVerbPolicy is null)
+            return (candidates, correction);
+
+        if (isMessy)
+            return (candidates, correction);
+
+        if (candidates.Count == 0)
+            return (candidates, correction);
+
+        if (correction is null)
+            correction = EvaluateShellProjectCorrection(candidates, context.Approval.Cwd, context.Invocation);
+
+        // Each removed candidate must satisfy both the reviewed verb and path rules. The approval store covers the remainder.
+        var uncovered = candidates
+            .Where(candidate => !_safeVerbPolicy.ShortCircuits(candidate, context.Approval.Cwd, context.Invocation))
+            .ToList();
+        return (uncovered, correction);
     }
 
     internal ToolCorrection? EvaluateShellTemporaryCorrection(

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -198,7 +198,7 @@ public sealed class ToolAccessPolicy
             tool,
             context,
             arguments,
-            deferReviewedSafeCoverage: false,
+            deferShellCompletion: false,
             out _);
 
     /// <summary>Builds canonical shell analysis and applies synchronous access rules before approval evidence.</summary>
@@ -211,7 +211,7 @@ public sealed class ToolAccessPolicy
             tool,
             context,
             arguments,
-            deferReviewedSafeCoverage: true,
+            deferShellCompletion: true,
             out var analysis);
 
         if (!decision.NeedsApproval)
@@ -232,8 +232,7 @@ public sealed class ToolAccessPolicy
             ? new ShellPolicyPreflightResult.Continue(
                 analysis,
                 approvalContext,
-                ShellEnvironment,
-                decision.AgentCorrection)
+                ShellEnvironment)
             : new ShellPolicyPreflightResult.Complete(
                 ToolAuthorizationDecision.Deny("internal_policy_failure"),
                 authorizedAnalysis: null);
@@ -243,7 +242,7 @@ public sealed class ToolAccessPolicy
         INetclawTool tool,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments,
-        bool deferReviewedSafeCoverage,
+        bool deferShellCompletion,
         out ShellCommandAnalysis? authorizedAnalysis)
     {
         authorizedAnalysis = null;
@@ -261,7 +260,7 @@ public sealed class ToolAccessPolicy
                 toolName,
                 context,
                 arguments,
-                deferReviewedSafeCoverage,
+                deferShellCompletion,
                 out authorizedAnalysis)
             : AuthorizeStructuredInvocation(tool, toolName, context, arguments);
     }
@@ -323,7 +322,7 @@ public sealed class ToolAccessPolicy
         ToolName toolName,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments,
-        bool deferReviewedSafeCoverage,
+        bool deferShellCompletion,
         out ShellCommandAnalysis? authorizedAnalysis)
     {
         authorizedAnalysis = null;
@@ -403,7 +402,7 @@ public sealed class ToolAccessPolicy
             mode,
             shellApproval,
             shellAnalysis,
-            deferReviewedSafeCoverage);
+            deferShellCompletion);
     }
 
     internal bool IsReviewedSafeCandidate(
@@ -683,7 +682,7 @@ public sealed class ToolAccessPolicy
         return ToolArgumentHelper.GetString(arguments, "WorkingDirectory");
     }
 
-    private static IDictionary<string, object?>? WithResolvedShellWorkingDirectory(
+    internal static IDictionary<string, object?>? WithResolvedShellWorkingDirectory(
         IDictionary<string, object?>? arguments,
         string? resolvedWorkingDirectory)
     {
@@ -712,7 +711,7 @@ public sealed class ToolAccessPolicy
         ToolApprovalMode mode,
         ShellApprovalAnalysis? shellApproval = null,
         ShellCommandAnalysis? shellAnalysis = null,
-        bool deferReviewedSafeCoverage = false)
+        bool deferShellCompletion = false)
     {
         var approvalModeDecision = GetApprovalModeDecision(mode);
         if (approvalModeDecision is not null)
@@ -761,9 +760,10 @@ public sealed class ToolAccessPolicy
         IReadOnlyList<ApprovalCandidate> approvalCandidates = candidates;
         ToolCorrection? agentCorrection = null;
 
-        if (isShell && shellAnalysis is not null)
+        // The public synchronous API retains preflight hints. Live shell dispatch collects corrections only in the coordinator.
+        if (isShell && shellAnalysis is not null && !deferShellCompletion)
         {
-            agentCorrection = _temporaryPathCorrectionPolicy.Evaluate(
+            agentCorrection = EvaluateShellTemporaryCorrection(
                 shellAnalysis,
                 approvalCandidates,
                 arguments,
@@ -787,17 +787,10 @@ public sealed class ToolAccessPolicy
             && !isMessy
             && approvalCandidates.Count > 0)
         {
-            if (agentCorrection is null
-                && !_temporaryPathCorrectionPolicy.IsPlatformTemporaryRoot(context.Approval.Cwd)
-                && _safeVerbPolicy.CanShortCircuitAfterProjectDeclaration(
-                    approvalCandidates,
-                    context.Approval.Cwd,
-                    context.Invocation))
-            {
-                agentCorrection = new ToolCorrection.ProjectDirectorySuggested(context.Approval.Cwd!);
-            }
+            if (!deferShellCompletion && agentCorrection is null)
+                agentCorrection = EvaluateShellProjectCorrection(approvalCandidates, context.Approval.Cwd, context.Invocation);
 
-            if (!deferReviewedSafeCoverage)
+            if (!deferShellCompletion)
             {
                 approvalCandidates = approvalCandidates
                     .Where(candidate => !_safeVerbPolicy.ShortCircuits(
@@ -856,6 +849,23 @@ public sealed class ToolAccessPolicy
             approvalContext,
             isManagedTemporaryRetry ? null : agentCorrection);
     }
+
+    internal ToolCorrection? EvaluateShellTemporaryCorrection(
+        ShellCommandAnalysis analysis,
+        IReadOnlyList<ApprovalCandidate> candidates,
+        IDictionary<string, object?>? arguments,
+        ToolInvocationContext invocation)
+        => _temporaryPathCorrectionPolicy.Evaluate(analysis, candidates, arguments, invocation);
+
+    internal ToolCorrection.ProjectDirectorySuggested? EvaluateShellProjectCorrection(
+        IReadOnlyList<ApprovalCandidate> candidates,
+        string? cwd,
+        ToolInvocationContext invocation)
+        => !_temporaryPathCorrectionPolicy.IsPlatformTemporaryRoot(cwd)
+           && _safeVerbPolicy is not null
+           && _safeVerbPolicy.CanShortCircuitAfterProjectDeclaration(candidates, cwd, invocation)
+            ? new ToolCorrection.ProjectDirectorySuggested(cwd!)
+            : null;
 
     private ToolApprovalMode GetApprovalMode(
         ToolName toolName,
@@ -1267,20 +1277,10 @@ public sealed class ToolAccessDeniedException : InvalidOperationException
 public sealed class ToolApprovalRequiredException : InvalidOperationException
 {
     public ToolApprovalRequiredException(ToolApprovalContext context)
-        : this(context, correction: null)
-    {
-    }
-
-    internal ToolApprovalRequiredException(
-        ToolApprovalContext context,
-        ToolCorrection? correction)
         : base($"Tool '{context.ToolName}' requires approval")
     {
         ApprovalContext = context;
-        Correction = correction;
     }
 
     public ToolApprovalContext ApprovalContext { get; }
-
-    internal ToolCorrection? Correction { get; }
 }

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -855,7 +855,15 @@ public sealed class ToolAccessPolicy
         IReadOnlyList<ApprovalCandidate> candidates,
         IDictionary<string, object?>? arguments,
         ToolInvocationContext invocation)
-        => _temporaryPathCorrectionPolicy.Evaluate(analysis, candidates, arguments, invocation);
+    {
+        var correction = _temporaryPathCorrectionPolicy.Evaluate(analysis, candidates, arguments, invocation);
+        // Diagnostic classification suppresses relocation advice only. Normal authorization still owns execution and path access.
+        return correction is not null
+               && _safeVerbPolicy is not null
+               && _safeVerbPolicy.IsReviewedDiagnosticInvocation(candidates, analysis.Environment.PathStyle)
+            ? null
+            : correction;
+    }
 
     internal ToolCorrection.ProjectDirectorySuggested? EvaluateShellProjectCorrection(
         IReadOnlyList<ApprovalCandidate> candidates,

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -857,23 +857,35 @@ public sealed class ToolAccessPolicy
         ToolInvocationContext invocation)
     {
         var correction = _temporaryPathCorrectionPolicy.Evaluate(analysis, candidates, arguments, invocation);
+        if (correction is null)
+            return null;
+
+        if (_safeVerbPolicy is null)
+            return correction;
+
         // Diagnostic classification suppresses relocation advice only. Normal authorization still owns execution and path access.
-        return correction is not null
-               && _safeVerbPolicy is not null
-               && _safeVerbPolicy.IsReviewedDiagnosticInvocation(candidates, analysis.Environment.PathStyle)
-            ? null
-            : correction;
+        if (_safeVerbPolicy.IsReviewedDiagnosticInvocation(candidates, analysis.Environment.PathStyle))
+            return null;
+
+        return correction;
     }
 
     internal ToolCorrection.ProjectDirectorySuggested? EvaluateShellProjectCorrection(
         IReadOnlyList<ApprovalCandidate> candidates,
         string? cwd,
         ToolInvocationContext invocation)
-        => !_temporaryPathCorrectionPolicy.IsPlatformTemporaryRoot(cwd)
-           && _safeVerbPolicy is not null
-           && _safeVerbPolicy.CanShortCircuitAfterProjectDeclaration(candidates, cwd, invocation)
-            ? new ToolCorrection.ProjectDirectorySuggested(cwd!)
-            : null;
+    {
+        if (_temporaryPathCorrectionPolicy.IsPlatformTemporaryRoot(cwd))
+            return null;
+
+        if (_safeVerbPolicy is null)
+            return null;
+
+        if (!_safeVerbPolicy.CanShortCircuitAfterProjectDeclaration(candidates, cwd, invocation))
+            return null;
+
+        return new ToolCorrection.ProjectDirectorySuggested(cwd!);
+    }
 
     private ToolApprovalMode GetApprovalMode(
         ToolName toolName,

--- a/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
+++ b/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
@@ -98,7 +98,8 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
             "Apply all compatible advice in a correction response before the next call",
             "A shell call can return correction advice under Auto",
             "Advice grants no authority. Every replacement call passes current policy",
-            "If you require the exact platform path, retry unchanged once through normal policy"
+            "If you require the exact platform path, retry unchanged once through normal policy",
+            "Reviewed diagnostics without file output do not receive temporary relocation advice"
         };
         foreach (var statement in statements)
         {

--- a/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
+++ b/src/Netclaw.Daemon.Tests/BuiltInSkillSeedingTests.cs
@@ -95,7 +95,10 @@ public sealed class BuiltInSkillSeedingTests : IDisposable
             "If approval is required but no interactive requester is available",
             "After an access denial, do not retry that call during the same user turn",
             "A later explicit user request can start a new call",
-            "Apply one `Tool execution deferred:` correction unchanged"
+            "Apply all compatible advice in a correction response before the next call",
+            "A shell call can return correction advice under Auto",
+            "Advice grants no authority. Every replacement call passes current policy",
+            "If you require the exact platform path, retry unchanged once through normal policy"
         };
         foreach (var statement in statements)
         {


### PR DESCRIPTION
Shell Auto currently skips temporary and project advice. Parent and child callers also select project advice from approval exceptions.

This change makes the shell coordinator collect compatible corrections from existing policy, registry, and invocation facts. Parent and child callers deliver one common result. Corrections precede Auto; hard denials remain authoritative. Temporary-only and project-only advice preserve stored-grant and exact one-time approval precedence.

The coordinator handles native replacement and Auto in separate branches. Explicit guards separate syntax validity, protected paths, directory eligibility, and prerequisite coverage. The public synchronous policy path retains its compatibility behavior in a separate helper. Correction delivery matches supported combinations directly and requires exact call semantics for temporary-only advice.

The PR removes caller branches that select project advice, their formatter, and correction payloads from approval exceptions. Shared process startup remains separate.

The operational skill, its project reference, and the approval runbook describe correction behavior. Reviewed diagnostics without file output retain their requested temporary directory through the existing diagnostic catalog. Normal authorization still applies.

CI also exposed a recall-gate test that raced real timers. The gate timer now uses its existing TimeProvider dependency. Virtual-time tests cover the gate ceiling, partial or exhausted outer budgets, and successful completion.

Validation:

- At `976ecd8a`, the Release actor suite passed 3,842 tests, with five platform skips and zero failures. Slopwatch, copyright headers, and diff checks passed.
- Nine additional delivery cases cover valid combinations, both native-plus-temporary orders, exact retry-state creation, missing call semantics, and invalid combinations.
- The aggressive sub-agent review found two further issues. Both were fixed and rechecked. No required issue remains within its inspected scope.
- At the earlier head, `b55e63b3`, the full Linux Release suite passed 8,222 tests, with 19 skips and zero failures. All 17 CI checks passed.
- Local actor tests exclude `Category=NativeShell`, as the Linux CI test job does. CI must validate the final commit.
- Strict OpenSpec validation passed before the CI repairs. The repairs and review refactors preserve the spec.
- Behavioral evals cannot start: no provider type, endpoint, or model is configured.

The bounded specification is in `openspec/changes/complete-shell-correction-cutover/`.

Please review before merge. This PR does not authorize rollout.
