### PR TITLE
Acquire Codex skill packages from GitHub

### DIFF
--- a/feeds/skills/.system/files/skill-authoring/SKILL.md
+++ b/feeds/skills/.system/files/skill-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: skill-authoring
 description: "How to create, edit, and manage Netclaw skills. Read this when you need to synthesize a new skill from a session, understand the skill file format, or use the skill_manage tool."
 metadata:
   author: netclaw
-  version: "1.9.0"
+  version: "1.10.0"
 ---
 
 # Skill Authoring
@@ -254,3 +254,30 @@ All skills — regardless of origin — are visible in the skill index and
 available to all sessions. The skill index is a compressed file listing
 injected into the system prompt that points the agent directly at SKILL.md
 files on disk for retrieval-led reasoning.
+
+## GitHub Plugin Sources
+
+Netclaw accepts public `github.com` repositories that use the Codex plugin
+format. Private repositories need a later credential feature.
+
+The plugin root must contain `.codex-plugin/plugin.json`. Netclaw reads only
+these manifest fields:
+
+- `name` is required. It uses lowercase letters, numbers, and hyphens.
+- `version` is optional. A present value must use strict SemVer.
+- `skills` is optional. It must contain one relative directory path.
+
+Netclaw always checks `./skills/`. It also checks the `skills` directory from
+the manifest. Each selected skill is a direct child directory with an exact
+`SKILL.md` filename. Netclaw imports the selected skill files and their safe
+resources only.
+
+Netclaw ignores plugin components that can run code or add authority. These
+components include `agents`, `apps`, `commands`, `hooks`, `mcpServers`, and
+`scripts`. Netclaw reports a notice for each ignored component.
+
+Netclaw rejects the complete candidate when it finds an unsafe path, link in a
+selected skill, special file, invalid manifest, invalid skill, or scanner
+rejection. Netclaw keeps the prior accepted package. Netclaw records a rejected
+commit and skips it during normal sync. An explicit retry checks that commit
+again.

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -48,8 +48,11 @@ public sealed class NetclawPaths
     public string ManagedGitSkillDirectory(string sourceName)
         => Path.Combine(ManagedGitSkillsDirectory, sourceName);
 
-    public string ManagedGitSkillCommitDirectory(string sourceName, string commit)
-        => Path.Combine(ManagedGitSkillDirectory(sourceName), "commits", commit);
+    public string ManagedGitSkillCommitDirectory(
+        string sourceName,
+        string sourceFingerprint,
+        string commit)
+        => Path.Combine(ManagedGitSkillDirectory(sourceName), sourceFingerprint, "commits", commit);
 
     public string ServerFeedDirectory(string feedName)
         => Path.Combine(ServerFeedsDirectory, feedName);

--- a/src/Netclaw.Daemon.Tests/Services/GitSkillPluginAcquirerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/GitSkillPluginAcquirerTests.cs
@@ -1,0 +1,610 @@
+// -----------------------------------------------------------------------
+// <copyright file="GitSkillPluginAcquirerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
+using Netclaw.Security.Skills;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class GitSkillPluginAcquirerTests : IDisposable
+{
+    private const string Commit = "13e26d39ed01d97ea592235d041304d289f4ba07";
+    private readonly DisposableTempDir _temp = new();
+
+    public void Dispose() => _temp.Dispose();
+
+    [Fact]
+    public async Task Acquire_imports_only_declared_skill_folders_and_resources()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.2.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/references/exact.md", "exact resource", TarEntryType.RegularFile),
+            ("repo/scripts/install.sh", "must not import", TarEntryType.RegularFile));
+        var candidate = await CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(Commit, candidate.Commit);
+        Assert.Equal("1.2.0", candidate.Version);
+        Assert.Equal("alpha", Assert.Single(candidate.Skills).Name);
+        Assert.Equal("exact resource", await File.ReadAllTextAsync(
+            Path.Combine(candidate.Directory, "alpha", "references", "exact.md"),
+            TestContext.Current.CancellationToken));
+        Assert.False(File.Exists(Path.Combine(candidate.Directory, "scripts", "install.sh")));
+    }
+
+    [Fact]
+    public async Task Acquire_ignores_an_unselected_root_link()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/CLAUDE.md", "AGENTS.md", TarEntryType.SymbolicLink));
+
+        var candidate = await CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("alpha", Assert.Single(candidate.Skills).Name);
+        Assert.False(File.Exists(Path.Combine(candidate.Directory, "CLAUDE.md")));
+    }
+
+    [Fact]
+    public async Task Acquire_ignores_archive_wide_PAX_metadata()
+    {
+        var archive = CreateArchive(
+            ("pax_global_header", "", TarEntryType.GlobalExtendedAttributes),
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var candidate = await CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("alpha", Assert.Single(candidate.Skills).Name);
+    }
+
+    [Fact]
+    public async Task Acquire_counts_archive_wide_PAX_metadata_against_the_entry_limit()
+    {
+        var archive = CreateArchive(
+            ("pax_global_header", "", TarEntryType.GlobalExtendedAttributes),
+            ("pax_global_header", "", TarEntryType.GlobalExtendedAttributes),
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+        var limits = Limits() with { MaximumArchiveEntries = 3 };
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive, limits: limits).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("entry-count limit", error.Message);
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_a_link_without_importing_any_candidate()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/escape", "target", TarEntryType.SymbolicLink));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.False(error.SecurityRejection);
+        var source = Source();
+        Assert.False(Directory.Exists(new NetclawPaths(_temp.Path).ManagedGitSkillCommitDirectory(
+            source.Name,
+            GitSkillPluginSourceValidator.Fingerprint(source),
+            Commit)));
+    }
+
+    [Fact]
+    public async Task Acquire_marks_only_a_confirmed_scanner_rejection_as_security_rejection()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive, new RejectScanner()).AcquireAsync(
+                Source(), TestContext.Current.CancellationToken));
+
+        Assert.True(error.SecurityRejection);
+    }
+
+    [Fact]
+    public async Task Acquire_surfaces_a_scanner_failure_as_a_retryable_error()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginScannerUnavailableException>(() =>
+            CreateAcquirer(archive, new FailedScanner()).AcquireAsync(
+                Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("scanner", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Acquire_surfaces_a_thrown_scanner_error_as_a_retryable_error()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        await Assert.ThrowsAsync<GitSkillPluginScannerUnavailableException>(() =>
+            CreateAcquirer(archive, new ThrowingScanner()).AcquireAsync(
+                Source(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Acquire_uses_the_default_skills_folder_when_the_manifest_omits_skills()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", "{ \"name\": \"fixture\", \"version\": \"1.0.0\" }", TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/skills/category/nested/SKILL.md", Skill("nested"), TarEntryType.RegularFile));
+
+        var candidate = await CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("alpha", Assert.Single(candidate.Skills).Name);
+        Assert.False(Directory.Exists(Path.Combine(candidate.Directory, "nested")));
+    }
+
+    [Theory]
+    [InlineData("1.0")]
+    [InlineData("01.0.0")]
+    [InlineData("1.0.0-01")]
+    public async Task Acquire_rejects_a_non_strict_plugin_version(string version)
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest(version), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("strict SemVer", error.Message);
+    }
+
+    [Theory]
+    [InlineData("1.0.0")]
+    [InlineData("1.0.0-beta.1")]
+    [InlineData("1.0.0-beta-name.1")]
+    [InlineData("1.0.0+build.7")]
+    [InlineData("1.0.0-beta.1+build.7")]
+    public async Task Acquire_accepts_strict_SemVer_versions(string version)
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest(version), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var candidate = await CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(version, candidate.Version);
+    }
+
+    [Theory]
+    [InlineData("\"\"")]
+    [InlineData("null")]
+    [InlineData("42")]
+    public async Task Acquire_rejects_a_present_invalid_plugin_version(string version)
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", $"{{ \"name\": \"fixture\", \"version\": {version} }}", TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("strict SemVer", error.Message);
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_an_invalid_manifest_name()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", "{ \"name\": \"Bad Name\" }", TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("manifest name", error.Message);
+    }
+
+    [Fact]
+    public async Task Acquire_reports_ignored_executable_components()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", """
+                { "name": "fixture", "hooks": {}, "mcpServers": {}, "apps": {}, "agents": {} }
+                """, TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var candidate = await CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, candidate.Notices.Count);
+        Assert.Contains(candidate.Notices, notice => notice.Contains("hooks", StringComparison.Ordinal));
+        Assert.Contains(candidate.Notices, notice => notice.Contains("mcpServers", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_the_complete_candidate_when_a_text_resource_is_rejected()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/references/risk.md", "blocked resource", TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive, new ResourceRejectScanner()).AcquireAsync(
+                Source(), TestContext.Current.CancellationToken));
+
+        Assert.True(error.SecurityRejection);
+        Assert.Contains("alpha:references/risk.md", error.Message);
+    }
+
+    [Fact]
+    public async Task Acquire_does_not_replace_an_existing_immutable_commit_directory()
+    {
+        var firstArchive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/reference.md", "first", TarEntryType.RegularFile));
+        var first = await CreateAcquirer(firstArchive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+        var secondArchive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/reference.md", "second", TarEntryType.RegularFile));
+
+        var second = await CreateAcquirer(secondArchive).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(first.Directory, second.Directory);
+        Assert.Equal("first", await File.ReadAllTextAsync(
+            Path.Combine(second.Directory, "alpha", "reference.md"), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Acquire_uses_a_separate_directory_for_each_source_fingerprint()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile),
+            ("repo/plugin/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/plugin/skills/beta/SKILL.md", Skill("beta"), TarEntryType.RegularFile));
+        var firstSource = Source();
+        var secondSource = Source();
+        secondSource.Subdirectory = "plugin";
+
+        var first = await CreateAcquirer(archive).AcquireAsync(firstSource, TestContext.Current.CancellationToken);
+        var second = await CreateAcquirer(archive).AcquireAsync(secondSource, TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(first.Directory, second.Directory);
+        Assert.Equal("alpha", Assert.Single(first.Skills).Name);
+        Assert.Equal("beta", Assert.Single(second.Skills).Name);
+    }
+
+    [Theory]
+    [InlineData("repo/skills/alpha/../escape/SKILL.md")]
+    [InlineData("repo/skills\\alpha/SKILL.md")]
+    public async Task Acquire_rejects_an_unsafe_archive_path(string path)
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            (path, Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("unsafe", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_a_skill_file_with_noncanonical_case()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/skill.md", Skill("alpha"), TarEntryType.RegularFile));
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("no skills", error.Message);
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_an_unsafe_archive_redirect()
+    {
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(new UnsafeRedirectHandler()).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("unsafe archive redirect", error.Message);
+    }
+
+    [Fact]
+    public void CreateHttpHandler_disables_automatic_redirects()
+    {
+        using var handler = GitSkillPluginAcquirer.CreateHttpHandler();
+
+        Assert.False(handler.AllowAutoRedirect);
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_a_selected_file_that_exceeds_the_limit()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha") + new string('x', 200), TarEntryType.RegularFile));
+        var limits = Limits() with { MaximumSelectedFileBytes = 128 };
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive, limits: limits).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("per-file limit", error.Message);
+        Assert.False(error.SecurityRejection);
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_an_archive_that_exceeds_the_decompressed_limit()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha") + new string('x', 2_000), TarEntryType.RegularFile));
+        var limits = Limits() with { MaximumDecompressedArchiveBytes = 512 };
+
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive, limits: limits).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("decompressed-size", error.Message);
+        Assert.False(error.SecurityRejection);
+    }
+
+    [Fact]
+    public async Task ResolveCommit_bounds_the_GitHub_JSON_response()
+    {
+        var limits = Limits() with { MaximumManifestBytes = 32 };
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            CreateAcquirer(new LargeCommitResponseHandler(), limits: limits)
+                .ResolveCommitAsync(Source(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Acquire_sends_the_Netclaw_user_agent_on_each_GitHub_request()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+        var handler = new GitHubHandler(archive);
+
+        await CreateAcquirer(handler).AcquireAsync(Source(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.UserAgents.Count);
+        Assert.All(handler.UserAgents, userAgent => Assert.Equal(NetclawUserAgent.Value, userAgent));
+    }
+
+    [Fact]
+    public async Task Acquire_uses_a_fixed_commit_without_a_GitHub_commit_lookup()
+    {
+        var archive = CreateArchive(
+            ("repo/.codex-plugin/plugin.json", Manifest("1.0.0"), TarEntryType.RegularFile),
+            ("repo/skills/alpha/SKILL.md", Skill("alpha"), TarEntryType.RegularFile));
+        var handler = new GitHubHandler(archive);
+        var source = Source();
+        source.ReferenceKind = GitSkillPluginReferenceKind.Commit;
+        source.Reference = Commit;
+
+        var candidate = await CreateAcquirer(handler).AcquireAsync(source, TestContext.Current.CancellationToken);
+
+        Assert.Equal(Commit, candidate.Commit);
+        Assert.Equal(0, handler.CommitRequestCount);
+        Assert.Single(handler.UserAgents);
+    }
+
+    [Theory]
+    [MemberData(nameof(CorruptArchives))]
+    public async Task Acquire_rejects_malformed_archive_content(byte[] archive)
+    {
+        var error = await Assert.ThrowsAsync<GitSkillPluginRejectedException>(() =>
+            CreateAcquirer(archive).AcquireAsync(Source(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("invalid GZip or tar", error.Message);
+    }
+
+    public static IEnumerable<object[]> CorruptArchives()
+    {
+        yield return [Encoding.UTF8.GetBytes("not a gzip archive")];
+        yield return [CreateCorruptTarArchive()];
+    }
+
+    private GitSkillPluginAcquirer CreateAcquirer(
+        byte[] archive,
+        ISkillContentScanner? scanner = null,
+        GitSkillPluginArchiveLimits? limits = null)
+    {
+        return CreateAcquirer(new GitHubHandler(archive), scanner, limits);
+    }
+
+    private GitSkillPluginAcquirer CreateAcquirer(
+        HttpMessageHandler handler,
+        ISkillContentScanner? scanner = null,
+        GitSkillPluginArchiveLimits? limits = null)
+    {
+        var client = new HttpClient(handler);
+        return new GitSkillPluginAcquirer(
+            client,
+            new NetclawPaths(_temp.Path),
+            TimeProvider.System,
+            scanner ?? new NoOpSkillContentScanner(),
+            limits ?? Limits());
+    }
+
+    private static GitSkillPluginArchiveLimits Limits() => GitSkillPluginArchiveLimits.Default;
+
+    private static GitSkillPluginSource Source() => new()
+    {
+        Name = "fixture",
+        Repository = "owner/repository",
+        Format = "codex",
+        ReferenceKind = GitSkillPluginReferenceKind.Branch,
+        Reference = "main",
+    };
+
+    private static string Manifest(string version) => $$"""
+        { "name": "fixture", "version": "{{version}}", "skills": "./skills/" }
+        """;
+
+    private static string Skill(string name) => $$"""
+        ---
+        name: {{name}}
+        description: A fixture skill.
+        ---
+
+        # Fixture
+        """;
+
+    private static byte[] CreateArchive(params (string Path, string Content, TarEntryType Type)[] entries)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        using (var writer = new TarWriter(gzip, leaveOpen: true))
+        {
+            foreach (var (path, content, type) in entries)
+            {
+                if (type == TarEntryType.GlobalExtendedAttributes)
+                {
+                    writer.WriteEntry(new PaxGlobalExtendedAttributesTarEntry(
+                        [new KeyValuePair<string, string>("comment", "fixture")]));
+                    continue;
+                }
+
+                var entry = new PaxTarEntry(type, path) { Mode = (UnixFileMode)0x1A4 };
+                if (type is TarEntryType.RegularFile or TarEntryType.V7RegularFile)
+                    entry.DataStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+                else if (type == TarEntryType.SymbolicLink)
+                    entry.LinkName = content;
+                writer.WriteEntry(entry);
+            }
+        }
+        return output.ToArray();
+    }
+
+    private static byte[] CreateCorruptTarArchive()
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            var invalidTar = Encoding.UTF8.GetBytes("this is not a tar archive");
+            gzip.Write(invalidTar);
+        }
+        return output.ToArray();
+    }
+
+    private sealed class GitHubHandler(byte[] archive) : HttpMessageHandler
+    {
+        public List<string?> UserAgents { get; } = [];
+        public int CommitRequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            UserAgents.Add(request.Headers.UserAgent.ToString());
+            var response = request.RequestUri!.AbsolutePath.Contains("/commits/", StringComparison.Ordinal)
+                ? CommitResponse()
+                : ArchiveResponse();
+            return Task.FromResult(response);
+        }
+
+        private HttpResponseMessage CommitResponse()
+        {
+            CommitRequestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"sha\":\"{Commit}\"}}", Encoding.UTF8, "application/json"),
+            };
+        }
+
+        private HttpResponseMessage ArchiveResponse() => new(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(archive),
+        };
+    }
+
+    private sealed class UnsafeRedirectHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri!.AbsolutePath.Contains("/commits/", StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{{\"sha\":\"{Commit}\"}}", Encoding.UTF8, "application/json"),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Found)
+            {
+                Headers = { Location = new Uri("https://example.test/archive.tar.gz") },
+            });
+        }
+    }
+
+    private sealed class LargeCommitResponseHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"sha\":\"{Commit}\",\"padding\":\"{new string('x', 100)}\"}}", Encoding.UTF8, "application/json"),
+            });
+    }
+
+    private sealed class RejectScanner : ISkillContentScanner
+    {
+        public Task<Netclaw.Security.Skills.SkillScanResult> ScanAsync(
+            string skillName,
+            string content,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Netclaw.Security.Skills.SkillScanResult.Reject("fixture rejection"));
+    }
+
+    private sealed class FailedScanner : ISkillContentScanner
+    {
+        public Task<Netclaw.Security.Skills.SkillScanResult> ScanAsync(
+            string skillName,
+            string content,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Netclaw.Security.Skills.SkillScanResult.Fail("scanner unavailable"));
+    }
+
+    private sealed class ResourceRejectScanner : ISkillContentScanner
+    {
+        public Task<Netclaw.Security.Skills.SkillScanResult> ScanAsync(
+            string skillName,
+            string content,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(skillName.Contains(':', StringComparison.Ordinal)
+                ? Netclaw.Security.Skills.SkillScanResult.Reject("fixture resource rejection")
+                : Netclaw.Security.Skills.SkillScanResult.Allow());
+    }
+
+    private sealed class ThrowingScanner : ISkillContentScanner
+    {
+        public Task<Netclaw.Security.Skills.SkillScanResult> ScanAsync(
+            string skillName,
+            string content,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("fixture scanner error");
+    }
+}

--- a/src/Netclaw.Daemon/Services/GitSkillPluginAcquirer.cs
+++ b/src/Netclaw.Daemon/Services/GitSkillPluginAcquirer.cs
@@ -1,0 +1,833 @@
+// -----------------------------------------------------------------------
+// <copyright file="GitSkillPluginAcquirer.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.Actors.Skills;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Security.Skills;
+using SecuritySkillScanResult = Netclaw.Security.Skills.SkillScanResult;
+
+namespace Netclaw.Daemon.Services;
+
+internal interface IGitSkillPluginAcquirer
+{
+    Task<GitSkillPluginCandidate> AcquireAsync(GitSkillPluginSource source, CancellationToken cancellationToken);
+}
+
+internal sealed record GitSkillPluginCandidate(
+    string Commit,
+    string? Version,
+    string Directory,
+    IReadOnlyList<SkillEntry> Skills,
+    IReadOnlyList<string> Notices);
+
+internal sealed class GitSkillPluginRejectedException(
+    string commit,
+    string message,
+    bool securityRejection = false) : Exception(message)
+{
+    public string Commit { get; } = commit;
+    public bool SecurityRejection { get; } = securityRejection;
+}
+
+/// <summary>
+/// The content scanner did not establish a security verdict.
+/// The sync service may retry this failure because it does not identify unsafe content.
+/// </summary>
+internal sealed class GitSkillPluginScannerUnavailableException(string message, Exception? innerException = null)
+    : Exception(message, innerException);
+
+internal sealed record GitSkillPluginArchiveLimits(
+    int MaximumManifestBytes,
+    int MaximumArchiveBytes,
+    long MaximumDecompressedArchiveBytes,
+    int MaximumArchiveEntries,
+    int MaximumSkillCount,
+    int MaximumSelectedFileCount,
+    int MaximumSelectedFileBytes,
+    long MaximumSelectedTotalBytes)
+{
+    public static GitSkillPluginArchiveLimits Default { get; } = new(
+        GitSkillPluginAcquirer.MaximumManifestBytes,
+        GitSkillPluginAcquirer.MaximumArchiveBytes,
+        GitSkillPluginAcquirer.MaximumDecompressedArchiveBytes,
+        GitSkillPluginAcquirer.MaximumArchiveEntries,
+        GitSkillPluginAcquirer.MaximumSkillCount,
+        GitSkillPluginAcquirer.MaximumSelectedFileCount,
+        GitSkillPluginAcquirer.MaximumSelectedFileBytes,
+        GitSkillPluginAcquirer.MaximumSelectedTotalBytes);
+}
+
+internal sealed class GitSkillPluginAcquirer : IGitSkillPluginAcquirer
+{
+    internal const int MaximumManifestBytes = 256 * 1024;
+    internal const int MaximumArchiveBytes = 64 * 1024 * 1024;
+    internal const long MaximumDecompressedArchiveBytes = 128L * 1024 * 1024;
+    internal const int MaximumArchiveEntries = 10_000;
+    internal const int MaximumSkillCount = 256;
+    internal const int MaximumSelectedFileCount = 4_096;
+    internal const int MaximumSelectedFileBytes = 4 * 1024 * 1024;
+    internal const long MaximumSelectedTotalBytes = 32L * 1024 * 1024;
+
+    private const string ManifestRelativePath = ".codex-plugin/plugin.json";
+    private static readonly HashSet<string> ExecutableComponentNames = new(StringComparer.Ordinal)
+    {
+        "agents",
+        "apps",
+        "commands",
+        "entrypoint",
+        "hooks",
+        "installers",
+        "lsp",
+        "mcp",
+        "mcpServers",
+        "scripts",
+        "servers",
+    };
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+    private readonly HttpClient _httpClient;
+    private readonly NetclawPaths _paths;
+    private readonly TimeProvider _timeProvider;
+    private readonly ISkillContentScanner _scanner;
+    private readonly GitSkillPluginArchiveLimits _limits;
+
+    public GitSkillPluginAcquirer(
+        HttpClient httpClient,
+        NetclawPaths paths,
+        TimeProvider timeProvider,
+        ISkillContentScanner scanner)
+        : this(httpClient, paths, timeProvider, scanner, GitSkillPluginArchiveLimits.Default)
+    {
+    }
+
+    internal GitSkillPluginAcquirer(
+        HttpClient httpClient,
+        NetclawPaths paths,
+        TimeProvider timeProvider,
+        ISkillContentScanner scanner,
+        GitSkillPluginArchiveLimits limits)
+    {
+        _httpClient = httpClient;
+        _paths = paths;
+        _timeProvider = timeProvider;
+        _scanner = scanner;
+        _limits = limits;
+    }
+
+    /// <summary>
+    /// Creates the production handler for GitHub archive requests.
+    /// The acquirer validates one allowed redirect itself.
+    /// </summary>
+    internal static HttpClientHandler CreateHttpHandler() => new() { AllowAutoRedirect = false };
+
+    public async Task<GitSkillPluginCandidate> AcquireAsync(
+        GitSkillPluginSource source,
+        CancellationToken cancellationToken)
+    {
+        if (!GitSkillPluginSourceValidator.TryValidateSource(source, out var sourceError))
+            throw new InvalidOperationException(sourceError);
+
+        using var timeout = new CancellationTokenSource(
+            TimeSpan.FromSeconds(source.TimeoutSeconds), _timeProvider);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
+        var token = linked.Token;
+        try
+        {
+            var commit = await ResolveCommitAsync(source, token);
+            var archivePath = Path.Combine(_paths.CacheDirectory, "git-skill-archives", $"{Guid.NewGuid():N}.tar.gz");
+            Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
+            try
+            {
+                await DownloadArchiveAsync(source.Repository, commit, archivePath, token);
+                var inventory = await InspectArchiveAsync(source, commit, archivePath, token);
+                var sourceDirectory = _paths.ManagedGitSkillDirectory(source.Name);
+                var sourceFingerprint = GitSkillPluginSourceValidator.Fingerprint(source);
+                var candidateDirectory = _paths.ManagedGitSkillCommitDirectory(
+                    source.Name, sourceFingerprint, commit);
+                var stagingDirectory = Path.Combine(
+                    sourceDirectory, ".staging", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(stagingDirectory);
+                var createdCandidate = false;
+                try
+                {
+                    await ExtractSelectedAsync(archivePath, inventory, stagingDirectory, commit, token);
+                    var scan = SkillScanner.Scan(stagingDirectory, false, false, false);
+                    if (scan.Issues.Count > 0 || scan.AcceptedSkills.Count != inventory.SkillRoots.Count)
+                    {
+                        throw new GitSkillPluginRejectedException(
+                            commit,
+                            scan.Issues.FirstOrDefault()?.Message
+                            ?? "One or more selected skill folders were invalid.");
+                    }
+
+                    foreach (var skill in scan.AcceptedSkills)
+                    {
+                        if (skill.HasSubagentRoutingMetadata)
+                        {
+                            throw new GitSkillPluginRejectedException(
+                                commit,
+                                $"Skill '{skill.Name}' declares a sub-agent route, which a plugin cannot grant.");
+                        }
+
+                        var content = await File.ReadAllTextAsync(skill.FilePath, StrictUtf8, token);
+                        var verdict = await ScanContentAsync(skill.Name, content, token);
+                        if (!verdict.IsAllowed)
+                        {
+                            if (verdict.Verdict == ScanVerdict.Failed)
+                            {
+                                throw new GitSkillPluginScannerUnavailableException(
+                                    $"The content scanner failed for skill '{skill.Name}': {verdict.Reason}");
+                            }
+                            throw new GitSkillPluginRejectedException(
+                                commit,
+                                $"The content scanner rejected skill '{skill.Name}': {verdict.Reason}",
+                                securityRejection: verdict.Verdict == ScanVerdict.Rejected);
+                        }
+
+                        foreach (var resourcePath in skill.ResourcePaths ?? [])
+                        {
+                            var resourceBytes = await File.ReadAllBytesAsync(
+                                Path.Combine(skill.SkillDirectory, resourcePath.Replace('/', Path.DirectorySeparatorChar)),
+                                token);
+                            string resourceContent;
+                            try
+                            {
+                                resourceContent = StrictUtf8.GetString(resourceBytes);
+                            }
+                            catch (DecoderFallbackException)
+                            {
+                                continue;
+                            }
+
+                            var resourceVerdict = await ScanContentAsync(
+                                $"{skill.Name}:{resourcePath}", resourceContent, token);
+                            if (!resourceVerdict.IsAllowed)
+                            {
+                                if (resourceVerdict.Verdict == ScanVerdict.Failed)
+                                {
+                                    throw new GitSkillPluginScannerUnavailableException(
+                                        $"The content scanner failed for resource '{skill.Name}:{resourcePath}': {resourceVerdict.Reason}");
+                                }
+                                throw new GitSkillPluginRejectedException(
+                                    commit,
+                                    $"The content scanner blocked resource '{skill.Name}:{resourcePath}': {resourceVerdict.Reason}",
+                                    securityRejection: resourceVerdict.Verdict == ScanVerdict.Rejected);
+                            }
+                        }
+                    }
+
+                    ProtectDirectory(stagingDirectory);
+                    Directory.CreateDirectory(Path.GetDirectoryName(candidateDirectory)!);
+                    if (Directory.Exists(candidateDirectory))
+                    {
+                        DeleteDirectory(stagingDirectory);
+                    }
+                    else
+                    {
+                        Directory.Move(stagingDirectory, candidateDirectory);
+                        createdCandidate = true;
+                    }
+
+                    var publishedScan = SkillScanner.Scan(candidateDirectory, false, false, false);
+                    if (publishedScan.Issues.Count > 0
+                        || publishedScan.AcceptedSkills.Count != inventory.SkillRoots.Count)
+                    {
+                        throw new InvalidDataException("The immutable candidate did not match its validated snapshot.");
+                    }
+                    return new GitSkillPluginCandidate(
+                        commit, inventory.Version, candidateDirectory, publishedScan.AcceptedSkills, inventory.Notices);
+                }
+                catch
+                {
+                    DeleteDirectory(stagingDirectory);
+                    if (createdCandidate)
+                        DeleteDirectory(candidateDirectory);
+                    throw;
+                }
+            }
+            finally
+            {
+                File.Delete(archivePath);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException("The GitHub plugin request exceeded its configured timeout.");
+        }
+    }
+
+    internal async Task<string> ResolveCommitAsync(
+        GitSkillPluginSource source,
+        CancellationToken cancellationToken)
+    {
+        if (source.ReferenceKind == GitSkillPluginReferenceKind.Commit)
+            return source.Reference.ToLowerInvariant();
+
+        var reference = Uri.EscapeDataString(source.Reference);
+        using var request = CreateGitHubRequest(
+            HttpMethod.Get,
+            $"https://api.github.com/repos/{source.Repository}/commits/{reference}");
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException("GitHub could not resolve the configured reference.", null, response.StatusCode);
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var limited = new LimitedReadStream(stream, _limits.MaximumManifestBytes, null,
+            "The GitHub commit response exceeds the JSON-size limit.");
+        using var document = await JsonDocument.ParseAsync(limited, cancellationToken: cancellationToken);
+        if (!document.RootElement.TryGetProperty("sha", out var shaElement)
+            || shaElement.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException("GitHub returned no commit identity.");
+        }
+        var commit = shaElement.GetString()!;
+        if (commit.Length != 40 || !commit.All(char.IsAsciiHexDigit))
+            throw new InvalidDataException("GitHub returned an invalid commit identity.");
+        return commit.ToLowerInvariant();
+    }
+
+    private async Task<SecuritySkillScanResult> ScanContentAsync(
+        string name,
+        string content,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _scanner.ScanAsync(name, content, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new GitSkillPluginScannerUnavailableException(
+                $"The content scanner failed for '{name}'.", ex);
+        }
+    }
+
+    private async Task DownloadArchiveAsync(
+        string repository,
+        string commit,
+        string destination,
+        CancellationToken cancellationToken)
+    {
+        using var initialRequest = CreateGitHubRequest(
+            HttpMethod.Get,
+            $"https://api.github.com/repos/{repository}/tarball/{commit}");
+        using var initial = await _httpClient.SendAsync(
+            initialRequest,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        HttpResponseMessage archiveResponse;
+        if (initial.StatusCode is HttpStatusCode.Found or HttpStatusCode.TemporaryRedirect
+            or HttpStatusCode.PermanentRedirect or HttpStatusCode.MovedPermanently)
+        {
+            var location = initial.Headers.Location;
+            if (location is null || !location.IsAbsoluteUri
+                || !string.Equals(location.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(location.Host, "codeload.github.com", StringComparison.OrdinalIgnoreCase)
+                || !location.IsDefaultPort || !string.IsNullOrEmpty(location.UserInfo))
+            {
+                throw new GitSkillPluginRejectedException(commit, "GitHub returned an unsafe archive redirect.");
+            }
+            using var redirectRequest = CreateGitHubRequest(HttpMethod.Get, location);
+            archiveResponse = await _httpClient.SendAsync(
+                redirectRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        }
+        else
+        {
+            archiveResponse = initial;
+        }
+
+        using (archiveResponse)
+        {
+            if (!archiveResponse.IsSuccessStatusCode)
+                throw new HttpRequestException("GitHub could not download the commit archive.", null, archiveResponse.StatusCode);
+            await using var source = await archiveResponse.Content.ReadAsStreamAsync(cancellationToken);
+            await using var file = new FileStream(destination, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            await CopyLimitedAsync(
+                source,
+                file,
+                _limits.MaximumArchiveBytes,
+                commit,
+                "The archive exceeds the compressed-size limit.",
+                cancellationToken);
+        }
+    }
+
+    private static HttpRequestMessage CreateGitHubRequest(HttpMethod method, string requestUri)
+        => CreateGitHubRequest(method, new Uri(requestUri, UriKind.Absolute));
+
+    private static HttpRequestMessage CreateGitHubRequest(HttpMethod method, Uri requestUri)
+    {
+        var request = new HttpRequestMessage(method, requestUri);
+        request.Headers.TryAddWithoutValidation("User-Agent", NetclawUserAgent.Value);
+        return request;
+    }
+
+    private async Task<ArchiveInventory> InspectArchiveAsync(
+        GitSkillPluginSource source,
+        string commit,
+        string archivePath,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await InspectArchiveCoreAsync(source, commit, archivePath, cancellationToken);
+        }
+        catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException)
+        {
+            throw new GitSkillPluginRejectedException(commit, "The archive has invalid GZip or tar content.");
+        }
+    }
+
+    private async Task<ArchiveInventory> InspectArchiveCoreAsync(
+        GitSkillPluginSource source,
+        string commit,
+        string archivePath,
+        CancellationToken cancellationToken)
+    {
+        var paths = new Dictionary<string, ArchiveFile>(StringComparer.Ordinal);
+        var foldedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        byte[]? manifest = null;
+        var pluginRoot = source.Subdirectory is null ? "" : source.Subdirectory + "/";
+        var manifestPath = pluginRoot + ManifestRelativePath;
+        var entryCount = 0;
+
+        await using var file = File.OpenRead(archivePath);
+        await using var gzip = new GZipStream(file, CompressionMode.Decompress);
+        await using var bounded = new LimitedReadStream(
+            gzip,
+            _limits.MaximumDecompressedArchiveBytes,
+            commit,
+            "The archive exceeds the decompressed-size limit.");
+        using var reader = new TarReader(bounded, leaveOpen: false);
+        while (await reader.GetNextEntryAsync(copyData: false, cancellationToken) is { } entry)
+        {
+            entryCount++;
+            if (entryCount > _limits.MaximumArchiveEntries)
+                throw new GitSkillPluginRejectedException(commit, "The archive exceeds the entry-count limit.");
+            if (entry.EntryType == TarEntryType.GlobalExtendedAttributes)
+                continue;
+            var path = NormalizeArchivePath(entry.Name, commit);
+            if (path.Length == 0 && entry.EntryType == TarEntryType.Directory)
+                continue;
+            if (!paths.TryAdd(path, new ArchiveFile(path, entry.Length, entry.EntryType, entry.Mode))
+                || !foldedPaths.Add(path))
+            {
+                throw new GitSkillPluginRejectedException(commit, "The archive contains duplicate normalized paths.");
+            }
+            if (!IsLink(entry.EntryType))
+                ValidateArchiveEntry(entry, commit);
+            if (string.Equals(path, manifestPath, StringComparison.Ordinal))
+            {
+                if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile)
+                    || entry.Length > _limits.MaximumManifestBytes)
+                {
+                    throw new GitSkillPluginRejectedException(commit, "The Codex manifest is not a valid regular file.");
+                }
+                manifest = await ReadLimitedAsync(
+                    entry.DataStream!,
+                    _limits.MaximumManifestBytes,
+                    commit,
+                    "The Codex manifest exceeds the size limit.",
+                    cancellationToken);
+            }
+        }
+
+        if (manifest is null)
+            throw new GitSkillPluginRejectedException(commit, "The Codex plugin manifest is missing.");
+        var parsed = ParseManifest(manifest, commit);
+        var roots = SelectSkillRoots(paths.Values, pluginRoot, parsed.SkillPaths, commit);
+        foreach (var link in paths.Values.Where(item => item.IsLink && roots.Any(root => IsWithin(item.Path, root))))
+            ValidateArchiveEntry(link, commit);
+        var selected = paths.Values
+            .Where(item => item.IsRegularFile && roots.Any(root => IsWithin(item.Path, root)))
+            .ToArray();
+        if (selected.Length > _limits.MaximumSelectedFileCount)
+            throw new GitSkillPluginRejectedException(commit, "The selected plugin exceeds the file-count limit.");
+        if (selected.Any(item => item.Length > _limits.MaximumSelectedFileBytes))
+            throw new GitSkillPluginRejectedException(commit, "A selected plugin file exceeds the per-file limit.");
+        long selectedTotal;
+        try
+        {
+            selectedTotal = checked(selected.Sum(item => item.Length));
+        }
+        catch (OverflowException)
+        {
+            throw new GitSkillPluginRejectedException(commit, "The selected plugin exceeds the total-size limit.");
+        }
+        if (selectedTotal > _limits.MaximumSelectedTotalBytes)
+            throw new GitSkillPluginRejectedException(commit, "The selected plugin exceeds the total-size limit.");
+        return new ArchiveInventory(
+            parsed.Version,
+            parsed.Notices,
+            roots,
+            selected.Select(item => item.Path).ToHashSet(StringComparer.Ordinal));
+    }
+
+    private async Task ExtractSelectedAsync(
+        string archivePath,
+        ArchiveInventory inventory,
+        string destinationRoot,
+        string commit,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ExtractSelectedCoreAsync(
+                archivePath, inventory, destinationRoot, commit, cancellationToken);
+        }
+        catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException)
+        {
+            throw new GitSkillPluginRejectedException(commit, "The archive has invalid GZip or tar content.");
+        }
+    }
+
+    private async Task ExtractSelectedCoreAsync(
+        string archivePath,
+        ArchiveInventory inventory,
+        string destinationRoot,
+        string commit,
+        CancellationToken cancellationToken)
+    {
+        await using var file = File.OpenRead(archivePath);
+        await using var gzip = new GZipStream(file, CompressionMode.Decompress);
+        await using var bounded = new LimitedReadStream(
+            gzip,
+            _limits.MaximumDecompressedArchiveBytes,
+            commit,
+            "The archive exceeds the decompressed-size limit.");
+        using var reader = new TarReader(bounded, leaveOpen: false);
+        while (await reader.GetNextEntryAsync(copyData: false, cancellationToken) is { } entry)
+        {
+            if (entry.EntryType == TarEntryType.GlobalExtendedAttributes)
+                continue;
+            var path = NormalizeArchivePath(entry.Name, commit);
+            if (!inventory.SelectedFiles.Contains(path)
+                || entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile))
+            {
+                continue;
+            }
+            var root = inventory.SkillRoots.Single(root => IsWithin(path, root));
+            var relative = path[root.Length..].TrimStart('/');
+            var skillName = Path.GetFileName(root.TrimEnd('/'));
+            var skillRoot = Path.Combine(destinationRoot, skillName);
+            var destination = Path.GetFullPath(Path.Combine(skillRoot, relative.Replace('/', Path.DirectorySeparatorChar)));
+            if (!PathUtility.IsWithinRoot(destination, skillRoot))
+                throw new GitSkillPluginRejectedException(commit, "A selected path escaped its skill directory.");
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            await using (var output = new FileStream(destination, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                await CopyLimitedAsync(
+                    entry.DataStream!,
+                    output,
+                    _limits.MaximumSelectedFileBytes,
+                    commit,
+                    "A selected plugin file exceeds the per-file limit.",
+                    cancellationToken);
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(destination, entry.Mode);
+        }
+    }
+
+    private static CodexManifest ParseManifest(byte[] bytes, string commit)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(StrictUtf8.GetString(bytes), new JsonDocumentOptions { MaxDepth = 32 });
+            if (document.RootElement.ValueKind != JsonValueKind.Object
+                || !document.RootElement.TryGetProperty("name", out var name)
+                || name.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidDataException("The Codex manifest requires a name.");
+            }
+            if (!GitSkillPluginSourceValidator.TryValidateName(name.GetString() ?? "", out var nameError))
+                throw new InvalidDataException($"The Codex manifest name is invalid: {nameError}");
+            string? version = null;
+            if (document.RootElement.TryGetProperty("version", out var versionElement))
+            {
+                if (versionElement.ValueKind != JsonValueKind.String
+                    || string.IsNullOrWhiteSpace(versionElement.GetString())
+                    || !IsStrictVersion(versionElement.GetString()!))
+                {
+                    throw new InvalidDataException("The Codex plugin version must use strict SemVer form.");
+                }
+                version = versionElement.GetString()!;
+            }
+            var declaredPaths = !document.RootElement.TryGetProperty("skills", out var skills)
+                ? Array.Empty<string>()
+                : skills.ValueKind == JsonValueKind.String
+                    ? [skills.GetString()!]
+                    : throw new InvalidDataException("The Codex skills field must be one string.");
+            var skillPaths = new[] { "./skills/" }.Concat(declaredPaths)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            var notices = document.RootElement.EnumerateObject()
+                .Where(property => ExecutableComponentNames.Contains(property.Name))
+                .Select(property => $"The importer ignored the '{property.Name}' plugin component.")
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            return new CodexManifest(version, skillPaths, notices);
+        }
+        catch (Exception ex) when (ex is JsonException or DecoderFallbackException or InvalidDataException)
+        {
+            throw new GitSkillPluginRejectedException(commit, ex.Message);
+        }
+    }
+
+    private IReadOnlyList<string> SelectSkillRoots(
+        IEnumerable<ArchiveFile> entries,
+        string pluginRoot,
+        IReadOnlyList<string> declaredPaths,
+        string commit)
+    {
+        var files = entries.Where(item => item.EntryType is TarEntryType.RegularFile or TarEntryType.V7RegularFile).ToArray();
+        var roots = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var declared in declaredPaths)
+        {
+            if (!GitSkillPluginSourceValidator.TryNormalizeRelativePath(declared, false, out var path, out var error))
+                throw new GitSkillPluginRejectedException(commit, error);
+            var prefix = pluginRoot + path!.TrimEnd('/');
+            foreach (var item in files.Where(item => item.Path.StartsWith(prefix + "/", StringComparison.Ordinal)
+                         && item.Path.EndsWith("/SKILL.md", StringComparison.Ordinal)))
+            {
+                var remainder = item.Path[(prefix.Length + 1)..];
+                if (remainder.Count(character => character == '/') == 1)
+                    roots.Add(item.Path[..^"SKILL.md".Length]);
+            }
+        }
+        if (roots.Count == 0 || roots.Count > _limits.MaximumSkillCount)
+            throw new GitSkillPluginRejectedException(commit, "The selected plugin has no skills or exceeds the skill-count limit.");
+        if (roots.GroupBy(root => Path.GetFileName(root.TrimEnd('/')), StringComparer.OrdinalIgnoreCase).Any(group => group.Count() > 1))
+            throw new GitSkillPluginRejectedException(commit, "Selected skills have duplicate directory names.");
+        return roots.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static string NormalizeArchivePath(string value, string commit)
+    {
+        if (value.Contains('\\', StringComparison.Ordinal)
+            || value.StartsWith("/", StringComparison.Ordinal) || value.Contains("//", StringComparison.Ordinal)
+            || value.Any(char.IsControl))
+            throw new GitSkillPluginRejectedException(commit, "The archive contains an unsafe path.");
+        var segments = value.TrimEnd('/').Split('/');
+        if (segments.Length == 0 || segments.Any(segment => segment.Length is 0 or > 255 || segment is "." or ".."))
+            throw new GitSkillPluginRejectedException(commit, "The archive contains an unsafe path segment.");
+        var relative = string.Join('/', segments.Skip(1));
+        if (relative.Length > 512)
+            throw new GitSkillPluginRejectedException(commit, "The archive contains a path that exceeds 512 characters.");
+        return relative;
+    }
+
+    private static void ValidateArchiveEntry(TarEntry entry, string commit)
+    {
+        if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile or TarEntryType.Directory))
+            throw new GitSkillPluginRejectedException(commit, "The archive contains a link or special file.");
+        if (entry.Length < 0)
+            throw new GitSkillPluginRejectedException(commit, "The archive contains an invalid file length.");
+        if (((int)entry.Mode & ~0x1FF) != 0)
+            throw new GitSkillPluginRejectedException(commit, "The archive contains unsupported mode bits.");
+    }
+
+    private static void ValidateArchiveEntry(ArchiveFile entry, string commit)
+    {
+        if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile or TarEntryType.Directory))
+            throw new GitSkillPluginRejectedException(commit, "The archive contains a link or special file.");
+        if (entry.Length < 0)
+            throw new GitSkillPluginRejectedException(commit, "The archive contains an invalid file length.");
+        if (((int)entry.Mode & ~0x1FF) != 0)
+            throw new GitSkillPluginRejectedException(commit, "The archive contains unsupported mode bits.");
+    }
+
+    private static bool IsLink(TarEntryType entryType)
+        => entryType is TarEntryType.SymbolicLink or TarEntryType.HardLink;
+
+    private static bool IsWithin(string path, string root) => path.StartsWith(root, StringComparison.Ordinal);
+
+    private static bool IsStrictVersion(string value)
+    {
+        if (value.Length > 256 || value.Any(char.IsWhiteSpace))
+            return false;
+        var buildIndex = value.IndexOf("+", StringComparison.Ordinal);
+        var coreAndPrerelease = buildIndex < 0 ? value : value[..buildIndex];
+        var build = buildIndex < 0 ? null : value[(buildIndex + 1)..];
+        if (buildIndex >= 0 && (build!.Length == 0 || build.Contains('+', StringComparison.Ordinal)
+            || !ValidIdentifiers(build, numericLeadingZeroAllowed: true)))
+        {
+            return false;
+        }
+        var prereleaseIndex = coreAndPrerelease.IndexOf("-", StringComparison.Ordinal);
+        var coreValue = prereleaseIndex < 0 ? coreAndPrerelease : coreAndPrerelease[..prereleaseIndex];
+        var prerelease = prereleaseIndex < 0 ? null : coreAndPrerelease[(prereleaseIndex + 1)..];
+        if (prereleaseIndex >= 0 && (prerelease!.Length == 0
+            || !ValidIdentifiers(prerelease, numericLeadingZeroAllowed: false)))
+        {
+            return false;
+        }
+        var core = coreValue.Split('.');
+        return core.Length == 3 && core.All(ValidCoreNumber);
+    }
+
+    private static bool ValidCoreNumber(string value)
+        => value.Length > 0 && value.All(char.IsAsciiDigit)
+            && (value.Length == 1 || value[0] != '0');
+
+    private static bool ValidIdentifiers(string value, bool numericLeadingZeroAllowed)
+    {
+        foreach (var identifier in value.Split('.'))
+        {
+            if (identifier.Length == 0
+                || !identifier.All(static character => char.IsAsciiLetterOrDigit(character) || character == '-'))
+                return false;
+            if (!numericLeadingZeroAllowed && identifier.All(char.IsAsciiDigit)
+                && identifier.Length > 1 && identifier[0] == '0')
+                return false;
+        }
+        return true;
+    }
+
+    private static async Task<byte[]> ReadLimitedAsync(
+        Stream stream,
+        int maximumBytes,
+        string commit,
+        string limitMessage,
+        CancellationToken cancellationToken)
+    {
+        await using var output = new MemoryStream();
+        await CopyLimitedAsync(stream, output, maximumBytes, commit, limitMessage, cancellationToken);
+        return output.ToArray();
+    }
+
+    private static async Task CopyLimitedAsync(
+        Stream source,
+        Stream destination,
+        long maximumBytes,
+        string commit,
+        string limitMessage,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[81920];
+        long total = 0;
+        while (true)
+        {
+            var read = await source.ReadAsync(buffer, cancellationToken);
+            if (read == 0)
+                return;
+            total += read;
+            if (total > maximumBytes)
+                throw new GitSkillPluginRejectedException(commit, limitMessage);
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+        }
+    }
+
+    private static void ProtectDirectory(string root)
+    {
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, File.GetAttributes(file) | FileAttributes.ReadOnly);
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(file, File.GetUnixFileMode(file) & ~(UnixFileMode.UserWrite | UnixFileMode.GroupWrite | UnixFileMode.OtherWrite));
+        }
+    }
+
+    internal static void DeleteDirectory(string directory)
+    {
+        if (!Directory.Exists(directory))
+            return;
+        foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+            File.SetAttributes(file, File.GetAttributes(file) & ~FileAttributes.ReadOnly);
+        Directory.Delete(directory, recursive: true);
+    }
+
+    private sealed record ArchiveFile(string Path, long Length, TarEntryType EntryType, UnixFileMode Mode)
+    {
+        public bool IsRegularFile => EntryType is TarEntryType.RegularFile or TarEntryType.V7RegularFile;
+        public bool IsLink => GitSkillPluginAcquirer.IsLink(EntryType);
+    }
+
+    private sealed record ArchiveInventory(
+        string? Version,
+        IReadOnlyList<string> Notices,
+        IReadOnlyList<string> SkillRoots,
+        HashSet<string> SelectedFiles);
+
+    private sealed record CodexManifest(
+        string? Version,
+        IReadOnlyList<string> SkillPaths,
+        IReadOnlyList<string> Notices);
+
+    private sealed class LimitedReadStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly long _maximumBytes;
+        private readonly string? _commit;
+        private readonly string _message;
+        private long _total;
+
+        public LimitedReadStream(Stream inner, long maximumBytes, string? commit, string message)
+        {
+            _inner = inner;
+            _maximumBytes = maximumBytes;
+            _commit = commit;
+            _message = message;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _inner.Read(buffer, offset, count);
+            CheckLimit(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await _inner.ReadAsync(buffer, cancellationToken);
+            CheckLimit(read);
+            return read;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override void Flush() => throw new NotSupportedException();
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.FromException(new NotSupportedException());
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+
+        private void CheckLimit(int read)
+        {
+            _total += read;
+            if (_total <= _maximumBytes)
+                return;
+            if (_commit is null)
+                throw new InvalidDataException(_message);
+            throw new GitSkillPluginRejectedException(_commit, _message);
+        }
+    }
+}


### PR DESCRIPTION
Netclaw needs a safe package boundary before the runtime can publish public Git skills.

This change resolves public GitHub branches and acquires exact commit archives. It imports only selected skill folders and their bundled files.

The importer rejects unsafe paths, selected links, special files, duplicate paths, invalid manifests, invalid skills, and exceeded resource limits. It ignores unselected repository links and archive-level PAX metadata.

The immutable path includes the source fingerprint and commit. A source change cannot reuse stale content from the same commit.

The importer sends the required GitHub user agent. It accepts only the controlled HTTPS redirect to codeload.github.com.

Validation:

- All 37 focused acquisition tests passed.
- The pinned public dotnet-skills commit loaded 36 skills and bundled resources.
- Two independent reviews found no unresolved defects.
- Format verification passed.
- Slopwatch passed.
- The copyright header check passed.
- The diff check passed.

Depends on #2153.
Part of #2134.

## Pull request stack

Review and merge these pull requests in this order:

1. [#2153: Add managed Git skill plugin state](https://github.com/netclaw-dev/netclaw/pull/2153)
2. [#2154: Acquire Codex skill packages from GitHub](https://github.com/netclaw-dev/netclaw/pull/2154) **(this pull request)**
3. [#2156: Publish managed Git skill plugins during external sync](https://github.com/netclaw-dev/netclaw/pull/2156)
4. [#2157: Add daemon API for managed Git skill plugins](https://github.com/netclaw-dev/netclaw/pull/2157)
5. [#2158: Add CLI management for Git skill plugins](https://github.com/netclaw-dev/netclaw/pull/2158)

This pull request is step 2 in the stack.
