### PR TITLE
Refactor shell authorization completion pipeline

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -244,6 +244,13 @@ Done when:
 - [ ] The policy pipeline replaces the shell branches in `ToolAccessPolicy`
   and `ShellApprovalMatcher`; any retained legacy scan is deny-only and cannot
   authorize, create candidates, or widen scope.
+  - [x] `ToolAccessPolicy` no longer completes shell authorization synchronously.
+    It produces preflight facts only. `ShellPolicyCoordinator` is the sole path
+    that applies corrections, reviewed-safe coverage, grants, and a final shell
+    authorization result.
+  - [ ] Move the remaining parser-to-candidate projection out of the broad
+    `ShellApprovalMatcher` compatibility surface without changing its released
+    approval shapes.
   The preliminary complete-footprint audit after PR #1947 found 1,484 added
   production lines and 52 added control-flow lines. Later slices reduced the
   post-corpus footprint from 10,085 lines and 663 control-flow lines to 9,693

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -3508,7 +3508,7 @@ public partial class DispatchingToolExecutorTests
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(ToolAuthorizationOutcome.Allowed, authorization.Decision.Outcome);
-            var analysis = Assert.IsType<ShellCommandAnalysis>(authorization.AuthorizedAnalysis);
+            var analysis = Assert.IsType<ShellAuthorizationResult.Authorized>(authorization).Analysis;
             Assert.Equal(phrase, analysis.Source);
             Assert.Equal(root, analysis.WorkingDirectory);
         }
@@ -3985,8 +3985,14 @@ public partial class DispatchingToolExecutorTests
         var preflight = Assert.IsType<ShellPolicyPreflightResult.Continue>(
             policy.AuthorizeShellPreflight(shellTool, context, arguments));
 
+        var collection = new ShellPolicyCoordinator(registry, policy, approvalService: null).CollectApplicableCorrections(
+            preflight.Analysis,
+            CreateToolCall("pair", ShellTool.ToolName, arguments),
+            context,
+            preflight);
+        Assert.NotNull(collection);
         var shellTemporary = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(
-            policy.AuthorizeInvocation(shellTool, context, arguments).AgentCorrection);
+            collection.Items[1]);
         var nativeCorrection = NativeToolShellCorrectionDetector.Detect(
             preflight.Analysis,
             registry,
@@ -4005,12 +4011,6 @@ public partial class DispatchingToolExecutorTests
             correctedNativeDecision.AgentCorrection);
         Assert.Equal(shellTemporary.Target, nativeTemporary.Target);
 
-        var collection = new ShellPolicyCoordinator(registry, policy, approvalService: null).CollectApplicableCorrections(
-            preflight.Analysis,
-            CreateToolCall("pair", ShellTool.ToolName, arguments),
-            context,
-            preflight);
-        Assert.NotNull(collection);
         Assert.Collection(
             collection.Items,
             correction => Assert.IsType<ToolCorrection.NativeToolSuggested>(correction),
@@ -4048,7 +4048,7 @@ public partial class DispatchingToolExecutorTests
             corrections.Items,
             correction => Assert.IsType<ToolCorrection.NativeToolSuggested>(correction),
             correction => Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(correction));
-        Assert.Null(authorization.AuthorizedAnalysis);
+        Assert.IsType<ShellAuthorizationResult.Stopped>(authorization);
         Assert.Equal(0, approvalService.RequestCount);
         Assert.Null(authoritativeContext.Receipt);
     }
@@ -4120,7 +4120,7 @@ public partial class DispatchingToolExecutorTests
 
         Assert.Equal(ToolAuthorizationOutcome.RequiresAgentCorrection, result.Decision.Outcome);
         Assert.Equal(directory, Assert.IsType<ToolCorrection.ProjectDirectorySuggested>(result.Decision.AgentCorrection).Directory);
-        Assert.Null(result.AuthorizedAnalysis);
+        Assert.IsType<ShellAuthorizationResult.Stopped>(result);
         Assert.Null(result.Decision.ApprovalContext);
         Assert.Null(context.Receipt);
     }
@@ -4140,7 +4140,7 @@ public partial class DispatchingToolExecutorTests
         var result = await new ShellPolicyCoordinator(registry, policy, service).EvaluateAsync(
             registry.GetByName(ShellTool.ToolName)!, call, context, TestContext.Current.CancellationToken);
 
-        Assert.Null(result.AuthorizedAnalysis);
+        Assert.IsType<ShellAuthorizationResult.Stopped>(result);
         Assert.Equal(0, service.RequestCount);
         if (mode == ToolApprovalMode.Auto)
         {
@@ -4187,9 +4187,11 @@ public partial class DispatchingToolExecutorTests
         else
             Assert.Null(result.Decision.AgentCorrections);
         if (expected == nameof(ToolAuthorizationOutcome.Allowed))
-            Assert.Equal(Path.GetFullPath(directory), result.AuthorizedAnalysis!.WorkingDirectory);
+            Assert.Equal(
+                Path.GetFullPath(directory),
+                Assert.IsType<ShellAuthorizationResult.Authorized>(result).Analysis.WorkingDirectory);
         else
-            Assert.Null(result.AuthorizedAnalysis);
+            Assert.IsType<ShellAuthorizationResult.Stopped>(result);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/ShellPolicyTestExtensions.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellPolicyTestExtensions.cs
@@ -1,0 +1,19 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellPolicyTestExtensions.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Tools;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+internal static class ShellPolicyTestExtensions
+{
+    internal static ToolAuthorizationDecision GetShellPreflightDecision(
+        this ToolAccessPolicy policy,
+        INetclawTool tool,
+        ToolExecutionContext context,
+        IDictionary<string, object?>? arguments = null)
+        => policy.AuthorizeShellPreflight(tool, context, arguments).Decision;
+}

--- a/src/Netclaw.Actors.Tests/Tools/TemporaryPathCorrectionPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/TemporaryPathCorrectionPolicyTests.cs
@@ -408,7 +408,7 @@ public sealed class TemporaryPathCorrectionPolicyTests
                 PosixSession,
                 inspector: HostPlatformTemporaryPathInspector.Instance);
 
-            var context = Assert.IsType<ToolApprovalContext>(decision.ApprovalContext);
+            Assert.Null(decision.ApprovalContext);
             var correction = Assert.IsType<ToolCorrection.ManagedTemporaryDirectorySuggested>(decision.AgentCorrection);
             Assert.Equal(realTemp, correction.Target.PlatformTemporaryRoot);
         }
@@ -492,7 +492,18 @@ public sealed class TemporaryPathCorrectionPolicyTests
                 "Command", command,
                 "WorkingDirectory", explicitWorkingDirectory);
 
-        return policy.AuthorizeInvocation(shellTool, context, arguments);
+        var preflight = policy.AuthorizeShellPreflight(shellTool, context, arguments);
+        if (preflight is not ShellPolicyPreflightResult.Continue continuation)
+            return preflight.Decision;
+
+        var correction = policy.EvaluateShellTemporaryCorrection(
+            continuation.Analysis,
+            continuation.ApprovalContext.Candidates!,
+            arguments,
+            context.Invocation);
+        return correction is null
+            ? preflight.Decision
+            : ToolAuthorizationDecision.RequireAgentCorrection(correction);
     }
 
     private static ShellExecutionEnvironment BashEnvironment()

--- a/src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyRequiredDependenciesTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyRequiredDependenciesTests.cs
@@ -55,6 +55,22 @@ public sealed class ToolAccessPolicyRequiredDependenciesTests
         => new ShellTool(ShellConfig(), new ToolPathPolicy([]), new ShellCommandPolicy());
 
     [Fact]
+    public void Shell_commands_cannot_bypass_the_coordinator()
+    {
+        var policy = new ToolAccessPolicy(
+            new NetclawPaths(),
+            ShellConfig(),
+            Defaults(),
+            new ShellCommandPolicy(),
+            new ToolPathPolicy([]));
+
+        Assert.Throws<InvalidOperationException>(() => policy.AuthorizeInvocation(
+            ShellTool(),
+            PersonalContext(),
+            ToolInput.Create("Command", "git status")));
+    }
+
+    [Fact]
     public void Protected_path_control_is_enforced_and_scoped()
     {
         var deniedRoot = Path.Combine(Path.GetTempPath(), "netclaw-protected-root");
@@ -67,7 +83,7 @@ public sealed class ToolAccessPolicyRequiredDependenciesTests
 
         // A command that touches the protected path is denied — the enforcement
         // a null toolPathPolicy silently lost.
-        var deniedDecision = policy.AuthorizeInvocation(
+        var deniedDecision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             ToolInput.Create("Command", $"cat {Path.Combine(deniedRoot, "secret.txt")}"));
@@ -78,7 +94,7 @@ public sealed class ToolAccessPolicyRequiredDependenciesTests
         // A command that touches a path outside the protected set is NOT denied
         // for that reason — proving the policy is actually consulted and scoped,
         // not a blanket deny.
-        var otherDecision = policy.AuthorizeInvocation(
+        var otherDecision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             ToolInput.Create("Command", $"cat {Path.Combine(otherRoot, "notes.txt")}"));
@@ -102,7 +118,7 @@ public sealed class ToolAccessPolicyRequiredDependenciesTests
             pathPolicy);
         var shellTool = new ShellTool(ShellConfig(), pathPolicy, commandPolicy);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             shellTool,
             PersonalContext(),
             ToolInput.Create("Command", @"Get-Content C:\protected\config\secret.txt"));

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -76,7 +76,7 @@ public sealed class ToolApprovalGateTests
         var context = PersonalContext();
         var args = ToolInput.Create("Command", "git push");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), context, args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), context, args);
 
         Assert.False(decision.Allowed);
         Assert.Equal("tool_denied_by_approval_policy", decision.DenyReason);
@@ -148,7 +148,7 @@ public sealed class ToolApprovalGateTests
     {
         var policy = CreatePolicy(mode);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             ToolInput.Create("Command", "rm -rf /"));
@@ -171,7 +171,7 @@ public sealed class ToolApprovalGateTests
         var policy = new ToolAccessPolicy(new NetclawPaths(), config, Defaults(), commandPolicy, pathPolicy);
         var tool = new ShellTool(config, pathPolicy, commandPolicy);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             tool,
             PersonalContext(),
             ToolInput.Create("Command", "cat /protected/secret.txt"));
@@ -190,7 +190,7 @@ public sealed class ToolApprovalGateTests
         var policy = CreatePolicy(mode);
         var context = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             context,
             ToolInput.Create("Command", "cat /external/data.txt"));
@@ -206,7 +206,7 @@ public sealed class ToolApprovalGateTests
         var policy = CreatePolicy((ToolApprovalMode)999);
         var context = PersonalContext();
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             context,
             ToolInput.Create("Command", "git status"));
@@ -231,7 +231,7 @@ public sealed class ToolApprovalGateTests
                 new ShellCommandPolicy(),
                 new ToolPathPolicy([]));
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             ToolInput.Create("Command", "git pull --ff-only"));
@@ -250,7 +250,7 @@ public sealed class ToolApprovalGateTests
             "Command", $"rm {dir.Path}/*.bak",
             "WorkingDirectory", dir.Path);
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         Assert.False(decision.ApprovalContext!.IsMessy);
@@ -268,7 +268,7 @@ public sealed class ToolApprovalGateTests
         var policy = CreatePolicy(ToolApprovalMode.Approval);
         var args = ToolInput.Create("Command", "git add . && git commit -m fix && git push");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         Assert.Contains("git add .", decision.ApprovalContext!.Patterns);
@@ -281,7 +281,7 @@ public sealed class ToolApprovalGateTests
     {
         var policy = CreatePolicy(ToolApprovalMode.Approval);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             ToolInput.Create("Command", "whoami user; whoami admin"));
@@ -723,7 +723,7 @@ public sealed class ToolApprovalGateTests
                 new ToolPathPolicy([]));
 
         var args = ToolInput.Create("Command", "git pull --ff-only");
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         // Shell default matcher fails closed on Personal → approval, not deny.
         Assert.True(decision.NeedsApproval);
@@ -880,7 +880,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?>
             {
                 ["command"] = TestShellEnvironment.ReadFileCommand(outsidePath)
@@ -901,7 +901,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?>
             {
                 ["command"] = TestShellEnvironment.ReadFileCommand(insidePath)
@@ -922,7 +922,7 @@ public sealed class ToolApprovalGateTests
         var ctx = PersonalContext(supportsApproval: false);
 
         // "git status" has no path-like arguments
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?> { ["command"] = "git status" });
 
         Assert.True(decision.NeedsApproval);
@@ -940,7 +940,7 @@ public sealed class ToolApprovalGateTests
 
         // The default Personal WriteFiles=All profile admits the path. The
         // approval layer still decides whether the shell call can execute.
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?> { ["command"] = "cat /etc/passwd" });
 
         Assert.True(decision.NeedsApproval);
@@ -956,7 +956,7 @@ public sealed class ToolApprovalGateTests
             ShellExecutionMode.Off,
             ToolFilesystemMode.None);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             new Dictionary<string, object?>
@@ -1019,7 +1019,7 @@ public sealed class ToolApprovalGateTests
             ShellExecutionMode.HostAllowed,
             ToolFilesystemMode.Roots);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             new Dictionary<string, object?>
@@ -1046,7 +1046,7 @@ public sealed class ToolApprovalGateTests
             ToolFilesystemMode.None,
             approvalMode);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             new Dictionary<string, object?>
@@ -1078,7 +1078,7 @@ public sealed class ToolApprovalGateTests
             ShellExecutionMode.HostAllowed,
             ToolFilesystemMode.Roots);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             new Dictionary<string, object?>
@@ -1097,7 +1097,7 @@ public sealed class ToolApprovalGateTests
     {
         var policy = CreatePolicy(ToolApprovalMode.Approval);
 
-        var decision = policy.AuthorizeInvocation(
+        var decision = policy.GetShellPreflightDecision(
             ShellTool(),
             PersonalContext(),
             ToolInput.Create("Command", "custom-command \"$TARGET_FILE\""));
@@ -1120,7 +1120,7 @@ public sealed class ToolApprovalGateTests
         var command = OperatingSystem.IsWindows()
             ? $"pwsh -NoProfile -Command \"Get-Content '{outsidePath}'\""
             : $"bash -c \"cat '{outsidePath}'\"";
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?> { ["command"] = command });
 
         Assert.False(decision.Allowed);
@@ -1143,7 +1143,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?>
             {
                 ["command"] = "cat README.md",
@@ -1166,7 +1166,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?>
             {
                 ["command"] = "cat README.md",
@@ -1185,7 +1185,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?> { ["command"] = "cat /etc/passwd" });
 
         Assert.False(decision.Allowed);
@@ -1200,7 +1200,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?>
             {
                 ["command"] = "cat README.md",
@@ -1241,7 +1241,7 @@ public sealed class ToolApprovalGateTests
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
-        var decision = policy.AuthorizeInvocation(tool, ctx,
+        var decision = policy.GetShellPreflightDecision(tool, ctx,
             new Dictionary<string, object?> { ["command"] = "git status" });
 
         Assert.Null(decision.DenyReason);
@@ -1318,7 +1318,7 @@ public sealed class ToolApprovalGateTests
         var logPath = Path.Combine(ApprovalTestRoot, "logs", "crash.log");
         var args = ToolInput.Create("Command", $"cat \"{logPath}\"");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         Assert.NotNull(decision.ApprovalContext);
@@ -1343,7 +1343,7 @@ public sealed class ToolApprovalGateTests
         var logPath = Path.Combine(ApprovalTestRoot, "logs", "app.log");
         var args = ToolInput.Create("Command", $"grep 'error' \"{logPath}\"");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         var options = decision.ApprovalContext!.Options;
@@ -1360,7 +1360,7 @@ public sealed class ToolApprovalGateTests
             "Command",
             $"cat \"{inputPath}\" > \"{outputPath}\"");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         var options = decision.ApprovalContext!.Options;
@@ -1377,7 +1377,7 @@ public sealed class ToolApprovalGateTests
             "Command", "grep timeout logs/app.log | wc -l",
             "WorkingDirectory", root);
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         // Pipelines stay inside one approval unit, so the candidate is
@@ -1395,7 +1395,7 @@ public sealed class ToolApprovalGateTests
         var policy = CreatePolicy(ToolApprovalMode.Approval);
         var args = ToolInput.Create("Command", "git push origin main");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         // ExtractVerbChain (post-ShellSyntaxTree-0.1.4) extracts greedily
@@ -1432,7 +1432,7 @@ public sealed class ToolApprovalGateTests
 
         var args = ToolInput.Create("Command", $"grep error \"{deepPath}\"");
 
-        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+        var decision = policy.GetShellPreflightDecision(ShellTool(), PersonalContext(), args);
 
         Assert.True(decision.NeedsApproval);
         var options = decision.ApprovalContext!.Options;

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -421,7 +421,16 @@ public sealed class DispatchingToolExecutor : IToolExecutor, IApprovalShellProvi
                 ct);
 
             LogAuthorizationDecision(toolCall, context, shellAuthorization.Decision);
-            return (shellAuthorization.Decision, shellAuthorization.AuthorizedAnalysis);
+            return shellAuthorization switch
+            {
+                ShellAuthorizationResult.Authorized authorized =>
+                    (authorized.Decision, authorized.Analysis),
+                ShellAuthorizationResult.ToolValidation toolValidation =>
+                    (toolValidation.Decision, null),
+                ShellAuthorizationResult.Stopped stopped =>
+                    (stopped.Decision, null),
+                _ => throw new InvalidOperationException("Unsupported shell authorization result.")
+            };
         }
 
         var accessDecision = _policy.AuthorizeInvocation(tool, context, toolCall.Arguments);

--- a/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyCoordinator.cs
@@ -26,7 +26,7 @@ internal sealed class ShellPolicyCoordinator(
     /// The coordinator then collects corrections before it accepts automatic policy approval or checks stored approval evidence.
     /// It returns the analysis only when the caller can start the authorized command.
     /// </remarks>
-    internal async Task<(ToolAuthorizationDecision Decision, ShellCommandAnalysis? AuthorizedAnalysis)> EvaluateAsync(
+    internal async Task<ShellAuthorizationResult> EvaluateAsync(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
@@ -53,15 +53,14 @@ internal sealed class ShellPolicyCoordinator(
         }
         catch (Exception)
         {
-            return (
+            return ShellAuthorizationResult.Stop(
                 CompleteWithTrace(
                     ToolAuthorizationDecision.Deny("internal_policy_failure"),
-                    trace),
-                null);
+                    trace));
         }
     }
 
-    private async Task<(ToolAuthorizationDecision Decision, ShellCommandAnalysis? AuthorizedAnalysis)> EvaluateCoreAsync(
+    private async Task<ShellAuthorizationResult> EvaluateCoreAsync(
         INetclawTool tool,
         FunctionCallContent toolCall,
         ToolExecutionContext context,
@@ -84,9 +83,8 @@ internal sealed class ShellPolicyCoordinator(
         // A native tool needs a separate call. Shell approval cannot authorize that replacement.
         if (corrections?.Items.Any(static correction => correction is ToolCorrection.NativeToolSuggested) == true)
         {
-            return (
-                Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
-                null);
+            return ShellAuthorizationResult.Stop(
+                Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace));
         }
 
         if (preflight is ShellPolicyPreflightResult.Complete complete)
@@ -95,9 +93,8 @@ internal sealed class ShellPolicyCoordinator(
             // Auto permits execution, but the agent must first receive any applicable directory advice.
             if (preflightDecision.AllowReason == ToolAllowReason.PolicyAuto && corrections is not null)
             {
-                return (
-                    Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace),
-                    null);
+                return ShellAuthorizationResult.Stop(
+                    Complete(ToolAuthorizationDecision.RequireAgentCorrection(corrections), [], trace));
             }
 
             if (preflightDecision.NeedsApproval
@@ -111,7 +108,7 @@ internal sealed class ShellPolicyCoordinator(
                 preflightDecision = ToolAuthorizationDecision.Allow(ToolAllowReason.OneTimeApproval);
             }
 
-            return (
+            return ShellAuthorizationResult.Create(
                 Complete(preflightDecision, [], trace),
                 complete.AuthorizedAnalysis);
         }
@@ -127,11 +124,10 @@ internal sealed class ShellPolicyCoordinator(
                 out var projection)
             || projection is null)
         {
-            return (
+            return ShellAuthorizationResult.Stop(
                 CompleteWithTrace(
                     ToolAuthorizationDecision.Deny("internal_policy_failure"),
-                    trace),
-                null);
+                    trace));
         }
 
         var projectedPathDecision = policy.EnforceProjectedShellFileProtection(
@@ -139,9 +135,8 @@ internal sealed class ShellPolicyCoordinator(
             context.Invocation);
         if (projectedPathDecision is not null)
         {
-            return (
-                CompleteWithTrace(projectedPathDecision, trace),
-                null);
+            return ShellAuthorizationResult.Stop(
+                CompleteWithTrace(projectedPathDecision, trace));
         }
 
         var decision = await CompleteAsync(
@@ -152,7 +147,7 @@ internal sealed class ShellPolicyCoordinator(
             corrections,
             cancellationToken);
 
-        return (
+        return ShellAuthorizationResult.Create(
             decision,
             decision.Outcome == ToolAuthorizationOutcome.Allowed
                 ? continuation.Analysis
@@ -167,7 +162,8 @@ internal sealed class ShellPolicyCoordinator(
         ShellPolicyPreflightResult preflight)
     {
         // Denial and approval without command analysis cannot become advice to submit a different call.
-        if (preflight is ShellPolicyPreflightResult.Complete { Decision.Allowed: false })
+        if (preflight is ShellPolicyPreflightResult.Complete
+            { Decision.Outcome: not ToolAuthorizationOutcome.Allowed })
             return null;
 
         var native = NativeToolShellCorrectionDetector.Detect(analysis, registry, policy, context.Invocation);

--- a/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
+++ b/src/Netclaw.Actors/Tools/ShellPolicyEvaluation.cs
@@ -8,6 +8,90 @@ using Netclaw.Security;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
+/// Represents the final shell authorization result before an execution adapter acts on it.
+/// </summary>
+/// <remarks>
+/// An authorized result always owns the exact analysis that the shell process can execute.
+/// A tool-validation result lets the shell tool report malformed arguments before a process exists.
+/// A stopped result cannot carry executable analysis.
+/// </remarks>
+internal abstract record ShellAuthorizationResult
+{
+    private protected ShellAuthorizationResult(ToolAuthorizationDecision decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        Decision = decision;
+    }
+
+    internal ToolAuthorizationDecision Decision { get; }
+
+    internal sealed record Authorized : ShellAuthorizationResult
+    {
+        internal Authorized(
+            ToolAuthorizationDecision decision,
+            ShellCommandAnalysis analysis)
+            : base(decision)
+        {
+            ArgumentNullException.ThrowIfNull(analysis);
+            if (decision.Outcome != ToolAuthorizationOutcome.Allowed)
+            {
+                throw new ArgumentException(
+                    "An authorized shell result requires an allowed decision.",
+                    nameof(decision));
+            }
+
+            Analysis = analysis;
+        }
+
+        internal ShellCommandAnalysis Analysis { get; }
+    }
+
+    internal sealed record ToolValidation : ShellAuthorizationResult
+    {
+        internal ToolValidation(ToolAuthorizationDecision decision)
+            : base(decision)
+        {
+            if (decision.Outcome != ToolAuthorizationOutcome.Allowed)
+            {
+                throw new ArgumentException(
+                    "Shell tool validation requires an allowed decision.",
+                    nameof(decision));
+            }
+        }
+    }
+
+    internal sealed record Stopped : ShellAuthorizationResult
+    {
+        internal Stopped(ToolAuthorizationDecision decision)
+            : base(decision)
+        {
+            if (decision.Outcome == ToolAuthorizationOutcome.Allowed)
+            {
+                throw new ArgumentException(
+                    "An allowed shell decision cannot use a stopped result.",
+                    nameof(decision));
+            }
+        }
+    }
+
+    internal static ShellAuthorizationResult Create(
+        ToolAuthorizationDecision decision,
+        ShellCommandAnalysis? authorizedAnalysis)
+        => (decision.Outcome, authorizedAnalysis) switch
+        {
+            (ToolAuthorizationOutcome.Allowed, not null) => new Authorized(decision, authorizedAnalysis),
+            (ToolAuthorizationOutcome.Allowed, null) => new ToolValidation(decision),
+            (_, null) => new Stopped(decision),
+            _ => throw new ArgumentException(
+                "A stopped shell result cannot carry executable analysis.",
+                nameof(authorizedAnalysis)),
+        };
+
+    internal static Stopped Stop(ToolAuthorizationDecision decision)
+        => new(decision);
+}
+
+/// <summary>
 /// Represents the synchronous shell access phase before the coordinator checks approval evidence.
 /// </summary>
 /// <remarks>
@@ -15,30 +99,30 @@ namespace Netclaw.Actors.Tools;
 /// </remarks>
 internal abstract record ShellPolicyPreflightResult
 {
-    private ShellPolicyPreflightResult()
+    private protected ShellPolicyPreflightResult(ToolAuthorizationDecision decision)
     {
+        ArgumentNullException.ThrowIfNull(decision);
+        Decision = decision;
     }
+
+    internal ToolAuthorizationDecision Decision { get; }
 
     internal sealed record Complete : ShellPolicyPreflightResult
     {
         internal Complete(
             ToolAuthorizationDecision decision,
             ShellCommandAnalysis? authorizedAnalysis)
+            : base(decision)
         {
-            ArgumentNullException.ThrowIfNull(decision);
             if (authorizedAnalysis is not null
-                && (!decision.Allowed || decision.NeedsApproval))
+                && decision.Outcome != ToolAuthorizationOutcome.Allowed)
             {
                 throw new ArgumentException(
                     "Only an immediate shell allow can carry analysis.",
                     nameof(authorizedAnalysis));
             }
-
-            Decision = decision;
             AuthorizedAnalysis = authorizedAnalysis;
         }
-
-        internal ToolAuthorizationDecision Decision { get; }
 
         internal ShellCommandAnalysis? AuthorizedAnalysis { get; }
     }
@@ -49,6 +133,7 @@ internal abstract record ShellPolicyPreflightResult
             ShellCommandAnalysis analysis,
             ToolApprovalContext approvalContext,
             ShellExecutionEnvironment environment)
+            : base(ToolAuthorizationDecision.RequiresApproval(approvalContext))
         {
             ArgumentNullException.ThrowIfNull(analysis);
             ArgumentNullException.ThrowIfNull(approvalContext);

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -187,19 +187,39 @@ public sealed class ToolAccessPolicy
         return true;
     }
 
+    /// <summary>Applies access and approval policy to a non-shell tool invocation.</summary>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="tool"/> is <c>shell_execute</c>, which requires the asynchronous shell coordinator.
+    /// </exception>
     public ToolAuthorizationDecision AuthorizeInvocation(INetclawTool tool, ToolExecutionContext context)
         => AuthorizeInvocation(tool, context, arguments: null);
 
+    /// <summary>Applies access and approval policy to a non-shell tool invocation.</summary>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="tool"/> is <c>shell_execute</c>, which requires the asynchronous shell coordinator.
+    /// </exception>
     public ToolAuthorizationDecision AuthorizeInvocation(
         INetclawTool tool,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments)
-        => AuthorizeInvocationCore(
-            tool,
-            context,
-            arguments,
-            deferShellCompletion: false,
-            out _);
+    {
+        if (IsShellTool(tool))
+        {
+            throw new InvalidOperationException(
+                "Shell commands require the asynchronous shell policy coordinator.");
+        }
+
+        if (tool is McpToolAdapter mcp)
+            return AuthorizeMcpInvocation(mcp, context, arguments);
+
+        var toolName = new ToolName(tool.Name);
+        if (!_profileResolver.IsToolAllowed(toolName, context.Invocation))
+            return ToolAuthorizationDecision.Deny("tool_not_allowed_for_audience_profile");
+
+        return string.Equals(tool.Name, CheckBackgroundJobTool.ToolName, StringComparison.Ordinal)
+            ? AuthorizeBackgroundJobControl(context)
+            : AuthorizeStructuredInvocation(tool, toolName, context, arguments);
+    }
 
     /// <summary>Builds canonical shell analysis and applies synchronous access rules before approval evidence.</summary>
     internal ShellPolicyPreflightResult AuthorizeShellPreflight(
@@ -207,18 +227,20 @@ public sealed class ToolAccessPolicy
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments)
     {
-        var decision = AuthorizeInvocationCore(
-            tool,
-            context,
-            arguments,
-            deferShellCompletion: true,
-            out var analysis);
+        if (!IsShellTool(tool))
+            throw new ArgumentException("Shell preflight requires the shell tool.", nameof(tool));
+
+        ShellCommandAnalysis? analysis = null;
+        var toolName = new ToolName(tool.Name);
+        var decision = !_profileResolver.IsToolAllowed(toolName, context.Invocation)
+            ? ToolAuthorizationDecision.Deny("tool_not_allowed_for_audience_profile")
+            : AuthorizeShellInvocation(toolName, context, arguments, out analysis);
 
         if (!decision.NeedsApproval)
         {
             return new ShellPolicyPreflightResult.Complete(
                 decision,
-                decision.Allowed ? analysis : null);
+                decision.Outcome == ToolAuthorizationOutcome.Allowed ? analysis : null);
         }
 
         if (analysis is null)
@@ -236,33 +258,6 @@ public sealed class ToolAccessPolicy
             : new ShellPolicyPreflightResult.Complete(
                 ToolAuthorizationDecision.Deny("internal_policy_failure"),
                 authorizedAnalysis: null);
-    }
-
-    private ToolAuthorizationDecision AuthorizeInvocationCore(
-        INetclawTool tool,
-        ToolExecutionContext context,
-        IDictionary<string, object?>? arguments,
-        bool deferShellCompletion,
-        out ShellCommandAnalysis? authorizedAnalysis)
-    {
-        authorizedAnalysis = null;
-
-        if (tool is McpToolAdapter mcp)
-            return AuthorizeMcpInvocation(mcp, context, arguments);
-
-        var toolName = new ToolName(tool.Name);
-        if (!_profileResolver.IsToolAllowed(toolName, context.Invocation))
-            return ToolAuthorizationDecision.Deny("tool_not_allowed_for_audience_profile");
-
-        return IsShellCoupledTool(tool)
-            ? AuthorizeShellInvocation(
-                tool,
-                toolName,
-                context,
-                arguments,
-                deferShellCompletion,
-                out authorizedAnalysis)
-            : AuthorizeStructuredInvocation(tool, toolName, context, arguments);
     }
 
     private ToolAuthorizationDecision AuthorizeMcpInvocation(
@@ -291,7 +286,7 @@ public sealed class ToolAccessPolicy
             context,
             approvalArguments,
             McpApprovalMatcher.Instance);
-        return CheckApprovalGate(
+        return AuthorizeNonShellApproval(
             toolName,
             context,
             approvalArguments,
@@ -314,35 +309,19 @@ public sealed class ToolAccessPolicy
         if (approvalMode == ToolApprovalMode.Deny)
             return ToolAuthorizationDecision.Deny("tool_denied_by_approval_policy");
 
-        return CheckApprovalGate(toolName, context, arguments, matcher, approvalMode);
+        return AuthorizeNonShellApproval(toolName, context, arguments, matcher, approvalMode);
     }
 
     private ToolAuthorizationDecision AuthorizeShellInvocation(
-        INetclawTool tool,
         ToolName toolName,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments,
-        bool deferShellCompletion,
         out ShellCommandAnalysis? authorizedAnalysis)
     {
         authorizedAnalysis = null;
 
-        var shellMode = ResolveShellMode();
-        if (shellMode == ShellExecutionMode.Off)
-            return ToolAuthorizationDecision.Deny("shell_disabled");
-
-        if (shellMode == ShellExecutionMode.SandboxOnly)
-            return ToolAuthorizationDecision.Deny("shell_requires_sandbox_backend");
-
-        var shellAudience = ResolveAudience(context.Invocation);
-        if (shellAudience != TrustAudience.Personal)
-            return ToolAuthorizationDecision.Deny("shell_requires_personal_context");
-
-        // shell_execute authorizes the process before the job starts. This tool
-        // can only control a job with the same session, audience, and boundary.
-        // It does not create a new shell invocation or require another approval.
-        if (string.Equals(tool.Name, CheckBackgroundJobTool.ToolName, StringComparison.Ordinal))
-            return ToolAuthorizationDecision.Allow(ToolAllowReason.BackgroundJobLifecycle);
+        if (EvaluateShellCapability(context.Invocation) is { } capabilityDecision)
+            return capabilityDecision;
 
         var shellCommand = ExtractShellCommand(arguments);
         var workingDirectory = context.ResolveShellCwd(ExtractWorkingDirectory(arguments));
@@ -386,7 +365,7 @@ public sealed class ToolAccessPolicy
 
         var mode = GetApprovalMode(toolName, context, arguments, _shellApprovalMatcher);
         var approvalModeDecision = GetApprovalModeDecision(mode);
-        if (approvalModeDecision is { Allowed: false })
+        if (approvalModeDecision is { Outcome: ToolAuthorizationOutcome.Denied })
             return approvalModeDecision;
 
         authorizedAnalysis = shellAnalysis;
@@ -394,15 +373,31 @@ public sealed class ToolAccessPolicy
         if (approvalModeDecision is not null)
             return approvalModeDecision;
 
-        return CheckApprovalGate(
+        return AuthorizeShellApproval(
             toolName,
             context,
             arguments,
-            _shellApprovalMatcher,
             mode,
             shellApproval,
-            shellAnalysis,
-            deferShellCompletion);
+            workingDirectory);
+    }
+
+    private ToolAuthorizationDecision AuthorizeBackgroundJobControl(ToolExecutionContext context)
+        => EvaluateShellCapability(context.Invocation)
+           ?? ToolAuthorizationDecision.Allow(ToolAllowReason.BackgroundJobLifecycle);
+
+    private ToolAuthorizationDecision? EvaluateShellCapability(ToolInvocationContext context)
+    {
+        var shellMode = ResolveShellMode();
+        if (shellMode == ShellExecutionMode.Off)
+            return ToolAuthorizationDecision.Deny("shell_disabled");
+
+        if (shellMode == ShellExecutionMode.SandboxOnly)
+            return ToolAuthorizationDecision.Deny("shell_requires_sandbox_backend");
+
+        return ResolveAudience(context) == TrustAudience.Personal
+            ? null
+            : ToolAuthorizationDecision.Deny("shell_requires_personal_context");
     }
 
     internal bool IsReviewedSafeCandidate(
@@ -703,87 +698,82 @@ public sealed class ToolAccessPolicy
         return analysisArguments;
     }
 
-    private ToolAuthorizationDecision CheckApprovalGate(
+    private ToolAuthorizationDecision AuthorizeNonShellApproval(
         ToolName toolName,
         ToolExecutionContext context,
         IDictionary<string, object?>? arguments,
         IToolApprovalMatcher matcher,
-        ToolApprovalMode mode,
-        ShellApprovalAnalysis? shellApproval = null,
-        ShellCommandAnalysis? shellAnalysis = null,
-        bool deferShellCompletion = false)
+        ToolApprovalMode mode)
     {
         var approvalModeDecision = GetApprovalModeDecision(mode);
         if (approvalModeDecision is not null)
             return approvalModeDecision;
 
-        // The approval policy is authoritative for every channel — there is no
-        // safe-list auto-grant for non-interactive callers. A non-interactive
-        // caller (reminder, webhook, sub-agent without an approval bridge) that
-        // hits an approval-gated tool fails closed unless the patterns are
-        // already in the persistent approval store.
+        var patterns = matcher.ExtractPatterns(toolName, arguments);
+        var candidates = matcher.ExtractCandidates(toolName, arguments);
+        var displayText = matcher.FormatForDisplay(toolName, arguments);
+        var isMessy = matcher.IsMessy(toolName, arguments);
+        var correction = _temporaryPathCorrectionPolicy.EvaluateStructuredFileChange(
+            toolName,
+            arguments,
+            context.Invocation,
+            _toolPathPolicy);
+        return BuildApprovalDecision(
+            toolName,
+            context,
+            patterns,
+            candidates,
+            displayText,
+            isMessy,
+            correction,
+            hasReusablePhrase: true,
+            directoryApprovalAvailable: false);
+    }
 
-        // Approval prompts carry three views of the invocation:
-        // - `patterns`: the exact blocked units shown to the user and reused by
-        //   approve-once retries.
-        // - `candidates`: the (verb, directory) pairs evaluated against
-        //   persisted ApprovalEntry records by the gate. Candidates include
-        //   path operands, redirect targets, and each pipeline clause.
-        //   A null directory uses ToolExecutionContext.Cwd.
-        // - `candidateVerbs`: the verb-only projection of `candidates`, kept
-        //   for renderers (Slack/Discord builders) that bullet-list verbs in
-        //   the prompt body. Button labels stay fixed; runtime values like
-        //   paths never enter button text because Slack caps button text at
-        //   76 chars and Discord at 80.
-        // The shell process and the approval parser must use one cwd. The tool
-        // argument can omit it because the context supplies the project or
-        // session directory. Give that resolved value to the parser too.
-        var isShell = string.Equals(toolName.Value, ShellTool.ToolName, StringComparison.Ordinal);
-        var resolvedShellCwd = isShell
-            ? context.ResolveShellCwd(ExtractWorkingDirectory(arguments))
-            : null;
-        if (isShell)
-            context.Approval.SetCwd(resolvedShellCwd);
+    private ToolAuthorizationDecision AuthorizeShellApproval(
+        ToolName toolName,
+        ToolExecutionContext context,
+        IDictionary<string, object?>? arguments,
+        ToolApprovalMode mode,
+        ShellApprovalAnalysis? analysis,
+        string? workingDirectory)
+    {
+        var approvalModeDecision = GetApprovalModeDecision(mode);
+        if (approvalModeDecision is not null)
+            return approvalModeDecision;
 
-        var analysisArguments = isShell
-            ? WithResolvedShellWorkingDirectory(arguments, resolvedShellCwd)
-            : arguments;
-        var patterns = shellApproval?.Patterns
-            ?? matcher.ExtractPatterns(toolName, analysisArguments);
-        var candidates = shellApproval?.Candidates
-            ?? matcher.ExtractCandidates(toolName, analysisArguments);
-        var displayText = shellApproval?.DisplayText
-            ?? matcher.FormatForDisplay(toolName, arguments);
-        var isMessy = shellApproval?.IsMessy
-            ?? matcher.IsMessy(toolName, analysisArguments);
+        context.Approval.SetCwd(workingDirectory);
+        analysis ??= _shellApprovalMatcher.AnalyzeInvocation(
+            toolName,
+            WithResolvedShellWorkingDirectory(arguments, workingDirectory));
+        return BuildApprovalDecision(
+            toolName,
+            context,
+            analysis.Patterns,
+            analysis.Candidates,
+            analysis.DisplayText,
+            analysis.IsMessy,
+            correction: null,
+            analysis.Candidates.All(HasReusableShellPhrase),
+            IsShellDirectoryApprovalAvailable(
+                analysis.Candidates,
+                context.Approval.Cwd,
+                GetSessionOwnedApprovalDirectories(context),
+                ShellEnvironment.PathStyle));
+    }
 
-        IReadOnlyList<ApprovalCandidate> approvalCandidates = candidates;
-        ToolCorrection? agentCorrection = null;
-
-        // The public synchronous API completes shell policy here. Live dispatch leaves those decisions to the coordinator.
-        if (isShell && !deferShellCompletion)
-        {
-            (approvalCandidates, agentCorrection) = EvaluateSynchronousShellPolicy(
-                shellAnalysis,
-                candidates,
-                isMessy,
-                arguments,
-                context);
-
-            // An empty original candidate set proves nothing. Only removal of covered candidates permits this early allow.
-            if (candidates.Count > 0 && approvalCandidates.Count == 0)
-                return ToolAuthorizationDecision.Allow(ToolAllowReason.ReviewedSafePolicy);
-        }
-        else if (!isShell)
-        {
-            agentCorrection = _temporaryPathCorrectionPolicy.EvaluateStructuredFileChange(
-                toolName,
-                arguments,
-                context.Invocation,
-                _toolPathPolicy);
-        }
-
-        var candidateVerbs = approvalCandidates
+    private ToolAuthorizationDecision BuildApprovalDecision(
+        ToolName toolName,
+        ToolExecutionContext context,
+        IReadOnlyList<string> patterns,
+        IReadOnlyList<ApprovalCandidate> candidates,
+        string displayText,
+        bool isMessy,
+        ToolCorrection? correction,
+        bool hasReusablePhrase,
+        bool directoryApprovalAvailable)
+    {
+        var candidateVerbs = candidates
             .Select(static candidate => candidate.Verb)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -797,17 +787,6 @@ public sealed class ToolAccessPolicy
         }
         else
         {
-            var hasReusablePhrase = !isShell || approvalCandidates.All(HasReusableShellPhrase);
-            var directoryApprovalAvailable = false;
-            if (matcher is ShellApprovalMatcher)
-            {
-                directoryApprovalAvailable = IsShellDirectoryApprovalAvailable(
-                    approvalCandidates,
-                    context.Approval.Cwd,
-                    GetSessionOwnedApprovalDirectories(context),
-                    ShellEnvironment.PathStyle);
-            }
-
             options = BuildApprovalOptions(GetApprovalOptionProfile(
                 toolName,
                 isMessy,
@@ -823,7 +802,7 @@ public sealed class ToolAccessPolicy
             options,
             Cwd: context.Approval.Cwd,
             IsMessy: isMessy,
-            Candidates: approvalCandidates)
+            Candidates: candidates)
         {
             IsManagedTemporaryRetry = isManagedTemporaryRetry,
             ManagedTemporaryDirectory = managedTemporaryRetry?.ManagedTemporaryDirectory,
@@ -832,37 +811,7 @@ public sealed class ToolAccessPolicy
 
         return ToolAuthorizationDecision.RequiresApproval(
             approvalContext,
-            isManagedTemporaryRetry ? null : agentCorrection);
-    }
-
-    private (IReadOnlyList<ApprovalCandidate> UncoveredCandidates, ToolCorrection? Correction) EvaluateSynchronousShellPolicy(
-        ShellCommandAnalysis? analysis,
-        IReadOnlyList<ApprovalCandidate> candidates,
-        bool isMessy,
-        IDictionary<string, object?>? arguments,
-        ToolExecutionContext context)
-    {
-        ToolCorrection? correction = null;
-        if (analysis is not null)
-            correction = EvaluateShellTemporaryCorrection(analysis, candidates, arguments, context.Invocation);
-
-        if (_safeVerbPolicy is null)
-            return (candidates, correction);
-
-        if (isMessy)
-            return (candidates, correction);
-
-        if (candidates.Count == 0)
-            return (candidates, correction);
-
-        if (correction is null)
-            correction = EvaluateShellProjectCorrection(candidates, context.Approval.Cwd, context.Invocation);
-
-        // Each removed candidate must satisfy both the reviewed verb and path rules. The approval store covers the remainder.
-        var uncovered = candidates
-            .Where(candidate => !_safeVerbPolicy.ShortCircuits(candidate, context.Approval.Cwd, context.Invocation))
-            .ToList();
-        return (uncovered, correction);
+            isManagedTemporaryRetry ? null : correction);
     }
 
     internal ToolCorrection? EvaluateShellTemporaryCorrection(


### PR DESCRIPTION
## Summary

- make ShellPolicyCoordinator the only component that completes shell authorization
- replace the nullable coordinator tuple with closed authorized, tool-validation, and stopped results
- separate shell and non-shell approval fact collection before one shared approval decision builder
- fail loudly if a caller tries to authorize shell_execute through the synchronous non-shell policy API
- remove the duplicate synchronous safe-policy and correction implementation

## Validation

- dotnet build Netclaw.slnx -c Release --no-restore
- dotnet test Netclaw.slnx -c Release --no-build
- Netclaw.Actors.Tests: 3,926 passed, 6 platform skips
- dotnet slopwatch analyze --output json: 0 issues
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- git diff --check

The full solution build reports the existing ASPIRE010 warning from the demo AppHost configuration; it has no build errors.