### PR TITLE
Separate allowed and denied path results

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/PathAccessDecisionAssertions.cs
+++ b/src/Netclaw.Actors.Tests/Tools/PathAccessDecisionAssertions.cs
@@ -14,10 +14,8 @@ internal static class PathAccessDecisionAssertions
         PathAccessPolicy.PathAccessDecision decision,
         string expectedCanonicalPath)
     {
-        Assert.True(decision.Allowed, decision.Error);
-        Assert.Equal(Path.GetFullPath(expectedCanonicalPath), decision.CanonicalPath);
-        Assert.Empty(decision.Error);
-        Assert.Null(decision.Failure);
+        var allowed = Assert.IsType<PathAccessPolicy.PathAccessDecision.Allowed>(decision);
+        Assert.Equal(Path.GetFullPath(expectedCanonicalPath), allowed.CanonicalPath);
     }
 
     public static void AssertDenied(
@@ -25,9 +23,9 @@ internal static class PathAccessDecisionAssertions
         string expectedCanonicalPath,
         PathAccessPolicy.PathAccessFailure expectedFailure = PathAccessPolicy.PathAccessFailure.AccessDenied)
     {
-        Assert.False(decision.Allowed);
-        Assert.Equal(expectedCanonicalPath, decision.CanonicalPath);
-        Assert.NotEmpty(decision.Error);
-        Assert.Equal(expectedFailure, decision.Failure);
+        var denied = Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision);
+        Assert.Equal(expectedCanonicalPath.Length == 0 ? null : expectedCanonicalPath, denied.DiagnosticPath);
+        Assert.NotEmpty(denied.Error);
+        Assert.Equal(expectedFailure, denied.Failure);
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/PersonalFileAccessPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/PersonalFileAccessPolicyTests.cs
@@ -110,12 +110,10 @@ public sealed class PersonalFileAccessPolicyTests : IDisposable
 
         var decision = policy.Evaluate(path, ctx, PathAccessPolicy.FileOperation.Read);
 
-        Assert.Equal(expectedAllow, decision.Allowed);
-        Assert.Equal(Path.GetFullPath(path), decision.CanonicalPath);
-        Assert.Equal(expectedAllow, string.IsNullOrEmpty(decision.Error));
-        Assert.Equal(
-            expectedAllow ? null : PathAccessPolicy.PathAccessFailure.AccessDenied,
-            decision.Failure);
+        if (expectedAllow)
+            AssertAllowed(decision, path);
+        else
+            AssertDenied(decision, Path.GetFullPath(path));
     }
 
     [Theory]
@@ -139,12 +137,10 @@ public sealed class PersonalFileAccessPolicyTests : IDisposable
 
         var decision = policy.Evaluate(path, ctx, PathAccessPolicy.FileOperation.Attach);
 
-        Assert.Equal(expectedAllow, decision.Allowed);
-        Assert.Equal(Path.GetFullPath(path), decision.CanonicalPath);
-        Assert.Equal(expectedAllow, string.IsNullOrEmpty(decision.Error));
-        Assert.Equal(
-            expectedAllow ? null : PathAccessPolicy.PathAccessFailure.AccessDenied,
-            decision.Failure);
+        if (expectedAllow)
+            AssertAllowed(decision, path);
+        else
+            AssertDenied(decision, Path.GetFullPath(path));
     }
 
     public static TheoryData<TrustAudience, bool, bool> AttachToolReachCases => new()
@@ -290,11 +286,9 @@ public sealed class PersonalFileAccessPolicyTests : IDisposable
         var path = Path.Combine(_outsideDir, "report.png");
         var decision = policy.Evaluate(path, ctx, PathAccessPolicy.FileOperation.Attach);
 
-        Assert.Equal(expectedAllow, decision.Allowed);
-        Assert.Equal(Path.GetFullPath(path), decision.CanonicalPath);
-        Assert.Equal(expectedAllow, string.IsNullOrEmpty(decision.Error));
-        Assert.Equal(
-            expectedAllow ? null : PathAccessPolicy.PathAccessFailure.AccessDenied,
-            decision.Failure);
+        if (expectedAllow)
+            AssertAllowed(decision, path);
+        else
+            AssertDenied(decision, Path.GetFullPath(path));
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/PublicAudienceFileAccessPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/PublicAudienceFileAccessPolicyTests.cs
@@ -101,12 +101,12 @@ public sealed class PublicAudienceFileAccessPolicyTests : IDisposable
         AssertDenied(decision, Path.GetFullPath(outsidePath));
         // Error must mention "Public" audience but should contain only session-scoped
         // roots (the session dir), not global infrastructure paths
-        Assert.Contains("Public", decision.Error);
-        Assert.DoesNotContain(_sessionDir, decision.Error);
-        Assert.DoesNotContain("configured roots", decision.Error, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain(_paths.SkillsDirectory, decision.Error);
-        Assert.DoesNotContain(_paths.IdentityDirectory, decision.Error);
-        Assert.DoesNotContain(_paths.WorkspacesDirectory, decision.Error);
+        Assert.Contains("Public", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
+        Assert.DoesNotContain(_sessionDir, Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
+        Assert.DoesNotContain("configured roots", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(_paths.SkillsDirectory, Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
+        Assert.DoesNotContain(_paths.IdentityDirectory, Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
+        Assert.DoesNotContain(_paths.WorkspacesDirectory, Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
     }
 
     [Fact]
@@ -131,10 +131,10 @@ public sealed class PublicAudienceFileAccessPolicyTests : IDisposable
             PathAccessPolicy.FileOperation.Write);
 
         AssertDenied(decision, Path.GetFullPath(path));
-        Assert.Contains("Public", decision.Error);
-        Assert.Contains("does not allow", decision.Error);
+        Assert.Contains("Public", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
+        Assert.Contains("does not allow", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
         // Ensure no internal paths leak
-        Assert.DoesNotContain(_paths.BasePath, decision.Error);
+        Assert.DoesNotContain(_paths.BasePath, Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
     }
 
     private ToolInvocationContext CreateContext(TrustAudience audience)

--- a/src/Netclaw.Actors.Tests/Tools/SessionStorageFileAccessPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SessionStorageFileAccessPolicyTests.cs
@@ -178,7 +178,7 @@ public sealed class SessionStorageFileAccessPolicyTests : IDisposable
             PathAccessPolicy.FileOperation.Read);
 
         AssertDenied(decision, Path.GetFullPath(requestedPath));
-        Assert.Contains("symlinked paths", decision.Error, StringComparison.Ordinal);
+        Assert.Contains("symlinked paths", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/Netclaw.Actors.Tests/Tools/UnattendedPathAccessTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/UnattendedPathAccessTests.cs
@@ -137,7 +137,7 @@ public sealed class UnattendedPathAccessTests : IDisposable
             PathAccessPolicy.FileOperation.Write);
 
         AssertDenied(decision, Path.GetFullPath(outside));
-        Assert.Contains("unattended session", decision.Error);
+        Assert.Contains("unattended session", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error);
     }
 
     [Fact]
@@ -286,8 +286,8 @@ public sealed class UnattendedPathAccessTests : IDisposable
             PathAccessPolicy.FileOperation.Read);
 
         AssertDenied(decision, string.Empty, PathAccessPolicy.PathAccessFailure.MissingBase);
-        Assert.Contains("invalid_context", decision.Error, StringComparison.Ordinal);
-        Assert.DoesNotContain("set_working_directory", decision.Error, StringComparison.Ordinal);
+        Assert.Contains("invalid_context", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error, StringComparison.Ordinal);
+        Assert.DoesNotContain("set_working_directory", Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(decision).Error, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -9,6 +9,8 @@ using Netclaw.Media;
 using Netclaw.Security;
 using Netclaw.Tools;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
@@ -50,10 +52,17 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             return Task.FromResult(context.InvalidInput("Error: invalid_context: No session directory available."));
 
         var access = _pathAccessPolicy.Evaluate(args.Path, context, PathAccessPolicy.FileOperation.Attach);
-        if (!access.Allowed)
-            return Task.FromResult(context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied));
-
-        var requestedPath = access.CanonicalPath;
+        string requestedPath;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
+            case PathAccessDecision.Allowed allowed:
+                requestedPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         var sessionDir = PathUtility.Normalize(context.SessionDirectory);
 
@@ -63,10 +72,16 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var resolvedPath = ResolveFinalPath(requestedPath);
 
         var resolvedAccess = _pathAccessPolicy.Evaluate(resolvedPath, context, PathAccessPolicy.FileOperation.Attach);
-        if (!resolvedAccess.Allowed)
-            return Task.FromResult(context.PathAccessFailure(resolvedAccess.Error, resolvedAccess.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied));
-
-        resolvedPath = resolvedAccess.CanonicalPath;
+        switch (resolvedAccess)
+        {
+            case PathAccessDecision.Denied denied:
+                return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
+            case PathAccessDecision.Allowed allowed:
+                resolvedPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
         var resolvedInCurrentSession = PathUtility.IsWithinRoot(resolvedPath, sessionDir);
 
         var attachPath = resolvedInCurrentSession

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -9,6 +9,8 @@ using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
@@ -78,10 +80,17 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>, IMa
     internal async Task<string> WriteFileAsync(string path, string content, ToolInvocationContext context, CancellationToken ct)
     {
         var access = _pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Write);
-        if (!access.Allowed)
-            return context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied);
-
-        var authorizedPath = access.CanonicalPath;
+        string authorizedPath;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return context.PathAccessFailure(denied.Error, denied.Failure);
+            case PathAccessDecision.Allowed allowed:
+                authorizedPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         try
         {
@@ -117,10 +126,17 @@ public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>, IMa
     private async Task<string> EditFileAsync(string path, string oldString, string newString, bool replaceAll, ToolInvocationContext context, CancellationToken ct)
     {
         var access = _pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Write);
-        if (!access.Allowed)
-            return context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied);
-
-        var authorizedPath = access.CanonicalPath;
+        string authorizedPath;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return context.PathAccessFailure(denied.Error, denied.Failure);
+            case PathAccessDecision.Allowed allowed:
+                authorizedPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         if (!File.Exists(authorizedPath))
             return context.NotFound($"Error: File not found: {authorizedPath}");

--- a/src/Netclaw.Actors/Tools/FileListTool.cs
+++ b/src/Netclaw.Actors/Tools/FileListTool.cs
@@ -9,6 +9,8 @@ using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
@@ -51,10 +53,17 @@ public sealed partial class FileListTool : NetclawTool<FileListTool.Params>
         // directories to the audience's read roots and emits an
         // audience-sanitized error (no configured root paths leaked to Public).
         var access = _pathAccessPolicy.Evaluate(args.Path, context, PathAccessPolicy.FileOperation.Read);
-        if (!access.Allowed)
-            return Task.FromResult(context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied));
-
-        var authorizedPath = access.CanonicalPath;
+        string authorizedPath;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
+            case PathAccessDecision.Allowed allowed:
+                authorizedPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         if (!Directory.Exists(authorizedPath))
         {
@@ -84,12 +93,12 @@ public sealed partial class FileListTool : NetclawTool<FileListTool.Params>
     private string FormatListing(string directory, ToolInvocationContext context)
     {
         var dirs = Directory.EnumerateDirectories(directory)
-            .Where(path => _pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Read).Allowed)
+            .Where(path => _pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Read) is PathAccessDecision.Allowed)
             .Select(Path.GetFileName)
             .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
             .ToList();
         var files = Directory.EnumerateFiles(directory)
-            .Where(path => _pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Read).Allowed)
+            .Where(path => _pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Read) is PathAccessDecision.Allowed)
             .Select(Path.GetFileName)
             .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
             .ToList();

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -14,6 +14,8 @@ using Netclaw.Media;
 using Netclaw.Security;
 using Netclaw.Tools;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
@@ -86,10 +88,17 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             return context.InvalidInput("Error: 'path' parameter is required.");
 
         var access = _pathAccessPolicy.Evaluate(args.Path, context, PathAccessPolicy.FileOperation.Read);
-        if (!access.Allowed)
-            return context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied);
-
-        var authorizedPath = access.CanonicalPath;
+        string authorizedPath;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return context.PathAccessFailure(denied.Error, denied.Failure);
+            case PathAccessDecision.Allowed allowed:
+                authorizedPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         if (!File.Exists(authorizedPath))
             return context.NotFound($"Error: File not found: {authorizedPath}");

--- a/src/Netclaw.Actors/Tools/FileSearchTool.cs
+++ b/src/Netclaw.Actors/Tools/FileSearchTool.cs
@@ -9,6 +9,8 @@ using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 [NetclawTool(ToolName,
@@ -58,10 +60,17 @@ public sealed partial class FileSearchTool : NetclawTool<FileSearchTool.Params>
             return context.InvalidInput(limitError);
 
         var access = _pathAccessPolicy.Evaluate(args.Root, context, PathAccessPolicy.FileOperation.Read);
-        if (!access.Allowed)
-            return context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied);
-
-        var root = access.CanonicalPath;
+        string root;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return context.PathAccessFailure(denied.Error, denied.Failure);
+            case PathAccessDecision.Allowed allowed:
+                root = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         if (!Directory.Exists(root))
             return context.NotFound($"Error: Directory not found: {root}");
@@ -133,7 +142,7 @@ public sealed partial class FileSearchTool : NetclawTool<FileSearchTool.Params>
                 continue;
             }
 
-            if (!_pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Read).Allowed)
+            if (_pathAccessPolicy.Evaluate(path, context, PathAccessPolicy.FileOperation.Read) is not PathAccessDecision.Allowed)
             {
                 state.SkippedEntries++;
                 continue;

--- a/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
@@ -45,42 +45,32 @@ internal sealed class PathAccessPolicy
     }
 
     /// <summary>Returns the canonical path and the typed result of one access check.</summary>
-    internal sealed record PathAccessDecision
+    internal abstract class PathAccessDecision
     {
-        private PathAccessDecision(
-            bool allowed,
-            string canonicalPath,
-            string error,
-            PathAccessFailure? failure)
+        private PathAccessDecision() { }
+
+        internal sealed class Allowed(string canonicalPath) : PathAccessDecision
         {
-            Allowed = allowed;
-            CanonicalPath = canonicalPath;
-            Error = error;
-            Failure = failure;
+            public string CanonicalPath { get; } = canonicalPath;
         }
 
-        /// <summary>Gets whether the policy allowed the operation.</summary>
-        public bool Allowed { get; }
+        internal sealed class Denied(
+            string error,
+            PathAccessFailure failure,
+            string? diagnosticPath) : PathAccessDecision
+        {
+            public string Error { get; } = error;
+            public PathAccessFailure Failure { get; } = failure;
+            public string? DiagnosticPath { get; } = diagnosticPath;
+        }
 
-        /// <summary>Gets the canonical path when path resolution succeeded.</summary>
-        public string CanonicalPath { get; }
+        public static PathAccessDecision Allow(string canonicalPath) => new Allowed(canonicalPath);
 
-        /// <summary>Gets the operator-readable error for a denied operation.</summary>
-        public string Error { get; }
-
-        /// <summary>Gets the failure category for a denied operation.</summary>
-        public PathAccessFailure? Failure { get; }
-
-        /// <summary>Creates an allowed decision for a canonical path.</summary>
-        public static PathAccessDecision Allow(string canonicalPath)
-            => new(true, canonicalPath, string.Empty, null);
-
-        /// <summary>Creates a denied decision with a failure category and optional canonical path.</summary>
         public static PathAccessDecision Deny(
             string error,
             PathAccessFailure failure,
             string canonicalPath = "")
-            => new(false, canonicalPath, error, failure);
+            => new Denied(error, failure, canonicalPath.Length == 0 ? null : canonicalPath);
     }
 
     private readonly ToolAudienceProfileResolver _profileResolver;

--- a/src/Netclaw.Actors/Tools/ReviewedSafeShellPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ReviewedSafeShellPolicy.cs
@@ -8,6 +8,8 @@ using Netclaw.Security;
 using Netclaw.Tools;
 using ShellSyntaxTree;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
@@ -69,7 +71,7 @@ internal sealed class ReviewedSafeShellPolicy
         var pathStyle = candidates[0].Shell == ApprovalShell.PowerShell
             ? ShellPathStyle.Windows
             : ShellPathStyle.Posix;
-        if (_pathAccessPolicy.EvaluateReviewedShellPath(fullCwd, context, pathStyle).Allowed)
+        if (_pathAccessPolicy.EvaluateReviewedShellPath(fullCwd, context, pathStyle) is PathAccessDecision.Allowed)
         {
             return false;
         }
@@ -78,7 +80,7 @@ internal sealed class ReviewedSafeShellPolicy
             fullCwd,
             context,
             PathAccessPolicy.FileOperation.DeclareProjectScope);
-        if (!declaration.Allowed)
+        if (declaration is not PathAccessDecision.Allowed admittedDeclaration)
             return false;
 
         foreach (var candidate in candidates)
@@ -92,7 +94,7 @@ internal sealed class ReviewedSafeShellPolicy
                     candidate.SourceOccurrence,
                     context,
                     resolvedPaths,
-                    declaration.CanonicalPath))
+                    admittedDeclaration.CanonicalPath))
             {
                 return false;
             }
@@ -111,11 +113,11 @@ internal sealed class ReviewedSafeShellPolicy
                 return false;
             }
 
-            if (!_pathAccessPolicy.EvaluateReviewedShellPath(
+            if (_pathAccessPolicy.EvaluateReviewedShellPath(
                     fullDirectory,
                     context,
                     pathStyle,
-                    declaration.CanonicalPath).Allowed)
+                    admittedDeclaration.CanonicalPath) is not PathAccessDecision.Allowed)
             {
                 return false;
             }
@@ -217,7 +219,7 @@ internal sealed class ReviewedSafeShellPolicy
         return _pathAccessPolicy.EvaluateReviewedShellPath(
             realPath.Value,
             context,
-            pathStyle).Allowed;
+            pathStyle) is PathAccessDecision.Allowed;
     }
 
     private static bool HasFileWritingRedirect(ShellPolicyResolvedPathView? resolvedPaths)
@@ -310,12 +312,12 @@ internal sealed class ReviewedSafeShellPolicy
                 || fact.State != ShellPolicyPathResolutionState.Known
                 || fact.Paths.Count == 0
                 || fact.Paths.Any(path =>
-                    !_pathAccessPolicy.EvaluateReviewedShellPath(
+                    _pathAccessPolicy.EvaluateReviewedShellPath(
                         path.Value,
                         context,
                         path.PathStyle,
                         proposedProjectRoot,
-                        includeTrustedRootInLinkCheck).Allowed))
+                        includeTrustedRootInLinkCheck) is not PathAccessDecision.Allowed))
             {
                 return false;
             }

--- a/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
@@ -8,6 +8,8 @@ using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
 
+using PathAccessDecision = Netclaw.Actors.Tools.PathAccessPolicy.PathAccessDecision;
+
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
@@ -62,10 +64,17 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
             return Task.FromResult(context.InvalidInput("Error: path must be absolute."));
 
         var access = _pathAccessPolicy.Evaluate(raw, context, PathAccessPolicy.FileOperation.DeclareProjectScope);
-        if (!access.Allowed)
-            return Task.FromResult(context.PathAccessFailure(access.Error, access.Failure ?? PathAccessPolicy.PathAccessFailure.AccessDenied));
-
-        var fullPath = access.CanonicalPath;
+        string fullPath;
+        switch (access)
+        {
+            case PathAccessDecision.Denied denied:
+                return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
+            case PathAccessDecision.Allowed allowed:
+                fullPath = allowed.CanonicalPath;
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected path decision.");
+        }
 
         if (!Directory.Exists(fullPath))
             return Task.FromResult(context.NotFound($"Error: directory does not exist: {fullPath}"));
@@ -78,7 +87,7 @@ public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDire
            && _pathAccessPolicy.Evaluate(
                path,
                context,
-               PathAccessPolicy.FileOperation.DeclareProjectScope) is { Allowed: true } access
+               PathAccessPolicy.FileOperation.DeclareProjectScope) is PathAccessDecision.Allowed access
            && PathUtility.AreEquivalentPaths(path, access.CanonicalPath)
            && Directory.Exists(access.CanonicalPath);
 

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -539,10 +539,10 @@ public sealed class ToolAccessPolicy
             if (expandedWorkingDirectory is null)
                 return ToolAuthorizationDecision.Deny("shell_invalid_working_directory");
 
-            if (!_pathAccessPolicy.Evaluate(
+            if (_pathAccessPolicy.Evaluate(
                     expandedWorkingDirectory,
                     context.Invocation,
-                    PathAccessPolicy.FileOperation.Write).Allowed)
+                    PathAccessPolicy.FileOperation.Write) is not PathAccessPolicy.PathAccessDecision.Allowed)
                 return ToolAuthorizationDecision.Deny("shell_working_directory_outside_trust_zone");
         }
 
@@ -574,7 +574,7 @@ public sealed class ToolAccessPolicy
                      .Where(static path => !IsNullDevice(path))
                      .DistinctBy(static path => (path.PathStyle, path.Value)))
         {
-            if (!_pathAccessPolicy.EvaluateShellPath(path, context).Allowed)
+            if (_pathAccessPolicy.EvaluateShellPath(path, context) is not PathAccessPolicy.PathAccessDecision.Allowed)
                 return ToolAuthorizationDecision.Deny("shell_path_outside_trust_zone");
         }
 
@@ -652,9 +652,9 @@ public sealed class ToolAccessPolicy
             return null;
 
         var decision = _pathAccessPolicy.Evaluate(rawPath, context, request.Operation);
-        return !decision.Allowed
-               && decision.Failure is PathAccessPolicy.PathAccessFailure.AccessDenied
-            ? ToolAuthorizationDecision.Deny("path_access_denied", decision.Error)
+        return decision is PathAccessPolicy.PathAccessDecision.Denied
+            { Failure: PathAccessPolicy.PathAccessFailure.AccessDenied } denied
+            ? ToolAuthorizationDecision.Deny("path_access_denied", denied.Error)
             : null;
     }
 


### PR DESCRIPTION
Superseded by #2144. The replacement uses the same commits in the repository-native stack.

Path consumers currently combine an allowed flag with nullable error data. This change gives the internal decision separate Allowed and Denied cases. Consumers access only the data for that case.

The existing factories already constrain state combinations. The new cases remove consumer fallback categories and success-only error fields. Error categories, tool text, public contracts, and serialized shapes remain unchanged. Explicit default branches handle unexpected hierarchy cases.

Validation: the full actor suite passed 3,883 tests with six platform-specific skips. Slopwatch, headers, and whitespace checks passed.

Stack: this PR targets the authority-correction branch from #2131. Its diff contains only the result conversion. Retarget it to dev after #2131 merges.

Stack order: #2131 → #2136 → #2137 → #2139.
