### PR TITLE
Fix the local control redirect test shutdown race

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
@@ -454,6 +454,7 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
         private readonly HttpStatusCode _statusCode;
         private readonly Uri? _redirectTarget;
         private int _receivedRequest;
+        private int _shutdownRequested;
 
         public OneRequestHttpServer(HttpStatusCode statusCode, Uri? redirectTarget = null)
         {
@@ -471,6 +472,8 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
 
         public async ValueTask DisposeAsync()
         {
+            // Close can abort a Windows accept before IsListening reports the stopped state.
+            Interlocked.Exchange(ref _shutdownRequested, 1);
             _listener.Close();
             await _serveTask;
         }
@@ -491,11 +494,11 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
                 await context.Response.OutputStream.WriteAsync(body);
                 context.Response.Close();
             }
-            catch (HttpListenerException) when (!_listener.IsListening)
+            catch (HttpListenerException) when (Volatile.Read(ref _shutdownRequested) == 1)
             {
                 return;
             }
-            catch (ObjectDisposedException) when (!_listener.IsListening)
+            catch (ObjectDisposedException) when (Volatile.Read(ref _shutdownRequested) == 1)
             {
                 return;
             }


### PR DESCRIPTION
## Summary

- Add an explicit shutdown signal to the one-request HTTP test server.
- Accept listener abort exceptions only after fixture shutdown starts.
- Keep unexpected listener failures visible.

## Cause

Windows aborted the active HttpListener accept during fixture disposal. The IsListening property could still report true when that exception reached the filter.

## Validation

- The exact redirect test passed 25 consecutive runs.
- All 21 DaemonApiAuthenticationTests passed.
- All 1,495 non-native-shell CLI tests passed.
- Slopwatch reported zero issues.
- The copyright header check passed.