### PR TITLE
Validate generated file destinations before writes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate attachment destinations before directory creation or file copy. Deny linked and write-protected destinations.
+
 - Public and Team file tools keep access to their current session and exact
   legacy log. Other sessions require explicit configured roots.
 - Child runs inherit parent roots and restrictions. Legacy cross-run raw logs

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.71.0"
+  version: "2.71.1"
 ---
 
 # Netclaw Operations
@@ -119,6 +119,9 @@ Use a legacy child's summary and shared-workspace artifacts instead.
 Directory list and search require directory authority; an exact log grants none.
 Do not use shell to find session logs.
 Normal audience and operation policy applies to every session path.
+Attachment copies and fetched files must pass destination checks before Netclaw saves them.
+A permitted copy or fetch does not enable general file-write access.
+If a save fails, report the tool error; do not claim that the file exists.
 Netclaw does not automatically remove managed temporary files or worktrees.
 
 Use `shell_execute` to run Git with a destination below `worktree_dir`.

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.70.0"
+  version: "2.71.0"
 ---
 
 # Netclaw Operations
@@ -43,6 +43,8 @@ When available, use `file_read` for a known local file read.
 When available, use `file_list` for a known local directory listing.
 Use `file_search` for bounded recursive name or literal text search.
 Use `file_read` for image metadata.
+Use `attach_file` with the authorized source path. The tool copies it into the session when necessary.
+A linked or protected destination causes a denial. Do not use shell to bypass that denial.
 Issue independent `file_read` calls in parallel when several paths are known.
 Use `tool_output_read` to continue a spilled result by call id.
 When available, use `file_write` or `file_edit` for a known local file change.

--- a/feeds/skills/.system/files/search-citation/SKILL.md
+++ b/feeds/skills/.system/files/search-citation/SKILL.md
@@ -3,7 +3,7 @@ name: search-citation
 description: "REQUIRED when the user asks you to search, look up, verify, buy, shop, compare, price-check, find current info, or check facts online. Contains citation format rules for web_search and web_fetch."
 metadata:
   author: netclaw
-  version: "1.1.1"
+  version: "1.1.2"
 ---
 
 ## Critical Rules Summary
@@ -104,3 +104,9 @@ summarization of article body text).
 
 - Tool grants and capabilities: load `netclaw-operations`
 - Search-type-specific guidance: see `references/` files in this skill directory
+
+## Saved Fetch Files
+
+`web_fetch` saves responses in the current session workspace.
+It rejects output paths that use filesystem links or protected write locations.
+A denied save returns an error. Report that error instead of inventing a saved file path.

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -852,3 +852,28 @@ files.
 
 None. A later cleanup specification will define retention, active-session
 leases, quotas, and deletion.
+
+## Generated destination review correction
+
+Attachment copies and fetch responses use `PathAccessPolicy.EvaluateGeneratedDestination`.
+The caller selects the output directory from existing runtime data:
+
+| Caller | Directory source | Permission that permits the operation |
+|---|---|---|
+| Attachment copy | Current session workspace | Source attachment permission |
+| Bound web fetch | Current session workspace | Web tool permission |
+| Sessionless web fetch | Configured fetch directory | Web tool permission |
+
+The directory is call-local. The helper creates no ownership record or persistent grant.
+Its caller passes a generated filename, never a destination supplied by the model.
+The policy checks containment, links, and protected writes before the caller creates a directory or writes a file.
+It reports malformed paths as `InvalidInput`. The existing operation permission remains required.
+
+```text
+permitted tool call -> generate output path -> check destination
+  denied -> return error, create nothing
+  allowed -> create output directory -> write response or copy source
+```
+
+This order does not bind the write to an operating-system directory handle.
+A process with directory-write permission can still replace a directory after the check.

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -274,6 +274,34 @@ delivery.
 - **THEN** the tool denies the request
 - **AND** broad Personal file authority does not bypass the denial
 
+`PathAccessPolicy` SHALL validate each tool-managed destination before directory creation or file copy.
+The destination SHALL remain inside the current session workspace without links across the workspace or its known storage ancestors.
+The destination SHALL pass the protected-path write check, including collision-suffix candidates.
+Source attach permission authorizes this bounded copy; the copy SHALL NOT require general `WriteFiles` permission.
+These checks are call-local. They do not form an operating-system sandbox against concurrent filesystem changes.
+
+#### Scenario: Counterexample - attachment destination redirects a copy
+
+- **GIVEN** an admitted source outside the current workspace
+- **AND** the attachments directory or its session ancestor is a link to another directory
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` before directory creation or file copy
+- **AND** the other directory remains unchanged and the tool emits no attachment
+
+#### Scenario: Counterexample - attachment destination is write protected
+
+- **GIVEN** an admitted source and a write-protected destination
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` without a destination file or new directory
+
+#### Scenario: Attach-only profile preserves the bounded copy
+
+- **GIVEN** an attach profile admits a source and the write profile is `None`
+- **AND** the current workspace destination passes containment, link, and protected-path checks
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool copies the source and emits the attachment
+- **AND** an existing destination file retains its bytes through the existing suffix rule
+
 ### Requirement: Working directory declaration stays scoped
 
 The `session-cwd` capability SHALL own `set_working_directory` behavior and

--- a/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/netclaw-tools/spec.md
@@ -242,6 +242,8 @@ video keyframe extraction SHALL NOT be built into `file_read`.
 
 ### Requirement: Attachment tool reach
 
+All audiences SHALL apply the `ToolPathPolicy` read-deny check to attachment sources.
+
 The system SHALL provide an `attach_file` first-party tool that sends a file to
 the user. It SHALL authorize the source with the shared `Attach` path access
 decision. An explicit `Roots` or `None` attach profile SHALL remain authoritative
@@ -664,3 +666,30 @@ secret storage remain authoritative.
 - **THEN** it receives the persisted non-secret file content
 - **AND** the tool does not claim that the file explains the source or
   effective value of every configuration setting
+
+### Requirement: Generated fetch destinations
+
+`PathAccessPolicy` SHALL check generated fetch paths before directory creation or file writes.
+A bound session SHALL use its current workspace. A sessionless fetch SHALL use its configured fetch directory.
+The check SHALL reject paths outside that directory, filesystem links, and protected write destinations.
+A permitted fetch SHALL NOT require general file-write permission to save its response.
+The tool SHALL return an explicit denial for an invalid destination and SHALL NOT create files or directories there.
+These checks do not prevent another process from replacing a directory after validation.
+
+#### Scenario: Fetch saves a response in an ordinary directory
+
+- **GIVEN** a permitted fetch and an output directory without links or write protection
+- **WHEN** the tool receives text or binary content
+- **THEN** it creates the output directory if needed and saves the response there
+
+#### Scenario: Fetch cannot write through a linked directory
+
+- **GIVEN** a session workspace or sessionless fetch directory that is a link
+- **WHEN** the tool receives a response
+- **THEN** it returns `AccessDenied` without writing through that link
+
+#### Scenario: Fetch cannot write protected output
+
+- **GIVEN** an output directory that the protected-path policy denies for writes
+- **WHEN** the tool receives a response
+- **THEN** it returns `AccessDenied` without creating that directory or an output file

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -92,4 +92,4 @@
 - [x] 11.1 Reproduce linked and protected destinations with an authorized source and an ordinary copy control.
 - [x] 11.2 Validate destinations before file operations through the shared path policy.
 - [x] 11.3 Verify no side effects on denial, attach-only profiles, collisions, and direct attachments.
-- [ ] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.
+- [x] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -86,3 +86,10 @@
 - [x] 10.3 Verify real file tools, child authority, explicit profiles, and the existing shell denial boundary.
 - [x] 10.4 Align specification, glossary references, profile comments, operations skill, and release notes.
 - [x] 10.5 Run focused and related tests, evals, Slopwatch, headers, and strict OpenSpec validation; record limits.
+
+## 11. Validate tool-managed attachment destinations
+
+- [x] 11.1 Reproduce linked and protected destinations with an authorized source and an ordinary copy control.
+- [x] 11.2 Validate destinations before file operations through the shared path policy.
+- [x] 11.3 Verify no side effects on denial, attach-only profiles, collisions, and direct attachments.
+- [ ] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -529,33 +529,64 @@ be built into `file_read`.
 ### Requirement: Attachment tool reach
 
 The system SHALL provide an `attach_file` first-party tool that sends a file to
-the user. Public and Team sessions SHALL attach only files admitted by their current
-session paths or explicit configured roots. Personal retains shared-session
-reach under its existing attach profile.
-Interactive Personal-audience sessions get shell-equivalent reach: any path that
-resolves through the read-access policy SHALL be attachable, and the file SHALL
-be copied into the current session's attachments directory before delivery.
-
-All audiences SHALL apply the `ToolPathPolicy` read-deny surface to attached
-files: a path that `IsReadDenied` (credentials, keys, secrets, control-plane
-state, or the shell indicator list) SHALL NOT be attachable, even when the
-proximity restriction is lifted.
+the user. It SHALL authorize the source with the shared `Attach` path access
+decision. An explicit `Roots` or `None` attach profile SHALL remain authoritative
+in every interaction mode. The default interactive Personal `All` profile MAY
+attach an external file after the protected-path checks pass. The tool SHALL
+copy an admitted file into the current session's attachments directory before
+delivery.
 
 #### Scenario: Interactive Personal session attaches an external file
 
-- **GIVEN** an interactive Personal session can read a file outside its session
-  directory
+- **GIVEN** the default interactive Personal attach profile permits an external
+  file
 - **WHEN** the agent invokes `attach_file` for that file
 - **THEN** the tool copies the file into the current session attachments directory
 - **AND** the tool sends the copied file to the user
 
+#### Scenario: Counterexample - explicit attach roots remain authoritative
+
+- **GIVEN** an interactive Personal profile explicitly limits attachments to
+  one root
+- **WHEN** the agent invokes `attach_file` outside that root
+- **THEN** file protection denies the invocation
+- **AND** user approval does not widen the attach profile
+
 #### Scenario: Protected control-plane file cannot be attached
 
-- **GIVEN** an interactive Personal session requests a file that
-  `ToolPathPolicy.IsReadDenied` protects
+- **GIVEN** an interactive Personal session requests a protected control-plane
+  file
 - **WHEN** the agent invokes `attach_file`
 - **THEN** the tool denies the request
-- **AND** the shell-equivalent read reach does not bypass the denial
+- **AND** broad Personal file authority does not bypass the denial
+
+`PathAccessPolicy` SHALL validate each tool-managed destination before directory creation or file copy.
+The destination SHALL remain inside the current session workspace without links across the workspace or its known storage ancestors.
+The destination SHALL pass the protected-path write check, including collision-suffix candidates.
+Source attach permission authorizes this bounded copy; the copy SHALL NOT require general `WriteFiles` permission.
+These checks are call-local. They do not form an operating-system sandbox against concurrent filesystem changes.
+
+#### Scenario: Counterexample - attachment destination redirects a copy
+
+- **GIVEN** an admitted source outside the current workspace
+- **AND** the attachments directory or its session ancestor is a link to another directory
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` before directory creation or file copy
+- **AND** the other directory remains unchanged and the tool emits no attachment
+
+#### Scenario: Counterexample - attachment destination is write protected
+
+- **GIVEN** an admitted source and a write-protected destination
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool returns `AccessDenied` without a destination file or new directory
+
+#### Scenario: Attach-only profile preserves the bounded copy
+
+- **GIVEN** an attach profile admits a source and the write profile is `None`
+- **AND** the current workspace destination passes containment, link, and protected-path checks
+- **WHEN** the agent invokes `attach_file`
+- **THEN** the tool copies the source and emits the attachment
+- **AND** an existing destination file retains its bytes through the existing suffix rule
 
 ### Requirement: Working directory declaration stays scoped
 

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -528,6 +528,8 @@ be built into `file_read`.
 
 ### Requirement: Attachment tool reach
 
+All audiences SHALL apply the `ToolPathPolicy` read-deny check to attachment sources.
+
 The system SHALL provide an `attach_file` first-party tool that sends a file to
 the user. It SHALL authorize the source with the shared `Attach` path access
 decision. An explicit `Roots` or `None` attach profile SHALL remain authoritative
@@ -786,3 +788,30 @@ an active log writer on POSIX and Windows.
 - **WHEN** either reads the other's log or enumerates the shared log parent
 - **THEN** access is denied without explicit authority
 - **AND** the parent can still read the child's shared-workspace artifacts
+
+### Requirement: Generated fetch destinations
+
+`PathAccessPolicy` SHALL check generated fetch paths before directory creation or file writes.
+A bound session SHALL use its current workspace. A sessionless fetch SHALL use its configured fetch directory.
+The check SHALL reject paths outside that directory, filesystem links, and protected write destinations.
+A permitted fetch SHALL NOT require general file-write permission to save its response.
+The tool SHALL return an explicit denial for an invalid destination and SHALL NOT create files or directories there.
+These checks do not prevent another process from replacing a directory after validation.
+
+#### Scenario: Fetch saves a response in an ordinary directory
+
+- **GIVEN** a permitted fetch and an output directory without links or write protection
+- **WHEN** the tool receives text or binary content
+- **THEN** it creates the output directory if needed and saves the response there
+
+#### Scenario: Fetch cannot write through a linked directory
+
+- **GIVEN** a session workspace or sessionless fetch directory that is a link
+- **WHEN** the tool receives a response
+- **THEN** it returns `AccessDenied` without writing through that link
+
+#### Scenario: Fetch cannot write protected output
+
+- **GIVEN** an output directory that the protected-path policy denies for writes
+- **WHEN** the tool receives a response
+- **THEN** it returns `AccessDenied` without creating that directory or an output file

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -387,6 +387,63 @@ public class AttachFileToolTests : IDisposable
         Assert.Equal("report", await File.ReadAllTextAsync(copy, TestContext.Current.CancellationToken));
     }
 
+    [Theory]
+    [InlineData("protected-suffix")]
+    [InlineData("file-link")]
+    [InlineData("dangling-link")]
+    public async Task ReviewRegression_Attachment_checks_each_destination_file(string boundary)
+    {
+        var source = Path.Combine(_dir.Path, "report.txt");
+        var session = Path.Combine(_dir.Path, "session");
+        var attachments = Path.Combine(session, "attachments");
+        var outside = Path.Combine(_dir.Path, "outside.txt");
+        Directory.CreateDirectory(attachments);
+        await File.WriteAllTextAsync(source, "source marker", TestContext.Current.CancellationToken);
+        var destination = Path.Combine(attachments, "report.txt");
+        var suffix = Path.Combine(attachments, "report-1.txt");
+        if (boundary == "protected-suffix")
+            await File.WriteAllTextAsync(destination, "previous marker", TestContext.Current.CancellationToken);
+        else
+        {
+            if (boundary == "file-link")
+                await File.WriteAllTextAsync(outside, "outside marker", TestContext.Current.CancellationToken);
+            File.CreateSymbolicLink(destination, outside);
+        }
+        var protectedPaths = new ToolPathPolicy(boundary == "protected-suffix" ? [suffix] : []);
+        var tool = new AttachFileTool(new ToolConfig(), new NetclawPaths(_dir.Path), protectedPaths);
+        var context = TestToolExecutionContext.CreateBound("probe", session, TrustAudience.Personal);
+
+        var result = await tool.ExecuteAsync(ToolInput.Create("Path", source), context, TestContext.Current.CancellationToken);
+
+        Assert.StartsWith("Error:", result);
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.Empty(context.FileAttachments);
+        Assert.False(File.Exists(suffix));
+        Assert.Equal("source marker", await File.ReadAllTextAsync(source, TestContext.Current.CancellationToken));
+        if (boundary == "protected-suffix")
+            Assert.Equal("previous marker", await File.ReadAllTextAsync(destination, TestContext.Current.CancellationToken));
+        else if (boundary == "file-link")
+            Assert.Equal("outside marker", await File.ReadAllTextAsync(outside, TestContext.Current.CancellationToken));
+        else
+            Assert.False(File.Exists(outside));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ReviewRegression_Invalid_generated_destination_returns_a_denial(bool missingDirectory)
+    {
+        var output = Path.Combine(_dir.Path, "output");
+        var policy = new PathAccessPolicy(new ToolConfig(), new NetclawPaths(_dir.Path), new ToolPathPolicy([]));
+        var result = policy.EvaluateGeneratedDestination(missingDirectory ? Path.Combine(output, "file.txt") : "invalid\0path",
+            missingDirectory ? string.Empty : output);
+
+        var denied = Assert.IsType<PathAccessPolicy.PathAccessDecision.Denied>(result);
+        Assert.Equal(PathAccessPolicy.PathAccessFailure.InvalidInput, denied.Failure);
+        Assert.StartsWith("Error:", denied.Error);
+        Assert.False(Directory.Exists(output));
+    }
+
     [Fact]
     public async Task Public_context_cannot_attach_file_outside_session_directory()
     {

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -291,6 +291,102 @@ public class AttachFileToolTests : IDisposable
         Assert.Equal("image/png", attachment.MimeType.Value);
     }
 
+    [Theory]
+    [InlineData("attachments")]
+    [InlineData("workspace")]
+    [InlineData("ancestor")]
+    [InlineData("protected")]
+    public async Task AuthorityRegression_AttachmentDestination_denies_before_copy(string boundary)
+    {
+        var paths = new NetclawPaths(_dir.Path);
+        var envelope = Path.Combine(paths.SessionsDirectory, "current");
+        var session = Path.Combine(envelope, "workspace");
+        var outside = Path.Combine(_dir.Path, "outside");
+        Directory.CreateDirectory(outside);
+        Directory.CreateDirectory(paths.SessionsDirectory);
+        var source = Path.Combine(_dir.Path, "source.txt");
+        await File.WriteAllTextAsync(source, "source marker", TestContext.Current.CancellationToken);
+
+        if (boundary == "ancestor")
+            Directory.CreateSymbolicLink(envelope, outside);
+        else
+            Directory.CreateDirectory(envelope);
+        if (boundary == "workspace")
+            Directory.CreateSymbolicLink(session, outside);
+        else
+            Directory.CreateDirectory(session);
+        var attachments = Path.Combine(session, "attachments");
+        if (boundary == "attachments")
+            Directory.CreateSymbolicLink(attachments, outside);
+
+        var tool = new AttachFileTool(new ToolConfig(), paths, new ToolPathPolicy(
+            boundary == "protected" ? [attachments] : [], [], []));
+        var before = Directory.GetFiles(outside, "*", SearchOption.AllDirectories);
+        var context = TestToolExecutionContext.CreateBound("current", session, TrustAudience.Personal);
+        await tool.ExecuteAsync(ToolInput.Create("Path", source), context, TestContext.Current.CancellationToken);
+
+        Assert.Equal(before, Directory.GetFiles(outside, "*", SearchOption.AllDirectories));
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.Empty(context.FileAttachments);
+        Assert.Equal("source marker", await File.ReadAllTextAsync(source, TestContext.Current.CancellationToken));
+        if (boundary != "attachments")
+            Assert.False(Directory.Exists(attachments));
+    }
+
+    [Fact]
+    public async Task AuthorityRegression_AttachmentDestination_copy_preserves_collision_and_direct_access()
+    {
+        var source = Path.Combine(_dir.Path, "report.txt");
+        var session = Path.Combine(_dir.Path, "session");
+        var attachments = Path.Combine(session, "attachments");
+        Directory.CreateDirectory(attachments);
+        await File.WriteAllTextAsync(source, "new report", TestContext.Current.CancellationToken);
+        var previous = Path.Combine(attachments, "report.txt");
+        await File.WriteAllTextAsync(previous, "previous report", TestContext.Current.CancellationToken);
+        var context = TestToolExecutionContext.CreateBound("current", session, TrustAudience.Personal);
+
+        await _tool.ExecuteAsync(ToolInput.Create("Path", source, "DisplayName", "Report.txt"), context,
+            TestContext.Current.CancellationToken);
+
+        var attachment = Assert.Single(context.FileAttachments);
+        Assert.Equal(Path.Combine(attachments, "report-1.txt"), attachment.FilePath);
+        Assert.Equal("Report.txt", attachment.FileName);
+        Assert.Equal("text/plain", attachment.MimeType.Value);
+        Assert.Equal("new report", await File.ReadAllTextAsync(attachment.FilePath, TestContext.Current.CancellationToken));
+        Assert.Equal("previous report", await File.ReadAllTextAsync(previous, TestContext.Current.CancellationToken));
+        var direct = TestToolExecutionContext.CreateBound("current", session, TrustAudience.Personal);
+        await _tool.ExecuteAsync(ToolInput.Create("Path", attachment.FilePath), direct, TestContext.Current.CancellationToken);
+        Assert.Equal(attachment.FilePath, Assert.Single(direct.FileAttachments).FilePath);
+        Assert.Equal(2, Directory.GetFiles(attachments).Length);
+    }
+
+    [Theory]
+    [InlineData(TrustAudience.Public)]
+    [InlineData(TrustAudience.Team)]
+    public async Task AuthorityRegression_AttachmentDestination_attach_permission_does_not_require_general_writes(TrustAudience audience)
+    {
+        var source = Path.Combine(_dir.Path, "report.txt");
+        await File.WriteAllTextAsync(source, "report", TestContext.Current.CancellationToken);
+        var session = Path.Combine(_dir.Path, "session");
+        var config = new ToolConfig();
+        var profile = audience == TrustAudience.Public ? config.AudienceProfiles.Public : config.AudienceProfiles.Team;
+        profile.AttachFiles.Roots.Add(source);
+        profile.WriteFiles.Mode = ToolFilesystemMode.None;
+        var tool = new AttachFileTool(config, new NetclawPaths(_dir.Path), new ToolPathPolicy([]));
+        var context = TestToolExecutionContext.CreateBound("current", session, audience);
+
+        await tool.ExecuteAsync(ToolInput.Create("Path", source), context, TestContext.Current.CancellationToken);
+
+        Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
+        var copy = Assert.Single(context.FileAttachments).FilePath;
+        Assert.Equal("report", await File.ReadAllTextAsync(copy, TestContext.Current.CancellationToken));
+        var write = TestToolExecutionContext.CreateBound("current", session, audience);
+        await new FileWriteTool(config, new NetclawPaths(_dir.Path), new ToolPathPolicy([])).ExecuteAsync(
+            ToolInput.Create("Path", copy, "Content", "replacement"), write, TestContext.Current.CancellationToken);
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, write.Receipt?.Category);
+        Assert.Equal("report", await File.ReadAllTextAsync(copy, TestContext.Current.CancellationToken));
+    }
+
     [Fact]
     public async Task Public_context_cannot_attach_file_outside_session_directory()
     {

--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tests.Utilities;
 using Xunit;
 
@@ -274,7 +275,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(html, "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/test"),
@@ -315,7 +316,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(html, "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/test", "Format", "text"),
@@ -347,7 +348,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(html, "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/page"),
@@ -371,7 +372,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(json, "application/json");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://api.example.com/data.json"),
@@ -394,7 +395,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(json, "application/json");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://api.example.com/data"),
@@ -415,7 +416,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(script, "text/plain");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/install.sh"),
@@ -435,7 +436,7 @@ public class WebFetchToolTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_rejects_invalid_url()
     {
-        var tool = new WebFetchTool(fetchDirectory: _dir.Path);
+        var tool = CreateTool(fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "not-a-url"),
@@ -449,7 +450,7 @@ public class WebFetchToolTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_rejects_http_when_https_required()
     {
-        var tool = new WebFetchTool(fetchDirectory: _dir.Path);
+        var tool = CreateTool(fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "http://example.com/page"),
@@ -466,7 +467,7 @@ public class WebFetchToolTests : IDisposable
         var config = new ToolConfig { WebFetch = new WebFetchConfig { RequireHttps = false } };
         var handler = new FakeHttpHandler("<html><body><p>OK</p></body></html>", "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(config, httpClient, _dir.Path);
+        var tool = CreateTool(config, httpClient, _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "http://example.com/page"),
@@ -485,7 +486,7 @@ public class WebFetchToolTests : IDisposable
     {
         var handler = new FakeHttpHandler("<html><body><p>Local</p></body></html>", "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", url),
@@ -500,7 +501,7 @@ public class WebFetchToolTests : IDisposable
     public async Task ExecuteAsync_rejects_http_localhost_when_not_in_allow_list()
     {
         var config = new ToolConfig { WebFetch = new WebFetchConfig { HttpAllowList = [] } };
-        var tool = new WebFetchTool(config, fetchDirectory: _dir.Path);
+        var tool = CreateTool(config, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "http://localhost:8080/"),
@@ -516,7 +517,7 @@ public class WebFetchToolTests : IDisposable
         var config = new ToolConfig { WebFetch = new WebFetchConfig { HttpAllowList = ["internal.corp"] } };
         var handler = new FakeHttpHandler("<html><body><p>Internal</p></body></html>", "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(config, httpClient, _dir.Path);
+        var tool = CreateTool(config, httpClient, _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "http://internal.corp/api"),
@@ -534,7 +535,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(imageBytes, "image/png");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/photo.png"),
@@ -563,7 +564,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(pdfBytes, "application/pdf");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://arxiv.org/pdf/2603.25414"),
@@ -587,7 +588,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(bytes, "image/gif");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/animation.gif"),
@@ -605,7 +606,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(bytes, "application/octet-stream");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/api/download"),
@@ -619,7 +620,7 @@ public class WebFetchToolTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_rejects_ftp_url()
     {
-        var tool = new WebFetchTool(fetchDirectory: _dir.Path);
+        var tool = CreateTool(fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "ftp://files.example.com/doc.txt"),
@@ -689,7 +690,7 @@ public class WebFetchToolTests : IDisposable
     {
         var handler = new CountingHttpHandler("irrelevant", "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/test", "Format", "markdown"),
@@ -711,7 +712,7 @@ public class WebFetchToolTests : IDisposable
         Array.Fill(oversized, (byte)'a');
         var handler = new FakeHttpHandler(oversized, "text/plain");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/huge.txt"),
@@ -726,7 +727,7 @@ public class WebFetchToolTests : IDisposable
     {
         var handler = new FakeHttpHandler("small body content", "text/plain");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path);
 
         var result = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/small.txt"),
@@ -750,7 +751,7 @@ public class WebFetchToolTests : IDisposable
             ("<html><head><title>First</title></head><body><p>First fetch content.</p></body></html>", "text/html"),
             ("<html><head><title>Second</title></head><body><p>Second fetch content.</p></body></html>", "text/html"));
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _dir.Path, timeProvider: frozenTime);
+        var tool = CreateTool(httpClient: httpClient, fetchDirectory: _dir.Path, timeProvider: frozenTime);
 
         var firstResult = await tool.ExecuteAsync(
             ToolInput.Create("Url", "https://example.com/same-page"),
@@ -824,6 +825,75 @@ public class WebFetchToolTests : IDisposable
             return Task.FromResult(response);
         }
     }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    public async Task ReviewRegression_Fetch_destination_checks_links(bool sessionless, bool binary, bool linked)
+    {
+        var outside = Path.Combine(_dir.Path, "outside");
+        var output = Path.Combine(_dir.Path, "output");
+        Directory.CreateDirectory(outside);
+        if (linked)
+            Directory.CreateSymbolicLink(output, outside);
+        var storage = SessionStoragePaths.CreateLegacy(output, Path.Combine(_dir.Path, "logs"), "probe");
+        using var client = new HttpClient(new FakeHttpHandler("response marker", binary ? "application/pdf" : "text/plain"));
+        var tool = CreateTool(new ToolConfig(), client, output);
+        var context = sessionless
+            ? TestToolExecutionContext.CreateUnbound()
+            : TestToolExecutionContext.CreateBoundWithStorage("probe", storage,
+                new TestToolExecutionContextOptions { Audience = TrustAudience.Public });
+
+        var result = await tool.ExecuteAsync(ToolInput.Create("Url", "https://example.com/report"),
+            context, TestContext.Current.CancellationToken);
+
+        Assert.Empty(Directory.GetFiles(outside));
+        if (linked)
+        {
+            Assert.StartsWith("Error:", result);
+            Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        }
+        else
+        {
+            Assert.DoesNotContain("Error:", result);
+            var saved = Assert.Single(Directory.GetFiles(output));
+            Assert.Contains("response marker", await File.ReadAllTextAsync(saved, TestContext.Current.CancellationToken));
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ReviewRegression_Fetch_rejects_protected_output(bool sessionless, bool binary)
+    {
+        var output = Path.Combine(_dir.Path, "protected-output");
+        var storage = SessionStoragePaths.CreateLegacy(output, Path.Combine(_dir.Path, "logs"), "probe");
+        using var client = new HttpClient(new FakeHttpHandler("response marker", binary ? "application/pdf" : "text/plain"));
+        var tool = CreateTool(httpClient: client, fetchDirectory: output, protectedPaths: new ToolPathPolicy([output]));
+        var context = sessionless ? TestToolExecutionContext.CreateUnbound()
+            : TestToolExecutionContext.CreateBoundWithStorage("probe", storage,
+                new TestToolExecutionContextOptions { Audience = TrustAudience.Public });
+
+        var result = await tool.ExecuteAsync(ToolInput.Create("Url", "https://example.com/report"),
+            context, TestContext.Current.CancellationToken);
+
+        Assert.StartsWith("Error:", result);
+        Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
+        Assert.False(Directory.Exists(output));
+    }
+
+    private WebFetchTool CreateTool(ToolConfig? config = null, HttpClient? httpClient = null,
+        string? fetchDirectory = null, TimeProvider? timeProvider = null, ToolPathPolicy? protectedPaths = null)
+        => new(config ?? new ToolConfig(), new NetclawPaths(_dir.Path), protectedPaths ?? new ToolPathPolicy([]),
+            httpClient, fetchDirectory, timeProvider);
 
     private sealed class FakeHttpHandler : HttpMessageHandler
     {

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -71,12 +71,23 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         resolvedPath = resolvedAccess.GetAllowedPath();
         var resolvedInCurrentSession = PathUtility.IsWithinRoot(resolvedPath, sessionDir);
 
-        var attachPath = resolvedInCurrentSession
-            ? resolvedPath
-            : CopyIntoCurrentSession(resolvedPath, sessionDir);
+        var attachPath = resolvedPath;
+        if (!resolvedInCurrentSession)
+        {
+            switch (ResolveCopyDestination(resolvedPath, sessionDir, context))
+            {
+                case PathAccessDecision.Denied denied:
+                    return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
+                case PathAccessDecision.Allowed allowed:
+                    attachPath = allowed.CanonicalPath;
+                    break;
+                default:
+                    throw new InvalidOperationException("Unexpected path decision.");
+            }
 
-        if (!PathUtility.IsWithinRoot(attachPath, sessionDir))
-            return Task.FromResult(context.AccessDenied($"Error: Attach path escaped the session directory ({sessionDir})."));
+            Directory.CreateDirectory(Path.GetDirectoryName(attachPath)!);
+            File.Copy(resolvedPath, attachPath);
+        }
 
         var rawFilename = args.DisplayName ?? Path.GetFileName(attachPath);
         var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
@@ -100,10 +111,13 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         return target is null ? fileInfo.FullName : target.FullName;
     }
 
-    private static string CopyIntoCurrentSession(string sourcePath, string sessionDir)
+    private PathAccessDecision ResolveCopyDestination(
+        string sourcePath, string sessionDir, ToolInvocationContext context)
     {
         var attachmentsDir = Path.Combine(sessionDir, "attachments");
-        Directory.CreateDirectory(attachmentsDir);
+        var directoryAccess = _pathAccessPolicy.EvaluateAttachmentDestination(attachmentsDir, context);
+        if (directoryAccess is PathAccessDecision.Denied)
+            return directoryAccess;
 
         var baseName = Path.GetFileNameWithoutExtension(sourcePath);
         var extension = Path.GetExtension(sourcePath);
@@ -112,15 +126,16 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var destination = Path.Combine(attachmentsDir, fileName);
         var suffix = 1;
 
-        while (File.Exists(destination))
+        while (true)
         {
+            var access = _pathAccessPolicy.EvaluateAttachmentDestination(destination, context);
+            if (access is PathAccessDecision.Denied || !File.Exists(destination))
+                return access;
+
             fileName = $"{sanitizedBase}-{suffix}{extension}";
             destination = Path.Combine(attachmentsDir, fileName);
             suffix++;
         }
-
-        File.Copy(sourcePath, destination);
-        return destination;
     }
 
 }

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -74,16 +74,11 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var attachPath = resolvedPath;
         if (!resolvedInCurrentSession)
         {
-            switch (ResolveCopyDestination(resolvedPath, sessionDir))
-            {
-                case PathAccessDecision.Denied denied:
-                    return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
-                case PathAccessDecision.Allowed allowed:
-                    attachPath = allowed.CanonicalPath;
-                    break;
-                default:
-                    throw new InvalidOperationException("Unexpected path decision.");
-            }
+            var destination = ResolveCopyDestination(resolvedPath, sessionDir);
+            if (destination is PathAccessDecision.Denied destinationDenied)
+                return Task.FromResult(context.PathAccessFailure(destinationDenied.Error, destinationDenied.Failure));
+
+            attachPath = destination.GetAllowedPath();
 
             // Another process can still replace a directory after the check. These checks are not an OS sandbox.
             Directory.CreateDirectory(Path.GetDirectoryName(attachPath)!);

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -74,7 +74,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var attachPath = resolvedPath;
         if (!resolvedInCurrentSession)
         {
-            switch (ResolveCopyDestination(resolvedPath, sessionDir, context))
+            switch (ResolveCopyDestination(resolvedPath, sessionDir))
             {
                 case PathAccessDecision.Denied denied:
                     return Task.FromResult(context.PathAccessFailure(denied.Error, denied.Failure));
@@ -85,6 +85,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
                     throw new InvalidOperationException("Unexpected path decision.");
             }
 
+            // Another process can still replace a directory after the check. These checks are not an OS sandbox.
             Directory.CreateDirectory(Path.GetDirectoryName(attachPath)!);
             File.Copy(resolvedPath, attachPath);
         }
@@ -112,10 +113,10 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
     }
 
     private PathAccessDecision ResolveCopyDestination(
-        string sourcePath, string sessionDir, ToolInvocationContext context)
+        string sourcePath, string sessionDir)
     {
         var attachmentsDir = Path.Combine(sessionDir, "attachments");
-        var directoryAccess = _pathAccessPolicy.EvaluateAttachmentDestination(attachmentsDir, context);
+        var directoryAccess = _pathAccessPolicy.EvaluateGeneratedDestination(attachmentsDir, sessionDir);
         if (directoryAccess is PathAccessDecision.Denied)
             return directoryAccess;
 
@@ -128,7 +129,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
 
         while (true)
         {
-            var access = _pathAccessPolicy.EvaluateAttachmentDestination(destination, context);
+            var access = _pathAccessPolicy.EvaluateGeneratedDestination(destination, sessionDir);
             if (access is PathAccessDecision.Denied || !File.Exists(destination))
                 return access;
 

--- a/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
@@ -158,6 +158,25 @@ internal sealed class PathAccessPolicy
         return AllowIfUnprotected(canonicalPath, ToProtectionOperation(operation));
     }
 
+    /// <summary>Checks a tool-managed attachment destination before any file operation.</summary>
+    internal PathAccessDecision EvaluateAttachmentDestination(string path, ToolInvocationContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.SessionDirectory))
+            return PathAccessDecision.Deny("Error: invalid_context: No session directory available.", PathAccessFailure.InvalidInput);
+
+        var canonicalPath = PathUtility.Normalize(path);
+        var sessionDirectory = PathUtility.Normalize(context.SessionDirectory);
+        if (GetHostPathRelationship(canonicalPath, [sessionDirectory]) != PathRelationship.WithinTrustedRoot)
+        {
+            return PathAccessDecision.Deny(
+                $"Error: Attachment destination must stay inside the current session directory without links ({sessionDirectory}).",
+                PathAccessFailure.AccessDenied, canonicalPath);
+        }
+
+        // Source authorization permits this tool-managed copy. It does not grant general file-write access.
+        return AllowIfUnprotected(canonicalPath, FileOperation.Write);
+    }
+
     /// <summary>Applies file protection to one parser-canonical shell path.</summary>
     public PathAccessDecision EvaluateShellPath(
         CanonicalShellPath path,

--- a/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/PathAccessPolicy.cs
@@ -158,22 +158,35 @@ internal sealed class PathAccessPolicy
         return AllowIfUnprotected(canonicalPath, ToProtectionOperation(operation));
     }
 
-    /// <summary>Checks a tool-managed attachment destination before any file operation.</summary>
-    internal PathAccessDecision EvaluateAttachmentDestination(string path, ToolInvocationContext context)
+    /// <summary>Checks a file that a tool creates as part of an already permitted operation.</summary>
+    /// <remarks>
+    /// The caller supplies the session workspace, or its configured output directory when no session exists.
+    /// This check does not require general file-write permission. It still rejects protected paths and filesystem links.
+    /// </remarks>
+    internal PathAccessDecision EvaluateGeneratedDestination(string path, string outputDirectory)
     {
-        if (string.IsNullOrWhiteSpace(context.SessionDirectory))
-            return PathAccessDecision.Deny("Error: invalid_context: No session directory available.", PathAccessFailure.InvalidInput);
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+            return PathAccessDecision.Deny("Error: invalid_context: No output directory available.", PathAccessFailure.InvalidInput);
 
-        var canonicalPath = PathUtility.Normalize(path);
-        var sessionDirectory = PathUtility.Normalize(context.SessionDirectory);
-        if (GetHostPathRelationship(canonicalPath, [sessionDirectory]) != PathRelationship.WithinTrustedRoot)
+        string canonicalPath;
+        string directory;
+        try
+        {
+            canonicalPath = PathUtility.Normalize(path);
+            directory = PathUtility.Normalize(outputDirectory);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return PathAccessDecision.Deny("Error: Invalid destination path.", PathAccessFailure.InvalidInput);
+        }
+
+        if (GetHostPathRelationship(canonicalPath, [directory]) != PathRelationship.WithinTrustedRoot)
         {
             return PathAccessDecision.Deny(
-                $"Error: Attachment destination must stay inside the current session directory without links ({sessionDirectory}).",
+                "Error: File destination must stay inside its output directory without links.",
                 PathAccessFailure.AccessDenied, canonicalPath);
         }
 
-        // Source authorization permits this tool-managed copy. It does not grant general file-write access.
         return AllowIfUnprotected(canonicalPath, FileOperation.Write);
     }
 

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -49,7 +49,7 @@ public static class ToolRegistrationExtensions
             registry.Register(new ListWebhooksTool(webhookRouteStore));
         if (searchBackend is not null)
             registry.Register(new WebSearchTool(searchBackend));
-        registry.Register(new WebFetchTool(config));
+        registry.Register(new WebFetchTool(config, sharedPathAccessPolicy));
         registry.RegisterCore(new SetWorkingDirectoryTool(sharedPathAccessPolicy));
 
         // Register search_tools and load_tool meta-tools (always loaded, "builtin" grant)

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -121,8 +121,7 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
                 var saved = SaveBytesToFile(bytes, uri, fetchDir, extension);
                 if (saved is PathAccessDecision.Denied denied)
                     return context.PathAccessFailure(denied.Error, denied.Failure);
-                var filePath = saved is PathAccessDecision.Allowed allowed
-                    ? allowed.CanonicalPath : throw new InvalidOperationException("Unexpected destination decision.");
+                var filePath = saved.GetAllowedPath();
 
                 var binarySummary = FormatBinarySummary(uri.ToString(), filePath, bytes.Length, contentType);
                 return binaryTruncated ? binarySummary + TruncationNotice : binarySummary;
@@ -167,8 +166,7 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
             var textSaved = SaveToFile(savedContent, uri, fetchDir, textExtension);
             if (textSaved is PathAccessDecision.Denied textDenied)
                 return context.PathAccessFailure(textDenied.Error, textDenied.Failure);
-            var textFilePath = textSaved is PathAccessDecision.Allowed textAllowed
-                ? textAllowed.CanonicalPath : throw new InvalidOperationException("Unexpected destination decision.");
+            var textFilePath = textSaved.GetAllowedPath();
             var lineCount = savedContent.Count(c => c == '\n') + 1;
 
             var summary = FormatSummary(uri.ToString(), title, textFilePath, savedContent.Length, lineCount, previewText);

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -11,6 +11,8 @@ using HtmlAgilityPack;
 using Netclaw.Configuration;
 using Netclaw.Media;
 using Netclaw.Tools;
+using Netclaw.Security;
+using static Netclaw.Actors.Tools.PathAccessPolicy;
 
 namespace Netclaw.Actors.Tools;
 
@@ -42,6 +44,7 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
     ];
 
+    private readonly PathAccessPolicy _pathAccessPolicy;
     private readonly WebFetchConfig _webFetchConfig;
     private readonly HttpClient _httpClient;
     private readonly string _fetchDirectory;
@@ -53,20 +56,19 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         [property: Description("Output format: 'raw' (default) preserves HTML structure (links, images, tables); 'text' extracts plain text only")]
         string? Format = null);
 
-    public WebFetchTool(ToolConfig config, HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
+    public WebFetchTool(ToolConfig config, NetclawPaths paths, ToolPathPolicy protectedPaths,
+        HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
+        : this(config, new PathAccessPolicy(config, paths, protectedPaths), httpClient, fetchDirectory, timeProvider) { }
+
+    internal WebFetchTool(ToolConfig config, PathAccessPolicy pathAccessPolicy,
+        HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
     {
+        _pathAccessPolicy = pathAccessPolicy;
         _webFetchConfig = config.WebFetch;
         _httpClient = httpClient ?? new HttpClient();
-        _fetchDirectory = fetchDirectory
-            ?? Path.Combine(Path.GetTempPath(), "netclaw-fetch");
+        _fetchDirectory = fetchDirectory ?? Path.Combine(Path.GetTempPath(), "netclaw-fetch");
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
-
-    /// <summary>
-    /// Test convenience constructor — uses default config.
-    /// </summary>
-    public WebFetchTool(HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
-        : this(new ToolConfig(), httpClient, fetchDirectory, timeProvider) { }
 
     protected override async Task<string> ExecuteAsync(Params args, ToolInvocationContext context, CancellationToken ct)
     {
@@ -116,7 +118,11 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
 
                 var extension = GetExtensionFromUrl(uri)
                     ?? GetFallbackExtension(contentType, isBinary: true);
-                var filePath = SaveBytesToFile(bytes, uri, fetchDir, extension);
+                var saved = SaveBytesToFile(bytes, uri, fetchDir, extension);
+                if (saved is PathAccessDecision.Denied denied)
+                    return context.PathAccessFailure(denied.Error, denied.Failure);
+                var filePath = saved is PathAccessDecision.Allowed allowed
+                    ? allowed.CanonicalPath : throw new InvalidOperationException("Unexpected destination decision.");
 
                 var binarySummary = FormatBinarySummary(uri.ToString(), filePath, bytes.Length, contentType);
                 return binaryTruncated ? binarySummary + TruncationNotice : binarySummary;
@@ -158,7 +164,11 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
             if (string.IsNullOrWhiteSpace(savedContent))
                 return $"Fetched {args.Url} but the page contained no extractable content.";
 
-            var textFilePath = SaveToFile(savedContent, uri, fetchDir, textExtension);
+            var textSaved = SaveToFile(savedContent, uri, fetchDir, textExtension);
+            if (textSaved is PathAccessDecision.Denied textDenied)
+                return context.PathAccessFailure(textDenied.Error, textDenied.Failure);
+            var textFilePath = textSaved is PathAccessDecision.Allowed textAllowed
+                ? textAllowed.CanonicalPath : throw new InvalidOperationException("Unexpected destination decision.");
             var lineCount = savedContent.Count(c => c == '\n') + 1;
 
             var summary = FormatSummary(uri.ToString(), title, textFilePath, savedContent.Length, lineCount, previewText);
@@ -264,7 +274,6 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
 
     private string BuildFilePath(Uri uri, string directory, string extension)
     {
-        Directory.CreateDirectory(directory);
         var sanitized = SanitizeForFilename(uri);
 
         // The timestamp is for a human to read and sort, not for uniqueness.
@@ -278,18 +287,26 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         return Path.Combine(directory, filename);
     }
 
-    private string SaveBytesToFile(byte[] content, Uri uri, string directory, string extension)
+    private PathAccessDecision SaveBytesToFile(byte[] content, Uri uri, string directory, string extension)
     {
-        var filePath = BuildFilePath(uri, directory, extension);
+        var decision = _pathAccessPolicy.EvaluateGeneratedDestination(BuildFilePath(uri, directory, extension), directory);
+        if (decision is not PathAccessDecision.Allowed allowed)
+            return decision;
+        var filePath = allowed.CanonicalPath;
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         File.WriteAllBytes(filePath, content);
-        return filePath;
+        return decision;
     }
 
-    private string SaveToFile(string content, Uri uri, string directory, string extension)
+    private PathAccessDecision SaveToFile(string content, Uri uri, string directory, string extension)
     {
-        var filePath = BuildFilePath(uri, directory, extension);
+        var decision = _pathAccessPolicy.EvaluateGeneratedDestination(BuildFilePath(uri, directory, extension), directory);
+        if (decision is not PathAccessDecision.Allowed allowed)
+            return decision;
+        var filePath = allowed.CanonicalPath;
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         File.WriteAllText(filePath, content, Encoding.UTF8);
-        return filePath;
+        return decision;
     }
 
     private static string FormatSummary(


### PR DESCRIPTION
An authorized external attachment source can copy through a linked destination directory. Saved web fetches can also follow a linked output directory. This change checks generated destinations before directory creation, file copy, or file writes.

The shared path policy checks containment, links through known storage ancestors, and protected write paths. Attach copies and bound fetches use the session workspace. Sessionless fetches retain their configured output directory. These admitted tool operations do not require general file-write permission.

Validation:

- Four attachment denial cases failed on the original baseline. Their allowed control passed. All cases pass after the correction.
- Four fetch link cases failed before the fetch correction. Four nearby allowed controls passed. All eight cases pass after the correction.
- Attachment, fetch, and tool registration tests passed: 120 tests. These cover protected suffixes, malformed paths, links, missing directories, and allowed writes.
- The `Reuse allowed path extraction` follow-up applies the shared method to the attachment and fetch consumers. It removes seven net lines.
- The final stack passed 3,925 actor tests and 1,098 daemon tests, with six actor platform skips.
- Focused evals passed: search skill 4/5, operations diagnostics 5/5, and direct attachment 5/5. The existing pass threshold is 80%.
- The generated destination check and both fetch write methods reached 100% sequence and branch coverage in the focused run.
- Slopwatch, headers, strict OpenSpec validation, and whitespace checks passed.

The checks reject links that exist at validation time. They do not provide an operating-system sandbox against concurrent filesystem changes. Native Windows proof remains pending.

Replaces #2137. All branches for the native stack reside in this repository.

Native stack: #2143 → #2144 → #2145 → #2146. Stack base: `dev`.
