### PR TITLE
fix: request JSON from OAuth token endpoints

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### MCP reliability
+
+- **OAuth token exchanges request JSON responses.** This keeps GitHub-compatible token endpoints aligned with the MCP SDK decoder ([#2141](https://github.com/netclaw-dev/netclaw/issues/2141)).
+
 ## 0.27.0-beta.3 (2026-09-12)
 
 Follow-up beta to 0.27.0-beta.2. Sessions now live in one versioned storage envelope with a managed temporary directory per process, system skills ship inside the daemon binary, and shell authorization completes in one place. Slack Socket Mode no longer drops silently, and `netclaw skill sync` runs an external source pass on demand.

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.74.3"
+  version: "2.74.4"
 ---
 
 # Netclaw Operations
@@ -234,6 +234,10 @@ presents the authorization URL, brokers the browser callback, and durably stores
 active credentials. Do not fetch metadata or token endpoints by hand, build PKCE
 requests, or create or repair `mcp-oauth-metadata.json`; legacy metadata files
 are ignored.
+
+Netclaw requests JSON token responses from providers that negotiate the response
+format, including GitHub. This request keeps the response compatible with the
+MCP SDK token decoder.
 
 Netclaw registers rather than letting the SDK do it because the SDK hard-codes
 `token_endpoint_auth_method: "client_secret_post"` and ignores what the

--- a/src/Netclaw.Configuration/Http/McpHttpClientFactory.cs
+++ b/src/Netclaw.Configuration/Http/McpHttpClientFactory.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Netclaw.Configuration.Http;
 
@@ -103,6 +104,12 @@ internal sealed class OAuthClientRejectionHandler : DelegatingHandler
         {
             return await base.SendAsync(request, cancellationToken);
         }
+
+        // MCP SDK 2.2.0 parses successful token responses as JSON. GitHub returns
+        // form data unless the request asks for JSON.
+        if (!request.Headers.Accept.Any(
+                value => string.Equals(value.MediaType, "application/json", StringComparison.OrdinalIgnoreCase)))
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
         var requestBody = await request.Content.ReadAsStringAsync(cancellationToken);
         var response = await base.SendAsync(request, cancellationToken);

--- a/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpSdkOAuthFlowIntegrationTests.cs
@@ -88,6 +88,23 @@ public sealed class McpSdkOAuthFlowIntegrationTests
     }
 
     [Fact]
+    public async Task ManagerExplicitAuthorization_RequestsJsonFromNegotiatedTokenEndpoint()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var server = await FakeOAuthMcpServer.StartAsync(
+            ct,
+            negotiateTokenResponseWithAccept: true);
+        using var directory = new DisposableTempDir();
+        await using var harness = CreateManagerHarness(server, directory.Path);
+
+        await CompleteManagerAuthorizationAsync(server, harness, ct);
+
+        var tokenRequest = Assert.Single(server.TokenRequests);
+        Assert.True(tokenRequest.AcceptsJson);
+        Assert.Equal(McpConnectionState.Connected, harness.Manager.GetServerStatuses()[harness.ServerName].State);
+    }
+
+    [Fact]
     public async Task ExplicitAuthorizationGivesTheOperatorTimeToFinishInTheBrowser()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -968,14 +985,16 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             bool requireOAuth = true,
             string? acceptedBearer = null,
             bool rejectDcrWithoutBody = false,
-            string? dcrRejectionBody = null)
+            string? dcrRejectionBody = null,
+            bool negotiateTokenResponseWithAccept = false)
         {
             var origin = new Uri("https://oauth-mcp.test");
             var state = new FakeOAuthMcpServerState(
                 origin,
                 requireOAuth,
                 rejectDcrWithoutBody,
-                dcrRejectionBody);
+                dcrRejectionBody,
+                negotiateTokenResponseWithAccept);
             if (acceptedBearer is not null)
                 state.AcceptBearer(acceptedBearer);
             var builder = WebApplication.CreateBuilder();
@@ -1117,12 +1136,14 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             Uri origin,
             bool requireOAuth,
             bool rejectDcrWithoutBody,
-            string? dcrRejectionBody)
+            string? dcrRejectionBody,
+            bool negotiateTokenResponseWithAccept)
         {
             Origin = origin;
             RequireOAuth = requireOAuth;
             RejectDcrWithoutBody = rejectDcrWithoutBody;
             DcrRejectionBody = dcrRejectionBody;
+            NegotiateTokenResponseWithAccept = negotiateTokenResponseWithAccept;
             McpEndpoint = new Uri(origin, "/mcp");
             ProtectedResourceMetadataEndpoint = new Uri(origin, "/.well-known/oauth-protected-resource/mcp");
             AuthorizationEndpoint = new Uri(origin, "/oauth/authorize");
@@ -1137,6 +1158,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         private bool RejectDcrWithoutBody { get; }
 
         private string? DcrRejectionBody { get; }
+
+        private bool NegotiateTokenResponseWithAccept { get; }
 
         public Uri McpEndpoint { get; }
 
@@ -1302,6 +1325,9 @@ public sealed class McpSdkOAuthFlowIntegrationTests
             if (!string.Equals(clientSecret, client.ClientSecret, StringComparison.Ordinal))
                 return Results.BadRequest("Invalid client_secret.");
 
+            var acceptsJson = context.Request.Headers.Accept.ToString()
+                .Contains("application/json", StringComparison.OrdinalIgnoreCase);
+
             var redirectUri = form["redirect_uri"].ToString();
             var codeVerifier = form["code_verifier"].ToString();
             var pkceVerified = string.Equals(
@@ -1321,7 +1347,8 @@ public sealed class McpSdkOAuthFlowIntegrationTests
                 Resource: form["resource"].ToString(),
                 PkceVerified: pkceVerified,
                 IssuedAccessToken: issuedAccessToken,
-                IssuedRefreshToken: issuedRefreshToken);
+                IssuedRefreshToken: issuedRefreshToken,
+                AcceptsJson: acceptsJson);
             _tokenRequests.Enqueue(observation);
 
             if (!string.Equals(clientId, authorizationCode.ClientId, StringComparison.Ordinal)
@@ -1337,6 +1364,14 @@ public sealed class McpSdkOAuthFlowIntegrationTests
 
             _acceptedAccessTokens[issuedAccessToken] = 0;
             _refreshTokens[issuedRefreshToken] = clientId;
+            if (NegotiateTokenResponseWithAccept && !acceptsJson)
+            {
+                return Results.Text(
+                    $"access_token={issuedAccessToken}&refresh_token={issuedRefreshToken}" +
+                    $"&token_type=Bearer&expires_in=3600&scope={Uri.EscapeDataString(authorizationCode.Scope ?? string.Empty)}",
+                    "application/x-www-form-urlencoded");
+            }
+
             return Results.Json(new
             {
                 access_token = issuedAccessToken,
@@ -1515,5 +1550,6 @@ public sealed class McpSdkOAuthFlowIntegrationTests
         string Resource,
         bool PkceVerified,
         string IssuedAccessToken,
-        string IssuedRefreshToken);
+        string IssuedRefreshToken,
+        bool AcceptsJson);
 }


### PR DESCRIPTION
## Summary

- Add Accept: application/json only to form-encoded OAuth token requests.
- Extend the in-process OAuth MCP fake with response-format negotiation.
- Update the release notes and the operations skill.

Part of #2141. This PR covers token-response negotiation only. It does not add static client-secret configuration.

Target release: 0.27.0-beta.4.

Spike: https://github.com/Aaronontheweb/mcp-github-oauth-spike

## Verification

- The new integration test failed before the production change.
- 8 focused HTTP handler tests passed.
- 24 focused OAuth integration tests passed.
- The full solution passed 8,441 tests and skipped 21 platform or opt-in tests.
- The Release build completed with zero errors and one existing ASPIRE010 warning.
- Changed-file format verification passed.
- Header verification passed.
- Slopwatch found zero new issues.
- Behavioral evals could not run because the required NETCLAW_EVAL provider settings are absent.