### PR TITLE
Remove obsolete correction exception API and document shell ownership

### DIFF
--- a/docs/runbooks/tool-approval-gates.md
+++ b/docs/runbooks/tool-approval-gates.md
@@ -244,11 +244,12 @@ authority, if any, covers each command occurrence.
 
 | Step | Input | Output | Owner |
 |------|-------|--------|-------|
-| Preflight and syntax analysis | Original tool call, shell environment, initial cwd, audience, and run scope | ShellSyntaxTree facts followed by hard deny, path deny, approval mode, or auto allow | ShellSyntaxTree and Netclaw |
+| Preflight and syntax analysis | Original tool call, shell environment, initial cwd, audience, and run scope | Canonical analysis and access, hard-denial, mode, and channel checks | `ToolAccessPolicy` |
+| Correction collection | Canonical analysis, exposed tools, and invocation facts | Compatible advice; applicable corrections precede an Auto allow | `ShellPolicyCoordinator` |
 | Policy projection | Syntax facts plus the unchanged approval context | Stable call-local candidate IDs and immutable scope facts | Netclaw |
 | Grant match | Candidates plus one session/persistent store snapshot | One typed match or one bounded near miss per candidate | Approval actor |
 | Coverage | Grant matches, reviewed-safe policy, and an exact one-time retry | One coverage result per candidate | Netclaw |
-| Completion | All candidate coverage results | `Allowed`, `RequiresApproval`, or `Denied` | Netclaw |
+| Completion | Coverage results and applicable advice | `Allowed`, `RequiresApproval`, `RequiresAgentCorrection`, or `Denied` | `ShellPolicyCoordinator` |
 
 The coordinator does not rewrite the original command. A prompt and an eventual
 execution still refer to the exact tool call the model authored. Candidate IDs
@@ -260,6 +261,7 @@ The coordinator returns one closed result shape:
 |---------|---------------|-------------|
 | `Allowed` | One allow reason and any stored matches that helped cover the call | Execute the original tool call |
 | `RequiresApproval` | A narrowed approval context plus any partial stored matches | Prompt only for the uncovered candidates |
+| `RequiresAgentCorrection` | The complete compatible collection and any prior approval matches | Deliver the advice without execution, a prompt, or a new grant |
 | `Denied` | One stable deny reason | Return the denial without execution or prompt |
 
 The important value-domain rules are:
@@ -405,6 +407,80 @@ Suppose the store has a Bash token-prefix grant for `git status` under
 an `OutsideDirectory` near miss. The candidate remains uncovered, so the final
 output is `RequiresApproval`. A same-verb grant is diagnostic evidence, not
 authority for a peer directory.
+
+### Checked process startup
+
+The dispatcher keeps the exact authorized command and directory in `ShellProcessLaunch`.
+It copies the approval state for that invocation and retains the child environment.
+The launch requires an absolute directory; its callers select that directory before construction.
+
+The launch follows this sequence:
+
+1. Check cancellation and current command and path policy.
+2. Prepare the managed temporary directory and the child environment.
+3. Capture known path targets and check current authority.
+4. Repeat the hard checks and reject changed path targets.
+5. Start one process without another await or actor message.
+
+A queued command with a valid grant can start once.
+A queued command whose grant was revoked fails without a process.
+These checks narrow filesystem races; they do not provide an OS sandbox.
+
+The foreground caller owns cancellation and process disposal.
+The background start task owns the process until the job actor adopts it.
+Actor stop cancels startup and reclaims a process that was not adopted.
+The job actor retains timeout, cancellation, output capture, and completion duties.
+It drains stdout and stderr to a bounded log while the process runs.
+`check_background_job` returns the current output tail and log path.
+Capture waits for complete lines, so output without a newline can remain buffered until EOF.
+
+### Maintainer boundaries
+
+Use [the engineering glossary](../spec/GLOSSARY.md) for shared terms.
+The coordinator owns shell correction selection.
+`TemporaryPathCorrectionPolicy` supplies directory eligibility and target facts.
+`ToolCorrectionDelivery` creates the common response, receipt, and proposed retry-state change.
+Parent and child callers deliver that result and apply their own lifecycle state.
+Their correction exception requires the complete collection; it has no single-correction adapter.
+
+The non-shell approval path still needs a single temporary-directory fact before stored grants are checked.
+`ToolAuthorizationDecision.AgentCorrection` serves that path and validates that exactly one fact exists.
+The single-fact decision factories and shared grant-evidence adapter therefore remain in use.
+The direct `ShellTool` API also retains its hard-policy contract for host callers.
+These consumers prevent blanket removal of every adapter or direct-call entry point.
+
+#### The same policy change before and after consolidation
+
+The comparison uses baseline `99cee4d2` and integrated source `03de93d5`.
+The fixed exercise redirects platform-temporary advice to the host's run-local managed directory.
+The session-storage implementation arrived separately in #2090; this comparison does not credit consolidation for that storage change.
+
+| Component | Baseline responsibility | Current responsibility for the same change |
+|-----------|-------------------------|--------------------------------------------|
+| Temporary-path policy | Select the session-directory target | Read the managed target from `ToolInvocationContext.SessionStorage` |
+| `ToolAccessPolicy` | Attach shell directory advice to an approval request | Supply deterministic shell facts; retain non-shell approval policy |
+| Shell coordinator | Complete shell approval after separate advice paths | Collect advice and select the terminal shell result |
+| Parent and child callers | Select advice within approval-exception branches | Deliver the common result and apply exact retry state |
+| Remediation presenter | Render the selected next action | Render the selected next action; it grants no authority |
+
+Changing the host's target now needs no new parent or child selection branch.
+The temporary-path policy owns target eligibility; the coordinator composes its result with other advice.
+A new correction kind still needs an explicit delivery shape and meaningful caller tests.
+This result demonstrates fewer independent decision sites, not unrestricted extension through configuration.
+
+The source inventory gives these concrete changes:
+
+- Parent and child components that select correction policy: two to zero.
+- Process-creation sites across foreground, stream, and background shell modes: three to one.
+- `ShellPolicyAuthorization` and `ToolAccessDecision` wrappers disappear; `ToolAuthorizationDecision` carries the common terminal result.
+- No old/new evaluator selector or comparison-only production implementation remains in these paths.
+- The five coordinator support files grow from 1,701 to 1,908 physical lines; this is not a code-size reduction.
+
+The count includes comments and blank lines at those exact revisions.
+It covers `ShellPolicyCoordinator`, `ShellPolicyEvaluation`, `ShellPolicyProjection`, `ShellPolicyDecisionTrace`, and `ShellApprovalEvidence`.
+It excludes callers, startup, tests, and docs and does not attribute every intervening edit to this project.
+Keep merged PR history for detailed changes and test evidence.
+Rollout, old-binary recovery checks, and real-model usability evidence remain separate from this source inventory.
 
 ### Persistent approvals
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -1452,7 +1452,8 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         }
 
         private static ToolCorrectionRequiredException CreateCorrection()
-            => new(new ToolCorrection.NativeToolSuggested(new ToolName("file_read")));
+            => new(new ToolCorrectionCollection(
+                [new ToolCorrection.NativeToolSuggested(new ToolName("file_read"))]));
     }
 
     private static DispatchingToolExecutor CreateApprovalGatedShellExecutor()
@@ -1510,7 +1511,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             ToolExecutionContext? context = null,
             CancellationToken ct = default)
             => throw new ToolCorrectionRequiredException(
-                new ToolCorrection.ManagedTemporaryDirectorySuggested(Key.Target));
+                new ToolCorrectionCollection([new ToolCorrection.ManagedTemporaryDirectorySuggested(Key.Target)]));
     }
 
     private sealed class ManagedTemporaryRetryApprovalExecutor

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -465,7 +465,7 @@ internal sealed class FakeToolExecutor : IToolExecutor
         if (Corrections.TryGetValue(toolCall.Name, out var correction))
         {
             BeforeCorrection?.Invoke();
-            throw new ToolCorrectionRequiredException(correction);
+            throw new ToolCorrectionRequiredException(new ToolCorrectionCollection([correction]));
         }
 
         if (FailForTools.Contains(toolCall.Name))
@@ -481,7 +481,7 @@ internal sealed class FakeToolExecutor : IToolExecutor
         if (Corrections.TryGetValue(toolCall.Name, out var correction))
         {
             BeforeCorrection?.Invoke();
-            throw new ToolCorrectionRequiredException(correction);
+            throw new ToolCorrectionRequiredException(new ToolCorrectionCollection([correction]));
         }
 
         if (FailForTools.Contains(toolCall.Name))

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3934,7 +3934,7 @@ public partial class DispatchingToolExecutorTests
 
         var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
             executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
-        var thrownCorrection = Assert.IsType<ToolCorrection.NativeToolSuggested>(exception.Correction);
+        var thrownCorrection = Assert.IsType<ToolCorrection.NativeToolSuggested>(Assert.Single(exception.Corrections.Items));
         Assert.Equal("file_read", thrownCorrection.ToolName.Value);
         Assert.Null(context.Receipt);
         Assert.Equal(0, approvalService.RequestCount);
@@ -3965,7 +3965,7 @@ public partial class DispatchingToolExecutorTests
 
         var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
             _executor.AuthorizeAsync(call, context, TestContext.Current.CancellationToken));
-        Assert.IsType<ToolCorrection.NativeToolSuggested>(exception.Correction);
+        Assert.IsType<ToolCorrection.NativeToolSuggested>(Assert.Single(exception.Corrections.Items));
     }
 
     [Fact]
@@ -4307,20 +4307,6 @@ public partial class DispatchingToolExecutorTests
         Assert.Null(context.Receipt);
     }
 
-    [Fact]
-    public void Scalar_correction_accessor_rejects_multiple_corrections()
-    {
-        var exception = new ToolCorrectionRequiredException(
-            new ToolCorrectionCollection(
-                [
-                    new ToolCorrection.NativeToolSuggested(new ToolName(FileWriteTool.ToolName)),
-                    new ToolCorrection.ManagedTemporaryDirectorySuggested(
-                        new ManagedTemporaryCorrectionTarget("/session/tmp", "/tmp"))
-                ]));
-
-        Assert.Throws<InvalidOperationException>(() => _ = exception.Correction);
-    }
-
     [Theory]
     [InlineData(ShellGrammar.Bash, "printf marker; file_read --path report.txt")]
     [InlineData(ShellGrammar.PowerShell, "Write-Output marker; file_read -Path report.txt")]
@@ -4352,7 +4338,7 @@ public partial class DispatchingToolExecutorTests
         var exception = await Assert.ThrowsAsync<ToolCorrectionRequiredException>(() =>
             executor.ExecuteAsync(call, context, TestContext.Current.CancellationToken));
 
-        var correction = Assert.IsType<ToolCorrection.NativeToolSuggested>(exception.Correction);
+        var correction = Assert.IsType<ToolCorrection.NativeToolSuggested>(Assert.Single(exception.Corrections.Items));
         Assert.Equal("file_read", correction.ToolName.Value);
         Assert.False(recordingShell.WasCalled);
     }

--- a/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
+++ b/src/Netclaw.Actors/Tools/ToolAuthorizationDecision.cs
@@ -383,11 +383,6 @@ public sealed record ToolAuthorizationDecision
 
 internal sealed class ToolCorrectionRequiredException : InvalidOperationException
 {
-    internal ToolCorrectionRequiredException(ToolCorrection correction)
-        : this(new ToolCorrectionCollection([correction]))
-    {
-    }
-
     internal ToolCorrectionRequiredException(ToolCorrectionCollection corrections)
         : base("Tool invocation requires agent correction.")
     {
@@ -396,9 +391,4 @@ internal sealed class ToolCorrectionRequiredException : InvalidOperationExceptio
     }
 
     internal ToolCorrectionCollection Corrections { get; }
-
-    internal ToolCorrection Correction
-        => Corrections.Items.Count == 1
-            ? Corrections.Items[0]
-            : throw new InvalidOperationException("A scalar correction consumer received multiple corrections.");
 }


### PR DESCRIPTION
The correction exception still exposed a single-item constructor and accessor after all production callers adopted complete collections. This PR removes that unused internal API. Test doubles now supply collections, and assertions check their cardinality directly.

The existing approval runbook now explains checked process startup, caller ownership, and the adapters that still serve non-shell consumers. It also compares the same policy change before and after consolidation. The inventory shows fewer decision sites and one process-start site; it does not claim a code-size reduction.

Review these areas:

- The collection-only exception contract and the retained combined-correction tests.
- The runbook's process ownership and policy-owner map.
- The explicit evidence limits. This cleanup does not establish rollout completion, old-binary recovery, or real-model usability.

Local validation at `b17b0c49` passed: 3,859 actor tests, 1,055 security tests, and 616 configuration tests. Six actor tests require another platform. Slopwatch found no issues, and header verification passed. An independent agent review found no required corrections after the test constructor fix.

This is the final source-retirement slice after #2122. The branch now starts from merged #2127, which fixes the Slack test race. The rebase preserves the reviewed patch. The change adds no new OpenSpec plan or runtime behavior. CI is active, and squash auto-merge is enabled.
