### PR TITLE
Restrict implicit session file roots by audience

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -118,7 +118,9 @@ Use the [engineering glossary](docs/spec/GLOSSARY.md) for path and authority ter
 - [x] Deny implicit sibling access for Public and Team; preserve current roots and exact own legacy logs.
 - [x] Verify parent/child authority and the approved legacy cross-run log exception.
 - [x] Keep result conversion and attachment-destination investigation in separate review slices.
-- [ ] Complete deterministic boundary tests, system-skill evals, and repository quality gates.
+- [x] Complete deterministic boundary tests, system-skill evals, and repository quality gates.
+  Local actor tests: 3,883 passed; six platform-specific skips. Daemon tests: 1,098 passed.
+  Focused child-log and operations evals each passed five runs. Native Windows proof remains pending.
 
 ### Priority: Unify Session Storage And Temporary Files
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -110,6 +110,16 @@ the smallest repeatable manual script plus expected output.
 
 ## NOW
 
+### Priority: Restore Restricted Session File Authority
+
+Source PRDs: PRD-002 and PRD-007. Owner: `PathAccessPolicy`.
+Use the [engineering glossary](docs/spec/GLOSSARY.md) for path and authority terms.
+
+- [x] Deny implicit sibling access for Public and Team; preserve current roots and exact own legacy logs.
+- [x] Verify parent/child authority and the approved legacy cross-run log exception.
+- [x] Keep result conversion and attachment-destination investigation in separate review slices.
+- [ ] Complete deterministic boundary tests, system-skill evals, and repository quality gates.
+
 ### Priority: Unify Session Storage And Temporary Files
 
 - [x] New sessions bind one durable, versioned

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Public and Team file tools keep access to their current session and exact
+  legacy log. Other sessions require explicit configured roots.
+- Child runs inherit parent roots and restrictions. Legacy cross-run raw logs
+  require explicit authority; child summaries and shared artifacts remain available.
+- Personal file access, existing paths, and session resumption remain unchanged.
+
 - New sessions keep work files, attachment staging, artifacts, temporary
   files, worktrees, and logs in one versioned storage envelope.
 - Each parent and child process receives its own managed temporary directory

--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -479,10 +479,11 @@ A raw session log is the diagnostic file for one main session or subagent run.
 New-layout raw logs are physically inside the session storage envelope but are
 outside the session directory.
 
-All session storage is below the configured trusted sessions root. Parent and
-child runs inherit this root, so one session can access another session's data.
-This permits one session to analyze another session's logs on a busy agent.
-The normal audience and file-operation permissions still apply.
+Personal retains the shared session roots. Public and Team receive the current
+session envelope and workspace roots. Each legacy run can access its exact raw
+log, but this grants no access to adjacent files or separate parent/child logs.
+Children inherit parent roots and restrictions. The operation profile, explicit
+configured roots, link checks, and protected paths still control each request.
 
 These reads return normal bounded file-tool output. A raw session log does not
 use a separate activity projection or log-specific redaction layer.

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -2529,10 +2529,11 @@ assert_parent_child_log_handoff() {
             path=$(jq -r '.Path // .Root // empty' <<<"$arguments")
             if [[ "$path" == /home/netclaw/.netclaw/sessions/*/subagents/*/logs/session.log \
                 || "$path" == /home/netclaw/.netclaw/sessions/*/subagents/*/logs ]]; then
-                grep -qaF "TOOL_RESULT: $tool_name call_id=$call_id result=" "$headless_log" \
+                if grep -qaF "TOOL_RESULT: $tool_name call_id=$call_id result=" "$headless_log" \
                     && ! grep -qaF "TOOL_RESULT: $tool_name call_id=$call_id result=Error:" "$headless_log" \
-                    && jq -e '.response | length > 0' "$STDOUT_FILE" >/dev/null
-                return
+                    && jq -e '.response | length > 0' "$STDOUT_FILE" >/dev/null; then
+                    return 0
+                fi
             fi
         done < <(jq -r --arg tool_name "$tool_name" '
             .toolCalls[]?

--- a/evals/test_session_log_eval.py
+++ b/evals/test_session_log_eval.py
@@ -1,0 +1,46 @@
+"""Verify the session-log eval with synthetic tool results."""
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class SessionLogEvalTests(unittest.TestCase):
+    def check_trace(self, results, expected, shell=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            logs = root / "logs"
+            logs.mkdir()
+            calls = [{"toolName": "spawn_agent", "callId": "spawn", "argumentsJson": "{}"}]
+            for index, result in enumerate(results):
+                calls.append({"toolName": "file_read", "callId": f"read-{index}", "argumentsJson": json.dumps({
+                    "Path": "/home/netclaw/.netclaw/sessions/fixture/subagents/child/logs/session.log"})})
+            if shell:
+                calls.append({"toolName": "shell_execute", "callId": "shell", "argumentsJson": "{}"})
+            output = root / "stdout.json"
+            output.write_text(json.dumps({"sessionId": "fixture", "response": "a log line", "toolCalls": calls}))
+            (logs / "fixture.log").write_text("\n".join(
+                f"TOOL_RESULT: file_read call_id=read-{index} result={result}"
+                for index, result in enumerate(results) if result is not None))
+            script = Path(__file__).with_name("run-evals.sh")
+            completed = subprocess.run([
+                "bash", "-c", 'source "$1"; EVAL_HOME="$2"; STDOUT_FILE="$3"; assert_parent_child_log_handoff',
+                "bash", str(script), str(root), str(output)], capture_output=True, text=True)
+            self.assertEqual(expected, completed.returncode == 0, completed.stderr)
+
+    def test_success_after_a_corrected_call_satisfies_the_handoff(self):
+        self.check_trace(["Error: Missing rationale", "a log line"], True)
+
+    def test_a_denied_or_unexecuted_read_is_insufficient(self):
+        for results in [["Error: Access denied"], [None], []]:
+            with self.subTest(results=results):
+                self.check_trace(results, False)
+
+    def test_shell_use_still_fails(self):
+        self.check_trace(["a log line"], False, shell=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.69.0"
+  version: "2.70.0"
 ---
 
 # Netclaw Operations
@@ -109,7 +109,12 @@ The `[session]` block separates five paths:
 - `worktree_dir` is the session area for Git worktrees.
 - `log_path` is the exact raw audit log for the current run.
 
-Use the existing file tools to read an exact parent or child log path.
+Use `file_read` to read the exact `log_path` for the current run.
+Public and Team cannot access other sessions without explicit configured roots.
+Versioned parent and child runs share the current session envelope.
+Legacy runs can read their own exact log, but not separate parent or child logs.
+Use a legacy child's summary and shared-workspace artifacts instead.
+Directory list and search require directory authority; an exact log grants none.
 Do not use shell to find session logs.
 Normal audience and operation policy applies to every session path.
 Netclaw does not automatically remove managed temporary files or worktrees.

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -171,11 +171,11 @@ The final edit will condense or remove duplicate requirements, scenarios,
 helpers, and tests. It will not preserve an old abstraction only to avoid a
 mechanical change.
 
-The Netclaw sessions directory is a trusted root for every parent and child
-run. All session directories are below this root and are accessible to other
-sessions under normal audience and operation permissions. This design lets
-one session analyze another session's logs, which supports diagnosis on a
-heavily used Netclaw agent.
+Personal retains the shared sessions and legacy logs roots. Public and Team
+receive the current envelope and workspace roots. Each legacy run also receives
+its exact log path through the operation profile. The exact grant permits no
+parent enumeration or cross-run legacy log access. Children inherit parent
+roots and restrictions. A returned path does not grant additional authority.
 
 ```text
 tool exposure and audience capability
@@ -187,7 +187,7 @@ tool exposure and audience capability
 ```
 
 **Counterexample:** Session identity does not create a separate access-control
-list. The shared sessions root provides containment, while audience and
+list. The current session roots provide containment, while audience and
 operation permissions still control the requested action.
 
 **Counterexample:** Temporary-path detection does not produce or override a path
@@ -411,8 +411,8 @@ and exact child artifact directory. Existing file tools keep their normal
 output bounds and pagination.
 
 The shared `netclaw-tools` path access decision authorizes these paths. The
-Netclaw sessions root covers all new session envelopes. The legacy log root
-remains available while legacy sessions exist.
+Netclaw sessions root covers all new session envelopes. Personal retains the legacy log root. Public and Team receive only their
+exact current legacy log, subject to the operation profile.
 
 This design adds no log reader, query language, ownership list, or output
 contract. One session can inspect another session's log when its audience and
@@ -438,7 +438,8 @@ must not fail because the path is not ready.
 
 **Counterexample:** Netclaw does not add a special session-log reader. The
 parent does not need `find`, `grep`, or `cat`. It uses `file_read` on the path.
-It can use `file_search` or `file_list` on the path's directory.
+It can use `file_search` or `file_list` only when its roots authorize the directory.
+An exact legacy log grant permits no directory enumeration.
 
 **Example:** One Personal session uses `file_read` to diagnose another
 session's log below the shared sessions root.
@@ -567,7 +568,7 @@ The initial source audit identifies these implementation groups:
 | Durable pending approvals | `ToolApprovalState`, `SessionProtocol.Events`, `netclaw_messages.proto`, `NetclawProtoMapper` | Add the new field, retain field 19 as legacy-read-only, and test recovery without reinterpretation |
 | Model-visible guidance | shipped `AGENTS.md`, `SessionMessageAssembler`, `SubAgentActor`, `ToolChoiceGuidance`, `ShellTool` | Extend the existing session block with `temp_dir`, `artifact_dir`, `worktree_dir`, and `log_path`; preserve current `session_dir` assembly |
 | Workspace file schemas | `FileReadTool`, `FileListTool`, `FileSearchTool`, `FileWriteTool`, `FileEditTool`, `AttachFileTool` | Replace “session scratch” with “session directory” for relative-path fallback |
-| Session data access | `ToolExecutionContext`, `PathAccessPolicy`, `FileReadTool`, `FileSearchTool`, `SessionLogActor` | Use the shared sessions root and one path access decision; use a writer-compatible file share mode |
+| Session data access | `ToolExecutionContext`, `PathAccessPolicy`, `FileReadTool`, `FileSearchTool`, `SessionLogActor` | Use audience-scoped session roots and one path access decision; use a writer-compatible file share mode |
 | Ordinary config reads | `ToolPathPolicy`, `DaemonToolPathPolicyFactory`, configuration persistence and validation | Separate structured read denies from broad shell indicators; allow validated `netclaw.json`; keep secret and control-plane files denied |
 | Background-job recovery | `BackgroundJobDefinitionStore`, `BackgroundJobManagerActor` | Read records without managed-temp metadata; keep existing `Lost` transition and notification semantics |
 | Approval scopes and prompts | `ApprovalBucketBuilder`, `ToolAccessPolicy`, Slack and Discord approval builders, approval runbook | Name each storage path that suppresses a persistent folder grant |
@@ -800,7 +801,7 @@ That pass does not prove environment injection, access control, or recovery.
   the shared path access decision.
 - **The model tries to change a log.** -> Apply ordinary write and edit policy;
   read permission is not write permission.
-- **The model tries to read another session.** -> Use the shared sessions root,
+- **The model tries to read another session.** -> Use audience-scoped session roots,
   audience policy, and requested file operation.
 - **A file tool reads while the log writer stays open.** -> Use a compatible
   read share mode and test the active writer on Windows and POSIX.

--- a/openspec/changes/unify-session-storage-and-temp/proposal.md
+++ b/openspec/changes/unify-session-storage-and-temp/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Source PRDs: `PRD-001`, `PRD-002`, and `PRD-006`.
+Source PRDs: `PRD-001`, `PRD-002`, `PRD-006`, and `PRD-007`.
 
 Live sessions still create disposable work under shared platform temporary
 roots, even after prompt guidance and interactive correction changes. Parent
@@ -21,10 +21,9 @@ use separate directory trees.
 - Treat the complete current session envelope as an implicit trusted root for
   parent and child runs. Existing file tools apply their ordinary audience and
   operation permissions inside it.
-- Store all session directories below the trusted Netclaw sessions root.
-  Parent and child runs inherit this root, so they can access other sessions
-  under normal audience and operation permissions. This supports a session
-  that analyzes another session's logs on a heavily used Netclaw agent.
+- Preserve shared session roots for Personal. Public and Team receive the current
+  envelope and workspace, plus exact own legacy log authority. Children inherit
+  parent roots and restrictions. Legacy cross-run logs require explicit authority.
 - Set `TMPDIR`, `TMP`, and `TEMP` for each parent and child execution scope.
   The values must identify that run's managed temporary directory.
 - Retire the ambiguous “session scratch” vocabulary. Use `session_dir` for the

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -395,29 +395,6 @@ The existing `file_read`, `file_search`, `file_list`, `file_write`,
 `file_edit`, and `attach_file` tools SHALL use this decision. They SHALL keep
 their existing output, pagination, query, and approval contracts.
 
-The Netclaw sessions root SHALL be a trusted root for parent and child runs.
-A path in another session SHALL use the same decision as any other path below
-that root. Session identity SHALL NOT add another access-control rule.
-
-The system SHALL NOT add a log-specific tool, ownership check, projection, or
-query language. `file_read` and `file_search` SHALL remain compatible with an
-active log writer on POSIX and Windows.
-
-#### Scenario: Example - one session reads another session's log
-
-- **GIVEN** the audience permits `file_read`
-- **AND** two sessions are below the Netclaw sessions root
-- **WHEN** one session requests the other session's canonical log path
-- **THEN** one `Read` path access decision allows the request
-- **AND** `file_read` applies its normal output bounds
-
-#### Scenario: Example - parent searches a child log
-
-- **GIVEN** a parent receives a child log path from `spawn_agent`
-- **WHEN** it calls `file_search` for that path
-- **THEN** the shared path access decision evaluates the request
-- **AND** the parent needs no shell or log-specific tool
-
 #### Scenario: Example - an active Windows log remains readable
 
 - **GIVEN** a log writer holds its append handle open
@@ -497,6 +474,67 @@ active log writer on POSIX and Windows.
 - **WHEN** any file operation requests that path
 - **THEN** the shared decision denies the request
 - **AND** no caller can bypass that result with another path policy
+
+### Requirement: Session file authority
+
+`PathAccessPolicy` SHALL derive session authority from the invocation audience
+and the current session storage. Personal MAY use the shared sessions and
+legacy logs roots. Public and Team SHALL NOT receive these shared roots as
+implicit authority. Explicit configured roots SHALL retain their authority.
+
+The current envelope and workspace SHALL remain roots for parent and child
+runs. A child SHALL inherit its parent's audience and workspace restrictions.
+Each legacy run MAY access its exact raw log through its operation profile.
+This exact-file grant SHALL NOT authorize the log's parent directory, adjacent
+files, or project declarations. Legacy cross-run logs SHALL receive no implicit
+grant. Child summaries and workspace artifacts SHALL remain available.
+
+The path decision SHALL retain profile, link, and protected-path checks.
+A storage ancestor used to inspect links SHALL NOT grant directory authority.
+Public and Team shell capability SHALL remain denied. Storage paths, audience
+derivation on resumption, and memory policy SHALL remain unchanged.
+
+The system SHALL NOT add a log-specific tool, ownership registry, projection,
+or query language. `file_read` SHALL support an exact legacy log. Directory
+search SHALL require directory authority. Reads SHALL remain compatible with
+an active log writer on POSIX and Windows.
+
+#### Scenario: Restricted session reads its own log
+
+- **GIVEN** a Public or Team session with the default file profiles
+- **WHEN** it requests its exact versioned or legacy raw log through `file_read`
+- **THEN** the path decision allows the read and applies normal output bounds
+- **AND** a `None` profile or protected path still denies access
+
+#### Scenario: Restricted session cannot inspect a sibling session
+
+- **GIVEN** a Public or Team session without an explicit root for a sibling
+- **WHEN** it reads, lists, searches, or attaches the sibling's files
+- **THEN** the path decision denies access before content or filenames escape
+- **AND** a Team write cannot change or create a sibling file
+
+#### Scenario: Personal session retains cross-session access
+
+- **GIVEN** a Personal session whose operation profile admits shared roots
+- **WHEN** it requests another session's ordinary raw log
+- **THEN** the same path decision permits the read
+- **AND** link and protected-path checks still apply
+
+#### Scenario: Parent and child share versioned session authority
+
+- **GIVEN** a Team parent and child with the same versioned envelope
+- **WHEN** either reads the other's log or shared workspace artifact
+- **THEN** its inherited roots permit the operation
+- **AND** neither can read an unrelated session without explicit authority
+
+#### Scenario: Legacy child keeps only its own raw log grant
+
+- **GIVEN** a Team parent and child with separate legacy raw log paths
+- **WHEN** either reads its own exact log
+- **THEN** the operation succeeds
+- **WHEN** either reads the other's log or enumerates the shared log parent
+- **THEN** access is denied without explicit authority
+- **AND** the parent can still read the child's shared-workspace artifacts
 
 ### Requirement: Git worktrees compose existing tools
 

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -85,4 +85,4 @@
 - [x] 10.2 Restrict shared roots to Personal; retain exact own legacy logs, inherited child roots, link checks, and protected paths.
 - [x] 10.3 Verify real file tools, child authority, explicit profiles, and the existing shell denial boundary.
 - [x] 10.4 Align specification, glossary references, profile comments, operations skill, and release notes.
-- [ ] 10.5 Run focused and related tests, evals, Slopwatch, headers, and strict OpenSpec validation; record limits.
+- [x] 10.5 Run focused and related tests, evals, Slopwatch, headers, and strict OpenSpec validation; record limits.

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -78,3 +78,11 @@
 - [x] 9.4 Run `openspec validate unify-session-storage-and-temp --strict`, focused tests, `dotnet build -c Release`, `dotnet test -c Release`, header verification, and Slopwatch; report existing skipped tests accurately instead of claiming zero skips
 - [ ] 9.5 Upgrade one existing session and restart one newly bound session; verify established and new paths remain usable, active writers remain healthy, paths stay stable, and no data is moved or deleted
 - [ ] 9.6 Harvest sanitized live traffic after the swap and classify remaining temp, log-discovery, worktree, configuration-read, and approval-friction patterns; add evidence to the corpus only after manual PII review
+
+## 10. Restore restricted session file authority
+
+- [x] 10.1 Prove sibling and legacy denial failures against the unchanged policy with nearby own-path controls.
+- [x] 10.2 Restrict shared roots to Personal; retain exact own legacy logs, inherited child roots, link checks, and protected paths.
+- [x] 10.3 Verify real file tools, child authority, explicit profiles, and the existing shell denial boundary.
+- [x] 10.4 Align specification, glossary references, profile comments, operations skill, and release notes.
+- [ ] 10.5 Run focused and related tests, evals, Slopwatch, headers, and strict OpenSpec validation; record limits.

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -529,8 +529,9 @@ be built into `file_read`.
 ### Requirement: Attachment tool reach
 
 The system SHALL provide an `attach_file` first-party tool that sends a file to
-the user. Non-interactive, Team, and Public sessions SHALL only attach files
-inside the current session directory or a sibling Netclaw session directory.
+the user. Public and Team sessions SHALL attach only files admitted by their current
+session paths or explicit configured roots. Personal retains shared-session
+reach under its existing attach profile.
 Interactive Personal-audience sessions get shell-equivalent reach: any path that
 resolves through the read-access policy SHALL be attachable, and the file SHALL
 be copied into the current session's attachments directory before delivery.
@@ -693,3 +694,64 @@ process-start builder. The tool schema SHALL remain unchanged.
 - **THEN** both use the same absolute executable path
 - **AND** both use the same fixed arguments in the same order
 - **AND** both append the submitted command as one argument
+
+### Requirement: Session file authority
+
+`PathAccessPolicy` SHALL derive session authority from the invocation audience
+and the current session storage. Personal MAY use the shared sessions and
+legacy logs roots. Public and Team SHALL NOT receive these shared roots as
+implicit authority. Explicit configured roots SHALL retain their authority.
+
+The current envelope and workspace SHALL remain roots for parent and child
+runs. A child SHALL inherit its parent's audience and workspace restrictions.
+Each legacy run MAY access its exact raw log through its operation profile.
+This exact-file grant SHALL NOT authorize the log's parent directory, adjacent
+files, or project declarations. Legacy cross-run logs SHALL receive no implicit
+grant. Child summaries and workspace artifacts SHALL remain available.
+
+The path decision SHALL retain profile, link, and protected-path checks.
+A storage ancestor used to inspect links SHALL NOT grant directory authority.
+Public and Team shell capability SHALL remain denied. Storage paths, audience
+derivation on resumption, and memory policy SHALL remain unchanged.
+
+The system SHALL NOT add a log-specific tool, ownership registry, projection,
+or query language. `file_read` SHALL support an exact legacy log. Directory
+search SHALL require directory authority. Reads SHALL remain compatible with
+an active log writer on POSIX and Windows.
+
+#### Scenario: Restricted session reads its own log
+
+- **GIVEN** a Public or Team session with the default file profiles
+- **WHEN** it requests its exact versioned or legacy raw log through `file_read`
+- **THEN** the path decision allows the read and applies normal output bounds
+- **AND** a `None` profile or protected path still denies access
+
+#### Scenario: Restricted session cannot inspect a sibling session
+
+- **GIVEN** a Public or Team session without an explicit root for a sibling
+- **WHEN** it reads, lists, searches, or attaches the sibling's files
+- **THEN** the path decision denies access before content or filenames escape
+- **AND** a Team write cannot change or create a sibling file
+
+#### Scenario: Personal session retains cross-session access
+
+- **GIVEN** a Personal session whose operation profile admits shared roots
+- **WHEN** it requests another session's ordinary raw log
+- **THEN** the same path decision permits the read
+- **AND** link and protected-path checks still apply
+
+#### Scenario: Parent and child share versioned session authority
+
+- **GIVEN** a Team parent and child with the same versioned envelope
+- **WHEN** either reads the other's log or shared workspace artifact
+- **THEN** its inherited roots permit the operation
+- **AND** neither can read an unrelated session without explicit authority
+
+#### Scenario: Legacy child keeps only its own raw log grant
+
+- **GIVEN** a Team parent and child with separate legacy raw log paths
+- **WHEN** either reads its own exact log
+- **THEN** the operation succeeds
+- **WHEN** either reads the other's log or enumerates the shared log parent
+- **THEN** access is denied without explicit authority
+- **AND** the parent can still read the child's shared-workspace artifacts

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
@@ -574,6 +574,83 @@ public sealed class SubAgentSpawnerTests : TestKit
         Assert.Equal((175L, 60L), call);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AuthorityRegression_Child_spawner_retains_team_file_authority(bool legacy)
+    {
+        using var directory = new DisposableTempDir();
+        var paths = new NetclawPaths(directory.Path);
+        paths.EnsureDirectoriesExist();
+        var parentRoot = Path.Combine(paths.SessionsDirectory, "parent");
+        var storage = legacy
+            ? SessionStoragePaths.CreateLegacy(parentRoot, paths.SessionLogsDirectory, "parent")
+            : SessionStoragePaths.CreateVersion2(new SessionStorageEnvelopeRoot(parentRoot));
+        Directory.CreateDirectory(storage.SessionDirectory.Value);
+        Directory.CreateDirectory(Path.GetDirectoryName(storage.LogPath.Value)!);
+        await File.WriteAllTextAsync(storage.LogPath.Value, "parent-marker", TestContext.Current.CancellationToken);
+        var sibling = Path.Combine(paths.SessionsDirectory, "foreign", "hidden.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(sibling)!);
+        await File.WriteAllTextAsync(sibling, "foreign-marker", TestContext.Current.CancellationToken);
+        var config = new ToolConfig();
+        var protectedPaths = new ToolPathPolicy([]);
+        var pathPolicy = new PathAccessPolicy(config, paths, protectedPaths);
+        var read = new FileReadTool(config, pathPolicy);
+        var registry = new ToolRegistry();
+        registry.Register(read);
+        var spawner = new SubAgentSpawner(
+            new SingleClientProvider(new FakeChatClient()), registry,
+            new ToolAccessPolicy(paths, config,
+                new EffectivePolicyDefaults(DeploymentPosture.Personal, TrustAudience.Personal, ShellExecutionMode.HostAllowed, UsedStrictFallback: false),
+                new ShellCommandPolicy(), protectedPaths),
+            approvalService: null,
+            new StaticSystemPromptProvider("Read the supplied file."),
+            new WorkingContextSnapshotProvider(new GitWorkingContextInspector(TimeProvider.System), NullLogger<WorkingContextSnapshotProvider>.Instance),
+            NullLogger<SubAgentSpawner>.Instance);
+        var probe = CreateTestProbe("authority-child");
+        var parent = TestToolExecutionContext.CreateBoundWithStorage("slack/parent", storage, new TestToolExecutionContextOptions
+        {
+            Audience = TrustAudience.Team,
+            Boundary = TrustBoundary.Team,
+            ChannelType = "slack",
+            SpawnChildActor = (_, _, _) => Task.FromResult<object>(probe.Ref)
+        });
+        var profile = new SubAgentProfile
+        {
+            Name = "reader", Description = "Read a file", SystemPrompt = "Read the supplied file.",
+            ToolNames = ["file_read"], Visibility = SubAgentVisibility.UserFacing
+        };
+        var spawn = spawner.SpawnAsync(profile, "Read the supplied file.", runtimeContext: null, parent.Invocation, TestContext.Current.CancellationToken);
+        var run = await probe.ExpectMsgAsync<RunSubAgent>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(parent.Audience, run.Scope.Authority.Audience);
+        Assert.Equal(parent.Boundary, run.Scope.Authority.Boundary);
+        var childStorage = Assert.IsType<ToolSessionScope.Bound>(run.Scope.Authority.Session).Storage;
+        Assert.Equal(storage.SessionDirectory, childStorage.SessionDirectory);
+        Assert.Equal(storage.Binding, childStorage.Binding);
+        foreach (var (target, allowed) in new[] { (storage.LogPath.Value, !legacy), (sibling, false), (childStorage.LogPath.Value, true) })
+        {
+            var child = new ToolExecutionContext(run.Scope.Authority, ToolExecutionTimeout.Default);
+            var result = await read.ExecuteAsync(ToolInput.Create("Path", target), child, TestContext.Current.CancellationToken);
+            Assert.Equal(allowed ? ToolInvocationOutcomeCategory.Success : ToolInvocationOutcomeCategory.AccessDenied, child.Receipt?.Category);
+            Assert.DoesNotContain("foreign-marker", result);
+        }
+        Directory.CreateDirectory(childStorage.ArtifactDirectory.Value);
+        var artifact = Path.Combine(childStorage.ArtifactDirectory.Value, "result.txt");
+        await File.WriteAllTextAsync(artifact, "child-artifact", TestContext.Current.CancellationToken);
+        probe.Reply(new SubAgentResult
+        {
+            Completion = new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
+            Output = "child-summary", AgentName = new AgentName("reader")
+        });
+        var completed = await spawn;
+        Assert.True(completed.Success);
+        Assert.Equal("child-summary", completed.Output);
+        Assert.Equal(childStorage.LogPath.Value, completed.LogPath);
+        Assert.Equal(childStorage.ArtifactDirectory.Value, completed.ArtifactDirectory);
+        var resultText = await read.ExecuteAsync(ToolInput.Create("Path", artifact), parent, TestContext.Current.CancellationToken);
+        Assert.Contains("child-artifact", resultText);
+    }
+
     private static SubAgentSpawner CreateSpawner()
         => CreateSpawner(new WorkingContextSnapshotProvider(
             new GitWorkingContextInspector(TimeProvider.System),

--- a/src/Netclaw.Actors.Tests/Tools/SessionStorageFileAccessPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SessionStorageFileAccessPolicyTests.cs
@@ -180,4 +180,260 @@ public sealed class SessionStorageFileAccessPolicyTests : IDisposable
         AssertDenied(decision, Path.GetFullPath(requestedPath));
         Assert.Contains("symlinked paths", decision.Error, StringComparison.Ordinal);
     }
+
+    [Theory]
+    [InlineData(TrustAudience.Public, false)]
+    [InlineData(TrustAudience.Team, false)]
+    [InlineData(TrustAudience.Personal, false)]
+    [InlineData(TrustAudience.Public, true)]
+    [InlineData(TrustAudience.Team, true)]
+    [InlineData(TrustAudience.Personal, true)]
+    public async Task AuthorityRegression_Sibling_tools_preserve_own_access(TrustAudience audience, bool legacy)
+    {
+        var own = CreateStorage("own", legacy);
+        var sibling = CreateStorage("own-extra", legacy);
+        var ownFile = await SeedFile(own.SessionDirectory.Value, "own.txt", "own-marker");
+        var siblingFile = await SeedFile(sibling.SessionDirectory.Value, "hidden.txt", "hidden-marker");
+        var read = new FileReadTool(new ToolConfig(), _policy);
+        var list = new FileListTool(_policy);
+        var search = new FileSearchTool(_policy);
+        var attach = new AttachFileTool(_policy);
+
+        foreach (var (storage, path, expected) in new[]
+                 {
+                     (own, ownFile, true),
+                     (sibling, siblingFile, audience == TrustAudience.Personal)
+                 })
+        {
+            var context = CreateContext(own, audience);
+            var result = await read.ExecuteAsync(ToolInput.Create("Path", path), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, expected);
+            Assert.Equal(expected, result.Contains(storage == own ? "own-marker" : "hidden-marker", StringComparison.Ordinal));
+
+            context = CreateContext(own, audience);
+            result = await list.ExecuteAsync(ToolInput.Create("Path", storage.SessionDirectory.Value), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, expected);
+            Assert.Equal(expected, result.Contains(Path.GetFileName(path), StringComparison.Ordinal));
+
+            context = CreateContext(own, audience);
+            result = await search.ExecuteAsync(ToolInput.Create("Root", storage.SessionDirectory.Value, "Query", "marker", "Mode", "content"), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, expected);
+            Assert.Equal(expected, result.Contains(storage == own ? "own-marker" : "hidden-marker", StringComparison.Ordinal));
+
+            context = CreateContext(own, audience);
+            await attach.ExecuteAsync(ToolInput.Create("Path", path), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, expected);
+            Assert.Equal(expected ? 1 : 0, context.FileAttachments.Count);
+        }
+
+        var traversal = Path.GetRelativePath(own.SessionDirectory.Value, siblingFile);
+        var traversed = CreateContext(own, audience);
+        await read.ExecuteAsync(ToolInput.Create("Path", traversal), traversed, TestContext.Current.CancellationToken);
+        AssertReceipt(traversed, audience == TrustAudience.Personal);
+        Assert.Equal("hidden-marker", await File.ReadAllTextAsync(siblingFile, TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(TrustAudience.Public)]
+    [InlineData(TrustAudience.Team)]
+    public async Task AuthorityRegression_Legacy_exact_log_has_no_directory_grant(TrustAudience audience)
+    {
+        var own = CreateStorage("legacy-own", true);
+        await SeedFile(Path.GetDirectoryName(own.LogPath.Value)!, "session.log", "own-log-marker");
+        var adjacent = await SeedFile(Path.GetDirectoryName(own.LogPath.Value)!, "adjacent.txt", "hidden-marker");
+        var read = new FileReadTool(new ToolConfig(), _policy);
+        var context = CreateContext(own, audience);
+        var result = await read.ExecuteAsync(ToolInput.Create("Path", own.LogPath.Value), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, true);
+        Assert.Contains("own-log-marker", result);
+
+        context = CreateContext(own, audience);
+        await new AttachFileTool(_policy).ExecuteAsync(ToolInput.Create("Path", own.LogPath.Value), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, true);
+        Assert.Single(context.FileAttachments);
+
+        context = CreateContext(own, audience);
+        result = await read.ExecuteAsync(ToolInput.Create("Path", adjacent), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, false);
+        Assert.DoesNotContain("hidden-marker", result);
+        foreach (var directory in new[] { Path.GetDirectoryName(own.LogPath.Value)!, _paths.SessionLogsDirectory })
+        {
+            context = CreateContext(own, audience);
+            await new FileListTool(_policy).ExecuteAsync(ToolInput.Create("Path", directory), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, false);
+            context = CreateContext(own, audience);
+            await new FileSearchTool(_policy).ExecuteAsync(ToolInput.Create("Root", directory, "Query", "marker", "Mode", "content"), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, false);
+        }
+        AssertDenied(_policy.Evaluate(Path.Combine(own.LogPath.Value, "child"), context.Invocation, PathAccessPolicy.FileOperation.Read), Path.Combine(own.LogPath.Value, "child"));
+        AssertDenied(_policy.Evaluate(own.LogPath.Value, context.Invocation, PathAccessPolicy.FileOperation.DeclareProjectScope), own.LogPath.Value);
+        Assert.DoesNotContain(own.LogPath.Value, _policy.GetTrustedRoots(context.Invocation, PathAccessPolicy.FileOperation.Read));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AuthorityRegression_Sibling_team_write_has_no_foreign_side_effect(bool legacy)
+    {
+        var own = CreateStorage("writer", legacy);
+        var sibling = CreateStorage("other-writer", legacy);
+        var write = new FileWriteTool(_policy);
+        foreach (var (storage, allowed) in new[] { (own, true), (sibling, false) })
+        {
+            var target = Path.Combine(storage.SessionDirectory.Value, "created", "result.txt");
+            var context = CreateContext(own, TrustAudience.Team);
+            await write.ExecuteAsync(ToolInput.Create("Path", target, "Content", "written"), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, allowed);
+            Assert.Equal(allowed, File.Exists(target));
+            Assert.Equal(allowed, Directory.Exists(Path.GetDirectoryName(target)));
+
+            var existing = await SeedFile(storage.SessionDirectory.Value, "existing.txt", "original");
+            context = CreateContext(own, TrustAudience.Team);
+            await new FileEditTool(_policy).ExecuteAsync(ToolInput.Create("Path", existing, "OldString", "original", "NewString", "changed"), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, allowed);
+            Assert.Equal(allowed ? "changed" : "original", await File.ReadAllTextAsync(existing, TestContext.Current.CancellationToken));
+        }
+    }
+
+    [Theory]
+    [InlineData(TrustAudience.Team, false)]
+    [InlineData(TrustAudience.Team, true)]
+    [InlineData(TrustAudience.Personal, false)]
+    [InlineData(TrustAudience.Personal, true)]
+    public async Task AuthorityRegression_Child_uses_inherited_roots_and_exact_own_log(TrustAudience audience, bool legacy)
+    {
+        var parent = CreateStorage("parent", legacy);
+        var child = parent.ForChild(new SubAgentRunId("child"), new SubAgentScopeId("parent/subagent/child"));
+        var peer = parent.ForChild(new SubAgentRunId("peer"), new SubAgentScopeId("parent/subagent/peer"));
+        var foreign = CreateStorage("foreign", legacy);
+        foreach (var storage in new[] { parent, child, peer, foreign })
+            await SeedFile(Path.GetDirectoryName(storage.LogPath.Value)!, "session.log", "log-marker");
+        var artifact = await SeedFile(child.ArtifactDirectory.Value, "result.txt", "artifact-marker");
+        var read = new FileReadTool(new ToolConfig(), _policy);
+        foreach (var caller in new[] { parent, child })
+        {
+            foreach (var target in new[] { parent, child, peer, foreign })
+            {
+                var allowed = audience == TrustAudience.Personal || (target != foreign && (!legacy || caller == target));
+                var context = CreateContext(caller, audience);
+                var result = await read.ExecuteAsync(ToolInput.Create("Path", target.LogPath.Value), context, TestContext.Current.CancellationToken);
+                AssertReceipt(context, allowed);
+                Assert.Equal(allowed, result.Contains("log-marker", StringComparison.Ordinal));
+            }
+            var artifactContext = CreateContext(caller, audience);
+            await read.ExecuteAsync(ToolInput.Create("Path", artifact), artifactContext, TestContext.Current.CancellationToken);
+            AssertReceipt(artifactContext, true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AuthorityRegression_Links_check_ancestors_above_the_current_root(bool legacy)
+    {
+        var outside = Path.Combine(_directory.Path, "outside");
+        Directory.CreateDirectory(outside);
+        var storageBase = legacy ? _paths.SessionLogsDirectory : _paths.SessionsDirectory;
+        var link = Path.Combine(storageBase, "linked");
+        Directory.CreateSymbolicLink(link, outside);
+        var storage = legacy
+            ? SessionStoragePaths.CreateLegacy(Path.Combine(_paths.SessionsDirectory, "own"), link, "nested")
+            : SessionStoragePaths.CreateVersion2(new SessionStorageEnvelopeRoot(Path.Combine(link, "nested")));
+        await SeedFile(Path.GetDirectoryName(storage.LogPath.Value)!, "session.log", "outside-marker");
+        var context = CreateContext(storage, TrustAudience.Team);
+        var result = await new FileReadTool(new ToolConfig(), _policy).ExecuteAsync(ToolInput.Create("Path", storage.LogPath.Value), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, false);
+        Assert.DoesNotContain("outside-marker", result);
+    }
+
+    private SessionStoragePaths CreateStorage(string id, bool legacy)
+    {
+        var root = Path.Combine(_paths.SessionsDirectory, id);
+        var storage = legacy
+            ? SessionStoragePaths.CreateLegacy(root, _paths.SessionLogsDirectory, id)
+            : SessionStoragePaths.CreateVersion2(new SessionStorageEnvelopeRoot(root));
+        Directory.CreateDirectory(storage.SessionDirectory.Value);
+        return storage;
+    }
+
+    private static ToolExecutionContext CreateContext(SessionStoragePaths storage, TrustAudience audience)
+        => TestToolExecutionContext.CreateBoundWithStorage("test/session", storage, new TestToolExecutionContextOptions
+        {
+            Audience = audience,
+            Boundary = SecurityPolicyDefaults.ResolveBoundaryFromAudience(audience),
+            ChannelType = audience == TrustAudience.Personal ? "signalr" : "slack"
+        });
+
+    private static async Task<string> SeedFile(string directory, string name, string content)
+    {
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, name);
+        await File.WriteAllTextAsync(path, content, TestContext.Current.CancellationToken);
+        return path;
+    }
+
+    private static void AssertReceipt(ToolExecutionContext context, bool allowed)
+    {
+        Assert.Equal(allowed ? ToolInvocationOutcomeCategory.Success : ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        if (!allowed)
+        {
+            Assert.Empty(context.FileAttachments);
+            Assert.Empty(context.ModelInputFiles);
+            Assert.Empty(context.Receipt!.FileActivity);
+        }
+    }
+
+    [Theory]
+    [InlineData(TrustAudience.Public, false)]
+    [InlineData(TrustAudience.Public, true)]
+    [InlineData(TrustAudience.Team, false)]
+    [InlineData(TrustAudience.Team, true)]
+    public async Task AuthorityRegression_Profiles_and_protection_remain_authoritative(TrustAudience audience, bool legacy)
+    {
+        var own = CreateStorage("profile-own", legacy);
+        var foreign = CreateStorage("profile-foreign", legacy);
+        await SeedFile(Path.GetDirectoryName(own.LogPath.Value)!, "session.log", "own-log");
+        await SeedFile(Path.GetDirectoryName(foreign.LogPath.Value)!, "session.log", "foreign-log");
+        var config = new ToolConfig();
+        var profile = audience == TrustAudience.Public ? config.AudienceProfiles.Public : config.AudienceProfiles.Team;
+        profile.ReadFiles.Roots = [Path.GetDirectoryName(foreign.LogPath.Value)!];
+        var configured = new PathAccessPolicy(config, _paths, new ToolPathPolicy([]));
+        var context = CreateContext(own, audience);
+        await new FileReadTool(config, configured).ExecuteAsync(ToolInput.Create("Path", foreign.LogPath.Value), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, true);
+
+        profile.ReadFiles.Mode = ToolFilesystemMode.None;
+        var denied = new PathAccessPolicy(config, _paths, new ToolPathPolicy([]));
+        context = CreateContext(own, audience);
+        await new FileReadTool(config, denied).ExecuteAsync(ToolInput.Create("Path", own.LogPath.Value), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, false);
+
+        var protectedPolicy = new PathAccessPolicy(new ToolConfig(), _paths, new ToolPathPolicy([own.LogPath.Value]));
+        context = CreateContext(own, audience);
+        await new FileReadTool(new ToolConfig(), protectedPolicy).ExecuteAsync(ToolInput.Create("Path", own.LogPath.Value), context, TestContext.Current.CancellationToken);
+        AssertReceipt(context, false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AuthorityRegression_Own_log_reader_preserves_writer_and_write_profile(bool legacy)
+    {
+        var storage = CreateStorage("active-log", legacy);
+        Directory.CreateDirectory(Path.GetDirectoryName(storage.LogPath.Value)!);
+        await using (var stream = new FileStream(storage.LogPath.Value, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
+        await using (var writer = new StreamWriter(stream) { AutoFlush = true })
+        {
+            await writer.WriteLineAsync("first-marker");
+            var context = CreateContext(storage, TrustAudience.Public);
+            var read = await new FileReadTool(new ToolConfig(), _policy).ExecuteAsync(ToolInput.Create("Path", storage.LogPath.Value), context, TestContext.Current.CancellationToken);
+            AssertReceipt(context, true);
+            Assert.Contains("first-marker", read);
+            await writer.WriteLineAsync("second-marker");
+        }
+        Assert.Contains("second-marker", await File.ReadAllTextAsync(storage.LogPath.Value, TestContext.Current.CancellationToken));
+        var team = CreateContext(storage, TrustAudience.Team);
+        await new FileEditTool(_policy).ExecuteAsync(ToolInput.Create("Path", storage.LogPath.Value, "OldString", "second-marker", "NewString", "changed-marker"), team, TestContext.Current.CancellationToken);
+        AssertReceipt(team, true);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/UnattendedPathAccessTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/UnattendedPathAccessTests.cs
@@ -291,7 +291,7 @@ public sealed class UnattendedPathAccessTests : IDisposable
     }
 
     [Fact]
-    public void Relative_traversal_into_shared_sessions_root_is_allowed()
+    public void Public_relative_traversal_into_shared_sessions_root_is_denied()
     {
         var policy = new PathAccessPolicy(new ToolConfig(), _paths, new ToolPathPolicy([]));
         var context = Ctx(TrustAudience.Public, autonomous: true, withProject: false);
@@ -303,7 +303,10 @@ public sealed class UnattendedPathAccessTests : IDisposable
             context,
             PathAccessPolicy.FileOperation.Read);
 
-        AssertAllowed(decision, expectedPath);
+        AssertDenied(decision, expectedPath);
+        AssertAllowed(
+            policy.Evaluate("own.txt", context, PathAccessPolicy.FileOperation.Read),
+            Path.Combine(_sessionDir, "own.txt"));
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -13,10 +13,10 @@ namespace Netclaw.Actors.Tools;
 
 /// <summary>
 /// Attaches a file as output to the user.
-/// Paths inside the current session are attached directly. Paths from sibling
-/// Netclaw session directories are copied into the current session first.
+/// Paths inside the current session are attached directly. Policy-authorized paths outside the current workspace
+/// are copied into the current session first.
 /// Interactive Personal sessions can copy another policy-authorized readable
-/// source. Other callers remain limited to the session tree.
+/// source. Public and Team require current-session or explicit configured authority.
 /// </summary>
 [NetclawTool("attach_file",
     "Attach an existing authorized file to the user. Pass the source path directly; Netclaw copies the file into the current session when required. Do not copy the file with shell or another file tool first.",

--- a/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
@@ -105,7 +105,7 @@ internal sealed class PathAccessPolicy
 
         // SessionsDirectory contains version-2 envelopes and legacy workspaces.
         // SessionLogsDirectory contains only legacy raw logs. Both roots remain
-        // readable so one session can inspect another session's authorized data.
+        // available to Personal; restricted audiences receive only their own paths.
         _sessionRoots = new[]
             {
                 paths.SessionsDirectory,
@@ -400,7 +400,7 @@ internal sealed class PathAccessPolicy
             return false;
         }
 
-        var relationship = GetHostPathRelationship(fullPath, roots);
+        var relationship = GetFilePathRelationship(fullPath, roots, context, accessKind);
         if (relationship == PathRelationship.WithinTrustedRoot)
         {
             error = string.Empty;
@@ -566,7 +566,7 @@ internal sealed class PathAccessPolicy
     /// Single source of truth for root resolution — used by both
     /// <see cref="GetTrustedRoots"/> and <see cref="TryResolvePath"/>.
     /// Public audience is excluded from global read roots (skills, identity,
-    /// workspaces) — it may only access the shared session trusted roots.
+    /// workspaces). Its implicit roots cover only the current session.
     /// </summary>
     private IReadOnlyList<string> ResolveAndMergeRoots(
         ToolFilesystemAccessProfile access,
@@ -608,7 +608,7 @@ internal sealed class PathAccessPolicy
             return false;
         }
 
-        var relationship = GetHostPathRelationship(fullPath, roots);
+        var relationship = GetFilePathRelationship(fullPath, roots, context, accessKind);
         if (relationship == PathRelationship.WithinTrustedRoot)
         {
             error = string.Empty;
@@ -631,7 +631,27 @@ internal sealed class PathAccessPolicy
         return false;
     }
 
-    private static PathRelationship GetHostPathRelationship(
+    private PathRelationship GetFilePathRelationship(
+        string fullPath,
+        IEnumerable<string> roots,
+        ToolInvocationContext context,
+        FileOperation operation)
+    {
+        var relationship = GetHostPathRelationship(fullPath, roots);
+        if (relationship != PathRelationship.OutsideTrustedRoots
+            || operation == FileOperation.DeclareProjectScope
+            || context.SessionStorage is not { Binding: null } storage
+            || !PathComparer.Equals(fullPath, storage.LogPath.Value))
+        {
+            return relationship;
+        }
+
+        // A legacy run owns this file, not its directory or another run's log.
+        // Equality grants authority; the common relationship check retains link checks.
+        return GetHostPathRelationship(fullPath, [fullPath]);
+    }
+
+    private PathRelationship GetHostPathRelationship(
         string fullPath,
         IEnumerable<string> roots)
     {
@@ -643,7 +663,11 @@ internal sealed class PathAccessPolicy
                 if (!PathUtility.IsWithinRoot(fullPath, root))
                     continue;
 
-                return PathUtility.ContainsSymlinkSegment(root, fullPath, includeRoot: true)
+                // Narrow authority must not omit links above the current envelope.
+                // The storage ancestor supplies link facts, not an access grant.
+                var linkRoot = _sessionRoots.FirstOrDefault(storageRoot =>
+                    PathUtility.IsWithinRoot(root, storageRoot)) ?? root;
+                return PathUtility.ContainsSymlinkSegment(linkRoot, fullPath, includeRoot: true)
                     ? PathRelationship.CrossesLinkBoundary
                     : PathRelationship.WithinTrustedRoot;
             }
@@ -697,7 +721,8 @@ internal sealed class PathAccessPolicy
 
     private void AddSessionRoots(List<string> roots, ToolInvocationContext context)
     {
-        roots.AddRange(_sessionRoots);
+        if (context.Audience == TrustAudience.Personal)
+            roots.AddRange(_sessionRoots);
 
         if (context.SessionStorage?.Binding is { } binding)
             roots.Add(binding.EnvelopeRoot.Value);


### PR DESCRIPTION
Superseded by #2143. The replacement uses the same commits in the repository-native stack.

Public and Team file tools can currently receive the shared session directories as implicit roots. This change limits those implicit roots to Personal. Public and Team retain their current envelope, workspace, and exact own legacy log through the existing operation profile.

Children retain parent roots and restrictions. Versioned parent/child logs remain accessible within the same envelope. Legacy runs keep their own log access; separate cross-run logs require explicit authority. Existing configured roots, protected paths, shell restrictions, storage paths, and resumption behavior remain unchanged.

Validation:

- The unchanged policy failed 10 new boundary cases and passed six controls. The same 16 tests passed after the correction.
- The full actor suite passed 3,883 tests, with six platform-specific skips.
- Slopwatch, headers, strict OpenSpec validation, and whitespace checks passed.
- The full daemon suite passed 1,098 tests.
- Focused child-log and operations evals each passed five runs. Three local tests verify the child-log assertion fix.
- The first child-log eval passed three of five runs. One timed out; another exposed an assertion defect after a corrected call.
- Native Windows checks remain pending. No deployment or merge occurred.

This is the first change in a planned stack. Path-result conversion, attachment-destination checks, and the remaining result contracts stay in separate PRs.

Stack order: #2131 → #2136 → #2137 → #2139.
