### PR TITLE
fix(deps): bump Microsoft.OpenApi pin to 2.12.2 with Microsoft.AspNetCore 10.0.12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
          once the AI packages move to a patch release. -->
     <MicrosoftExtensionsTimeProviderTestingVersion>10.9.0</MicrosoftExtensionsTimeProviderTestingVersion>
     <OpenAIVersion>2.12.0</OpenAIVersion>
-    <MicrosoftAspNetCoreVersion>10.0.11</MicrosoftAspNetCoreVersion>
+    <MicrosoftAspNetCoreVersion>10.0.12</MicrosoftAspNetCoreVersion>
     <SkiaSharpVersion>4.151.1</SkiaSharpVersion>
     <!-- Aspire pins are exercised only by samples/Netclaw.Demo.AppHost and its
          integration tests. The 13.x line is the .NET 10 generation of Aspire;
@@ -43,8 +43,12 @@
          Microsoft.OpenApi 2.0.0, which trips NU1903 (CVE-2026-49451 /
          GHSA-v5pm-xwqc-g5wc, circular schema references can terminate OpenAPI
          parsing). Keep this on the patched 2.x line until ASP.NET Core ships a
-         non-vulnerable transitive dependency. -->
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
+         non-vulnerable transitive dependency.
+         Microsoft.AspNetCore.OpenApi 10.0.12 requires Microsoft.OpenApi
+         >= 2.12.0 && < 3.0.0. Central transitive pinning turns a lower pin
+         into an NU1109 downgrade error, so keep this version at or above the
+         floor that MicrosoftAspNetCoreVersion demands. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />


### PR DESCRIPTION
## Problem

Dependabot PR #2149 raises `MicrosoftAspNetCoreVersion` from 10.0.11 to 10.0.12. Restore then fails for the whole solution:

```
error NU1109: Detected package downgrade: Microsoft.OpenApi from 2.12.0 to centrally defined 2.7.5.
netclawd -> Microsoft.AspNetCore.OpenApi 10.0.12 -> Microsoft.OpenApi (>= 2.12.0 && < 3.0.0)
```

`Directory.Packages.props` pins `Microsoft.OpenApi` at 2.7.5 as a transitive security pin for CVE-2026-49451 (#1543). `CentralPackageTransitivePinningEnabled` is true, so the lower pin becomes a downgrade error.

Every CI job restores first. Eight jobs failed from this one cause: Auto-format, Test-ubuntu-latest, Test-macos-26, Test-windows-latest, Validate Docker Build, and both Publish native binaries jobs.

## Fix

- `MicrosoftAspNetCoreVersion`: 10.0.11 -> 10.0.12
- `Microsoft.OpenApi`: 2.7.5 -> 2.12.2 (latest patched 2.x, satisfies `< 3.0.0`)
- The comment now records that the OpenApi pin must stay at or above the floor that `MicrosoftAspNetCoreVersion` demands. A lower pin fails restore for the whole solution.

`Microsoft.OpenApi` has no direct references in the solution. The pin only forces the transitive version.

## Testing

- `dotnet restore Netclaw.slnx` — clean, no NU1109 and no NU1903
- `dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj -c Release` — 0 warnings, 0 errors

Supersedes #2149.
