### PR TITLE
Recheck shell authority at shared process startup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,6 +77,7 @@
     <PackageVersion Include="Netclaw.SkillClient" Version="0.4.1" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.3.5" />
     <PackageVersion Include="Termina" Version="0.16.2" />
+    <PackageVersion Include="xunit.v3.mtp-off" Version="4.0.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.68.0"
+  version: "2.69.0"
 ---
 
 # Netclaw Operations

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -311,6 +311,10 @@ Rules:
   model server that takes minutes to respond) should run as background jobs.
 - The user must approve the command before it starts running in the background.
 - Maximum 5 concurrent background jobs; overflow queues FIFO.
+- Submission confirms acceptance. A queued job still needs a policy check when its slot opens.
+- The job keeps its exact command, cwd, shell, and child environment while it waits.
+- A revoked grant or a newly protected path can cause a failed launch. Read the job result before another request.
+- A background job keeps its own lifetime after submission. Use its job identifier to cancel it.
 - Job definitions persist to `~/.netclaw/jobs/{id}.json` until 24 hours after
   the job reaches a terminal state.
 

--- a/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
+++ b/feeds/skills/.system/files/netclaw-operations/references/scheduling.md
@@ -313,6 +313,7 @@ Rules:
 - Maximum 5 concurrent background jobs; overflow queues FIFO.
 - Submission confirms acceptance. A queued job still needs a policy check when its slot opens.
 - The job keeps its exact command, cwd, shell, and child environment while it waits.
+- Use an absolute `WorkingDirectory`, or omit it to use the session or project directory.
 - A revoked grant or a newly protected path can cause a failed launch. Read the job result before another request.
 - A background job keeps its own lifetime after submission. Use its job identifier to cancel it.
 - Job definitions persist to `~/.netclaw/jobs/{id}.json` until 24 hours after

--- a/openspec/changes/share-checked-shell-start/.openspec.yaml
+++ b/openspec/changes/share-checked-shell-start/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/share-checked-shell-start/design.md
+++ b/openspec/changes/share-checked-shell-start/design.md
@@ -1,0 +1,56 @@
+## Context
+
+See [proposal.md](proposal.md). ShellTool starts normal and streamed processes directly.
+BackgroundJobExecutionActor starts persisted command fields without a policy check.
+The manager queues job identifiers and marks unfinished records as lost after restart.
+
+## Goals / Non-Goals
+
+The shared boundary owns preparation and process creation. Existing callers own the process lifetime.
+This change does not add a grant store, shell parser, or durable authorization token.
+
+## Decisions
+
+ShellProcessLaunch retains one exact invocation and its environment snapshot.
+The dispatcher supplies a required policy check that reads current grant evidence.
+It copies mutable approval state so a later tool call cannot alter the queued request.
+The background submission carries this call-local launch; the manager retains it only while the job waits.
+Persisted definitions retain the existing format and never authorize a replay.
+
+The launch creates one process directly after the final authority check, without another actor message or await.
+It compares resolved path targets before and after the grant await. Changed path facts cause a visible denial.
+The background actor receives the process through its mailbox. Cancellation remains available while policy awaits the grant service.
+The start task owns the process until the actor adopts it. Actor stop cancels startup and reclaims an unclaimed process result.
+
+The public direct ShellTool API retains its existing command and protected-path checks.
+Routed calls additionally require the coordinator. Background submission cannot use an unchecked legacy path.
+
+Ordered flow:
+1. Copy the exact invocation and child environment.
+2. Authorize submission through the coordinator.
+3. Retain the launch while the job waits.
+4. Prepare cwd and managed temporary storage at launch.
+5. Recheck current authority through the coordinator.
+6. Check cancellation and current command/path policy.
+7. Create one process and transfer ownership to the caller.
+
+## Risks / Trade-offs
+
+- OS path changes can race any userspace check. Final path checks narrow that window; this change does not provide filesystem sandbox isolation.
+- A queued grant can expire. The job reports a failed launch without a new interactive prompt.
+- An in-process launch retains authority context. Completion, cancellation, and reaping must remove queued references.
+
+## Migration Plan
+
+The in-process StartBackgroundJob contract now requires ShellProcessLaunch. Its command, directory, session, and trust properties derive from that launch.
+BackgroundJobExecutionActor constructors also require the checked launch. Host extensions must create it through DispatchingToolExecutor.PrepareShellLaunchAsync.
+The former unchecked actor constructors cannot remain executable without the required authority context.
+BackgroundJobManagerActor retains both constructor signatures. The launch now supplies its shell identity; the compatibility constructor no longer selects another shell.
+
+No persisted format changes occur. Restart recovery continues to mark unfinished jobs as lost.
+A source revert cannot undo process side effects. Deployment remains a separate operator action.
+
+## Delivery
+
+One PR implements T12–T14 after PR #2117. It includes source, regression tests, skill guidance, and an independent aggressive review.
+Evidence must cover stale authority, path mutation, cancellation, one process, output, and detached lifetime.

--- a/openspec/changes/share-checked-shell-start/proposal.md
+++ b/openspec/changes/share-checked-shell-start/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Background jobs can wait after approval and then start without a current policy check. Three separate process start paths can drift.
+
+## What Changes
+
+- Use one checked start boundary for normal, streamed, and background shell calls.
+- Preserve the exact command, shell, cwd, environment, and call authority across the queue.
+- Recheck policy at launch. Keep each existing process owner responsible for output, timeout, cancellation, and disposal.
+- **BREAKING:** Require a checked launch in the in-process background submission contract and execution actor constructors. Persisted job records retain their current format.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `canonical-shell-execution`: Require a shared checked start and current authority at launch.
+
+## Impact
+
+This change implements T12–T14 of the accepted shell authorization plan after PR #2117. It supports PRD-006 tool authority.
+The scope includes the dispatcher, shell tool, session pipeline, and background actors.
+It excludes new tools, grant formats, parser semantics, and deployment.
+
+### Security and operational impact
+
+A queued job can fail when its grant expires or its path becomes protected. Job status must report that failure.
+Restart recovery continues to mark unfinished jobs as lost. It does not replay stored commands.

--- a/openspec/changes/share-checked-shell-start/specs/canonical-shell-execution/spec.md
+++ b/openspec/changes/share-checked-shell-start/specs/canonical-shell-execution/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Every routed shell launch checks current authority
+
+Normal, streamed, and background shell calls SHALL use the same checked process start boundary.
+The boundary SHALL retain the exact command, cwd, shell identity, and child environment.
+It SHALL check current policy before launch and reject a denied, corrected, or cancelled request without a process.
+One accepted launch request SHALL start at most one process.
+See the [engineering glossary](../../../../../docs/spec/GLOSSARY.md) for shared terms.
+
+#### Scenario: Queued grant remains valid
+- **GIVEN** a background command has a valid stored grant
+- **WHEN** a queue slot becomes available and that grant still covers the exact call
+- **THEN** the command starts once without another approval prompt
+
+#### Scenario: Grant is revoked in the queue
+- **GIVEN** a background command needs a stored grant
+- **WHEN** the grant is revoked before launch
+- **THEN** no process starts
+- **AND** the job reports the policy failure
+
+#### Scenario: A path changes before launch
+- **GIVEN** a queued command refers to an allowed path
+- **WHEN** that path becomes a link to protected storage
+- **THEN** the launch fails without a process
+
+#### Scenario: Cancellation precedes launch
+- **WHEN** the process owner cancels the request before launch
+- **THEN** no process starts
+
+### Requirement: Shared startup preserves process lifetime ownership
+
+A foreground caller SHALL retain cancellation control over its process tree.
+A background actor SHALL own its process after submission.
+The caller's return or cancellation after accepted submission SHALL NOT terminate that background process.
+The owner SHALL retain output capture, timeout, completion, and process disposal.
+
+#### Scenario: Background submission returns
+- **WHEN** the submission call returns while its background process remains active
+- **THEN** the process continues
+- **AND** the owner can query and cancel the job
+
+#### Scenario: Foreground caller cancels
+- **GIVEN** a foreground command has a child process
+- **WHEN** the caller cancels the command
+- **THEN** the process tree exits

--- a/openspec/changes/share-checked-shell-start/specs/canonical-shell-execution/spec.md
+++ b/openspec/changes/share-checked-shell-start/specs/canonical-shell-execution/spec.md
@@ -3,7 +3,7 @@
 ### Requirement: Every routed shell launch checks current authority
 
 Normal, streamed, and background shell calls SHALL use the same checked process start boundary.
-The boundary SHALL retain the exact command, cwd, shell identity, and child environment.
+The boundary SHALL retain the exact command, absolute cwd, shell identity, and child environment.
 It SHALL check current policy before launch and reject a denied, corrected, or cancelled request without a process.
 One accepted launch request SHALL start at most one process.
 See the [engineering glossary](../../../../../docs/spec/GLOSSARY.md) for shared terms.
@@ -23,6 +23,11 @@ See the [engineering glossary](../../../../../docs/spec/GLOSSARY.md) for shared 
 - **GIVEN** a queued command refers to an allowed path
 - **WHEN** that path becomes a link to protected storage
 - **THEN** the launch fails without a process
+
+#### Scenario: Relative cwd cannot bind the launch
+- **WHEN** a shell request supplies a relative working directory
+- **THEN** the request fails before process creation
+- **AND** it does not inherit the daemon directory
 
 #### Scenario: Cancellation precedes launch
 - **WHEN** the process owner cancels the request before launch

--- a/openspec/changes/share-checked-shell-start/tasks.md
+++ b/openspec/changes/share-checked-shell-start/tasks.md
@@ -1,11 +1,13 @@
 ## 1. Shared launch
 
-- [ ] 1.1 Implement one checked start for all three modes. Verify the focused shell and job suites.
-- [ ] 1.2 Bind the queued invocation to current authority. Verify revoked grants, path changes, and exact request retention.
+- [x] 1.1 Implement one checked start for all three modes. Verify the focused shell and job suites.
+- [x] 1.2 Bind the queued invocation to current authority. Verify revoked grants, path changes, and exact request retention.
 
 ## 2. Lifecycle and delivery
 
-- [ ] 2.1 Verify one start, cancellation before launch, process tree exit, output, timeout, and detached lifetime.
-- [ ] 2.2 Update operational skill guidance and verify the spec with strict validation.
+- [x] 2.1 Verify one start, cancellation before launch, process tree exit, output, timeout, and detached lifetime.
+- [x] 2.2 Update operational skill guidance and verify the spec with strict validation.
 - [ ] 2.3 Run integrated tests, Slopwatch, headers, and applicable evals. Record each result and limitation.
-- [ ] 2.4 Run an independent aggressive review. Fix all confirmed findings and publish a labeled PR.
+- [x] 2.4 Run an independent aggressive review. Fix all confirmed findings and publish a labeled PR.
+
+Task 2.3 remains open because behavioral evals need a provider type, endpoint, and model ID. CI remains a separate gate.

--- a/openspec/changes/share-checked-shell-start/tasks.md
+++ b/openspec/changes/share-checked-shell-start/tasks.md
@@ -1,0 +1,11 @@
+## 1. Shared launch
+
+- [ ] 1.1 Implement one checked start for all three modes. Verify the focused shell and job suites.
+- [ ] 1.2 Bind the queued invocation to current authority. Verify revoked grants, path changes, and exact request retention.
+
+## 2. Lifecycle and delivery
+
+- [ ] 2.1 Verify one start, cancellation before launch, process tree exit, output, timeout, and detached lifetime.
+- [ ] 2.2 Update operational skill guidance and verify the spec with strict validation.
+- [ ] 2.3 Run integrated tests, Slopwatch, headers, and applicable evals. Record each result and limitation.
+- [ ] 2.4 Run an independent aggressive review. Fix all confirmed findings and publish a labeled PR.

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobExecutionActorTests.cs
@@ -3,11 +3,17 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
 using Akka.Actor;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Jobs;
+using Netclaw.Actors.Tools;
+using Netclaw.Actors.Tests.Tools;
+using Netclaw.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tests.Utilities;
@@ -66,8 +72,57 @@ public class BackgroundJobExecutionActorTests : TestKit
             definition,
             outputPath,
             TimeProvider.System,
-            environment ?? ShellEnvironment));
+            BackgroundShellLaunchFixture.Create(
+                definition.Command, _dir.Path, definition.SessionId.Value, environment ?? ShellEnvironment, definition.WorkingDirectory)));
         return Sys.ActorOf(ForwardingParent.Props(props, probe), $"exec-{definition.Id}");
+    }
+
+    public static bool IsPosix => !OperatingSystem.IsWindows();
+
+    [SlopwatchSuppress("SW001", "This test uses the native Bash TCP redirection and process identifier.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "Native Bash process ownership proof")]
+    public async Task Stop_before_actor_adoption_reclaims_the_real_process()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var command = $"printf '%s\\n' $$ > /dev/tcp/127.0.0.1/{port}; sleep 120";
+        var definition = MakeDefinition(command);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = TestToolExecutionContext.CreateBound("test/thread", _dir.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
+        var launch = new ShellProcessLaunch(command, _dir.Path, context.Invocation,
+            new ShellCommandPolicy(ShellEnvironment), new ToolPathPolicy(ShellEnvironment, []), async ct =>
+            {
+                entered.SetResult();
+                await release.Task.WaitAsync(ct);
+            });
+        var actor = Sys.ActorOf(Props.Create(() => new BackgroundJobExecutionActor(
+            definition, _store.GetOutputLogPath(definition.Id), TimeProvider.System, launch)));
+        await WatchAsync(actor);
+        await entered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        // System messages precede user messages. Suspend prevents adoption but still permits Stop.
+        ((IInternalActorRef)actor).Suspend();
+        release.SetResult();
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        deadline.CancelAfter(TimeSpan.FromSeconds(20));
+        try
+        {
+            using var connection = await listener.AcceptTcpClientAsync(deadline.Token);
+            using var reader = new StreamReader(connection.GetStream());
+            var pid = int.Parse((await reader.ReadLineAsync(deadline.Token))!);
+            using var process = Process.GetProcessById(pid);
+            Assert.False(process.HasExited);
+            Sys.Stop(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: deadline.Token);
+            await process.WaitForExitAsync(deadline.Token);
+            Assert.True(process.HasExited);
+        }
+        finally
+        {
+            Sys.Stop(actor);
+        }
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs
@@ -3,6 +3,13 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Tools;
+using Netclaw.Actors.Tests.Tools;
+using Netclaw.Security;
 using Akka.Actor;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
@@ -61,17 +68,74 @@ public class BackgroundJobIntegrationTests : TestKit
 
     private StartBackgroundJob MakeStartCommand(string command, ChannelType channelType = ChannelType.Slack, string? workingDirectory = null) => new()
     {
-        Command = command,
-        ManagedTemporaryDirectory = Path.Combine(Path.GetTempPath(), "netclaw-tests", "managed-temp"),
-        ManagedTemporaryStorageRoot = Path.Combine(Path.GetTempPath(), "netclaw-tests"),
-        WorkingDirectory = workingDirectory,
-        SessionId = new SessionId("C0123ABC/1712000000.000001"),
+        Launch = BackgroundShellLaunchFixture.Create(command, _dir.Path, "C0123ABC/1712000000.000001", TestShellEnvironment.Current, workingDirectory),
         Rationale = "integration test",
-        Audience = TrustAudience.Personal,
-        Boundary = TrustBoundary.Personal,
         OriginChannelType = channelType,
         TimeoutSeconds = 30
     };
+
+    public static bool IsPosix => !OperatingSystem.IsWindows();
+
+    [SlopwatchSuppress("SW001", "This test uses native Bash TCP redirection and a process identifier.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "Native Bash detached process proof")]
+    public async Task Dispatcher_launch_survives_submission_cancellation_and_the_manager_can_stop_it()
+    {
+        // The original manager constructor must accept the canonical identity carried by a checked launch.
+        var manager = Sys.ActorOf(Props.Create(() => new BackgroundJobManagerActor(_store, TimeProvider.System)));
+        await manager.Ask<BackgroundJobManagerHealthResponse>(GetBackgroundJobManagerHealth.Instance,
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var command = $"printf '%s\\n' $$ > /dev/tcp/127.0.0.1/{port}; sleep 120";
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode> { [ShellTool.ToolName] = ToolApprovalMode.Auto }
+        };
+        var commandPolicy = new ShellCommandPolicy(TestShellEnvironment.Current);
+        var pathPolicy = new ToolPathPolicy(TestShellEnvironment.Current, []);
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy));
+        var policy = TestToolAccessPolicy.Create(config, commandPolicy, pathPolicy);
+        var executor = new DispatchingToolExecutor(registry, policy);
+        var context = TestToolExecutionContext.CreateBound("launch/detached", _dir.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
+        using var submissionCancellation = new CancellationTokenSource();
+        var launch = await executor.PrepareShellLaunchAsync(
+            new FunctionCallContent("detached", ShellTool.ToolName, ToolInput.Create("Command", command)),
+            context, submissionCancellation.Token);
+        var request = new StartBackgroundJob
+        {
+            Launch = launch,
+            Rationale = "Verify detached lifetime.",
+            OriginChannelType = ChannelType.Tui
+        };
+        var accepted = await manager.Ask<BackgroundJobStarted>(request, TimeSpan.FromSeconds(10), submissionCancellation.Token);
+        submissionCancellation.Cancel();
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        deadline.CancelAfter(TimeSpan.FromSeconds(20));
+        try
+        {
+            using var connection = await listener.AcceptTcpClientAsync(deadline.Token);
+            using var reader = new StreamReader(connection.GetStream());
+            using var process = Process.GetProcessById(int.Parse((await reader.ReadLineAsync(deadline.Token))!));
+            Assert.False(process.HasExited);
+            var status = await manager.Ask<BackgroundJobStatusResponse>(
+                new QueryBackgroundJob(accepted.JobId, request.SessionId, request.Audience, request.Boundary),
+                TimeSpan.FromSeconds(10), deadline.Token);
+            Assert.Equal(BackgroundJobStatus.Running, status.Status);
+            await manager.Ask<BackgroundJobCancelResponse>(
+                new CancelBackgroundJob(accepted.JobId, request.SessionId, request.Audience, request.Boundary),
+                TimeSpan.FromSeconds(10), deadline.Token);
+            await process.WaitForExitAsync(deadline.Token);
+            Assert.True(process.HasExited);
+        }
+        finally
+        {
+            Sys.Stop(manager);
+        }
+    }
 
     [Fact]
     public async Task BackgroundJob_Completes_And_DeliversResult_ViaGateway()

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobManagerActorTests.cs
@@ -10,6 +10,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Jobs;
+using Netclaw.Actors.Tools;
+using Netclaw.Security;
+using Netclaw.Tools;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
@@ -102,18 +105,66 @@ public class BackgroundJobManagerActorTests : TestKit
         OriginChannelType = ChannelType.Tui
     };
 
-    private StartBackgroundJob MakeStartCommand(string command = "echo hello") => new()
+    private StartBackgroundJob MakeStartCommand(string command = "echo hello", string sessionId = "test/thread") => new()
     {
-        Command = command,
-        ManagedTemporaryDirectory = Path.Combine(Path.GetTempPath(), "netclaw-tests", "managed-temp"),
-        ManagedTemporaryStorageRoot = Path.Combine(Path.GetTempPath(), "netclaw-tests"),
-        SessionId = new SessionId("test/thread"),
+        Launch = BackgroundShellLaunchFixture.Create(command, _dir.Path, sessionId, TestShellEnvironment.Current),
         Rationale = "test run",
-        Audience = TrustAudience.Personal,
-        Boundary = TrustBoundary.Personal,
         OriginChannelType = ChannelType.Tui,
         TimeoutSeconds = 60
     };
+
+    [Fact]
+    public async Task Queue_rechecks_authority_and_cancel_remains_available_during_authorization()
+    {
+        var manager = await GetReadyManagerAsync();
+        var blocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requests = new List<StartBackgroundJob>();
+        var ids = new List<BackgroundJobId>();
+        for (var index = 0; index < BackgroundJobManagerActor.MaxConcurrentJobs; index++)
+        {
+            var request = MakeStartCommand("echo forbidden > must-not-start.txt");
+            var context = request.Launch.Context;
+            var launch = new ShellProcessLaunch(request.Command, request.WorkingDirectory, context,
+                new ShellCommandPolicy(TestShellEnvironment.Current),
+                new ToolPathPolicy(TestShellEnvironment.Current, []),
+                async cancellationToken =>
+                {
+                    entered.TrySetResult();
+                    await blocked.Task.WaitAsync(cancellationToken);
+                });
+            request = request with { Launch = launch };
+            requests.Add(request);
+            var accepted = await manager.Ask<BackgroundJobStarted>(request, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            ids.Add(accepted.JobId);
+        }
+        await entered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        var queued = MakeStartCommand("echo forbidden > revoked.txt");
+        var revoked = 0;
+        queued = queued with
+        {
+            Launch = new ShellProcessLaunch(queued.Command, queued.WorkingDirectory, queued.Launch.Context,
+                new ShellCommandPolicy(TestShellEnvironment.Current), new ToolPathPolicy(TestShellEnvironment.Current, []),
+                _ => Volatile.Read(ref revoked) == 1 ? Task.FromException(new ToolAccessDeniedException("grant_revoked")) : Task.CompletedTask)
+        };
+        var queuedId = (await manager.Ask<BackgroundJobStarted>(queued, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)).JobId;
+        Assert.Equal(BackgroundJobStatus.Pending, _store.Get(queuedId)!.Status);
+        Volatile.Write(ref revoked, 1);
+
+        await manager.Ask<BackgroundJobCancelResponse>(new CancelBackgroundJob(
+            ids[0], requests[0].SessionId, requests[0].Audience, requests[0].Boundary),
+            TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Equal(BackgroundJobStatus.Cancelled, _store.Get(ids[0])!.Status);
+            Assert.Equal(BackgroundJobStatus.Failed, _store.Get(queuedId)!.Status);
+            return Task.CompletedTask;
+        }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(File.Exists(Path.Combine(_dir.Path, "must-not-start.txt")));
+        Assert.False(File.Exists(Path.Combine(_dir.Path, "revoked.txt")));
+        manager.Tell(new KillJobsForSession(requests[0].SessionId));
+    }
 
     [Fact]
     public async Task ConcurrencyLimit_QueuesOverflowJobs()
@@ -176,13 +227,13 @@ public class BackgroundJobManagerActorTests : TestKit
         var sessionB = new SessionId("reap/session-b");
 
         var jobA1 = await manager.Ask<BackgroundJobStarted>(
-            MakeStartCommand(TestShellEnvironment.LongRunningCommand) with { SessionId = sessionA },
+            MakeStartCommand(TestShellEnvironment.LongRunningCommand, sessionA.Value),
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         var jobA2 = await manager.Ask<BackgroundJobStarted>(
-            MakeStartCommand(TestShellEnvironment.LongRunningCommand) with { SessionId = sessionA },
+            MakeStartCommand(TestShellEnvironment.LongRunningCommand, sessionA.Value),
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         var jobB = await manager.Ask<BackgroundJobStarted>(
-            MakeStartCommand(TestShellEnvironment.LongRunningCommand) with { SessionId = sessionB },
+            MakeStartCommand(TestShellEnvironment.LongRunningCommand, sessionB.Value),
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Guard against environmental spawn failure (fork pressure under the
@@ -229,7 +280,7 @@ public class BackgroundJobManagerActorTests : TestKit
         ActorRegistry.For(Sys).Register<SignalRGatewayActorKey>(gatewayProbe.Ref);
 
         var started = await manager.Ask<BackgroundJobStarted>(
-            MakeStartCommand(TestShellEnvironment.LongRunningCommand) with { SessionId = sessionId },
+            MakeStartCommand(TestShellEnvironment.LongRunningCommand, sessionId.Value),
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await manager.Ask<SessionJobsReaped>(

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundShellLaunchFixture.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundShellLaunchFixture.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="BackgroundShellLaunchFixture.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tests.Jobs;
+
+internal static class BackgroundShellLaunchFixture
+{
+    // Lifecycle tests supply explicit authority. Coordinator tests exercise grant decisions separately.
+    internal static ShellProcessLaunch Create(
+        string command,
+        string sessionDirectory,
+        string sessionId,
+        ShellExecutionEnvironment environment,
+        string? workingDirectory = null)
+    {
+        var context = TestToolExecutionContext.CreateBound(sessionId, sessionDirectory,
+            new TestToolExecutionContextOptions
+            {
+                Audience = TrustAudience.Personal,
+                Boundary = TrustBoundary.Personal
+            });
+        return new ShellProcessLaunch(command, workingDirectory, context.Invocation,
+            new ShellCommandPolicy(environment), new ToolPathPolicy(environment, []),
+            static _ => Task.CompletedTask);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundShellLaunchFixture.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundShellLaunchFixture.cs
@@ -26,7 +26,7 @@ internal static class BackgroundShellLaunchFixture
                 Audience = TrustAudience.Personal,
                 Boundary = TrustBoundary.Personal
             });
-        return new ShellProcessLaunch(command, workingDirectory, context.Invocation,
+        return new ShellProcessLaunch(command, workingDirectory ?? sessionDirectory, context.Invocation,
             new ShellCommandPolicy(environment), new ToolPathPolicy(environment, []),
             static _ => Task.CompletedTask);
     }

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Akka.Persistence.Hosting" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Verify.XunitV3" />
+    <PackageReference Include="xunit.v3.mtp-off" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,22 +34,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Netclaw.Security.Tests/ShellPolicyEvidenceModels.cs"
-             Link="Tools/ApprovalEvidence/ShellPolicyEvidenceModels.cs" />
-    <Compile Include="../Netclaw.Security.Tests/ToolFrictionEvidenceModels.cs"
-             Link="Tools/ToolFrictionEvidenceModels.cs" />
-    <None Include="../../openspec/changes/archive/2026-08-15-structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json"
-          Link="ApprovalEvidence/netclaw-policy-fixtures.json"
-          CopyToOutputDirectory="PreserveNewest" />
-    <None Include="../../openspec/changes/reduce-fresh-session-approval-spam/evidence/fresh-session-policy-fixtures.json"
-          Link="ApprovalEvidence/fresh-session-policy-fixtures.json"
-          CopyToOutputDirectory="PreserveNewest" />
-    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-schema-footprint-baseline.json"
-          Link="ToolFootprintEvidence/tool-schema-footprint-baseline.json"
-          CopyToOutputDirectory="PreserveNewest" />
-    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json"
-          Link="ToolFrictionEvidence/tool-friction-fixtures.json"
-          CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="../Netclaw.Security.Tests/ShellPolicyEvidenceModels.cs" Link="Tools/ApprovalEvidence/ShellPolicyEvidenceModels.cs" />
+    <Compile Include="../Netclaw.Security.Tests/ToolFrictionEvidenceModels.cs" Link="Tools/ToolFrictionEvidenceModels.cs" />
+    <None Include="../../openspec/changes/archive/2026-08-15-structure-shell-approval-policy/evidence/netclaw-policy-fixtures.json" Link="ApprovalEvidence/netclaw-policy-fixtures.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../openspec/changes/reduce-fresh-session-approval-spam/evidence/fresh-session-policy-fixtures.json" Link="ApprovalEvidence/fresh-session-policy-fixtures.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-schema-footprint-baseline.json" Link="ToolFootprintEvidence/tool-schema-footprint-baseline.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../openspec/changes/make-agent-tools-pit-of-success/evidence/tool-friction-fixtures.json" Link="ToolFrictionEvidence/tool-friction-fixtures.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.html" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Tools/Fixtures/*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Netclaw.Actors.Tests/Sessions/BackgroundJobReapOnPassivationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/BackgroundJobReapOnPassivationTests.cs
@@ -280,7 +280,8 @@ public sealed class BackgroundJobReapOnPassivationTests : LlmSessionTestBase
             FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
             => Task.FromResult(new ShellProcessLaunch(
                 ToolArgumentHelper.GetString(toolCall.Arguments, "Command")!,
-                ToolArgumentHelper.GetString(toolCall.Arguments, "WorkingDirectory"),
+                context.ResolveShellCwd(ToolArgumentHelper.GetString(toolCall.Arguments, "WorkingDirectory"))
+                    ?? throw new InvalidOperationException("The test launch requires a working directory."),
                 context.Invocation,
                 new Netclaw.Security.ShellCommandPolicy(TestShellEnvironment.Current),
                 new Netclaw.Security.ToolPathPolicy(TestShellEnvironment.Current, []),

--- a/src/Netclaw.Actors.Tests/Sessions/BackgroundJobReapOnPassivationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/BackgroundJobReapOnPassivationTests.cs
@@ -276,6 +276,16 @@ public sealed class BackgroundJobReapOnPassivationTests : LlmSessionTestBase
 
     private sealed class PermissiveToolExecutor : IToolExecutor
     {
+        public Task<ShellProcessLaunch> PrepareShellLaunchAsync(
+            FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
+            => Task.FromResult(new ShellProcessLaunch(
+                ToolArgumentHelper.GetString(toolCall.Arguments, "Command")!,
+                ToolArgumentHelper.GetString(toolCall.Arguments, "WorkingDirectory"),
+                context.Invocation,
+                new Netclaw.Security.ShellCommandPolicy(TestShellEnvironment.Current),
+                new Netclaw.Security.ToolPathPolicy(TestShellEnvironment.Current, []),
+                static _ => Task.CompletedTask));
+
         public Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
             => Task.CompletedTask;
 

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
@@ -411,6 +411,16 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
 
     private sealed class EchoExecutor : IToolExecutor
     {
+        public Task<ShellProcessLaunch> PrepareShellLaunchAsync(
+            FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
+            => Task.FromResult(new ShellProcessLaunch(
+                ToolArgumentHelper.GetString(toolCall.Arguments, "Command")!,
+                ToolArgumentHelper.GetString(toolCall.Arguments, "WorkingDirectory"),
+                context.Invocation,
+                new Netclaw.Security.ShellCommandPolicy(TestShellEnvironment.Current),
+                new Netclaw.Security.ToolPathPolicy(TestShellEnvironment.Current, []),
+                static _ => Task.CompletedTask));
+
         public Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
             => Task.CompletedTask;
 
@@ -423,6 +433,10 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
 
     private sealed class DenyingExecutor : IToolExecutor
     {
+        public Task<ShellProcessLaunch> PrepareShellLaunchAsync(
+            FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
+            => Task.FromException<ShellProcessLaunch>(new ToolAccessDeniedException("shell_disabled"));
+
         public Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext? context = null, CancellationToken ct = default)
             => Task.FromException(new ToolAccessDeniedException("shell_disabled"));
 

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
@@ -210,6 +210,7 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
     [Fact]
     public async Task ExplicitBackground_PreservesWorkingDirectory()
     {
+        var projectDirectory = Path.Combine(Path.GetTempPath(), "project");
         var executor = new EchoExecutor();
         var probe = CreateTestProbe("pipeline-probe-workingdir");
         var jobManagerProbe = CreateTestProbe("job-manager-workingdir");
@@ -220,7 +221,7 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             new("call-bg-dir", "shell_execute", new Dictionary<string, object?>
             {
                 ["command"] = "dotnet test",
-                ["working_directory"] = "/tmp/project",
+                ["working_directory"] = projectDirectory,
                 ["_background"] = true,
                 ["_rationale"] = "run tests in repo"
             })
@@ -239,12 +240,13 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
         var received = await jobManagerProbe.ExpectMsgAsync<StartBackgroundJob>(
             TimeSpan.FromSeconds(3),
             cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal("/tmp/project", received.WorkingDirectory);
+        Assert.Equal(projectDirectory, received.WorkingDirectory);
     }
 
     [Fact]
     public async Task ExplicitBackground_PersistsResolvedProjectDirectoryWhenArgumentIsOmitted()
     {
+        var projectDirectory = Path.Combine(Path.GetTempPath(), "active-project");
         var executor = new EchoExecutor();
         var probe = CreateTestProbe("pipeline-probe-resolved-workingdir");
         var jobManagerProbe = CreateTestProbe("job-manager-resolved-workingdir");
@@ -263,7 +265,7 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
         await new SessionToolPipelineTestFixture(
                 executor, toolCalls, new SessionId("test/background-resolved-dir"), probe.Ref)
             .From(TestMessageSource())
-            .InProject("/tmp/active-project")
+            .InProject(projectDirectory)
             .WithBackgroundJobs(fakeJobManager)
             .ExecuteAsync(TestContext.Current.CancellationToken);
 
@@ -274,7 +276,7 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
         var received = await jobManagerProbe.ExpectMsgAsync<StartBackgroundJob>(
             TimeSpan.FromSeconds(3),
             cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal("/tmp/active-project", received.WorkingDirectory);
+        Assert.Equal(projectDirectory, received.WorkingDirectory);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/BackgroundRoutingTests.cs
@@ -417,7 +417,8 @@ public sealed class BackgroundRoutingTests(ITestOutputHelper output) : TestKit(o
             FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
             => Task.FromResult(new ShellProcessLaunch(
                 ToolArgumentHelper.GetString(toolCall.Arguments, "Command")!,
-                ToolArgumentHelper.GetString(toolCall.Arguments, "WorkingDirectory"),
+                context.ResolveShellCwd(ToolArgumentHelper.GetString(toolCall.Arguments, "WorkingDirectory"))
+                    ?? throw new InvalidOperationException("The test launch requires a working directory."),
                 context.Invocation,
                 new Netclaw.Security.ShellCommandPolicy(TestShellEnvironment.Current),
                 new Netclaw.Security.ToolPathPolicy(TestShellEnvironment.Current, []),

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -1426,6 +1426,13 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
 
         public int ExecutionBoundaryAttempts { get; private set; }
 
+        public Task<ShellProcessLaunch> PrepareShellLaunchAsync(
+            FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
+        {
+            AuthorizationAttempts++;
+            throw CreateCorrection();
+        }
+
         public Task AuthorizeAsync(
             FunctionCallContent toolCall,
             ToolExecutionContext? context = null,

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorLaunchTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorLaunchTests.cs
@@ -50,12 +50,14 @@ public partial class DispatchingToolExecutorTests
     public async Task Launch_rechecks_revoked_grants_in_every_mode(string mode)
     {
         using var directory = new DisposableTempDir();
+        // macOS temporary roots contain symlinks. Stored-grant tests need a physical path, not an exact-approval path.
+        ToolPathPolicy.TryResolveSymlinksInPath(directory.Path, out var sessionDirectory);
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var checks = 0;
         var service = new FixedShellApprovalService(request =>
             LaunchGrantResult(request, ++checks == 1));
         var executor = new DispatchingToolExecutor(registry, policy, service);
-        var context = TestToolExecutionContext.CreateBound("launch/revoked", directory.Path,
+        var context = TestToolExecutionContext.CreateBound("launch/revoked", sessionDirectory,
             new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var marker = Path.Combine(directory.Path, "must-not-exist.txt");
         var call = CreateToolCall("launch-revoked", ShellTool.ToolName,
@@ -91,10 +93,11 @@ public partial class DispatchingToolExecutorTests
     public async Task Launch_retains_exact_arguments_and_starts_once()
     {
         using var directory = new DisposableTempDir();
+        ToolPathPolicy.TryResolveSymlinksInPath(directory.Path, out var sessionDirectory);
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var service = new FixedShellApprovalService(request => LaunchGrantResult(request, true));
         var executor = new DispatchingToolExecutor(registry, policy, service);
-        var context = TestToolExecutionContext.CreateBound("launch/exact", directory.Path,
+        var context = TestToolExecutionContext.CreateBound("launch/exact", sessionDirectory,
             new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var call = CreateToolCall("launch-exact", ShellTool.ToolName,
             ToolInput.Create("Command", "echo once >> count.txt"));
@@ -117,9 +120,10 @@ public partial class DispatchingToolExecutorTests
     public async Task Launch_cancellation_after_authorization_creates_no_process()
     {
         using var directory = new DisposableTempDir();
+        ToolPathPolicy.TryResolveSymlinksInPath(directory.Path, out var sessionDirectory);
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var executor = new DispatchingToolExecutor(registry, policy, GrantEveryShellCandidate());
-        var context = TestToolExecutionContext.CreateBound("launch/cancel", directory.Path,
+        var context = TestToolExecutionContext.CreateBound("launch/cancel", sessionDirectory,
             new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var call = CreateToolCall("launch-cancel", ShellTool.ToolName,
             ToolInput.Create("Command", "echo forbidden > cancelled.txt"));

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorLaunchTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorLaunchTests.cs
@@ -1,0 +1,169 @@
+// -----------------------------------------------------------------------
+// <copyright file="DispatchingToolExecutorLaunchTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public partial class DispatchingToolExecutorTests
+{
+    [Theory]
+    [InlineData("normal")]
+    [InlineData("stream")]
+    [InlineData("background")]
+    public async Task Launch_rechecks_revoked_grants_in_every_mode(string mode)
+    {
+        using var directory = new DisposableTempDir();
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var checks = 0;
+        var service = new FixedShellApprovalService(request =>
+            LaunchGrantResult(request, ++checks == 1));
+        var executor = new DispatchingToolExecutor(registry, policy, service);
+        var context = TestToolExecutionContext.CreateBound("launch/revoked", directory.Path, TrustAudience.Personal);
+        var marker = Path.Combine(directory.Path, "must-not-exist.txt");
+        var call = CreateToolCall("launch-revoked", ShellTool.ToolName,
+            ToolInput.Create("Command", "echo forbidden > must-not-exist.txt"));
+
+        await Assert.ThrowsAsync<ToolApprovalRequiredException>(async () =>
+        {
+            switch (mode)
+            {
+                case "normal":
+                    await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
+                    break;
+                case "stream":
+                    await foreach (var unused in executor.ExecuteStreamAsync(call, context, TestContext.Current.CancellationToken))
+                    {
+                        Assert.Fail("A revoked launch must not emit a process result.");
+                    }
+                    break;
+                case "background":
+                    var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
+                    (await launch.StartAsync(TestContext.Current.CancellationToken)).Dispose();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
+            }
+        });
+
+        Assert.Equal(2, checks);
+        Assert.False(File.Exists(marker));
+    }
+
+    [Fact]
+    public async Task Launch_retains_exact_arguments_and_starts_once()
+    {
+        using var directory = new DisposableTempDir();
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var service = new FixedShellApprovalService(request => LaunchGrantResult(request, true));
+        var executor = new DispatchingToolExecutor(registry, policy, service);
+        var context = TestToolExecutionContext.CreateBound("launch/exact", directory.Path, TrustAudience.Personal);
+        var call = CreateToolCall("launch-exact", ShellTool.ToolName,
+            ToolInput.Create("Command", "echo once >> count.txt"));
+        var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
+
+        call.Arguments!["Command"] = "echo changed > changed.txt";
+        call.Arguments["WorkingDirectory"] = Path.GetTempPath();
+        using var process = await launch.StartAsync(TestContext.Current.CancellationToken);
+        process.StandardInput.Close();
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, process.ExitCode);
+        Assert.Single(await File.ReadAllLinesAsync(Path.Combine(directory.Path, "count.txt"), TestContext.Current.CancellationToken));
+        Assert.False(File.Exists(Path.Combine(directory.Path, "changed.txt")));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => launch.StartAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(2, service.RequestCount);
+    }
+
+    [Fact]
+    public async Task Launch_cancellation_after_authorization_creates_no_process()
+    {
+        using var directory = new DisposableTempDir();
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var executor = new DispatchingToolExecutor(registry, policy, GrantEveryShellCandidate());
+        var context = TestToolExecutionContext.CreateBound("launch/cancel", directory.Path, TrustAudience.Personal);
+        var call = CreateToolCall("launch-cancel", ShellTool.ToolName,
+            ToolInput.Create("Command", "echo forbidden > cancelled.txt"));
+        var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => launch.StartAsync(cancellation.Token));
+        Assert.False(File.Exists(Path.Combine(directory.Path, "cancelled.txt")));
+    }
+
+    [Fact]
+    public async Task Launch_keeps_exact_one_time_approval_after_the_submitter_clears_its_state()
+    {
+        using var directory = new DisposableTempDir();
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
+        var service = new FixedShellApprovalService(request => LaunchGrantResult(request, false));
+        var executor = new DispatchingToolExecutor(registry, policy, service);
+        var context = TestToolExecutionContext.CreateBound("launch/one-time", directory.Path, TrustAudience.Personal);
+        var call = CreateToolCall("launch-one-time", ShellTool.ToolName,
+            ToolInput.Create("Command", "echo approved > once.txt"));
+        var decision = await executor.EvaluateAuthorizationAsync(call, context, TestContext.Current.CancellationToken);
+        var approval = Assert.IsType<ToolApprovalContext>(decision.ApprovalContext);
+        context.Approval.SeedOneTimeApproval(ShellTool.ToolName, OneTimeApprovalKeys.Create(approval));
+        var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
+        context.Approval.ClearOneTimeApproval();
+
+        using var process = await launch.StartAsync(TestContext.Current.CancellationToken);
+        process.StandardInput.Close();
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, process.ExitCode);
+        Assert.Equal("approved", (await File.ReadAllTextAsync(Path.Combine(directory.Path, "once.txt"), TestContext.Current.CancellationToken)).Trim());
+        Assert.Null(context.Approval.OneTimeApprovedToolName);
+    }
+
+    public static bool SupportsLaunchLinks => !OperatingSystem.IsWindows();
+
+    [SlopwatchSuppress("SW001", "This test requires native POSIX symbolic-link behavior.")]
+    [Fact(SkipUnless = nameof(SupportsLaunchLinks), Skip = "POSIX-only symbolic-link semantics")]
+    public async Task Launch_rejects_causal_path_changes_inside_the_grant_await()
+    {
+        using var directory = new DisposableTempDir();
+        var alias = Directory.CreateDirectory(Path.Combine(directory.Path, "alias")).FullName;
+        var outside = Directory.CreateDirectory(Path.Combine(directory.Path, "outside")).FullName;
+        var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment,
+            safeVerbs: SafeVerbList.FromVerbs(ApprovalShell.Bash, ["head"]));
+        var calls = 0;
+        var service = new FixedShellApprovalService(request =>
+        {
+            if (++calls == 2)
+            {
+                Directory.Delete(alias);
+                Directory.CreateSymbolicLink(alias, outside);
+            }
+            return LaunchGrantResult(request, true);
+        });
+        var executor = new DispatchingToolExecutor(registry, policy, service);
+        var context = TestToolExecutionContext.CreateBound("launch/causal", directory.Path, TrustAudience.Personal);
+        var call = CreateToolCall("launch-causal", ShellTool.ToolName,
+            ToolInput.Create("Command", $"cd '{alias}' && echo forbidden > marker.txt; head result.log"));
+        var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
+
+        var denied = await Assert.ThrowsAsync<ToolAccessDeniedException>(() => launch.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("shell_launch_paths_changed", denied.DenyReason);
+        Assert.Equal(2, calls);
+        Assert.False(File.Exists(Path.Combine(outside, "marker.txt")));
+    }
+
+    private static ShellApprovalMatchResult LaunchGrantResult(ShellApprovalMatchRequest request, bool approved)
+        => new(new PersistentGrantStoreStatus.Ready(),
+            request.Candidates.Select(candidate => approved
+                ? new ShellGrantCandidateMatch(candidate.CandidateId,
+                    new ToolApprovalMatch(candidate.Candidate.Verb, "session", "this chat"),
+                    ShellCoverageKind.Session, [])
+                : new ShellGrantCandidateMatch(candidate.CandidateId, null, null, [])).ToArray());
+}

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorLaunchTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorLaunchTests.cs
@@ -15,6 +15,34 @@ namespace Netclaw.Actors.Tests.Tools;
 
 public partial class DispatchingToolExecutorTests
 {
+    [Fact]
+    public async Task Background_launch_rejects_missing_trust_context_before_the_handoff()
+    {
+        using var directory = new DisposableTempDir();
+        var context = TestToolExecutionContext.CreateBound("launch/missing-boundary", directory.Path, TrustAudience.Personal);
+        var call = CreateToolCall("missing-boundary", ShellTool.ToolName, ToolInput.Create("Command", "echo rejected"));
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken));
+
+        Assert.Contains("trust boundary", failure.Message);
+    }
+
+    [Fact]
+    public async Task Background_launch_rejects_a_cwd_that_depends_on_the_daemon_directory()
+    {
+        using var directory = new DisposableTempDir();
+        var context = TestToolExecutionContext.CreateBound("launch/relative", directory.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
+        var call = CreateToolCall("relative-cwd", ShellTool.ToolName,
+            ToolInput.Create("Command", "echo rejected", "WorkingDirectory", "."));
+
+        var failure = await Assert.ThrowsAsync<ShellProcessStartException>(() =>
+            _executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken));
+
+        Assert.Contains("absolute working directory", failure.Message);
+    }
+
     [Theory]
     [InlineData("normal")]
     [InlineData("stream")]
@@ -27,7 +55,8 @@ public partial class DispatchingToolExecutorTests
         var service = new FixedShellApprovalService(request =>
             LaunchGrantResult(request, ++checks == 1));
         var executor = new DispatchingToolExecutor(registry, policy, service);
-        var context = TestToolExecutionContext.CreateBound("launch/revoked", directory.Path, TrustAudience.Personal);
+        var context = TestToolExecutionContext.CreateBound("launch/revoked", directory.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var marker = Path.Combine(directory.Path, "must-not-exist.txt");
         var call = CreateToolCall("launch-revoked", ShellTool.ToolName,
             ToolInput.Create("Command", "echo forbidden > must-not-exist.txt"));
@@ -65,7 +94,8 @@ public partial class DispatchingToolExecutorTests
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var service = new FixedShellApprovalService(request => LaunchGrantResult(request, true));
         var executor = new DispatchingToolExecutor(registry, policy, service);
-        var context = TestToolExecutionContext.CreateBound("launch/exact", directory.Path, TrustAudience.Personal);
+        var context = TestToolExecutionContext.CreateBound("launch/exact", directory.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var call = CreateToolCall("launch-exact", ShellTool.ToolName,
             ToolInput.Create("Command", "echo once >> count.txt"));
         var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
@@ -89,7 +119,8 @@ public partial class DispatchingToolExecutorTests
         using var directory = new DisposableTempDir();
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var executor = new DispatchingToolExecutor(registry, policy, GrantEveryShellCandidate());
-        var context = TestToolExecutionContext.CreateBound("launch/cancel", directory.Path, TrustAudience.Personal);
+        var context = TestToolExecutionContext.CreateBound("launch/cancel", directory.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var call = CreateToolCall("launch-cancel", ShellTool.ToolName,
             ToolInput.Create("Command", "echo forbidden > cancelled.txt"));
         var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);
@@ -107,7 +138,8 @@ public partial class DispatchingToolExecutorTests
         var (registry, policy) = CreateApprovalGatedShellRegistryAndPolicy(ShellEnvironment);
         var service = new FixedShellApprovalService(request => LaunchGrantResult(request, false));
         var executor = new DispatchingToolExecutor(registry, policy, service);
-        var context = TestToolExecutionContext.CreateBound("launch/one-time", directory.Path, TrustAudience.Personal);
+        var context = TestToolExecutionContext.CreateBound("launch/one-time", directory.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var call = CreateToolCall("launch-one-time", ShellTool.ToolName,
             ToolInput.Create("Command", "echo approved > once.txt"));
         var decision = await executor.EvaluateAuthorizationAsync(call, context, TestContext.Current.CancellationToken);
@@ -147,7 +179,8 @@ public partial class DispatchingToolExecutorTests
             return LaunchGrantResult(request, true);
         });
         var executor = new DispatchingToolExecutor(registry, policy, service);
-        var context = TestToolExecutionContext.CreateBound("launch/causal", directory.Path, TrustAudience.Personal);
+        var context = TestToolExecutionContext.CreateBound("launch/causal", directory.Path,
+            new TestToolExecutionContextOptions { Audience = TrustAudience.Personal, Boundary = TrustBoundary.Personal });
         var call = CreateToolCall("launch-causal", ShellTool.ToolName,
             ToolInput.Create("Command", $"cd '{alias}' && echo forbidden > marker.txt; head result.log"));
         var launch = await executor.PrepareShellLaunchAsync(call, context, TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Tools;
 
-public class DispatchingToolExecutorTests
+public partial class DispatchingToolExecutorTests
 {
     private const string MissingShellCommandError =
         "Error parsing arguments for tool 'shell_execute': Required parameter 'Command' is missing.";
@@ -3519,7 +3519,7 @@ public class DispatchingToolExecutorTests
     }
 
     [Fact]
-    public async Task Authorization_only_and_each_execution_use_separate_authorizations()
+    public async Task Authorization_only_does_not_replace_dispatch_or_launch_checks()
     {
         var approvalService = GrantEveryShellCandidate();
         var executor = CreateApprovalGatedShellExecutor(ShellEnvironment, approvalService);
@@ -3534,10 +3534,15 @@ public class DispatchingToolExecutorTests
                 "Inspect the current working directory."));
 
         await executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken);
-        _ = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
-        _ = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
+        Assert.Equal(1, approvalService.RequestCount);
 
+        var first = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
+        Assert.Contains("Exit code: 0", first);
         Assert.Equal(3, approvalService.RequestCount);
+
+        var second = await executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken);
+        Assert.Contains("Exit code: 0", second);
+        Assert.Equal(5, approvalService.RequestCount);
     }
 
     [Theory]

--- a/src/Netclaw.Actors.Tests/Tools/ShellProcessLaunchTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellProcessLaunchTests.cs
@@ -20,6 +20,18 @@ public sealed class ShellProcessLaunchTests
     public static bool IsPosix => !OperatingSystem.IsWindows();
 
     [Fact]
+    public void Launch_does_not_select_a_working_directory_from_context()
+    {
+        using var directory = new DisposableTempDir();
+        var environment = TestShellEnvironment.Current;
+        var context = TestToolExecutionContext.CreateBound("launch/cwd", directory.Path, TrustAudience.Personal);
+
+        Assert.Throws<ArgumentNullException>(() => new ShellProcessLaunch(
+            "echo unexpected", null!, context.Invocation,
+            new ShellCommandPolicy(environment), new ToolPathPolicy(environment, []), static _ => Task.CompletedTask));
+    }
+
+    [Fact]
     public async Task Child_environment_remains_the_submission_snapshot()
     {
         using var directory = new DisposableTempDir();

--- a/src/Netclaw.Actors.Tests/Tools/ShellProcessLaunchTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellProcessLaunchTests.cs
@@ -1,0 +1,128 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellProcessLaunchTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class ShellProcessLaunchTests
+{
+    public static bool IsPosix => !OperatingSystem.IsWindows();
+
+    [Fact]
+    public async Task Child_environment_remains_the_submission_snapshot()
+    {
+        using var directory = new DisposableTempDir();
+        var environment = TestShellEnvironment.Current;
+        var key = "NETCLAW_LAUNCH_TEST_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            Environment.SetEnvironmentVariable(key, "submitted");
+            var command = environment.Grammar == ShellGrammar.Bash ? $"echo ${key}" : $"echo $env:{key}";
+            var context = TestToolExecutionContext.CreateBound("launch/environment", directory.Path, TrustAudience.Personal);
+            var launch = new ShellProcessLaunch(command, directory.Path, context.Invocation,
+                new ShellCommandPolicy(environment), new ToolPathPolicy(environment, []), static _ => Task.CompletedTask);
+            Environment.SetEnvironmentVariable(key, "changed");
+
+            using var process = await launch.StartAsync(TestContext.Current.CancellationToken);
+            process.StandardInput.Close();
+            var output = await process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+            await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal("submitted", output.Trim());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, null);
+        }
+    }
+
+    [SlopwatchSuppress("SW001", "This test requires native POSIX symbolic-link behavior.")]
+    [Fact(SkipUnless = nameof(IsPosix), Skip = "POSIX-only symbolic-link semantics")]
+    public async Task Final_start_rejects_a_link_that_changes_after_authorization()
+    {
+        using var directory = new DisposableTempDir();
+        var safe = Directory.CreateDirectory(Path.Combine(directory.Path, "safe"));
+        var denied = Directory.CreateDirectory(Path.Combine(directory.Path, "denied"));
+        var link = Path.Combine(directory.Path, "target");
+        Directory.CreateSymbolicLink(link, safe.FullName);
+        var environment = TestShellEnvironment.Current;
+        var context = TestToolExecutionContext.CreateBound("launch/path", directory.Path, TrustAudience.Personal);
+        var launch = new ShellProcessLaunch("echo forbidden > target/output.txt", directory.Path, context.Invocation,
+            new ShellCommandPolicy(environment), new ToolPathPolicy(environment, [denied.FullName]), _ =>
+            {
+                Directory.Delete(link);
+                Directory.CreateSymbolicLink(link, denied.FullName);
+                return Task.CompletedTask;
+            });
+
+        await Assert.ThrowsAsync<ShellProcessStartException>(() => launch.StartAsync(TestContext.Current.CancellationToken));
+        Assert.False(File.Exists(Path.Combine(denied.FullName, "output.txt")));
+    }
+
+    [SlopwatchSuppress("SW001", "This test uses the native Bash TCP redirection and process identifiers.")]
+    [Theory(SkipUnless = nameof(IsPosix), Skip = "Native Bash process-tree proof")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Foreground_cancellation_stops_the_parent_and_child_process(bool stream)
+    {
+        using var directory = new DisposableTempDir();
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var environment = TestShellEnvironment.Current;
+        var tool = new ShellTool(new ToolConfig(), new ToolPathPolicy(environment, []), new ShellCommandPolicy(environment));
+        var context = TestToolExecutionContext.CreateBound("launch/tree", directory.Path, TrustAudience.Personal);
+        var command = $"sleep 120 & child=$!; printf '%s %s\\n' $$ \"$child\" > /dev/tcp/127.0.0.1/{port}; wait";
+        using var cancellation = new CancellationTokenSource();
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        deadline.CancelAfter(TimeSpan.FromSeconds(20));
+        var call = ToolInput.Create("Command", command);
+        var execution = stream ? ConsumeStreamAsync(tool, call, context, cancellation.Token)
+            : tool.ExecuteAsync(call, context, cancellation.Token);
+
+        try
+        {
+            using var connection = await listener.AcceptTcpClientAsync(deadline.Token);
+            using var reader = new StreamReader(connection.GetStream());
+            var ids = (await reader.ReadLineAsync(deadline.Token))!.Split(' ').Select(int.Parse).ToArray();
+            using var parent = Process.GetProcessById(ids[0]);
+            using var child = Process.GetProcessById(ids[1]);
+            Assert.False(parent.HasExited);
+            Assert.False(child.HasExited);
+
+            cancellation.Cancel();
+            await execution.WaitAsync(deadline.Token);
+            await parent.WaitForExitAsync(deadline.Token);
+            await child.WaitForExitAsync(deadline.Token);
+            Assert.True(parent.HasExited);
+            Assert.True(child.HasExited);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await execution.WaitAsync(deadline.Token);
+        }
+    }
+
+    private static async Task<string> ConsumeStreamAsync(
+        ShellTool tool, IDictionary<string, object?> arguments, ToolExecutionContext context, CancellationToken cancellationToken)
+    {
+        await foreach (var update in tool.ExecuteStreamAsync(arguments, context, cancellationToken))
+        {
+            if (update is ToolCompletedUpdate completed)
+                return completed.Result;
+        }
+        throw new InvalidOperationException("The shell stream has no completion.");
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -725,7 +725,7 @@ public class ShellToolTests
                     "WorkingDirectory",
                     root.FullName),
                 CreateExecutionContext().Invocation,
-                analysis,
+                tool.CreateLaunch(command, root.FullName, CreateExecutionContext().Invocation, static _ => Task.CompletedTask),
                 TestContext.Current.CancellationToken);
 
             Assert.Contains("protected file path", result);

--- a/src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs
@@ -22,38 +22,31 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
     private readonly BackgroundJobDefinition _definition;
     private readonly string _outputLogPath;
     private readonly TimeProvider _timeProvider;
-    private readonly ShellExecutionEnvironment _environment;
+    private readonly ShellProcessLaunch _launch;
+    private readonly CancellationTokenSource _launchCancellation = new();
     private readonly ILoggingAdapter _log;
     private Process? _process;
+    private Task<Process>? _startTask;
     private ICancelable? _timeoutHandle;
 
     public BackgroundJobExecutionActor(
         BackgroundJobDefinition definition,
         string outputLogPath,
-        TimeProvider timeProvider)
-        : this(
-            definition,
-            outputLogPath,
-            timeProvider,
-            ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux))
-    {
-    }
-
-    public BackgroundJobExecutionActor(
-        BackgroundJobDefinition definition,
-        string outputLogPath,
         TimeProvider timeProvider,
-        ShellExecutionEnvironment environment)
+        ShellProcessLaunch launch)
     {
         _definition = definition;
         _outputLogPath = outputLogPath;
         _timeProvider = timeProvider;
-        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        _launch = launch ?? throw new ArgumentNullException(nameof(launch));
         _log = Context.GetLogger();
 
         Receive<CancelBackgroundJob>(_ => HandleCancel());
         Receive<TimeoutTick>(_ => HandleTimeout());
         Receive<ProcessExited>(HandleProcessExited);
+        Receive<ProcessStarted>(HandleProcessStarted);
+        Receive<Status.Failure>(failure =>
+            ReportCompletion(BackgroundJobStatus.Failed, -1, $"Failed to start: {failure.Cause.Message}"));
     }
 
     protected override void PreStart()
@@ -61,7 +54,8 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_outputLogPath)!);
-            SpawnProcess();
+            _startTask = _launch.StartAsync(_launchCancellation.Token);
+            _startTask.PipeTo(Self, success: process => new ProcessStarted(process));
         }
         catch (Exception ex)
         {
@@ -72,6 +66,10 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
 
     protected override void PostStop()
     {
+        _launchCancellation.Cancel();
+        _launchCancellation.Dispose();
+        if (_process is null && _startTask is { } pendingStart)
+            _ = DisposeUnclaimedProcessAsync(pendingStart, _log);
         _timeoutHandle?.Cancel();
         KillProcess();
 
@@ -92,91 +90,9 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
         }
     }
 
-    private void SpawnProcess()
+    private void HandleProcessStarted(ProcessStarted started)
     {
-        var psi = _environment.CreateProcessStartInfo(_definition.Command);
-        if (string.IsNullOrWhiteSpace(_definition.ManagedTemporaryDirectory)
-            || string.IsNullOrWhiteSpace(_definition.ManagedTemporaryAuthorityRoot))
-        {
-            ReportCompletion(
-                BackgroundJobStatus.Failed,
-                -1,
-                "Error: Background job has no managed temporary storage context.");
-            return;
-        }
-
-        ManagedTemporaryLocation temporaryLocation;
-        try
-        {
-            temporaryLocation = ManagedTemporaryLocation.FromPersistedPaths(
-                _definition.ManagedTemporaryDirectory,
-                _definition.ManagedTemporaryAuthorityRoot);
-        }
-        catch (Exception ex) when (ex is ArgumentException
-                                   or IOException
-                                   or NotSupportedException
-                                   or UnauthorizedAccessException
-                                   or System.Security.SecurityException)
-        {
-            ReportCompletion(
-                BackgroundJobStatus.Failed,
-                -1,
-                $"Error preparing managed temporary directory: {ex.Message}");
-            return;
-        }
-
-        var temporaryDirectoryError = ManagedTemporaryEnvironment.Prepare(psi, temporaryLocation);
-        if (temporaryDirectoryError is not null)
-        {
-            ReportCompletion(BackgroundJobStatus.Failed, -1, temporaryDirectoryError);
-            return;
-        }
-
-        if (!string.IsNullOrWhiteSpace(_definition.WorkingDirectory))
-        {
-            // ProcessStartInfo.WorkingDirectory must point at an existing directory or
-            // Process.Start throws an opaque, platform-specific error that surfaces as a
-            // cryptic "Failed to start: ...". Report the missing directory with the mkdir
-            // remedy so the agent creates it instead of retry-looping on the opaque error.
-            if (!Directory.Exists(_definition.WorkingDirectory))
-            {
-                if (File.Exists(_definition.WorkingDirectory))
-                {
-                    ReportCompletion(BackgroundJobStatus.Failed, -1,
-                        $"Working directory '{_definition.WorkingDirectory}' is a file, not a directory.");
-                    return;
-                }
-
-                var mkdirHint = CreateDirectoryHint(_definition.WorkingDirectory);
-                ReportCompletion(BackgroundJobStatus.Failed, -1,
-                    $"Working directory '{_definition.WorkingDirectory}' does not exist. "
-                    + $"Create it first, e.g.: {mkdirHint}");
-                return;
-            }
-
-            psi.WorkingDirectory = _definition.WorkingDirectory;
-        }
-
-        try
-        {
-            _process = Process.Start(psi);
-        }
-        catch (Exception ex)
-        {
-            ReportCompletion(
-                BackgroundJobStatus.Failed,
-                -1,
-                $"Failed to start shell '{_environment.ExecutableName}' "
-                + $"at '{_environment.ExecutablePath}': {ex.Message}");
-            return;
-        }
-
-        if (_process is null)
-        {
-            ReportCompletion(BackgroundJobStatus.Failed, -1, "Process.Start returned null");
-            return;
-        }
-
+        _process = started.Process;
         _process.StandardInput.Close();
 
         _log.Info("Background job {JobId} started PID {Pid}: {Command}",
@@ -233,6 +149,31 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
         });
     }
 
+    // The start task owns the process until this actor adopts it. Stop must reclaim an undelivered result.
+    private static async Task DisposeUnclaimedProcessAsync(Task<Process> startTask, ILoggingAdapter log)
+    {
+        try
+        {
+            using var process = await startTask.ConfigureAwait(false);
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException ex)
+            {
+                log.Debug("The unclaimed background process already exited: {Error}", ex.Message);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            log.Debug("Background process startup was cancelled before ownership transfer.");
+        }
+        catch (Exception ex)
+        {
+            log.Error(ex, "Failed to reclaim a background process after its actor stopped.");
+        }
+    }
+
     private static async Task PumpToLogAsync(StreamReader reader, JobOutputLog outputLog, bool isStderr)
     {
         while (await reader.ReadLineAsync() is { } line)
@@ -240,11 +181,6 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
             await outputLog.WriteLineAsync(line, isStderr);
         }
     }
-
-    private string CreateDirectoryHint(string path)
-        => _environment.PathStyle == ShellPathStyle.Windows
-            ? $"New-Item -ItemType Directory -Force -Path '{path.Replace("'", "''", StringComparison.Ordinal)}'"
-            : $"mkdir -p -- '{path.Replace("'", "'\\''", StringComparison.Ordinal)}'";
 
     private void HandleProcessExited(ProcessExited msg)
     {
@@ -268,6 +204,7 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
 
     private void HandleCancel()
     {
+        _launchCancellation.Cancel();
         _log.Info("Background job {JobId} cancellation requested", _definition.Id);
         _timeoutHandle?.Cancel();
         KillProcess();
@@ -311,6 +248,8 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
 
         Context.Stop(Self);
     }
+
+    private sealed record ProcessStarted(Process Process);
 
     private sealed record ProcessExited(int ExitCode, string? Output);
 

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -12,6 +12,7 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
+using Netclaw.Actors.Tools;
 using static Netclaw.Actors.Sessions.SessionProtocol;
 using static Netclaw.Actors.Jobs.BackgroundJobProtocol;
 
@@ -55,12 +56,12 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
 
     private readonly BackgroundJobDefinitionStore _store;
     private readonly TimeProvider _timeProvider;
-    private readonly ShellExecutionEnvironment _environment;
     private readonly IOperationalNotificationSink _notificationSink;
     private readonly ILoggingAdapter _log;
 
     private readonly HashSet<string> _activeJobIds = [];
     private readonly Queue<string> _deferredQueue = new();
+    private readonly Dictionary<string, ShellProcessLaunch> _pendingLaunches = new();
     private readonly Dictionary<string, BackgroundJobDefinition> _definitions = [];
 
     /// <summary>
@@ -74,27 +75,26 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
     /// </summary>
     public ITimerScheduler Timers { get; set; } = null!;
 
-    public BackgroundJobManagerActor(
-        BackgroundJobDefinitionStore store,
-        TimeProvider timeProvider,
-        IOperationalNotificationSink? notificationSink = null)
-        : this(
-            store,
-            timeProvider,
-            ShellExecutionEnvironment.CreateBash(ShellPlatform.Linux),
-            notificationSink)
-    {
-    }
-
+    /// <summary>
+    /// Retains the earlier host constructor. Each checked launch supplies its authorized shell identity.
+    /// </summary>
     public BackgroundJobManagerActor(
         BackgroundJobDefinitionStore store,
         TimeProvider timeProvider,
         ShellExecutionEnvironment environment,
         IOperationalNotificationSink? notificationSink = null)
+        : this(store, timeProvider, notificationSink)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+    }
+
+    public BackgroundJobManagerActor(
+        BackgroundJobDefinitionStore store,
+        TimeProvider timeProvider,
+        IOperationalNotificationSink? notificationSink = null)
     {
         _store = store;
         _timeProvider = timeProvider;
-        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         _notificationSink = notificationSink ?? NullNotificationSink.Instance;
         _log = Context.GetLogger();
 
@@ -125,6 +125,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
 
     private async Task HandleStartAsync(StartBackgroundJob cmd)
     {
+        ArgumentNullException.ThrowIfNull(cmd.Launch);
         var jobId = new BackgroundJobId(Guid.NewGuid().ToString("N")[..12]);
         var now = _timeProvider.GetUtcNow();
 
@@ -148,6 +149,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
 
         _store.Save(definition);
         _definitions[jobId.Value] = definition;
+        _pendingLaunches.Add(jobId.Value, cmd.Launch);
 
         var outputLogPath = _store.GetOutputLogPathOnly(jobId);
 
@@ -167,6 +169,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
     private void HandleCompleted(BackgroundJobCompleted completed)
     {
         _activeJobIds.Remove(completed.JobId.Value);
+        _pendingLaunches.Remove(completed.JobId.Value);
 
         BackgroundJobDefinition? def = null;
         var wasReaped = false;
@@ -209,6 +212,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
                 CompletedAtMs = nowMs
             };
             _definitions[def.Id.Value] = reaped;
+            _pendingLaunches.Remove(def.Id.Value);
             _store.Save(reaped);
 
             var child = Context.Child($"job-{def.Id.Value}");
@@ -259,6 +263,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
                 CompletedAtMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds()
             };
             _definitions[cmd.JobId.Value] = updated;
+            _pendingLaunches.Remove(cmd.JobId.Value);
             _store.Save(updated);
             Sender.Tell(new BackgroundJobCancelResponse(cmd.JobId, true));
         }
@@ -423,6 +428,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
                 if (_store.DeleteJobArtifacts(def.Id))
                 {
                     _definitions.Remove(def.Id.Value);
+                    _pendingLaunches.Remove(def.Id.Value);
                     swept++;
                     _log.Info(
                         "Swept terminal background job {JobId} (status={Status}, completed_at={CompletedAtMs}) past retention window",
@@ -523,7 +529,8 @@ public sealed class BackgroundJobManagerActor : ReceiveActor, IWithTimers
                 running,
                 outputLogPath,
                 _timeProvider,
-                _environment);
+                _pendingLaunches[running.Id.Value]);
+        _pendingLaunches.Remove(running.Id.Value);
         Context.ActorOf(props, $"job-{running.Id}");
     }
 

--- a/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
@@ -75,16 +75,17 @@ public static partial class BackgroundJobProtocol
     /// </summary>
     public sealed record StartBackgroundJob : IBackgroundJobCommand
     {
-        public required string Command { get; init; }
-        public string? WorkingDirectory { get; init; }
-        /// <summary>Gets the directory exposed through the child process temporary variables.</summary>
-        public required string ManagedTemporaryDirectory { get; init; }
-        /// <summary>Gets the storage root that must contain the managed temporary directory.</summary>
-        public required string ManagedTemporaryStorageRoot { get; init; }
-        public required Protocol.SessionId SessionId { get; init; }
+        public required Tools.ShellProcessLaunch Launch { get; init; }
+        public string Command => Launch.Command;
+        public string WorkingDirectory => Launch.WorkingDirectory;
+        public string ManagedTemporaryDirectory => Launch.Storage.ManagedTemporary.Directory.Value;
+        public string ManagedTemporaryStorageRoot => Launch.Storage.ManagedTemporary.StorageRoot.Value;
+        public Protocol.SessionId SessionId => new(Launch.Context.SessionId
+            ?? throw new InvalidOperationException("A background launch requires a session."));
+        public TrustAudience Audience => Launch.Context.Audience;
+        public TrustBoundary Boundary => Launch.Context.Boundary
+            ?? throw new InvalidOperationException("A background launch requires a trust boundary.");
         public required string Rationale { get; init; }
-        public required TrustAudience Audience { get; init; }
-        public required TrustBoundary Boundary { get; init; }
         public required Channels.ChannelType OriginChannelType { get; init; }
 
         /// <summary>

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -634,10 +634,10 @@ internal sealed class SessionToolExecutionPipeline
                 }
                 else if (batch.BackgroundJobs is BackgroundJobDispatch.Available backgroundJobs)
                 {
-                    await _executor.AuthorizeAsync(tc, context, batch.CancellationToken);
+                    var launch = await _executor.PrepareShellLaunchAsync(tc, context, batch.CancellationToken);
                     sw.Stop();
                     var backgroundResult = await RouteToBackgroundJobAsync(
-                        tc, batch, context,
+                        tc, batch, context, launch,
                         meta, backgroundJobs.Manager,
                         // Honor the agent's requested timeout; when absent, no
                         // kill timer is armed — a background job is a detached
@@ -766,10 +766,10 @@ internal sealed class SessionToolExecutionPipeline
                     && string.Equals(tc.Name, Tools.ShellTool.ToolName, StringComparison.Ordinal)
                     && batch.BackgroundJobs is BackgroundJobDispatch.Available backgroundJobs)
                 {
-                    await _executor.AuthorizeAsync(tc, context, batch.CancellationToken);
+                    var launch = await _executor.PrepareShellLaunchAsync(tc, context, batch.CancellationToken);
                     sw.Stop();
                     var backgroundResult = await RouteToBackgroundJobAsync(
-                        tc, batch, context,
+                        tc, batch, context, launch,
                         meta, backgroundJobs.Manager,
                         // Honor the agent's requested timeout; when absent, no
                         // kill timer is armed — a background job is a detached
@@ -1025,27 +1025,11 @@ internal sealed class SessionToolExecutionPipeline
         FunctionCallContent tc,
         SessionToolBatch batch,
         ToolExecutionContext context,
+        Tools.ShellProcessLaunch launch,
         ToolCallMeta meta,
         IActorRef backgroundJobManager,
         int timeoutSeconds)
     {
-        var command = ToolArgumentHelper.GetString(tc.Arguments, "Command");
-        var workingDirectory = context.ResolveShellCwd(
-            ToolArgumentHelper.GetString(tc.Arguments, "WorkingDirectory"));
-
-        if (string.IsNullOrWhiteSpace(command))
-        {
-            var message = new SerializableChatMessage
-            {
-                Role = Protocol.ChatRole.Tool,
-                Content = "Error: background shell execution requires a 'command' parameter",
-                ToolCallId = new ToolCallId(tc.CallId),
-                Name = tc.Name
-            };
-            return new ToolCallResult(
-                message, [], [], [], [], context.Approval.AuthorizationAttemptId);
-        }
-
         // A background job inherits the submitting turn's authority context.
         // There is no safe default — defaulting a missing context to Personal
         // would silently escalate the job's audience.
@@ -1054,23 +1038,16 @@ internal sealed class SessionToolExecutionPipeline
             throw new InvalidOperationException(
                 "Background-job submission requires turn authority context; trust context cannot be defaulted.");
 
-        var storage = context.SessionStorage
-            ?? throw new InvalidOperationException("Background shell execution requires resolved session storage.");
         var startCmd = new StartBackgroundJob
         {
-            Command = command,
-            WorkingDirectory = workingDirectory,
-            ManagedTemporaryDirectory = storage.ManagedTemporary.Directory.Value,
-            ManagedTemporaryStorageRoot = storage.ManagedTemporary.StorageRoot.Value,
-            SessionId = batch.SessionId,
+            Launch = launch,
             Rationale = meta.Rationale ?? "background shell execution",
-            Audience = batch.TurnContext.Audience,
-            Boundary = batch.TurnContext.Boundary,
             OriginChannelType = channelType.Value,
             TimeoutSeconds = timeoutSeconds,
             SenderId = batch.TurnContext.RequesterSenderId
         };
 
+        batch.CancellationToken.ThrowIfCancellationRequested();
         try
         {
             var started = await backgroundJobManager.Ask<BackgroundJobStarted>(
@@ -1095,11 +1072,11 @@ internal sealed class SessionToolExecutionPipeline
             var jobInfo = new Jobs.ActiveJobInfo
             {
                 JobId = started.JobId,
-                Command = command,
+                Command = launch.Command,
                 Rationale = startCmd.Rationale,
                 StartedAtMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-                Audience = batch.TurnContext.Audience,
-                Boundary = batch.TurnContext.Boundary,
+                Audience = startCmd.Audience,
+                Boundary = startCmd.Boundary,
                 OutputLogPath = started.OutputLogPath
             };
             return new ToolCallResult(

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -204,7 +204,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 ? await shellTool.ExecuteAuthorizedAsync(
                     toolCall.Arguments,
                     context.Invocation,
-                    shellAnalysis,
+                    CreateShellLaunch(shellTool, toolCall.CallId, context, shellAnalysis),
                     ct)
                 : await tool.ExecuteAsync(toolCall.Arguments, context.Invocation, ct);
 
@@ -325,7 +325,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
             ? shellTool.ExecuteAuthorizedStreamAsync(
                 toolCall.Arguments,
                 context.Invocation,
-                shellAnalysis,
+                CreateShellLaunch(shellTool, toolCall.CallId, context, shellAnalysis),
                 ct)
             : tool.ExecuteStreamAsync(toolCall.Arguments, context.Invocation, ct);
         var sw = Stopwatch.StartNew();
@@ -499,6 +499,50 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         var authorizationDecision = CompleteAuthorizationDecision(accessDecision, approvalMatches);
         LogAuthorizationDecision(toolCall, context, authorizationDecision);
         return (authorizationDecision, null);
+    }
+
+    public async Task<ShellProcessLaunch> PrepareShellLaunchAsync(
+        FunctionCallContent toolCall,
+        ToolExecutionContext context,
+        CancellationToken ct)
+    {
+        var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
+        if (authorized.Tool is not ShellTool shellTool || authorized.AuthorizedAnalysis is not { } analysis)
+            throw new InvalidOperationException("Background execution requires an authorized shell tool.");
+
+        return CreateShellLaunch(shellTool, toolCall.CallId, context, analysis);
+    }
+
+    private ShellProcessLaunch CreateShellLaunch(
+        ShellTool tool,
+        string callId,
+        ToolExecutionContext context,
+        ShellCommandAnalysis analysis)
+    {
+        if (!ReferenceEquals(tool.ShellEnvironment, _policy.ShellEnvironment))
+            throw new InvalidOperationException("Shell execution and authorization must use the same environment.");
+
+        var launchContext = new ToolExecutionContext(context.RunScope, context.ExecutionTimeout);
+        launchContext.Approval.RestoreAuthorizationAttemptId(context.Approval.AuthorizationAttemptId);
+        if (context.Approval.OneTimeApprovedToolName is { } approvedTool)
+            launchContext.Approval.SeedOneTimeApproval(approvedTool, context.Approval.OneTimeApprovedPatterns);
+        if (context.Approval.ManagedTemporaryRetry is { } retry)
+            launchContext.Approval.MarkManagedTemporaryRetry(retry);
+
+        // Use the authorized source, not the caller's mutable argument dictionary.
+        var exactCall = new FunctionCallContent(callId, ShellTool.ToolName, new Dictionary<string, object?>
+        {
+            ["Command"] = analysis.Source,
+            ["WorkingDirectory"] = analysis.WorkingDirectory
+        });
+        return tool.CreateLaunch(
+            analysis.Source,
+            analysis.WorkingDirectory,
+            launchContext.Invocation,
+            async cancellationToken =>
+            {
+                await GetAuthorizedToolAsync(exactCall, launchContext, cancellationToken);
+            });
     }
 
     ApprovalShell IApprovalShellProvider.Shell => _policy.Shell;

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -525,6 +525,8 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         if (!ReferenceEquals(tool.ShellEnvironment, _policy.ShellEnvironment))
             throw new InvalidOperationException("Shell execution and authorization must use the same environment.");
 
+        var workingDirectory = analysis.WorkingDirectory
+            ?? throw new InvalidOperationException("Authorized shell execution requires a working directory.");
         var launchContext = new ToolExecutionContext(context.RunScope, context.ExecutionTimeout);
         launchContext.Approval.RestoreAuthorizationAttemptId(context.Approval.AuthorizationAttemptId);
         if (context.Approval.OneTimeApprovedToolName is { } approvedTool)
@@ -536,11 +538,11 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         var exactCall = new FunctionCallContent(callId, ShellTool.ToolName, new Dictionary<string, object?>
         {
             ["Command"] = analysis.Source,
-            ["WorkingDirectory"] = analysis.WorkingDirectory
+            ["WorkingDirectory"] = workingDirectory
         });
         return tool.CreateLaunch(
             analysis.Source,
-            analysis.WorkingDirectory,
+            workingDirectory,
             launchContext.Invocation,
             async cancellationToken =>
             {

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -506,6 +506,9 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
         ToolExecutionContext context,
         CancellationToken ct)
     {
+        if (context.RunScope.Session is not ToolSessionScope.Bound || context.Boundary is null)
+            throw new InvalidOperationException("A background launch requires a bound session and a trust boundary.");
+
         var authorized = await GetAuthorizedToolAsync(toolCall, context, ct);
         if (authorized.Tool is not ShellTool shellTool || authorized.AuthorizedAnalysis is not { } analysis)
             throw new InvalidOperationException("Background execution requires an authorized shell tool.");

--- a/src/Netclaw.Actors/Tools/IToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/IToolExecutor.cs
@@ -22,6 +22,11 @@ public interface IToolExecutor
 
     Task AuthorizeAsync(FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct = default);
 
+    /// <summary>Creates the exact launch that the background actor must reauthorize before process creation.</summary>
+    Task<ShellProcessLaunch> PrepareShellLaunchAsync(
+        FunctionCallContent toolCall, ToolExecutionContext context, CancellationToken ct)
+        => throw new NotSupportedException("This executor does not support checked background shell launches.");
+
     /// <summary>
     /// Pre-dispatch argument validation shared by every caller (main session
     /// pipeline AND sub-agent loop AND any direct caller): provider args-parse

--- a/src/Netclaw.Actors/Tools/ShellProcessLaunch.cs
+++ b/src/Netclaw.Actors/Tools/ShellProcessLaunch.cs
@@ -1,0 +1,168 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellProcessLaunch.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Diagnostics;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Retains one exact shell invocation across the background queue. This object is never persisted.
+/// </summary>
+public sealed class ShellProcessLaunch
+{
+    private readonly ShellCommandPolicy _commandPolicy;
+    private readonly ToolPathPolicy _pathPolicy;
+    private readonly ToolInvocationContext _context;
+    private readonly Func<CancellationToken, Task> _authorize;
+    private readonly ProcessStartInfo _startInfo;
+    private int _startRequested;
+
+    internal ShellProcessLaunch(
+        string command,
+        string? workingDirectory,
+        ToolInvocationContext context,
+        ShellCommandPolicy commandPolicy,
+        ToolPathPolicy pathPolicy,
+        Func<CancellationToken, Task> authorize)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(authorize);
+        if (!ReferenceEquals(commandPolicy.Environment, pathPolicy.Environment))
+            throw new ArgumentException("Shell command and path policies must use the same shell environment.");
+
+        Command = command;
+        WorkingDirectory = context.ResolveShellCwd(workingDirectory)
+            ?? throw new InvalidOperationException("Shell execution requires a working directory.");
+        _context = context;
+        _commandPolicy = commandPolicy;
+        _pathPolicy = pathPolicy;
+        _authorize = authorize;
+        _startInfo = commandPolicy.Environment.CreateProcessStartInfo(command);
+        // Materialize the inherited environment before a queued request can observe later daemon changes.
+        _ = _startInfo.Environment.Count;
+    }
+
+    public string Command { get; }
+    public string WorkingDirectory { get; }
+    internal ToolInvocationContext Context => _context;
+    internal ShellExecutionEnvironment Environment => _commandPolicy.Environment;
+    internal SessionStoragePaths Storage => _context.SessionStorage
+        ?? throw new InvalidOperationException("Shell execution requires resolved session storage.");
+
+    internal async Task<Process> StartAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _startRequested, 1) != 0)
+            throw new InvalidOperationException("A shell launch can start only one process.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var analysis = CheckHardPolicies();
+        PrepareDirectories();
+        var pathsBeforeApproval = CapturePathState(analysis);
+        await _authorize(cancellationToken).ConfigureAwait(false);
+        // Do not put a queue or another await between the final policy result and process creation.
+        cancellationToken.ThrowIfCancellationRequested();
+        analysis = CheckHardPolicies();
+        PrepareDirectories();
+        if (!pathsBeforeApproval.SequenceEqual(CapturePathState(analysis)))
+            throw new ToolAccessDeniedException("shell_launch_paths_changed",
+                "Shell paths changed during authorization. The command did not start.");
+        cancellationToken.ThrowIfCancellationRequested();
+        try
+        {
+            return Process.Start(_startInfo)
+                ?? throw new InvalidOperationException("Process.Start returned null.");
+        }
+        catch (Exception ex)
+        {
+            var environment = _commandPolicy.Environment;
+            throw new ShellProcessStartException(
+                $"Error starting shell '{environment.ExecutableName}' at '{environment.ExecutablePath}': {ex.Message}", ex);
+        }
+    }
+
+    private LaunchPathState[] CapturePathState(ShellCommandAnalysis analysis)
+    {
+        var paths = new HashSet<string>(StringComparer.Ordinal)
+        {
+            WorkingDirectory,
+            Storage.ManagedTemporary.Directory.Value,
+            Storage.ManagedTemporary.StorageRoot.Value,
+            Environment.ExecutablePath
+        };
+        if (_context.ProjectDirectory is { } projectDirectory)
+            paths.Add(projectDirectory);
+        foreach (var view in ShellPolicyPathFacts.CreateExecutionViews(analysis))
+        {
+            if (view.ResolutionBase.Path is { } resolutionBase)
+                paths.Add(resolutionBase.Value);
+            foreach (var fact in view.Facts)
+            foreach (var path in fact.Paths)
+                paths.Add(path.Value);
+        }
+
+        return paths.Order(StringComparer.Ordinal).Select(static path =>
+        {
+            ToolPathPolicy.TryResolveSymlinksInPath(path, out var target);
+            return new LaunchPathState(path, target, Directory.Exists(path));
+        }).ToArray();
+    }
+
+    private readonly record struct LaunchPathState(string Path, string Target, bool DirectoryExists);
+
+    private ShellCommandAnalysis CheckHardPolicies()
+    {
+        // Parse again because filesystem facts and policy can change while the request waits.
+        var analysis = _commandPolicy.Analyze(Command, WorkingDirectory);
+        var decision = _commandPolicy.Evaluate(analysis);
+        if (!decision.Allowed)
+            throw new ShellProcessStartException($"Error: Command blocked by hard deny policy: {decision.DenyReason}");
+        if (_pathPolicy.CommandReferencesDeniedPath(analysis))
+            throw new ShellProcessStartException("Error: Command references a protected file path. Access denied by security policy.");
+        return analysis;
+    }
+
+    private void PrepareDirectories()
+    {
+        var temporaryError = ManagedTemporaryEnvironment.Prepare(_startInfo, Storage.ManagedTemporary);
+        if (temporaryError is not null)
+            throw new ShellProcessStartException(temporaryError);
+
+        if (_context.SessionDirectory is { } sessionDirectory
+            && PathUtility.AreEquivalentPaths(WorkingDirectory, sessionDirectory))
+        {
+            try
+            {
+                Directory.CreateDirectory(WorkingDirectory);
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException
+                                       or UnauthorizedAccessException or System.Security.SecurityException)
+            {
+                throw new ShellProcessStartException($"Error preparing session working directory: {ex.Message}", ex);
+            }
+        }
+        else if (!Directory.Exists(WorkingDirectory))
+        {
+            if (File.Exists(WorkingDirectory))
+                throw new ShellProcessStartException($"Error: Working directory '{WorkingDirectory}' is a file, not a directory.");
+
+            throw new ShellProcessStartException(
+                $"Error: Working directory '{WorkingDirectory}' does not exist. Create it first, e.g.: {CreateDirectoryHint()}");
+        }
+
+        _startInfo.WorkingDirectory = WorkingDirectory;
+    }
+
+    private string CreateDirectoryHint()
+        => _commandPolicy.Environment.PathStyle == ShellPathStyle.Windows
+            ? $"New-Item -ItemType Directory -Force -Path '{WorkingDirectory.Replace("'", "''", StringComparison.Ordinal)}'"
+            : $"mkdir -p -- '{WorkingDirectory.Replace("'", "'\\''", StringComparison.Ordinal)}'";
+
+}
+
+internal sealed class ShellProcessStartException(string message, Exception? innerException = null)
+    : Exception(message, innerException);

--- a/src/Netclaw.Actors/Tools/ShellProcessLaunch.cs
+++ b/src/Netclaw.Actors/Tools/ShellProcessLaunch.cs
@@ -38,6 +38,8 @@ public sealed class ShellProcessLaunch
         Command = command;
         WorkingDirectory = context.ResolveShellCwd(workingDirectory)
             ?? throw new InvalidOperationException("Shell execution requires a working directory.");
+        if (!Path.IsPathFullyQualified(WorkingDirectory))
+            throw new ShellProcessStartException("Shell execution requires an absolute working directory.");
         _context = context;
         _commandPolicy = commandPolicy;
         _pathPolicy = pathPolicy;

--- a/src/Netclaw.Actors/Tools/ShellProcessLaunch.cs
+++ b/src/Netclaw.Actors/Tools/ShellProcessLaunch.cs
@@ -23,21 +23,21 @@ public sealed class ShellProcessLaunch
 
     internal ShellProcessLaunch(
         string command,
-        string? workingDirectory,
+        string workingDirectory,
         ToolInvocationContext context,
         ShellCommandPolicy commandPolicy,
         ToolPathPolicy pathPolicy,
         Func<CancellationToken, Task> authorize)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(authorize);
         if (!ReferenceEquals(commandPolicy.Environment, pathPolicy.Environment))
             throw new ArgumentException("Shell command and path policies must use the same shell environment.");
 
         Command = command;
-        WorkingDirectory = context.ResolveShellCwd(workingDirectory)
-            ?? throw new InvalidOperationException("Shell execution requires a working directory.");
+        WorkingDirectory = workingDirectory;
         if (!Path.IsPathFullyQualified(WorkingDirectory))
             throw new ShellProcessStartException("Shell execution requires an absolute working directory.");
         _context = context;
@@ -130,6 +130,8 @@ public sealed class ShellProcessLaunch
 
     private void PrepareDirectories()
     {
+        // Reject unsafe filesystem links before the child can use session temporary storage.
+        // Prepare creates the directory and sets TMPDIR, TMP, and TEMP on the child environment only.
         var temporaryError = ManagedTemporaryEnvironment.Prepare(_startInfo, Storage.ManagedTemporary);
         if (temporaryError is not null)
             throw new ShellProcessStartException(temporaryError);

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -49,7 +49,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
     private readonly ToolConfig _config;
     private readonly ToolPathPolicy _pathPolicy;
     private readonly ShellCommandPolicy _commandPolicy;
-    private readonly ShellExecutionEnvironment _environment;
+    internal ShellExecutionEnvironment ShellEnvironment => _commandPolicy.Environment;
 
     public record Params(
         [param: Description(
@@ -71,84 +71,48 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
                 nameof(commandPolicy));
         }
 
-        _environment = commandPolicy.Environment;
     }
 
     protected override Task<string> ExecuteAsync(
         Params args,
         ToolInvocationContext context,
         CancellationToken ct)
-        => ExecuteCoreAsync(args, context, authorizedAnalysis: null, ct);
+        => ExecuteCoreAsync(args, context, authorizedLaunch: null, ct);
 
     internal async Task<string> ExecuteAuthorizedAsync(
         IDictionary<string, object?>? arguments,
         ToolInvocationContext context,
-        ShellCommandAnalysis analysis,
+        ShellProcessLaunch launch,
         CancellationToken ct)
     {
         if (!TryParse(arguments, out var error, out var args))
             return error;
 
-        return await ExecuteCoreAsync(args, context, analysis, ct);
+        return await ExecuteCoreAsync(args, context, launch, ct);
     }
 
     private async Task<string> ExecuteCoreAsync(
         Params args,
         ToolInvocationContext context,
-        ShellCommandAnalysis? authorizedAnalysis,
+        ShellProcessLaunch? authorizedLaunch,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Command))
             return "Error: 'command' parameter is required.";
 
-        // Resolve once before parsing or execution. The same cwd and parse
-        // facts feed both security policies and the launched process.
-        var resolvedCwd = context.ResolveShellCwd(args.WorkingDirectory);
-        var analysis = ResolveAnalysis(args.Command, resolvedCwd, authorizedAnalysis);
-        var commandDecision = _commandPolicy.Evaluate(analysis);
-        if (!commandDecision.Allowed)
-            return $"Error: Command blocked by hard deny policy: {commandDecision.DenyReason}";
-
-        if (_pathPolicy.CommandReferencesDeniedPath(analysis))
-            return "Error: Command references a protected file path. Access denied by security policy.";
-
-        var psi = _environment.CreateProcessStartInfo(args.Command);
-        var storage = context.SessionStorage
-            ?? throw new InvalidOperationException("Shell execution requires resolved session storage.");
-        var temporaryDirectoryError = ManagedTemporaryEnvironment.Prepare(psi, storage.ManagedTemporary);
-        if (temporaryDirectoryError is not null)
-            return temporaryDirectoryError;
-
-        // Resolve working directory in priority order: explicit arg →
-        // WorkingContext.ProjectDirectory (declared via set_working_directory)
-        // → SessionDirectory (the session workspace). Never falls through to
-        // ProcessStartInfo's default of inheriting the daemon process's cwd —
-        // that location is wherever the daemon happened to be launched and is
-        // unrelated to what the agent is "working on," which makes it
-        // impossible for the approval policy to reason about path containment.
-        // The matcher reads context.Cwd against the same
-        // resolution chain so the gate evaluates folder-scoped ApprovalEntry
-        // records against the directory the spawned process will run in.
-        var workingDirectoryError = PrepareWorkingDirectory(
-            psi,
-            resolvedCwd,
-            context.SessionDirectory);
-        if (workingDirectoryError is not null)
-            return workingDirectoryError;
-
+        var launch = authorizedLaunch ?? CreateDirectLaunch(args.Command, args.WorkingDirectory, context);
         var effectiveTimeout = context.ExecutionTimeout.Value;
-
         using var timeoutCts = new CancellationTokenSource();
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         Process process;
         try
         {
-            process = Process.Start(psi)!;
+            process = await launch.StartAsync(ct);
         }
-        catch (Exception ex)
+        catch (ShellProcessStartException ex)
         {
-            return FormatStartError(ex);
+            return ex.Message;
         }
 
         // Start the timeout countdown only after the shell process exists, so
@@ -267,23 +231,23 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         IDictionary<string, object?>? arguments,
         ToolInvocationContext context,
         CancellationToken ct = default)
-        => ExecuteStreamWithAnalysisAsync(
+        => ExecuteStreamWithLaunchAsync(
             arguments,
             context,
-            authorizedAnalysis: null,
+            authorizedLaunch: null,
             ct);
 
     internal IAsyncEnumerable<ToolCallUpdate> ExecuteAuthorizedStreamAsync(
         IDictionary<string, object?>? arguments,
         ToolInvocationContext context,
-        ShellCommandAnalysis analysis,
+        ShellProcessLaunch launch,
         CancellationToken ct)
-        => ExecuteStreamWithAnalysisAsync(arguments, context, analysis, ct);
+        => ExecuteStreamWithLaunchAsync(arguments, context, launch, ct);
 
-    private async IAsyncEnumerable<ToolCallUpdate> ExecuteStreamWithAnalysisAsync(
+    private async IAsyncEnumerable<ToolCallUpdate> ExecuteStreamWithLaunchAsync(
         IDictionary<string, object?>? arguments,
         ToolInvocationContext context,
-        ShellCommandAnalysis? authorizedAnalysis,
+        ShellProcessLaunch? authorizedLaunch,
         [EnumeratorCancellation] CancellationToken ct)
     {
         // All items (activities + completion) are produced by the non-iterator
@@ -296,7 +260,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         _ = ExecuteStreamCoreAsync(
             arguments,
             context,
-            authorizedAnalysis,
+            authorizedLaunch,
             channel.Writer,
             ct);
 
@@ -307,7 +271,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
     private async Task ExecuteStreamCoreAsync(
         IDictionary<string, object?>? arguments,
         ToolInvocationContext context,
-        ShellCommandAnalysis? authorizedAnalysis,
+        ShellProcessLaunch? authorizedLaunch,
         ChannelWriter<ToolCallUpdate> output,
         CancellationToken ct)
     {
@@ -325,50 +289,15 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
                 return;
             }
 
-            var resolvedCwd = context.ResolveShellCwd(args.WorkingDirectory);
-            var analysis = ResolveAnalysis(args.Command, resolvedCwd, authorizedAnalysis);
-            var commandDecision = _commandPolicy.Evaluate(analysis);
-            if (!commandDecision.Allowed)
-            {
-                output.TryWrite(new ToolCompletedUpdate(
-                    $"Error: Command blocked by hard deny policy: {commandDecision.DenyReason}"));
-                return;
-            }
-
-            if (_pathPolicy.CommandReferencesDeniedPath(analysis))
-            {
-                output.TryWrite(new ToolCompletedUpdate(
-                    "Error: Command references a protected file path. Access denied by security policy."));
-                return;
-            }
-
-            var psi = _environment.CreateProcessStartInfo(args.Command);
-            var storage = context.SessionStorage
-                ?? throw new InvalidOperationException("Shell execution requires resolved session storage.");
-            var temporaryDirectoryError = ManagedTemporaryEnvironment.Prepare(psi, storage.ManagedTemporary);
-            if (temporaryDirectoryError is not null)
-            {
-                output.TryWrite(new ToolCompletedUpdate(temporaryDirectoryError));
-                return;
-            }
-            var workingDirectoryError = PrepareWorkingDirectory(
-                psi,
-                resolvedCwd,
-                context.SessionDirectory);
-            if (workingDirectoryError is not null)
-            {
-                output.TryWrite(new ToolCompletedUpdate(workingDirectoryError));
-                return;
-            }
-
+            var launch = authorizedLaunch ?? CreateDirectLaunch(args.Command, args.WorkingDirectory, context);
             Process process;
             try
             {
-                process = Process.Start(psi)!;
+                process = await launch.StartAsync(ct);
             }
-            catch (Exception ex)
+            catch (ShellProcessStartException ex)
             {
-                output.TryWrite(new ToolCompletedUpdate(FormatStartError(ex)));
+                output.TryWrite(new ToolCompletedUpdate(ex.Message));
                 return;
             }
 
@@ -477,6 +406,10 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
                     $"Exit code: {process.ExitCode}{Environment.NewLine}{captured}"));
             }
         }
+        catch (Exception ex) when (ex is ToolApprovalRequiredException or ToolCorrectionRequiredException or ToolAccessDeniedException)
+        {
+            output.TryComplete(ex);
+        }
         catch (Exception ex)
         {
             // Catch-all so an unexpected exception (e.g. from Window() or
@@ -491,26 +424,16 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         }
     }
 
-    private ShellCommandAnalysis ResolveAnalysis(
+    internal ShellProcessLaunch CreateLaunch(
         string command,
-        string? resolvedCwd,
-        ShellCommandAnalysis? authorizedAnalysis)
-    {
-        if (authorizedAnalysis is null)
-            return _commandPolicy.Analyze(command, resolvedCwd);
+        string? workingDirectory,
+        ToolInvocationContext context,
+        Func<CancellationToken, Task> authorize)
+        => new(command, workingDirectory, context, _commandPolicy, _pathPolicy, authorize);
 
-        if (!string.Equals(authorizedAnalysis.Source, command, StringComparison.Ordinal)
-            || !string.Equals(
-                authorizedAnalysis.WorkingDirectory,
-                resolvedCwd,
-                StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
-                "The authorized shell analysis does not match the executed command.");
-        }
-
-        return authorizedAnalysis;
-    }
+    // Direct host callers retain the public tool's hard-policy contract. Routed calls require the coordinator.
+    private ShellProcessLaunch CreateDirectLaunch(string command, string? workingDirectory, ToolInvocationContext context)
+        => CreateLaunch(command, workingDirectory, context, static _ => Task.CompletedTask);
 
     private static readonly TimeSpan CoalesceInterval = TimeSpan.FromMilliseconds(500);
 
@@ -624,51 +547,6 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         }
     }
 
-    private string? PrepareWorkingDirectory(
-        ProcessStartInfo startInfo,
-        string? resolvedCwd,
-        string? sessionDirectory)
-    {
-        if (string.IsNullOrWhiteSpace(resolvedCwd))
-            return null;
-
-        if (IsResolvedSessionDirectory(resolvedCwd, sessionDirectory))
-        {
-            try
-            {
-                Directory.CreateDirectory(resolvedCwd);
-            }
-            catch (Exception ex) when (ex is ArgumentException
-                                       or IOException
-                                       or NotSupportedException
-                                       or UnauthorizedAccessException
-                                       or System.Security.SecurityException)
-            {
-                return $"Error preparing session working directory: {ex.Message}";
-            }
-        }
-        else if (!Directory.Exists(resolvedCwd))
-        {
-            if (File.Exists(resolvedCwd))
-                return $"Error: Working directory '{resolvedCwd}' is a file, not a directory.";
-
-            return $"Error: Working directory '{resolvedCwd}' does not exist. "
-                   + $"Create it first, e.g.: {CreateDirectoryHint(resolvedCwd)}";
-        }
-
-        startInfo.WorkingDirectory = resolvedCwd;
-        return null;
-    }
-
-    private string CreateDirectoryHint(string path)
-        => _environment.PathStyle == ShellPathStyle.Windows
-            ? $"New-Item -ItemType Directory -Force -Path '{path.Replace("'", "''", StringComparison.Ordinal)}'"
-            : $"mkdir -p -- '{path.Replace("'", "'\\''", StringComparison.Ordinal)}'";
-
-    private string FormatStartError(Exception exception)
-        => $"Error starting shell '{_environment.ExecutableName}' "
-           + $"at '{_environment.ExecutablePath}': {exception.Message}";
-
     // Retained for compatibility with tests/benchmark that call it directly; the
     // main execution path no longer uses this — output is bounded at read time by
     // BoundedOutputReader.
@@ -680,7 +558,4 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         return string.Concat(output.AsSpan(0, maxChars), $"{Environment.NewLine}... [output truncated]");
     }
 
-    private static bool IsResolvedSessionDirectory(string resolvedCwd, string? sessionDirectory)
-        => !string.IsNullOrWhiteSpace(sessionDirectory)
-           && PathUtility.AreEquivalentPaths(resolvedCwd, sessionDirectory);
 }

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -426,14 +426,18 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
 
     internal ShellProcessLaunch CreateLaunch(
         string command,
-        string? workingDirectory,
+        string workingDirectory,
         ToolInvocationContext context,
         Func<CancellationToken, Task> authorize)
         => new(command, workingDirectory, context, _commandPolicy, _pathPolicy, authorize);
 
     // Direct host callers retain the public tool's hard-policy contract. Routed calls require the coordinator.
     private ShellProcessLaunch CreateDirectLaunch(string command, string? workingDirectory, ToolInvocationContext context)
-        => CreateLaunch(command, workingDirectory, context, static _ => Task.CompletedTask);
+    {
+        var resolvedDirectory = context.ResolveShellCwd(workingDirectory)
+            ?? throw new InvalidOperationException("Shell execution requires a working directory.");
+        return CreateLaunch(command, resolvedDirectory, context, static _ => Task.CompletedTask);
+    }
 
     private static readonly TimeSpan CoalesceInterval = TimeSpan.FromMilliseconds(500);
 

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 using System.Net;
 using Microsoft.Extensions.AI;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Channels;
@@ -115,14 +114,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         if (!Directory.Exists(path))
             return;
 
-        // Clear only the connection pool for THIS test's database, not all pools.
-        // Using ClearAllPools() would interfere with other parallel tests.
-        var dbPath = Path.Combine(path, "netclaw.db");
-        if (File.Exists(dbPath))
-        {
-            var connectionString = new SqliteConnectionStringBuilder { DataSource = dbPath }.ToString();
-            SqliteConnection.ClearPool(new SqliteConnection(connectionString));
-        }
+        SqliteTestPools.Clear(new NetclawPaths(path));
 
         for (var i = 0; i < 8; i++)
         {

--- a/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration;
@@ -73,7 +72,7 @@ public sealed class DailyStatsActorTests : IDisposable
     public void Dispose()
     {
         _system.Terminate().GetAwaiter().GetResult();
-        SqliteConnection.ClearAllPools();
+        SqliteTestPools.Clear(_paths);
         _dir.Dispose();
     }
 }

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
@@ -38,9 +38,7 @@ public sealed class SessionCatalogServiceTests : IDisposable
 
     public void Dispose()
     {
-        // Drain the SQLite connection pool before deleting the temp directory.
-        // On Windows, pooled connections keep file handles open, causing Directory.Delete to fail.
-        SqliteConnection.ClearAllPools();
+        SqliteTestPools.Clear(new NetclawPaths(_tempBase));
 
         if (Directory.Exists(_tempBase))
             Directory.Delete(_tempBase, recursive: true);

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionStorageResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionStorageResolverTests.cs
@@ -23,7 +23,7 @@ public sealed class SessionStorageResolverTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
+        SqliteTestPools.Clear(new NetclawPaths(_basePath));
         if (Directory.Exists(_basePath))
             Directory.Delete(_basePath, recursive: true);
     }
@@ -35,14 +35,69 @@ public sealed class SessionStorageResolverTests : IDisposable
         await MigrateAsync(paths, paths.SqliteDbPath);
         var resolver = new SqliteSessionStorageResolver(paths, new FakeTimeProvider());
         var sessionId = new SessionId("signalr/new-session");
+        using var ready = new CountdownEvent(16);
+        using var start = new ManualResetEventSlim();
 
-        var resolutions = await Task.WhenAll(
-            Enumerable.Range(0, 16)
-                .Select(_ => Task.Run(() => resolver.Resolve(sessionId))));
+        var tasks = Enumerable.Range(0, 16)
+            .Select(_ => Task.Factory.StartNew(
+                () => ResolveAfterSignal(resolver, sessionId, ready, start),
+                TestContext.Current.CancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default))
+            .ToArray();
+        ready.Wait(TestContext.Current.CancellationToken);
+        start.Set();
+        var resolutions = await Task.WhenAll(tasks);
 
         var root = Assert.IsType<SessionStorageBinding>(resolutions[0].Binding).EnvelopeRoot;
         Assert.All(resolutions, result => Assert.Equal(root, result.Binding?.EnvelopeRoot));
         Assert.Equal(1, CountBindings(paths));
+    }
+
+    [Fact]
+    public async Task Resolution_does_not_inherit_state_from_a_shared_pooled_connection()
+    {
+        var paths = CreatePaths();
+        await MigrateAsync(paths, paths.SqliteDbPath);
+        using var pooledConnection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = paths.SqliteDbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString());
+        pooledConnection.Open();
+        using (var command = pooledConnection.CreateCommand())
+        {
+            // A pool can return a native handle with state from a previous owner.
+            command.CommandText = "PRAGMA query_only=ON";
+            command.ExecuteNonQuery();
+        }
+        pooledConnection.Close();
+
+        var storage = new SqliteSessionStorageResolver(paths, new FakeTimeProvider())
+            .Resolve(new SessionId("signalr/isolated-connection"));
+
+        Assert.NotNull(storage.Binding);
+        Assert.Equal(1, CountBindings(paths));
+    }
+
+    [Fact]
+    public async Task Fixture_cleanup_preserves_another_database_pool()
+    {
+        var paths = CreatePaths();
+        await MigrateAsync(paths, paths.SqliteDbPath);
+        Assert.Equal(0, CountBindings(paths));
+        using var otherFixture = new SessionStorageResolverTests();
+        var otherPaths = otherFixture.CreatePaths();
+        using var otherConnection = new SqliteConnection($"Data Source={otherPaths.SqliteDbPath}");
+        otherConnection.Open();
+        var otherHandle = otherConnection.Handle;
+        otherConnection.Close();
+
+        Dispose();
+
+        Assert.False(Directory.Exists(_basePath));
+        otherConnection.Open();
+        Assert.Same(otherHandle, otherConnection.Handle);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Services/RestartRecoveryServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/RestartRecoveryServiceTests.cs
@@ -6,7 +6,6 @@
 using System.Collections.Concurrent;
 using Akka.Actor;
 using Akka.Hosting;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
@@ -76,7 +75,7 @@ public sealed class RestartRecoveryServiceTests : IDisposable
     public void Dispose()
     {
         _system.Terminate().GetAwaiter().GetResult();
-        SqliteConnection.ClearAllPools();
+        SqliteTestPools.Clear(_paths);
         _dir.Dispose();
     }
 

--- a/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
@@ -174,7 +174,7 @@ public sealed class SchemaMigratorTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
+        SqliteTestPools.Clear(_paths);
         _dir.Dispose();
     }
 }

--- a/src/Netclaw.Daemon.Tests/SqliteTestPools.cs
+++ b/src/Netclaw.Daemon.Tests/SqliteTestPools.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="SqliteTestPools.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Data.Sqlite;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Tests;
+
+internal static class SqliteTestPools
+{
+    public static void Clear(NetclawPaths paths)
+    {
+        // Pool keys use the exact connection string. Both forms occur in daemon fixtures.
+        var builder = new SqliteConnectionStringBuilder { DataSource = paths.SqliteDbPath };
+        using var defaultMode = new SqliteConnection(builder.ToString());
+        SqliteConnection.ClearPool(defaultMode);
+
+        builder.Mode = SqliteOpenMode.ReadWriteCreate;
+        using var explicitMode = new SqliteConnection(builder.ToString());
+        SqliteConnection.ClearPool(explicitMode);
+    }
+}

--- a/src/Netclaw.Daemon/Gateway/SqliteSessionStorageResolver.cs
+++ b/src/Netclaw.Daemon/Gateway/SqliteSessionStorageResolver.cs
@@ -56,7 +56,9 @@ public sealed class SqliteSessionStorageResolver : ISessionStorageResolver
         _connectionString = new SqliteConnectionStringBuilder
         {
             DataSource = paths.SqliteDbPath,
-            Mode = SqliteOpenMode.ReadWriteCreate
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            // Cache misses own their native connection; shared pool state and reclamation cannot affect the transaction.
+            Pooling = false
         }.ToString();
         _sessionsDirectory = Path.GetFullPath(sessionsDirectory);
         _sessionLogsDirectory = paths.SessionLogsDirectory;

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -435,7 +435,7 @@ public sealed class ToolPathPolicy
     // skips a failed resolution, while the deny-check call sites (IsDeniedAgainst,
     // CommandReferencesDeniedPath) fail closed. A blanket catch here would hide
     // that distinction and force every caller back to the same (wrong) answer.
-    private static bool TryResolveSymlinksInPath(string path, out string canonical)
+    internal static bool TryResolveSymlinksInPath(string path, out string canonical)
     {
         canonical = string.Empty;
         if (string.IsNullOrEmpty(path))


### PR DESCRIPTION
A queued shell command can outlive its approval. This change checks current authority at process creation for normal, streamed, and background calls. An expired grant or a changed known path target now prevents launch.

`ShellProcessLaunch` retains the exact command, absolute cwd, shell, child environment, and approval context. It starts at most one process. The background actor owns detached processes and reclaims a process if stop precedes ownership transfer.

Review the shared launch boundary, the dispatcher context copy, and the background process owner. The in-process submission and execution actor contracts now require a checked launch. Host extensions must use `DispatchingToolExecutor.PrepareShellLaunchAsync`. Persisted job records keep their format.

The [aggressive review](https://github.com/netclaw-dev/netclaw/pull/2122#pullrequestreview-5156693271) found authority gaps and a constructor compatibility defect. All confirmed findings are fixed. A final review also checked the session-authority and absolute-cwd guards. No required source corrections remain.

Validation:

- Full actor suite: 3,856 passed; five platform skips.
- Security suite: 1,055 passed.
- Final guards and native shell checks: 54 passed; one platform skip.
- Coverage subset on the final source: 1,596 passed; five platform skips. The launch has 93.9% line coverage and 85% branch coverage.
- Slopwatch, copyright headers, and strict OpenSpec validation passed.
- Spec verification found both requirements and all seven scenarios covered. Five of six tasks are complete; the eval task remains open.
- All 17 CI checks passed on `8092611f`, including Linux, Windows, macOS, both native smoke jobs, and screenshot regression.
- #2124 merged. The fixed harness and assets at `099e2431` tested baseline `df8ad6e2` and candidate `57df7c0f`, with five attempts per runtime case.
- Valid-grant control: baseline 5/5; candidate 5/5. Revoked-grant prevention: baseline 0/5; candidate 5/5. All five baseline jobs started after revocation; no candidate job did.
- Both runs reported zero harness errors and zero external model requests. The archives retain distinct image IDs, CLI hashes, grant snapshots, and job records.
- The same fixed harness also tested the SQLite repair at `0fa2a526`: valid grant 5/5; revoked grant 5/5. No harness errors occurred. External model requests: zero.
- Real-model lifecycle and job-report evals remain pending. The provider endpoint and model ID remain required. The runtime comparison does not supply model behavior evidence.
- The branch uses the merged eval PR as its base. Windows CI on `57df7c0f` exposed a concurrent session-storage failure. Windows, Linux, and macOS test jobs pass on `0fa2a526`. Windows passes all 1,098 daemon tests. Both native smoke jobs also passed on `0fa2a526`.
- The SQLite repair passes all 1,098 daemon tests. Both isolation regressions failed before the repair and pass after it. Slopwatch and headers pass.

CI exposed POSIX-only fixture paths on Windows and symlinked temporary roots on macOS. The fixtures now use native absolute paths and physical grant scopes. A local symlink-root reproduction changed from five failures to 23 passed tests. The independent reviewer accepted both fixes.

The session-storage resolver now opens a private SQLite connection for each cache miss. Fixture cleanup clears only the pools for its own database. Tests inject stale connection state and verify that cleanup preserves another database's native handle. The concurrent-first-use test uses explicit start signals. No retry or sleep masks the failure. These regressions prove isolation defects; they do not reproduce the exact Windows native error.

Real process tests prove foreground tree exit, detached lifetime, and cleanup before actor adoption. Other tests cover stale grants, exact one-time approval, queue cancellation, and path mutation during authorization.

This PR implements T12–T14 after #2117. Task 2.3 remains open for behavioral evals. Deployment remains separate.


Review revision `87cbbf06` requires callers to supply the launch directory and explains temporary-storage preparation. The focused suite passes 296 tests, with one Windows-only skip. Slopwatch and headers pass. All 18 checks passed on `0fa2a526`; Windows discovery failed on `87cbbf06`; The platform test jobs pass on `03de93d5`.

The actor test project now uses `xunit.v3.mtp-off` 4.0.0 with VSTest. The previous runner could append shutdown diagnostics to assembly-info JSON before test execution. This matches [xUnit #3576](https://github.com/xunit/xunit/issues/3576). Version 4.0.0 includes the [protocol fix](https://github.com/xunit/xunit/commit/8b317b752315bbba12030464734a8f62faab2ce7). Other test projects keep their existing package.

A separate probe held a foreground thread through watchdog exit. Version 3.2.2 produced invalid JSON; 4.0.0 produced one valid object. Both probe exits were intentionally nonzero due to that blocked thread. The actual actor assembly returned clean JSON and exit zero in five checks. Its full suite passed 3,859 tests, with six platform skips. Slopwatch and headers passed. The independent reviewer found no required correction. Windows, Linux, and macOS test jobs pass on `03de93d5`. Windows passes 3,565 actor tests, one separate native-shell test, and all 1,098 daemon tests. Native smoke and screenshot checks remain active.
