### PR TITLE
Validate attachment destinations before file operations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate attachment destinations before directory creation or file copy. Deny linked and write-protected destinations.
+
 - Public and Team file tools keep access to their current session and exact
   legacy log. Other sessions require explicit configured roots.
 - Child runs inherit parent roots and restrictions. Legacy cross-run raw logs

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.70.0"
+  version: "2.71.0"
 ---
 
 # Netclaw Operations
@@ -43,6 +43,8 @@ When available, use `file_read` for a known local file read.
 When available, use `file_list` for a known local directory listing.
 Use `file_search` for bounded recursive name or literal text search.
 Use `file_read` for image metadata.
+Use `attach_file` with the authorized source path. The tool copies it into the session when necessary.
+A linked or protected destination causes a denial. Do not use shell to bypass that denial.
 Issue independent `file_read` calls in parallel when several paths are known.
 Use `tool_output_read` to continue a spilled result by call id.
 When available, use `file_write` or `file_edit` for a known local file change.

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -274,6 +274,34 @@ delivery.
 - **THEN** the tool denies the request
 - **AND** broad Personal file authority does not bypass the denial
 
+`PathAccessPolicy` SHALL validate each tool-managed destination before directory creation or file copy.
+The destination SHALL remain inside the current session workspace without links across the workspace or its known storage ancestors.
+The destination SHALL pass the protected-path write check, including collision-suffix candidates.
+Source attach permission authorizes this bounded copy; the copy SHALL NOT require general `WriteFiles` permission.
+These checks are call-local. They do not form an operating-system sandbox against concurrent filesystem changes.
+
+#### Scenario: Counterexample - attachment destination redirects a copy
+
+- **GIVEN** an admitted source outside the current workspace
+- **AND** the attachments directory or its session ancestor is a link to another directory
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` before directory creation or file copy
+- **AND** the other directory remains unchanged and the tool emits no attachment
+
+#### Scenario: Counterexample - attachment destination is write protected
+
+- **GIVEN** an admitted source and a write-protected destination
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` without a destination file or new directory
+
+#### Scenario: Attach-only profile preserves the bounded copy
+
+- **GIVEN** an attach profile admits a source and the write profile is `None`
+- **AND** the current workspace destination passes containment, link, and protected-path checks
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool copies the source and emits the attachment
+- **AND** an existing destination file retains its bytes through the existing suffix rule
+
 ### Requirement: Working directory declaration stays scoped
 
 The `session-cwd` capability SHALL own `set_working_directory` behavior and

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -92,4 +92,4 @@
 - [x] 11.1 Reproduce linked and protected destinations with an authorized source and an ordinary copy control.
 - [x] 11.2 Validate destinations before file operations through the shared path policy.
 - [x] 11.3 Verify no side effects on denial, attach-only profiles, collisions, and direct attachments.
-- [ ] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.
+- [x] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -86,3 +86,10 @@
 - [x] 10.3 Verify real file tools, child authority, explicit profiles, and the existing shell denial boundary.
 - [x] 10.4 Align specification, glossary references, profile comments, operations skill, and release notes.
 - [x] 10.5 Run focused and related tests, evals, Slopwatch, headers, and strict OpenSpec validation; record limits.
+
+## 11. Validate tool-managed attachment destinations
+
+- [x] 11.1 Reproduce linked and protected destinations with an authorized source and an ordinary copy control.
+- [x] 11.2 Validate destinations before file operations through the shared path policy.
+- [x] 11.3 Verify no side effects on denial, attach-only profiles, collisions, and direct attachments.
+- [ ] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -529,33 +529,64 @@ be built into `file_read`.
 ### Requirement: Attachment tool reach
 
 The system SHALL provide an `attach_file` first-party tool that sends a file to
-the user. Public and Team sessions SHALL attach only files admitted by their current
-session paths or explicit configured roots. Personal retains shared-session
-reach under its existing attach profile.
-Interactive Personal-audience sessions get shell-equivalent reach: any path that
-resolves through the read-access policy SHALL be attachable, and the file SHALL
-be copied into the current session's attachments directory before delivery.
-
-All audiences SHALL apply the `ToolPathPolicy` read-deny surface to attached
-files: a path that `IsReadDenied` (credentials, keys, secrets, control-plane
-state, or the shell indicator list) SHALL NOT be attachable, even when the
-proximity restriction is lifted.
+the user. It SHALL authorize the source with the shared `Attach` path access
+decision. An explicit `Roots` or `None` attach profile SHALL remain authoritative
+in every interaction mode. The default interactive Personal `All` profile MAY
+attach an external file after the protected-path checks pass. The tool SHALL
+copy an admitted file into the current session's attachments directory before
+delivery.
 
 #### Scenario: Interactive Personal session attaches an external file
 
-- **GIVEN** an interactive Personal session can read a file outside its session
-  directory
+- **GIVEN** the default interactive Personal attach profile permits an external
+  file
 - **WHEN** the agent invokes `attach_file` for that file
 - **THEN** the tool copies the file into the current session attachments directory
 - **AND** the tool sends the copied file to the user
 
+#### Scenario: Counterexample - explicit attach roots remain authoritative
+
+- **GIVEN** an interactive Personal profile explicitly limits attachments to
+  one root
+- **WHEN** the agent invokes `attach_file` outside that root
+- **THEN** file protection denies the invocation
+- **AND** user approval does not widen the attach profile
+
 #### Scenario: Protected control-plane file cannot be attached
 
-- **GIVEN** an interactive Personal session requests a file that
-  `ToolPathPolicy.IsReadDenied` protects
+- **GIVEN** an interactive Personal session requests a protected control-plane
+  file
 - **WHEN** the agent invokes `attach_file`
 - **THEN** the tool denies the request
-- **AND** the shell-equivalent read reach does not bypass the denial
+- **AND** broad Personal file authority does not bypass the denial
+
+`PathAccessPolicy` SHALL validate each tool-managed destination before directory creation or file copy.
+The destination SHALL remain inside the current session workspace without links across the workspace or its known storage ancestors.
+The destination SHALL pass the protected-path write check, including collision-suffix candidates.
+Source attach permission authorizes this bounded copy; the copy SHALL NOT require general `WriteFiles` permission.
+These checks are call-local. They do not form an operating-system sandbox against concurrent filesystem changes.
+
+#### Scenario: Counterexample - attachment destination redirects a copy
+
+- **GIVEN** an admitted source outside the current workspace
+- **AND** the attachments directory or its session ancestor is a link to another directory
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` before directory creation or file copy
+- **AND** the other directory remains unchanged and the tool emits no attachment
+
+#### Scenario: Counterexample - attachment destination is write protected
+
+- **GIVEN** an admitted source and a write-protected destination
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` without a destination file or new directory
+
+#### Scenario: Attach-only profile preserves the bounded copy
+
+- **GIVEN** an attach profile admits a source and the write profile is `None`
+- **AND** the current workspace destination passes containment, link, and protected-path checks
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool copies the source and emits the attachment
+- **AND** an existing destination file retains its bytes through the existing suffix rule
 
 ### Requirement: Working directory declaration stays scoped
 

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -291,6 +291,102 @@ public class AttachFileToolTests : IDisposable
         Assert.Equal("image/png", attachment.MimeType.Value);
     }
 
+    [Theory]
+    [InlineData("attachments")]
+    [InlineData("workspace")]
+    [InlineData("ancestor")]
+    [InlineData("protected")]
+    public async Task AuthorityRegression_AttachmentDestination_denies_before_copy(string boundary)
+    {
+        var paths = new NetclawPaths(_dir.Path);
+        var envelope = Path.Combine(paths.SessionsDirectory, "current");
+        var session = Path.Combine(envelope, "workspace");
+        var outside = Path.Combine(_dir.Path, "outside");
+        Directory.CreateDirectory(outside);
+        Directory.CreateDirectory(paths.SessionsDirectory);
+        var source = Path.Combine(_dir.Path, "source.txt");
+        await File.WriteAllTextAsync(source, "source marker", TestContext.Current.CancellationToken);
+
+        if (boundary == "ancestor")
+            Directory.CreateSymbolicLink(envelope, outside);
+        else
+            Directory.CreateDirectory(envelope);
+        if (boundary == "workspace")
+            Directory.CreateSymbolicLink(session, outside);
+        else
+            Directory.CreateDirectory(session);
+        var attachments = Path.Combine(session, "attachments");
+        if (boundary == "attachments")
+            Directory.CreateSymbolicLink(attachments, outside);
+
+        var tool = new AttachFileTool(new ToolConfig(), paths, new ToolPathPolicy(
+            boundary == "protected" ? [attachments] : [], [], []));
+        var before = Directory.GetFiles(outside, "*", SearchOption.AllDirectories);
+        var context = TestToolExecutionContext.CreateBound("current", session, TrustAudience.Personal);
+        await tool.ExecuteAsync(ToolInput.Create("Path", source), context, TestContext.Current.CancellationToken);
+
+        Assert.Equal(before, Directory.GetFiles(outside, "*", SearchOption.AllDirectories));
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.Empty(context.FileAttachments);
+        Assert.Equal("source marker", await File.ReadAllTextAsync(source, TestContext.Current.CancellationToken));
+        if (boundary != "attachments")
+            Assert.False(Directory.Exists(attachments));
+    }
+
+    [Fact]
+    public async Task AuthorityRegression_AttachmentDestination_copy_preserves_collision_and_direct_access()
+    {
+        var source = Path.Combine(_dir.Path, "report.txt");
+        var session = Path.Combine(_dir.Path, "session");
+        var attachments = Path.Combine(session, "attachments");
+        Directory.CreateDirectory(attachments);
+        await File.WriteAllTextAsync(source, "new report", TestContext.Current.CancellationToken);
+        var previous = Path.Combine(attachments, "report.txt");
+        await File.WriteAllTextAsync(previous, "previous report", TestContext.Current.CancellationToken);
+        var context = TestToolExecutionContext.CreateBound("current", session, TrustAudience.Personal);
+
+        await _tool.ExecuteAsync(ToolInput.Create("Path", source, "DisplayName", "Report.txt"), context,
+            TestContext.Current.CancellationToken);
+
+        var attachment = Assert.Single(context.FileAttachments);
+        Assert.Equal(Path.Combine(attachments, "report-1.txt"), attachment.FilePath);
+        Assert.Equal("Report.txt", attachment.FileName);
+        Assert.Equal("text/plain", attachment.MimeType.Value);
+        Assert.Equal("new report", await File.ReadAllTextAsync(attachment.FilePath, TestContext.Current.CancellationToken));
+        Assert.Equal("previous report", await File.ReadAllTextAsync(previous, TestContext.Current.CancellationToken));
+        var direct = TestToolExecutionContext.CreateBound("current", session, TrustAudience.Personal);
+        await _tool.ExecuteAsync(ToolInput.Create("Path", attachment.FilePath), direct, TestContext.Current.CancellationToken);
+        Assert.Equal(attachment.FilePath, Assert.Single(direct.FileAttachments).FilePath);
+        Assert.Equal(2, Directory.GetFiles(attachments).Length);
+    }
+
+    [Theory]
+    [InlineData(TrustAudience.Public)]
+    [InlineData(TrustAudience.Team)]
+    public async Task AuthorityRegression_AttachmentDestination_attach_permission_does_not_require_general_writes(TrustAudience audience)
+    {
+        var source = Path.Combine(_dir.Path, "report.txt");
+        await File.WriteAllTextAsync(source, "report", TestContext.Current.CancellationToken);
+        var session = Path.Combine(_dir.Path, "session");
+        var config = new ToolConfig();
+        var profile = audience == TrustAudience.Public ? config.AudienceProfiles.Public : config.AudienceProfiles.Team;
+        profile.AttachFiles.Roots.Add(source);
+        profile.WriteFiles.Mode = ToolFilesystemMode.None;
+        var tool = new AttachFileTool(config, new NetclawPaths(_dir.Path), new ToolPathPolicy([]));
+        var context = TestToolExecutionContext.CreateBound("current", session, audience);
+
+        await tool.ExecuteAsync(ToolInput.Create("Path", source), context, TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
+        var copy = Assert.Single(context.FileAttachments).FilePath;
+        Assert.Equal("report", await File.ReadAllTextAsync(copy, TestContext.Current.CancellationToken));
+        var write = TestToolExecutionContext.CreateBound("current", session, audience);
+        await new FileWriteTool(config, new NetclawPaths(_dir.Path), new ToolPathPolicy([])).ExecuteAsync(
+            ToolInput.Create("Path", copy, "Content", "replacement"), write, TestContext.Current.CancellationToken);
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, write.Receipt?.Category);
+        Assert.Equal("report", await File.ReadAllTextAsync(copy, TestContext.Current.CancellationToken));
+    }
+
     [Fact]
     public async Task Public_context_cannot_attach_file_outside_session_directory()
     {

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -84,12 +84,23 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         }
         var resolvedInCurrentSession = PathUtility.IsWithinRoot(resolvedPath, sessionDir);
 
-        var attachPath = resolvedInCurrentSession
-            ? resolvedPath
-            : CopyIntoCurrentSession(resolvedPath, sessionDir);
+        var attachPath = resolvedPath;
+        if (!resolvedInCurrentSession)
+        {
+            switch (ResolveCopyDestination(resolvedPath, sessionDir, context))
+            {
+                case PathAccessDecision.Denied denied:
+                    return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
+                case PathAccessDecision.Allowed allowed:
+                    attachPath = allowed.CanonicalPath;
+                    break;
+                default:
+                    throw new InvalidOperationException("Unexpected path decision.");
+            }
 
-        if (!PathUtility.IsWithinRoot(attachPath, sessionDir))
-            return Task.FromResult(context.AccessDenied($"Error: Attach path escaped the session directory ({sessionDir})."));
+            Directory.CreateDirectory(Path.GetDirectoryName(attachPath)!);
+            File.Copy(resolvedPath, attachPath);
+        }
 
         var rawFilename = args.DisplayName ?? Path.GetFileName(attachPath);
         var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
@@ -113,10 +124,13 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         return target is null ? fileInfo.FullName : target.FullName;
     }
 
-    private static string CopyIntoCurrentSession(string sourcePath, string sessionDir)
+    private PathAccessDecision ResolveCopyDestination(
+        string sourcePath, string sessionDir, ToolInvocationContext context)
     {
         var attachmentsDir = Path.Combine(sessionDir, "attachments");
-        Directory.CreateDirectory(attachmentsDir);
+        var directoryAccess = _pathAccessPolicy.EvaluateAttachmentDestination(attachmentsDir, context);
+        if (directoryAccess is PathAccessDecision.Denied)
+            return directoryAccess;
 
         var baseName = Path.GetFileNameWithoutExtension(sourcePath);
         var extension = Path.GetExtension(sourcePath);
@@ -125,15 +139,16 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var destination = Path.Combine(attachmentsDir, fileName);
         var suffix = 1;
 
-        while (File.Exists(destination))
+        while (true)
         {
+            var access = _pathAccessPolicy.EvaluateAttachmentDestination(destination, context);
+            if (access is PathAccessDecision.Denied || !File.Exists(destination))
+                return access;
+
             fileName = $"{sanitizedBase}-{suffix}{extension}";
             destination = Path.Combine(attachmentsDir, fileName);
             suffix++;
         }
-
-        File.Copy(sourcePath, destination);
-        return destination;
     }
 
 }

--- a/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
@@ -139,6 +139,25 @@ internal sealed class PathAccessPolicy
         return AllowIfUnprotected(canonicalPath, ToProtectionOperation(operation));
     }
 
+    /// <summary>Checks a tool-managed attachment destination before any file operation.</summary>
+    internal PathAccessDecision EvaluateAttachmentDestination(string path, ToolInvocationContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.SessionDirectory))
+            return PathAccessDecision.Deny("Error: invalid_context: No session directory available.", PathAccessFailure.InvalidInput);
+
+        var canonicalPath = PathUtility.Normalize(path);
+        var sessionDirectory = PathUtility.Normalize(context.SessionDirectory);
+        if (GetHostPathRelationship(canonicalPath, [sessionDirectory]) != PathRelationship.WithinTrustedRoot)
+        {
+            return PathAccessDecision.Deny(
+                $"Error: Attachment destination must stay inside the current session directory without links ({sessionDirectory}).",
+                PathAccessFailure.AccessDenied, canonicalPath);
+        }
+
+        // Source authorization permits this tool-managed copy. It does not grant general file-write access.
+        return AllowIfUnprotected(canonicalPath, FileOperation.Write);
+    }
+
     /// <summary>Applies file protection to one parser-canonical shell path.</summary>
     public PathAccessDecision EvaluateShellPath(
         CanonicalShellPath path,


### PR DESCRIPTION
Superseded by #2145. The replacement uses the same commits in the repository-native stack.

An authorized external attachment source can currently copy through a linked destination directory. The tool also misses the destination write-protection check. This change validates each generated destination before directory creation or file copy.

The shared path policy checks current-workspace containment, links through known storage ancestors, and protected write paths. The copy remains a bounded part of attach permission. Public and Team do not need general file-write permission for an authorized attachment.

Validation:

- Four new denial cases failed on the unchanged baseline. The ordinary-copy control passed. The same cases passed after the correction.
- The full actor suite passed 3,890 tests, with six platform-specific skips. Controls cover direct attachments, suffix collisions, and attach-only profiles.
- The direct-attachment and operations-skill evals each passed four of five runs at the existing 80% threshold. The failed attachment run added a file_list prelude. The failed operations run timed out without output.
- Slopwatch, headers, strict OpenSpec validation, and whitespace checks passed.

These checks address pre-existing destination links. They do not provide an operating-system sandbox against concurrent filesystem changes. Native Windows proof remains pending.

Stack: this PR targets #2136. Retarget it after that PR merges. Storage paths and file layout retain their current form.

Stack order: #2131 → #2136 → #2137 → #2139.
