### PR TITLE
Separate receipt, child, and Git result cases

### DIFF
--- a/docs/spec/GLOSSARY.md
+++ b/docs/spec/GLOSSARY.md
@@ -250,6 +250,9 @@ A tool receipt is trusted internal data about one completed invocation attempt.
 The attempt can end before the tool implementation runs. An actor uses the
 receipt to update state without parsing model-facing text or authored arguments.
 
+Success carries file activity and an optional project declaration. A correction carries its remediation code.
+Other outcomes carry no success payload. The internal cases preserve the constructor guards and collection ownership.
+
 **Code anchor:** `ToolInvocationReceipt`
 
 Example:

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -885,7 +885,7 @@ These changes retain the [engineering glossary](../../../docs/spec/GLOSSARY.md) 
 | Contract | Producer and consumer | Lifetime and compatibility |
 |---|---|---|
 | Path result | `PathAccessPolicy` produces `Allowed` or `Denied`; file tools and shell policy consume the cases | Call-local; errors and public tool text retain their shapes |
-| Tool receipt | Tool completion creates `Succeeded`, `Correction`, or `OtherOutcome`; actors update context from the matching case | Call-local and actor-local; `ToolExecutionCompleted` excludes serialization verification; no persistence format changes |
+| Tool receipt | Tool completion creates `Succeeded`, `Correction`, or `OtherOutcome`; actors update context from the matching case | Call-local and actor-local; `ToolExecutionCompleted` carries receipts in local actor messages only; receipts have no persistence or wire representation |
 | Child result | The child actor returns `SubAgentResult`; the spawner adds typed locations; `SpawnAgentTool` consumes the enriched case | Actor-local; public `SpawnAsync` maps back to the unchanged `SubAgentResult` shape |
 | Git head | The inspector parses head state; the context renderer consumes detached or attached state | Call-local snapshots; the public flat snapshot retains its JSON members through an explicit map |
 
@@ -909,3 +909,17 @@ Detached state cannot carry branch or upstream metadata. Divergence requires an 
 Malformed Git status becomes the existing `Unavailable` inspection through the existing `FormatException` path.
 The public snapshot remains a boundary shape; its independent fields are not a closed internal state.
 No compiler-exhaustiveness claim applies to these C# hierarchies. Consumers retain explicit unexpected-case checks.
+
+## Git snapshot review correction
+
+The public Git snapshot retains its flat JSON fields. Other callers can construct it without the Git parser.
+`ToContextBlock` validates those fields through an explicit method before it writes Git context.
+If validation fails, it emits the existing `status: unavailable` form with a reason.
+It does not emit partial branch or commit details and does not change the snapshot.
+The normal Git inspector still rejects invalid status text before it returns a snapshot.
+
+```text
+public snapshot -> validate head fields
+  valid -> emit branch, commit, and repository counts
+  invalid -> emit unavailable status and reason -> continue the session
+```

--- a/openspec/changes/unify-session-storage-and-temp/design.md
+++ b/openspec/changes/unify-session-storage-and-temp/design.md
@@ -877,3 +877,35 @@ permitted tool call -> generate output path -> check destination
 
 This order does not bind the write to an operating-system directory handle.
 A process with directory-write permission can still replace a directory after the check.
+
+## Internal result contracts
+
+These changes retain the [engineering glossary](../../../docs/spec/GLOSSARY.md) and the existing authority model.
+
+| Contract | Producer and consumer | Lifetime and compatibility |
+|---|---|---|
+| Path result | `PathAccessPolicy` produces `Allowed` or `Denied`; file tools and shell policy consume the cases | Call-local; errors and public tool text retain their shapes |
+| Tool receipt | Tool completion creates `Succeeded`, `Correction`, or `OtherOutcome`; actors update context from the matching case | Call-local and actor-local; `ToolExecutionCompleted` excludes serialization verification; no persistence format changes |
+| Child result | The child actor returns `SubAgentResult`; the spawner adds typed locations; `SpawnAgentTool` consumes the enriched case | Actor-local; public `SpawnAsync` maps back to the unchanged `SubAgentResult` shape |
+| Git head | The inspector parses head state; the context renderer consumes detached or attached state | Call-local snapshots; the public flat snapshot retains its JSON members through an explicit map |
+
+Ordered child flow:
+
+```text
+child actor -> completion without locations
+spawner -> SuccessfulRun(Completed or Partial, locations) or OtherRun(Failed or Cancelled)
+spawn_agent -> one successful-case path block
+public SpawnAsync adapter -> original SubAgentResult fields
+```
+
+Partial completion already counts as success. It retains its reason, delta, and paths.
+A child location is data. It does not grant file authority.
+Case constructors retain enum validation, canonical-path checks, and activity collection ownership.
+The aggregate receipt factory is removed. Types now exclude failure activity and correction without remediation.
+The success receipt retains a private copy of its activity collection.
+
+Git snapshots retain optional branch metadata for compatibility. A null commit still represents an unborn branch.
+Detached state cannot carry branch or upstream metadata. Divergence requires an upstream.
+Malformed Git status becomes the existing `Unavailable` inspection through the existing `FormatException` path.
+The public snapshot remains a boundary shape; its independent fields are not a closed internal state.
+No compiler-exhaustiveness claim applies to these C# hierarchies. Consumers retain explicit unexpected-case checks.

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -10,6 +10,52 @@ This delta uses terms from the
 
 ## MODIFIED Requirements
 
+### Requirement: Working context includes derived Git worktree state
+For Team and Personal turns whose `WorkingContext.ProjectDirectory` is declared and Git identifies it as a worktree, the system SHALL asynchronously derive a fresh Git snapshot at turn start and render it as a nested section of `[working-context]`. The snapshot SHALL include worktree root, common repository directory, branch or detached state, HEAD, upstream and ahead/behind when configured, and staged, modified, and untracked counts. Derived Git state SHALL NOT be persisted in session state. Git inspection SHALL return explicit available, not-repository, executable-not-found, or unavailable outcomes.
+
+#### Scenario: Linked worktree is distinguished from common repository
+- **GIVEN** a Team or Personal session project directory inside a linked Git worktree
+- **WHEN** the next turn-start working-context snapshot is built
+- **THEN** the model-visible context identifies the linked worktree path and common repository directory
+- **AND** reports the linked worktree's branch and HEAD
+
+#### Scenario: Git state refreshes on the next turn
+- **GIVEN** a tool changes branch, HEAD, or dirty state during one turn
+- **WHEN** the session begins its next turn
+- **THEN** the new volatile working-context nudge contains the updated Git snapshot
+- **AND** earlier history messages are not rewritten
+
+#### Scenario: Non-Git project has no Git section
+- **GIVEN** a declared project directory that Git identifies as not a repository
+- **WHEN** working context is assembled
+- **THEN** normal project and recent-file context remains available
+- **AND** no Git section is rendered
+
+#### Scenario: Git inspection failure is visible
+- **GIVEN** an eligible project directory whose Git state cannot be inspected because Git is missing, times out, or the repository is invalid
+- **WHEN** working context is assembled
+- **THEN** Git status is reported as unavailable with a sanitized reason
+- **AND** the failure is not represented as a clean or non-Git worktree
+
+#### Scenario: Stale Git result is discarded
+- **GIVEN** asynchronous Git inspection began for an earlier turn generation
+- **WHEN** its result arrives after the session has advanced to another turn
+- **THEN** the actor discards the stale result
+- **AND** it is not rendered into the active turn
+
+#### Scenario: Git remote credentials are never rendered
+- **GIVEN** a repository with a credential-bearing remote URL
+- **WHEN** Git working context is rendered
+- **THEN** no remote credentials or complete remote URL appears in model-visible context or logs
+
+#### Scenario: Contradictory Git head metadata is unavailable
+
+- **GIVEN** Git reports a detached head with upstream metadata, a detached unborn head, or divergence without an upstream
+- **WHEN** the inspector parses that status
+- **THEN** the inspector returns the existing unavailable outcome with a bounded reason
+- **AND** the model receives no contradictory branch or tracking state
+
+
 ### Requirement: Existing session context announces managed paths
 
 The system SHALL preserve the existing `[session]` context block and its

--- a/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
+++ b/openspec/changes/unify-session-storage-and-temp/specs/session-cwd/spec.md
@@ -56,6 +56,14 @@ For Team and Personal turns whose `WorkingContext.ProjectDirectory` is declared 
 - **AND** the model receives no contradictory branch or tracking state
 
 
+#### Scenario: Invalid public Git snapshot does not interrupt a turn
+
+- **GIVEN** a caller constructs or deserializes a Git snapshot with contradictory head fields
+- **WHEN** the context renderer processes the snapshot
+- **THEN** it emits the existing unavailable status with a reason
+- **AND** it emits no branch or commit details and does not modify the snapshot
+- **AND** the session can continue its turn
+
 ### Requirement: Existing session context announces managed paths
 
 The system SHALL preserve the existing `[session]` context block and its

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -99,4 +99,4 @@
 - [x] 12.1 Inventory receipt, child, and Git consumers; preserve public shapes and partial-child semantics.
 - [x] 12.2 Convert internal cases and consumers with boundary maps; preserve existing guards and collection ownership.
 - [x] 12.3 Verify context updates, failed outcomes, child completion, and old Git JSON shapes.
-- [ ] 12.4 Run actor and daemon tests, relevant evals, Slopwatch, headers, and strict specification validation.
+- [x] 12.4 Run actor and daemon tests, relevant evals, Slopwatch, headers, and strict specification validation.

--- a/openspec/changes/unify-session-storage-and-temp/tasks.md
+++ b/openspec/changes/unify-session-storage-and-temp/tasks.md
@@ -93,3 +93,10 @@
 - [x] 11.2 Validate destinations before file operations through the shared path policy.
 - [x] 11.3 Verify no side effects on denial, attach-only profiles, collisions, and direct attachments.
 - [x] 11.4 Run related tests, skill evals, Slopwatch, headers, and strict specification validation.
+
+## 12. Simplify internal result contracts
+
+- [x] 12.1 Inventory receipt, child, and Git consumers; preserve public shapes and partial-child semantics.
+- [x] 12.2 Convert internal cases and consumers with boundary maps; preserve existing guards and collection ownership.
+- [x] 12.3 Verify context updates, failed outcomes, child completion, and old Git JSON shapes.
+- [ ] 12.4 Run actor and daemon tests, relevant evals, Slopwatch, headers, and strict specification validation.

--- a/openspec/specs/session-cwd/spec.md
+++ b/openspec/specs/session-cwd/spec.md
@@ -360,6 +360,13 @@ For Team and Personal turns whose `WorkingContext.ProjectDirectory` is declared 
 - **WHEN** Git working context is rendered
 - **THEN** no remote credentials or complete remote URL appears in model-visible context or logs
 
+#### Scenario: Contradictory Git head metadata is unavailable
+
+- **GIVEN** Git reports a detached head with upstream metadata, a detached unborn head, or divergence without an upstream
+- **WHEN** the inspector parses that status
+- **THEN** the inspector returns the existing unavailable outcome with a bounded reason
+- **AND** the model receives no contradictory branch or tracking state
+
 ### Requirement: Project-directory declarations reject control characters
 
 The `set_working_directory` tool SHALL reject a path that contains NUL, CR, or

--- a/openspec/specs/session-cwd/spec.md
+++ b/openspec/specs/session-cwd/spec.md
@@ -381,6 +381,14 @@ echoing the authored path.
 - **AND** the project scope remains unchanged
 - **AND** project instructions are not loaded from that path
 
+#### Scenario: Invalid public Git snapshot does not interrupt a turn
+
+- **GIVEN** a caller constructs or deserializes a Git snapshot with contradictory head fields
+- **WHEN** the context renderer processes the snapshot
+- **THEN** it emits the existing unavailable status with a reason
+- **AND** it emits no branch or commit details and does not modify the snapshot
+- **AND** the session can continue its turn
+
 ### Requirement: Existing session context announces managed paths
 
 The system SHALL preserve the existing `[session]` context block and its

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -765,9 +765,7 @@ public class CompactionIntegrationTests : LlmSessionTestBase
         ];
         _fakeToolExecutor.Results["file_read"] = "public readonly record struct Rect { ... }";
         var canonicalPath = Path.GetFullPath(Path.Join(Path.GetTempPath(), "src", "Rect.cs"));
-        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.Success,
-            [new ToolFileActivity(canonicalPath, ToolFileActivityKind.Read)]);
+        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt.Succeeded([new ToolFileActivity(canonicalPath, ToolFileActivityKind.Read)], null);
         _fakeChatClient.UsageOverride = new UsageDetails
         {
             InputTokenCount = 100,

--- a/src/Netclaw.Actors.Tests/Sessions/ResultBoundaryTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ResultBoundaryTests.cs
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResultBoundaryTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.SubAgents;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using static Netclaw.Actors.SubAgents.SubAgentProtocol;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public sealed class ResultBoundaryTests
+{
+    [Fact]
+    public void Receipt_cases_retain_payload_ownership_and_reject_wrong_categories()
+    {
+        var path = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "receipt-file.txt"));
+        var activity = new List<ToolFileActivity> { new(path, ToolFileActivityKind.Read) };
+        var success = new ToolInvocationReceipt.Succeeded(activity, null);
+        activity.Clear();
+        var updated = WorkingContextUpdater.UpdateFromToolReceipt(WorkingContext.Empty, success);
+        Assert.Contains(path, updated.RecentFiles);
+        Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt.Succeeded([], "relative/project"));
+        Assert.Same(updated, WorkingContextUpdater.UpdateFromToolReceipt(updated,
+            new ToolInvocationReceipt.Correction(ToolRemediationCode.SetWorkingDirectory)));
+    }
+
+    [Theory]
+    [InlineData(false, "main", "abc123", "origin/main", 2, 1)]
+    [InlineData(false, "main", null, null, 0, 0)]
+    [InlineData(false, null, null, null, 0, 0)]
+    [InlineData(true, null, "abc123", null, 0, 0)]
+    public void Git_old_shape_round_trip_retains_head_state_and_context_text(
+        bool detached, string? branch, string? head, string? upstream, int ahead, int behind)
+    {
+        var oldShape = new JsonObject
+        {
+            ["Worktree"] = "/repo", ["CommonDirectory"] = "/repo/.git", ["Branch"] = branch,
+            ["Detached"] = detached, ["Head"] = head, ["Upstream"] = upstream, ["Ahead"] = ahead,
+            ["Behind"] = behind, ["Staged"] = 1, ["Modified"] = 2, ["Untracked"] = 3,
+            ["ChangedFiles"] = new JsonArray("a.txt")
+        };
+        var loaded = oldShape.Deserialize<GitWorkingContextSnapshot>()!;
+        var mapped = loaded.HeadState.ApplyTo(loaded);
+        Assert.True(JsonNode.DeepEquals(oldShape, JsonSerializer.SerializeToNode(mapped)));
+        var block = new WorkingContextSnapshot
+        {
+            WorkingContext = WorkingContext.Empty,
+            Git = new GitWorkingContextInspection.Available(mapped)
+        }.ToContextBlock();
+        Assert.Contains($"branch: {(detached ? "(detached)" : branch)}\n  head: {head ?? "(unborn)"}", block);
+        Assert.Equal(upstream is not null, block.Contains("upstream:", StringComparison.Ordinal));
+        if (detached)
+            Assert.IsType<GitHeadState.DetachedHead>(mapped.HeadState);
+        else
+            Assert.IsType<GitHeadState.AttachedHead>(mapped.HeadState);
+    }
+
+    [Theory]
+    [InlineData("# branch.oid abc123\n# branch.head (detached)\n# branch.upstream origin/main")]
+    [InlineData("# branch.oid (initial)\n# branch.head (detached)")]
+    [InlineData("# branch.oid abc123\n# branch.head main\n# branch.ab +2 -1")]
+    public void Git_parser_rejects_contradictory_head_metadata(string status)
+        => Assert.Throws<FormatException>(() => GitWorkingContextInspector.ParseStatus("/repo", "/repo/.git", status));
+
+    [Theory]
+    [InlineData("completed")]
+    [InlineData("partial")]
+    [InlineData("failed")]
+    [InlineData("cancelled")]
+    public void Child_enrichment_preserves_public_shape_and_completion(string outcome)
+    {
+        ChildRunCompletion completion = outcome switch
+        {
+            "completed" => new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
+            "partial" => new ChildRunCompletion.Partial(SubAgentOutcomeReason.ToolIterationBudgetExhausted, WorkingContextDelta.Empty),
+            "failed" => new ChildRunCompletion.Failed(SubAgentOutcomeReason.LlmCallFailed),
+            "cancelled" => new ChildRunCompletion.Cancelled(SubAgentOutcomeReason.CancelledByParent),
+            _ => throw new ArgumentException("Unexpected test outcome.", nameof(outcome))
+        };
+        var actorResponse = new SubAgentResult { Completion = completion, Output = "result", AgentName = new AgentName("helper") };
+        var storage = SessionStoragePaths.CreateVersion2(new SessionStorageEnvelopeRoot(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "child-result-fixture"))));
+        var locations = new EnrichedChildRunResult.RunLocations(storage.LogPath, storage.ArtifactDirectory);
+        Assert.Throws<ArgumentNullException>(() => new EnrichedChildRunResult.RunLocations(default, storage.ArtifactDirectory));
+        EnrichedChildRunResult enriched = completion.Success
+            ? new EnrichedChildRunResult.SuccessfulRun(actorResponse, locations)
+            : new EnrichedChildRunResult.OtherRun(actorResponse);
+        var protocol = enriched.ToProtocolResult();
+        Assert.Same(completion, protocol.Completion);
+        Assert.Null(actorResponse.LogPath);
+        Assert.Null(actorResponse.ArtifactDirectory);
+        var expected = actorResponse with
+        {
+            LogPath = completion.Success ? storage.LogPath.Value : null,
+            ArtifactDirectory = completion.Success ? storage.ArtifactDirectory.Value : null
+        };
+        Assert.True(JsonNode.DeepEquals(JsonSerializer.SerializeToNode(expected), JsonSerializer.SerializeToNode(protocol)));
+        if (completion.Success)
+            Assert.Throws<ArgumentException>(() => new EnrichedChildRunResult.OtherRun(actorResponse));
+        else
+            Assert.Throws<ArgumentException>(() => new EnrichedChildRunResult.SuccessfulRun(actorResponse, locations));
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/ResultBoundaryTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ResultBoundaryTests.cs
@@ -45,7 +45,7 @@ public sealed class ResultBoundaryTests
             ["ChangedFiles"] = new JsonArray("a.txt")
         };
         var loaded = oldShape.Deserialize<GitWorkingContextSnapshot>()!;
-        var mapped = loaded.HeadState.ApplyTo(loaded);
+        var mapped = loaded.GetHeadState().ApplyTo(loaded);
         Assert.True(JsonNode.DeepEquals(oldShape, JsonSerializer.SerializeToNode(mapped)));
         var block = new WorkingContextSnapshot
         {
@@ -55,9 +55,35 @@ public sealed class ResultBoundaryTests
         Assert.Contains($"branch: {(detached ? "(detached)" : branch)}\n  head: {head ?? "(unborn)"}", block);
         Assert.Equal(upstream is not null, block.Contains("upstream:", StringComparison.Ordinal));
         if (detached)
-            Assert.IsType<GitHeadState.DetachedHead>(mapped.HeadState);
+            Assert.IsType<GitHeadState.DetachedHead>(mapped.GetHeadState());
         else
-            Assert.IsType<GitHeadState.AttachedHead>(mapped.HeadState);
+            Assert.IsType<GitHeadState.AttachedHead>(mapped.GetHeadState());
+    }
+
+    [Theory]
+    [InlineData(true, "main", "abc123", 0)]
+    [InlineData(false, "main", "abc123", 2)]
+    [InlineData(true, null, null, 0)]
+    public void ReviewRegression_Invalid_public_git_snapshot_reports_unavailable(
+        bool detached, string? branch, string? head, int ahead)
+    {
+        var json = JsonSerializer.Serialize(new GitWorkingContextSnapshot
+        {
+            Worktree = "/repo", CommonDirectory = "/repo/.git",
+            Detached = detached, Branch = branch, Head = head, Ahead = ahead
+        });
+        var snapshot = JsonSerializer.Deserialize<GitWorkingContextSnapshot>(json)!;
+        var block = new WorkingContextSnapshot
+        {
+            WorkingContext = WorkingContext.Empty,
+            Git = new GitWorkingContextInspection.Available(snapshot)
+        }.ToContextBlock();
+
+        Assert.Contains("status: unavailable", block);
+        Assert.Contains("reason:", block);
+        Assert.DoesNotContain("branch:", block);
+        Assert.DoesNotContain("head:", block);
+        Assert.Equal(json, JsonSerializer.Serialize(snapshot));
     }
 
     [Theory]
@@ -82,6 +108,7 @@ public sealed class ResultBoundaryTests
             "cancelled" => new ChildRunCompletion.Cancelled(SubAgentOutcomeReason.CancelledByParent),
             _ => throw new ArgumentException("Unexpected test outcome.", nameof(outcome))
         };
+        Assert.Throws<ArgumentNullException>(() => new EnrichedChildRunResult.OtherRun(null!));
         var actorResponse = new SubAgentResult { Completion = completion, Output = "result", AgentName = new AgentName("helper") };
         var storage = SessionStoragePaths.CreateVersion2(new SessionStorageEnvelopeRoot(
             Path.GetFullPath(Path.Combine(Path.GetTempPath(), "child-result-fixture"))));

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -298,7 +298,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             result.Content);
         Assert.Equal(
             ToolRemediationCode.SetWorkingDirectory,
-            completed.ToolReceipts["call-1"].RemediationCode);
+            Assert.IsType<ToolInvocationReceipt.Correction>(completed.ToolReceipts["call-1"]).RemediationCode);
         Assert.Empty(approvals);
         Assert.False(shellTool.WasCalled);
         Assert.Empty(completed.ManagedTemporaryCorrectionChanges);
@@ -378,7 +378,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
             result.Message.Content);
         Assert.Equal(ToolInvocationOutcomeCategory.RecoverableCorrection, result.Receipt?.Category);
-        Assert.Equal(ToolRemediationCode.UseNativeTool, result.Receipt?.RemediationCode);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, Assert.IsType<ToolInvocationReceipt.Correction>(result.Receipt).RemediationCode);
         Assert.Equal("file_read", result.ExposureRequest?.ToolName.Value);
         Assert.True(AuthorizationAttemptId.TryParse(result.AuthorizationAttemptId.Value, out _));
         Assert.Empty(approvals);
@@ -425,7 +425,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             $"Managed temporary directory: '{Path.Combine(Path.GetTempPath(), "tmp", "parent")}'.\n" +
             "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
             result.Content);
-        Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-temporary-collection"].RemediationCode);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, Assert.IsType<ToolInvocationReceipt.Correction>(completed.ToolReceipts["call-native-temporary-collection"]).RemediationCode);
         Assert.Equal("file_write", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
         Assert.Empty(completed.ManagedTemporaryCorrectionChanges);
     }
@@ -467,7 +467,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             "Next action: call the native Netclaw tool named in this result directly instead of shell_execute.",
             result.Content);
         Assert.DoesNotContain("Managed temporary directory", result.Content, StringComparison.Ordinal);
-        Assert.Equal(ToolRemediationCode.UseNativeTool, completed.ToolReceipts["call-native-read-without-temporary"].RemediationCode);
+        Assert.Equal(ToolRemediationCode.UseNativeTool, Assert.IsType<ToolInvocationReceipt.Correction>(completed.ToolReceipts["call-native-read-without-temporary"]).RemediationCode);
         Assert.Equal("file_read", Assert.Single(completed.ToolExposureRequests).Value.ToolName.Value);
     }
 
@@ -520,7 +520,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             result.Content);
         Assert.Equal(
             ToolRemediationCode.UseManagedTemporaryDirectory,
-            completed.ToolReceipts[call.CallId].RemediationCode);
+            Assert.IsType<ToolInvocationReceipt.Correction>(completed.ToolReceipts[call.CallId]).RemediationCode);
         Assert.IsType<ManagedTemporaryCorrectionChange.Arm>(
             Assert.Single(completed.ManagedTemporaryCorrectionChanges));
         Assert.Empty(completed.ToolExposureRequests);
@@ -557,7 +557,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
             "Error: invalid_context: No project or session directory is available.\n" +
             "Next action: call set_working_directory with an allowed project directory for this task, then retry the failed tool call.",
             completed.Result.Message.Content);
-        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, completed.Result.Receipt?.RemediationCode);
+        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, Assert.IsType<ToolInvocationReceipt.Correction>(completed.Result.Receipt).RemediationCode);
     }
 
     [Fact]
@@ -622,7 +622,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
                 "Next action: use the managed temporary directory from this result for disposable files, or retry unchanged for exact platform paths.",
                 result.Content));
         Assert.All(completed.ToolReceipts.Values, receipt =>
-            Assert.Equal(ToolRemediationCode.UseManagedTemporaryDirectory, receipt.RemediationCode));
+            Assert.Equal(ToolRemediationCode.UseManagedTemporaryDirectory, Assert.IsType<ToolInvocationReceipt.Correction>(receipt).RemediationCode));
         Assert.Equal(2, completed.ManagedTemporaryCorrectionChanges.Count);
         Assert.All(completed.ManagedTemporaryCorrectionChanges,
             change => Assert.IsType<ManagedTemporaryCorrectionChange.Arm>(change));
@@ -1413,9 +1413,7 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
         {
             var requiredContext = context
                 ?? throw new InvalidOperationException("Execution context is required.");
-            requiredContext.Outputs.TryComplete(new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.RecoverableCorrection,
-                remediationCode: ToolRemediationCode.SetWorkingDirectory));
+            requiredContext.Outputs.TryComplete(new ToolInvocationReceipt.Correction(ToolRemediationCode.SetWorkingDirectory));
             return Task.FromResult("Error: invalid_context: No project or session directory is available.");
         }
     }

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -282,9 +282,7 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
                 new Dictionary<string, object?> { ["Path"] = "src/Rect.cs" })
         ];
         _fakeToolExecutor.Results["file_read"] = "public readonly record struct Rect { ... }";
-        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.Success,
-            [new ToolFileActivity(canonicalPath, ToolFileActivityKind.Read)]);
+        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt.Succeeded([new ToolFileActivity(canonicalPath, ToolFileActivityKind.Read)], null);
 
         var sessionId = new SessionId("console/working-context-populated");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
@@ -351,7 +349,7 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         ];
         _fakeToolExecutor.Results["set_working_directory"] = deniedPath;
         _fakeToolExecutor.Receipts["set_working_directory"] =
-            new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied);
+            new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied);
 
         var nextTurn = await RunToolTurnAndCaptureNextTurnAsync("failed-project-declaration");
 
@@ -371,9 +369,7 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
                 new Dictionary<string, object?> { ["Path"] = declaredPath })
         ];
         _fakeToolExecutor.Results["set_working_directory"] = misleadingPath;
-        _fakeToolExecutor.Receipts["set_working_directory"] = new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.Success,
-            declaredProjectDirectory: declaredPath);
+        _fakeToolExecutor.Receipts["set_working_directory"] = new ToolInvocationReceipt.Succeeded([], declaredPath);
 
         var nextTurn = await RunToolTurnAndCaptureNextTurnAsync("successful-project-declaration");
 
@@ -393,9 +389,7 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
                 new Dictionary<string, object?> { ["Path"] = "README.md" })
         ];
         _fakeToolExecutor.Results["file_read"] = "content";
-        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.Success,
-            declaredProjectDirectory: declaredPath);
+        _fakeToolExecutor.Receipts["file_read"] = new ToolInvocationReceipt.Succeeded([], declaredPath);
 
         var nextTurn = await RunToolTurnAndCaptureNextTurnAsync("forged-project-declaration");
 

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextUpdaterTests.cs
@@ -53,11 +53,9 @@ public class WorkingContextUpdaterTests
     {
         var category = Enum.Parse<ToolInvocationOutcomeCategory>(categoryName);
         var result = Result("call-1", "file_read", "successful-looking presentation");
-        var receipt = category == ToolInvocationOutcomeCategory.RecoverableCorrection
-            ? new ToolInvocationReceipt(
-                category,
-                remediationCode: ToolRemediationCode.SetWorkingDirectory)
-            : new ToolInvocationReceipt(category);
+        ToolInvocationReceipt receipt = category == ToolInvocationOutcomeCategory.RecoverableCorrection
+            ? new ToolInvocationReceipt.Correction(ToolRemediationCode.SetWorkingDirectory)
+            : new ToolInvocationReceipt.OtherOutcome(category);
 
         var updated = WorkingContextUpdater.UpdateFromToolReceipts(
             WorkingContext.Empty,
@@ -86,53 +84,34 @@ public class WorkingContextUpdaterTests
     {
         var outputs = new ToolExecutionOutputs();
 
-        Assert.True(outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied)));
+        Assert.True(outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied)));
         Assert.False(outputs.TryComplete(Success(
             Path.GetFullPath(Path.Combine(Path.GetTempPath(), "late.txt")),
             ToolFileActivityKind.Read)));
         Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, outputs.Receipt?.Category);
-        Assert.Empty(outputs.Receipt?.FileActivity ?? []);
+        Assert.False(outputs.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]
-    public void Non_success_receipt_rejects_file_activity()
-    {
-        var path = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "invalid.txt"));
-
-        var exception = Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.AccessDenied,
-            [new ToolFileActivity(path, ToolFileActivityKind.Read)]));
-
-        Assert.Contains("successful", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
+    public void Other_outcome_rejects_success_category()
+        => Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.Success));
 
     [Fact]
-    public void Recoverable_receipt_requires_remediation()
-    {
-        Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.RecoverableCorrection));
-    }
+    public void Other_outcome_rejects_correction_without_remediation()
+        => Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.RecoverableCorrection));
 
     [Fact]
-    public void Non_corrective_receipt_rejects_remediation()
-    {
-        Assert.Throws<ArgumentException>(() => new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.AccessDenied,
-            remediationCode: ToolRemediationCode.SetWorkingDirectory));
-    }
+    public void Other_outcome_rejects_undefined_category()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new ToolInvocationReceipt.OtherOutcome((ToolInvocationOutcomeCategory)int.MaxValue));
 
     [Fact]
     public void Remediation_rejects_undefined_code()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.RecoverableCorrection,
-            remediationCode: (ToolRemediationCode)int.MaxValue));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ToolInvocationReceipt.Correction((ToolRemediationCode)int.MaxValue));
     }
 
     private static ToolInvocationReceipt Success(string path, ToolFileActivityKind kind)
-        => new(
-            ToolInvocationOutcomeCategory.Success,
-            [new ToolFileActivity(path, kind)]);
+        => new ToolInvocationReceipt.Succeeded([new ToolFileActivity(path, kind)], null);
 
     private static SerializableChatMessage Result(string callId, string name, string content)
         => new()

--- a/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
@@ -38,8 +38,10 @@ public class SpawnAgentStreamingTests : TestKit
         // No persistence or hosting needed — SubAgentActor is spawned standalone.
     }
 
-    [Fact]
-    public async Task Spawn_agent_streams_activity_through_executor_dispatch_to_watchdog()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Spawn_agent_streams_activity_through_executor_dispatch_to_watchdog(bool fail)
     {
         using var dir = new DisposableTempDir();
         var paths = new NetclawPaths(dir.Path);
@@ -71,7 +73,7 @@ public class SpawnAgentStreamingTests : TestKit
         });
 
         var spawner = new SubAgentSpawner(
-            new SingleClientProvider(new FakeChatClient()),
+            new SingleClientProvider(new FakeChatClient { Failure = fail ? new InvalidOperationException("fixture LLM failure") : null }),
             registry,
             toolAccessPolicy,
             approvalService: null,
@@ -121,7 +123,17 @@ public class SpawnAgentStreamingTests : TestKit
 
         // The DIM dispatch gap ran spawn_agent on the non-streaming path: zero
         // activity items. The streaming override emits progress.
+        if (fail)
+        {
+            Assert.NotNull(result);
+            Assert.Contains("Outcome: failed", result, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("LogPath:", result);
+            Assert.DoesNotContain("ArtifactDirectory:", result);
+            return;
+        }
         Assert.NotEmpty(activity);
+        Assert.Contains("LogPath:", result);
+        Assert.Contains("ArtifactDirectory:", result);
 
         // The terminal result still flows through — a successful sub-agent run,
         // not a "Subagent '...' failed: ..." message from FormatResult.

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -2119,9 +2119,7 @@ public class SubAgentActorTests : TestKit
         var editTool = new FakeNetclawTool(
             "file_edit",
             "Successfully edited src/Calculator.cs: replaced 1 occurrence(s)",
-            onExecute: context => context.TryComplete(new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.Success,
-                [new ToolFileActivity(changedPath, ToolFileActivityKind.Changed)])));
+            onExecute: context => context.TryComplete(new ToolInvocationReceipt.Succeeded([new ToolFileActivity(changedPath, ToolFileActivityKind.Changed)], null)));
         var fakeClient = new FakeChatClient
         {
             ToolCallsOnFirstCall =
@@ -2154,7 +2152,7 @@ public class SubAgentActorTests : TestKit
             "file_edit",
             "Error: Permission denied: src/Calculator.cs",
             onExecute: context => context.TryComplete(
-                new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied)));
+                new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied)));
         var fakeClient = new FakeChatClient
         {
             ToolCallsOnFirstCall =
@@ -2222,9 +2220,7 @@ public class SubAgentActorTests : TestKit
         var readTool = new FakeNetclawTool(
             FileReadTool.ToolName,
             "content",
-            onExecute: context => context.TryComplete(new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.Success,
-                declaredProjectDirectory: forgedProject)));
+            onExecute: context => context.TryComplete(new ToolInvocationReceipt.Succeeded([], forgedProject)));
         var fakeClient = new FakeChatClient
         {
             ToolCallsOnFirstCall = [CreateToolCall("call-read", FileReadTool.ToolName)]

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentSpawnerTests.cs
@@ -575,9 +575,11 @@ public sealed class SubAgentSpawnerTests : TestKit
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task AuthorityRegression_Child_spawner_retains_team_file_authority(bool legacy)
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task AuthorityRegression_Child_spawner_retains_team_file_authority(bool legacy, bool partial)
     {
         using var directory = new DisposableTempDir();
         var paths = new NetclawPaths(directory.Path);
@@ -639,7 +641,9 @@ public sealed class SubAgentSpawnerTests : TestKit
         await File.WriteAllTextAsync(artifact, "child-artifact", TestContext.Current.CancellationToken);
         probe.Reply(new SubAgentResult
         {
-            Completion = new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
+            Completion = partial
+                ? new ChildRunCompletion.Partial(SubAgentOutcomeReason.ToolIterationBudgetExhausted, WorkingContextDelta.Empty)
+                : new ChildRunCompletion.Completed(WorkingContextDelta.Empty),
             Output = "child-summary", AgentName = new AgentName("reader")
         });
         var completed = await spawn;

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -54,7 +54,7 @@ public class AttachFileToolTests : IDisposable
         Assert.Contains("invalid_context", result, StringComparison.Ordinal);
         Assert.DoesNotContain("set_working_directory", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
-        Assert.Null(context.Receipt?.RemediationCode);
+        Assert.IsNotType<ToolInvocationReceipt.Correction>(context.Receipt);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -356,7 +356,7 @@ public partial class DispatchingToolExecutorTests
             Assert.Equal(
                 ToolInvocationOutcomeCategory.Success,
                 continuationContext.Invocation.Receipt?.Category);
-            Assert.Empty(continuationContext.Invocation.Receipt?.FileActivity ?? []);
+            Assert.False(continuationContext.Invocation.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
         }
         finally
         {
@@ -454,7 +454,7 @@ public partial class DispatchingToolExecutorTests
         var ex = await Assert.ThrowsAsync<ToolAccessDeniedException>(() => _restrictedExecutor.ExecuteAsync(toolCall, context, TestContext.Current.CancellationToken));
         Assert.Equal("shell_requires_personal_context", ex.DenyReason);
         Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]
@@ -4410,7 +4410,7 @@ public partial class DispatchingToolExecutorTests
 
         Assert.Contains("Meta argument '_background'", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
-        Assert.Null(context.Receipt?.RemediationCode);
+        Assert.IsNotType<ToolInvocationReceipt.Correction>(context.Receipt);
         Assert.Equal(0, approvalService.RequestCount);
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
@@ -67,7 +67,7 @@ public class FileEditToolTests : IDisposable
 
         Assert.Contains("matches 3 locations", result);
         Assert.DoesNotContain("Next action", result, StringComparison.Ordinal);
-        Assert.Equal(ToolRemediationCode.ProvideUniqueOldString, context.Receipt?.RemediationCode);
+        Assert.Equal(ToolRemediationCode.ProvideUniqueOldString, Assert.IsType<ToolInvocationReceipt.Correction>(context.Receipt).RemediationCode);
         Assert.Equal(original, await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
     }
 
@@ -82,7 +82,7 @@ public class FileEditToolTests : IDisposable
         var result = await _tool.ExecuteAsync(ToolInput.Create("Path", filePath, "OldString", "goodbye", "NewString", "farewell"), context, CancellationToken.None);
 
         Assert.Contains("not found", result);
-        Assert.Equal(ToolRemediationCode.ProvideUniqueOldString, context.Receipt?.RemediationCode);
+        Assert.Equal(ToolRemediationCode.ProvideUniqueOldString, Assert.IsType<ToolInvocationReceipt.Correction>(context.Receipt).RemediationCode);
         Assert.Equal(original, await File.ReadAllTextAsync(filePath, TestContext.Current.CancellationToken));
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
@@ -158,7 +158,7 @@ public class FileWriteToolTests : IDisposable
         Assert.Contains("Successfully wrote", result, StringComparison.Ordinal);
         Assert.Equal("done", await File.ReadAllTextAsync(expected, TestContext.Current.CancellationToken));
         Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
-        var activity = Assert.Single(context.Receipt?.FileActivity ?? []);
+        var activity = Assert.Single(Assert.IsType<ToolInvocationReceipt.Succeeded>(context.Receipt).FileActivity);
         Assert.Equal(expected, activity.CanonicalPath);
         Assert.Equal(ToolFileActivityKind.Changed, activity.Kind);
     }
@@ -201,7 +201,7 @@ public class FileWriteToolTests : IDisposable
             CancellationToken.None);
 
         Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
         Assert.False(File.Exists(filePath));
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/SessionStorageFileAccessPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SessionStorageFileAccessPolicyTests.cs
@@ -379,7 +379,7 @@ public sealed class SessionStorageFileAccessPolicyTests : IDisposable
         {
             Assert.Empty(context.FileAttachments);
             Assert.Empty(context.ModelInputFiles);
-            Assert.Empty(context.Receipt!.FileActivity);
+            Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Tools/StructuredWorkspaceToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/StructuredWorkspaceToolTests.cs
@@ -61,7 +61,7 @@ public sealed class StructuredWorkspaceToolTests : IDisposable
         Assert.Contains("skipped=1", result, StringComparison.Ordinal);
         Assert.Contains("truncated=false", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRemediationPresenterTests.cs
@@ -39,9 +39,7 @@ public class ToolRemediationPresenterTests
         string expectedAction)
     {
         var code = Enum.Parse<ToolRemediationCode>(codeName);
-        var receipt = new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.RecoverableCorrection,
-            remediationCode: code);
+        var receipt = new ToolInvocationReceipt.Correction(code);
 
         var result = ToolRemediationPresenter.Present(
             Message("bounded failure"),
@@ -55,9 +53,7 @@ public class ToolRemediationPresenterTests
     [Fact]
     public void Presenter_suppresses_hidden_working_directory_tool()
     {
-        var receipt = new ToolInvocationReceipt(
-            ToolInvocationOutcomeCategory.RecoverableCorrection,
-            remediationCode: ToolRemediationCode.SetWorkingDirectory);
+        var receipt = new ToolInvocationReceipt.Correction(ToolRemediationCode.SetWorkingDirectory);
 
         var result = ToolRemediationPresenter.Present(
             Message("bounded failure"),
@@ -72,7 +68,7 @@ public class ToolRemediationPresenterTests
     public void Presenter_leaves_non_corrective_result_unchanged()
     {
         var message = Message("denied");
-        var receipt = new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied);
+        var receipt = new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied);
 
         Assert.Same(message, ToolRemediationPresenter.Present(message, receipt, true));
         Assert.Same(message, ToolRemediationPresenter.Present(message, null, true));

--- a/src/Netclaw.Actors.Tests/Tools/WorkspaceToolRelativePathTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WorkspaceToolRelativePathTests.cs
@@ -66,7 +66,7 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
 
         Assert.Contains("App.cs", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
 
         Assert.Contains("Access denied", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.AccessDenied, context.Receipt?.Category);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
 
         Assert.Contains("Invalid path", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]
@@ -158,8 +158,8 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
         Assert.Contains("invalid_context", result, StringComparison.Ordinal);
         Assert.DoesNotContain("set_working_directory", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.RecoverableCorrection, context.Receipt?.Category);
-        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, context.Receipt?.RemediationCode);
-        Assert.Empty(context.Receipt?.FileActivity ?? []);
+        Assert.Equal(ToolRemediationCode.SetWorkingDirectory, Assert.IsType<ToolInvocationReceipt.Correction>(context.Receipt).RemediationCode);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { FileActivity.Count: > 0 });
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
 
         Assert.Contains("must be absolute", result, StringComparison.Ordinal);
         Assert.Equal(ToolInvocationOutcomeCategory.InvalidInput, context.Receipt?.Category);
-        Assert.Null(context.Receipt?.DeclaredProjectDirectory);
+        Assert.False(context.Receipt is ToolInvocationReceipt.Succeeded { DeclaredProjectDirectory: not null });
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
 
         Assert.Equal(_projectDirectory, result);
         Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
-        Assert.Equal(_projectDirectory, context.Receipt?.DeclaredProjectDirectory);
+        Assert.Equal(_projectDirectory, Assert.IsType<ToolInvocationReceipt.Succeeded>(context.Receipt).DeclaredProjectDirectory);
     }
 
     private ToolExecutionContext CreateContext()
@@ -210,7 +210,7 @@ public sealed class WorkspaceToolRelativePathTests : IDisposable
         ToolFileActivityKind expectedKind)
     {
         Assert.Equal(ToolInvocationOutcomeCategory.Success, context.Receipt?.Category);
-        var activity = Assert.Single(context.Receipt?.FileActivity ?? []);
+        var activity = Assert.Single(Assert.IsType<ToolInvocationReceipt.Succeeded>(context.Receipt).FileActivity);
         Assert.Equal(Path.GetFullPath(expectedPath), activity.CanonicalPath);
         Assert.Equal(expectedKind, activity.Kind);
     }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -960,8 +960,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (result.Name is not SetWorkingDirectoryTool.ToolName
                 || result.ToolCallId is not { } callId
                 || !msg.ToolReceipts.TryGetValue(callId.Value, out var receipt)
-                || receipt.Category != ToolInvocationOutcomeCategory.Success
-                || receipt.DeclaredProjectDirectory is not { } projectDir)
+                || receipt is not ToolInvocationReceipt.Succeeded { DeclaredProjectDirectory: { } projectDir })
             {
                 continue;
             }
@@ -4676,7 +4675,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             toolCallId.Value,
             toolMessage.Name ?? "unknown",
             result.Receipt?.Category.ToString(),
-            result.Receipt?.RemediationCode?.ToString());
+            (result.Receipt as ToolInvocationReceipt.Correction)?.RemediationCode.ToString());
 
         EmitOutput(new ToolResultOutput
         {
@@ -4700,9 +4699,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             TryActivateDiscoveredTool(toolMessage.Content.Trim());
 
         if (toolMessage.Name is SetWorkingDirectoryTool.ToolName
-            && result.Receipt is
+            && result.Receipt is ToolInvocationReceipt.Succeeded
             {
-                Category: ToolInvocationOutcomeCategory.Success,
                 DeclaredProjectDirectory: { } projectDir
             })
         {

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -335,7 +335,7 @@ internal sealed class SessionToolExecutionPipeline
                         batch.SessionId.Value,
                         callId,
                         receipt.Category,
-                        receipt.RemediationCode?.ToString());
+                        (receipt as ToolInvocationReceipt.Correction)?.RemediationCode.ToString());
             }
 
             if (batch.StreamResults)
@@ -447,7 +447,7 @@ internal sealed class SessionToolExecutionPipeline
                 ToolCallId = new ToolCallId(tc.CallId),
                 Name = tc.Name
             }, [], [], [], [], authorizationAttemptId, FailureCode: rejection.DenyReason,
-                Receipt: new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
+                Receipt: new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.InvalidInput));
         }
 
         var meta = interpretation.Meta;
@@ -610,7 +610,7 @@ internal sealed class SessionToolExecutionPipeline
                     [],
                     [],
                     authorizationAttemptId,
-                    Receipt: new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied),
+                    Receipt: new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied),
                     ManagedTemporaryCorrectionUpdate: consumedManagedTemporaryKey is { } deniedConsumed
                         ? new ManagedTemporaryCorrectionChange.Consume(deniedConsumed)
                         : null);
@@ -693,7 +693,7 @@ internal sealed class SessionToolExecutionPipeline
                     Name = tc.Name
                 }, [], context.Outputs.FileAttachments, completedRuns, acceptedFindings,
                     authorizationAttemptId,
-                    Receipt: new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
+                    Receipt: new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied));
             }
 
             // Mid-turn approval pause: emit request to channel, block on TCS
@@ -812,7 +812,7 @@ internal sealed class SessionToolExecutionPipeline
                     invocation: context.Invocation,
                     canDeclare: batch.CanDeclareWorkingDirectory);
                 resultText = string.IsNullOrEmpty(hint) ? reason : $"{reason}\n{hint}";
-                context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
+                context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied));
 
             }
         }
@@ -820,7 +820,7 @@ internal sealed class SessionToolExecutionPipeline
         {
             sw.Stop();
             resultText = ex.ToAgentResult();
-            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied));
 
         }
         catch (OperationCanceledException) when (batch.CancellationToken.IsCancellationRequested)
@@ -841,7 +841,7 @@ internal sealed class SessionToolExecutionPipeline
                 FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
                 _ => ToolInvocationOutcomeCategory.TransientFailure
             };
-            context.Outputs.TryComplete(new ToolInvocationReceipt(category));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(category));
 
         }
 
@@ -856,7 +856,7 @@ internal sealed class SessionToolExecutionPipeline
                 modelInputMaterialization.RequestedCount - modelInputMaterialization.MediaReferences.Count);
 
         var receipt = context.Receipt
-            ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success);
+            ?? new ToolInvocationReceipt.Succeeded([], null);
         var message = new SerializableChatMessage
         {
             Role = Protocol.ChatRole.Tool,

--- a/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
@@ -27,7 +27,7 @@ public sealed record GitWorkingContextSnapshot
     public int Untracked { get; init; }
     public ImmutableHashSet<string> ChangedFiles { get; init; } = [];
 
-    internal GitHeadState HeadState => GitHeadState.Create(Detached, Branch, Head, Upstream, Ahead, Behind);
+    internal GitHeadState GetHeadState() => GitHeadState.Create(Detached, Branch, Head, Upstream, Ahead, Behind);
 }
 
 internal abstract class GitHeadState
@@ -149,10 +149,24 @@ public sealed record WorkingContextSnapshot
         switch (Git)
         {
             case GitWorkingContextInspection.Available { Snapshot: var git }:
+                GitHeadState headState;
+                try
+                {
+                    headState = git.GetHeadState();
+                }
+                catch (FormatException ex)
+                {
+                    // Public snapshots can come from callers other than the Git parser.
+                    // Report invalid metadata instead of interrupting the actor's next turn.
+                    sb.Append("\ngit:")
+                        .Append("\n  status: unavailable")
+                        .Append("\n  reason: ").Append(ex.Message);
+                    break;
+                }
                 sb.Append("\ngit:")
                     .Append("\n  worktree: ").Append(git.Worktree)
                     .Append("\n  common_dir: ").Append(git.CommonDirectory);
-                switch (git.HeadState)
+                switch (headState)
                 {
                     case GitHeadState.DetachedHead detached:
                         sb.Append("\n  branch: (detached)").Append("\n  head: ").Append(detached.Head);

--- a/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextSnapshot.cs
@@ -26,6 +26,71 @@ public sealed record GitWorkingContextSnapshot
     public int Modified { get; init; }
     public int Untracked { get; init; }
     public ImmutableHashSet<string> ChangedFiles { get; init; } = [];
+
+    internal GitHeadState HeadState => GitHeadState.Create(Detached, Branch, Head, Upstream, Ahead, Behind);
+}
+
+internal abstract class GitHeadState
+{
+    private GitHeadState() { }
+
+    internal sealed class DetachedHead(string head) : GitHeadState
+    {
+        internal string Head { get; } = !string.IsNullOrWhiteSpace(head)
+            ? head : throw new FormatException("A detached Git head requires a commit.");
+    }
+
+    internal sealed class AttachedHead(string? branch, string? head, BranchTracking? tracking) : GitHeadState
+    {
+        // Public snapshots can omit branch metadata. A null commit also represents an unborn branch.
+        internal string? Branch { get; } = branch;
+        internal string? Head { get; } = head;
+        internal BranchTracking? Tracking { get; } = tracking;
+    }
+
+    internal sealed class BranchTracking
+    {
+        internal BranchTracking(string upstream, int ahead, int behind)
+        {
+            if (string.IsNullOrWhiteSpace(upstream) || ahead < 0 || behind < 0)
+                throw new FormatException("Git tracking requires an upstream and nonnegative counts.");
+            Upstream = upstream;
+            Ahead = ahead;
+            Behind = behind;
+        }
+
+        internal string Upstream { get; }
+        internal int Ahead { get; }
+        internal int Behind { get; }
+    }
+
+    internal static GitHeadState Create(bool detached, string? branch, string? head, string? upstream, int ahead, int behind)
+    {
+        if (detached)
+        {
+            if (branch is not null || upstream is not null || ahead != 0 || behind != 0)
+                throw new FormatException("A detached Git head cannot carry branch or tracking metadata.");
+            return new DetachedHead(head ?? throw new FormatException("A detached Git head requires a commit."));
+        }
+
+        if (upstream is null && (ahead != 0 || behind != 0))
+            throw new FormatException("Git divergence requires an upstream.");
+        return new AttachedHead(branch, head, upstream is null ? null : new BranchTracking(upstream, ahead, behind));
+    }
+
+    internal GitWorkingContextSnapshot ApplyTo(GitWorkingContextSnapshot snapshot) => this switch
+    {
+        DetachedHead detached => snapshot with
+        {
+            Detached = true, Head = detached.Head, Branch = null, Upstream = null, Ahead = 0, Behind = 0
+        },
+        AttachedHead branch => snapshot with
+        {
+            Detached = false, Head = branch.Head, Branch = branch.Branch,
+            Upstream = branch.Tracking?.Upstream, Ahead = branch.Tracking?.Ahead ?? 0, Behind = branch.Tracking?.Behind ?? 0
+        },
+        _ => throw new InvalidOperationException("Unexpected Git head state.")
+    };
 }
 
 public abstract record GitWorkingContextInspection
@@ -86,14 +151,24 @@ public sealed record WorkingContextSnapshot
             case GitWorkingContextInspection.Available { Snapshot: var git }:
                 sb.Append("\ngit:")
                     .Append("\n  worktree: ").Append(git.Worktree)
-                    .Append("\n  common_dir: ").Append(git.CommonDirectory)
-                    .Append("\n  branch: ").Append(git.Detached ? "(detached)" : git.Branch)
-                    .Append("\n  head: ").Append(git.Head ?? "(unborn)");
-                if (git.Upstream is not null)
+                    .Append("\n  common_dir: ").Append(git.CommonDirectory);
+                switch (git.HeadState)
                 {
-                    sb.Append("\n  upstream: ").Append(git.Upstream)
-                        .Append("\n  ahead: ").Append(git.Ahead)
-                        .Append("\n  behind: ").Append(git.Behind);
+                    case GitHeadState.DetachedHead detached:
+                        sb.Append("\n  branch: (detached)").Append("\n  head: ").Append(detached.Head);
+                        break;
+                    case GitHeadState.AttachedHead branch:
+                        sb.Append("\n  branch: ").Append(branch.Branch)
+                            .Append("\n  head: ").Append(branch.Head ?? "(unborn)");
+                        if (branch.Tracking is { } tracking)
+                        {
+                            sb.Append("\n  upstream: ").Append(tracking.Upstream)
+                                .Append("\n  ahead: ").Append(tracking.Ahead)
+                                .Append("\n  behind: ").Append(tracking.Behind);
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected Git head state.");
                 }
 
                 sb.Append("\n  staged: ").Append(git.Staged)
@@ -384,21 +459,16 @@ public sealed class GitWorkingContextInspector : IGitWorkingContextInspector
             }
         }
 
-        return new GitWorkingContextSnapshot
+        var headState = GitHeadState.Create(detached, branch, head, upstream, ahead, behind);
+        return headState.ApplyTo(new GitWorkingContextSnapshot
         {
             Worktree = worktree,
             CommonDirectory = commonDirectory,
-            Branch = branch,
-            Detached = detached,
-            Head = head,
-            Upstream = upstream,
-            Ahead = ahead,
-            Behind = behind,
             Staged = staged,
             Modified = modified,
             Untracked = untracked,
             ChangedFiles = files.ToImmutable()
-        };
+        });
     }
 
     internal readonly record struct GitInspectionDeadline(DateTimeOffset ExpiresAt)

--- a/src/Netclaw.Actors/Sessions/WorkingContextUpdater.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextUpdater.cs
@@ -24,12 +24,12 @@ internal static class WorkingContextUpdater
         {
             if (result.ToolCallId is not { } callId
                 || !receipts.TryGetValue(callId.Value, out var receipt)
-                || receipt.Category != ToolInvocationOutcomeCategory.Success)
+                || receipt is not ToolInvocationReceipt.Succeeded success)
             {
                 continue;
             }
 
-            foreach (var activity in receipt.FileActivity)
+            foreach (var activity in success.FileActivity)
                 updated = updated.AddRecentFile(activity.CanonicalPath);
         }
 
@@ -40,11 +40,11 @@ internal static class WorkingContextUpdater
         WorkingContext current,
         ToolInvocationReceipt? receipt)
     {
-        if (receipt?.Category != ToolInvocationOutcomeCategory.Success)
+        if (receipt is not ToolInvocationReceipt.Succeeded success)
             return current;
 
         var updated = current;
-        foreach (var activity in receipt.FileActivity)
+        foreach (var activity in success.FileActivity)
             updated = updated.AddRecentFile(activity.CanonicalPath);
         return updated;
     }

--- a/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
+++ b/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
@@ -65,7 +65,7 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
         if (error is not null)
             return error;
 
-        var result = await _spawner.SpawnAsync(profile!, args.Task, args.Context, context, ct);
+        var result = await _spawner.SpawnRunAsync(profile!, args.Task, args.Context, context, ct, systemPromptOverlay: null, activitySink: null);
         return FormatResult(args.Agent, result);
     }
 
@@ -94,8 +94,8 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
         // The spawner writes the sub-agent's activity into this channel and
         // completes it (even on failure) when the run ends.
         var channel = Channel.CreateUnbounded<ToolActivityUpdate>();
-        var spawnTask = _spawner.SpawnAsync(
-            profile!, args!.Task, args.Context, context, ct, activitySink: channel.Writer);
+        var spawnTask = _spawner.SpawnRunAsync(
+            profile!, args!.Task, args.Context, context, ct, systemPromptOverlay: null, activitySink: channel.Writer);
         try
         {
             await foreach (var activity in channel.Reader.ReadAllAsync(ct))
@@ -111,8 +111,9 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
         }
     }
 
-    private static string FormatResult(string agent, SubAgentResult result)
+    private static string FormatResult(string agent, EnrichedChildRunResult enriched)
     {
+        var result = enriched.Response;
         var builder = new StringBuilder();
         builder.AppendLine("Subagent run finished.");
         builder.AppendLine($"Agent: {agent}");
@@ -121,10 +122,11 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
         builder.AppendLine($"Outcome: {result.Outcome.ToString().ToLowerInvariant()}");
         if (result.OutcomeReason is { } reason)
             builder.AppendLine($"Reason: {reason.Value}");
-        if (result.Success && result.LogPath is { } logPath)
-            builder.AppendLine($"LogPath: {logPath}");
-        if (result.Success && result.ArtifactDirectory is { } artifactDirectory)
-            builder.AppendLine($"ArtifactDirectory: {artifactDirectory}");
+        if (enriched is EnrichedChildRunResult.SuccessfulRun success)
+        {
+            builder.AppendLine($"LogPath: {success.Locations.LogPath.Value}");
+            builder.AppendLine($"ArtifactDirectory: {success.Locations.ArtifactDirectory.Value}");
+        }
 
         builder.AppendLine();
         builder.AppendLine(result.Success ? "Summary:" : "Error:");

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -588,7 +588,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                             _subSessionId,
                             callId.Value,
                             receipt?.Category.ToString(),
-                            receipt?.RemediationCode?.ToString());
+                            (receipt as ToolInvocationReceipt.Correction)?.RemediationCode.ToString());
                     }
                     if (msg.ToolExposureRequests.TryGetValue(callId.Value, out var exposureRequest))
                         TryActivateDiscoveredTool(exposureRequest.ToolName.Value);
@@ -1176,9 +1176,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private void TryApplyProjectDirectory(string? toolName, ToolInvocationReceipt? receipt)
     {
         if (toolName is not SetWorkingDirectoryTool.ToolName
-            || receipt is not
+            || receipt is not ToolInvocationReceipt.Succeeded
             {
-                Category: ToolInvocationOutcomeCategory.Success,
                 DeclaredProjectDirectory: { } projectDirectory
             })
         {
@@ -1427,7 +1426,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                 if (interpretation.Rejection is { } rejection)
                 {
                     toolContext.Outputs.TryComplete(
-                        new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
+                        new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.InvalidInput));
                     return BuildToolResult(tc, rejection.Message, toolContext, modelInputBudget);
                 }
 
@@ -1567,7 +1566,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     }
 
                     toolContext.Outputs.TryComplete(
-                        new ToolInvocationReceipt(ToolInvocationOutcomeCategory.AccessDenied));
+                        new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied));
 
                     return BuildToolResult(
                         tc,
@@ -1602,7 +1601,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         FileNotFoundException or DirectoryNotFoundException => ToolInvocationOutcomeCategory.NotFound,
                         _ => ToolInvocationOutcomeCategory.TransientFailure
                     };
-                    toolContext.Outputs.TryComplete(new ToolInvocationReceipt(category));
+                    toolContext.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(category));
                     var error = ex is ToolAccessDeniedException denied
                         ? denied.ToAgentResult()
                         : $"Error: {ex.Message}";
@@ -1693,7 +1692,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         }
 
         var receipt = toolContext.Receipt
-            ?? new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success);
+            ?? new ToolInvocationReceipt.Succeeded([], null);
         return new SubAgentToolCallResult(
             new SerializableChatMessage
             {
@@ -1783,10 +1782,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
         public void Apply(ToolInvocationReceipt? receipt)
         {
-            if (receipt?.Category != ToolInvocationOutcomeCategory.Success)
+            if (receipt is not ToolInvocationReceipt.Succeeded success)
                 return;
 
-            foreach (var activity in receipt.FileActivity)
+            foreach (var activity in success.FileActivity)
             {
                 _workingContext = _workingContext.AddRecentFile(activity.CanonicalPath);
                 if (activity.Kind == ToolFileActivityKind.Read)

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -352,7 +352,8 @@ public sealed class SubAgentSpawner
                 ChildRunCompletion.Completed or ChildRunCompletion.Partial =>
                     new EnrichedChildRunResult.SuccessfulRun(response,
                         new EnrichedChildRunResult.RunLocations(childStorage.LogPath, childStorage.ArtifactDirectory)),
-                _ => new EnrichedChildRunResult.OtherRun(response)
+                ChildRunCompletion.Failed or ChildRunCompletion.Cancelled => new EnrichedChildRunResult.OtherRun(response),
+                _ => throw new InvalidOperationException("Unexpected child run completion.")
             };
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -549,7 +550,10 @@ public sealed class SubAgentSpawner
 internal abstract class EnrichedChildRunResult
 {
     private EnrichedChildRunResult(SubAgentResult response)
-        => Response = response with { LogPath = null, ArtifactDirectory = null };
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        Response = response with { LogPath = null, ArtifactDirectory = null };
+    }
 
     // Preserve the public response at the adapter boundary. Locations exist only on SuccessfulRun.
     internal SubAgentResult Response { get; }

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -82,6 +82,20 @@ public sealed class SubAgentSpawner
         string? systemPromptOverlay = null,
         ChannelWriter<ToolActivityUpdate>? activitySink = null)
     {
+        var result = await SpawnRunAsync(profile, task, runtimeContext, context, ct, systemPromptOverlay, activitySink)
+            .ConfigureAwait(false);
+        return result.ToProtocolResult();
+    }
+
+    internal async Task<EnrichedChildRunResult> SpawnRunAsync(
+        SubAgentProfile profile,
+        string task,
+        string? runtimeContext,
+        ToolInvocationContext context,
+        CancellationToken ct,
+        string? systemPromptOverlay,
+        ChannelWriter<ToolActivityUpdate>? activitySink)
+    {
         // Parent-side spawn breadcrumbs — each event is fanned out to daemon.log/Seq and
         // the parent's session.log from one place (see SubAgentSpawnBreadcrumbs), covering
         // request → outcome plus early rejections that happen before the child even exists.
@@ -91,12 +105,12 @@ public sealed class SubAgentSpawner
         {
             SubAgentSpawnBreadcrumbs.NoSessionContext(_logger, context, profile.Name);
             activitySink?.TryComplete();
-            return new SubAgentResult
+            return new EnrichedChildRunResult.OtherRun(new SubAgentResult
             {
                 Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.SpawnUnavailable),
                 Output = $"Cannot spawn subagent '{profile.Name}': no session context available.",
                 AgentName = new AgentName(profile.Name)
-            };
+            });
         }
 
         var exposure = ResolveTools(context);
@@ -104,12 +118,12 @@ public sealed class SubAgentSpawner
         {
             SubAgentSpawnBreadcrumbs.NoToolsAvailable(_logger, context, profile.Name);
             activitySink?.TryComplete();
-            return new SubAgentResult
+            return new EnrichedChildRunResult.OtherRun(new SubAgentResult
             {
                 Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.NoToolsAvailable),
                 Output = $"Cannot spawn subagent '{profile.Name}': no tools are available under the parent audience policy.",
                 AgentName = new AgentName(profile.Name)
-            };
+            });
         }
 
         var definition = new SubAgentDefinition
@@ -154,20 +168,20 @@ public sealed class SubAgentSpawner
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             activitySink?.TryComplete();
-            return CancelledResult(definition.Name, runId, scopeId);
+            return new EnrichedChildRunResult.OtherRun(CancelledResult(definition.Name, runId, scopeId));
         }
         catch (Exception ex) when (!FatalExceptionPolicy.IsFatal(ex))
         {
             SubAgentSpawnBreadcrumbs.RunFailed(_logger, context, profile.Name, runId, ex);
             activitySink?.TryComplete();
-            return new SubAgentResult
+            return new EnrichedChildRunResult.OtherRun(new SubAgentResult
             {
                 Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.SpawnError),
                 Output = $"Subagent error: {ex.Message}",
                 AgentName = definition.Name,
                 RunId = runId,
                 ScopeId = scopeId
-            };
+            });
         }
         catch (Exception ex) when (FatalExceptionPolicy.IsFatal(ex))
         {
@@ -236,7 +250,7 @@ public sealed class SubAgentSpawner
                 OutcomeReason = SubAgentOutcomeReason.CancelledByParent
             });
             activitySink?.TryComplete();
-            return CancelledResult(definition.Name, runId, scopeId);
+            return new EnrichedChildRunResult.OtherRun(CancelledResult(definition.Name, runId, scopeId));
         }
         catch (Exception ex) when (!FatalExceptionPolicy.IsFatal(ex))
         {
@@ -332,12 +346,13 @@ public sealed class SubAgentSpawner
 
             SubAgentSpawnBreadcrumbs.Completed(_logger, context, profile.Name, runId, result.Success, sw.ElapsedMilliseconds);
 
-            return result with
+            var response = result with { RunId = runId, ScopeId = scopeId };
+            return result.Completion switch
             {
-                RunId = runId,
-                ScopeId = scopeId,
-                LogPath = result.Success ? childStorage.LogPath.Value : null,
-                ArtifactDirectory = result.Success ? childStorage.ArtifactDirectory.Value : null
+                ChildRunCompletion.Completed or ChildRunCompletion.Partial =>
+                    new EnrichedChildRunResult.SuccessfulRun(response,
+                        new EnrichedChildRunResult.RunLocations(childStorage.LogPath, childStorage.ArtifactDirectory)),
+                _ => new EnrichedChildRunResult.OtherRun(response)
             };
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -356,7 +371,7 @@ public sealed class SubAgentSpawner
                 Duration = sw.Elapsed
             });
 
-            return CancelledResult(definition.Name, runId, scopeId);
+            return new EnrichedChildRunResult.OtherRun(CancelledResult(definition.Name, runId, scopeId));
         }
         catch (Exception ex) when (!FatalExceptionPolicy.IsFatal(ex))
         {
@@ -376,14 +391,14 @@ public sealed class SubAgentSpawner
             });
 
             SubAgentSpawnBreadcrumbs.RunFailed(_logger, context, profile.Name, runId, ex);
-            return new SubAgentResult
+            return new EnrichedChildRunResult.OtherRun(new SubAgentResult
             {
                 Completion = new ChildRunCompletion.Failed(SubAgentOutcomeReason.SpawnError),
                 Output = $"Subagent error: {ex.Message}",
                 AgentName = new AgentName(profile.Name),
                 RunId = runId,
                 ScopeId = scopeId
-            };
+            });
         }
         finally
         {
@@ -528,4 +543,60 @@ public sealed class SubAgentSpawner
         // operator's quality workflow aligned without exposing SOUL.md or TOOLING.md.
         return _promptProvider.GetOperatingRules(context.Audience);
     }
+}
+
+/// <summary>Separates child completion from the locations that the spawner adds.</summary>
+internal abstract class EnrichedChildRunResult
+{
+    private EnrichedChildRunResult(SubAgentResult response)
+        => Response = response with { LogPath = null, ArtifactDirectory = null };
+
+    // Preserve the public response at the adapter boundary. Locations exist only on SuccessfulRun.
+    internal SubAgentResult Response { get; }
+
+    internal sealed record RunLocations
+    {
+        internal RunLocations(SessionLogPath logPath, ArtifactDirectory artifactDirectory)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(logPath.Value);
+            ArgumentException.ThrowIfNullOrWhiteSpace(artifactDirectory.Value);
+            LogPath = logPath;
+            ArtifactDirectory = artifactDirectory;
+        }
+
+        internal SessionLogPath LogPath { get; }
+        internal ArtifactDirectory ArtifactDirectory { get; }
+    }
+
+    internal sealed class SuccessfulRun : EnrichedChildRunResult
+    {
+        internal SuccessfulRun(SubAgentResult response, RunLocations locations) : base(response)
+        {
+            if (response.Completion is not (ChildRunCompletion.Completed or ChildRunCompletion.Partial))
+                throw new ArgumentException("A successful run requires completed or partial completion.", nameof(response));
+            Locations = locations ?? throw new ArgumentNullException(nameof(locations));
+        }
+
+        internal RunLocations Locations { get; }
+    }
+
+    internal sealed class OtherRun : EnrichedChildRunResult
+    {
+        internal OtherRun(SubAgentResult response) : base(response)
+        {
+            if (response.Completion is not (ChildRunCompletion.Failed or ChildRunCompletion.Cancelled))
+                throw new ArgumentException("An unsuccessful run requires failed or cancelled completion.", nameof(response));
+        }
+    }
+
+    internal SubAgentResult ToProtocolResult() => this switch
+    {
+        SuccessfulRun success => Response with
+        {
+            LogPath = success.Locations.LogPath.Value,
+            ArtifactDirectory = success.Locations.ArtifactDirectory.Value
+        },
+        OtherRun => Response,
+        _ => throw new InvalidOperationException("Unexpected enriched child result.")
+    };
 }

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -170,7 +170,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 context.Approval.AuthorizationAttemptId.Value,
                 context.SessionId,
                 toolCall.CallId);
-            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.NotFound));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.NotFound));
             return $"Unknown tool: {toolCall.Name}";
         }
 
@@ -188,7 +188,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 context.Approval.AuthorizationAttemptId.Value,
                 context.SessionId,
                 toolCall.CallId);
-            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.InvalidInput));
             return rejection.Message;
         }
 
@@ -208,7 +208,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                     ct)
                 : await tool.ExecuteAsync(toolCall.Arguments, context.Invocation, ct);
 
-            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.Succeeded([], null));
 
             var redacted = SecretOutputRedactor.Redact(result);
 
@@ -283,7 +283,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 context.Approval.AuthorizationAttemptId.Value,
                 context.SessionId,
                 toolCall.CallId);
-            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.NotFound));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.NotFound));
             yield return new ToolCompletedUpdate($"Unknown tool: {toolCall.Name}");
             yield break;
         }
@@ -301,7 +301,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 context.Approval.AuthorizationAttemptId.Value,
                 context.SessionId,
                 toolCall.CallId);
-            context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
+            context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.InvalidInput));
             yield return new ToolCompletedUpdate(rejection.Message);
             yield break;
         }
@@ -335,7 +335,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
             {
                 case ToolCompletedUpdate completed:
                     sw.Stop();
-                    context.Outputs.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.Success));
+                    context.Outputs.TryComplete(new ToolInvocationReceipt.Succeeded([], null));
                     var redacted = SecretOutputRedactor.Redact(completed.Result);
                     var modelResult = tool.SuppressOutputRedaction ? completed.Result : redacted;
                     modelResult = await ToolOutputSpill.BoundAndSpillAsync(
@@ -380,7 +380,7 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
             IOException or TimeoutException => ToolInvocationOutcomeCategory.TransientFailure,
             _ => ToolInvocationOutcomeCategory.TransientFailure
         };
-        context.Outputs.TryComplete(new ToolInvocationReceipt(category));
+        context.Outputs.TryComplete(new ToolInvocationReceipt.OtherOutcome(category));
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
+++ b/src/Netclaw.Actors/Tools/ManagedTemporaryCorrection.cs
@@ -61,7 +61,7 @@ internal sealed class ToolCorrectionCollection
 /// <summary>Defines the shared correction content, receipt, and actor state change.</summary>
 internal sealed record ToolCorrectionDelivery(
     string Content,
-    ToolInvocationReceipt Receipt,
+    ToolInvocationReceipt.Correction Receipt,
     ToolName? NativeTool,
     ManagedTemporaryCorrectionChange? ManagedTemporaryStateChange)
 {
@@ -96,9 +96,7 @@ internal sealed record ToolCorrectionDelivery(
         => new(
             "Tool execution deferred: working_directory_not_declared\n" +
             $"Project directory: '{directory}'.",
-            new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.RecoverableCorrection,
-                remediationCode: ToolRemediationCode.SetWorkingDirectory),
+            new ToolInvocationReceipt.Correction(ToolRemediationCode.SetWorkingDirectory),
             NativeTool: null,
             ManagedTemporaryStateChange: null);
 
@@ -110,9 +108,7 @@ internal sealed record ToolCorrectionDelivery(
 
         return new ToolCorrectionDelivery(
             content,
-            new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.RecoverableCorrection,
-                remediationCode: ToolRemediationCode.UseNativeTool),
+            new ToolInvocationReceipt.Correction(ToolRemediationCode.UseNativeTool),
             tool,
             ManagedTemporaryStateChange: null);
     }
@@ -124,9 +120,7 @@ internal sealed record ToolCorrectionDelivery(
         var correctionKey = new ManagedTemporaryCorrectionKey(managedTemporaryCall, retryTarget);
         return new ToolCorrectionDelivery(
             ManagedTemporaryCorrection.BuildSuggestion(retryTarget.ManagedTemporaryDirectory),
-            new ToolInvocationReceipt(
-                ToolInvocationOutcomeCategory.RecoverableCorrection,
-                remediationCode: ToolRemediationCode.UseManagedTemporaryDirectory),
+            new ToolInvocationReceipt.Correction(ToolRemediationCode.UseManagedTemporaryDirectory),
             NativeTool: null,
             new ManagedTemporaryCorrectionChange.Arm(correctionKey));
     }

--- a/src/Netclaw.Actors/Tools/ToolOutcomeResults.cs
+++ b/src/Netclaw.Actors/Tools/ToolOutcomeResults.cs
@@ -10,15 +10,15 @@ namespace Netclaw.Actors.Tools;
 internal static class ToolOutcomeResults
 {
     public static string Success(this ToolInvocationContext context, string result)
-        => Complete(context, result, ToolInvocationOutcomeCategory.Success);
+        => Complete(context, result, new ToolInvocationReceipt.Succeeded([], null));
 
     public static string SuccessFile(
         this ToolInvocationContext context,
         string result,
         string canonicalPath,
         ToolFileActivityKind kind)
-        => Complete(context, result, ToolInvocationOutcomeCategory.Success,
-            [new ToolFileActivity(canonicalPath, kind)]);
+        => Complete(context, result, new ToolInvocationReceipt.Succeeded(
+            [new ToolFileActivity(canonicalPath, kind)], null));
 
     public static string SuccessFiles(
         this ToolInvocationContext context,
@@ -28,8 +28,8 @@ internal static class ToolOutcomeResults
         => Complete(
             context,
             result,
-            ToolInvocationOutcomeCategory.Success,
-            [.. canonicalPaths.Select(path => new ToolFileActivity(path, kind))]);
+            new ToolInvocationReceipt.Succeeded(
+                [.. canonicalPaths.Select(path => new ToolFileActivity(path, kind))], null));
 
     public static string SuccessProject(
         this ToolInvocationContext context,
@@ -38,8 +38,7 @@ internal static class ToolOutcomeResults
         => Complete(
             context,
             result,
-            ToolInvocationOutcomeCategory.Success,
-            declaredProjectDirectory: canonicalProjectDirectory);
+            new ToolInvocationReceipt.Succeeded([], canonicalProjectDirectory));
 
     public static string SuccessProjectChange(
         this ToolInvocationContext context,
@@ -49,21 +48,20 @@ internal static class ToolOutcomeResults
         => Complete(
             context,
             result,
-            ToolInvocationOutcomeCategory.Success,
-            [new ToolFileActivity(canonicalChangedPath, ToolFileActivityKind.Changed)],
-            declaredProjectDirectory: canonicalProjectDirectory);
+            new ToolInvocationReceipt.Succeeded(
+                [new ToolFileActivity(canonicalChangedPath, ToolFileActivityKind.Changed)], canonicalProjectDirectory));
 
     public static string InvalidInput(this ToolInvocationContext context, string result)
-        => Complete(context, result, ToolInvocationOutcomeCategory.InvalidInput);
+        => Complete(context, result, new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.InvalidInput));
 
     public static string AccessDenied(this ToolInvocationContext context, string result)
-        => Complete(context, result, ToolInvocationOutcomeCategory.AccessDenied);
+        => Complete(context, result, new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.AccessDenied));
 
     public static string NotFound(this ToolInvocationContext context, string result)
-        => Complete(context, result, ToolInvocationOutcomeCategory.NotFound);
+        => Complete(context, result, new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.NotFound));
 
     public static string TransientFailure(this ToolInvocationContext context, string result)
-        => Complete(context, result, ToolInvocationOutcomeCategory.TransientFailure);
+        => Complete(context, result, new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.TransientFailure));
 
     public static string RecoverableCorrection(
         this ToolInvocationContext context,
@@ -72,8 +70,7 @@ internal static class ToolOutcomeResults
         => Complete(
             context,
             result,
-            ToolInvocationOutcomeCategory.RecoverableCorrection,
-            remediationCode: remediationCode);
+            new ToolInvocationReceipt.Correction(remediationCode));
 
     public static string PathAccessFailure(
         this ToolInvocationContext context,
@@ -92,16 +89,9 @@ internal static class ToolOutcomeResults
     private static string Complete(
         ToolInvocationContext context,
         string result,
-        ToolInvocationOutcomeCategory category,
-        IReadOnlyList<ToolFileActivity>? fileActivity = null,
-        ToolRemediationCode? remediationCode = null,
-        string? declaredProjectDirectory = null)
+        ToolInvocationReceipt receipt)
     {
-        context.TryComplete(new ToolInvocationReceipt(
-            category,
-            fileActivity,
-            remediationCode,
-            declaredProjectDirectory));
+        context.TryComplete(receipt);
         return result;
     }
 }

--- a/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
+++ b/src/Netclaw.Actors/Tools/ToolRemediationPresenter.cs
@@ -15,7 +15,7 @@ internal static class ToolRemediationPresenter
         ToolInvocationReceipt? receipt,
         bool setWorkingDirectoryAvailable)
     {
-        if (receipt?.RemediationCode is not { } remediationCode)
+        if (receipt is not ToolInvocationReceipt.Correction { RemediationCode: var remediationCode })
             return message;
 
         var action = remediationCode switch

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -47,7 +47,7 @@ public abstract partial class NetclawTool<TParams> : INetclawTool where TParams 
         if (TryParse(arguments, out var error, out var args))
             return await ExecuteAsync(args, context, ct);
 
-        context.TryComplete(new ToolInvocationReceipt(ToolInvocationOutcomeCategory.InvalidInput));
+        context.TryComplete(new ToolInvocationReceipt.OtherOutcome(ToolInvocationOutcomeCategory.InvalidInput));
         return error;
     }
 

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -60,57 +60,49 @@ internal sealed record ToolFileActivity
     public ToolFileActivityKind Kind { get; }
 }
 
-internal sealed record ToolInvocationReceipt
+internal abstract class ToolInvocationReceipt
 {
-    public ToolInvocationReceipt(
-        ToolInvocationOutcomeCategory category,
-        IReadOnlyList<ToolFileActivity>? fileActivity = null,
-        ToolRemediationCode? remediationCode = null,
-        string? declaredProjectDirectory = null)
-    {
-        if (!Enum.IsDefined(category))
-            throw new ArgumentOutOfRangeException(nameof(category));
-
-        var activity = fileActivity?.ToArray() ?? [];
-        if (category != ToolInvocationOutcomeCategory.Success
-            && (activity.Length > 0 || declaredProjectDirectory is not null))
-        {
-            throw new ArgumentException("Only successful outcomes may report working-context activity.");
-        }
-
-        if (category != ToolInvocationOutcomeCategory.RecoverableCorrection
-            && remediationCode is not null)
-        {
-            throw new ArgumentException("Only a recoverable correction may report remediation.", nameof(remediationCode));
-        }
-
-        if (category == ToolInvocationOutcomeCategory.RecoverableCorrection
-            && remediationCode is null)
-        {
-            throw new ArgumentException("A recoverable correction requires remediation.", nameof(remediationCode));
-        }
-
-        if (remediationCode is { } code && !Enum.IsDefined(code))
-            throw new ArgumentOutOfRangeException(nameof(remediationCode));
-
-        if (declaredProjectDirectory is not null
-            && !IsCanonicalAbsolutePath(declaredProjectDirectory))
-        {
-            throw new ArgumentException(
-                "Declared project directory requires a canonical absolute path.",
-                nameof(declaredProjectDirectory));
-        }
-
-        Category = category;
-        FileActivity = Array.AsReadOnly(activity);
-        RemediationCode = remediationCode;
-        DeclaredProjectDirectory = declaredProjectDirectory;
-    }
+    private ToolInvocationReceipt(ToolInvocationOutcomeCategory category) => Category = category;
 
     public ToolInvocationOutcomeCategory Category { get; }
-    public IReadOnlyList<ToolFileActivity> FileActivity { get; }
-    public ToolRemediationCode? RemediationCode { get; }
-    public string? DeclaredProjectDirectory { get; }
+
+    internal sealed class Succeeded : ToolInvocationReceipt
+    {
+        public Succeeded(IReadOnlyList<ToolFileActivity> fileActivity, string? declaredProjectDirectory)
+            : base(ToolInvocationOutcomeCategory.Success)
+        {
+            if (declaredProjectDirectory is not null && !IsCanonicalAbsolutePath(declaredProjectDirectory))
+                throw new ArgumentException("Declared project directory requires a canonical absolute path.", nameof(declaredProjectDirectory));
+            FileActivity = Array.AsReadOnly(fileActivity.ToArray());
+            DeclaredProjectDirectory = declaredProjectDirectory;
+        }
+
+        public IReadOnlyList<ToolFileActivity> FileActivity { get; }
+        public string? DeclaredProjectDirectory { get; }
+    }
+
+    internal sealed class Correction : ToolInvocationReceipt
+    {
+        public Correction(ToolRemediationCode remediationCode) : base(ToolInvocationOutcomeCategory.RecoverableCorrection)
+        {
+            if (!Enum.IsDefined(remediationCode))
+                throw new ArgumentOutOfRangeException(nameof(remediationCode));
+            RemediationCode = remediationCode;
+        }
+
+        public ToolRemediationCode RemediationCode { get; }
+    }
+
+    internal sealed class OtherOutcome : ToolInvocationReceipt
+    {
+        public OtherOutcome(ToolInvocationOutcomeCategory category) : base(category)
+        {
+            if (!Enum.IsDefined(category))
+                throw new ArgumentOutOfRangeException(nameof(category));
+            if (category is ToolInvocationOutcomeCategory.Success or ToolInvocationOutcomeCategory.RecoverableCorrection)
+                throw new ArgumentException("This outcome requires its dedicated receipt case.", nameof(category));
+        }
+    }
 
     internal static bool IsCanonicalAbsolutePath(string path)
     {


### PR DESCRIPTION
Tool receipts combine outcome categories with optional payloads. Child and Git results also expose fields that only fit some states. This change gives internal consumers distinct cases while public child and Git shapes remain unchanged.

- Tool producers construct success, correction, or other-outcome receipts directly. The aggregate factory is removed. Enum validation, canonical paths, and collection ownership remain enforced.
- The spawner adds locations after the child actor returns completion. Completed and partial runs retain their paths. Failed and cancelled runs expose none. The public SpawnAsync adapter retains SubAgentResult.
- Git state separates detached and attached heads. Tracking requires an upstream. The public flat snapshot retains its JSON shape, absent branch metadata, and unborn branches. Contradictory Git output becomes the existing unavailable outcome.

The specification includes the producer and consumer map and their lifetimes. Returned paths still provide location data. They grant no authority.

The `Report invalid Git snapshots and verify child result paths` correction handles malformed public Git snapshots in the context formatter. It reports the existing unavailable outcome with a reason. The parser stays strict. The spawner uses explicit completion cases, rejects null responses, and retains required locations for successful runs.

Validation:

- Three malformed JSON snapshot tests failed before the correction and pass after it. Valid attached, detached, unborn, and missing-branch controls also pass.
- Focused result tests passed: 62 tests. The tool output tests verify paths on completion and no paths on failure.
- The final stack passed 3,925 actor tests and 1,098 daemon tests, with six actor platform skips.
- A focused coverage run passed 153 tests. The context formatter reached 98.36% sequence coverage and 96.42% branch coverage.
- Slopwatch, headers, whitespace checks, and strict OpenSpec validation passed.
- The child-log eval passed 5/5 before this review correction. That eval was not repeated for this commit.

Replaces #2139. All branches for the native stack reside in this repository.

Native stack: #2143 → #2144 → #2145 → #2146. Stack base: `dev`.
