### PR TITLE
test(smoke): isolate daemon output from screenshots

### DIFF
--- a/tests/smoke/tapes/README.md
+++ b/tests/smoke/tapes/README.md
@@ -128,6 +128,12 @@ How it differs from the flow tapes:
 - The harness points `run-native-tape.sh` at them via the `TAPE_PREAMBLE`
   and `TAPE_BODY_DIR` env vars.
 
+The daemon inherits the VHS terminal when `netclaw daemon start` starts it.
+Each screenshot tape that starts the daemon must redirect its output to
+`__NETCLAW_HOME__/logs/daemon-stdio.log`.
+This rule keeps asynchronous native-library messages outside the captured terminal.
+The artifact keeps the redirected output for fault analysis.
+
 Keep the recorder at 60 frames per second. End the tape with `Sleep 250ms` after
 the final state anchor. This recorder barrier produces 15 final-state frames.
 Do not send a terminal key after the final anchor. Use visible state anchors

--- a/tests/smoke/tapes/screenshots/mcp-permissions-server-list.tape
+++ b/tests/smoke/tapes/screenshots/mcp-permissions-server-list.tape
@@ -13,7 +13,7 @@ Wait+Screen@10s /TAPE\$/
 Type "netclaw mcp add --transport stdio --grant-all smoke-math -- __NETCLAW_SMOKE_MCP_SERVER__"
 Enter
 Wait+Screen@10s /TAPE\$/
-Type "netclaw daemon start"
+Type "mkdir -p __NETCLAW_HOME__/logs && netclaw daemon start >__NETCLAW_HOME__/logs/daemon-stdio.log 2>&1"
 Enter
 Wait+Screen@20s /TAPE\$/
 Type "until netclaw mcp list 2>/dev/null | grep -q 'connected (4 tools)'; do sleep 2; done"

--- a/tests/smoke/tapes/screenshots/mcp-permissions-tool-grid.tape
+++ b/tests/smoke/tapes/screenshots/mcp-permissions-tool-grid.tape
@@ -13,7 +13,7 @@ Wait+Screen@10s /TAPE\$/
 Type "netclaw mcp add --transport stdio --grant-all smoke-math -- __NETCLAW_SMOKE_MCP_SERVER__"
 Enter
 Wait+Screen@10s /TAPE\$/
-Type "netclaw daemon start"
+Type "mkdir -p __NETCLAW_HOME__/logs && netclaw daemon start >__NETCLAW_HOME__/logs/daemon-stdio.log 2>&1"
 Enter
 Wait+Screen@20s /TAPE\$/
 Type "until netclaw mcp list 2>/dev/null | grep -q 'connected (4 tools)'; do sleep 2; done"


### PR DESCRIPTION
## Summary

- Redirect daemon output in the two MCP screenshot tapes.
- Preserve that output in the isolated smoke log directory.
- Document the required output isolation for screenshot tapes.

This change fixes the intermittent screenshot failures seen on #2155.

## Cause

The detached daemon inherits the VHS terminal output streams.
ONNX Runtime can write a native warning after MCP readiness.
That warning changes the final terminal image.

## Verification

- The full screenshot profile passed all nine frames at `AE=0`.
- The full profile exited with code `0`.
- Both fault tests redirected ten injected error messages.
- Both fault-test frames remained at `AE=0`.
- The unchanged comparator rejected the prior CI frames.
- `dotnet slopwatch analyze` passed.
- The copyright-header check passed.
- `git diff --check` passed.
- An independent verifier returned `PASS`.

## Scope

This change does not modify the baselines, tolerance, retries, comparator, or quorum rules.
This change does not modify the general daemon launch behavior.
